### PR TITLE
Add regression test for concat string through println then shell

### DIFF
--- a/baml_language/crates/baml_tests/tests/shell.rs
+++ b/baml_language/crates/baml_tests/tests/shell.rs
@@ -105,7 +105,13 @@ async fn shell_concat_command_survives_println_before_shell() {
             !stdout.is_empty(),
             "{case}: shell stdout should not be silently emptied"
         );
-        assert_eq!(stdout.as_str(), "hello_world\n", "{case}");
+        assert_eq!(
+            stdout
+                .as_str()
+                .trim_end_matches(|c| matches!(c, '\r' | '\n')),
+            "hello_world",
+            "{case}"
+        );
     }
 }
 

--- a/baml_language/crates/baml_tests/tests/shell.rs
+++ b/baml_language/crates/baml_tests/tests/shell.rs
@@ -48,6 +48,68 @@ async fn shell_with_pipe() {
 }
 
 #[tokio::test]
+async fn shell_concat_command_survives_println_before_shell() {
+    let cases = [
+        (
+            "single println",
+            r#"
+            function main() -> string {
+                let cmd = "echo " + "hello_world";
+                baml.io.println("-> " + cmd);
+                baml.sys.shell(cmd, null).stdout.to_string()
+            }
+            "#,
+        ),
+        (
+            "println twice",
+            r#"
+            function main() -> string {
+                let cmd = "echo " + "hello_world";
+                baml.io.println("first -> " + cmd);
+                baml.io.println("second -> " + cmd);
+                baml.sys.shell(cmd, null).stdout.to_string()
+            }
+            "#,
+        ),
+        (
+            "multi-step concat",
+            r#"
+            function main() -> string {
+                let echo = "echo ";
+                let message = "hello_world";
+                let cmd = echo + message;
+                baml.io.println("-> " + cmd);
+                baml.sys.shell(cmd, null).stdout.to_string()
+            }
+            "#,
+        ),
+        (
+            "assigned println result",
+            r#"
+            function main() -> string {
+                let cmd = "echo " + "hello_world";
+                let _ = baml.io.println("-> " + cmd);
+                baml.sys.shell(cmd, null).stdout.to_string()
+            }
+            "#,
+        ),
+    ];
+
+    for (case, source) in cases {
+        let output = baml_test!(source);
+
+        let Ok(BexExternalValue::String(stdout)) = &output.result else {
+            panic!("{case}: expected string stdout, got {:?}", output.result);
+        };
+        assert!(
+            !stdout.is_empty(),
+            "{case}: shell stdout should not be silently emptied"
+        );
+        assert_eq!(stdout.as_str(), "hello_world\n", "{case}");
+    }
+}
+
+#[tokio::test]
 async fn shell_nonexistent_command() {
     let output = baml_test!(
         r#"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The error

Reported failing BAML snippet:

```baml
function main() -> string {
    let cmd = "echo " + "hello_world";
    baml.io.println("-> " + cmd);
    baml.sys.shell(cmd, null).stdout.to_string()
}
```

I could not reproduce the reported silent-empty failure on the current compiler2 implementation. Before changing repository files, I ran the snippet through the `baml_tests` VM harness from a disposable crate outside the repo. Its real output was:

```text
-> echo hello_world
result: Ok(String("hello_world\n"))
```

## Root cause

No current compiler/runtime defect was observed in `baml_language/`. The gap is test coverage: `crates/baml_tests/tests/shell.rs` covered dynamic shell command strings, but did not specifically lock down the sequence where a concat-built command is first consumed by `baml.io.println` and then passed to `baml.sys.shell`.

## The fix

Added a regression test in `baml_language/crates/baml_tests/tests/shell.rs` that executes BAML snippets covering:

- `let cmd = "echo " + "hello_world"`
- `baml.io.println("-> " + cmd)` before `baml.sys.shell(cmd, null)`
- println called twice before shell
- multi-step concat through two `let` bindings
- assigning the `println` result to `_`

Each case asserts that shell stdout is not empty and exactly equals `"hello_world\n"`.

## Verification

Initial reproduction before repository changes:

```text
cargo +1.93.0 run  # from disposable /tmp/baml-concat-shell-repro
-> echo hello_world
result: Ok(String("hello_world\n"))
```

Targeted regression test:

```text
cargo test --package baml_tests shell_concat_command_survives_println_before_shell -- --nocapture
-> echo hello_world
first -> echo hello_world
second -> echo hello_world
-> echo hello_world
-> echo hello_world
test shell_concat_command_survives_println_before_shell ... ok
```

Workspace/test gates run from `baml_language/`:

```text
cargo test --quiet
# exit code 0

cargo test --workspace --lib --exclude bridge_nodejs
# ok; bridge_nodejs documents that forced Rust lib tests cannot link because Node provides napi_* symbols at addon-load time

cargo fmt --all
cargo clippy --all-targets -- -D warnings
# finished successfully
```

Additional setup/checks needed for the full local run:

```text
/home/ubuntu/.local/bin/mise trust /workspace/baml_language
./sdk_tests/crates/typescript_node/setup.sh
cargo test -p sdk_test_python_pydantic2 --lib
# 14 passed
cargo test -p sdk_test_typescript_node --lib
# 15 passed
```

Snapshot status: no snapshot failures occurred during the full `cargo test --quiet` run, so no snapshots were regenerated.

CodeRabbit: not run because `CODERABBIT_API_KEY` is missing from the environment; the CLI could not be authenticated non-interactively.

## Issue Reference
- [ ] This PR fixes/closes #[issue number]

## Changes
Added targeted compiler2 regression coverage for concat-built shell command strings after `baml.io.println` consumption.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in local Linux cloud-agent environment

## Screenshots
Not applicable.

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
No compiler/runtime fix was added because the reported failure did not reproduce on the current compiler2 code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-309bd4c8-7561-4d10-8c01-ac904c69d0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-309bd4c8-7561-4d10-8c01-ac904c69d0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a non-Windows async test verifying shell commands built via string concatenation still execute correctly even if println is called beforehand; asserts execution succeeds and stdout equals the expected trimmed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->