### PR TITLE
feat(sage-backend): Add Qdrant as vector store backend

### DIFF
--- a/fern/01-guide/06-prompt-engineering/rag.mdx
+++ b/fern/01-guide/06-prompt-engineering/rag.mdx
@@ -372,7 +372,7 @@ When you run this code, you'll get the same type of responses as before, but now
 
 ### Using Qdrant as Vector Database
 
-[Qdrant](https://qdrant.tech/) is an open-source vector database you can run locally or in the cloud. Here's how to implement the same RAG pipeline using Qdrant:
+[Qdrant](https://qdrant.tech/) is an open-source vector search engine built for high-performance at massive scale. Here's how to implement the same RAG pipeline using Qdrant:
 
 First, install the required packages:
 

--- a/fern/01-guide/06-prompt-engineering/rag.mdx
+++ b/fern/01-guide/06-prompt-engineering/rag.mdx
@@ -370,4 +370,104 @@ The BAML functions (`RAG` and `RAGWithCitations`) remain exactly the same, demon
 
 When you run this code, you'll get the same type of responses as before, but now you're using a production-ready serverless vector database that can scale automatically based on your usage.
 
+### Using Qdrant as Vector Database
 
+[Qdrant](https://qdrant.tech/) is an open-source vector database you can run locally or in the cloud. Here's how to implement the same RAG pipeline using Qdrant:
+
+First, install the required packages:
+
+```bash
+pip install qdrant-client sentence-transformers
+```
+
+Start a local Qdrant instance with Docker (or use [Qdrant Cloud](https://cloud.qdrant.io/)):
+
+```bash
+docker run -p 6333:6333 qdrant/qdrant
+```
+
+Now, let's modify our Python code to use Qdrant:
+
+```py rag_qdrant.py
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams, PointStruct
+from sentence_transformers import SentenceTransformer
+from baml_client import b
+
+client = QdrantClient(url="http://localhost:6333")
+# For Qdrant Cloud: QdrantClient(url="YOUR_CLUSTER_URL", api_key="YOUR_API_KEY")
+
+class QdrantStore:
+    def __init__(self, collection_name: str):
+        self.collection_name = collection_name
+        self.encoder = SentenceTransformer('all-MiniLM-L6-v2')
+        dimension = self.encoder.get_sentence_embedding_dimension()
+
+        if not client.collection_exists(collection_name):
+            client.create_collection(
+                collection_name=collection_name,
+                vectors_config=VectorParams(size=dimension, distance=Distance.COSINE),
+            )
+
+    def add_documents(self, documents: list[str], ids: list[int] = None):
+        if ids is None:
+            ids = list(range(len(documents)))
+
+        embeddings = self.encoder.encode(documents)
+
+        points = [
+            PointStruct(id=id, vector=emb.tolist(), payload={"text": doc})
+            for id, emb, doc in zip(ids, embeddings, documents)
+        ]
+        client.upsert(collection_name=self.collection_name, points=points)
+
+    def retrieve_context(self, query: str, k: int = 2) -> str:
+        query_embedding = self.encoder.encode(query).tolist()
+
+        results = client.query_points(
+            collection_name=self.collection_name,
+            query=query_embedding,
+            limit=k,
+            with_payload=True,
+        )
+
+        contexts = [hit.payload["text"] for hit in results.points]
+        return "\n".join(contexts)
+
+if __name__ == "__main__":
+    vector_store = QdrantStore("baml-rag-demo")
+
+    documents = [
+        "SpaceX is an American spacecraft manufacturer and space transportation company founded by Elon Musk in 2002.",
+        "Fiji is a country in the South Pacific known for its rugged landscapes, palm-lined beaches, and coral reefs with clear lagoons.",
+        "Dunkirk is a 2017 war film depicting the Dunkirk evacuation of World War II, featuring intense aerial combat scenes with Spitfire aircraft.",
+        "BoundaryML is the company that makes BAML, the best way to get structured outputs with LLMs."
+    ]
+
+    vector_store.add_documents(documents)
+
+    questions = [
+        "What is BAML?",
+        "Which aircraft was featured in Dunkirk?",
+        "When was SpaceX founded?",
+        "Where is Fiji located?",
+        "What is the capital of Fiji?"
+    ]
+
+    for question in questions:
+        context = vector_store.retrieve_context(question)
+        response = b.RAGWithCitations(question, context)
+        print(response)
+        print("-" * 10)
+```
+
+The key differences when using Qdrant are:
+
+1. Documents are stored in Qdrant's persistent storage (local or cloud) instead of in memory
+2. You can run Qdrant locally with Docker at no cost, making it easy to develop and test without an account
+
+Note that you'll need to:
+1. Start a local Qdrant instance (`docker run -p 6333:6333 qdrant/qdrant`) or [create a free Qdrant Cloud cluster](https://cloud.qdrant.io/)
+2. For cloud usage, replace the `QdrantClient` URL and provide your API key
+
+The BAML functions (`RAG` and `RAGWithCitations`) remain exactly the same — BAML cleanly separates prompt engineering from the choice of vector database.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,9 @@ importers:
       '@pinecone-database/pinecone':
         specifier: ^6.1.2
         version: 6.1.2
+      '@qdrant/js-client-rest':
+        specifier: ^1.13.0
+        version: 1.18.0(typescript@5.8.3)
       '@slack/web-api':
         specifier: ^7.9.3
         version: 7.9.3
@@ -5408,6 +5411,16 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@qdrant/js-client-rest@1.18.0':
+    resolution: {integrity: sha512-/0dqX5uV9chC1DnYSnU4gNMrDqse/pt6hHg3Rqqpl5isH7xl1xSNvffjzBoxycDD79luWn7Ho6Rh/61sOs5DNw==}
+    engines: {node: '>=18.17.0', pnpm: '>=8'}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@qdrant/openapi-typescript-fetch@1.2.6':
+    resolution: {integrity: sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==}
+    engines: {node: '>=18.0.0', pnpm: '>=8'}
 
   '@radix-ui/colors@3.0.0':
     resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
@@ -12195,6 +12208,7 @@ packages:
     resolution: {integrity: sha512-Quz3MvAwHxVYNXsOByL7xI5EB2WYOeFswqaHIA3qOK3isRWTxiplBEocmmru6XmxDB2L7jDNYtYA4FyimoAFEw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
+    bundledDependencies: []
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -21416,6 +21430,14 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@qdrant/js-client-rest@1.18.0(typescript@5.8.3)':
+    dependencies:
+      '@qdrant/openapi-typescript-fetch': 1.2.6
+      typescript: 5.8.3
+      undici: 6.25.0
+
+  '@qdrant/openapi-typescript-fetch@1.2.6': {}
 
   '@radix-ui/colors@3.0.0': {}
 

--- a/typescript/apps/sage-backend/app/actions/query.ts
+++ b/typescript/apps/sage-backend/app/actions/query.ts
@@ -3,42 +3,30 @@
 import type { QueryRequest, QueryResponse } from '@baml/sage-interface';
 import { b } from '../../baml_client';
 import { searchPinecone } from '../../lib/pinecone-api';
+import { searchQdrant } from '../../lib/qdrant-api';
+
+const searchDocs = process.env.VECTOR_DB === 'qdrant' ? searchQdrant : searchPinecone;
 
 export async function submitQuery(request: QueryRequest): Promise<QueryResponse> {
-  const docs = await searchPinecone(request.message.text);
-  const pineconeRankedDocs = docs.map((doc) => ({
-    title: doc.title,
-    url: doc.url,
-    body: doc.body,
-  }));
+  const contextDocs = await searchDocs(request.message.text);
 
   const plan = await b.PlanQuery({
     text: request.message.text,
     language_preference: request.message.language_preference,
-    context_docs: pineconeRankedDocs.map((doc) => ({
-      title: doc.title,
-      body: doc.body,
-    })),
+    context_docs: contextDocs.map(({ title, body }) => ({ title, body })),
     prev_messages: request.prev_messages.map((msg) => {
       if (msg.role === 'assistant') {
-        return {
-          role: 'assistant',
-          text: msg.text ?? '',
-        };
+        return { role: 'assistant', text: msg.text ?? '' };
       }
       return msg;
     }),
   });
 
-  // Merge titles from rankedDocs into plan.ranked_docs
-  const relevantDocs = (plan.ranked_docs ?? []).map((planDoc) => {
-    const matchingRankedDoc = pineconeRankedDocs.find((rd) => rd.title === planDoc.title);
-    return {
-      title: planDoc.title,
-      url: matchingRankedDoc?.url ?? '',
-      relevance: planDoc.relevance,
-    };
-  });
+  const relevantDocs = (plan.ranked_docs ?? []).map((planDoc) => ({
+    title: planDoc.title,
+    url: contextDocs.find((d) => d.title === planDoc.title)?.url ?? '',
+    relevance: planDoc.relevance,
+  }));
 
   return {
     session_id: request.session_id,

--- a/typescript/apps/sage-backend/app/actions/query.ts
+++ b/typescript/apps/sage-backend/app/actions/query.ts
@@ -22,11 +22,10 @@ export async function submitQuery(request: QueryRequest): Promise<QueryResponse>
     }),
   });
 
-  const relevantDocs = (plan.ranked_docs ?? []).map((planDoc) => ({
-    title: planDoc.title,
-    url: contextDocs.find((d) => d.title === planDoc.title)?.url ?? '',
-    relevance: planDoc.relevance,
-  }));
+  const relevantDocs = (plan.ranked_docs ?? []).flatMap((planDoc) => {
+    const url = contextDocs.find((d) => d.title === planDoc.title)?.url;
+    return url ? [{ title: planDoc.title, url, relevance: planDoc.relevance }] : [];
+  });
 
   return {
     session_id: request.session_id,

--- a/typescript/apps/sage-backend/lib/corpus.ts
+++ b/typescript/apps/sage-backend/lib/corpus.ts
@@ -91,7 +91,8 @@ export function chunkMarkdown(text: string, maxChunkSize = 3000): string[] {
     }
   }
 
-  return validated.filter((c) => c.length > 50);
+  const nonEmpty = validated.filter((c) => c.trim().length > 0);
+  return nonEmpty.length > 0 ? nonEmpty : [text.trim()].filter(Boolean);
 }
 
 export async function loadCorpusDocs(docsYmlPath: string): Promise<CorpusDocument[]> {

--- a/typescript/apps/sage-backend/lib/corpus.ts
+++ b/typescript/apps/sage-backend/lib/corpus.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'node:fs';
+import { Sema } from 'async-sema';
+import matter from 'gray-matter';
+import OpenAI from 'openai';
+import z from 'zod';
+import { fetchBlogContent } from './external-sitemap';
+import { SitemapGenerator } from './sitemap';
+
+export const EMBEDDING_MODEL = 'text-embedding-3-large';
+
+export const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY ?? '' });
+
+export const CorpusDocumentSchema = z.object({
+  title: z.string(),
+  url: z.string(),
+  body: z.string(),
+  chunkIndex: z.number().optional(),
+});
+
+export type CorpusDocument = z.infer<typeof CorpusDocumentSchema>;
+
+export interface EmbeddingWithMetadata {
+  embedding: number[];
+  document: CorpusDocument;
+}
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export function chunkMarkdown(text: string, maxChunkSize = 3000): string[] {
+  const chunks: string[] = [];
+  const headerRegex = /^#{1,2}\s+.+$/gm;
+  const sections = text.split(headerRegex);
+  const headers = text.match(headerRegex) ?? [];
+
+  for (let i = 0; i < sections.length; i++) {
+    const header = headers[i - 1] ?? '';
+    const content = sections[i].trim();
+    if (!content) continue;
+
+    const sectionText = header ? `${header}\n${content}` : content;
+    if (sectionText.length <= maxChunkSize) {
+      chunks.push(sectionText);
+      continue;
+    }
+
+    let currentChunk = header ? `${header}\n` : '';
+    for (const paragraph of content.split(/\n\s*\n/)) {
+      const trimmed = paragraph.trim();
+      if (!trimmed) continue;
+
+      if ((currentChunk + trimmed).length > maxChunkSize) {
+        if (currentChunk.trim()) chunks.push(currentChunk.trim());
+        currentChunk = trimmed;
+      } else {
+        currentChunk = currentChunk ? `${currentChunk}\n\n${trimmed}` : trimmed;
+      }
+
+      if (currentChunk.length > maxChunkSize) {
+        let sentenceChunk = '';
+        for (const sentence of currentChunk.split(/[.!?]+\s+/)) {
+          if ((sentenceChunk + sentence).length > maxChunkSize) {
+            if (sentenceChunk.trim()) chunks.push(sentenceChunk.trim());
+            sentenceChunk = sentence;
+          } else {
+            sentenceChunk = sentenceChunk ? `${sentenceChunk}. ${sentence}` : sentence;
+          }
+        }
+        currentChunk = sentenceChunk.trim();
+      }
+    }
+    if (currentChunk.trim()) chunks.push(currentChunk.trim());
+  }
+
+  const validated: string[] = [];
+  for (const c of chunks) {
+    if (estimateTokens(c) <= 7000) {
+      validated.push(c);
+    } else {
+      let wordChunk = '';
+      for (const word of c.split(/\s+/)) {
+        if ((wordChunk + word).length > 2500) {
+          if (wordChunk.trim()) validated.push(wordChunk.trim());
+          wordChunk = word;
+        } else {
+          wordChunk = wordChunk ? `${wordChunk} ${word}` : word;
+        }
+      }
+      if (wordChunk.trim()) validated.push(wordChunk.trim());
+    }
+  }
+
+  return validated.filter((c) => c.length > 50);
+}
+
+export async function loadCorpusDocs(docsYmlPath: string): Promise<CorpusDocument[]> {
+  const sem = new Sema(10);
+  const entries = await new SitemapGenerator(docsYmlPath).generateSitemap({ includeBlogPosts: true });
+  console.log(`Loaded ${entries.length} sitemap entries`);
+
+  const fern = entries
+    .filter((e) => e.type === 'fern')
+    .map((e) => ({ title: e.displayTitle, url: e.href, body: matter(readFileSync(e.filepath, 'utf-8')).content }));
+
+  const blog = await Promise.all(
+    entries
+      .filter((e) => e.type === 'blog')
+      .map(async (e) => {
+        try {
+          await sem.acquire();
+          return { title: e.title, url: e.url, body: await fetchBlogContent(e.url) };
+        } finally {
+          sem.release();
+        }
+      }),
+  );
+
+  const other = entries
+    .filter((e) => e.type === 'other')
+    .map((e) => ({ title: e.title, url: e.url, body: e.title }));
+
+  console.log('Loaded corpus docs', { fern: fern.length, blog: blog.length, other: other.length });
+  return [...fern, ...blog, ...other];
+}
+
+export async function embedDocs(docs: CorpusDocument[]): Promise<EmbeddingWithMetadata[]> {
+  const chunked = docs.flatMap((doc) =>
+    chunkMarkdown(doc.body).map((chunk, chunkIndex) => ({ doc, chunk, chunkIndex })),
+  );
+  console.log(`Created ${chunked.length} chunks from ${docs.length} documents`);
+
+  return Promise.all(
+    chunked.map(async ({ doc, chunk, chunkIndex }) => {
+      const tokens = estimateTokens(chunk);
+      if (tokens > 7500) {
+        console.warn(`⚠️  Chunk ${chunkIndex} for ${doc.url}: ~${tokens} tokens`);
+        if (tokens > 8000) chunk = `${chunk.substring(0, 2000)}...`;
+      }
+      const { data } = await openai.embeddings.create({ model: EMBEDDING_MODEL, input: chunk });
+      return { embedding: data[0].embedding, document: { ...doc, body: chunk, chunkIndex } };
+    }),
+  );
+}

--- a/typescript/apps/sage-backend/lib/pinecone-api.ts
+++ b/typescript/apps/sage-backend/lib/pinecone-api.ts
@@ -1,327 +1,52 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { Pinecone } from '@pinecone-database/pinecone';
-import { Sema } from 'async-sema';
-import matter from 'gray-matter';
 import { chunk } from 'lodash';
-import OpenAI from 'openai';
-import z from 'zod';
-import { fetchBlogContent } from './external-sitemap';
-import { type SitemapEntry, SitemapGenerator } from './sitemap';
+import {
+  EMBEDDING_MODEL,
+  CorpusDocumentSchema,
+  embedDocs,
+  loadCorpusDocs,
+  openai,
+} from './corpus';
 
-const EMBEDDING_MODEL = 'text-embedding-3-large';
-const PINECONE_INDEX_NAME =
+export type { CorpusDocument, EmbeddingWithMetadata } from './corpus';
+export { estimateTokens, chunkMarkdown } from './corpus';
+
+const INDEX_NAME =
   process.env.PINECONE_ENV === 'prod' || process.env.PINECONE_ENV === 'production'
     ? 'ask-baml-prod'
     : 'ask-baml-dev';
-console.log('Using pinecone index:', PINECONE_INDEX_NAME);
+console.log('Using Pinecone index:', INDEX_NAME);
 
-const openaiClient = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY ?? '',
-});
+const pineconeIndex = new Pinecone({ apiKey: process.env.PINECONE_API_KEY ?? '' }).Index(INDEX_NAME);
 
-const pineconeClient = new Pinecone({
-  apiKey: process.env.PINECONE_API_KEY ?? '',
-});
+export async function populatePinecone(docsYmlPath: string): Promise<void> {
+  const docs = await loadCorpusDocs(docsYmlPath);
+  const embeddings = await embedDocs(docs);
+  console.log(`Computed embeddings for ${embeddings.length} chunks`);
 
-const pineconeIndex = pineconeClient.Index(PINECONE_INDEX_NAME);
+  console.log('Before stats', await pineconeIndex.describeIndexStats());
+  console.log('Deleted old embeddings', await pineconeIndex.deleteAll());
 
-const CorpusDocumentSchema = z.object({
-  title: z.string(),
-  url: z.string(),
-  body: z.string(),
-  chunkIndex: z.number().optional(),
-});
-
-export type CorpusDocument = z.infer<typeof CorpusDocumentSchema>;
-
-export interface EmbeddingWithMetadata {
-  embedding: number[];
-  document: CorpusDocument;
-}
-
-/**
- * Rough token estimation (1 token ≈ 4 characters for English text)
- */
-export function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
-}
-
-/**
- * Chunk markdown content into smaller pieces for embedding
- */
-export function chunkMarkdown(text: string, maxChunkSize = 3000): string[] {
-  const chunks: string[] = [];
-
-  // First, split by major headers (H1, H2)
-  const headerRegex = /^#{1,2}\s+.+$/gm;
-  const sections = text.split(headerRegex);
-  const headers = text.match(headerRegex) || [];
-
-  for (let i = 0; i < sections.length; i++) {
-    const header = headers[i - 1] || '';
-    const content = sections[i].trim();
-
-    if (!content) continue;
-
-    const sectionText = header ? `${header}\n${content}` : content;
-
-    // If section is small enough, add it directly
-    if (sectionText.length <= maxChunkSize) {
-      chunks.push(sectionText);
-      continue;
-    }
-
-    // If section is too large, split by paragraphs
-    const paragraphs = content.split(/\n\s*\n/);
-    let currentChunk = header ? `${header}\n` : '';
-
-    for (const paragraph of paragraphs) {
-      const trimmedParagraph = paragraph.trim();
-      if (!trimmedParagraph) continue;
-
-      // If adding this paragraph would exceed limit, start new chunk
-      if ((currentChunk + trimmedParagraph).length > maxChunkSize) {
-        if (currentChunk.trim()) {
-          chunks.push(currentChunk.trim());
-        }
-        currentChunk = trimmedParagraph;
-      } else {
-        currentChunk = currentChunk ? `${currentChunk}\n\n${trimmedParagraph}` : trimmedParagraph;
-      }
-
-      // If even a single paragraph is too large, split by sentences
-      if (currentChunk.length > maxChunkSize) {
-        const sentences = currentChunk.split(/[.!?]+\s+/);
-        let sentenceChunk = '';
-
-        for (const sentence of sentences) {
-          if ((sentenceChunk + sentence).length > maxChunkSize) {
-            if (sentenceChunk.trim()) {
-              chunks.push(sentenceChunk.trim());
-            }
-            sentenceChunk = sentence;
-          } else {
-            sentenceChunk = sentenceChunk ? `${sentenceChunk}. ${sentence}` : sentence;
-          }
-        }
-
-        if (sentenceChunk.trim()) {
-          currentChunk = sentenceChunk;
-        } else {
-          currentChunk = '';
-        }
-      }
-    }
-
-    if (currentChunk.trim()) {
-      chunks.push(currentChunk.trim());
-    }
-  }
-
-  // Final validation: ensure no chunk exceeds token limits
-  const validatedChunks: string[] = [];
-  for (const chunk of chunks) {
-    if (estimateTokens(chunk) > 7000) {
-      // Leave some buffer below 8192
-      // Force split by character count as last resort
-      const words = chunk.split(/\s+/);
-      let wordChunk = '';
-
-      for (const word of words) {
-        if ((wordChunk + word).length > 2500) {
-          // Very conservative
-          if (wordChunk.trim()) {
-            validatedChunks.push(wordChunk.trim());
-          }
-          wordChunk = word;
-        } else {
-          wordChunk = wordChunk ? `${wordChunk} ${word}` : word;
-        }
-      }
-
-      if (wordChunk.trim()) {
-        validatedChunks.push(wordChunk.trim());
-      }
-    } else {
-      validatedChunks.push(chunk);
-    }
-  }
-
-  return validatedChunks.filter((chunk) => chunk.length > 50); // Remove very small chunks
-}
-
-/**
- * Generate embeddings for text chunks and prepare for Pinecone upsert
- */
-async function generateEmbeddingsForDocs(docs: CorpusDocument[]): Promise<EmbeddingWithMetadata[]> {
-  const chunkedDocs: {
-    doc: CorpusDocument;
-    chunk: string;
-    chunkIndex: number;
-  }[] = docs.flatMap((doc: CorpusDocument) => {
-    const chunks = chunkMarkdown(doc.body);
-    return chunks.map((chunk, chunkIndex) => ({
-      doc,
-      chunk,
-      chunkIndex,
-    }));
-  });
-
-  console.log(`Created ${chunkedDocs.length} chunks from ${docs.length} documents`);
-
-  // Generate embeddings for all chunks
-  const embeddingsWithMetadata: EmbeddingWithMetadata[] = await Promise.all(
-    chunkedDocs.map(async ({ doc, chunk, chunkIndex }) => {
-      // Validate chunk size before sending to OpenAI
-      const estimatedTokens = estimateTokens(chunk);
-      if (estimatedTokens > 7500) {
-        console.warn(
-          `⚠️  Chunk ${chunkIndex} for ${doc.url} is large: ~${estimatedTokens} tokens (${chunk.length} chars)`,
-        );
-        // Truncate if still too large
-        if (estimatedTokens > 8000) {
-          chunk = `${chunk.substring(0, 2000)}...`;
-          console.warn('✂️  Truncated chunk to avoid API error');
-        }
-      }
-
-      const embeddingResponse = await openaiClient.embeddings.create({
-        model: 'text-embedding-3-large',
-        input: chunk,
-      });
-
-      return {
-        embedding: embeddingResponse.data[0].embedding,
-        document: {
-          url: doc.url,
-          body: chunk,
-          title: doc.title,
-          chunkIndex,
-        },
-      };
-    }),
-  );
-
-  return embeddingsWithMetadata;
-}
-
-/**
- * Upsert embeddings to Pinecone in batches
- */
-async function upsertToPinecone(embeddingsWithMetadata: EmbeddingWithMetadata[]): Promise<void> {
-  // Prepare records for Pinecone using the combined data
-  const records = embeddingsWithMetadata.map(({ embedding, document }) => ({
+  const records = embeddings.map(({ embedding, document }) => ({
     id: `${document.url}::chunk-${document.chunkIndex}`,
     values: embedding,
     metadata: document,
   }));
-
-  // Use lodash chunk to create batches of 100 records
   const batches = chunk(records, 100);
   console.log(`Upserting ${records.length} records in ${batches.length} batches`);
-
-  // Execute all batches in parallel
   await Promise.all(
-    batches.map(async (batch, index) => {
-      await pineconeIndex.upsert(batch);
-      console.log(`Upserted batch ${index + 1}/${batches.length} with ${batch.length} records`);
-    }),
+    batches.map((batch, i) =>
+      pineconeIndex.upsert(batch).then(() => console.log(`Batch ${i + 1}/${batches.length}`)),
+    ),
   );
 
-  console.log(`Successfully upserted all ${records.length} records to Pinecone`);
+  console.log('After stats', await pineconeIndex.describeIndexStats());
+  console.log(`✅ Successfully populated Pinecone with ${embeddings.length} chunks`);
 }
 
-/**
- * Main function to populate Pinecone with documents from sitemap
- */
-export async function populatePinecone(docsYmlPath: string): Promise<void> {
-  const BLOG_FETCH_CONCURRENCY = new Sema(10);
-  const USE_CACHE = { readFromFile: false, writeToFile: false };
-
-  const sitemapEntries = await (async () => {
-    const SITEMAP_CACHE_PATH = './sitemap.json';
-    if (USE_CACHE.readFromFile && existsSync(SITEMAP_CACHE_PATH)) {
-      return JSON.parse(readFileSync(SITEMAP_CACHE_PATH, 'utf-8')) as SitemapEntry[];
-    }
-    const generator = new SitemapGenerator(docsYmlPath);
-    const sitemap = await generator.generateSitemap({
-      includeBlogPosts: true,
-    });
-    if (USE_CACHE.writeToFile) {
-      writeFileSync(SITEMAP_CACHE_PATH, JSON.stringify(sitemap, null, 2));
-    }
-    return sitemap;
-  })();
-  console.log(`Loaded ${sitemapEntries.length} sitemap entries`);
-
-  const fernCorpusDocs = sitemapEntries
-    .filter((entry) => entry.type === 'fern')
-    .map((entry) => ({
-      title: entry.displayTitle,
-      url: entry.href,
-      body: matter(readFileSync(entry.filepath, 'utf-8')).content,
-    }));
-  const blogCorpusDocs = await Promise.all(
-    sitemapEntries
-      .filter((entry) => entry.type === 'blog')
-      .map(async (entry) => {
-        try {
-          await BLOG_FETCH_CONCURRENCY.acquire();
-          return {
-            title: entry.title,
-            url: entry.url,
-            body: await fetchBlogContent(entry.url),
-          };
-        } finally {
-          BLOG_FETCH_CONCURRENCY.release();
-        }
-      }),
-  );
-  const otherCorpusDocs = sitemapEntries
-    .filter((entry) => entry.type === 'other')
-    .map((entry) => ({
-      title: entry.title,
-      url: entry.url,
-      body: entry.title,
-    }));
-  console.log('Loaded corpus documents', {
-    fern: fernCorpusDocs.length,
-    blog: blogCorpusDocs.length,
-    other: otherCorpusDocs.length,
-  });
-
-  const embeddingsWithMetadata = await generateEmbeddingsForDocs([
-    ...fernCorpusDocs,
-    ...blogCorpusDocs,
-    ...otherCorpusDocs,
-  ]);
-  console.log(`Computed embeddings for ${embeddingsWithMetadata.length} chunks`);
-
-  const beforeStats = await pineconeIndex.describeIndexStats();
-  console.log('Before stats', beforeStats);
-  const deleted = await pineconeIndex.deleteAll();
-  console.log('Deleted old embeddings from Pinecone', deleted);
-  await upsertToPinecone(embeddingsWithMetadata);
-  console.log('Upserted new embeddings to Pinecone');
-  const afterStats = await pineconeIndex.describeIndexStats();
-  console.log('After stats', afterStats);
-  console.log(`✅ Successfully populated Pinecone with ${embeddingsWithMetadata.length} chunks`);
-}
-
-/**
- * Search Pinecone for relevant documents using vector similarity
- */
 export async function searchPinecone(query: string) {
-  const results = await pineconeIndex.query({
-    vector: await openaiClient.embeddings
-      .create({
-        model: EMBEDDING_MODEL,
-        input: query,
-      })
-      .then((res) => res.data[0].embedding),
-    topK: 7,
-    includeMetadata: true,
-  });
-  console.info(`Found ${results.matches.length} matches in pinecone for query`);
-  return results.matches.map((match) => CorpusDocumentSchema.parse(match.metadata));
+  const { data } = await openai.embeddings.create({ model: EMBEDDING_MODEL, input: query });
+  const results = await pineconeIndex.query({ vector: data[0].embedding, topK: 7, includeMetadata: true });
+  console.info(`Found ${results.matches.length} matches in Pinecone for query`);
+  return results.matches.map((m) => CorpusDocumentSchema.parse(m.metadata));
 }

--- a/typescript/apps/sage-backend/lib/qdrant-api.ts
+++ b/typescript/apps/sage-backend/lib/qdrant-api.ts
@@ -2,6 +2,7 @@ import { QdrantClient } from '@qdrant/js-client-rest';
 import { chunk } from 'lodash';
 import {
   EMBEDDING_MODEL,
+  type CorpusDocument,
   CorpusDocumentSchema,
   embedDocs,
   loadCorpusDocs,
@@ -48,7 +49,7 @@ export async function populateQdrant(docsYmlPath: string): Promise<void> {
   console.log(`✅ Successfully populated Qdrant with ${embeddings.length} chunks`);
 }
 
-export async function searchQdrant(query: string) {
+export async function searchQdrant(query: string): Promise<CorpusDocument[]> {
   const { data } = await openai.embeddings.create({ model: EMBEDDING_MODEL, input: query });
   const { points } = await qdrant.query(COLLECTION, { query: data[0].embedding, limit: 7, with_payload: true });
   console.info(`Found ${points.length} matches in Qdrant for query`);

--- a/typescript/apps/sage-backend/lib/qdrant-api.ts
+++ b/typescript/apps/sage-backend/lib/qdrant-api.ts
@@ -1,0 +1,56 @@
+import { QdrantClient } from '@qdrant/js-client-rest';
+import { chunk } from 'lodash';
+import {
+  EMBEDDING_MODEL,
+  CorpusDocumentSchema,
+  embedDocs,
+  loadCorpusDocs,
+  openai,
+} from './corpus';
+
+const COLLECTION =
+  process.env.QDRANT_ENV === 'prod' || process.env.QDRANT_ENV === 'production'
+    ? 'ask-baml-prod'
+    : 'ask-baml-dev';
+console.log('Using Qdrant collection:', COLLECTION);
+
+const qdrant = new QdrantClient({
+  url: process.env.QDRANT_URL ?? 'http://localhost:6333',
+  apiKey: process.env.QDRANT_API_KEY,
+});
+
+const VECTOR_SIZE = 3072;
+
+export async function populateQdrant(docsYmlPath: string): Promise<void> {
+  const docs = await loadCorpusDocs(docsYmlPath);
+  const embeddings = await embedDocs(docs);
+  console.log(`Computed embeddings for ${embeddings.length} chunks`);
+
+  const { exists } = await qdrant.collectionExists(COLLECTION);
+  if (exists) await qdrant.deleteCollection(COLLECTION);
+  await qdrant.createCollection(COLLECTION, { vectors: { size: VECTOR_SIZE, distance: 'Cosine' } });
+
+  const points = embeddings.map(({ embedding, document }, id) => ({
+    id,
+    vector: embedding,
+    payload: document as Record<string, unknown>,
+  }));
+  const batches = chunk(points, 100);
+  console.log(`Upserting ${points.length} points in ${batches.length} batches`);
+  await Promise.all(
+    batches.map((batch, i) =>
+      qdrant.upsert(COLLECTION, { wait: true, points: batch }).then(() => console.log(`Batch ${i + 1}/${batches.length}`)),
+    ),
+  );
+
+  const { count } = await qdrant.count(COLLECTION);
+  console.log('After stats', { count });
+  console.log(`✅ Successfully populated Qdrant with ${embeddings.length} chunks`);
+}
+
+export async function searchQdrant(query: string) {
+  const { data } = await openai.embeddings.create({ model: EMBEDDING_MODEL, input: query });
+  const { points } = await qdrant.query(COLLECTION, { query: data[0].embedding, limit: 7, with_payload: true });
+  console.info(`Found ${points.length} matches in Qdrant for query`);
+  return points.map((p) => CorpusDocumentSchema.parse(p.payload));
+}

--- a/typescript/apps/sage-backend/package.json
+++ b/typescript/apps/sage-backend/package.json
@@ -15,6 +15,7 @@
     "@boundaryml/baml-nextjs-plugin": "^0.1.0",
     "@notionhq/client": "^4.0.1",
     "@pinecone-database/pinecone": "^6.1.2",
+    "@qdrant/js-client-rest": "^1.18.0",
     "@slack/web-api": "^7.9.3",
     "async-sema": "^3.1.1",
     "cheerio": "^1.1.2",

--- a/typescript/apps/sage-backend/tools/update-qdrant.ts
+++ b/typescript/apps/sage-backend/tools/update-qdrant.ts
@@ -27,6 +27,10 @@ async function waitForQdrantReady(queries: string[]) {
 }
 
 async function main() {
+  if (!process.argv[2]) {
+    console.error('Usage: tsx update-qdrant.ts <docsYmlPath>');
+    process.exit(1);
+  }
   console.log('Starting Qdrant update...');
   await populateQdrant(process.argv[2]);
   console.log('Qdrant update completed successfully!');

--- a/typescript/apps/sage-backend/tools/update-qdrant.ts
+++ b/typescript/apps/sage-backend/tools/update-qdrant.ts
@@ -1,0 +1,43 @@
+import { populateQdrant, searchQdrant } from '@/lib/qdrant-api';
+import pRetry from 'p-retry';
+
+async function waitForQdrantReady(queries: string[]) {
+  for (const query of queries) {
+    await pRetry(
+      async () => {
+        const results = await searchQdrant(query);
+        if (results.length === 0) {
+          throw new Error('No results found yet');
+        }
+        console.log('Got query results', {
+          query,
+          results: results.map(({ title, url }) => `${title} (${url})`),
+        });
+      },
+      {
+        retries: 30,
+        minTimeout: 2000,
+        factor: 1,
+        onFailedAttempt: (error) => {
+          console.log(`No results yet for "${query}" (attempt ${error.attemptNumber}/30)`);
+        },
+      },
+    );
+  }
+}
+
+async function main() {
+  console.log('Starting Qdrant update...');
+  await populateQdrant(process.argv[2]);
+  console.log('Qdrant update completed successfully!');
+
+  console.log('Testing a few Qdrant queries with retry logic...');
+  await waitForQdrantReady(['dynamic types', 'alias', 'attributes']);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Error updating Qdrant:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Description

This PR adds Qdrant as an alternative to Pinecone for vector search in `typescript/apps/sage-backend`. 

[Qdrant](https://qdrant.tech/) is an open-source vector search engine built for high-performance at massive scale.

Which backend to use is controlled by a new `VECTOR_DB` env (`pinecone` by default, so existing deployments are unaffected).

The content of the new file `typescript/apps/sage-backend/lib/corpus.ts` is from `typescript/apps/sage-backend/lib/pinecone-api.ts` to allow code re-use by both Pinecone and Qdrant.

The PR also updates `fern/01-guide/06-prompt-engineering/rag.mdx`to demonstrate BAML usage with Qdrant.

### Testing

I've unit tested the implementation against a local Qdrant instance.

### Setup

You can run Qdrant with:

```bash
docker run -p 6333:6333 qdrant/qdrant
```

The dashboard is accessible at http://localhost:6333/dashboard