### PR TITLE
Add indexed Array.set and fixed-size array constructor

### DIFF
--- a/baml_language/ARCHITECTURE.md
+++ b/baml_language/ARCHITECTURE.md
@@ -577,7 +577,7 @@ Use expression IDs and the span lookup infrastructure instead. If you're unsure 
 
 ## Mutability
 
-BAML supports mutable variables. You can reassign variables (`x = newValue`), use compound assignment operators (`i += 1`, `x -= 1`, etc.), and mutate data structures via methods like `.push()`. The MIR models this through `Assign` and `AssignOp` statements, and mutable variables captured by lambdas are wrapped in cells (indirection pointers) so that inner and outer scopes can mutate the same value.
+BAML supports mutable variables. You can reassign variables (`x = newValue`), use compound assignment operators (`i += 1`, `x -= 1`, etc.), and mutate data structures via methods like `.push()` and `.set(index, value)`. The MIR models this through `Assign` and `AssignOp` statements, and mutable variables captured by lambdas are wrapped in cells (indirection pointers) so that inner and outer scopes can mutate the same value.
 
 ---
 

--- a/baml_language/crates/baml_builtins2/baml_std/baml/containers.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/containers.baml
@@ -1,5 +1,18 @@
 /// An ordered, growable collection of elements of type T.
 class Array<T> {
+  /// Creates an array of length `size`, filled with `default`.
+  ///
+  /// Throws `InvalidArgument` if `size` is negative or cannot be allocated.
+  ///
+  /// # Examples
+  /// ```
+  /// int[](3, 0)        // [0, 0, 0]
+  /// string[](2, "x")  // ["x", "x"]
+  /// ```
+  function new(size: int, default: T) -> T[] throws root.errors.InvalidArgument {
+    $rust_function
+  }
+
   /// Returns the number of elements in the array.
   function length(self) -> int throws never {
     $rust_function
@@ -22,6 +35,21 @@ class Array<T> {
   /// Appends `item` to the end of the array. Returns the new length. Mutates `self`.
   //baml:mut_self
   function push(self, item: T) -> int throws never {
+    $rust_function
+  }
+
+  /// Replaces the element at `index` with `value`. Mutates `self`.
+  ///
+  /// Throws `InvalidArgument` if `index < 0` or `index >= length()`.
+  ///
+  /// # Examples
+  /// ```
+  /// let xs = int[](3, 0);
+  /// xs.set(1, 99);
+  /// xs  // [0, 99, 0]
+  /// ```
+  //baml:mut_self
+  function set(self, index: int, value: T) -> null throws root.errors.InvalidArgument {
     $rust_function
   }
 

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -5,7 +5,7 @@ expression: output
 class            Bigint                           <builtin>/baml/bigint.baml:26
 class            Bool                             <builtin>/baml/bool.baml:2
 class            Array                            <builtin>/baml/containers.baml:2
-class            Map                              <builtin>/baml/containers.baml:385
+class            Map                              <builtin>/baml/containers.baml:413
 function         deep_copy                        <builtin>/baml/core.baml:3
 function         deep_equals                      <builtin>/baml/core.baml:9
 class            Float                            <builtin>/baml/float.baml:2

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -2111,6 +2111,9 @@ impl LoweringContext {
     fn lower_call_expr(&mut self, node: &SyntaxNode) -> ExprId {
         // CALL_EXPR structure: callee expr node (or WORD token), then CALL_ARGS node
         let callee_node = node.children().find(|n| n.kind() != SyntaxKind::CALL_ARGS);
+        let array_constructor_element_type = callee_node
+            .as_ref()
+            .and_then(Self::array_constructor_element_type);
 
         // Extract explicit type arguments from the callee node.
         //
@@ -2126,10 +2129,15 @@ impl LoweringContext {
         //      method's frame correctly (e.g. `Box.from_json` sees
         //      `T = Secret`).
         let callee_generic_args = callee_node.as_ref().and_then(find_callee_generic_args);
-        let type_args: Vec<TypeExpr> = callee_generic_args
-            .as_ref()
-            .map(Self::lower_generic_args_node)
-            .unwrap_or_default();
+        let type_args: Vec<TypeExpr> =
+            if let Some(element_type) = array_constructor_element_type.clone() {
+                vec![element_type]
+            } else {
+                callee_generic_args
+                    .as_ref()
+                    .map(Self::lower_generic_args_node)
+                    .unwrap_or_default()
+            };
         // Mark EVERY `GENERIC_ARGS` node in the callee subtree as consumed, so
         // lowering the callee/receiver below does not wrap any of them into an
         // `Expr::GenericApply`. `foo<int>(x)` keeps its callee a plain path (the
@@ -2146,7 +2154,16 @@ impl LoweringContext {
             }
         }
 
-        let callee = if let Some(n) = callee_node {
+        let callee = if array_constructor_element_type.is_some() {
+            self.alloc_expr(
+                Expr::Path(vec![
+                    Name::new("baml"),
+                    Name::new("Array"),
+                    Name::new("new"),
+                ]),
+                node.text_range(),
+            )
+        } else if let Some(n) = callee_node {
             self.lower_expr_in_chain(&n)
         } else {
             // No callee node - check for an identifier token (simple function name)
@@ -2185,6 +2202,18 @@ impl LoweringContext {
             self.needs_chain_wrap.insert(id);
         }
         id
+    }
+
+    fn array_constructor_element_type(node: &SyntaxNode) -> Option<TypeExpr> {
+        if node.kind() != SyntaxKind::TYPE_EXPR {
+            return None;
+        }
+        let cst_ty = baml_compiler_syntax::ast::TypeExpr::cast(node.clone())?;
+        let lowered = crate::lower_type_expr::lower_type_expr_node(&cst_ty);
+        match lowered {
+            TypeExpr::List { inner, .. } => Some(*inner),
+            _ => None,
+        }
     }
 
     fn finalize_call_args(

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -12833,6 +12833,80 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.record_expr_type(callee_id, callee_expr_ty);
                 Some(result)
             }
+            "set" if args.len() == 2 => {
+                let (elem_ty, is_evolving, container_attr) = match &local_ty {
+                    Ty::EvolvingList(elem, attr) => (elem, true, attr.clone()),
+                    Ty::List(elem, attr) => (elem, false, attr.clone()),
+                    _ => return None,
+                };
+
+                let index_ty = self.infer_expr(args[0], body);
+                let expected_index_ty = Ty::Primitive(PrimitiveType::Int, TyAttr::default());
+                if !self.is_subtype(&index_ty, &expected_index_ty) {
+                    self.context.report(
+                        TirTypeError::TypeMismatch {
+                            expected: expected_index_ty,
+                            got: index_ty.clone(),
+                        },
+                        args[0],
+                        Vec::new(),
+                    );
+                }
+
+                let value_ty = self.infer_expr(args[1], body);
+                let widened_value = value_ty.clone().widen_fresh();
+
+                let effective_local_ty = if matches!(**elem_ty, Ty::Never { .. }) {
+                    let new_ty = if is_evolving {
+                        Ty::EvolvingList(Box::new(widened_value), container_attr)
+                    } else {
+                        Ty::List(Box::new(widened_value), container_attr)
+                    };
+                    self.assign_local(local_name.clone(), new_ty.clone());
+                    self.sync_let_binding_type(&local_name, new_ty.clone());
+                    new_ty
+                } else if !self.is_subtype(&widened_value, elem_ty) {
+                    self.context.report(
+                        TirTypeError::TypeMismatch {
+                            expected: *elem_ty.clone(),
+                            got: widened_value,
+                        },
+                        args[1],
+                        Vec::new(),
+                    );
+                    local_ty.clone()
+                } else {
+                    local_ty.clone()
+                };
+
+                let effective_elem = match &effective_local_ty {
+                    Ty::EvolvingList(e, _) | Ty::List(e, _) => e.as_ref().clone(),
+                    _ => Ty::Unknown {
+                        attr: TyAttr::default(),
+                    },
+                };
+                let method_ty = self
+                    .resolve_builtin_member(&["Array"], &[effective_elem], &method_name, callee_id)
+                    .unwrap_or(Ty::Unknown {
+                        attr: TyAttr::default(),
+                    });
+                let result = match &method_ty {
+                    Ty::Function { ret, .. } => ret.as_ref().clone(),
+                    _ => Ty::Unknown {
+                        attr: TyAttr::default(),
+                    },
+                };
+                let callee_expr_ty = match &body.exprs[callee_id] {
+                    Expr::OptionalMemberAccess { .. } => Ty::nullable(method_ty),
+                    _ => method_ty,
+                };
+
+                self.record_expr_type(base_id, effective_local_ty);
+                self.record_expr_type(args[0], index_ty);
+                self.record_expr_type(args[1], value_ty);
+                self.record_expr_type(callee_id, callee_expr_ty);
+                Some(result)
+            }
             _ => None,
         }
     }

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -5434,6 +5434,8 @@ impl<'a> Parser<'a> {
         } else if self.at(TokenKind::Throw) {
             // Throw expression
             self.parse_throw_expr();
+        } else if self.looks_like_array_type_constructor() {
+            self.parse_array_type_constructor_expr();
         } else if self.at(TokenKind::Word) {
             // Collect text as owned String so the borrow is released before any &mut calls.
             let text: String = self.current().map(|t| t.text.clone()).unwrap_or_default();
@@ -5507,6 +5509,75 @@ impl<'a> Parser<'a> {
             // Consume the unexpected token to avoid infinite loops
             if !self.at_end() {
                 self.bump();
+            }
+        }
+    }
+
+    /// Parse `T[](size, default)` as a call-shaped expression whose callee is a
+    /// `TYPE_EXPR`. AST lowering desugars it to `baml.Array.new<T>(size, default)`.
+    fn parse_array_type_constructor_expr(&mut self) {
+        self.with_node(SyntaxKind::CALL_EXPR, |p| {
+            p.parse_type();
+            p.parse_call_args();
+        });
+    }
+
+    /// Recognize a type expression ending in `[]` followed immediately by call
+    /// arguments. This keeps ordinary calls (`foo(...)`) and indexing
+    /// (`foo[i]`) on their existing paths while admitting `int[](3, 0)`.
+    fn looks_like_array_type_constructor(&self) -> bool {
+        if !self.is_at_type_start() {
+            return false;
+        }
+
+        let mut i = 0;
+        let mut generic_depth = 0i32;
+        let mut saw_array_suffix = false;
+
+        loop {
+            let Some(tok) = self.peek(i) else {
+                return false;
+            };
+
+            if generic_depth > 0 {
+                match tok.kind {
+                    TokenKind::Less => generic_depth += 1,
+                    TokenKind::Greater => generic_depth -= 1,
+                    TokenKind::GreaterGreater => generic_depth -= 2,
+                    _ => {}
+                }
+                if generic_depth < 0 {
+                    return false;
+                }
+                i += 1;
+                continue;
+            }
+
+            match tok.kind {
+                TokenKind::Less => {
+                    generic_depth += 1;
+                    i += 1;
+                }
+                TokenKind::Word
+                | TokenKind::Dot
+                | TokenKind::Question
+                | TokenKind::Quote
+                | TokenKind::Hash
+                | TokenKind::BigintLiteral
+                | TokenKind::IntegerLiteral
+                | TokenKind::FloatLiteral
+                | TokenKind::Minus => {
+                    i += 1;
+                }
+                TokenKind::LBracket => {
+                    if self.peek(i + 1).map(|t| t.kind) != Some(TokenKind::RBracket) {
+                        return false;
+                    }
+                    saw_array_suffix = true;
+                    i += 2;
+                }
+                TokenKind::LParen => return saw_array_suffix,
+                _ => return false,
             }
         }
     }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 4158
 ---
 === HIR2 ===
 
@@ -82,6 +83,7 @@ function baml.last_index_of(self: ?, item: T) -> int?  [builtin]
 function baml.length(self: ?) -> int  [builtin]
 function baml.length(self: ?) -> int  [builtin]
 function baml.map(self: ?, f: (T) -> U throws E) -> U[]  [builtin]
+function baml.new(size: int, default: T) -> T[]  [builtin]
 function baml.peekable(self: ?) -> baml.iter.Peekable<T, never>  [expr] {
   {  } baml.iter.Peekable { source: baml.iter.ArrayIterator.new(self.slice(0, self.length())), buffer: baml.iter.Done {  }, has_buffer: false }
 }
@@ -90,6 +92,7 @@ function baml.push(self: ?, item: T) -> int  [builtin]
 function baml.reduce(self: ?, reducer: (A, T) -> A throws E, initial: A) -> A  [builtin]
 function baml.reverse(self: ?) -> T[]  [builtin]
 function baml.set(self: ?, key: K, value: V) -> V?  [builtin]
+function baml.set(self: ?, index: int, value: T) -> null  [builtin]
 function baml.shift(self: ?) -> T?  [builtin]
 function baml.slice(self: ?, start: int, end: int) -> T[]  [builtin]
 function baml.some(self: ?, predicate: (T) -> bool throws E) -> bool  [builtin]

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 4252
 ---
 === MIR2 ===
 
@@ -1097,6 +1098,8 @@ fn baml.Array.length = builtin(vm)
 
 fn baml.Array.map = builtin(vm)
 
+fn baml.Array.new = builtin(vm)
+
 fn baml.Array.peekable(self: baml.Array) -> baml.iter.Peekable<void, void> {
     // Locals:
     let _0: baml.iter.Peekable<void, void> // _0 // return
@@ -1143,6 +1146,8 @@ fn baml.Array.reduce = builtin(vm)
 fn baml.Array.reverse = builtin(vm)
 
 fn baml.Map.set = builtin(vm)
+
+fn baml.Array.set = builtin(vm)
 
 fn baml.Array.shift = builtin(vm)
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 4386
 ---
 function baml.Array.at(self: baml.Array<unknown>, index: int) -> unknown | null {
 }
@@ -911,6 +912,9 @@ function baml.Array.length(self: baml.Array<unknown>) -> int {
 function baml.Array.map(self: baml.Array<unknown>, f: (unknown) -> unknown throws unknown) -> unknown[] {
 }
 
+function baml.Array.new(size: int, default: unknown) -> unknown[] {
+}
+
 function baml.Array.peekable(self: baml.Array<unknown>) -> baml.iter.Peekable<unknown, void> {
     load_type #0
     load_var self
@@ -942,6 +946,9 @@ function baml.Array.reduce(self: baml.Array<unknown>, reducer: (unknown, unknown
 }
 
 function baml.Array.reverse(self: baml.Array<unknown>) -> unknown[] {
+}
+
+function baml.Array.set(self: baml.Array<unknown>, index: int, value: unknown) -> null {
 }
 
 function baml.Array.shift(self: baml.Array<unknown>) -> unknown | null {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/baml_tests/src/compiler2_tir/phase5.rs
+assertion_line: 389
 expression: output
 ---
 namespace baml:
-  class Array<T> { methods: [length, at, push, pop, concat, for_each, filter, filter_map, step_by, chain, peekable, collect, count, reverse, slice, join, map, to_json, some, every, find, find_index, find_last, find_last_index, includes, index_of, last_index_of, reduce, flat_map, clear, shift, unshift, insert, splice, from_json] }
+  class Array<T> { methods: [new, length, at, push, set, pop, concat, for_each, filter, filter_map, step_by, chain, peekable, collect, count, reverse, slice, join, map, to_json, some, every, find, find_index, find_last, find_last_index, includes, index_of, last_index_of, reduce, flat_map, clear, shift, unshift, insert, splice, from_json] }
   class Bigint { methods: [to_json, abs, min, max, clamp, isqrt, pow, ilog, parse, random, from_json] }
   class Bool { methods: [to_json, from_json] }
   class Float { methods: [to_json, is_nan, is_infinite, is_finite, abs, min, max, clamp, floor, ceil, round, trunc, fract, ifloor, iceil, iround, itrunc, sqrt, pow, log, hypot, sin, cos, tan, asin, acos, atan, atan2, sinh, cosh, tanh, asinh, acosh, atanh, to_radians, to_degrees, parse, random, pi, e, golden_ratio, nan, inf, from_json] }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
+assertion_line: 42
 ---
 function assert.contains(haystack: string, needle: string) -> null {
   32   0   load_var2 1 2          
-       1   call 176 ntypeargs=0   (baml.String.includes)
+       1   call 178 ntypeargs=0   (baml.String.includes)
        2   unary_op !             
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
@@ -13,7 +14,7 @@ function assert.contains(haystack: string, needle: string) -> null {
   32   6   jump +3                (to 9)
 
   33   7   load_const 1           ("assertion failed: string does not contain expected substring")
-       8   call 292 ntypeargs=0   (baml.sys.panic)
+       8   call 294 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -28,7 +29,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   23   5   jump +3                (to 8)
 
   24   6   load_const 1           ("assertion failed: expected equal values")
-       7   call 292 ntypeargs=0   (baml.sys.panic)
+       7   call 294 ntypeargs=0   (baml.sys.panic)
        8   return                 
 }
 
@@ -43,7 +44,7 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 292 ntypeargs=0   (baml.sys.panic)
+      7   call 294 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
@@ -59,7 +60,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 292 ntypeargs=0   (baml.sys.panic)
+       8   call 294 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -72,18 +73,18 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
   7   0    load_var 1             (j)
       1    load_const 0           ("outcome")
-      2    call 394 ntypeargs=0   (baml.json.field)
+      2    call 396 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 386 ntypeargs=1   (baml.json.from_json)
+      6    call 388 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("duration_ms")
-      9    call 394 ntypeargs=0   (baml.json.field)
+      9    call 396 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 386 ntypeargs=1   (baml.json.from_json)
+      13   call 388 ntypeargs=1   (baml.json.from_json)
       14   init_instance 0        (testing.RunReport .outcome, .duration_ms)
       15   return                 
 }
@@ -96,7 +97,7 @@ function testing.RunReport.to_json(self: testing.RunReport) -> baml.json.json {
       4    call_indirect         
       5    load_var 1            (self)
       6    load_field 1          (duration_ms)
-      7    call 60 ntypeargs=0   (baml.Int.to_json)
+      7    call 62 ntypeargs=0   (baml.Int.to_json)
       8    load_const 1          ("outcome")
       9    load_const 2          ("duration_ms")
       10   alloc_map 2           
@@ -106,18 +107,18 @@ function testing.RunReport.to_json(self: testing.RunReport) -> baml.json.json {
 function testing.SerializedTest.from_json(j: baml.json.json) -> testing.SerializedTest {
   78   0    load_var 1             (j)
        1    load_const 0           ("type")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("name")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 1            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.SerializedTest .type, .name)
        15   return                 
 }
@@ -125,10 +126,10 @@ function testing.SerializedTest.from_json(j: baml.json.json) -> testing.Serializ
 function testing.SerializedTest.to_json(self: testing.SerializedTest) -> baml.json.json {
   78   0   load_var 1             (self)
        1   load_field 0           (type)
-       2   call 161 ntypeargs=0   (baml.String.to_json)
+       2   call 163 ntypeargs=0   (baml.String.to_json)
        3   load_var 1             (self)
        4   load_field 1           (name)
-       5   call 161 ntypeargs=0   (baml.String.to_json)
+       5   call 163 ntypeargs=0   (baml.String.to_json)
        6   load_const 0           ("type")
        7   load_const 1           ("name")
        8   alloc_map 2            
@@ -138,25 +139,25 @@ function testing.SerializedTest.to_json(self: testing.SerializedTest) -> baml.js
 function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.SerializedTestSet {
   83   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("items")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loadingTimeMs")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
        22   return                 
 }
@@ -164,14 +165,14 @@ function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.Seria
 function testing.SerializedTestSet.to_json(self: testing.SerializedTestSet) -> baml.json.json {
   83   0    load_var 1             (self)
        1    load_field 0           (name)
-       2    call 161 ntypeargs=0   (baml.String.to_json)
+       2    call 163 ntypeargs=0   (baml.String.to_json)
        3    load_type 0            
        4    load_var 1             (self)
        5    load_field 1           (items)
-       6    call 36 ntypeargs=1    (baml.Array.to_json)
+       6    call 38 ntypeargs=1    (baml.Array.to_json)
        7    load_var 1             (self)
        8    load_field 2           (loadingTimeMs)
-       9    call 60 ntypeargs=0    (baml.Int.to_json)
+       9    call 62 ntypeargs=0    (baml.Int.to_json)
        10   load_const 1           ("name")
        11   load_const 2           ("items")
        12   load_const 3           ("loadingTimeMs")
@@ -231,27 +232,27 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        48    pop_jump_if_false +176   (to 224)
        49    load_type 11             
        50    load_var 3               (_3)
-       51    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       51    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        52    store_var 4              (_4)
        53    jump +61                 (to 114)
        54    load_type 11             
        55    load_var 3               (_3)
-       56    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       56    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        57    store_var 4              (_4)
        58    jump +56                 (to 114)
        59    load_type 11             
        60    load_type 12             
        61    load_var 3               (_3)
-       62    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+       62    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
        63    store_var 4              (_4)
        64    jump +50                 (to 114)
        65    load_var 3               (_3)
-       66    make_bound_method 497    
+       66    make_bound_method 499    
        67    call_indirect            
        68    store_var 4              (_4)
        69    jump +45                 (to 114)
        70    load_var 3               (_3)
-       71    make_bound_method 510    
+       71    make_bound_method 512    
        72    call_indirect            
        73    store_var 4              (_4)
        74    jump +40                 (to 114)
@@ -259,39 +260,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        76    load_type 12             
        77    load_type 12             
        78    load_var 3               (_3)
-       79    call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+       79    call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
        80    store_var 4              (_4)
        81    jump +33                 (to 114)
        82    load_var 3               (_3)
-       83    make_bound_method 540    
+       83    make_bound_method 542    
        84    call_indirect            
        85    store_var 4              (_4)
        86    jump +28                 (to 114)
        87    load_type 11             
        88    load_var 3               (_3)
-       89    call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+       89    call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
        90    store_var 4              (_4)
        91    jump +23                 (to 114)
        92    load_type 11             
        93    load_type 12             
        94    load_type 12             
        95    load_var 3               (_3)
-       96    call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+       96    call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
        97    store_var 4              (_4)
        98    jump +16                 (to 114)
        99    load_type 11             
        100   load_type 12             
        101   load_var 3               (_3)
-       102   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+       102   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
        103   store_var 4              (_4)
        104   jump +10                 (to 114)
        105   load_type 11             
        106   load_var 3               (_3)
-       107   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+       107   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
        108   store_var 4              (_4)
        109   jump +5                  (to 114)
        110   load_var 3               (_3)
-       111   make_bound_method 571    
+       111   make_bound_method 573    
        112   call_indirect            
        113   store_var 4              (_4)
        114   load_var 4               (_4)
@@ -336,16 +337,16 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        153   load_type 11             
        154   load_type 12             
        155   load_var 4               (_4)
-       156   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       156   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        157   store_var 5              (_35)
        158   jump +50                 (to 208)
        159   load_var 4               (_4)
-       160   make_bound_method 551    
+       160   make_bound_method 553    
        161   call_indirect            
        162   store_var 5              (_35)
        163   jump +45                 (to 208)
        164   load_var 4               (_4)
-       165   make_bound_method 564    
+       165   make_bound_method 566    
        166   call_indirect            
        167   store_var 5              (_35)
        168   jump +40                 (to 208)
@@ -353,39 +354,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        170   load_type 12             
        171   load_type 12             
        172   load_var 4               (_4)
-       173   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       173   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        174   store_var 5              (_35)
        175   jump +33                 (to 208)
        176   load_var 4               (_4)
-       177   make_bound_method 500    
+       177   make_bound_method 502    
        178   call_indirect            
        179   store_var 5              (_35)
        180   jump +28                 (to 208)
        181   load_type 11             
        182   load_var 4               (_4)
-       183   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       183   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        184   store_var 5              (_35)
        185   jump +23                 (to 208)
        186   load_type 11             
        187   load_type 12             
        188   load_type 12             
        189   load_var 4               (_4)
-       190   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       190   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        191   store_var 5              (_35)
        192   jump +16                 (to 208)
        193   load_type 11             
        194   load_type 12             
        195   load_var 4               (_4)
-       196   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       196   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        197   store_var 5              (_35)
        198   jump +10                 (to 208)
        199   load_type 11             
        200   load_var 4               (_4)
-       201   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       201   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        202   store_var 5              (_35)
        203   jump +5                  (to 208)
        204   load_var 4               (_4)
-       205   make_bound_method 535    
+       205   make_bound_method 537    
        206   call_indirect            
        207   store_var 5              (_35)
        208   load_var 5               (_35)
@@ -413,25 +414,25 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
   29   0    load_var 1             (j)
        1    load_const 0           ("prefix")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("tests")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("testsets")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        22   return                 
 }
@@ -521,27 +522,27 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        70    pop_jump_if_false +213   (to 283)
        71    load_type 15             
        72    load_var 8               (_13)
-       73    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       73    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        74    store_var 9              (_14)
        75    jump +61                 (to 136)
        76    load_type 15             
        77    load_var 8               (_13)
-       78    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       78    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        79    store_var 9              (_14)
        80    jump +56                 (to 136)
        81    load_type 15             
        82    load_type 16             
        83    load_var 8               (_13)
-       84    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+       84    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
        85    store_var 9              (_14)
        86    jump +50                 (to 136)
        87    load_var 8               (_13)
-       88    make_bound_method 497    
+       88    make_bound_method 499    
        89    call_indirect            
        90    store_var 9              (_14)
        91    jump +45                 (to 136)
        92    load_var 8               (_13)
-       93    make_bound_method 510    
+       93    make_bound_method 512    
        94    call_indirect            
        95    store_var 9              (_14)
        96    jump +40                 (to 136)
@@ -549,39 +550,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        98    load_type 16             
        99    load_type 16             
        100   load_var 8               (_13)
-       101   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+       101   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
        102   store_var 9              (_14)
        103   jump +33                 (to 136)
        104   load_var 8               (_13)
-       105   make_bound_method 540    
+       105   make_bound_method 542    
        106   call_indirect            
        107   store_var 9              (_14)
        108   jump +28                 (to 136)
        109   load_type 15             
        110   load_var 8               (_13)
-       111   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+       111   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
        112   store_var 9              (_14)
        113   jump +23                 (to 136)
        114   load_type 15             
        115   load_type 16             
        116   load_type 16             
        117   load_var 8               (_13)
-       118   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+       118   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
        119   store_var 9              (_14)
        120   jump +16                 (to 136)
        121   load_type 15             
        122   load_type 16             
        123   load_var 8               (_13)
-       124   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+       124   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
        125   store_var 9              (_14)
        126   jump +10                 (to 136)
        127   load_type 15             
        128   load_var 8               (_13)
-       129   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+       129   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
        130   store_var 9              (_14)
        131   jump +5                  (to 136)
        132   load_var 8               (_13)
-       133   make_bound_method 571    
+       133   make_bound_method 573    
        134   call_indirect            
        135   store_var 9              (_14)
        136   load_var 9               (_14)
@@ -626,16 +627,16 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        175   load_type 15             
        176   load_type 16             
        177   load_var 9               (_14)
-       178   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       178   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        179   store_var 10             (_45)
        180   jump +50                 (to 230)
        181   load_var 9               (_14)
-       182   make_bound_method 551    
+       182   make_bound_method 553    
        183   call_indirect            
        184   store_var 10             (_45)
        185   jump +45                 (to 230)
        186   load_var 9               (_14)
-       187   make_bound_method 564    
+       187   make_bound_method 566    
        188   call_indirect            
        189   store_var 10             (_45)
        190   jump +40                 (to 230)
@@ -643,39 +644,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        192   load_type 16             
        193   load_type 16             
        194   load_var 9               (_14)
-       195   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       195   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        196   store_var 10             (_45)
        197   jump +33                 (to 230)
        198   load_var 9               (_14)
-       199   make_bound_method 500    
+       199   make_bound_method 502    
        200   call_indirect            
        201   store_var 10             (_45)
        202   jump +28                 (to 230)
        203   load_type 15             
        204   load_var 9               (_14)
-       205   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       205   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        206   store_var 10             (_45)
        207   jump +23                 (to 230)
        208   load_type 15             
        209   load_type 16             
        210   load_type 16             
        211   load_var 9               (_14)
-       212   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       212   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        213   store_var 10             (_45)
        214   jump +16                 (to 230)
        215   load_type 15             
        216   load_type 16             
        217   load_var 9               (_14)
-       218   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       218   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        219   store_var 10             (_45)
        220   jump +10                 (to 230)
        221   load_type 15             
        222   load_var 9               (_14)
-       223   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       223   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        224   store_var 10             (_45)
        225   jump +5                  (to 230)
        226   load_var 9               (_14)
-       227   make_bound_method 535    
+       227   make_bound_method 537    
        228   call_indirect            
        229   store_var 10             (_45)
        230   load_var 10              (_45)
@@ -694,7 +695,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        242   load_var 11              (t)
        243   load_field 0             (name)
        244   load_var 7               (hash_prefix)
-       245   call 149 ntypeargs=0     (baml.String.starts_with)
+       245   call 151 ntypeargs=0     (baml.String.starts_with)
        246   pop_jump_if_false -110   (to 136)
        247   load_var 6               (count)
        248   load_const 18            (1)
@@ -718,7 +719,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        265   load_var 6               (count)
        266   load_const 18            (1)
        267   add_int                  
-       268   call 406 ntypeargs=1     (baml.unstable.string)
+       268   call 408 ntypeargs=1     (baml.unstable.string)
        269   store_var 14             (_86)
        270   load_var2 13 14          
        271   bin_op +                 
@@ -730,7 +731,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        276   load_var2 12 3           
        277   load_var 4               (runner)
        278   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
+       279   call 18 ntypeargs=1      (baml.Array.push)
        280   pop 1                    
 
   38   281   load_const 21            (null)
@@ -815,27 +816,27 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        70    pop_jump_if_false +213   (to 283)
        71    load_type 15             
        72    load_var 8               (_13)
-       73    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       73    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        74    store_var 9              (_14)
        75    jump +61                 (to 136)
        76    load_type 15             
        77    load_var 8               (_13)
-       78    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       78    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        79    store_var 9              (_14)
        80    jump +56                 (to 136)
        81    load_type 15             
        82    load_type 16             
        83    load_var 8               (_13)
-       84    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+       84    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
        85    store_var 9              (_14)
        86    jump +50                 (to 136)
        87    load_var 8               (_13)
-       88    make_bound_method 497    
+       88    make_bound_method 499    
        89    call_indirect            
        90    store_var 9              (_14)
        91    jump +45                 (to 136)
        92    load_var 8               (_13)
-       93    make_bound_method 510    
+       93    make_bound_method 512    
        94    call_indirect            
        95    store_var 9              (_14)
        96    jump +40                 (to 136)
@@ -843,39 +844,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        98    load_type 16             
        99    load_type 16             
        100   load_var 8               (_13)
-       101   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+       101   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
        102   store_var 9              (_14)
        103   jump +33                 (to 136)
        104   load_var 8               (_13)
-       105   make_bound_method 540    
+       105   make_bound_method 542    
        106   call_indirect            
        107   store_var 9              (_14)
        108   jump +28                 (to 136)
        109   load_type 15             
        110   load_var 8               (_13)
-       111   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+       111   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
        112   store_var 9              (_14)
        113   jump +23                 (to 136)
        114   load_type 15             
        115   load_type 16             
        116   load_type 16             
        117   load_var 8               (_13)
-       118   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+       118   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
        119   store_var 9              (_14)
        120   jump +16                 (to 136)
        121   load_type 15             
        122   load_type 16             
        123   load_var 8               (_13)
-       124   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+       124   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
        125   store_var 9              (_14)
        126   jump +10                 (to 136)
        127   load_type 15             
        128   load_var 8               (_13)
-       129   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+       129   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
        130   store_var 9              (_14)
        131   jump +5                  (to 136)
        132   load_var 8               (_13)
-       133   make_bound_method 571    
+       133   make_bound_method 573    
        134   call_indirect            
        135   store_var 9              (_14)
        136   load_var 9               (_14)
@@ -920,16 +921,16 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        175   load_type 15             
        176   load_type 16             
        177   load_var 9               (_14)
-       178   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       178   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        179   store_var 10             (_45)
        180   jump +50                 (to 230)
        181   load_var 9               (_14)
-       182   make_bound_method 551    
+       182   make_bound_method 553    
        183   call_indirect            
        184   store_var 10             (_45)
        185   jump +45                 (to 230)
        186   load_var 9               (_14)
-       187   make_bound_method 564    
+       187   make_bound_method 566    
        188   call_indirect            
        189   store_var 10             (_45)
        190   jump +40                 (to 230)
@@ -937,39 +938,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        192   load_type 16             
        193   load_type 16             
        194   load_var 9               (_14)
-       195   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       195   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        196   store_var 10             (_45)
        197   jump +33                 (to 230)
        198   load_var 9               (_14)
-       199   make_bound_method 500    
+       199   make_bound_method 502    
        200   call_indirect            
        201   store_var 10             (_45)
        202   jump +28                 (to 230)
        203   load_type 15             
        204   load_var 9               (_14)
-       205   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       205   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        206   store_var 10             (_45)
        207   jump +23                 (to 230)
        208   load_type 15             
        209   load_type 16             
        210   load_type 16             
        211   load_var 9               (_14)
-       212   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       212   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        213   store_var 10             (_45)
        214   jump +16                 (to 230)
        215   load_type 15             
        216   load_type 16             
        217   load_var 9               (_14)
-       218   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       218   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        219   store_var 10             (_45)
        220   jump +10                 (to 230)
        221   load_type 15             
        222   load_var 9               (_14)
-       223   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       223   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        224   store_var 10             (_45)
        225   jump +5                  (to 230)
        226   load_var 9               (_14)
-       227   make_bound_method 535    
+       227   make_bound_method 537    
        228   call_indirect            
        229   store_var 10             (_45)
        230   load_var 10              (_45)
@@ -988,7 +989,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        242   load_var 11              (ts)
        243   load_field 0             (name)
        244   load_var 7               (hash_prefix)
-       245   call 149 ntypeargs=0     (baml.String.starts_with)
+       245   call 151 ntypeargs=0     (baml.String.starts_with)
        246   pop_jump_if_false -110   (to 136)
        247   load_var 6               (count)
        248   load_const 18            (1)
@@ -1012,7 +1013,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        265   load_var 6               (count)
        266   load_const 18            (1)
        267   add_int                  
-       268   call 406 ntypeargs=1     (baml.unstable.string)
+       268   call 408 ntypeargs=1     (baml.unstable.string)
        269   store_var 14             (_86)
        270   load_var2 13 14          
        271   bin_op +                 
@@ -1024,7 +1025,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        276   load_var2 12 3           
        277   load_var 4               (runner)
        278   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
+       279   call 18 ntypeargs=1      (baml.Array.push)
        280   pop 1                    
 
   49   281   load_const 21            (null)
@@ -1035,15 +1036,15 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {
   29   0    load_var 1             (self)
        1    load_field 0           (prefix)
-       2    call 161 ntypeargs=0   (baml.String.to_json)
+       2    call 163 ntypeargs=0   (baml.String.to_json)
        3    load_type 0            
        4    load_var 1             (self)
        5    load_field 1           (tests)
-       6    call 36 ntypeargs=1    (baml.Array.to_json)
+       6    call 38 ntypeargs=1    (baml.Array.to_json)
        7    load_type 1            
        8    load_var 1             (self)
        9    load_field 2           (testsets)
-       10   call 36 ntypeargs=1    (baml.Array.to_json)
+       10   call 38 ntypeargs=1    (baml.Array.to_json)
        11   load_const 2           ("prefix")
        12   load_const 3           ("tests")
        13   load_const 4           ("testsets")
@@ -1054,25 +1055,25 @@ function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json
 function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRegistration {
   5   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 394 ntypeargs=0   (baml.json.field)
+      2    call 396 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 386 ntypeargs=1   (baml.json.from_json)
+      6    call 388 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("body")
-      9    call 394 ntypeargs=0   (baml.json.field)
+      9    call 396 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 386 ntypeargs=1   (baml.json.from_json)
+      13   call 388 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("runner")
-      16   call 394 ntypeargs=0   (baml.json.field)
+      16   call 396 ntypeargs=0   (baml.json.field)
       17   store_var 4            (_9)
       18   load_type 5            
       19   load_var 4             (_9)
-      20   call 386 ntypeargs=1   (baml.json.from_json)
+      20   call 388 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (testing.TestRegistration .name, .body, .runner)
       22   return                 
 }
@@ -1080,8 +1081,8 @@ function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRe
 function testing.TestRegistration.to_json(self: testing.TestRegistration) -> baml.json.json {
   13   0   load_type 0            
        1   load_var 1             (self)
-       2   call 396 ntypeargs=1   (baml.json.to_string)
-       3   call 391 ntypeargs=0   (baml.json.parse)
+       2   call 398 ntypeargs=1   (baml.json.to_string)
+       3   call 393 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
@@ -1139,27 +1140,27 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         49    pop_jump_if_false +432   (to 481)
         50    load_type 11             
         51    load_var 3               (_3)
-        52    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        52    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         53    store_var 4              (_4)
         54    jump +61                 (to 115)
         55    load_type 11             
         56    load_var 3               (_3)
-        57    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        57    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         58    store_var 4              (_4)
         59    jump +56                 (to 115)
         60    load_type 11             
         61    load_type 12             
         62    load_var 3               (_3)
-        63    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        63    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         64    store_var 4              (_4)
         65    jump +50                 (to 115)
         66    load_var 3               (_3)
-        67    make_bound_method 497    
+        67    make_bound_method 499    
         68    call_indirect            
         69    store_var 4              (_4)
         70    jump +45                 (to 115)
         71    load_var 3               (_3)
-        72    make_bound_method 510    
+        72    make_bound_method 512    
         73    call_indirect            
         74    store_var 4              (_4)
         75    jump +40                 (to 115)
@@ -1167,39 +1168,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         77    load_type 12             
         78    load_type 12             
         79    load_var 3               (_3)
-        80    call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        80    call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         81    store_var 4              (_4)
         82    jump +33                 (to 115)
         83    load_var 3               (_3)
-        84    make_bound_method 540    
+        84    make_bound_method 542    
         85    call_indirect            
         86    store_var 4              (_4)
         87    jump +28                 (to 115)
         88    load_type 11             
         89    load_var 3               (_3)
-        90    call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        90    call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         91    store_var 4              (_4)
         92    jump +23                 (to 115)
         93    load_type 11             
         94    load_type 12             
         95    load_type 12             
         96    load_var 3               (_3)
-        97    call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        97    call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         98    store_var 4              (_4)
         99    jump +16                 (to 115)
         100   load_type 11             
         101   load_type 12             
         102   load_var 3               (_3)
-        103   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        103   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         104   store_var 4              (_4)
         105   jump +10                 (to 115)
         106   load_type 11             
         107   load_var 3               (_3)
-        108   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        108   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         109   store_var 4              (_4)
         110   jump +5                  (to 115)
         111   load_var 3               (_3)
-        112   make_bound_method 571    
+        112   make_bound_method 573    
         113   call_indirect            
         114   store_var 4              (_4)
         115   load_var 4               (_4)
@@ -1244,16 +1245,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         154   load_type 11             
         155   load_type 12             
         156   load_var 4               (_4)
-        157   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        157   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         158   store_var 5              (_35)
         159   jump +50                 (to 209)
         160   load_var 4               (_4)
-        161   make_bound_method 551    
+        161   make_bound_method 553    
         162   call_indirect            
         163   store_var 5              (_35)
         164   jump +45                 (to 209)
         165   load_var 4               (_4)
-        166   make_bound_method 564    
+        166   make_bound_method 566    
         167   call_indirect            
         168   store_var 5              (_35)
         169   jump +40                 (to 209)
@@ -1261,39 +1262,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         171   load_type 12             
         172   load_type 12             
         173   load_var 4               (_4)
-        174   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        174   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         175   store_var 5              (_35)
         176   jump +33                 (to 209)
         177   load_var 4               (_4)
-        178   make_bound_method 500    
+        178   make_bound_method 502    
         179   call_indirect            
         180   store_var 5              (_35)
         181   jump +28                 (to 209)
         182   load_type 11             
         183   load_var 4               (_4)
-        184   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        184   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         185   store_var 5              (_35)
         186   jump +23                 (to 209)
         187   load_type 11             
         188   load_type 12             
         189   load_type 12             
         190   load_var 4               (_4)
-        191   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        191   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         192   store_var 5              (_35)
         193   jump +16                 (to 209)
         194   load_type 11             
         195   load_type 12             
         196   load_var 4               (_4)
-        197   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        197   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         198   store_var 5              (_35)
         199   jump +10                 (to 209)
         200   load_type 11             
         201   load_var 4               (_4)
-        202   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        202   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         203   store_var 5              (_35)
         204   jump +5                  (to 209)
         205   load_var 4               (_4)
-        206   make_bound_method 535    
+        206   make_bound_method 537    
         207   call_indirect            
         208   store_var 5              (_35)
         209   load_var 5               (_35)
@@ -1308,7 +1309,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         217   cmp_op ==                
         218   pop_jump_if_false -103   (to 115)
 
-  159   219   call 288 ntypeargs=0     (baml.sys.now_ms)
+  159   219   call 290 ntypeargs=0     (baml.sys.now_ms)
         220   store_var 7              (start)
 
   160   221   load_var 2               (name)
@@ -1322,7 +1323,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         228   call_indirect            
         229   pop 1                    
 
-  162   230   call 288 ntypeargs=0     (baml.sys.now_ms)
+  162   230   call 290 ntypeargs=0     (baml.sys.now_ms)
         231   store_var 9              (_75)
 
   168   232   load_type 14             
@@ -1336,18 +1337,18 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   162   238   load_var2 9 7            
         239   sub_int                  
         240   init_instance 1          (testing.TestRegistry .collector, .expansions, .loading_time_ms)
-        241   call 22 ntypeargs=2      (baml.Map.set)
+        241   call 9 ntypeargs=2       (baml.Map.set)
         242   pop 1                    
 
   169   243   load_var 1               (self)
-        244   call 705 ntypeargs=0     (testing.TestRegistry.serialize)
+        244   call 707 ntypeargs=0     (testing.TestRegistry.serialize)
         245   jump +231                (to 476)
 
   173   246   load_type 14             
         247   load_type 15             
         248   load_var 1               (self)
         249   load_field 1             (expansions)
-        250   call 20 ntypeargs=2      (baml.Map.keys)
+        250   call 23 ntypeargs=2      (baml.Map.keys)
         251   store_var 10             (_86)
 
   172   252   load_var 10              (_86)
@@ -1399,27 +1400,27 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         298   pop_jump_if_false +183   (to 481)
         299   load_type 14             
         300   load_var 10              (_86)
-        301   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        301   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         302   store_var 11             (_90)
         303   jump +61                 (to 364)
         304   load_type 14             
         305   load_var 10              (_86)
-        306   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        306   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         307   store_var 11             (_90)
         308   jump +56                 (to 364)
         309   load_type 14             
         310   load_type 12             
         311   load_var 10              (_86)
-        312   call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        312   call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         313   store_var 11             (_90)
         314   jump +50                 (to 364)
         315   load_var 10              (_86)
-        316   make_bound_method 497    
+        316   make_bound_method 499    
         317   call_indirect            
         318   store_var 11             (_90)
         319   jump +45                 (to 364)
         320   load_var 10              (_86)
-        321   make_bound_method 510    
+        321   make_bound_method 512    
         322   call_indirect            
         323   store_var 11             (_90)
         324   jump +40                 (to 364)
@@ -1427,39 +1428,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         326   load_type 12             
         327   load_type 12             
         328   load_var 10              (_86)
-        329   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        329   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         330   store_var 11             (_90)
         331   jump +33                 (to 364)
         332   load_var 10              (_86)
-        333   make_bound_method 540    
+        333   make_bound_method 542    
         334   call_indirect            
         335   store_var 11             (_90)
         336   jump +28                 (to 364)
         337   load_type 14             
         338   load_var 10              (_86)
-        339   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        339   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         340   store_var 11             (_90)
         341   jump +23                 (to 364)
         342   load_type 14             
         343   load_type 12             
         344   load_type 12             
         345   load_var 10              (_86)
-        346   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        346   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         347   store_var 11             (_90)
         348   jump +16                 (to 364)
         349   load_type 14             
         350   load_type 12             
         351   load_var 10              (_86)
-        352   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        352   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         353   store_var 11             (_90)
         354   jump +10                 (to 364)
         355   load_type 14             
         356   load_var 10              (_86)
-        357   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        357   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         358   store_var 11             (_90)
         359   jump +5                  (to 364)
         360   load_var 10              (_86)
-        361   make_bound_method 571    
+        361   make_bound_method 573    
         362   call_indirect            
         363   store_var 11             (_90)
         364   load_var 11              (_90)
@@ -1504,16 +1505,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         403   load_type 14             
         404   load_type 12             
         405   load_var 11              (_90)
-        406   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        406   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         407   store_var 12             (_121)
         408   jump +50                 (to 458)
         409   load_var 11              (_90)
-        410   make_bound_method 551    
+        410   make_bound_method 553    
         411   call_indirect            
         412   store_var 12             (_121)
         413   jump +45                 (to 458)
         414   load_var 11              (_90)
-        415   make_bound_method 564    
+        415   make_bound_method 566    
         416   call_indirect            
         417   store_var 12             (_121)
         418   jump +40                 (to 458)
@@ -1521,39 +1522,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         420   load_type 12             
         421   load_type 12             
         422   load_var 11              (_90)
-        423   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        423   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         424   store_var 12             (_121)
         425   jump +33                 (to 458)
         426   load_var 11              (_90)
-        427   make_bound_method 500    
+        427   make_bound_method 502    
         428   call_indirect            
         429   store_var 12             (_121)
         430   jump +28                 (to 458)
         431   load_type 14             
         432   load_var 11              (_90)
-        433   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        433   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         434   store_var 12             (_121)
         435   jump +23                 (to 458)
         436   load_type 14             
         437   load_type 12             
         438   load_type 12             
         439   load_var 11              (_90)
-        440   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        440   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         441   store_var 12             (_121)
         442   jump +16                 (to 458)
         443   load_type 14             
         444   load_type 12             
         445   load_var 11              (_90)
-        446   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        446   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         447   store_var 12             (_121)
         448   jump +10                 (to 458)
         449   load_type 14             
         450   load_var 11              (_90)
-        451   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        451   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         452   store_var 12             (_121)
         453   jump +5                  (to 458)
         454   load_var 11              (_90)
-        455   make_bound_method 535    
+        455   make_bound_method 537    
         456   call_indirect            
         457   store_var 12             (_121)
         458   load_var 12              (_121)
@@ -1572,11 +1573,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   175   469   load_var2 2 13           
         470   load_const 26            ("/")
         471   bin_op +                 
-        472   call 149 ntypeargs=0     (baml.String.starts_with)
+        472   call 151 ntypeargs=0     (baml.String.starts_with)
         473   pop_jump_if_false -109   (to 364)
 
   176   474   load_var2 14 2           
-        475   call 710 ntypeargs=0     (testing.TestRegistry.expand_set)
+        475   call 712 ntypeargs=0     (testing.TestRegistry.expand_set)
         476   return                   
 
   179   477   load_const 27            ("TestSet not found for expansion: ")
@@ -1589,25 +1590,25 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
   93   0    load_var 1             (j)
        1    load_const 0           ("collector")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("expansions")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loading_time_ms")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
        22   return                 
 }
@@ -1675,27 +1676,27 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         49    pop_jump_if_false +411   (to 460)
         50    load_type 11             
         51    load_var 3               (_3)
-        52    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        52    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         53    store_var 4              (_4)
         54    jump +61                 (to 115)
         55    load_type 11             
         56    load_var 3               (_3)
-        57    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        57    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         58    store_var 4              (_4)
         59    jump +56                 (to 115)
         60    load_type 11             
         61    load_type 12             
         62    load_var 3               (_3)
-        63    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        63    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         64    store_var 4              (_4)
         65    jump +50                 (to 115)
         66    load_var 3               (_3)
-        67    make_bound_method 497    
+        67    make_bound_method 499    
         68    call_indirect            
         69    store_var 4              (_4)
         70    jump +45                 (to 115)
         71    load_var 3               (_3)
-        72    make_bound_method 510    
+        72    make_bound_method 512    
         73    call_indirect            
         74    store_var 4              (_4)
         75    jump +40                 (to 115)
@@ -1703,39 +1704,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         77    load_type 12             
         78    load_type 12             
         79    load_var 3               (_3)
-        80    call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        80    call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         81    store_var 4              (_4)
         82    jump +33                 (to 115)
         83    load_var 3               (_3)
-        84    make_bound_method 540    
+        84    make_bound_method 542    
         85    call_indirect            
         86    store_var 4              (_4)
         87    jump +28                 (to 115)
         88    load_type 11             
         89    load_var 3               (_3)
-        90    call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        90    call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         91    store_var 4              (_4)
         92    jump +23                 (to 115)
         93    load_type 11             
         94    load_type 12             
         95    load_type 12             
         96    load_var 3               (_3)
-        97    call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        97    call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         98    store_var 4              (_4)
         99    jump +16                 (to 115)
         100   load_type 11             
         101   load_type 12             
         102   load_var 3               (_3)
-        103   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        103   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         104   store_var 4              (_4)
         105   jump +10                 (to 115)
         106   load_type 11             
         107   load_var 3               (_3)
-        108   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        108   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         109   store_var 4              (_4)
         110   jump +5                  (to 115)
         111   load_var 3               (_3)
-        112   make_bound_method 571    
+        112   make_bound_method 573    
         113   call_indirect            
         114   store_var 4              (_4)
         115   load_var 4               (_4)
@@ -1780,16 +1781,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         154   load_type 11             
         155   load_type 12             
         156   load_var 4               (_4)
-        157   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        157   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         158   store_var 5              (_35)
         159   jump +50                 (to 209)
         160   load_var 4               (_4)
-        161   make_bound_method 551    
+        161   make_bound_method 553    
         162   call_indirect            
         163   store_var 5              (_35)
         164   jump +45                 (to 209)
         165   load_var 4               (_4)
-        166   make_bound_method 564    
+        166   make_bound_method 566    
         167   call_indirect            
         168   store_var 5              (_35)
         169   jump +40                 (to 209)
@@ -1797,39 +1798,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         171   load_type 12             
         172   load_type 12             
         173   load_var 4               (_4)
-        174   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        174   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         175   store_var 5              (_35)
         176   jump +33                 (to 209)
         177   load_var 4               (_4)
-        178   make_bound_method 500    
+        178   make_bound_method 502    
         179   call_indirect            
         180   store_var 5              (_35)
         181   jump +28                 (to 209)
         182   load_type 11             
         183   load_var 4               (_4)
-        184   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        184   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         185   store_var 5              (_35)
         186   jump +23                 (to 209)
         187   load_type 11             
         188   load_type 12             
         189   load_type 12             
         190   load_var 4               (_4)
-        191   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        191   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         192   store_var 5              (_35)
         193   jump +16                 (to 209)
         194   load_type 11             
         195   load_type 12             
         196   load_var 4               (_4)
-        197   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        197   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         198   store_var 5              (_35)
         199   jump +10                 (to 209)
         200   load_type 11             
         201   load_var 4               (_4)
-        202   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        202   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         203   store_var 5              (_35)
         204   jump +5                  (to 209)
         205   load_var 4               (_4)
-        206   make_bound_method 535    
+        206   make_bound_method 537    
         207   call_indirect            
         208   store_var 5              (_35)
         209   load_var 5               (_35)
@@ -1848,14 +1849,14 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         220   load_field 1             (body)
         221   load_var 6               (t)
         222   load_field 2             (runner)
-        223   call 716 ntypeargs=0     (testing.run_test)
+        223   call 718 ntypeargs=0     (testing.run_test)
         224   jump +231                (to 455)
 
   143   225   load_type 14             
         226   load_type 15             
         227   load_var 1               (self)
         228   load_field 1             (expansions)
-        229   call 20 ntypeargs=2      (baml.Map.keys)
+        229   call 23 ntypeargs=2      (baml.Map.keys)
         230   store_var 7              (_69)
 
   142   231   load_var 7               (_69)
@@ -1907,27 +1908,27 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         277   pop_jump_if_false +183   (to 460)
         278   load_type 14             
         279   load_var 7               (_69)
-        280   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        280   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         281   store_var 8              (_73)
         282   jump +61                 (to 343)
         283   load_type 14             
         284   load_var 7               (_69)
-        285   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        285   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         286   store_var 8              (_73)
         287   jump +56                 (to 343)
         288   load_type 14             
         289   load_type 12             
         290   load_var 7               (_69)
-        291   call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        291   call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         292   store_var 8              (_73)
         293   jump +50                 (to 343)
         294   load_var 7               (_69)
-        295   make_bound_method 497    
+        295   make_bound_method 499    
         296   call_indirect            
         297   store_var 8              (_73)
         298   jump +45                 (to 343)
         299   load_var 7               (_69)
-        300   make_bound_method 510    
+        300   make_bound_method 512    
         301   call_indirect            
         302   store_var 8              (_73)
         303   jump +40                 (to 343)
@@ -1935,39 +1936,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         305   load_type 12             
         306   load_type 12             
         307   load_var 7               (_69)
-        308   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        308   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         309   store_var 8              (_73)
         310   jump +33                 (to 343)
         311   load_var 7               (_69)
-        312   make_bound_method 540    
+        312   make_bound_method 542    
         313   call_indirect            
         314   store_var 8              (_73)
         315   jump +28                 (to 343)
         316   load_type 14             
         317   load_var 7               (_69)
-        318   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        318   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         319   store_var 8              (_73)
         320   jump +23                 (to 343)
         321   load_type 14             
         322   load_type 12             
         323   load_type 12             
         324   load_var 7               (_69)
-        325   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        325   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         326   store_var 8              (_73)
         327   jump +16                 (to 343)
         328   load_type 14             
         329   load_type 12             
         330   load_var 7               (_69)
-        331   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        331   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         332   store_var 8              (_73)
         333   jump +10                 (to 343)
         334   load_type 14             
         335   load_var 7               (_69)
-        336   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        336   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         337   store_var 8              (_73)
         338   jump +5                  (to 343)
         339   load_var 7               (_69)
-        340   make_bound_method 571    
+        340   make_bound_method 573    
         341   call_indirect            
         342   store_var 8              (_73)
         343   load_var 8               (_73)
@@ -2012,16 +2013,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         382   load_type 14             
         383   load_type 12             
         384   load_var 8               (_73)
-        385   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        385   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         386   store_var 9              (_104)
         387   jump +50                 (to 437)
         388   load_var 8               (_73)
-        389   make_bound_method 551    
+        389   make_bound_method 553    
         390   call_indirect            
         391   store_var 9              (_104)
         392   jump +45                 (to 437)
         393   load_var 8               (_73)
-        394   make_bound_method 564    
+        394   make_bound_method 566    
         395   call_indirect            
         396   store_var 9              (_104)
         397   jump +40                 (to 437)
@@ -2029,39 +2030,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         399   load_type 12             
         400   load_type 12             
         401   load_var 8               (_73)
-        402   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        402   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         403   store_var 9              (_104)
         404   jump +33                 (to 437)
         405   load_var 8               (_73)
-        406   make_bound_method 500    
+        406   make_bound_method 502    
         407   call_indirect            
         408   store_var 9              (_104)
         409   jump +28                 (to 437)
         410   load_type 14             
         411   load_var 8               (_73)
-        412   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        412   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         413   store_var 9              (_104)
         414   jump +23                 (to 437)
         415   load_type 14             
         416   load_type 12             
         417   load_type 12             
         418   load_var 8               (_73)
-        419   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        419   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         420   store_var 9              (_104)
         421   jump +16                 (to 437)
         422   load_type 14             
         423   load_type 12             
         424   load_var 8               (_73)
-        425   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        425   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         426   store_var 9              (_104)
         427   jump +10                 (to 437)
         428   load_type 14             
         429   load_var 8               (_73)
-        430   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        430   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         431   store_var 9              (_104)
         432   jump +5                  (to 437)
         433   load_var 8               (_73)
-        434   make_bound_method 535    
+        434   make_bound_method 537    
         435   call_indirect            
         436   store_var 9              (_104)
         437   load_var 9               (_104)
@@ -2080,12 +2081,12 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
   146   448   load_var2 2 10           
         449   load_const 26            ("/")
         450   bin_op +                 
-        451   call 149 ntypeargs=0     (baml.String.starts_with)
+        451   call 151 ntypeargs=0     (baml.String.starts_with)
 
   145   452   pop_jump_if_false -109   (to 343)
 
   147   453   load_var2 11 2           
-        454   call 709 ntypeargs=0     (testing.TestRegistry.run_test)
+        454   call 711 ntypeargs=0     (testing.TestRegistry.run_test)
         455   return                   
 
   150   456   load_const 27            ("Test not found: ")
@@ -2151,27 +2152,27 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         51    pop_jump_if_false +424   (to 475)
         52    load_type 11             
         53    load_var 3               (_3)
-        54    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        54    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         55    store_var 4              (_4)
         56    jump +61                 (to 117)
         57    load_type 11             
         58    load_var 3               (_3)
-        59    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        59    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         60    store_var 4              (_4)
         61    jump +56                 (to 117)
         62    load_type 11             
         63    load_type 12             
         64    load_var 3               (_3)
-        65    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        65    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         66    store_var 4              (_4)
         67    jump +50                 (to 117)
         68    load_var 3               (_3)
-        69    make_bound_method 497    
+        69    make_bound_method 499    
         70    call_indirect            
         71    store_var 4              (_4)
         72    jump +45                 (to 117)
         73    load_var 3               (_3)
-        74    make_bound_method 510    
+        74    make_bound_method 512    
         75    call_indirect            
         76    store_var 4              (_4)
         77    jump +40                 (to 117)
@@ -2179,39 +2180,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         79    load_type 12             
         80    load_type 12             
         81    load_var 3               (_3)
-        82    call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        82    call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         83    store_var 4              (_4)
         84    jump +33                 (to 117)
         85    load_var 3               (_3)
-        86    make_bound_method 540    
+        86    make_bound_method 542    
         87    call_indirect            
         88    store_var 4              (_4)
         89    jump +28                 (to 117)
         90    load_type 11             
         91    load_var 3               (_3)
-        92    call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        92    call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         93    store_var 4              (_4)
         94    jump +23                 (to 117)
         95    load_type 11             
         96    load_type 12             
         97    load_type 12             
         98    load_var 3               (_3)
-        99    call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        99    call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         100   store_var 4              (_4)
         101   jump +16                 (to 117)
         102   load_type 11             
         103   load_type 12             
         104   load_var 3               (_3)
-        105   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        105   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         106   store_var 4              (_4)
         107   jump +10                 (to 117)
         108   load_type 11             
         109   load_var 3               (_3)
-        110   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        110   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         111   store_var 4              (_4)
         112   jump +5                  (to 117)
         113   load_var 3               (_3)
-        114   make_bound_method 571    
+        114   make_bound_method 573    
         115   call_indirect            
         116   store_var 4              (_4)
         117   load_var 4               (_4)
@@ -2256,16 +2257,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         156   load_type 11             
         157   load_type 12             
         158   load_var 4               (_4)
-        159   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        159   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         160   store_var 5              (_35)
         161   jump +50                 (to 211)
         162   load_var 4               (_4)
-        163   make_bound_method 551    
+        163   make_bound_method 553    
         164   call_indirect            
         165   store_var 5              (_35)
         166   jump +45                 (to 211)
         167   load_var 4               (_4)
-        168   make_bound_method 564    
+        168   make_bound_method 566    
         169   call_indirect            
         170   store_var 5              (_35)
         171   jump +40                 (to 211)
@@ -2273,39 +2274,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         173   load_type 12             
         174   load_type 12             
         175   load_var 4               (_4)
-        176   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        176   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         177   store_var 5              (_35)
         178   jump +33                 (to 211)
         179   load_var 4               (_4)
-        180   make_bound_method 500    
+        180   make_bound_method 502    
         181   call_indirect            
         182   store_var 5              (_35)
         183   jump +28                 (to 211)
         184   load_type 11             
         185   load_var 4               (_4)
-        186   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        186   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         187   store_var 5              (_35)
         188   jump +23                 (to 211)
         189   load_type 11             
         190   load_type 12             
         191   load_type 12             
         192   load_var 4               (_4)
-        193   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        193   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         194   store_var 5              (_35)
         195   jump +16                 (to 211)
         196   load_type 11             
         197   load_type 12             
         198   load_var 4               (_4)
-        199   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        199   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         200   store_var 5              (_35)
         201   jump +10                 (to 211)
         202   load_type 11             
         203   load_var 4               (_4)
-        204   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        204   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         205   store_var 5              (_35)
         206   jump +5                  (to 211)
         207   load_var 4               (_4)
-        208   make_bound_method 535    
+        208   make_bound_method 537    
         209   call_indirect            
         210   store_var 5              (_35)
         211   load_var 5               (_35)
@@ -2319,7 +2320,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
   113   217   load_var 5               (_35)
         218   load_field 0             (name)
         219   init_instance 0          (testing.SerializedTest .type, .name)
-        220   call 17 ntypeargs=0      (baml.Array.push)
+        220   call 18 ntypeargs=0      (baml.Array.push)
         221   pop 1                    
         222   jump -105                (to 117)
 
@@ -2375,27 +2376,27 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         272   pop_jump_if_false +203   (to 475)
         273   load_type 25             
         274   load_var 6               (_68)
-        275   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        275   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         276   store_var 7              (_69)
         277   jump +61                 (to 338)
         278   load_type 25             
         279   load_var 6               (_68)
-        280   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        280   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         281   store_var 7              (_69)
         282   jump +56                 (to 338)
         283   load_type 25             
         284   load_type 12             
         285   load_var 6               (_68)
-        286   call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        286   call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         287   store_var 7              (_69)
         288   jump +50                 (to 338)
         289   load_var 6               (_68)
-        290   make_bound_method 497    
+        290   make_bound_method 499    
         291   call_indirect            
         292   store_var 7              (_69)
         293   jump +45                 (to 338)
         294   load_var 6               (_68)
-        295   make_bound_method 510    
+        295   make_bound_method 512    
         296   call_indirect            
         297   store_var 7              (_69)
         298   jump +40                 (to 338)
@@ -2403,39 +2404,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         300   load_type 12             
         301   load_type 12             
         302   load_var 6               (_68)
-        303   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        303   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         304   store_var 7              (_69)
         305   jump +33                 (to 338)
         306   load_var 6               (_68)
-        307   make_bound_method 540    
+        307   make_bound_method 542    
         308   call_indirect            
         309   store_var 7              (_69)
         310   jump +28                 (to 338)
         311   load_type 25             
         312   load_var 6               (_68)
-        313   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        313   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         314   store_var 7              (_69)
         315   jump +23                 (to 338)
         316   load_type 25             
         317   load_type 12             
         318   load_type 12             
         319   load_var 6               (_68)
-        320   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        320   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         321   store_var 7              (_69)
         322   jump +16                 (to 338)
         323   load_type 25             
         324   load_type 12             
         325   load_var 6               (_68)
-        326   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        326   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         327   store_var 7              (_69)
         328   jump +10                 (to 338)
         329   load_type 25             
         330   load_var 6               (_68)
-        331   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        331   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         332   store_var 7              (_69)
         333   jump +5                  (to 338)
         334   load_var 6               (_68)
-        335   make_bound_method 571    
+        335   make_bound_method 573    
         336   call_indirect            
         337   store_var 7              (_69)
         338   load_var 7               (_69)
@@ -2480,16 +2481,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         377   load_type 25             
         378   load_type 12             
         379   load_var 7               (_69)
-        380   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        380   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         381   store_var 8              (_100)
         382   jump +50                 (to 432)
         383   load_var 7               (_69)
-        384   make_bound_method 551    
+        384   make_bound_method 553    
         385   call_indirect            
         386   store_var 8              (_100)
         387   jump +45                 (to 432)
         388   load_var 7               (_69)
-        389   make_bound_method 564    
+        389   make_bound_method 566    
         390   call_indirect            
         391   store_var 8              (_100)
         392   jump +40                 (to 432)
@@ -2497,39 +2498,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         394   load_type 12             
         395   load_type 12             
         396   load_var 7               (_69)
-        397   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        397   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         398   store_var 8              (_100)
         399   jump +33                 (to 432)
         400   load_var 7               (_69)
-        401   make_bound_method 500    
+        401   make_bound_method 502    
         402   call_indirect            
         403   store_var 8              (_100)
         404   jump +28                 (to 432)
         405   load_type 25             
         406   load_var 7               (_69)
-        407   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        407   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         408   store_var 8              (_100)
         409   jump +23                 (to 432)
         410   load_type 25             
         411   load_type 12             
         412   load_type 12             
         413   load_var 7               (_69)
-        414   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        414   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         415   store_var 8              (_100)
         416   jump +16                 (to 432)
         417   load_type 25             
         418   load_type 12             
         419   load_var 7               (_69)
-        420   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        420   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         421   store_var 8              (_100)
         422   jump +10                 (to 432)
         423   load_type 25             
         424   load_var 7               (_69)
-        425   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        425   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         426   store_var 8              (_100)
         427   jump +5                  (to 432)
         428   load_var 7               (_69)
-        429   make_bound_method 535    
+        429   make_bound_method 537    
         430   call_indirect            
         431   store_var 8              (_100)
         432   load_var 8               (_100)
@@ -2545,7 +2546,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         441   load_field 1             (expansions)
         442   load_var 9               (ts)
         443   load_field 0             (name)
-        444   call 50 ntypeargs=2      (baml.Map.get)
+        444   call 52 ntypeargs=2      (baml.Map.get)
         445   store_var 10             (expanded)
 
   118   446   load_var 10              (expanded)
@@ -2558,7 +2559,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         452   load_var 9               (ts)
         453   load_field 0             (name)
         454   init_instance 1          (testing.SerializedTest .type, .name)
-        455   call 17 ntypeargs=0      (baml.Array.push)
+        455   call 18 ntypeargs=0      (baml.Array.push)
         456   pop 1                    
         457   jump -119                (to 338)
 
@@ -2570,7 +2571,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         462   store_var 12             (_139)
 
   122   463   load_var 11              (sub)
-        464   call 705 ntypeargs=0     (testing.TestRegistry.serialize)
+        464   call 707 ntypeargs=0     (testing.TestRegistry.serialize)
         465   store_var 13             (_140)
 
   120   466   load_var2 2 12           
@@ -2578,7 +2579,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 
   123   468   load_field 2             (loading_time_ms)
         469   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        470   call 17 ntypeargs=0      (baml.Array.push)
+        470   call 18 ntypeargs=0      (baml.Array.push)
         471   pop 1                    
         472   jump -134                (to 338)
 
@@ -2590,15 +2591,15 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 717 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 719 ntypeargs=0   (testing.TestCollector.to_json)
        3    load_type 0            
        4    load_type 1            
        5    load_var 1             (self)
        6    load_field 1           (expansions)
-       7    call 23 ntypeargs=2    (baml.Map.to_json)
+       7    call 24 ntypeargs=2    (baml.Map.to_json)
        8    load_var 1             (self)
        9    load_field 2           (loading_time_ms)
-       10   call 60 ntypeargs=0    (baml.Int.to_json)
+       10   call 62 ntypeargs=0    (baml.Int.to_json)
        11   load_const 2           ("collector")
        12   load_const 3           ("expansions")
        13   load_const 4           ("loading_time_ms")
@@ -2609,18 +2610,18 @@ function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.j
 function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
   18   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("runs")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.TestReport .outcome, .runs)
        15   return                 
 }
@@ -2634,7 +2635,7 @@ function testing.TestReport.to_json(self: testing.TestReport) -> baml.json.json 
        5    load_type 1           
        6    load_var 1            (self)
        7    load_field 1          (runs)
-       8    call 36 ntypeargs=1   (baml.Array.to_json)
+       8    call 38 ntypeargs=1   (baml.Array.to_json)
        9    load_const 2          ("outcome")
        10   load_const 3          ("runs")
        11   alloc_map 2           
@@ -2644,25 +2645,25 @@ function testing.TestReport.to_json(self: testing.TestReport) -> baml.json.json 
 function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.TestSetRegistration {
   17   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("collector")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("runner")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestSetRegistration .name, .collector, .runner)
        22   return                 
 }
@@ -2670,47 +2671,47 @@ function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.Tes
 function testing.TestSetRegistration.to_json(self: testing.TestSetRegistration) -> baml.json.json {
   25   0   load_type 0            
        1   load_var 1             (self)
-       2   call 396 ntypeargs=1   (baml.json.to_string)
-       3   call 391 ntypeargs=0   (baml.json.parse)
+       2   call 398 ntypeargs=1   (baml.json.to_string)
+       3   call 393 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
 function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetReport {
   25   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("passed")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("failed")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 3            
        19   load_var 4             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   load_var 1             (j)
        22   load_const 5           ("total")
-       23   call 394 ntypeargs=0   (baml.json.field)
+       23   call 396 ntypeargs=0   (baml.json.field)
        24   store_var 5            (_12)
        25   load_type 3            
        26   load_var 5             (_12)
-       27   call 386 ntypeargs=1   (baml.json.from_json)
+       27   call 388 ntypeargs=1   (baml.json.from_json)
        28   load_var 1             (j)
        29   load_const 6           ("results")
-       30   call 394 ntypeargs=0   (baml.json.field)
+       30   call 396 ntypeargs=0   (baml.json.field)
        31   store_var 6            (_15)
        32   load_type 7            
        33   load_var 6             (_15)
-       34   call 386 ntypeargs=1   (baml.json.from_json)
+       34   call 388 ntypeargs=1   (baml.json.from_json)
        35   init_instance 0        (testing.TestSetReport .outcome, .passed, .failed, .total, .results)
        36   return                 
 }
@@ -2723,17 +2724,17 @@ function testing.TestSetReport.to_json(self: testing.TestSetReport) -> baml.json
        4    call_indirect         
        5    load_var 1            (self)
        6    load_field 1          (passed)
-       7    call 60 ntypeargs=0   (baml.Int.to_json)
+       7    call 62 ntypeargs=0   (baml.Int.to_json)
        8    load_var 1            (self)
        9    load_field 2          (failed)
-       10   call 60 ntypeargs=0   (baml.Int.to_json)
+       10   call 62 ntypeargs=0   (baml.Int.to_json)
        11   load_var 1            (self)
        12   load_field 3          (total)
-       13   call 60 ntypeargs=0   (baml.Int.to_json)
+       13   call 62 ntypeargs=0   (baml.Int.to_json)
        14   load_type 1           
        15   load_var 1            (self)
        16   load_field 4          (results)
-       17   call 36 ntypeargs=1   (baml.Array.to_json)
+       17   call 38 ntypeargs=1   (baml.Array.to_json)
        18   load_const 2          ("outcome")
        19   load_const 3          ("passed")
        20   load_const 4          ("failed")
@@ -2749,7 +2750,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 1333 1    
+        4    make_closure 1335 1    
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)
@@ -2790,18 +2791,18 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
   26   0    load_var 1             (j)
        1    load_const 0           ("code")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("message")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (user.ErrorInfo .code, .message)
        15   return                 
 }
@@ -2809,10 +2810,10 @@ function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
 function user.ErrorInfo.to_json(self: ErrorInfo) -> baml.json.json {
   26   0   load_var 1             (self)
        1   load_field 0           (code)
-       2   call 60 ntypeargs=0    (baml.Int.to_json)
+       2   call 62 ntypeargs=0    (baml.Int.to_json)
        3   load_var 1             (self)
        4   load_field 1           (message)
-       5   call 161 ntypeargs=0   (baml.String.to_json)
+       5   call 163 ntypeargs=0   (baml.String.to_json)
        6   load_const 0           ("code")
        7   load_const 1           ("message")
        8   alloc_map 2            
@@ -2822,25 +2823,25 @@ function user.ErrorInfo.to_json(self: ErrorInfo) -> baml.json.json {
 function user.Report.from_json(j: baml.json.json) -> Report {
   20   0    load_var 1             (j)
        1    load_const 0           ("score")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("label")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("breakdown")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (user.Report .score, .label, .breakdown)
        22   return                 
 }
@@ -2848,15 +2849,15 @@ function user.Report.from_json(j: baml.json.json) -> Report {
 function user.Report.to_json(self: Report) -> baml.json.json {
   20   0    load_var 1             (self)
        1    load_field 0           (score)
-       2    call 60 ntypeargs=0    (baml.Int.to_json)
+       2    call 62 ntypeargs=0    (baml.Int.to_json)
        3    load_var 1             (self)
        4    load_field 1           (label)
-       5    call 161 ntypeargs=0   (baml.String.to_json)
+       5    call 163 ntypeargs=0   (baml.String.to_json)
        6    load_type 0            
        7    load_type 1            
        8    load_var 1             (self)
        9    load_field 2           (breakdown)
-       10   call 23 ntypeargs=2    (baml.Map.to_json)
+       10   call 24 ntypeargs=2    (baml.Map.to_json)
        11   load_const 2           ("score")
        12   load_const 3           ("label")
        13   load_const 4           ("breakdown")
@@ -2867,25 +2868,25 @@ function user.Report.to_json(self: Report) -> baml.json.json {
 function user.User.from_json(j: baml.json.json) -> User {
   3   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 394 ntypeargs=0   (baml.json.field)
+      2    call 396 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 386 ntypeargs=1   (baml.json.from_json)
+      6    call 388 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("age")
-      9    call 394 ntypeargs=0   (baml.json.field)
+      9    call 396 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 386 ntypeargs=1   (baml.json.from_json)
+      13   call 388 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("role")
-      16   call 394 ntypeargs=0   (baml.json.field)
+      16   call 396 ntypeargs=0   (baml.json.field)
       17   store_var 4            (_9)
       18   load_type 5            
       19   load_var 4             (_9)
-      20   call 386 ntypeargs=1   (baml.json.from_json)
+      20   call 388 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (user.User .name, .age, .role)
       22   return                 
 }
@@ -2919,10 +2920,10 @@ function user.User.promote(self: User, bonus: int) -> Report {
 function user.User.to_json(self: User) -> baml.json.json {
   3   0    load_var 1             (self)
       1    load_field 0           (name)
-      2    call 161 ntypeargs=0   (baml.String.to_json)
+      2    call 163 ntypeargs=0   (baml.String.to_json)
       3    load_var 1             (self)
       4    load_field 1           (age)
-      5    call 60 ntypeargs=0    (baml.Int.to_json)
+      5    call 62 ntypeargs=0    (baml.Int.to_json)
       6    load_var 1             (self)
       7    load_field 2           (role)
       8    load_const 0           ("to_json")

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
+assertion_line: 43
 ---
 function assert.contains(haystack: string, needle: string) -> null {
   32   0   load_var2 1 2          
-       1   call 176 ntypeargs=0   (baml.String.includes)
+       1   call 178 ntypeargs=0   (baml.String.includes)
        2   unary_op !             
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
@@ -13,7 +14,7 @@ function assert.contains(haystack: string, needle: string) -> null {
   32   6   jump +3                (to 9)
 
   33   7   load_const 1           ("assertion failed: string does not contain expected substring")
-       8   call 292 ntypeargs=0   (baml.sys.panic)
+       8   call 294 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -28,7 +29,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   23   5   jump +3                (to 8)
 
   24   6   load_const 1           ("assertion failed: expected equal values")
-       7   call 292 ntypeargs=0   (baml.sys.panic)
+       7   call 294 ntypeargs=0   (baml.sys.panic)
        8   return                 
 }
 
@@ -43,7 +44,7 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 292 ntypeargs=0   (baml.sys.panic)
+      7   call 294 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
@@ -59,7 +60,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 292 ntypeargs=0   (baml.sys.panic)
+       8   call 294 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -72,18 +73,18 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
   7   0    load_var 1             (j)
       1    load_const 0           ("outcome")
-      2    call 394 ntypeargs=0   (baml.json.field)
+      2    call 396 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 386 ntypeargs=1   (baml.json.from_json)
+      6    call 388 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("duration_ms")
-      9    call 394 ntypeargs=0   (baml.json.field)
+      9    call 396 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 386 ntypeargs=1   (baml.json.from_json)
+      13   call 388 ntypeargs=1   (baml.json.from_json)
       14   init_instance 0        (testing.RunReport .outcome, .duration_ms)
       15   store_var 2            (_0)
       16   load_var 2             (_0)
@@ -98,7 +99,7 @@ function testing.RunReport.to_json(self: testing.RunReport) -> baml.json.json {
       4    call_indirect         
       5    load_var 1            (self)
       6    load_field 1          (duration_ms)
-      7    call 60 ntypeargs=0   (baml.Int.to_json)
+      7    call 62 ntypeargs=0   (baml.Int.to_json)
       8    load_const 1          ("outcome")
       9    load_const 2          ("duration_ms")
       10   alloc_map 2           
@@ -110,18 +111,18 @@ function testing.RunReport.to_json(self: testing.RunReport) -> baml.json.json {
 function testing.SerializedTest.from_json(j: baml.json.json) -> testing.SerializedTest {
   78   0    load_var 1             (j)
        1    load_const 0           ("type")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("name")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 1            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.SerializedTest .type, .name)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -131,10 +132,10 @@ function testing.SerializedTest.from_json(j: baml.json.json) -> testing.Serializ
 function testing.SerializedTest.to_json(self: testing.SerializedTest) -> baml.json.json {
   78   0    load_var 1             (self)
        1    load_field 0           (type)
-       2    call 161 ntypeargs=0   (baml.String.to_json)
+       2    call 163 ntypeargs=0   (baml.String.to_json)
        3    load_var 1             (self)
        4    load_field 1           (name)
-       5    call 161 ntypeargs=0   (baml.String.to_json)
+       5    call 163 ntypeargs=0   (baml.String.to_json)
        6    load_const 0           ("type")
        7    load_const 1           ("name")
        8    alloc_map 2            
@@ -146,25 +147,25 @@ function testing.SerializedTest.to_json(self: testing.SerializedTest) -> baml.js
 function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.SerializedTestSet {
   83   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("items")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loadingTimeMs")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -174,14 +175,14 @@ function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.Seria
 function testing.SerializedTestSet.to_json(self: testing.SerializedTestSet) -> baml.json.json {
   83   0    load_var 1             (self)
        1    load_field 0           (name)
-       2    call 161 ntypeargs=0   (baml.String.to_json)
+       2    call 163 ntypeargs=0   (baml.String.to_json)
        3    load_type 0            
        4    load_var 1             (self)
        5    load_field 1           (items)
-       6    call 36 ntypeargs=1    (baml.Array.to_json)
+       6    call 38 ntypeargs=1    (baml.Array.to_json)
        7    load_var 1             (self)
        8    load_field 2           (loadingTimeMs)
-       9    call 60 ntypeargs=0    (baml.Int.to_json)
+       9    call 62 ntypeargs=0    (baml.Int.to_json)
        10   load_const 1           ("name")
        11   load_const 2           ("items")
        12   load_const 3           ("loadingTimeMs")
@@ -243,27 +244,27 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        48    pop_jump_if_false +178   (to 226)
        49    load_type 11             
        50    load_var 4               (_3)
-       51    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       51    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        52    store_var 5              (_4)
        53    jump +61                 (to 114)
        54    load_type 11             
        55    load_var 4               (_3)
-       56    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       56    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        57    store_var 5              (_4)
        58    jump +56                 (to 114)
        59    load_type 11             
        60    load_type 12             
        61    load_var 4               (_3)
-       62    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+       62    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
        63    store_var 5              (_4)
        64    jump +50                 (to 114)
        65    load_var 4               (_3)
-       66    make_bound_method 497    
+       66    make_bound_method 499    
        67    call_indirect            
        68    store_var 5              (_4)
        69    jump +45                 (to 114)
        70    load_var 4               (_3)
-       71    make_bound_method 510    
+       71    make_bound_method 512    
        72    call_indirect            
        73    store_var 5              (_4)
        74    jump +40                 (to 114)
@@ -271,39 +272,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        76    load_type 12             
        77    load_type 12             
        78    load_var 4               (_3)
-       79    call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+       79    call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
        80    store_var 5              (_4)
        81    jump +33                 (to 114)
        82    load_var 4               (_3)
-       83    make_bound_method 540    
+       83    make_bound_method 542    
        84    call_indirect            
        85    store_var 5              (_4)
        86    jump +28                 (to 114)
        87    load_type 11             
        88    load_var 4               (_3)
-       89    call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+       89    call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
        90    store_var 5              (_4)
        91    jump +23                 (to 114)
        92    load_type 11             
        93    load_type 12             
        94    load_type 12             
        95    load_var 4               (_3)
-       96    call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+       96    call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
        97    store_var 5              (_4)
        98    jump +16                 (to 114)
        99    load_type 11             
        100   load_type 12             
        101   load_var 4               (_3)
-       102   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+       102   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
        103   store_var 5              (_4)
        104   jump +10                 (to 114)
        105   load_type 11             
        106   load_var 4               (_3)
-       107   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+       107   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
        108   store_var 5              (_4)
        109   jump +5                  (to 114)
        110   load_var 4               (_3)
-       111   make_bound_method 571    
+       111   make_bound_method 573    
        112   call_indirect            
        113   store_var 5              (_4)
        114   load_var 5               (_4)
@@ -348,16 +349,16 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        153   load_type 11             
        154   load_type 12             
        155   load_var 5               (_4)
-       156   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       156   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        157   store_var 6              (_35)
        158   jump +50                 (to 208)
        159   load_var 5               (_4)
-       160   make_bound_method 551    
+       160   make_bound_method 553    
        161   call_indirect            
        162   store_var 6              (_35)
        163   jump +45                 (to 208)
        164   load_var 5               (_4)
-       165   make_bound_method 564    
+       165   make_bound_method 566    
        166   call_indirect            
        167   store_var 6              (_35)
        168   jump +40                 (to 208)
@@ -365,39 +366,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        170   load_type 12             
        171   load_type 12             
        172   load_var 5               (_4)
-       173   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       173   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        174   store_var 6              (_35)
        175   jump +33                 (to 208)
        176   load_var 5               (_4)
-       177   make_bound_method 500    
+       177   make_bound_method 502    
        178   call_indirect            
        179   store_var 6              (_35)
        180   jump +28                 (to 208)
        181   load_type 11             
        182   load_var 5               (_4)
-       183   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       183   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        184   store_var 6              (_35)
        185   jump +23                 (to 208)
        186   load_type 11             
        187   load_type 12             
        188   load_type 12             
        189   load_var 5               (_4)
-       190   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       190   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        191   store_var 6              (_35)
        192   jump +16                 (to 208)
        193   load_type 11             
        194   load_type 12             
        195   load_var 5               (_4)
-       196   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       196   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        197   store_var 6              (_35)
        198   jump +10                 (to 208)
        199   load_type 11             
        200   load_var 5               (_4)
-       201   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       201   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        202   store_var 6              (_35)
        203   jump +5                  (to 208)
        204   load_var 5               (_4)
-       205   make_bound_method 535    
+       205   make_bound_method 537    
        206   call_indirect            
        207   store_var 6              (_35)
        208   load_var 6               (_35)
@@ -427,25 +428,25 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
   29   0    load_var 1             (j)
        1    load_const 0           ("prefix")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("tests")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("testsets")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -539,27 +540,27 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        70    pop_jump_if_false +215   (to 285)
        71    load_type 15             
        72    load_var 9               (_13)
-       73    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       73    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        74    store_var 10             (_14)
        75    jump +61                 (to 136)
        76    load_type 15             
        77    load_var 9               (_13)
-       78    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       78    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        79    store_var 10             (_14)
        80    jump +56                 (to 136)
        81    load_type 15             
        82    load_type 16             
        83    load_var 9               (_13)
-       84    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+       84    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
        85    store_var 10             (_14)
        86    jump +50                 (to 136)
        87    load_var 9               (_13)
-       88    make_bound_method 497    
+       88    make_bound_method 499    
        89    call_indirect            
        90    store_var 10             (_14)
        91    jump +45                 (to 136)
        92    load_var 9               (_13)
-       93    make_bound_method 510    
+       93    make_bound_method 512    
        94    call_indirect            
        95    store_var 10             (_14)
        96    jump +40                 (to 136)
@@ -567,39 +568,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        98    load_type 16             
        99    load_type 16             
        100   load_var 9               (_13)
-       101   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+       101   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
        102   store_var 10             (_14)
        103   jump +33                 (to 136)
        104   load_var 9               (_13)
-       105   make_bound_method 540    
+       105   make_bound_method 542    
        106   call_indirect            
        107   store_var 10             (_14)
        108   jump +28                 (to 136)
        109   load_type 15             
        110   load_var 9               (_13)
-       111   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+       111   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
        112   store_var 10             (_14)
        113   jump +23                 (to 136)
        114   load_type 15             
        115   load_type 16             
        116   load_type 16             
        117   load_var 9               (_13)
-       118   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+       118   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
        119   store_var 10             (_14)
        120   jump +16                 (to 136)
        121   load_type 15             
        122   load_type 16             
        123   load_var 9               (_13)
-       124   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+       124   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
        125   store_var 10             (_14)
        126   jump +10                 (to 136)
        127   load_type 15             
        128   load_var 9               (_13)
-       129   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+       129   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
        130   store_var 10             (_14)
        131   jump +5                  (to 136)
        132   load_var 9               (_13)
-       133   make_bound_method 571    
+       133   make_bound_method 573    
        134   call_indirect            
        135   store_var 10             (_14)
        136   load_var 10              (_14)
@@ -644,16 +645,16 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        175   load_type 15             
        176   load_type 16             
        177   load_var 10              (_14)
-       178   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       178   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        179   store_var 11             (_45)
        180   jump +50                 (to 230)
        181   load_var 10              (_14)
-       182   make_bound_method 551    
+       182   make_bound_method 553    
        183   call_indirect            
        184   store_var 11             (_45)
        185   jump +45                 (to 230)
        186   load_var 10              (_14)
-       187   make_bound_method 564    
+       187   make_bound_method 566    
        188   call_indirect            
        189   store_var 11             (_45)
        190   jump +40                 (to 230)
@@ -661,39 +662,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        192   load_type 16             
        193   load_type 16             
        194   load_var 10              (_14)
-       195   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       195   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        196   store_var 11             (_45)
        197   jump +33                 (to 230)
        198   load_var 10              (_14)
-       199   make_bound_method 500    
+       199   make_bound_method 502    
        200   call_indirect            
        201   store_var 11             (_45)
        202   jump +28                 (to 230)
        203   load_type 15             
        204   load_var 10              (_14)
-       205   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       205   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        206   store_var 11             (_45)
        207   jump +23                 (to 230)
        208   load_type 15             
        209   load_type 16             
        210   load_type 16             
        211   load_var 10              (_14)
-       212   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       212   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        213   store_var 11             (_45)
        214   jump +16                 (to 230)
        215   load_type 15             
        216   load_type 16             
        217   load_var 10              (_14)
-       218   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       218   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        219   store_var 11             (_45)
        220   jump +10                 (to 230)
        221   load_type 15             
        222   load_var 10              (_14)
-       223   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       223   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        224   store_var 11             (_45)
        225   jump +5                  (to 230)
        226   load_var 10              (_14)
-       227   make_bound_method 535    
+       227   make_bound_method 537    
        228   call_indirect            
        229   store_var 11             (_45)
        230   load_var 11              (_45)
@@ -712,7 +713,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        242   load_var 12              (t)
        243   load_field 0             (name)
        244   load_var 8               (hash_prefix)
-       245   call 149 ntypeargs=0     (baml.String.starts_with)
+       245   call 151 ntypeargs=0     (baml.String.starts_with)
        246   pop_jump_if_false -110   (to 136)
        247   load_var 7               (count)
        248   load_const 18            (1)
@@ -736,7 +737,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        265   load_var 7               (count)
        266   load_const 18            (1)
        267   add_int                  
-       268   call 406 ntypeargs=1     (baml.unstable.string)
+       268   call 408 ntypeargs=1     (baml.unstable.string)
        269   store_var 15             (_86)
        270   load_var2 14 15          
        271   bin_op +                 
@@ -748,7 +749,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        276   load_var2 13 3           
        277   load_var 4               (runner)
        278   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
+       279   call 18 ntypeargs=1      (baml.Array.push)
        280   pop 1                    
 
   38   281   load_const 21            (null)
@@ -835,27 +836,27 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        70    pop_jump_if_false +215   (to 285)
        71    load_type 15             
        72    load_var 9               (_13)
-       73    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       73    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        74    store_var 10             (_14)
        75    jump +61                 (to 136)
        76    load_type 15             
        77    load_var 9               (_13)
-       78    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       78    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        79    store_var 10             (_14)
        80    jump +56                 (to 136)
        81    load_type 15             
        82    load_type 16             
        83    load_var 9               (_13)
-       84    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+       84    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
        85    store_var 10             (_14)
        86    jump +50                 (to 136)
        87    load_var 9               (_13)
-       88    make_bound_method 497    
+       88    make_bound_method 499    
        89    call_indirect            
        90    store_var 10             (_14)
        91    jump +45                 (to 136)
        92    load_var 9               (_13)
-       93    make_bound_method 510    
+       93    make_bound_method 512    
        94    call_indirect            
        95    store_var 10             (_14)
        96    jump +40                 (to 136)
@@ -863,39 +864,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        98    load_type 16             
        99    load_type 16             
        100   load_var 9               (_13)
-       101   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+       101   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
        102   store_var 10             (_14)
        103   jump +33                 (to 136)
        104   load_var 9               (_13)
-       105   make_bound_method 540    
+       105   make_bound_method 542    
        106   call_indirect            
        107   store_var 10             (_14)
        108   jump +28                 (to 136)
        109   load_type 15             
        110   load_var 9               (_13)
-       111   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+       111   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
        112   store_var 10             (_14)
        113   jump +23                 (to 136)
        114   load_type 15             
        115   load_type 16             
        116   load_type 16             
        117   load_var 9               (_13)
-       118   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+       118   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
        119   store_var 10             (_14)
        120   jump +16                 (to 136)
        121   load_type 15             
        122   load_type 16             
        123   load_var 9               (_13)
-       124   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+       124   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
        125   store_var 10             (_14)
        126   jump +10                 (to 136)
        127   load_type 15             
        128   load_var 9               (_13)
-       129   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+       129   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
        130   store_var 10             (_14)
        131   jump +5                  (to 136)
        132   load_var 9               (_13)
-       133   make_bound_method 571    
+       133   make_bound_method 573    
        134   call_indirect            
        135   store_var 10             (_14)
        136   load_var 10              (_14)
@@ -940,16 +941,16 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        175   load_type 15             
        176   load_type 16             
        177   load_var 10              (_14)
-       178   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       178   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        179   store_var 11             (_45)
        180   jump +50                 (to 230)
        181   load_var 10              (_14)
-       182   make_bound_method 551    
+       182   make_bound_method 553    
        183   call_indirect            
        184   store_var 11             (_45)
        185   jump +45                 (to 230)
        186   load_var 10              (_14)
-       187   make_bound_method 564    
+       187   make_bound_method 566    
        188   call_indirect            
        189   store_var 11             (_45)
        190   jump +40                 (to 230)
@@ -957,39 +958,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        192   load_type 16             
        193   load_type 16             
        194   load_var 10              (_14)
-       195   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       195   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        196   store_var 11             (_45)
        197   jump +33                 (to 230)
        198   load_var 10              (_14)
-       199   make_bound_method 500    
+       199   make_bound_method 502    
        200   call_indirect            
        201   store_var 11             (_45)
        202   jump +28                 (to 230)
        203   load_type 15             
        204   load_var 10              (_14)
-       205   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       205   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        206   store_var 11             (_45)
        207   jump +23                 (to 230)
        208   load_type 15             
        209   load_type 16             
        210   load_type 16             
        211   load_var 10              (_14)
-       212   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       212   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        213   store_var 11             (_45)
        214   jump +16                 (to 230)
        215   load_type 15             
        216   load_type 16             
        217   load_var 10              (_14)
-       218   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       218   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        219   store_var 11             (_45)
        220   jump +10                 (to 230)
        221   load_type 15             
        222   load_var 10              (_14)
-       223   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       223   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        224   store_var 11             (_45)
        225   jump +5                  (to 230)
        226   load_var 10              (_14)
-       227   make_bound_method 535    
+       227   make_bound_method 537    
        228   call_indirect            
        229   store_var 11             (_45)
        230   load_var 11              (_45)
@@ -1008,7 +1009,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        242   load_var 12              (ts)
        243   load_field 0             (name)
        244   load_var 8               (hash_prefix)
-       245   call 149 ntypeargs=0     (baml.String.starts_with)
+       245   call 151 ntypeargs=0     (baml.String.starts_with)
        246   pop_jump_if_false -110   (to 136)
        247   load_var 7               (count)
        248   load_const 18            (1)
@@ -1032,7 +1033,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        265   load_var 7               (count)
        266   load_const 18            (1)
        267   add_int                  
-       268   call 406 ntypeargs=1     (baml.unstable.string)
+       268   call 408 ntypeargs=1     (baml.unstable.string)
        269   store_var 15             (_86)
        270   load_var2 14 15          
        271   bin_op +                 
@@ -1044,7 +1045,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        276   load_var2 13 3           
        277   load_var 4               (runner)
        278   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
+       279   call 18 ntypeargs=1      (baml.Array.push)
        280   pop 1                    
 
   49   281   load_const 21            (null)
@@ -1057,15 +1058,15 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {
   29   0    load_var 1             (self)
        1    load_field 0           (prefix)
-       2    call 161 ntypeargs=0   (baml.String.to_json)
+       2    call 163 ntypeargs=0   (baml.String.to_json)
        3    load_type 0            
        4    load_var 1             (self)
        5    load_field 1           (tests)
-       6    call 36 ntypeargs=1    (baml.Array.to_json)
+       6    call 38 ntypeargs=1    (baml.Array.to_json)
        7    load_type 1            
        8    load_var 1             (self)
        9    load_field 2           (testsets)
-       10   call 36 ntypeargs=1    (baml.Array.to_json)
+       10   call 38 ntypeargs=1    (baml.Array.to_json)
        11   load_const 2           ("prefix")
        12   load_const 3           ("tests")
        13   load_const 4           ("testsets")
@@ -1078,25 +1079,25 @@ function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json
 function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRegistration {
   5   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 394 ntypeargs=0   (baml.json.field)
+      2    call 396 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 386 ntypeargs=1   (baml.json.from_json)
+      6    call 388 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("body")
-      9    call 394 ntypeargs=0   (baml.json.field)
+      9    call 396 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 386 ntypeargs=1   (baml.json.from_json)
+      13   call 388 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("runner")
-      16   call 394 ntypeargs=0   (baml.json.field)
+      16   call 396 ntypeargs=0   (baml.json.field)
       17   store_var 5            (_9)
       18   load_type 5            
       19   load_var 5             (_9)
-      20   call 386 ntypeargs=1   (baml.json.from_json)
+      20   call 388 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (testing.TestRegistration .name, .body, .runner)
       22   store_var 2            (_0)
       23   load_var 2             (_0)
@@ -1106,8 +1107,8 @@ function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRe
 function testing.TestRegistration.to_json(self: testing.TestRegistration) -> baml.json.json {
   13   0   load_type 0            
        1   load_var 1             (self)
-       2   call 396 ntypeargs=1   (baml.json.to_string)
-       3   call 391 ntypeargs=0   (baml.json.parse)
+       2   call 398 ntypeargs=1   (baml.json.to_string)
+       3   call 393 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
@@ -1165,27 +1166,27 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         49    pop_jump_if_false +435   (to 484)
         50    load_type 11             
         51    load_var 3               (_3)
-        52    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        52    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         53    store_var 4              (_4)
         54    jump +61                 (to 115)
         55    load_type 11             
         56    load_var 3               (_3)
-        57    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        57    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         58    store_var 4              (_4)
         59    jump +56                 (to 115)
         60    load_type 11             
         61    load_type 12             
         62    load_var 3               (_3)
-        63    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        63    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         64    store_var 4              (_4)
         65    jump +50                 (to 115)
         66    load_var 3               (_3)
-        67    make_bound_method 497    
+        67    make_bound_method 499    
         68    call_indirect            
         69    store_var 4              (_4)
         70    jump +45                 (to 115)
         71    load_var 3               (_3)
-        72    make_bound_method 510    
+        72    make_bound_method 512    
         73    call_indirect            
         74    store_var 4              (_4)
         75    jump +40                 (to 115)
@@ -1193,39 +1194,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         77    load_type 12             
         78    load_type 12             
         79    load_var 3               (_3)
-        80    call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        80    call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         81    store_var 4              (_4)
         82    jump +33                 (to 115)
         83    load_var 3               (_3)
-        84    make_bound_method 540    
+        84    make_bound_method 542    
         85    call_indirect            
         86    store_var 4              (_4)
         87    jump +28                 (to 115)
         88    load_type 11             
         89    load_var 3               (_3)
-        90    call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        90    call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         91    store_var 4              (_4)
         92    jump +23                 (to 115)
         93    load_type 11             
         94    load_type 12             
         95    load_type 12             
         96    load_var 3               (_3)
-        97    call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        97    call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         98    store_var 4              (_4)
         99    jump +16                 (to 115)
         100   load_type 11             
         101   load_type 12             
         102   load_var 3               (_3)
-        103   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        103   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         104   store_var 4              (_4)
         105   jump +10                 (to 115)
         106   load_type 11             
         107   load_var 3               (_3)
-        108   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        108   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         109   store_var 4              (_4)
         110   jump +5                  (to 115)
         111   load_var 3               (_3)
-        112   make_bound_method 571    
+        112   make_bound_method 573    
         113   call_indirect            
         114   store_var 4              (_4)
         115   load_var 4               (_4)
@@ -1270,16 +1271,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         154   load_type 11             
         155   load_type 12             
         156   load_var 4               (_4)
-        157   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        157   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         158   store_var 5              (_35)
         159   jump +50                 (to 209)
         160   load_var 4               (_4)
-        161   make_bound_method 551    
+        161   make_bound_method 553    
         162   call_indirect            
         163   store_var 5              (_35)
         164   jump +45                 (to 209)
         165   load_var 4               (_4)
-        166   make_bound_method 564    
+        166   make_bound_method 566    
         167   call_indirect            
         168   store_var 5              (_35)
         169   jump +40                 (to 209)
@@ -1287,39 +1288,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         171   load_type 12             
         172   load_type 12             
         173   load_var 4               (_4)
-        174   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        174   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         175   store_var 5              (_35)
         176   jump +33                 (to 209)
         177   load_var 4               (_4)
-        178   make_bound_method 500    
+        178   make_bound_method 502    
         179   call_indirect            
         180   store_var 5              (_35)
         181   jump +28                 (to 209)
         182   load_type 11             
         183   load_var 4               (_4)
-        184   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        184   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         185   store_var 5              (_35)
         186   jump +23                 (to 209)
         187   load_type 11             
         188   load_type 12             
         189   load_type 12             
         190   load_var 4               (_4)
-        191   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        191   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         192   store_var 5              (_35)
         193   jump +16                 (to 209)
         194   load_type 11             
         195   load_type 12             
         196   load_var 4               (_4)
-        197   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        197   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         198   store_var 5              (_35)
         199   jump +10                 (to 209)
         200   load_type 11             
         201   load_var 4               (_4)
-        202   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        202   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         203   store_var 5              (_35)
         204   jump +5                  (to 209)
         205   load_var 4               (_4)
-        206   make_bound_method 535    
+        206   make_bound_method 537    
         207   call_indirect            
         208   store_var 5              (_35)
         209   load_var 5               (_35)
@@ -1334,7 +1335,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         217   cmp_op ==                
         218   pop_jump_if_false -103   (to 115)
 
-  159   219   call 288 ntypeargs=0     (baml.sys.now_ms)
+  159   219   call 290 ntypeargs=0     (baml.sys.now_ms)
         220   store_var 7              (start)
 
   160   221   load_var 2               (name)
@@ -1348,7 +1349,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         228   call_indirect            
         229   pop 1                    
 
-  162   230   call 288 ntypeargs=0     (baml.sys.now_ms)
+  162   230   call 290 ntypeargs=0     (baml.sys.now_ms)
         231   load_var 7               (start)
         232   sub_int                  
         233   store_var 9              (elapsed)
@@ -1366,18 +1367,18 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         241   load_var 1               (self)
         242   load_field 1             (expansions)
         243   load_var2 2 10           
-        244   call 22 ntypeargs=2      (baml.Map.set)
+        244   call 9 ntypeargs=2       (baml.Map.set)
         245   pop 1                    
 
   169   246   load_var 1               (self)
-        247   call 705 ntypeargs=0     (testing.TestRegistry.serialize)
+        247   call 707 ntypeargs=0     (testing.TestRegistry.serialize)
         248   jump +231                (to 479)
 
   173   249   load_type 14             
         250   load_type 15             
         251   load_var 1               (self)
         252   load_field 1             (expansions)
-        253   call 20 ntypeargs=2      (baml.Map.keys)
+        253   call 23 ntypeargs=2      (baml.Map.keys)
         254   store_var 11             (_86)
 
   172   255   load_var 11              (_86)
@@ -1429,27 +1430,27 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         301   pop_jump_if_false +183   (to 484)
         302   load_type 14             
         303   load_var 11              (_86)
-        304   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        304   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         305   store_var 12             (_90)
         306   jump +61                 (to 367)
         307   load_type 14             
         308   load_var 11              (_86)
-        309   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        309   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         310   store_var 12             (_90)
         311   jump +56                 (to 367)
         312   load_type 14             
         313   load_type 12             
         314   load_var 11              (_86)
-        315   call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        315   call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         316   store_var 12             (_90)
         317   jump +50                 (to 367)
         318   load_var 11              (_86)
-        319   make_bound_method 497    
+        319   make_bound_method 499    
         320   call_indirect            
         321   store_var 12             (_90)
         322   jump +45                 (to 367)
         323   load_var 11              (_86)
-        324   make_bound_method 510    
+        324   make_bound_method 512    
         325   call_indirect            
         326   store_var 12             (_90)
         327   jump +40                 (to 367)
@@ -1457,39 +1458,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         329   load_type 12             
         330   load_type 12             
         331   load_var 11              (_86)
-        332   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        332   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         333   store_var 12             (_90)
         334   jump +33                 (to 367)
         335   load_var 11              (_86)
-        336   make_bound_method 540    
+        336   make_bound_method 542    
         337   call_indirect            
         338   store_var 12             (_90)
         339   jump +28                 (to 367)
         340   load_type 14             
         341   load_var 11              (_86)
-        342   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        342   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         343   store_var 12             (_90)
         344   jump +23                 (to 367)
         345   load_type 14             
         346   load_type 12             
         347   load_type 12             
         348   load_var 11              (_86)
-        349   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        349   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         350   store_var 12             (_90)
         351   jump +16                 (to 367)
         352   load_type 14             
         353   load_type 12             
         354   load_var 11              (_86)
-        355   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        355   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         356   store_var 12             (_90)
         357   jump +10                 (to 367)
         358   load_type 14             
         359   load_var 11              (_86)
-        360   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        360   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         361   store_var 12             (_90)
         362   jump +5                  (to 367)
         363   load_var 11              (_86)
-        364   make_bound_method 571    
+        364   make_bound_method 573    
         365   call_indirect            
         366   store_var 12             (_90)
         367   load_var 12              (_90)
@@ -1534,16 +1535,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         406   load_type 14             
         407   load_type 12             
         408   load_var 12              (_90)
-        409   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        409   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         410   store_var 13             (_121)
         411   jump +50                 (to 461)
         412   load_var 12              (_90)
-        413   make_bound_method 551    
+        413   make_bound_method 553    
         414   call_indirect            
         415   store_var 13             (_121)
         416   jump +45                 (to 461)
         417   load_var 12              (_90)
-        418   make_bound_method 564    
+        418   make_bound_method 566    
         419   call_indirect            
         420   store_var 13             (_121)
         421   jump +40                 (to 461)
@@ -1551,39 +1552,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         423   load_type 12             
         424   load_type 12             
         425   load_var 12              (_90)
-        426   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        426   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         427   store_var 13             (_121)
         428   jump +33                 (to 461)
         429   load_var 12              (_90)
-        430   make_bound_method 500    
+        430   make_bound_method 502    
         431   call_indirect            
         432   store_var 13             (_121)
         433   jump +28                 (to 461)
         434   load_type 14             
         435   load_var 12              (_90)
-        436   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        436   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         437   store_var 13             (_121)
         438   jump +23                 (to 461)
         439   load_type 14             
         440   load_type 12             
         441   load_type 12             
         442   load_var 12              (_90)
-        443   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        443   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         444   store_var 13             (_121)
         445   jump +16                 (to 461)
         446   load_type 14             
         447   load_type 12             
         448   load_var 12              (_90)
-        449   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        449   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         450   store_var 13             (_121)
         451   jump +10                 (to 461)
         452   load_type 14             
         453   load_var 12              (_90)
-        454   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        454   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         455   store_var 13             (_121)
         456   jump +5                  (to 461)
         457   load_var 12              (_90)
-        458   make_bound_method 535    
+        458   make_bound_method 537    
         459   call_indirect            
         460   store_var 13             (_121)
         461   load_var 13              (_121)
@@ -1602,11 +1603,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   175   472   load_var2 2 14           
         473   load_const 26            ("/")
         474   bin_op +                 
-        475   call 149 ntypeargs=0     (baml.String.starts_with)
+        475   call 151 ntypeargs=0     (baml.String.starts_with)
         476   pop_jump_if_false -109   (to 367)
 
   176   477   load_var2 15 2           
-        478   call 710 ntypeargs=0     (testing.TestRegistry.expand_set)
+        478   call 712 ntypeargs=0     (testing.TestRegistry.expand_set)
         479   return                   
 
   179   480   load_const 27            ("TestSet not found for expansion: ")
@@ -1619,25 +1620,25 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
   93   0    load_var 1             (j)
        1    load_const 0           ("collector")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("expansions")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loading_time_ms")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -1709,27 +1710,27 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         49    pop_jump_if_false +411   (to 460)
         50    load_type 11             
         51    load_var 3               (_3)
-        52    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        52    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         53    store_var 4              (_4)
         54    jump +61                 (to 115)
         55    load_type 11             
         56    load_var 3               (_3)
-        57    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        57    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         58    store_var 4              (_4)
         59    jump +56                 (to 115)
         60    load_type 11             
         61    load_type 12             
         62    load_var 3               (_3)
-        63    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        63    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         64    store_var 4              (_4)
         65    jump +50                 (to 115)
         66    load_var 3               (_3)
-        67    make_bound_method 497    
+        67    make_bound_method 499    
         68    call_indirect            
         69    store_var 4              (_4)
         70    jump +45                 (to 115)
         71    load_var 3               (_3)
-        72    make_bound_method 510    
+        72    make_bound_method 512    
         73    call_indirect            
         74    store_var 4              (_4)
         75    jump +40                 (to 115)
@@ -1737,39 +1738,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         77    load_type 12             
         78    load_type 12             
         79    load_var 3               (_3)
-        80    call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        80    call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         81    store_var 4              (_4)
         82    jump +33                 (to 115)
         83    load_var 3               (_3)
-        84    make_bound_method 540    
+        84    make_bound_method 542    
         85    call_indirect            
         86    store_var 4              (_4)
         87    jump +28                 (to 115)
         88    load_type 11             
         89    load_var 3               (_3)
-        90    call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        90    call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         91    store_var 4              (_4)
         92    jump +23                 (to 115)
         93    load_type 11             
         94    load_type 12             
         95    load_type 12             
         96    load_var 3               (_3)
-        97    call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        97    call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         98    store_var 4              (_4)
         99    jump +16                 (to 115)
         100   load_type 11             
         101   load_type 12             
         102   load_var 3               (_3)
-        103   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        103   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         104   store_var 4              (_4)
         105   jump +10                 (to 115)
         106   load_type 11             
         107   load_var 3               (_3)
-        108   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        108   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         109   store_var 4              (_4)
         110   jump +5                  (to 115)
         111   load_var 3               (_3)
-        112   make_bound_method 571    
+        112   make_bound_method 573    
         113   call_indirect            
         114   store_var 4              (_4)
         115   load_var 4               (_4)
@@ -1814,16 +1815,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         154   load_type 11             
         155   load_type 12             
         156   load_var 4               (_4)
-        157   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        157   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         158   store_var 5              (_35)
         159   jump +50                 (to 209)
         160   load_var 4               (_4)
-        161   make_bound_method 551    
+        161   make_bound_method 553    
         162   call_indirect            
         163   store_var 5              (_35)
         164   jump +45                 (to 209)
         165   load_var 4               (_4)
-        166   make_bound_method 564    
+        166   make_bound_method 566    
         167   call_indirect            
         168   store_var 5              (_35)
         169   jump +40                 (to 209)
@@ -1831,39 +1832,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         171   load_type 12             
         172   load_type 12             
         173   load_var 4               (_4)
-        174   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        174   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         175   store_var 5              (_35)
         176   jump +33                 (to 209)
         177   load_var 4               (_4)
-        178   make_bound_method 500    
+        178   make_bound_method 502    
         179   call_indirect            
         180   store_var 5              (_35)
         181   jump +28                 (to 209)
         182   load_type 11             
         183   load_var 4               (_4)
-        184   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        184   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         185   store_var 5              (_35)
         186   jump +23                 (to 209)
         187   load_type 11             
         188   load_type 12             
         189   load_type 12             
         190   load_var 4               (_4)
-        191   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        191   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         192   store_var 5              (_35)
         193   jump +16                 (to 209)
         194   load_type 11             
         195   load_type 12             
         196   load_var 4               (_4)
-        197   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        197   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         198   store_var 5              (_35)
         199   jump +10                 (to 209)
         200   load_type 11             
         201   load_var 4               (_4)
-        202   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        202   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         203   store_var 5              (_35)
         204   jump +5                  (to 209)
         205   load_var 4               (_4)
-        206   make_bound_method 535    
+        206   make_bound_method 537    
         207   call_indirect            
         208   store_var 5              (_35)
         209   load_var 5               (_35)
@@ -1882,14 +1883,14 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         220   load_field 1             (body)
         221   load_var 6               (t)
         222   load_field 2             (runner)
-        223   call 716 ntypeargs=0     (testing.run_test)
+        223   call 718 ntypeargs=0     (testing.run_test)
         224   jump +231                (to 455)
 
   143   225   load_type 14             
         226   load_type 15             
         227   load_var 1               (self)
         228   load_field 1             (expansions)
-        229   call 20 ntypeargs=2      (baml.Map.keys)
+        229   call 23 ntypeargs=2      (baml.Map.keys)
         230   store_var 7              (_69)
 
   142   231   load_var 7               (_69)
@@ -1941,27 +1942,27 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         277   pop_jump_if_false +183   (to 460)
         278   load_type 14             
         279   load_var 7               (_69)
-        280   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        280   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         281   store_var 8              (_73)
         282   jump +61                 (to 343)
         283   load_type 14             
         284   load_var 7               (_69)
-        285   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        285   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         286   store_var 8              (_73)
         287   jump +56                 (to 343)
         288   load_type 14             
         289   load_type 12             
         290   load_var 7               (_69)
-        291   call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        291   call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         292   store_var 8              (_73)
         293   jump +50                 (to 343)
         294   load_var 7               (_69)
-        295   make_bound_method 497    
+        295   make_bound_method 499    
         296   call_indirect            
         297   store_var 8              (_73)
         298   jump +45                 (to 343)
         299   load_var 7               (_69)
-        300   make_bound_method 510    
+        300   make_bound_method 512    
         301   call_indirect            
         302   store_var 8              (_73)
         303   jump +40                 (to 343)
@@ -1969,39 +1970,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         305   load_type 12             
         306   load_type 12             
         307   load_var 7               (_69)
-        308   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        308   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         309   store_var 8              (_73)
         310   jump +33                 (to 343)
         311   load_var 7               (_69)
-        312   make_bound_method 540    
+        312   make_bound_method 542    
         313   call_indirect            
         314   store_var 8              (_73)
         315   jump +28                 (to 343)
         316   load_type 14             
         317   load_var 7               (_69)
-        318   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        318   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         319   store_var 8              (_73)
         320   jump +23                 (to 343)
         321   load_type 14             
         322   load_type 12             
         323   load_type 12             
         324   load_var 7               (_69)
-        325   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        325   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         326   store_var 8              (_73)
         327   jump +16                 (to 343)
         328   load_type 14             
         329   load_type 12             
         330   load_var 7               (_69)
-        331   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        331   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         332   store_var 8              (_73)
         333   jump +10                 (to 343)
         334   load_type 14             
         335   load_var 7               (_69)
-        336   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        336   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         337   store_var 8              (_73)
         338   jump +5                  (to 343)
         339   load_var 7               (_69)
-        340   make_bound_method 571    
+        340   make_bound_method 573    
         341   call_indirect            
         342   store_var 8              (_73)
         343   load_var 8               (_73)
@@ -2046,16 +2047,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         382   load_type 14             
         383   load_type 12             
         384   load_var 8               (_73)
-        385   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        385   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         386   store_var 9              (_104)
         387   jump +50                 (to 437)
         388   load_var 8               (_73)
-        389   make_bound_method 551    
+        389   make_bound_method 553    
         390   call_indirect            
         391   store_var 9              (_104)
         392   jump +45                 (to 437)
         393   load_var 8               (_73)
-        394   make_bound_method 564    
+        394   make_bound_method 566    
         395   call_indirect            
         396   store_var 9              (_104)
         397   jump +40                 (to 437)
@@ -2063,39 +2064,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         399   load_type 12             
         400   load_type 12             
         401   load_var 8               (_73)
-        402   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        402   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         403   store_var 9              (_104)
         404   jump +33                 (to 437)
         405   load_var 8               (_73)
-        406   make_bound_method 500    
+        406   make_bound_method 502    
         407   call_indirect            
         408   store_var 9              (_104)
         409   jump +28                 (to 437)
         410   load_type 14             
         411   load_var 8               (_73)
-        412   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        412   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         413   store_var 9              (_104)
         414   jump +23                 (to 437)
         415   load_type 14             
         416   load_type 12             
         417   load_type 12             
         418   load_var 8               (_73)
-        419   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        419   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         420   store_var 9              (_104)
         421   jump +16                 (to 437)
         422   load_type 14             
         423   load_type 12             
         424   load_var 8               (_73)
-        425   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        425   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         426   store_var 9              (_104)
         427   jump +10                 (to 437)
         428   load_type 14             
         429   load_var 8               (_73)
-        430   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        430   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         431   store_var 9              (_104)
         432   jump +5                  (to 437)
         433   load_var 8               (_73)
-        434   make_bound_method 535    
+        434   make_bound_method 537    
         435   call_indirect            
         436   store_var 9              (_104)
         437   load_var 9               (_104)
@@ -2114,12 +2115,12 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
   146   448   load_var2 2 10           
         449   load_const 26            ("/")
         450   bin_op +                 
-        451   call 149 ntypeargs=0     (baml.String.starts_with)
+        451   call 151 ntypeargs=0     (baml.String.starts_with)
 
   145   452   pop_jump_if_false -109   (to 343)
 
   147   453   load_var2 11 2           
-        454   call 709 ntypeargs=0     (testing.TestRegistry.run_test)
+        454   call 711 ntypeargs=0     (testing.TestRegistry.run_test)
         455   return                   
 
   150   456   load_const 27            ("Test not found: ")
@@ -2185,27 +2186,27 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         51    pop_jump_if_false +428   (to 479)
         52    load_type 11             
         53    load_var 4               (_3)
-        54    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        54    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         55    store_var 5              (_4)
         56    jump +61                 (to 117)
         57    load_type 11             
         58    load_var 4               (_3)
-        59    call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        59    call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         60    store_var 5              (_4)
         61    jump +56                 (to 117)
         62    load_type 11             
         63    load_type 12             
         64    load_var 4               (_3)
-        65    call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        65    call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         66    store_var 5              (_4)
         67    jump +50                 (to 117)
         68    load_var 4               (_3)
-        69    make_bound_method 497    
+        69    make_bound_method 499    
         70    call_indirect            
         71    store_var 5              (_4)
         72    jump +45                 (to 117)
         73    load_var 4               (_3)
-        74    make_bound_method 510    
+        74    make_bound_method 512    
         75    call_indirect            
         76    store_var 5              (_4)
         77    jump +40                 (to 117)
@@ -2213,39 +2214,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         79    load_type 12             
         80    load_type 12             
         81    load_var 4               (_3)
-        82    call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        82    call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         83    store_var 5              (_4)
         84    jump +33                 (to 117)
         85    load_var 4               (_3)
-        86    make_bound_method 540    
+        86    make_bound_method 542    
         87    call_indirect            
         88    store_var 5              (_4)
         89    jump +28                 (to 117)
         90    load_type 11             
         91    load_var 4               (_3)
-        92    call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        92    call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         93    store_var 5              (_4)
         94    jump +23                 (to 117)
         95    load_type 11             
         96    load_type 12             
         97    load_type 12             
         98    load_var 4               (_3)
-        99    call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        99    call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         100   store_var 5              (_4)
         101   jump +16                 (to 117)
         102   load_type 11             
         103   load_type 12             
         104   load_var 4               (_3)
-        105   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        105   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         106   store_var 5              (_4)
         107   jump +10                 (to 117)
         108   load_type 11             
         109   load_var 4               (_3)
-        110   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        110   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         111   store_var 5              (_4)
         112   jump +5                  (to 117)
         113   load_var 4               (_3)
-        114   make_bound_method 571    
+        114   make_bound_method 573    
         115   call_indirect            
         116   store_var 5              (_4)
         117   load_var 5               (_4)
@@ -2290,16 +2291,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         156   load_type 11             
         157   load_type 12             
         158   load_var 5               (_4)
-        159   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        159   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         160   store_var 6              (_35)
         161   jump +50                 (to 211)
         162   load_var 5               (_4)
-        163   make_bound_method 551    
+        163   make_bound_method 553    
         164   call_indirect            
         165   store_var 6              (_35)
         166   jump +45                 (to 211)
         167   load_var 5               (_4)
-        168   make_bound_method 564    
+        168   make_bound_method 566    
         169   call_indirect            
         170   store_var 6              (_35)
         171   jump +40                 (to 211)
@@ -2307,39 +2308,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         173   load_type 12             
         174   load_type 12             
         175   load_var 5               (_4)
-        176   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        176   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         177   store_var 6              (_35)
         178   jump +33                 (to 211)
         179   load_var 5               (_4)
-        180   make_bound_method 500    
+        180   make_bound_method 502    
         181   call_indirect            
         182   store_var 6              (_35)
         183   jump +28                 (to 211)
         184   load_type 11             
         185   load_var 5               (_4)
-        186   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        186   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         187   store_var 6              (_35)
         188   jump +23                 (to 211)
         189   load_type 11             
         190   load_type 12             
         191   load_type 12             
         192   load_var 5               (_4)
-        193   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        193   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         194   store_var 6              (_35)
         195   jump +16                 (to 211)
         196   load_type 11             
         197   load_type 12             
         198   load_var 5               (_4)
-        199   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        199   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         200   store_var 6              (_35)
         201   jump +10                 (to 211)
         202   load_type 11             
         203   load_var 5               (_4)
-        204   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        204   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         205   store_var 6              (_35)
         206   jump +5                  (to 211)
         207   load_var 5               (_4)
-        208   make_bound_method 535    
+        208   make_bound_method 537    
         209   call_indirect            
         210   store_var 6              (_35)
         211   load_var 6               (_35)
@@ -2354,7 +2355,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         219   load_var 7               (t)
         220   load_field 0             (name)
         221   init_instance 0          (testing.SerializedTest .type, .name)
-        222   call 17 ntypeargs=0      (baml.Array.push)
+        222   call 18 ntypeargs=0      (baml.Array.push)
         223   pop 1                    
         224   jump -107                (to 117)
 
@@ -2410,27 +2411,27 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         274   pop_jump_if_false +205   (to 479)
         275   load_type 25             
         276   load_var 8               (_68)
-        277   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        277   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         278   store_var 9              (_69)
         279   jump +61                 (to 340)
         280   load_type 25             
         281   load_var 8               (_68)
-        282   call 515 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        282   call 517 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         283   store_var 9              (_69)
         284   jump +56                 (to 340)
         285   load_type 25             
         286   load_type 12             
         287   load_var 8               (_68)
-        288   call 562 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
+        288   call 564 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
         289   store_var 9              (_69)
         290   jump +50                 (to 340)
         291   load_var 8               (_68)
-        292   make_bound_method 497    
+        292   make_bound_method 499    
         293   call_indirect            
         294   store_var 9              (_69)
         295   jump +45                 (to 340)
         296   load_var 8               (_68)
-        297   make_bound_method 510    
+        297   make_bound_method 512    
         298   call_indirect            
         299   store_var 9              (_69)
         300   jump +40                 (to 340)
@@ -2438,39 +2439,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         302   load_type 12             
         303   load_type 12             
         304   load_var 8               (_68)
-        305   call 524 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
+        305   call 526 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
         306   store_var 9              (_69)
         307   jump +33                 (to 340)
         308   load_var 8               (_68)
-        309   make_bound_method 540    
+        309   make_bound_method 542    
         310   call_indirect            
         311   store_var 9              (_69)
         312   jump +28                 (to 340)
         313   load_type 25             
         314   load_var 8               (_68)
-        315   call 558 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
+        315   call 560 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
         316   store_var 9              (_69)
         317   jump +23                 (to 340)
         318   load_type 25             
         319   load_type 12             
         320   load_type 12             
         321   load_var 8               (_68)
-        322   call 533 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
+        322   call 535 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
         323   store_var 9              (_69)
         324   jump +16                 (to 340)
         325   load_type 25             
         326   load_type 12             
         327   load_var 8               (_68)
-        328   call 548 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
+        328   call 550 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
         329   store_var 9              (_69)
         330   jump +10                 (to 340)
         331   load_type 25             
         332   load_var 8               (_68)
-        333   call 493 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
+        333   call 495 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
         334   store_var 9              (_69)
         335   jump +5                  (to 340)
         336   load_var 8               (_68)
-        337   make_bound_method 571    
+        337   make_bound_method 573    
         338   call_indirect            
         339   store_var 9              (_69)
         340   load_var 9               (_69)
@@ -2515,16 +2516,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         379   load_type 25             
         380   load_type 12             
         381   load_var 9               (_69)
-        382   call 520 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        382   call 522 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         383   store_var 10             (_100)
         384   jump +50                 (to 434)
         385   load_var 9               (_69)
-        386   make_bound_method 551    
+        386   make_bound_method 553    
         387   call_indirect            
         388   store_var 10             (_100)
         389   jump +45                 (to 434)
         390   load_var 9               (_69)
-        391   make_bound_method 564    
+        391   make_bound_method 566    
         392   call_indirect            
         393   store_var 10             (_100)
         394   jump +40                 (to 434)
@@ -2532,39 +2533,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         396   load_type 12             
         397   load_type 12             
         398   load_var 9               (_69)
-        399   call 487 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        399   call 489 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         400   store_var 10             (_100)
         401   jump +33                 (to 434)
         402   load_var 9               (_69)
-        403   make_bound_method 500    
+        403   make_bound_method 502    
         404   call_indirect            
         405   store_var 10             (_100)
         406   jump +28                 (to 434)
         407   load_type 25             
         408   load_var 9               (_69)
-        409   call 514 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        409   call 516 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         410   store_var 10             (_100)
         411   jump +23                 (to 434)
         412   load_type 25             
         413   load_type 12             
         414   load_type 12             
         415   load_var 9               (_69)
-        416   call 490 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        416   call 492 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         417   store_var 10             (_100)
         418   jump +16                 (to 434)
         419   load_type 25             
         420   load_type 12             
         421   load_var 9               (_69)
-        422   call 504 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        422   call 506 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         423   store_var 10             (_100)
         424   jump +10                 (to 434)
         425   load_type 25             
         426   load_var 9               (_69)
-        427   call 546 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        427   call 548 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         428   store_var 10             (_100)
         429   jump +5                  (to 434)
         430   load_var 9               (_69)
-        431   make_bound_method 535    
+        431   make_bound_method 537    
         432   call_indirect            
         433   store_var 10             (_100)
         434   load_var 10              (_100)
@@ -2580,7 +2581,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         443   load_field 1             (expansions)
         444   load_var 11              (ts)
         445   load_field 0             (name)
-        446   call 50 ntypeargs=2      (baml.Map.get)
+        446   call 52 ntypeargs=2      (baml.Map.get)
         447   store_var 12             (expanded)
 
   118   448   load_var 12              (expanded)
@@ -2593,7 +2594,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         454   load_var 11              (ts)
         455   load_field 0             (name)
         456   init_instance 1          (testing.SerializedTest .type, .name)
-        457   call 17 ntypeargs=0      (baml.Array.push)
+        457   call 18 ntypeargs=0      (baml.Array.push)
         458   pop 1                    
         459   jump -119                (to 340)
 
@@ -2605,7 +2606,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         464   store_var 14             (_139)
 
   122   465   load_var 13              (sub)
-        466   call 705 ntypeargs=0     (testing.TestRegistry.serialize)
+        466   call 707 ntypeargs=0     (testing.TestRegistry.serialize)
         467   store_var 15             (_140)
 
   120   468   load_var2 3 14           
@@ -2613,7 +2614,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 
   123   470   load_field 2             (loading_time_ms)
         471   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        472   call 17 ntypeargs=0      (baml.Array.push)
+        472   call 18 ntypeargs=0      (baml.Array.push)
         473   pop 1                    
         474   jump -134                (to 340)
 
@@ -2627,15 +2628,15 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 717 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 719 ntypeargs=0   (testing.TestCollector.to_json)
        3    load_type 0            
        4    load_type 1            
        5    load_var 1             (self)
        6    load_field 1           (expansions)
-       7    call 23 ntypeargs=2    (baml.Map.to_json)
+       7    call 24 ntypeargs=2    (baml.Map.to_json)
        8    load_var 1             (self)
        9    load_field 2           (loading_time_ms)
-       10   call 60 ntypeargs=0    (baml.Int.to_json)
+       10   call 62 ntypeargs=0    (baml.Int.to_json)
        11   load_const 2           ("collector")
        12   load_const 3           ("expansions")
        13   load_const 4           ("loading_time_ms")
@@ -2648,18 +2649,18 @@ function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.j
 function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
   18   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("runs")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.TestReport .outcome, .runs)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -2675,7 +2676,7 @@ function testing.TestReport.to_json(self: testing.TestReport) -> baml.json.json 
        5    load_type 1           
        6    load_var 1            (self)
        7    load_field 1          (runs)
-       8    call 36 ntypeargs=1   (baml.Array.to_json)
+       8    call 38 ntypeargs=1   (baml.Array.to_json)
        9    load_const 2          ("outcome")
        10   load_const 3          ("runs")
        11   alloc_map 2           
@@ -2687,25 +2688,25 @@ function testing.TestReport.to_json(self: testing.TestReport) -> baml.json.json 
 function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.TestSetRegistration {
   17   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("collector")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("runner")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestSetRegistration .name, .collector, .runner)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -2715,47 +2716,47 @@ function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.Tes
 function testing.TestSetRegistration.to_json(self: testing.TestSetRegistration) -> baml.json.json {
   25   0   load_type 0            
        1   load_var 1             (self)
-       2   call 396 ntypeargs=1   (baml.json.to_string)
-       3   call 391 ntypeargs=0   (baml.json.parse)
+       2   call 398 ntypeargs=1   (baml.json.to_string)
+       3   call 393 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
 function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetReport {
   25   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("passed")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("failed")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 3            
        19   load_var 5             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   load_var 1             (j)
        22   load_const 5           ("total")
-       23   call 394 ntypeargs=0   (baml.json.field)
+       23   call 396 ntypeargs=0   (baml.json.field)
        24   store_var 6            (_12)
        25   load_type 3            
        26   load_var 6             (_12)
-       27   call 386 ntypeargs=1   (baml.json.from_json)
+       27   call 388 ntypeargs=1   (baml.json.from_json)
        28   load_var 1             (j)
        29   load_const 6           ("results")
-       30   call 394 ntypeargs=0   (baml.json.field)
+       30   call 396 ntypeargs=0   (baml.json.field)
        31   store_var 7            (_15)
        32   load_type 7            
        33   load_var 7             (_15)
-       34   call 386 ntypeargs=1   (baml.json.from_json)
+       34   call 388 ntypeargs=1   (baml.json.from_json)
        35   init_instance 0        (testing.TestSetReport .outcome, .passed, .failed, .total, .results)
        36   store_var 2            (_0)
        37   load_var 2             (_0)
@@ -2770,17 +2771,17 @@ function testing.TestSetReport.to_json(self: testing.TestSetReport) -> baml.json
        4    call_indirect         
        5    load_var 1            (self)
        6    load_field 1          (passed)
-       7    call 60 ntypeargs=0   (baml.Int.to_json)
+       7    call 62 ntypeargs=0   (baml.Int.to_json)
        8    load_var 1            (self)
        9    load_field 2          (failed)
-       10   call 60 ntypeargs=0   (baml.Int.to_json)
+       10   call 62 ntypeargs=0   (baml.Int.to_json)
        11   load_var 1            (self)
        12   load_field 3          (total)
-       13   call 60 ntypeargs=0   (baml.Int.to_json)
+       13   call 62 ntypeargs=0   (baml.Int.to_json)
        14   load_type 1           
        15   load_var 1            (self)
        16   load_field 4          (results)
-       17   call 36 ntypeargs=1   (baml.Array.to_json)
+       17   call 38 ntypeargs=1   (baml.Array.to_json)
        18   load_const 2          ("outcome")
        19   load_const 3          ("passed")
        20   load_const 4          ("failed")
@@ -2798,7 +2799,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 1333 1    
+        4    make_closure 1335 1    
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)
@@ -2843,18 +2844,18 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
   26   0    load_var 1             (j)
        1    load_const 0           ("code")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("message")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (user.ErrorInfo .code, .message)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -2864,10 +2865,10 @@ function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
 function user.ErrorInfo.to_json(self: ErrorInfo) -> baml.json.json {
   26   0    load_var 1             (self)
        1    load_field 0           (code)
-       2    call 60 ntypeargs=0    (baml.Int.to_json)
+       2    call 62 ntypeargs=0    (baml.Int.to_json)
        3    load_var 1             (self)
        4    load_field 1           (message)
-       5    call 161 ntypeargs=0   (baml.String.to_json)
+       5    call 163 ntypeargs=0   (baml.String.to_json)
        6    load_const 0           ("code")
        7    load_const 1           ("message")
        8    alloc_map 2            
@@ -2879,25 +2880,25 @@ function user.ErrorInfo.to_json(self: ErrorInfo) -> baml.json.json {
 function user.Report.from_json(j: baml.json.json) -> Report {
   20   0    load_var 1             (j)
        1    load_const 0           ("score")
-       2    call 394 ntypeargs=0   (baml.json.field)
+       2    call 396 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 386 ntypeargs=1   (baml.json.from_json)
+       6    call 388 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("label")
-       9    call 394 ntypeargs=0   (baml.json.field)
+       9    call 396 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 386 ntypeargs=1   (baml.json.from_json)
+       13   call 388 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("breakdown")
-       16   call 394 ntypeargs=0   (baml.json.field)
+       16   call 396 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 386 ntypeargs=1   (baml.json.from_json)
+       20   call 388 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (user.Report .score, .label, .breakdown)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -2907,15 +2908,15 @@ function user.Report.from_json(j: baml.json.json) -> Report {
 function user.Report.to_json(self: Report) -> baml.json.json {
   20   0    load_var 1             (self)
        1    load_field 0           (score)
-       2    call 60 ntypeargs=0    (baml.Int.to_json)
+       2    call 62 ntypeargs=0    (baml.Int.to_json)
        3    load_var 1             (self)
        4    load_field 1           (label)
-       5    call 161 ntypeargs=0   (baml.String.to_json)
+       5    call 163 ntypeargs=0   (baml.String.to_json)
        6    load_type 0            
        7    load_type 1            
        8    load_var 1             (self)
        9    load_field 2           (breakdown)
-       10   call 23 ntypeargs=2    (baml.Map.to_json)
+       10   call 24 ntypeargs=2    (baml.Map.to_json)
        11   load_const 2           ("score")
        12   load_const 3           ("label")
        13   load_const 4           ("breakdown")
@@ -2928,25 +2929,25 @@ function user.Report.to_json(self: Report) -> baml.json.json {
 function user.User.from_json(j: baml.json.json) -> User {
   3   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 394 ntypeargs=0   (baml.json.field)
+      2    call 396 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 386 ntypeargs=1   (baml.json.from_json)
+      6    call 388 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("age")
-      9    call 394 ntypeargs=0   (baml.json.field)
+      9    call 396 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 386 ntypeargs=1   (baml.json.from_json)
+      13   call 388 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("role")
-      16   call 394 ntypeargs=0   (baml.json.field)
+      16   call 396 ntypeargs=0   (baml.json.field)
       17   store_var 5            (_9)
       18   load_type 5            
       19   load_var 5             (_9)
-      20   call 386 ntypeargs=1   (baml.json.from_json)
+      20   call 388 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (user.User .name, .age, .role)
       22   store_var 2            (_0)
       23   load_var 2             (_0)
@@ -2985,10 +2986,10 @@ function user.User.promote(self: User, bonus: int) -> Report {
 function user.User.to_json(self: User) -> baml.json.json {
   3   0    load_var 1             (self)
       1    load_field 0           (name)
-      2    call 161 ntypeargs=0   (baml.String.to_json)
+      2    call 163 ntypeargs=0   (baml.String.to_json)
       3    load_var 1             (self)
       4    load_field 1           (age)
-      5    call 60 ntypeargs=0    (baml.Int.to_json)
+      5    call 62 ntypeargs=0    (baml.Int.to_json)
       6    load_var 1             (self)
       7    load_field 2           (role)
       8    load_const 0           ("to_json")

--- a/baml_language/crates/bex_engine/tests/array_set_constructor.rs
+++ b/baml_language/crates/bex_engine/tests/array_set_constructor.rs
@@ -1,0 +1,61 @@
+mod common;
+
+use bex_engine::BexExternalValue;
+use common::{EngineProgram, assert_engine_executes};
+
+#[tokio::test]
+async fn array_constructor_preallocates_and_set_updates_by_index() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            function main() -> int {
+                let width = 3;
+                let dp = int[](6, 0);
+                dp.set(0, 4);
+                dp.set(1 * width + 2, 9);
+                (dp.at(0) ?? 0) + (dp.at(5) ?? 0) + dp.length()
+            }
+        "#,
+        expected: Ok(BexExternalValue::Int(19)),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn array_set_out_of_bounds_throws_invalid_argument() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            function main() -> int {
+                {
+                    let xs = int[](2, 0);
+                    xs.set(2, 1);
+                    0
+                } catch (e) {
+                    baml.errors.InvalidArgument => 1
+                }
+            }
+        "#,
+        expected: Ok(BexExternalValue::Int(1)),
+        ..Default::default()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn array_constructor_negative_size_throws_invalid_argument() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        source: r#"
+            function main() -> int {
+                {
+                    let xs = int[](-1, 0);
+                    xs.length()
+                } catch (e) {
+                    baml.errors.InvalidArgument => 1
+                }
+            }
+        "#,
+        expected: Ok(BexExternalValue::Int(1)),
+        ..Default::default()
+    })
+    .await
+}

--- a/baml_language/crates/bex_vm/src/package_baml/array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/array.rs
@@ -407,6 +407,24 @@ impl Continuation for ToJsonContinuation {
 }
 
 impl BamlClassArray for PackageBamlImpl {
+    fn new(size: i64, default: &Value) -> Result<Vec<Value>, VmRustFnError> {
+        let Ok(size) = usize::try_from(size) else {
+            return Err(VmBamlError::InvalidArgument {
+                message: format!("array constructor: size ({size}) is negative"),
+            }
+            .into());
+        };
+
+        let mut array = Vec::new();
+        array.try_reserve_exact(size).map_err(|_| {
+            VmRustFnError::from(VmBamlError::InvalidArgument {
+                message: format!("array constructor: unable to allocate array of length {size}"),
+            })
+        })?;
+        array.resize(size, *default);
+        Ok(array)
+    }
+
     #[allow(clippy::cast_possible_wrap)]
     fn length(array: &[Value]) -> i64 {
         array.len() as i64
@@ -416,6 +434,27 @@ impl BamlClassArray for PackageBamlImpl {
     fn push(array: &mut Vec<Value>, item: &Value) -> i64 {
         array.push(*item);
         array.len() as i64
+    }
+
+    #[allow(clippy::unused_unit)]
+    fn set(array: &mut Vec<Value>, index: i64, value: &Value) -> Result<(), VmRustFnError> {
+        let len = array.len();
+        let Ok(index_usize) = usize::try_from(index) else {
+            return Err(VmBamlError::InvalidArgument {
+                message: format!("array.set: index ({index}) is negative"),
+            }
+            .into());
+        };
+        if index_usize >= len {
+            return Err(VmBamlError::InvalidArgument {
+                message: format!(
+                    "array.set: index ({index_usize}) is outside the array length ({len})"
+                ),
+            }
+            .into());
+        }
+        array[index_usize] = *value;
+        Ok(())
     }
 
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The error

A mutable random-write array update was not expressible. Before this change, the smallest `.set` repro failed:

```baml
function main() -> int {
  let dp = [0, 0, 0, 0, 0, 0];
  dp.set(5, 9);
  dp.at(5) ?? 0
}
```

Old compiler output:

```text
error: type `int[]` has no member `set`
   ╭─[ main.baml:2:31 ]
   │
 2 │ ╭─▶   let dp = [0, 0, 0, 0, 0, 0];
 3 │ ├─▶   dp.set(5, 9);
   │ │                     
   │ ╰───────────────────── type `int[]` has no member `set`
   │     
   │     Note: Error code: E0007
───╯
```

The requested fixed-size constructor syntax also failed before the change:

```baml
function main() -> int {
  let dp = int[](6, 0);
  dp.set(5, 9);
  dp.at(5) ?? 0
}
```

Old compiler output:

```text
error: unresolved name: int
   ╭─[ main.baml:2:12 ]
   │
 2 │   let dp = int[](6, 0);
   │            ─┬─  
   │             ╰─── unresolved name: int
   │ 
   │ Note: Error code: E0003
───╯

error: Expected expression, found ']'
   ╭─[ main.baml:2:16 ]
   │
 2 │   let dp = int[](6, 0);
   │                ┬  
   │                ╰── Expected expression, found ']'
   │ 
   │ Note: Error code: E0010
───╯

error: Expected ']', found ';'
   ╭─[ main.baml:2:23 ]
   │
 2 │   let dp = int[](6, 0);
   │                       ┬  
   │                       ╰── Expected ']', found ';'
   │ 
   │ Note: Error code: E0010
───╯
```

## Root cause

- `crates/baml_builtins2/baml_std/baml/containers.baml` defined `Array<T>` methods such as `at`, `push`, and `splice`, but did not define an indexed `set` method or any fixed-size constructor.
- `crates/baml_compiler_parser/src/parser.rs` only treated `[]` in expression position as array literals or indexing, so `int[](6, 0)` was parsed as a value path `int` followed by an invalid empty index expression rather than as an array constructor.
- `crates/baml_compiler2_tir/src/builder.rs::try_container_method_call` only had evolving-container special handling for `push`/`append`, so unannotated arrays could not establish or validate element type through `.set`.
- `crates/bex_vm/src/package_baml/array.rs` had no native runtime implementation for either operation.

## The fix

- Added `Array<T>.set(index: int, value: T) -> null throws baml.errors.InvalidArgument` to the stdlib and implemented it in the VM array package with negative/out-of-bounds validation.
- Added `Array<T>.new(size: int, default: T) -> T[] throws baml.errors.InvalidArgument` and parser/AST lowering for `T[](size, default)` as sugar for `baml.Array.new<T>(size, default)`.
- Extended TIR evolving-array mutation handling so `let xs = []; xs.set(i, v)` type-checks consistently with `push`, including index validation as `int` and value validation against the element type.
- Added focused engine tests for successful preallocation + indexed write, out-of-bounds `set`, and negative constructor size.
- Updated stdlib/compiler snapshots and compiler2 mutability docs.

## Verification

Reproduction after the change:

```bash
PATH="$HOME/.local/bin:$PATH" RUSTFLAGS="-C link-arg=-lnode" \
  cargo run -q -p baml_cli --manifest-path /workspace/baml_language/Cargo.toml -- \
  check --from /tmp/baml-array-project
```

Output:

```text
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
     Loading /tmp/baml-array-project/baml_src/main.baml
    Checking 1 file(s)
   Compiling 1 file(s)
    Finished checked 1 file(s) in 4s
```

```bash
PATH="$HOME/.local/bin:$PATH" RUSTFLAGS="-C link-arg=-lnode" \
  cargo run -q -p baml_cli --manifest-path /workspace/baml_language/Cargo.toml -- \
  run main --from /tmp/baml-array-project
```

Output:

```text
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
     Loading /tmp/baml-array-project/baml_src/main.baml
    Checking 1 file(s)
   Compiling 1 file(s)
warning: Your code is unformatted — run `baml fmt` to format it. Continuing.
     Running main
9
    Finished main in 4s
```

Test commands run from `baml_language/`:

```bash
cargo test -p bex_engine --test array_set_constructor
# test result: ok. 3 passed; 0 failed; 0 ignored

PATH="$HOME/.local/bin:$PATH" RUSTFLAGS="-C link-arg=-lnode" cargo test --lib
# passed

PATH="$HOME/.local/bin:$PATH" RUSTFLAGS="-C link-arg=-lnode" cargo test --workspace --exclude sdk_test_typescript_node
# exit_code: 0

CI=true PATH="$HOME/.local/bin:$PATH" ./sdk_tests/crates/typescript_node/setup.sh
PATH="$HOME/.local/bin:$PATH" CARGO_MANIFEST_DIR="/workspace/baml_language/sdk_tests/crates/typescript_node" \
  ./target/debug/deps/sdk_test_typescript_node-0df1538f20582eac
# test result: ok. 15 passed; 0 failed; 0 ignored
```

Note: `sdk_test_typescript_node` is run with its documented setup split because `sdk_tests/README.md` states plain `cargo test` regenerates the TypeScript fixtures without running their setup script.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4be7672d-aaa0-59b2-9489-cb579d2582f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4be7672d-aaa0-59b2-9489-cb579d2582f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

