### PR TITLE
[codex] fix baml describe budget handling

### DIFF
--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -527,6 +527,10 @@ pub fn write_description(
     let body_lines: Vec<&str> = desc.full_body.lines().collect();
 
     if !is_local {
+        // The separator blank line is deliberately not counted against the
+        // budget: the body's available-line computation predates the section
+        // budgeting below and is a documented guarantee (a fields-only class
+        // body must fit at budget 5).
         writeln!(w)?;
         let available_for_body = budget.saturating_sub(lines_used);
         let was_truncated = body_lines.len() > available_for_body;
@@ -562,17 +566,40 @@ pub fn write_description(
                 total = body_lines.len(),
                 needed = body_lines.len() + 1,
             )?;
+            lines_used += 2;
         }
     }
 
+    // Whatever budget the body didn't consume flows into the list sections
+    // below (methods, dependencies, references), in priority order. The
+    // budget is soft: section headers are always emitted (so the symbol's
+    // surface stays discoverable), entries are never split mid-unit, and
+    // anything elided is replaced by an explicit "… <n> more lines" marker.
+    let mut remaining = budget.saturating_sub(lines_used);
+
     // ── Methods (instance) ───────────────────────────────────────────────────
-    // Methods are always shown in full — they bypass the body budget entirely.
-    write_method_section(w, db, project_root, "methods", &desc.instance_methods)?;
+    remaining = write_method_section(
+        w,
+        db,
+        project_root,
+        "methods",
+        &desc.instance_methods,
+        remaining,
+    )?;
 
     // ── Static methods ───────────────────────────────────────────────────────
-    write_method_section(w, db, project_root, "static_methods", &desc.static_methods)?;
+    remaining = write_method_section(
+        w,
+        db,
+        project_root,
+        "static_methods",
+        &desc.static_methods,
+        remaining,
+    )?;
 
     // ── Container ────────────────────────────────────────────────────────────
+    // Always shown in full: it's a single entry and part of the symbol's
+    // identity, like the header.
     if let Some(ref c) = desc.container {
         writeln!(w)?;
         writeln!(w, "container:")?;
@@ -586,13 +613,20 @@ pub fn write_description(
             c_path.display(),
             c_line
         )?;
+        remaining = remaining.saturating_sub(3);
     }
 
     // ── Dependencies ─────────────────────────────────────────────────────────
     if !desc.dependencies.is_empty() {
         writeln!(w)?;
         writeln!(w, "dependencies:")?;
+        remaining = remaining.saturating_sub(2);
+        let mut elided = 0usize;
         for dep in &desc.dependencies {
+            if remaining == 0 {
+                elided += 1;
+                continue;
+            }
             let dep_path = relative_path(&dep.file.path(db), project_root);
             let dep_line = line_number_at_offset(dep.file.text(db), dep.name_span.start().into());
             writeln!(
@@ -603,13 +637,23 @@ pub fn write_description(
                 dep_path.display(),
                 dep_line,
             )?;
+            remaining -= 1;
         }
+        write_elision_marker(w, elided)?;
     }
 
     // ── References ───────────────────────────────────────────────────────────
+    // Lowest priority: references are the first thing to give way under a
+    // tight budget. The header always shows the total count.
     writeln!(w)?;
     writeln!(w, "references ({}):", desc.references.len())?;
+    remaining = remaining.saturating_sub(2);
+    let mut elided = 0usize;
     for r in &desc.references {
+        if remaining == 0 {
+            elided += 1;
+            continue;
+        }
         let ref_path = relative_path(&r.file.path(db), project_root);
         writeln!(
             w,
@@ -618,9 +662,19 @@ pub fn write_description(
             r.line_number,
             r.line_text.trim()
         )?;
+        remaining -= 1;
     }
+    write_elision_marker(w, elided)?;
 
-    let _ = lines_used; // budget tracking removed with new format
+    Ok(())
+}
+
+/// Write the soft-budget elision marker for `elided` hidden lines (no-op when
+/// nothing was elided).
+fn write_elision_marker(w: &mut impl std::io::Write, elided: usize) -> std::io::Result<()> {
+    if elided > 0 {
+        writeln!(w, "  … {elided} more lines (re-run with a higher --budget)")?;
+    }
     Ok(())
 }
 
@@ -673,21 +727,32 @@ pub(crate) fn definition_line_range(
 /// Render a `methods:` / `static_methods:` section.
 ///
 /// Each method shows its first-line docstring (when present) followed by its
-/// canonical signature and full definition line range. Methods are always
-/// rendered in full — they never pass through the body budget/truncation.
+/// canonical signature and full definition line range. The section consumes
+/// from the soft line `budget` and returns what's left: the header is always
+/// emitted, each method is an atomic unit (docstring + signature are never
+/// split, even if the last one runs slightly over), and methods that don't
+/// fit are summarized by an elision marker.
 fn write_method_section(
     w: &mut impl std::io::Write,
     db: &ProjectDatabase,
     project_root: &std::path::Path,
     label: &str,
     methods: &[describe::MethodRef],
-) -> std::io::Result<()> {
+    budget: usize,
+) -> std::io::Result<usize> {
     if methods.is_empty() {
-        return Ok(());
+        return Ok(budget);
     }
     writeln!(w)?;
     writeln!(w, "{label}:")?;
+    let mut remaining = budget.saturating_sub(2);
+    let mut elided_lines = 0usize;
     for m in methods {
+        let unit_cost = 1 + usize::from(m.docstring.is_some());
+        if remaining == 0 {
+            elided_lines += unit_cost;
+            continue;
+        }
         if let Some(doc) = &m.docstring {
             writeln!(w, "  /// {doc}")?;
         }
@@ -703,8 +768,10 @@ fn write_method_section(
             start,
             end
         )?;
+        remaining = remaining.saturating_sub(unit_cost);
     }
-    Ok(())
+    write_elision_marker(w, elided_lines)?;
+    Ok(remaining)
 }
 
 /// Render a flat listing of entries to stdout.

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -848,12 +848,10 @@ fn definition_line_range_comment_only_span_does_not_reverse() {
 
 // ── Truncation / budget tests ────────────────────────────────────────────────
 
-/// Methods are always discoverable. They are rendered after the body and
-/// bypass the body budget entirely, so even at budget 5 every method of
-/// `String` (40+) is still present, and the `methods:`/`static_methods:`
-/// sections are byte-identical regardless of budget.
+/// Methods remain discoverable under tight budgets, but their entries consume
+/// the remaining section budget and overflow is summarized explicitly.
 #[test]
-fn render_describe_methods_never_truncated() {
+fn render_describe_methods_share_remaining_budget() {
     let db = simple_project();
     let files = baml_compiler2_hir::compiler2_all_files(&db);
     let descs = baml_lsp2_actions::describe(&db, &files, "String");
@@ -864,9 +862,8 @@ fn render_describe_methods_never_truncated() {
 
     for needle in [
         "methods:",
-        "function to_json(self) -> json",
         "static_methods:",
-        "function from_code_points(unicode: int[]) -> string",
+        "more lines (re-run with a higher --budget)",
     ] {
         assert!(
             tight.contains(needle),
@@ -874,14 +871,19 @@ fn render_describe_methods_never_truncated() {
         );
     }
 
-    // The method sections are unaffected by the budget (only the body block is).
-    let methods_onward = |s: &str| s[s.find("\nmethods:").expect("methods section")..].to_string();
-    assert_eq!(methods_onward(&tight), methods_onward(&full));
+    assert!(
+        !tight.contains("function to_json(self) -> json"),
+        "late methods should be elided under budget 5:\n{tight}"
+    );
+    assert!(
+        full.contains("function to_json(self) -> json")
+            && full.contains("function from_code_points(unicode: int[]) -> string"),
+        "generous budgets should still show full method details:\n{full}"
+    );
 }
 
-/// A class with a fields-only body (no docstring) renders identically at a tight
-/// budget and a generous one — the body fits any reasonable budget. This is the
-/// spec's `baml describe User --budget 5` guarantee.
+/// A class with a fields-only body (no docstring) still fits that body under a
+/// tight budget, while later method sections use elision markers as needed.
 #[test]
 fn render_describe_fields_only_body_fits_tight_budget() {
     let db = methods_project();
@@ -895,7 +897,21 @@ fn render_describe_fields_only_body_fits_tight_budget() {
         !tight.contains("[INFO] Showing"),
         "fields-only body must not truncate at budget 5:\n{tight}"
     );
-    assert_eq!(tight, full);
+    for needle in ["class User {", "    name: string,", "    age: int,", "}"] {
+        assert!(
+            tight.contains(needle),
+            "`{needle}` missing from fields-only body under budget 5:\n{tight}"
+        );
+    }
+    assert!(
+        tight.contains("methods:\n  … 2 more lines"),
+        "methods should be summarized after the tight body budget is spent:\n{tight}"
+    );
+    assert!(
+        full.contains("function Greet(self) -> string")
+            && full.contains("function IsAdult(self) -> bool"),
+        "generous budgets should still show full methods:\n{full}"
+    );
 }
 
 /// Full budget shows no truncation hint.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
@@ -34,67 +34,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:104-106
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:109-111
-  /// Splits the string by `delimiter` and returns an array of substrings.
-  function split(self, delimiter: string) -> string[]  <builtin>/baml/string.baml:121-123
-  /// Splits the string into lines, recognizing both `\n` and `\r\n` as line
-  function lines(self) -> string[]  <builtin>/baml/string.baml:137-139
-  /// Returns the substring between two **character** offsets `[start, end)`.
-  function substring(self, start: int, end: int) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:155-157
-  /// Replaces the first occurrence of `search` with `replacement`.
-  function replace(self, search: string, replacement: string) -> string  <builtin>/baml/string.baml:160-162
-  /// Returns the **character index** of the first occurrence of `search`, or
-  function index_of(self, search: string) -> int  <builtin>/baml/string.baml:174-176
-  /// Returns the character at the given **codepoint index** as a
-  function char_at(self, index: int) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:192-194
-  /// Returns a new string that repeats `self` the given number of times.
-  function repeat(self, count: int) -> string  <builtin>/baml/string.baml:205-207
-  /// Returns true if the string contains the given `substring`.
-  function matches(self, substring: string) -> bool  <builtin>/baml/string.baml:210-212
-  /// Replaces all occurrences of `search` with `replacement`.
-  function replace_all(self, search: string, replacement: string) -> string  <builtin>/baml/string.baml:215-217
-  /// Returns true if every character is numeric per Unicode (general categories
-  function is_numeric(self) -> bool  <builtin>/baml/string.baml:237-239
-  /// Returns true if every character is a Unicode letter (general category `L`).
-  function is_alphabetic(self) -> bool  <builtin>/baml/string.baml:250-252
-  /// Returns true if every character is alphabetic OR numeric per Unicode.
-  function is_alphanumeric(self) -> bool  <builtin>/baml/string.baml:264-266
-  /// Returns true if every character is uppercase per Unicode (general
-  function is_uppercase(self) -> bool  <builtin>/baml/string.baml:279-281
-  /// Returns true if every character is lowercase per Unicode (general
-  function is_lowercase(self) -> bool  <builtin>/baml/string.baml:292-294
-  /// Returns true if every character is whitespace per Unicode (`White_Space`
-  function is_whitespace(self) -> bool  <builtin>/baml/string.baml:306-308
-  /// Returns true if every character is a control character per Unicode
-  function is_control(self) -> bool  <builtin>/baml/string.baml:318-320
-  /// Returns true if every character is a "graphic" character — that is,
-  function is_graphic(self) -> bool  <builtin>/baml/string.baml:335-337
-  /// Returns true if every character is ASCII (i.e. has a code point in
-  function is_ascii(self) -> bool  <builtin>/baml/string.baml:352-354
-  /// Returns true if every character is an ASCII decimal digit (`0`..=`9`).
-  function is_ascii_numeric(self) -> bool  <builtin>/baml/string.baml:365-367
-  /// Returns true if every character is an ASCII letter (`A`..=`Z` or
-  function is_ascii_alphabetic(self) -> bool  <builtin>/baml/string.baml:371-373
-  /// Returns true if every character is an ASCII letter or digit. Empty
-  function is_ascii_alphanumeric(self) -> bool  <builtin>/baml/string.baml:377-379
-  /// Returns true if every character is an ASCII uppercase letter
-  function is_ascii_uppercase(self) -> bool  <builtin>/baml/string.baml:383-385
-  /// Returns true if every character is an ASCII lowercase letter
-  function is_ascii_lowercase(self) -> bool  <builtin>/baml/string.baml:389-391
-  /// Returns true if every character is ASCII whitespace: space (`\x20`),
-  function is_ascii_whitespace(self) -> bool  <builtin>/baml/string.baml:397-399
-  /// Returns true if every character is an ASCII control character — code
-  function is_ascii_control(self) -> bool  <builtin>/baml/string.baml:403-405
-  /// Returns true if every character is an ASCII "graphic" character —
-  function is_ascii_graphic(self) -> bool  <builtin>/baml/string.baml:410-412
-  /// Returns true if every character is an ASCII hexadecimal digit:
-  function is_ascii_hex(self) -> bool  <builtin>/baml/string.baml:422-424
-  /// Returns the string encoded as a `uint8array` of UTF-8 bytes.
-  function to_utf8(self) -> uint8array  <builtin>/baml/string.baml:437-439
+  … 56 more lines (re-run with a higher --budget)
 
 static_methods:
-  /// Decodes a `uint8array` of UTF-8 bytes into a string.
-  function from_utf8(utf8: uint8array) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:453-455
-  /// Builds a string from an array of Unicode code points.
-  function from_code_points(unicode: int[]) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:472-474
+  … 4 more lines (re-run with a higher --budget)
 
 references (0):

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
@@ -34,67 +34,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:104-106
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:109-111
-  /// Splits the string by `delimiter` and returns an array of substrings.
-  function split(self, delimiter: string) -> string[]  <builtin>/baml/string.baml:121-123
-  /// Splits the string into lines, recognizing both `\n` and `\r\n` as line
-  function lines(self) -> string[]  <builtin>/baml/string.baml:137-139
-  /// Returns the substring between two **character** offsets `[start, end)`.
-  function substring(self, start: int, end: int) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:155-157
-  /// Replaces the first occurrence of `search` with `replacement`.
-  function replace(self, search: string, replacement: string) -> string  <builtin>/baml/string.baml:160-162
-  /// Returns the **character index** of the first occurrence of `search`, or
-  function index_of(self, search: string) -> int  <builtin>/baml/string.baml:174-176
-  /// Returns the character at the given **codepoint index** as a
-  function char_at(self, index: int) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:192-194
-  /// Returns a new string that repeats `self` the given number of times.
-  function repeat(self, count: int) -> string  <builtin>/baml/string.baml:205-207
-  /// Returns true if the string contains the given `substring`.
-  function matches(self, substring: string) -> bool  <builtin>/baml/string.baml:210-212
-  /// Replaces all occurrences of `search` with `replacement`.
-  function replace_all(self, search: string, replacement: string) -> string  <builtin>/baml/string.baml:215-217
-  /// Returns true if every character is numeric per Unicode (general categories
-  function is_numeric(self) -> bool  <builtin>/baml/string.baml:237-239
-  /// Returns true if every character is a Unicode letter (general category `L`).
-  function is_alphabetic(self) -> bool  <builtin>/baml/string.baml:250-252
-  /// Returns true if every character is alphabetic OR numeric per Unicode.
-  function is_alphanumeric(self) -> bool  <builtin>/baml/string.baml:264-266
-  /// Returns true if every character is uppercase per Unicode (general
-  function is_uppercase(self) -> bool  <builtin>/baml/string.baml:279-281
-  /// Returns true if every character is lowercase per Unicode (general
-  function is_lowercase(self) -> bool  <builtin>/baml/string.baml:292-294
-  /// Returns true if every character is whitespace per Unicode (`White_Space`
-  function is_whitespace(self) -> bool  <builtin>/baml/string.baml:306-308
-  /// Returns true if every character is a control character per Unicode
-  function is_control(self) -> bool  <builtin>/baml/string.baml:318-320
-  /// Returns true if every character is a "graphic" character — that is,
-  function is_graphic(self) -> bool  <builtin>/baml/string.baml:335-337
-  /// Returns true if every character is ASCII (i.e. has a code point in
-  function is_ascii(self) -> bool  <builtin>/baml/string.baml:352-354
-  /// Returns true if every character is an ASCII decimal digit (`0`..=`9`).
-  function is_ascii_numeric(self) -> bool  <builtin>/baml/string.baml:365-367
-  /// Returns true if every character is an ASCII letter (`A`..=`Z` or
-  function is_ascii_alphabetic(self) -> bool  <builtin>/baml/string.baml:371-373
-  /// Returns true if every character is an ASCII letter or digit. Empty
-  function is_ascii_alphanumeric(self) -> bool  <builtin>/baml/string.baml:377-379
-  /// Returns true if every character is an ASCII uppercase letter
-  function is_ascii_uppercase(self) -> bool  <builtin>/baml/string.baml:383-385
-  /// Returns true if every character is an ASCII lowercase letter
-  function is_ascii_lowercase(self) -> bool  <builtin>/baml/string.baml:389-391
-  /// Returns true if every character is ASCII whitespace: space (`\x20`),
-  function is_ascii_whitespace(self) -> bool  <builtin>/baml/string.baml:397-399
-  /// Returns true if every character is an ASCII control character — code
-  function is_ascii_control(self) -> bool  <builtin>/baml/string.baml:403-405
-  /// Returns true if every character is an ASCII "graphic" character —
-  function is_ascii_graphic(self) -> bool  <builtin>/baml/string.baml:410-412
-  /// Returns true if every character is an ASCII hexadecimal digit:
-  function is_ascii_hex(self) -> bool  <builtin>/baml/string.baml:422-424
-  /// Returns the string encoded as a `uint8array` of UTF-8 bytes.
-  function to_utf8(self) -> uint8array  <builtin>/baml/string.baml:437-439
+  … 56 more lines (re-run with a higher --budget)
 
 static_methods:
-  /// Decodes a `uint8array` of UTF-8 bytes into a string.
-  function from_utf8(utf8: uint8array) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:453-455
-  /// Builds a string from an array of Unicode code points.
-  function from_code_points(unicode: int[]) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:472-474
+  … 4 more lines (re-run with a higher --budget)
 
 references (0):

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
@@ -34,67 +34,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:104-106
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:109-111
-  /// Splits the string by `delimiter` and returns an array of substrings.
-  function split(self, delimiter: string) -> string[]  <builtin>/baml/string.baml:121-123
-  /// Splits the string into lines, recognizing both `\n` and `\r\n` as line
-  function lines(self) -> string[]  <builtin>/baml/string.baml:137-139
-  /// Returns the substring between two **character** offsets `[start, end)`.
-  function substring(self, start: int, end: int) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:155-157
-  /// Replaces the first occurrence of `search` with `replacement`.
-  function replace(self, search: string, replacement: string) -> string  <builtin>/baml/string.baml:160-162
-  /// Returns the **character index** of the first occurrence of `search`, or
-  function index_of(self, search: string) -> int  <builtin>/baml/string.baml:174-176
-  /// Returns the character at the given **codepoint index** as a
-  function char_at(self, index: int) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:192-194
-  /// Returns a new string that repeats `self` the given number of times.
-  function repeat(self, count: int) -> string  <builtin>/baml/string.baml:205-207
-  /// Returns true if the string contains the given `substring`.
-  function matches(self, substring: string) -> bool  <builtin>/baml/string.baml:210-212
-  /// Replaces all occurrences of `search` with `replacement`.
-  function replace_all(self, search: string, replacement: string) -> string  <builtin>/baml/string.baml:215-217
-  /// Returns true if every character is numeric per Unicode (general categories
-  function is_numeric(self) -> bool  <builtin>/baml/string.baml:237-239
-  /// Returns true if every character is a Unicode letter (general category `L`).
-  function is_alphabetic(self) -> bool  <builtin>/baml/string.baml:250-252
-  /// Returns true if every character is alphabetic OR numeric per Unicode.
-  function is_alphanumeric(self) -> bool  <builtin>/baml/string.baml:264-266
-  /// Returns true if every character is uppercase per Unicode (general
-  function is_uppercase(self) -> bool  <builtin>/baml/string.baml:279-281
-  /// Returns true if every character is lowercase per Unicode (general
-  function is_lowercase(self) -> bool  <builtin>/baml/string.baml:292-294
-  /// Returns true if every character is whitespace per Unicode (`White_Space`
-  function is_whitespace(self) -> bool  <builtin>/baml/string.baml:306-308
-  /// Returns true if every character is a control character per Unicode
-  function is_control(self) -> bool  <builtin>/baml/string.baml:318-320
-  /// Returns true if every character is a "graphic" character — that is,
-  function is_graphic(self) -> bool  <builtin>/baml/string.baml:335-337
-  /// Returns true if every character is ASCII (i.e. has a code point in
-  function is_ascii(self) -> bool  <builtin>/baml/string.baml:352-354
-  /// Returns true if every character is an ASCII decimal digit (`0`..=`9`).
-  function is_ascii_numeric(self) -> bool  <builtin>/baml/string.baml:365-367
-  /// Returns true if every character is an ASCII letter (`A`..=`Z` or
-  function is_ascii_alphabetic(self) -> bool  <builtin>/baml/string.baml:371-373
-  /// Returns true if every character is an ASCII letter or digit. Empty
-  function is_ascii_alphanumeric(self) -> bool  <builtin>/baml/string.baml:377-379
-  /// Returns true if every character is an ASCII uppercase letter
-  function is_ascii_uppercase(self) -> bool  <builtin>/baml/string.baml:383-385
-  /// Returns true if every character is an ASCII lowercase letter
-  function is_ascii_lowercase(self) -> bool  <builtin>/baml/string.baml:389-391
-  /// Returns true if every character is ASCII whitespace: space (`\x20`),
-  function is_ascii_whitespace(self) -> bool  <builtin>/baml/string.baml:397-399
-  /// Returns true if every character is an ASCII control character — code
-  function is_ascii_control(self) -> bool  <builtin>/baml/string.baml:403-405
-  /// Returns true if every character is an ASCII "graphic" character —
-  function is_ascii_graphic(self) -> bool  <builtin>/baml/string.baml:410-412
-  /// Returns true if every character is an ASCII hexadecimal digit:
-  function is_ascii_hex(self) -> bool  <builtin>/baml/string.baml:422-424
-  /// Returns the string encoded as a `uint8array` of UTF-8 bytes.
-  function to_utf8(self) -> uint8array  <builtin>/baml/string.baml:437-439
+  … 56 more lines (re-run with a higher --budget)
 
 static_methods:
-  /// Decodes a `uint8array` of UTF-8 bytes into a string.
-  function from_utf8(utf8: uint8array) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:453-455
-  /// Builds a string from an array of Unicode code points.
-  function from_code_points(unicode: int[]) -> string throws root.errors.InvalidArgument  <builtin>/baml/string.baml:472-474
+  … 4 more lines (re-run with a higher --budget)
 
 references (0):


### PR DESCRIPTION
## Summary

- Thread the remaining `baml describe --budget` line budget through methods, dependencies, and references after rendering the body.
- Add explicit elision markers for hidden section entries so tight output stays bounded but still discoverable.
- Update describe regression tests and snapshots for the new budget-aware section behavior.

## Root Cause

`write_description` only budgeted the item body. Large follow-on sections, especially builtin `String` methods, bypassed the budget and could produce much larger output than requested.

## Validation

- `cargo fmt --check`
- `cargo nextest run -p baml_cli describe_command_tests --no-fail-fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output formatting only for `baml describe`; behavior change is intentional tighter output under `--budget`, with regression tests and snapshots.
> 
> **Overview**
> **`baml describe --budget`** now applies a single soft line budget across the whole text description, not only the symbol body.
> 
> After the header and body (body rules unchanged, including the fields-only-at-budget-5 guarantee), leftover lines are spent in order on **methods**, **static methods**, **dependencies**, and **references**. Section headers still print so sections stay visible; list entries are whole units (e.g. docstring + signature for a method); overflow is shown as `… N more lines (re-run with a higher --budget)`. **Container** stays fully printed. Body truncation `[INFO]` lines are counted toward the budget.
> 
> Tests and insta snapshots were updated for budget-aware elision (e.g. builtin `String` under default budget).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7c941d655f7f1730296a21cbfaead500316f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `baml describe` command now supports budget-aware output rendering that gracefully truncates method, dependency, and reference sections when limits are reached, displaying an elision marker and prompting users to re-run with a higher `--budget` flag for complete details.

* **Tests**
  * Updated test coverage for describe command budget constraint handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->