### PR TITLE
feat(stdlib): generic array sort via Comparable/Sortable interfaces

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/comparable.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/comparable.baml
@@ -1,0 +1,174 @@
+/// A total natural ordering for values of the implementing type.
+///
+/// `compare` follows the `sort_by` comparator convention: negative means
+/// `self` orders before `other`, zero preserves relative order, positive
+/// means `self` orders after `other`.
+///
+/// `CmpError` is the error a single comparison may throw. A total order that
+/// never fails binds `type CmpError = never`; a fallible comparator binds
+/// `type CmpError = MyError` and the error propagates to whoever compares (or
+/// sorts) the values.
+///
+/// ```
+/// class Resume {
+///   name string
+///   implements Comparable {
+///     type CmpError = never
+///     function compare(self, other: Self) -> int throws never {
+///       self.name.compare(other.name)
+///     }
+///   }
+/// }
+/// ```
+///
+/// Note: `CmpError` is intentionally *not* defaulted. A defaulted associated
+/// type would be injected into a bare `T extends Comparable` bound as the
+/// concrete default, which then rejects any implementor that overrides it —
+/// so `MyError[].sort()` (a fallible comparator) would stop compiling. Leaving
+/// it undefaulted keeps the `Comparable` bound permissive over `CmpError`.
+interface Comparable {
+  type CmpError
+
+  function compare(self, other: Self) -> int throws CmpError
+}
+
+implements Comparable for int {
+  type CmpError = never
+  function compare(self, other: Self) -> int throws never {
+    if (self < other) { -1 } else if (self > other) { 1 } else { 0 }
+  }
+}
+
+implements Comparable for bigint {
+  type CmpError = never
+  function compare(self, other: Self) -> int throws never {
+    if (self < other) { -1 } else if (self > other) { 1 } else { 0 }
+  }
+}
+
+implements Comparable for string {
+  type CmpError = never
+  function compare(self, other: Self) -> int throws never {
+    if (self < other) { -1 } else if (self > other) { 1 } else { 0 }
+  }
+}
+
+/// Sorting for collections whose elements have a natural order.
+///
+/// Implemented for `T[]` whenever `T implements Comparable`. `SortError` is
+/// the element's `CmpError`: sorting a primitive array (`int[]`, `bigint[]`,
+/// `string[]`, `float[]`) can never fail, and sorting a user type with a
+/// fallible comparator propagates that comparator's error.
+interface Sortable {
+  type SortError
+
+  function sort(self) -> Self throws SortError
+}
+
+implements<T extends Comparable> Sortable for T[] {
+  type SortError = T.CmpError
+
+  /// Sorts this array in place by the elements' natural order
+  /// (`Comparable.compare`), then returns `self`. The sort is stable. If a
+  /// comparison throws mid-sort, the array is left in its pre-sort state
+  /// (`sort_by` only writes back once the whole sort completes; the primitive
+  /// fast path is infallible).
+  ///
+  /// Dispatch: naturally-sortable primitive element types
+  /// (`int`/`bigint`/`string`/`float`, detected by `_is_primitive_array` from
+  /// the first element's runtime tag) take the native `_rust_sort` fast path —
+  /// an in-place natural sort with a pure-Rust comparator, no per-pair BAML
+  /// round trips. Every other `Comparable` element type falls back to
+  /// `sort_by` with a `_compare_shim` comparator.
+  ///
+  /// The fallback goes through `_compare_shim` rather than `a.compare(b)`
+  /// directly: `compare` takes two `Self` params, so it cannot be dispatched
+  /// through an interface-typed value, and the static dispatch from this
+  /// (stdlib) package can only see `Comparable` impls visible here — not
+  /// downstream user classes. `_compare_shim` resolves `compare` on the
+  /// element's runtime class instead.
+  function sort(self) -> Self throws T.CmpError {
+    if (root._is_primitive_array(self)) {
+      root._rust_sort(self)
+    } else {
+      self.sort_by((a: T, b: T) -> int throws T.CmpError { root._compare_shim(a, b) })
+    }
+  }
+}
+
+/// Three-way compares two `Comparable` values by their natural order, resolving
+/// `Comparable.compare` on the values' runtime class.
+///
+/// This is the dispatch shim for the `Sortable` blanket `sort` (above):
+/// `compare`'s two `Self` parameters make it undispatchable through an
+/// interface-typed value (BEP-044), and a static dispatch from this package
+/// cannot enumerate `Comparable` impls defined in downstream packages. Both
+/// arguments must share a runtime type (`sort` only ever feeds it elements of
+/// one array). Internal (the leading underscore is the convention for
+/// non-public stdlib shims); prefer calling `a.compare(b)` directly where the
+/// concrete type is statically known.
+//baml:mut_vm
+//baml:may_yield
+function _compare_shim<T extends Comparable>(a: T, b: T) -> int throws T.CmpError {
+  $rust_function
+}
+
+// Floats order by IEEE 754 `totalOrder` (`f64::total_cmp`): a *total* order
+// over all doubles that places NaN deterministically
+// (`-NaN < -inf < … < -0.0 < +0.0 < … < +inf < +NaN`), so `compare` — and
+// therefore `float[].sort()` — never fails. The comparison is delegated to
+// the native `_float_total_cmp` so it is bit-exact `total_cmp` (the sign of
+// NaN and of zero participate in the order), matching the comparator the
+// native `_rust_sort` fast path uses for the float domain.
+implements Comparable for float {
+  type CmpError = never
+
+  function compare(self, other: Self) -> int throws never {
+    root._float_total_cmp(self, other)
+  }
+}
+
+/// Three-way compares two floats by IEEE 754 `totalOrder` (`f64::total_cmp`).
+///
+/// Internal shim backing `Comparable for float` (above) and kept bit-exact
+/// with the float comparator inside the native `_rust_sort`; not part of the
+/// public `Comparable`/`Sortable` surface.
+function _float_total_cmp(a: float, b: float) -> int throws never {
+  $rust_function
+}
+
+/// Whether `arr` is a homogeneous primitive array (`int`/`bigint`/`string`/
+/// `float`) that the native `_rust_sort` fast path can natural-sort, decided
+/// by the first element's runtime type tag (a `T[]`'s homogeneity plus the
+/// `T extends Comparable` bound at the call sites guarantee the first element
+/// speaks for the whole array). Empty arrays return `true` — the native sort
+/// is a no-op on them. Internal: this is `Sortable.sort`'s dispatch guard. It
+/// tests runtime *values* rather than type arguments for the same reason
+/// `_compare_shim` exists: a BAML-level `is`-test on a `T`-typed value
+/// constant-folds to false, and frame type args are not reliable across every
+/// call path into a blanket impl.
+//baml:vm
+function _is_primitive_array<T extends Comparable>(arr: T[]) -> bool throws never {
+  $rust_function
+}
+
+/// Sorts a primitive array (`int`/`bigint`/`string`/`float`) in place by its
+/// natural order and returns it (the same array object — no copy). Total and
+/// infallible for every supported element type — `float` uses
+/// `f64::total_cmp`, a total order over all doubles including NaN, so it
+/// never throws. Only reached from `Sortable.sort`'s primitive fast path
+/// (guarded by `_is_primitive_array`), where the element type is known to be
+/// one of these — other element types use `sort_by`.
+///
+/// `arr` is typed as a bare generic (`A`, not `T[]` with `T extends
+/// Comparable`): the native-glue codegen passes generic parameters as raw
+/// values, which is what lets the implementation sort the receiver's backing
+/// storage in place and return the receiver itself — a `T[]`-typed parameter
+/// would be deconstructed to a slice and re-allocated on return. The
+/// `may_yield` directive is likewise glue-shaping only (raw receiver + error
+/// channel); the comparator is pure Rust and never yields to BAML.
+//baml:mut_vm
+//baml:may_yield
+function _rust_sort<A>(arr: A) -> A throws never {
+  $rust_function
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/containers.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/containers.baml
@@ -87,23 +87,23 @@ class Array<T> {
     $rust_function
   }
 
-  /// Sorts this array in place using natural ascending order, then returns `self`.
-  ///
-  /// Natural ordering supports ints, floats, bigints, strings, and supported
-  /// int/float or int/bigint mixes. Nulls, NaN, and non-orderable values throw
-  /// `InvalidArgument`.
-  //baml:mut_vm
-  //baml:may_yield
-  //baml:mut_self
-  function sort(self) -> T[] throws root.errors.InvalidArgument {
-    $rust_function
-  }
+  // `sort()` is no longer a method of `Array<T>`: it is provided by the
+  // `Sortable` interface (`baml/comparable.baml`), blanket-implemented for
+  // `T[]` where `T implements Comparable`. This makes `sort()` reject
+  // non-orderable element types at compile time (with a `sort_by` pointer)
+  // and infallible (`throws never`) for `int`/`bigint`/`string`, instead of
+  // the old unconditional `throws InvalidArgument`. `sort_by`/`sort_by_key`
+  // remain here.
 
   /// Sorts this array in place using a comparator, then returns `self`.
   ///
   /// The comparator follows the JavaScript convention: negative means the
   /// first argument sorts before the second, zero preserves relative order, and
   /// positive means it sorts after the second.
+  ///
+  /// Stable: elements the comparator reports as equal keep their relative
+  /// order. If the comparator throws, `self` is left in its pre-sort state —
+  /// the sorted result is written back only once the whole sort completes.
   //baml:mut_vm
   //baml:may_yield
   //baml:mut_self
@@ -111,14 +111,48 @@ class Array<T> {
     $rust_function
   }
 
-  /// Sorts this array in place by keys computed once per element, then returns `self`.
+  /// Sorts this array in place by keys computed once per element, then returns
+  /// `self`.
   ///
-  /// Keys are computed left-to-right and sorted by natural ascending order.
-  //baml:mut_vm
-  //baml:may_yield
+  /// Each key is computed exactly once, left-to-right, and the elements are
+  /// ordered by their keys' natural order (`Comparable.compare`). The sort is
+  /// stable: elements with equal keys keep their relative order. If computing a
+  /// key — or comparing two keys — throws, `self` is left in its pre-sort
+  /// state.
+  ///
+  /// The key type must be `Comparable`; `U.CmpError` (the key's comparison
+  /// error) propagates to the caller alongside the key callback's own `E`. For
+  /// `int`/`bigint`/`string` keys that is `never`, so the only error is `E`.
   //baml:mut_self
-  function sort_by_key<U, E>(self, key: (T) -> U throws E) -> T[] throws E | root.errors.InvalidArgument {
-    $rust_function
+  function sort_by_key<U extends Comparable, E>(self, key: (T) -> U throws E) -> T[] throws E | U.CmpError {
+    let n = self.length();
+    if (n <= 1) { return self; }
+    let items = self.slice(0, n);
+    // Compute each key exactly once, left to right.
+    let keys: U[] = [];
+    for (let x in items) { keys.push(key(x)); }
+    // Stably sort the positions `[0, n)` by their keys. `sort_by` is stable, so
+    // equal keys keep their original relative order with no explicit tie-break.
+    let order: int[] = [];
+    let p = 0;
+    while (p < n) { order.push(p); p += 1; }
+    order.sort_by((i: int, j: int) -> int throws U.CmpError {
+      match (keys.at(i)) {
+        null => 0
+        let ki: U => match (keys.at(j)) {
+          null => 0
+          let kj: U => ki.compare(kj)
+        }
+      }
+    });
+    // Materialize the reordered elements, then write them back in place.
+    let sorted: T[] = [];
+    for (let i in order) {
+      match (items.at(i)) { null => {} let item: T => { sorted.push(item); } }
+    }
+    self.clear();
+    for (let s in sorted) { self.push(s); }
+    return self;
   }
 
   /// Returns a sub-array from index `start` (inclusive) to `end` (exclusive).

--- a/baml_language/crates/baml_builtins2/src/lib.rs
+++ b/baml_language/crates/baml_builtins2/src/lib.rs
@@ -82,6 +82,7 @@ macro_rules! builtin {
 pub const ALL: &[BuiltinFile] = &[
     // --- Root namespace (no ns_* prefix) ---
     builtin!("baml", "containers.baml"),
+    builtin!("baml", "comparable.baml"),
     builtin!("baml", "core.baml"),
     builtin!("baml", "int.baml"),
     builtin!("baml", "bigint.baml"),

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -4,8 +4,14 @@ expression: output
 ---
 class            Bigint                           <builtin>/baml/bigint.baml:26
 class            Bool                             <builtin>/baml/bool.baml:2
+interface        Comparable                       <builtin>/baml/comparable.baml:29
+interface        Sortable                         <builtin>/baml/comparable.baml:62
+function         _compare_shim                    <builtin>/baml/comparable.baml:112
+function         _float_total_cmp                 <builtin>/baml/comparable.baml:136
+function         _is_primitive_array              <builtin>/baml/comparable.baml:151
+function         _rust_sort                       <builtin>/baml/comparable.baml:172
 class            Array                            <builtin>/baml/containers.baml:2
-class            Map                              <builtin>/baml/containers.baml:419
+class            Map                              <builtin>/baml/containers.baml:453
 function         deep_copy                        <builtin>/baml/core.baml:3
 function         deep_equals                      <builtin>/baml/core.baml:9
 class            Float                            <builtin>/baml/float.baml:2

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -1822,7 +1822,24 @@ impl<'db> SemanticIndexBuilder<'db> {
                     && allowed_generic_params
                         .iter()
                         .any(|name| name == &segments[0]);
-                if !is_builtin_error && !is_builtin_class_ref && !is_allowed_generic {
+                // A projection off one of the function's own generic params —
+                // e.g. `T.CmpError` for `<T extends Comparable>`, which parses
+                // as a dotted path at this phase. The concrete error is the
+                // implementor's associated type, resolved at the call site; the
+                // host fn just propagates whatever the dispatched method throws
+                // (the declared `throws` is erased for builtins). Lets
+                // `_compare_shim` declare `throws T.CmpError` instead of an
+                // unconstrained error param that call sites cannot pin.
+                let is_generic_param_projection = segments.len() >= 2
+                    && generic_args.is_empty()
+                    && allowed_generic_params
+                        .iter()
+                        .any(|name| name == &segments[0]);
+                if !is_builtin_error
+                    && !is_builtin_class_ref
+                    && !is_allowed_generic
+                    && !is_generic_param_projection
+                {
                     invalid.push(Self::render_type_expr(type_expr));
                 }
             }
@@ -1831,6 +1848,21 @@ impl<'db> SemanticIndexBuilder<'db> {
                     Self::collect_invalid_builtin_throw_types(ty, allowed_generic_params, invalid);
                 }
             }
+            // A projection off one of the function's own generic params — e.g.
+            // `T.CmpError` for `<T extends Comparable>`. The concrete error is
+            // the implementor's associated type, resolved at the call site; the
+            // host fn just propagates whatever the dispatched method throws (the
+            // declared `throws` is erased for builtins), so this is sound. Lets
+            // `_compare_shim` declare `throws T.CmpError` rather than an
+            // unconstrained error param that call sites cannot pin.
+            ast::TypeExpr::AssociatedTypeProjection { base, .. }
+                if matches!(
+                    base.as_ref(),
+                    ast::TypeExpr::Path { segments, generic_args, .. }
+                        if generic_args.is_empty()
+                            && segments.len() == 1
+                            && allowed_generic_params.iter().any(|name| name == &segments[0])
+                ) => {}
             // `throws never` is the explicit "infallible" marker — always valid.
             ast::TypeExpr::Never { .. } => {}
             _ => invalid.push(Self::render_type_expr(type_expr)),

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1658,6 +1658,14 @@ struct LoweringContext<'db> {
     // access through the interface dispatch machinery.
     generic_param_bounds: FxHashMap<Name, Tir2Ty>,
 
+    // TIR types of the in-scope lambda parameters, by name. TIR does not record
+    // `path_segment_types` for a lambda-parameter receiver (`(a: T) -> a.m()`),
+    // so interface dispatch on such a receiver falls back to this map to learn
+    // its static type — e.g. a bounded type variable whose `extends` bound
+    // names the dispatching interface (`a.compare(b)` where `T extends
+    // Comparable`). Saved/restored across nested lambdas.
+    lambda_param_tir_types: FxHashMap<Name, Tir2Ty>,
+
     // The FileScopeId of the expression body currently being lowered.
     // Updated when descending into lambda bodies (Phase 3+).
     current_scope: FileScopeId,
@@ -2830,6 +2838,7 @@ impl<'db> LoweringContext<'db> {
             call_plans,
             function_coercions,
             generic_param_bounds,
+            lambda_param_tir_types: FxHashMap::default(),
             current_scope: func_scope_id,
             current_metadata_scope: MetadataScope::Body(func_scope_id),
             body: expr_body,
@@ -3050,6 +3059,7 @@ impl<'db> LoweringContext<'db> {
             call_plans,
             function_coercions,
             generic_param_bounds: FxHashMap::default(),
+            lambda_param_tir_types: FxHashMap::default(),
             current_scope: let_scope_id,
             current_metadata_scope: MetadataScope::Body(let_scope_id),
             body: expr_body,
@@ -4216,7 +4226,15 @@ impl<'db> LoweringContext<'db> {
             false,
         );
 
-        // Declare parameter locals _1..=_n.
+        // Declare parameter locals _1..=_n. Lower their annotations with the
+        // enclosing generic params in scope so a parameter typed as an
+        // enclosing type variable (`(a: T) -> ...`) resolves to that variable,
+        // and record the lowered TIR type so interface dispatch on the
+        // parameter can recover its (possibly bounded) static type — TIR does
+        // not surface it via `path_segment_types` for lambda receivers.
+        // Restored after the body (`saved_lambda_param_tir_types` below).
+        let saved_lambda_param_tir_types = self.lambda_param_tir_types.clone();
+        let enclosing_generics = self.enclosing_generic_params();
         for (param_idx, param) in func_def.params.iter().enumerate() {
             let param_ty = match &param.type_expr {
                 Some(spanned_te) => {
@@ -4226,9 +4244,11 @@ impl<'db> LoweringContext<'db> {
                         &spanned_te.expr,
                         pkg_items,
                         &pkg_info.namespace_path,
-                        &[],
+                        &enclosing_generics,
                         &mut diags,
                     );
+                    self.lambda_param_tir_types
+                        .insert(param.name.clone(), tir_ty.clone());
                     self.resolved_aliases.convert(&tir_ty)
                 }
                 None => baml_type::Ty::Null {
@@ -4296,6 +4316,7 @@ impl<'db> LoweringContext<'db> {
         let newly_needed_transitive = std::mem::take(&mut self.transitive_captures_needed);
 
         // Restore parent state.
+        self.lambda_param_tir_types = saved_lambda_param_tir_types;
         self.builder = saved_builder;
         self.body = saved_body;
         self.source_map = saved_source_map;
@@ -6055,6 +6076,16 @@ impl LoweringContext<'_> {
                                 Name::new("Self"),
                                 baml_compiler2_tir::ty::TyAttr::default(),
                             ))
+                        } else {
+                            None
+                        }
+                    })
+                    // A lambda-parameter receiver (`(a: T) -> a.compare(b)`) has
+                    // no `path_segment_types` entry; recover its declared type so
+                    // a method on its (bounded) type variable dispatches.
+                    .or_else(|| {
+                        if segments.len() == 2 {
+                            self.lambda_param_tir_types.get(&segments[0]).cloned()
                         } else {
                             None
                         }
@@ -8686,17 +8717,19 @@ impl<'db> LoweringContext<'db> {
                 method,
             )
         {
+            // A concrete non-class receiver (e.g. `int[]`, `map<string, T>`)
+            // statically pins exactly one implementor of `method` — there is
+            // nothing to discriminate at runtime. Return that single candidate
+            // so dispatch lowers to an unconditional call: this is both an
+            // optimization and a correctness fix, since a container receiver's
+            // `Type` guard (`int[]`) has no representable `IsType` form and
+            // would otherwise always fail and hit the `unreachable` arm.
             let runtime_ty = self.convert_tir_ty_for_runtime(recv_tir_ty);
-            if !resolved.iter().any(|candidate| {
-                matches!(&candidate.guard, InterfaceDispatchGuard::Type(ty) if *ty == runtime_ty)
-                    && candidate.item_ref == item_ref
-            }) {
-                resolved.push(InterfaceMethodCandidate {
-                    guard: InterfaceDispatchGuard::Type(runtime_ty),
-                    item_ref,
-                    frame_seed: CalleeFrameSeed::Static(frame_type_args),
-                });
-            }
+            return vec![InterfaceMethodCandidate {
+                guard: InterfaceDispatchGuard::Type(runtime_ty),
+                item_ref,
+                frame_seed: CalleeFrameSeed::Static(frame_type_args),
+            }];
         }
         resolved
     }
@@ -8728,6 +8761,14 @@ impl<'db> LoweringContext<'db> {
         let bb_join = self.builder.create_block();
         let bb_otherwise = self.builder.create_block();
 
+        // A single candidate means the static receiver type admits exactly one
+        // implementor, so it provably matches at runtime and the guard is
+        // redundant. Skipping it also handles concrete container receivers
+        // (e.g. `int[]` dispatched through a blanket `implements ... for T[]`),
+        // whose `IsType` guard has no representable form and would otherwise
+        // always fail and fall to the `unreachable` arm.
+        let single_candidate = resolved.len() == 1;
+
         let mut next_check = bb_entry;
         for (idx, candidate) in resolved.iter().enumerate() {
             let bb_body = self.builder.create_block();
@@ -8738,12 +8779,16 @@ impl<'db> LoweringContext<'db> {
             };
 
             self.builder.set_current_block(next_check);
-            self.emit_interface_dispatch_guard_branch(
-                recv_local,
-                &candidate.guard,
-                bb_body,
-                bb_next,
-            );
+            if single_candidate {
+                self.builder.goto(bb_body);
+            } else {
+                self.emit_interface_dispatch_guard_branch(
+                    recv_local,
+                    &candidate.guard,
+                    bb_body,
+                    bb_next,
+                );
+            }
             self.builder.set_current_block(bb_body);
             // Seed the callee frame's `type_args` so a dispatched method that
             // reads its enclosing `T` at runtime — e.g. building `Other<T>{}` or
@@ -8971,6 +9016,11 @@ impl<'db> LoweringContext<'db> {
         let bb_join = self.builder.create_block();
         let bb_otherwise = self.builder.create_block();
 
+        // See `emit_method_candidate_switch`: a single candidate provably
+        // matches, so the guard is redundant (and unrepresentable for some
+        // concrete container receiver types).
+        let single_candidate = resolved.len() == 1;
+
         let mut next_check = bb_entry;
         for (idx, candidate) in resolved.iter().enumerate() {
             let bb_body = self.builder.create_block();
@@ -8981,12 +9031,16 @@ impl<'db> LoweringContext<'db> {
             };
 
             self.builder.set_current_block(next_check);
-            self.emit_interface_dispatch_guard_branch(
-                recv_local,
-                &candidate.guard,
-                bb_body,
-                bb_next,
-            );
+            if single_candidate {
+                self.builder.goto(bb_body);
+            } else {
+                self.emit_interface_dispatch_guard_branch(
+                    recv_local,
+                    &candidate.guard,
+                    bb_body,
+                    bb_next,
+                );
+            }
             self.builder.set_current_block(bb_body);
             self.builder.assign(
                 dest.clone(),

--- a/baml_language/crates/baml_compiler2_tir/src/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/associated_projection.rs
@@ -344,7 +344,81 @@ impl<'a, 'db, B: TypeVarBounds + ?Sized> AssociatedProjectionResolver<'a, 'db, B
                 };
                 self.resolve_projection(&bound_projection)
             }),
+            // Primitive / non-class concrete base types (`int`, `string`, …)
+            // can carry out-of-body `implements I for int` blocks, so a
+            // projection like `int.CmpError` must resolve through those rules.
+            // Classes have an in-body path above; this mirrors it for the
+            // builtin types stdlib interfaces are implemented on.
+            other if crate::interfaces::implementation_key_for_ty(other).is_some() => {
+                self.resolve_primitive_projection(other, interface.as_deref(), member)
+            }
             _ => None,
+        }
+    }
+
+    /// Resolve a projection whose base is a primitive / non-class concrete
+    /// type by consulting the out-of-body `implements` rules visible to the
+    /// resolver.
+    fn resolve_primitive_projection(
+        &self,
+        base_ty: &Ty,
+        projected_interface: Option<&Ty>,
+        member: &Name,
+    ) -> Option<Ty> {
+        let candidate_ty = crate::interfaces::implementation_key_for_ty(base_ty)
+            .unwrap_or_else(|| base_ty.clone());
+        let mut matches = Vec::new();
+        for pkg_name in self.candidate_registry_packages() {
+            let registry = crate::interfaces::package_implements_registry(
+                self.db,
+                PackageId::new(self.db, pkg_name),
+            );
+            self.collect_out_of_body_matches_in_registry(
+                registry,
+                &candidate_ty,
+                projected_interface,
+                member,
+                &mut matches,
+            );
+        }
+        let mut unique = Vec::new();
+        for ty in matches {
+            if !unique.contains(&ty) {
+                unique.push(ty);
+            }
+        }
+        if unique.len() == 1 {
+            unique.pop()
+        } else {
+            None
+        }
+    }
+
+    /// Packages whose `implements` registries are visible to this resolver.
+    ///
+    /// Out-of-body impls on primitives live in the package that owns the
+    /// `implements … for int` block — which (per the orphan rule) is either
+    /// the user's own package or the interface's package. With a resolution
+    /// context we know those directly; without one (VM metadata / MIR
+    /// lowering) we fall back to every package in the program.
+    fn candidate_registry_packages(&self) -> Vec<Name> {
+        if let Some(res_ctx) = self.res_ctx {
+            let mut pkgs = vec![res_ctx.own_package_name.clone()];
+            for (name, _) in &res_ctx.dep_interfaces {
+                if !pkgs.contains(name) {
+                    pkgs.push(name.clone());
+                }
+            }
+            pkgs
+        } else {
+            let mut pkgs = Vec::new();
+            for file in baml_compiler2_hir::compiler2_all_files(self.db) {
+                let pkg = baml_compiler2_hir::file_package::file_package(self.db, file).package;
+                if !pkgs.contains(&pkg) {
+                    pkgs.push(pkg);
+                }
+            }
+            pkgs
         }
     }
 
@@ -779,7 +853,26 @@ impl<'a, 'db, B: TypeVarBounds + ?Sized> AssociatedProjectionResolver<'a, 'db, B
             class_args.to_vec(),
             crate::ty::TyAttr::default(),
         );
+        self.collect_out_of_body_matches_in_registry(
+            registry,
+            &candidate_ty,
+            projected_interface,
+            member,
+            matches,
+        );
+    }
 
+    /// Scan one package's out-of-body `implements` rules for a rule whose
+    /// `for` target matches `candidate_ty` and whose interface declares
+    /// `member`, pushing the projected member type into `matches`.
+    fn collect_out_of_body_matches_in_registry(
+        &self,
+        registry: &crate::interfaces::ImplementsRegistry,
+        candidate_ty: &Ty,
+        projected_interface: Option<&Ty>,
+        member: &Name,
+        matches: &mut Vec<Ty>,
+    ) {
         for rule in &registry.interface_impl_rules {
             if !matches!(
                 rule.origin,
@@ -794,7 +887,7 @@ impl<'a, 'db, B: TypeVarBounds + ?Sized> AssociatedProjectionResolver<'a, 'db, B
             let Some(instantiation) = registry.instantiate_rule_for_requested_interface(
                 rule,
                 &requested_iface_ty,
-                Some(&candidate_ty),
+                Some(candidate_ty),
                 self.aliases,
                 |actual, bound| self.type_satisfies_bound(actual, bound),
             ) else {

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -1558,7 +1558,23 @@ pub fn infer_scope_types<'db>(
                                                                     .collect()
                                                             })
                                                             .unwrap_or_default();
-                                                        Ty::Class(qtn, class_args, TyAttr::default())
+                                                        // The builtin `Array<T>` is the array sugar
+                                                        // `T[]` (`Ty::List`), not a nominal class:
+                                                        // type its methods' `self` structurally so a
+                                                        // body that returns `self` (e.g. the in-place
+                                                        // `sort_by`/`sort_by_key`) matches the `T[]`
+                                                        // return type. Members still resolve (a `List`
+                                                        // receiver dispatches to the `Array` builtins).
+                                                        if qtn.is_builtin_root_type("Array")
+                                                            && class_args.len() == 1
+                                                        {
+                                                            Ty::List(
+                                                                Box::new(class_args[0].clone()),
+                                                                TyAttr::default(),
+                                                            )
+                                                        } else {
+                                                            Ty::Class(qtn, class_args, TyAttr::default())
+                                                        }
                                                     }
                                                 }
                                             })

--- a/baml_language/crates/baml_tests/baml_src/ns_arrays/arrays.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_arrays/arrays.baml
@@ -89,46 +89,35 @@ test "array_sort_bigints" {
     assert.is_true(baml.deep_equals(xs, expected))
 }
 
-test "array_sort_mixed_int_float" {
-    let xs: (int | float)[] = [2.5, 1, 2];
+test "array_sort_floats" {
+    let xs = [2.5, 0.5, 1.5];
+    let result = xs.sort();
+    let expected = [0.5, 1.5, 2.5];
+    assert.is_true(result == xs);
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+// PHASE-5 cutover: `sort()` is now the `Sortable` blanket method requiring
+// `T implements Comparable`. The previously-runtime rejections below became
+// compile errors and moved to Rust `assert_compile_error_*` tests in
+// `tests/comparable_sort.rs` (`phase5_*`):
+//   • `(int | float)[].sort()` — unions can't implement `Comparable`
+//   • `(float | bigint)[].sort()` — likewise
+//   • `int?[].sort()` (optional = union)
+//   • `ArraySortItem[].sort()` (class without a `Comparable` impl)
+//   • `(int | string)[].sort()` — rollback now pinned via `sort_by`
+//     (`array_sort_by_callback_throws`)
+// 02-PLAN cutover (reverses the 01b NaN decision): `float` now binds
+// `type CmpError = never` and orders by `f64::total_cmp`, so `float[].sort()`
+// no longer rejects NaN — NaN sorts deterministically after +inf.
+test "array_sort_nan_sorts_last" {
+    let xs = [1.0, float.nan()];
     xs.sort();
-    let expected: (int | float)[] = [1, 2, 2.5];
-    assert.is_true(baml.deep_equals(xs, expected))
-}
-
-test "array_sort_rejects_null" {
-    {
-        let xs: int?[] = [1, null, 2];
-        xs.sort();
-        baml.sys.panic("expected sort to throw")
-    } catch (e) {
-        baml.errors.InvalidArgument => null
+    assert.equal(xs.at(0), 1.0);
+    match (xs.at(1)) {
+        null => assert.is_true(false)
+        let f: float => assert.is_true(f.is_nan())
     }
-}
-
-test "array_sort_rejects_class_instances" {
-    {
-        let xs = [
-            ArraySortItem { key: 2, label: "b", nullable: 2 },
-            ArraySortItem { key: 1, label: "a", nullable: 1 }
-        ];
-        xs.sort();
-        baml.sys.panic("expected sort to throw")
-    } catch (e) {
-        baml.errors.InvalidArgument => null
-    }
-}
-
-test "array_sort_failure_does_not_write_back" {
-    let xs: (int | string)[] = [2, "x", 1];
-    {
-        xs.sort();
-        baml.sys.panic("expected sort to throw")
-    } catch (e) {
-        baml.errors.InvalidArgument => null
-    }
-    let expected: (int | string)[] = [2, "x", 1];
-    assert.is_true(baml.deep_equals(xs, expected))
 }
 
 // ─── sort_by ─────────────────────────────────────────────────────────────────
@@ -246,19 +235,11 @@ test "array_sort_by_key_throw_does_not_write_back" {
     assert.is_true(baml.deep_equals(xs, expected))
 }
 
-test "array_sort_by_key_rejects_nullable_key" {
-    let xs = [3, 1, 2];
-    {
-        xs.sort_by_key((x: int) -> int? {
-            if (x == 1) { null } else { x }
-        });
-        baml.sys.panic("expected sort_by_key to throw")
-    } catch (e) {
-        baml.errors.InvalidArgument => null
-    }
-    let expected = [3, 1, 2];
-    assert.is_true(baml.deep_equals(xs, expected))
-}
+// `sort_by_key` now requires the key type to be `Comparable` (it sorts by the
+// key's natural order, `Comparable.compare`). A nullable key (`int?` = a union)
+// cannot implement `Comparable`, so it is a *compile* error rather than the old
+// runtime `InvalidArgument` — pinned by the Rust test
+// `phase5_sort_by_key_nullable_key_is_compile_error`.
 
 test "array_sort_by_key_returns_self" {
     let xs = [3, 1, 2];

--- a/baml_language/crates/baml_tests/baml_src/ns_arrays/sort_comparable.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_arrays/sort_comparable.baml
@@ -1,0 +1,362 @@
+// Tests for the `Comparable` interface (stdlib `comparable.baml`) and the
+// `Sortable`-based array sort built on top of it.
+//
+// Phase 2 of thoughts/sam-projects/array-sort/01b-option-5-tdd-plan.md
+// (float semantics updated by the 02 follow-up): builtin impls for
+// int/float/bigint/string, `type CmpError = never` for all four — float
+// orders by IEEE 754 totalOrder (`f64::total_cmp`), so NaN has a defined
+// position and `compare` never throws.
+
+// NB on shape: receivers are *annotated* test-block locals and arguments are
+// literals (or inline calls). The annotation widens the receiver's literal
+// type — `(5).compare(3)` would bind `Self` to the literal type `5` and
+// reject `3` — and literal arguments widen into `Self` fine. Arguments must
+// not be test-block locals: a local passed as the `other` argument of a
+// two-`Self` interface method arrives boxed in a `test` block (pre-existing
+// VM quirk, see the user-class section note below) and the comparison op
+// rejects the box. Receiver-position locals unbox fine.
+
+test "comparable_int_compare" {
+    let five: int = 5;
+    let three: int = 3;
+    assert.is_true(five.compare(3) > 0);
+    assert.is_true(three.compare(5) < 0);
+    assert.is_true(three.compare(3) == 0)
+}
+
+test "comparable_string_compare" {
+    // Annotated receivers widen the literal types ("a".compare("b") would
+    // bind `Self` to the literal type "a" and reject "b"); literal arguments
+    // widen into `Self` fine.
+    let a: string = "a";
+    let b: string = "b";
+    let aa: string = "aa";
+    assert.is_true(a.compare("b") < 0);
+    assert.is_true(b.compare("a") > 0);
+    assert.is_true(aa.compare("a") > 0);
+    assert.is_true(a.compare("a") == 0)
+}
+
+test "comparable_bigint_compare" {
+    let one: bigint = 1n;
+    let two: bigint = 2n;
+    assert.is_true(two.compare(1n) > 0);
+    assert.is_true(one.compare(2n) < 0);
+    assert.is_true(two.compare(2n) == 0)
+}
+
+test "comparable_float_compare" {
+    // Same literal-type widening dance as the string test above.
+    let lo: float = 1.5;
+    let hi: float = 2.5;
+    assert.is_true(hi.compare(1.5) > 0);
+    assert.is_true(lo.compare(2.5) < 0);
+    assert.is_true(lo.compare(1.5) == 0)
+}
+
+// DECISION TEST (02-plan Phase 3, reverses the 01b NaN decision): float
+// comparison no longer throws on NaN — `total_cmp` orders NaN after +inf
+// (`… < +inf < +NaN`) and equal to itself.
+test "comparable_float_nan_total_order" {
+    let one: float = 1.0;
+    assert.is_true(one.compare(float.nan()) < 0);
+    assert.is_true(float.nan().compare(1.0) > 0);
+    assert.is_true(float.nan().compare(float.inf()) > 0);
+    assert.is_true(float.nan().compare(float.nan()) == 0)
+}
+
+// ─── user classes opting in ──────────────────────────────────────────────────
+//
+// KNOWN VM BUG (pre-existing, not Comparable-specific): a class instance read
+// back from a *test-block local* stays boxed, and passing a boxed value to a
+// two-`Self`-param interface method (`compare(self, other: Self)`) panics the
+// VM with "unreachable code executed". The same calls work from ordinary
+// functions. Workaround used throughout: construct instances at the call
+// boundary (inline arguments), never via test-block `let`.
+
+// Total-order user type: binds `type CmpError = never` and writes the
+// matching `throws never` (an omitted `throws` is inferred, not `never`, and
+// fails conformance E0120).
+class ComparableScore {
+    points int
+    implements baml.Comparable {
+        type CmpError = never
+        function compare(self, other: Self) -> int throws never {
+            self.points.compare(other.points)
+        }
+    }
+}
+
+test "comparable_user_class_default_cmperror_is_never" {
+    assert.is_true(ComparableScore { points: 9 }.compare(ComparableScore { points: 1 }) > 0);
+    assert.is_true(ComparableScore { points: 1 }.compare(ComparableScore { points: 9 }) < 0);
+    assert.is_true(ComparableScore { points: 1 }.compare(ComparableScore { points: 1 }) == 0)
+}
+
+// Fallible comparator: binds `type CmpError = ComparableCmpError` and throws.
+class ComparableCmpError {
+    message string
+}
+
+class ComparableFlaky {
+    value int?
+    implements baml.Comparable {
+        type CmpError = ComparableCmpError
+
+        function compare(self, other: Self) -> int throws ComparableCmpError {
+            if let a: int = self.value {
+                if let b: int = other.value {
+                    return a.compare(b)
+                }
+            }
+            throw ComparableCmpError { message: "cannot compare null" }
+        }
+    }
+}
+
+// The fallible comparator's happy path: both values present, delegates to
+// the builtin `int.compare` from inside the impl body. The catch value is
+// compared inline (a catch result stored in a test-block `let` stays boxed).
+test "comparable_user_class_fallible_happy_path" {
+    assert.is_true((ComparableFlaky { value: 1 }.compare(ComparableFlaky { value: 2 }) catch (e) {
+        ComparableCmpError => 99
+    }) < 0)
+}
+
+test "comparable_user_class_custom_cmperror_propagates" {
+    let msg = {
+        let v = ComparableFlaky { value: 1 }.compare(ComparableFlaky { value: null });
+        "no throw"
+    } catch (e) {
+        ComparableCmpError => e.message
+    };
+    assert.is_true(msg.matches("cannot compare null"))
+}
+
+// ─── Sortable: `sort` (Phase 3 — new path alongside the old `sort`) ─────────
+//
+// Parity with the Phase 0 `sort()` corpus. These exercise `sort()` on *local*
+// array receivers (`xs.sort()`).
+//
+// NB: these run the sort on a *local* receiver rather than through a
+// `sort_ints(xs)` helper. Passing a test-block `let` local to a function
+// delivers it as `Null` inside the callee — a pre-existing VM quirk of `test`
+// blocks (see the `arrays.baml` header note), unrelated to sort. Param-receiver
+// dispatch itself works in real functions (Rust `phase3_*` tests). The helper
+// functions below are still *declared* (and compile) to pin the `throws never`
+// normalization for parameter receivers at compile time.
+
+function sort_ints(xs: int[]) -> int[] throws never { xs.sort() }
+function sort_strings(xs: string[]) -> string[] throws never { xs.sort() }
+function sort_bigints(xs: bigint[]) -> bigint[] throws never { xs.sort() }
+
+test "sort_ints_in_place_returns_self" {
+    let xs = [3, 1, 2];
+    let result = xs.sort();
+    let expected = [1, 2, 3];
+    assert.is_true(result == xs);
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+test "sort_empty_is_noop" {
+    let xs: int[] = [];
+    let result = xs.sort();
+    let expected: int[] = [];
+    assert.is_true(result == xs);
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+test "sort_duplicates" {
+    let xs = [3, 1, 2, 1, 3];
+    xs.sort();
+    let expected = [1, 1, 2, 3, 3];
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+test "sort_strings_match_sort" {
+    let xs = ["b", "a", "aa"];
+    xs.sort();
+    let expected = ["a", "aa", "b"];
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+test "sort_bigints_match_sort" {
+    let xs = [3n, 1n, 2n];
+    xs.sort();
+    let expected = [1n, 2n, 3n];
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+// float's SortError is `never` (total_cmp decision) — infallible like int.
+function sort_floats(xs: float[]) -> float[] throws never {
+    xs.sort()
+}
+
+test "sort_floats_match_sort" {
+    let xs = [2.5, 0.5, 1.5];
+    xs.sort();
+    let expected = [0.5, 1.5, 2.5];
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+// DECISION TEST (02-plan Phase 3): NaN no longer throws — `total_cmp` is a
+// total order over all doubles, so NaN sorts deterministically after +inf.
+test "sort_floats_nan_sorts_last" {
+    let xs = [1.0, float.nan(), 0.5];
+    xs.sort();
+    assert.is_true(baml.deep_equals(xs.length(), 3));
+    assert.equal(xs.at(0), 0.5);
+    assert.equal(xs.at(1), 1.0);
+    // NaN != NaN under `==`; assert positionally via is_nan.
+    let last = xs.at(2);
+    match (last) {
+        null => assert.is_true(false)
+        let f: float => assert.is_true(f.is_nan())
+    }
+}
+
+// User class with an infallible (`never`) CmpError sorts by its compare —
+// stably, in place, returning self.
+class SortableItem {
+    rank int
+    label string
+    implements baml.Comparable {
+        type CmpError = never
+        function compare(self, other: Self) -> int throws never {
+            self.rank.compare(other.rank)
+        }
+    }
+}
+
+// `sort_items` is declared (and compiles) to pin the `throws never`
+// normalization for an infallible user `Comparable` at compile time; the
+// runtime tests below dispatch on local receivers (see the param-receiver
+// limitation note above).
+function sort_items(xs: SortableItem[]) -> SortableItem[] throws never {
+    xs.sort()
+}
+
+test "sort_user_class_sorts_by_compare" {
+    let xs = [
+        SortableItem { rank: 3, label: "c" },
+        SortableItem { rank: 1, label: "a" },
+        SortableItem { rank: 2, label: "b" }
+    ];
+    let result = xs.sort();
+    assert.is_true(result == xs);
+    let labels = xs.map((x: SortableItem) -> string { x.label });
+    let expected = ["a", "b", "c"];
+    assert.is_true(baml.deep_equals(labels, expected))
+}
+
+test "sort_user_class_is_stable" {
+    let xs = [
+        SortableItem { rank: 2, label: "a" },
+        SortableItem { rank: 1, label: "b" },
+        SortableItem { rank: 2, label: "c" },
+        SortableItem { rank: 1, label: "d" }
+    ];
+    xs.sort();
+    let labels = xs.map((x: SortableItem) -> string { x.label });
+    let expected = ["b", "d", "a", "c"];
+    assert.is_true(baml.deep_equals(labels, expected))
+}
+
+// Fallible comparator (CmpError = ComparableCmpError): the call site must
+// handle it, and a throw mid-sort leaves the array in pre-sort state.
+function sort_flaky(xs: ComparableFlaky[]) -> ComparableFlaky[] throws ComparableCmpError {
+    xs.sort()
+}
+
+test "sort_fallible_comparator_throw_rolls_back" {
+    let xs = [
+        ComparableFlaky { value: 3 },
+        ComparableFlaky { value: null },
+        ComparableFlaky { value: 1 }
+    ];
+    let msg = {
+        sort_flaky(xs);
+        "no throw"
+    } catch (e) {
+        ComparableCmpError => e.message
+    };
+    assert.is_true(msg.matches("cannot compare null"));
+    // rollback: original order intact
+    let vals = xs.map((x: ComparableFlaky) -> int {
+        if let v: int = x.value { v } else { -1 }
+    });
+    let expected = [3, -1, 1];
+    assert.is_true(baml.deep_equals(vals, expected))
+}
+
+test "sort_fallible_comparator_happy_path" {
+    let xs = [
+        ComparableFlaky { value: 3 },
+        ComparableFlaky { value: 1 },
+        ComparableFlaky { value: 2 }
+    ];
+    // No-throw contract: all values present, so the comparator never fails.
+    // Asserted inline — a catch result stored in a test-block `let` stays
+    // boxed (same VM quirk as above) and `== false` would reject the box.
+    assert.is_true(({
+        sort_flaky(xs);
+        false
+    } catch (e) {
+        ComparableCmpError => true
+    }) == false);
+    let vals = xs.map((x: ComparableFlaky) -> int {
+        if let v: int = x.value { v } else { -1 }
+    });
+    let expected = [1, 2, 3];
+    assert.is_true(baml.deep_equals(vals, expected))
+}
+
+// Generic propagation: a function over `U extends Comparable` may call
+// `xs.sort()`, propagating `U.CmpError` symbolically; the test routes
+// through it to pin the runtime instantiation too. The array is built in a
+// wrapper *function* — a test-block local passed to a generic function
+// arrives boxed (the VM quirk above) and the native sort rejects the box.
+function sort_generic<U extends baml.Comparable>(xs: U[]) -> U[] throws U.CmpError {
+    xs.sort()
+}
+
+function run_sort_generic_ints() -> int[] throws never {
+    let xs = [3, 1, 2];
+    sort_generic(xs)
+}
+
+test "sort_generic_propagation" {
+    let result = run_sort_generic_ints();
+    let expected = [1, 2, 3];
+    assert.is_true(baml.deep_equals(result, expected))
+}
+
+// ─── out-of-body `implements baml.Comparable for <class>` ───────────────────
+//
+// The impl methods register under the synthetic `Comparable$for$<class>`
+// name (as spelled at the impl site), in this file's namespace. Pins that
+// `_compare_shim`'s runtime dispatch finds them for class elements — the
+// namespaced complement to the flat-package Rust test
+// (`sort_user_class_with_out_of_body_comparable_impl`).
+class OutOfBodyScore {
+    points int
+}
+
+implements baml.Comparable for OutOfBodyScore {
+    type CmpError = never
+    function compare(self, other: Self) -> int throws never {
+        self.points.compare(other.points)
+    }
+}
+
+test "sort_user_class_out_of_body_impl" {
+    let xs = [
+        OutOfBodyScore { points: 3 },
+        OutOfBodyScore { points: 1 },
+        OutOfBodyScore { points: 2 }
+    ];
+    xs.sort();
+    let pts = xs.map((x: OutOfBodyScore) -> int { x.points });
+    let expected = [1, 2, 3];
+    assert.is_true(baml.deep_equals(pts, expected))
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 140
 ---
 function $init() -> null {
     call $init_let_0
@@ -10,6 +9,9 @@ function $init() -> null {
 }
 
 function $init_test(registry: unknown) -> null {
+    load_var ?1
+    call ?
+    pop 1
     load_var ?1
     call ?
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/arrays.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/arrays.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 140
 ---
 function arrays.$init_test_ns_arrays_arrays(registry: testing.TestCollector) -> null {
     load_var registry
@@ -58,521 +57,813 @@ function arrays.$init_test_ns_arrays_arrays(registry: testing.TestCollector) -> 
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_sort_mixed_int_float"
+    load_const "array_sort_floats"
     make_closure .<lambda($init_test_ns_arrays_arrays, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_sort_rejects_null"
+    load_const "array_sort_nan_sorts_last"
     make_closure .<lambda($init_test_ns_arrays_arrays, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_sort_rejects_class_instances"
+    load_const "array_sort_by_descending"
     make_closure .<lambda($init_test_ns_arrays_arrays, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_sort_failure_does_not_write_back"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 12)>, 0
-    load_const null
-    call testing.TestCollector.register_test
-    pop 1
-    load_var registry
-    load_const "array_sort_by_descending"
+    load_const "array_sort_by_returns_self"
     make_closure .<lambda($init_test_ns_arrays_arrays, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_sort_by_returns_self"
+    load_const "array_sort_by_callback_throws"
     make_closure .<lambda($init_test_ns_arrays_arrays, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_sort_by_callback_throws"
+    load_const "array_sort_by_key_class_field"
     make_closure .<lambda($init_test_ns_arrays_arrays, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_sort_by_key_class_field"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 19)>, 0
-    load_const null
-    call testing.TestCollector.register_test
-    pop 1
-    load_var registry
     load_const "array_sort_by_key_stable"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 22)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_sort_by_key_called_once_per_element"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 25)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_sort_by_key_empty_does_not_call_callback"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 27)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_sort_by_key_callback_throws"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 29)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_sort_by_key_throw_does_not_write_back"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 31)>, 0
-    load_const null
-    call testing.TestCollector.register_test
-    pop 1
-    load_var registry
-    load_const "array_sort_by_key_rejects_nullable_key"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 33)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_sort_by_key_returns_self"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 35)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_simple_double"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 37)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_empty_array"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 39)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_single_element"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 41)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_closure_captures_multiple_variables"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 43)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_callback_throws"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 45)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_callback_in_catch_base_keeps_parameter_scope"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 47)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_map_string_elements"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 49)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_clear_non_empty"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 51)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_clear_already_empty_is_noop"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 52)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_clear_returns_array_after"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 53)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_shift_returns_first_element"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 54)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_shift_modifies_array_in_place"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 55)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_shift_empty_returns_null"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 56)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_shift_repeated_drains_array"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 57)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_unshift_returns_new_length"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 58)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_unshift_inserts_at_front"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 59)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_unshift_empty_array"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 60)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_in_middle"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 61)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_at_zero"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 62)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_at_length_appends"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 63)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_returns_new_length"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 64)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_empty_array_at_zero"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 65)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_negative_throws"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 66)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_insert_past_length_throws"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 67)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_replaces_range"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 68)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_pure_insertion"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 69)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_pure_removal"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 70)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_count_clamped_to_length"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 71)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_at_length_appends"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 72)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_replace_with_longer"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 73)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_negative_start_throws"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 74)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_start_past_length_throws"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 75)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_splice_negative_count_throws"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 76)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_finds_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 77)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_no_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 79)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_empty_is_false"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 81)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_short_circuits"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 83)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_propagates_error"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 85)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_all_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 87)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_one_fails"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 89)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_empty_is_true"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 91)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_short_circuits_on_false"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 93)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_returns_first_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 95)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_returns_null_when_no_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 97)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_empty_is_null"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 99)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_index_returns_first_index"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 101)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_index_returns_null_when_no_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 103)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_short_circuits"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 105)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_returns_last_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 107)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_returns_null_when_no_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 109)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_index_returns_last_index"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 111)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_iterates_back_to_front"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 113)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_empty_is_null"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 115)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_includes_present"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 117)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 113)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_includes_absent"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 118)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 114)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_includes_empty"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 119)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 115)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_includes_strings"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 120)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 116)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_index_of_present"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 121)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 117)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_index_of_first_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 122)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 118)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_index_of_absent"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 123)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 119)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_last_index_of_returns_last_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 124)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 120)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_last_index_of_absent"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 125)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 121)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_sum"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 126)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 122)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_with_nonzero_initial"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 128)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 124)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_empty_returns_initial"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 130)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 126)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_visits_every_element"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 132)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 128)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_concat_strings"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 134)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 130)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_doubles_each_element"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 136)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 132)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_with_empty_inner_arrays"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 138)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 134)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_empty_input"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 140)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 136)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_uneven_inner_lengths"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 142)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 138)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_const null
+    return
+}
+
+function arrays.$init_test_ns_arrays_sort_comparable(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "comparable_int_compare"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "comparable_string_compare"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "comparable_bigint_compare"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "comparable_float_compare"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "comparable_float_nan_total_order"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "comparable_user_class_default_cmperror_is_never"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 5)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "comparable_user_class_fallible_happy_path"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 6)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "comparable_user_class_custom_cmperror_propagates"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 7)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_ints_in_place_returns_self"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 8)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_empty_is_noop"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 9)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_duplicates"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 10)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_strings_match_sort"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 11)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_bigints_match_sort"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 12)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_floats_match_sort"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 13)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_floats_nan_sorts_last"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 14)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_user_class_sorts_by_compare"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 15)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_user_class_is_stable"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 17)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_fallible_comparator_throw_rolls_back"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 19)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_fallible_comparator_happy_path"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 21)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_generic_propagation"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 23)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "sort_user_class_out_of_body_impl"
+    make_closure .<lambda($init_test_ns_arrays_sort_comparable, 24)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_const null
+    return
+}
+
+function arrays.ComparableFlaky$stream.baml.Comparable.compare(self: arrays.ComparableFlaky$stream, other: arrays.ComparableFlaky$stream) -> int {
+    load_var self
+    load_field .0
+    store_var_load_var _3
+    is_type int
+    pop_jump_if_false L0
+    load_var other
+    load_field .0
+    store_var_load_var _6
+    is_type int
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const "cannot compare null"
+    init_instance user.arrays.ComparableCmpError .message
+    throw
+
+  L1:
+    load_var2 3 4
+    call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.ComparableFlaky.baml.Comparable.compare(self: arrays.ComparableFlaky, other: arrays.ComparableFlaky) -> int {
+    load_var self
+    load_field .0
+    store_var_load_var _3
+    is_type int
+    pop_jump_if_false L0
+    load_var other
+    load_field .0
+    store_var_load_var _6
+    is_type int
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const "cannot compare null"
+    init_instance user.arrays.ComparableCmpError .message
+    throw
+
+  L1:
+    load_var2 3 4
+    call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.ComparableScore$stream.baml.Comparable.compare(self: arrays.ComparableScore$stream, other: arrays.ComparableScore$stream) -> int {
+    load_var self
+    load_field .0
+    store_var _3
+    load_var other
+    load_field .0
+    store_var _4
+    load_var2 3 4
+    call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.ComparableScore.baml.Comparable.compare(self: arrays.ComparableScore, other: arrays.ComparableScore) -> int {
+    load_var self
+    load_field .0
+    store_var _3
+    load_var other
+    load_field .0
+    store_var _4
+    load_var2 3 4
+    call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.OutOfBodyScore$stream.baml.Comparable.compare(self: arrays.OutOfBodyScore$stream, other: arrays.OutOfBodyScore$stream) -> int {
+    load_var self
+    load_field .0
+    store_var _3
+    load_var other
+    load_field .0
+    store_var _4
+    load_var2 3 4
+    call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.OutOfBodyScore.baml.Comparable.compare(self: arrays.OutOfBodyScore, other: arrays.OutOfBodyScore) -> int {
+    load_var self
+    load_field .0
+    store_var _3
+    load_var other
+    load_field .0
+    store_var _4
+    load_var2 3 4
+    call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.SortableItem$stream.baml.Comparable.compare(self: arrays.SortableItem$stream, other: arrays.SortableItem$stream) -> int {
+    load_var self
+    load_field .0
+    store_var _3
+    load_var other
+    load_field .0
+    store_var _4
+    load_var2 3 4
+    call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.SortableItem.baml.Comparable.compare(self: arrays.SortableItem, other: arrays.SortableItem) -> int {
+    load_var self
+    load_field .0
+    store_var _3
+    load_var other
+    load_field .0
+    store_var _4
+    load_var2 3 4
+    call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.run_sort_generic_ints() -> int[] {
+    load_type int
+    load_const 3
+    load_const 1
+    load_const 2
+    alloc_array 3
+    call user.arrays.sort_generic
+    return
+}
+
+function arrays.sort_bigints(xs: bigint[]) -> bigint[] {
+    load_type unknown
+    load_var xs
+    call baml.Sortable$for$T[].sort
+    return
+}
+
+function arrays.sort_flaky(xs: arrays.ComparableFlaky[]) -> arrays.ComparableFlaky[] {
+    load_type unknown
+    load_var xs
+    call baml.Sortable$for$T[].sort
+    return
+}
+
+function arrays.sort_floats(xs: float[]) -> float[] {
+    load_type unknown
+    load_var xs
+    call baml.Sortable$for$T[].sort
+    return
+}
+
+function arrays.sort_generic(xs: unknown[]) -> unknown[] {
+    load_type unknown
+    load_var xs
+    call baml.Sortable$for$T[].sort
+    return
+}
+
+function arrays.sort_ints(xs: int[]) -> int[] {
+    load_type unknown
+    load_var xs
+    call baml.Sortable$for$T[].sort
+    return
+}
+
+function arrays.sort_items(xs: arrays.SortableItem[]) -> arrays.SortableItem[] {
+    load_type unknown
+    load_var xs
+    call baml.Sortable$for$T[].sort
+    return
+}
+
+function arrays.sort_strings(xs: string[]) -> string[] {
+    load_type unknown
+    load_var xs
+    call baml.Sortable$for$T[].sort
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
@@ -95,3645 +95,1876 @@ function for_loops.for_loops_c_for_sum_to_ten() -> int {
 }
 
 function for_loops.for_loops_first_even(xs: int[]) -> int {
+    load_type int
     load_var xs
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _2
 
   L0:
-    load_var xs
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var xs
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var xs
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var xs
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var xs
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var xs
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var xs
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var xs
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var xs
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var xs
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var xs
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var xs
-    is_type int[]
-    pop_jump_if_false L49
-    load_type int
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _2
-    jump L24
-
-  L12:
-    load_type int
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _2
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var xs
-    call baml.iter.Peekable.Iterable.iter
-    store_var _2
-    jump L24
-
-  L14:
-    load_var xs
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _2
-    jump L24
-
-  L15:
-    load_var xs
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _2
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Filter.Iterable.iter
-    store_var _2
-    jump L24
-
-  L17:
-    load_var xs
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _2
-    jump L24
-
-  L18:
-    load_type int
-    load_var xs
-    call baml.iter.Repeat.Iterable.iter
-    store_var _2
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Chain.Iterable.iter
-    store_var _2
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var xs
-    call baml.iter.StepBy.Iterable.iter
-    store_var _2
-    jump L24
-
-  L21:
-    load_type int
-    load_var xs
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _2
-    jump L24
-
-  L22:
-    load_var xs
-    call baml.iter.Range.Iterable.iter
-    store_var _2
-    jump L24
-
-  L23:
-    load_var xs
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _2
-
-  L24:
     load_var _2
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _2
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _2
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _2
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _2
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _2
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _2
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _2
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _2
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _2
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _2
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L49
+    pop_jump_if_false L25
     load_type int
     load_type void
     load_var _2
     call baml.iter.Peekable.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L35:
+  L11:
     load_var _2
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L36:
+  L12:
     load_var _2
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _2
     call baml.iter.Filter.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L38:
+  L14:
     load_var _2
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _2
     call baml.iter.Repeat.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _2
     call baml.iter.Chain.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _2
     call baml.iter.StepBy.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _2
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L43:
+  L19:
     load_var _2
     call baml.iter.Range.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L44:
+  L20:
     load_var _2
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _34
+    store_var _4
 
-  L45:
-    load_var _34
+  L21:
+    load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var _34
+  L22:
+    load_var _4
     store_var_load_var x
     load_const 2
     mod_int
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L24
+    pop_jump_if_false L0
     load_var x
-    jump L48
+    jump L24
 
-  L47:
+  L23:
     load_const 1
     unary_op -
 
-  L48:
+  L24:
     return
 
-  L49:
+  L25:
     unreachable
 }
 
 function for_loops.for_loops_for_with_break(xs: int[]) -> int {
     load_const 0
     store_var result
+    load_type int
     load_var xs
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var xs
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var xs
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var xs
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var xs
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var xs
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var xs
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var xs
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var xs
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var xs
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var xs
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var xs
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var xs
-    is_type int[]
-    pop_jump_if_false L49
-    load_type int
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var xs
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var xs
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var xs
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var xs
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var xs
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var xs
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var xs
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var xs
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var xs
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L49
+    pop_jump_if_false L25
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L48
+    pop_jump_if_false L22
+    jump L24
 
-  L46:
-    load_var _35
+  L22:
+    load_var _5
     store_var_load_var x
     load_const 10
     cmp_int_op >
-    pop_jump_if_false L47
-    jump L48
+    pop_jump_if_false L23
+    jump L24
 
-  L47:
+  L23:
     load_var2 2 5
     add_int
     store_var result
-    jump L24
+    jump L0
 
-  L48:
+  L24:
     load_var result
     return
 
-  L49:
+  L25:
     unreachable
 }
 
 function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
     load_const 0
     store_var result
-    load_var xs
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
-
-  L0:
-    load_var xs
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var xs
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var xs
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var xs
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var xs
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var xs
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var xs
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var xs
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var xs
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var xs
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var xs
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var xs
-    is_type int[]
-    pop_jump_if_false L49
     load_type int
     load_var xs
     call baml.iter.Iterable$for$T[].iter
     store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var xs
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var xs
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var xs
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var xs
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var xs
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var xs
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var xs
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var xs
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var xs
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
-    load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
-
-  L25:
-    load_var _3
-    is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
-
-  L26:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
-
-  L27:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
-
-  L28:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
-
-  L29:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
-
-  L30:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
-
-  L31:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
-
-  L32:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
-
-  L33:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
-
-  L34:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L49
-    load_type int
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
-
-  L35:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _35
-    jump L45
-
-  L36:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _35
-    jump L45
-
-  L37:
-    load_type int
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
-
-  L38:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _35
-    jump L45
-
-  L39:
-    load_type int
-    load_var _3
-    call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
-
-  L40:
-    load_type int
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
-
-  L41:
-    load_type int
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
-
-  L42:
-    load_type int
-    load_var _3
-    call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
-
-  L43:
-    load_var _3
-    call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
-
-  L44:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterator.next
-    call_indirect
-    store_var _35
-
-  L45:
-    load_var _35
-    is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L48
-
-  L46:
-    load_var _35
-    store_var_load_var x
-    load_const 10
-    cmp_int_op >
-    pop_jump_if_false L47
-    jump L24
-
-  L47:
-    load_var2 2 5
-    add_int
-    store_var result
-    jump L24
-
-  L48:
-    load_var result
-    return
-
-  L49:
-    unreachable
-}
-
-function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
-    load_var grid
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
 
   L0:
-    load_var grid
-    is_type baml.iter.ArrayIterator<...>
+    load_var _3
+    is_type baml.iter.Flatten<...>
     pop_jump_if_false L1
     jump L20
 
   L1:
-    load_var grid
-    is_type baml.iter.StepBy<...>
+    load_var _3
+    is_type baml.iter.Range
     pop_jump_if_false L2
     jump L19
 
   L2:
-    load_var grid
-    is_type baml.iter.Chain<...>
+    load_var _3
+    is_type baml.iter.ArrayIterator<...>
     pop_jump_if_false L3
     jump L18
 
   L3:
-    load_var grid
-    is_type baml.iter.Repeat<...>
+    load_var _3
+    is_type baml.iter.StepBy<...>
     pop_jump_if_false L4
     jump L17
 
   L4:
-    load_var grid
-    is_type baml.iter.Map<...>
+    load_var _3
+    is_type baml.iter.Chain<...>
     pop_jump_if_false L5
     jump L16
 
   L5:
-    load_var grid
-    is_type baml.iter.Filter<...>
+    load_var _3
+    is_type baml.iter.Repeat<...>
     pop_jump_if_false L6
     jump L15
 
   L6:
-    load_var grid
-    is_type baml.iter.FilterMap<...>
+    load_var _3
+    is_type baml.iter.Map<...>
     pop_jump_if_false L7
     jump L14
 
   L7:
-    load_var grid
-    is_type baml.iter.FlatMap<...>
+    load_var _3
+    is_type baml.iter.Filter<...>
     pop_jump_if_false L8
     jump L13
 
   L8:
-    load_var grid
-    is_type baml.iter.Peekable<...>
+    load_var _3
+    is_type baml.iter.FilterMap<...>
     pop_jump_if_false L9
     jump L12
 
   L9:
-    load_var grid
-    is_type unknown[]
+    load_var _3
+    is_type baml.iter.FlatMap<...>
     pop_jump_if_false L10
     jump L11
 
   L10:
-    load_var grid
-    is_type string[][]
-    pop_jump_if_false L88
-    load_type string[]
-    load_var grid
-    call baml.iter.Iterable$for$T[].iter
-    store_var _2
-    jump L22
+    load_var _3
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L25
+    load_type int
+    load_type void
+    load_var _3
+    call baml.iter.Peekable.Iterator.next
+    store_var _5
+    jump L21
 
   L11:
+    load_var _3
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _5
+    jump L21
+
+  L12:
+    load_var _3
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _5
+    jump L21
+
+  L13:
+    load_type int
+    load_type void
+    load_type void
+    load_var _3
+    call baml.iter.Filter.Iterator.next
+    store_var _5
+    jump L21
+
+  L14:
+    load_var _3
+    make_bound_method baml.iter.Map.Iterator.next
+    call_indirect
+    store_var _5
+    jump L21
+
+  L15:
+    load_type int
+    load_var _3
+    call baml.iter.Repeat.Iterator.next
+    store_var _5
+    jump L21
+
+  L16:
+    load_type int
+    load_type void
+    load_type void
+    load_var _3
+    call baml.iter.Chain.Iterator.next
+    store_var _5
+    jump L21
+
+  L17:
+    load_type int
+    load_type void
+    load_var _3
+    call baml.iter.StepBy.Iterator.next
+    store_var _5
+    jump L21
+
+  L18:
+    load_type int
+    load_var _3
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _5
+    jump L21
+
+  L19:
+    load_var _3
+    call baml.iter.Range.Iterator.next
+    store_var _5
+    jump L21
+
+  L20:
+    load_var _3
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _5
+
+  L21:
+    load_var _5
+    is_type baml.iter.Done
+    pop_jump_if_false L22
+    jump L24
+
+  L22:
+    load_var _5
+    store_var_load_var x
+    load_const 10
+    cmp_int_op >
+    pop_jump_if_false L23
+    jump L0
+
+  L23:
+    load_var2 2 5
+    add_int
+    store_var result
+    jump L0
+
+  L24:
+    load_var result
+    return
+
+  L25:
+    unreachable
+}
+
+function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
     load_type string[]
     load_var grid
     call baml.iter.Iterable$for$T[].iter
     store_var _2
-    jump L22
+
+  L0:
+    load_var _2
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L1
+    jump L18
+
+  L1:
+    load_var _2
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L2
+    jump L17
+
+  L2:
+    load_var _2
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L3
+    jump L16
+
+  L3:
+    load_var _2
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L4
+    jump L15
+
+  L4:
+    load_var _2
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L5
+    jump L14
+
+  L5:
+    load_var _2
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L6
+    jump L13
+
+  L6:
+    load_var _2
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L7
+    jump L12
+
+  L7:
+    load_var _2
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L8
+    jump L11
+
+  L8:
+    load_var _2
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L9
+    jump L10
+
+  L9:
+    load_var _2
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L44
+    load_type string[]
+    load_type void
+    load_var _2
+    call baml.iter.Peekable.Iterator.next
+    store_var _4
+    jump L19
+
+  L10:
+    load_var _2
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _4
+    jump L19
+
+  L11:
+    load_var _2
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _4
+    jump L19
 
   L12:
     load_type string[]
     load_type void
-    load_var grid
-    call baml.iter.Peekable.Iterable.iter
-    store_var _2
-    jump L22
+    load_type void
+    load_var _2
+    call baml.iter.Filter.Iterator.next
+    store_var _4
+    jump L19
 
   L13:
-    load_var grid
-    make_bound_method baml.iter.FlatMap.Iterable.iter
+    load_var _2
+    make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _2
-    jump L22
+    store_var _4
+    jump L19
 
   L14:
-    load_var grid
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _2
-    jump L22
+    load_type string[]
+    load_var _2
+    call baml.iter.Repeat.Iterator.next
+    store_var _4
+    jump L19
 
   L15:
     load_type string[]
     load_type void
     load_type void
-    load_var grid
-    call baml.iter.Filter.Iterable.iter
-    store_var _2
-    jump L22
+    load_var _2
+    call baml.iter.Chain.Iterator.next
+    store_var _4
+    jump L19
 
   L16:
-    load_var grid
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _2
-    jump L22
+    load_type string[]
+    load_type void
+    load_var _2
+    call baml.iter.StepBy.Iterator.next
+    store_var _4
+    jump L19
 
   L17:
     load_type string[]
-    load_var grid
-    call baml.iter.Repeat.Iterable.iter
-    store_var _2
-    jump L22
+    load_var _2
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _4
+    jump L19
 
   L18:
-    load_type string[]
-    load_type void
-    load_type void
-    load_var grid
-    call baml.iter.Chain.Iterable.iter
-    store_var _2
-    jump L22
+    load_var _2
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _4
 
   L19:
-    load_type string[]
-    load_type void
-    load_var grid
-    call baml.iter.StepBy.Iterable.iter
-    store_var _2
-    jump L22
+    load_var _4
+    is_type baml.iter.Done
+    pop_jump_if_false L20
+    jump L42
 
   L20:
-    load_type string[]
-    load_var grid
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _2
-    jump L22
+    load_var _4
+    store_var _34
+    load_type string
+    load_var _34
+    call baml.iter.Iterable$for$T[].iter
+    store_var _35
 
   L21:
-    load_var grid
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _2
-
-  L22:
-    load_var _2
+    load_var _35
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
-
-  L23:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
+    pop_jump_if_false L22
     jump L39
 
-  L24:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
+  L22:
+    load_var _35
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L23
     jump L38
 
-  L25:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
+  L23:
+    load_var _35
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L24
     jump L37
 
-  L26:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
+  L24:
+    load_var _35
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L25
     jump L36
 
-  L27:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L28
+  L25:
+    load_var _35
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L26
     jump L35
 
-  L28:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
+  L26:
+    load_var _35
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L27
     jump L34
 
-  L29:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
+  L27:
+    load_var _35
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L28
     jump L33
 
-  L30:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
+  L28:
+    load_var _35
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L29
     jump L32
 
-  L31:
-    load_var _2
+  L29:
+    load_var _35
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L30
+    jump L31
+
+  L30:
+    load_var _35
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L88
-    load_type string[]
+    pop_jump_if_false L44
+    load_type string
     load_type void
-    load_var _2
+    load_var _35
     call baml.iter.Peekable.Iterator.next
-    store_var _33
-    jump L41
+    store_var _37
+    jump L40
+
+  L31:
+    load_var _35
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _37
+    jump L40
 
   L32:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterator.next
+    load_var _35
+    make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _33
-    jump L41
+    store_var _37
+    jump L40
 
   L33:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _33
-    jump L41
+    load_type string
+    load_type void
+    load_type void
+    load_var _35
+    call baml.iter.Filter.Iterator.next
+    store_var _37
+    jump L40
 
   L34:
-    load_type string[]
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterator.next
-    store_var _33
-    jump L41
+    load_var _35
+    make_bound_method baml.iter.Map.Iterator.next
+    call_indirect
+    store_var _37
+    jump L40
 
   L35:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _33
-    jump L41
+    load_type string
+    load_var _35
+    call baml.iter.Repeat.Iterator.next
+    store_var _37
+    jump L40
 
   L36:
-    load_type string[]
-    load_var _2
-    call baml.iter.Repeat.Iterator.next
-    store_var _33
-    jump L41
+    load_type string
+    load_type void
+    load_type void
+    load_var _35
+    call baml.iter.Chain.Iterator.next
+    store_var _37
+    jump L40
 
   L37:
-    load_type string[]
+    load_type string
     load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterator.next
-    store_var _33
-    jump L41
+    load_var _35
+    call baml.iter.StepBy.Iterator.next
+    store_var _37
+    jump L40
 
   L38:
-    load_type string[]
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterator.next
-    store_var _33
-    jump L41
+    load_type string
+    load_var _35
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _37
+    jump L40
 
   L39:
-    load_type string[]
-    load_var _2
-    call baml.iter.ArrayIterator.Iterator.next
-    store_var _33
-    jump L41
+    load_var _35
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _37
 
   L40:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterator.next
-    call_indirect
-    store_var _33
+    load_var _37
+    is_type baml.iter.Done
+    pop_jump_if_false L41
+    jump L0
 
   L41:
-    load_var _33
-    is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L86
-
-  L42:
-    load_var _33
-    store_var_load_var _63
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L43
-    jump L64
-
-  L43:
-    load_var _63
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L44
-    jump L63
-
-  L44:
-    load_var _63
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L45
-    jump L62
-
-  L45:
-    load_var _63
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L46
-    jump L61
-
-  L46:
-    load_var _63
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L47
-    jump L60
-
-  L47:
-    load_var _63
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L48
-    jump L59
-
-  L48:
-    load_var _63
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L49
-    jump L58
-
-  L49:
-    load_var _63
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L50
-    jump L57
-
-  L50:
-    load_var _63
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L51
-    jump L56
-
-  L51:
-    load_var _63
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L52
-    jump L55
-
-  L52:
-    load_var _63
-    is_type unknown[]
-    pop_jump_if_false L53
-    jump L54
-
-  L53:
-    load_var _63
-    is_type string[]
-    pop_jump_if_false L88
-    load_type string
-    load_var _63
-    call baml.iter.Iterable$for$T[].iter
-    store_var _64
-    jump L65
-
-  L54:
-    load_type string
-    load_var _63
-    call baml.iter.Iterable$for$T[].iter
-    store_var _64
-    jump L65
-
-  L55:
-    load_type string
-    load_type void
-    load_var _63
-    call baml.iter.Peekable.Iterable.iter
-    store_var _64
-    jump L65
-
-  L56:
-    load_var _63
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _64
-    jump L65
-
-  L57:
-    load_var _63
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _64
-    jump L65
-
-  L58:
-    load_type string
-    load_type void
-    load_type void
-    load_var _63
-    call baml.iter.Filter.Iterable.iter
-    store_var _64
-    jump L65
-
-  L59:
-    load_var _63
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _64
-    jump L65
-
-  L60:
-    load_type string
-    load_var _63
-    call baml.iter.Repeat.Iterable.iter
-    store_var _64
-    jump L65
-
-  L61:
-    load_type string
-    load_type void
-    load_type void
-    load_var _63
-    call baml.iter.Chain.Iterable.iter
-    store_var _64
-    jump L65
-
-  L62:
-    load_type string
-    load_type void
-    load_var _63
-    call baml.iter.StepBy.Iterable.iter
-    store_var _64
-    jump L65
-
-  L63:
-    load_type string
-    load_var _63
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _64
-    jump L65
-
-  L64:
-    load_var _63
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _64
-
-  L65:
-    load_var _64
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L66
-    jump L83
-
-  L66:
-    load_var _64
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L67
-    jump L82
-
-  L67:
-    load_var _64
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L68
-    jump L81
-
-  L68:
-    load_var _64
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L69
-    jump L80
-
-  L69:
-    load_var _64
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L70
-    jump L79
-
-  L70:
-    load_var _64
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L71
-    jump L78
-
-  L71:
-    load_var _64
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L72
-    jump L77
-
-  L72:
-    load_var _64
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L73
-    jump L76
-
-  L73:
-    load_var _64
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L74
-    jump L75
-
-  L74:
-    load_var _64
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L88
-    load_type string
-    load_type void
-    load_var _64
-    call baml.iter.Peekable.Iterator.next
-    store_var _95
-    jump L84
-
-  L75:
-    load_var _64
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _95
-    jump L84
-
-  L76:
-    load_var _64
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _95
-    jump L84
-
-  L77:
-    load_type string
-    load_type void
-    load_type void
-    load_var _64
-    call baml.iter.Filter.Iterator.next
-    store_var _95
-    jump L84
-
-  L78:
-    load_var _64
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _95
-    jump L84
-
-  L79:
-    load_type string
-    load_var _64
-    call baml.iter.Repeat.Iterator.next
-    store_var _95
-    jump L84
-
-  L80:
-    load_type string
-    load_type void
-    load_type void
-    load_var _64
-    call baml.iter.Chain.Iterator.next
-    store_var _95
-    jump L84
-
-  L81:
-    load_type string
-    load_type void
-    load_var _64
-    call baml.iter.StepBy.Iterator.next
-    store_var _95
-    jump L84
-
-  L82:
-    load_type string
-    load_var _64
-    call baml.iter.ArrayIterator.Iterator.next
-    store_var _95
-    jump L84
-
-  L83:
-    load_var _64
-    make_bound_method baml.iter.Flatten.Iterator.next
-    call_indirect
-    store_var _95
-
-  L84:
-    load_var _95
-    is_type baml.iter.Done
-    pop_jump_if_false L85
-    jump L22
-
-  L85:
-    load_var _95
+    load_var _37
     load_const ""
     cmp_op ==
-    pop_jump_if_false L65
+    pop_jump_if_false L21
     load_const true
-    jump L87
+    jump L43
 
-  L86:
+  L42:
     load_const false
 
-  L87:
+  L43:
     return
 
-  L88:
+  L44:
     unreachable
 }
 
 function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
     load_const 0
     store_var result
+    load_type int
     load_var arr_a
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var arr_a
-    is_type baml.iter.Range
+    load_var _4
+    is_type baml.iter.Flatten<...>
     pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var arr_a
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var arr_a
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
     jump L20
 
-  L3:
-    load_var arr_a
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
+  L1:
+    load_var _4
+    is_type baml.iter.Range
+    pop_jump_if_false L2
     jump L19
 
-  L4:
-    load_var arr_a
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
+  L2:
+    load_var _4
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L3
     jump L18
 
-  L5:
-    load_var arr_a
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
+  L3:
+    load_var _4
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L4
     jump L17
 
-  L6:
-    load_var arr_a
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
+  L4:
+    load_var _4
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L5
     jump L16
 
-  L7:
-    load_var arr_a
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
+  L5:
+    load_var _4
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L6
     jump L15
 
-  L8:
-    load_var arr_a
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
+  L6:
+    load_var _4
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L7
     jump L14
 
-  L9:
-    load_var arr_a
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
+  L7:
+    load_var _4
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L8
     jump L13
 
-  L10:
-    load_var arr_a
-    is_type unknown[]
-    pop_jump_if_false L11
+  L8:
+    load_var _4
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L9
     jump L12
 
-  L11:
-    load_var arr_a
-    is_type int[]
-    pop_jump_if_false L95
+  L9:
+    load_var _4
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L10
+    jump L11
+
+  L10:
+    load_var _4
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L47
     load_type int
-    load_var arr_a
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L24
+    load_type void
+    load_var _4
+    call baml.iter.Peekable.Iterator.next
+    store_var _6
+    jump L21
+
+  L11:
+    load_var _4
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L21
 
   L12:
-    load_type int
-    load_var arr_a
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L24
+    load_var _4
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L21
 
   L13:
     load_type int
     load_type void
-    load_var arr_a
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L24
+    load_type void
+    load_var _4
+    call baml.iter.Filter.Iterator.next
+    store_var _6
+    jump L21
 
   L14:
-    load_var arr_a
-    make_bound_method baml.iter.FlatMap.Iterable.iter
+    load_var _4
+    make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _4
-    jump L24
+    store_var _6
+    jump L21
 
   L15:
-    load_var arr_a
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
+    load_type int
+    load_var _4
+    call baml.iter.Repeat.Iterator.next
+    store_var _6
+    jump L21
 
   L16:
     load_type int
     load_type void
     load_type void
-    load_var arr_a
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L24
+    load_var _4
+    call baml.iter.Chain.Iterator.next
+    store_var _6
+    jump L21
 
   L17:
-    load_var arr_a
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
+    load_type int
+    load_type void
+    load_var _4
+    call baml.iter.StepBy.Iterator.next
+    store_var _6
+    jump L21
 
   L18:
     load_type int
-    load_var arr_a
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L24
+    load_var _4
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _6
+    jump L21
 
   L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var arr_a
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L24
+    load_var _4
+    call baml.iter.Range.Iterator.next
+    store_var _6
+    jump L21
 
   L20:
-    load_type int
-    load_type void
-    load_var arr_a
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L24
+    load_var _4
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _6
 
   L21:
-    load_type int
-    load_var arr_a
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L24
+    load_var _6
+    is_type baml.iter.Done
+    pop_jump_if_false L22
+    jump L46
 
   L22:
-    load_var arr_a
-    call baml.iter.Range.Iterable.iter
-    store_var _4
-    jump L24
+    load_var _6
+    store_var a
+    load_type int
+    load_var arr_b
+    call baml.iter.Iterable$for$T[].iter
+    store_var _37
 
   L23:
-    load_var arr_a
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L24:
-    load_var _4
+    load_var _37
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
-
-  L25:
-    load_var _4
-    is_type baml.iter.Range
-    pop_jump_if_false L26
+    pop_jump_if_false L24
     jump L43
 
-  L26:
-    load_var _4
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
+  L24:
+    load_var _37
+    is_type baml.iter.Range
+    pop_jump_if_false L25
     jump L42
 
-  L27:
-    load_var _4
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
+  L25:
+    load_var _37
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L26
     jump L41
 
-  L28:
-    load_var _4
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
+  L26:
+    load_var _37
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L27
     jump L40
 
-  L29:
-    load_var _4
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
+  L27:
+    load_var _37
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L28
     jump L39
 
-  L30:
-    load_var _4
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L31
+  L28:
+    load_var _37
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L29
     jump L38
 
-  L31:
-    load_var _4
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
+  L29:
+    load_var _37
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L30
     jump L37
 
-  L32:
-    load_var _4
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
+  L30:
+    load_var _37
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L31
     jump L36
 
-  L33:
-    load_var _4
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
+  L31:
+    load_var _37
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L32
     jump L35
 
-  L34:
-    load_var _4
+  L32:
+    load_var _37
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L33
+    jump L34
+
+  L33:
+    load_var _37
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L95
+    pop_jump_if_false L47
     load_type int
     load_type void
-    load_var _4
+    load_var _37
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L45
+    store_var _39
+    jump L44
 
-  L35:
-    load_var _4
+  L34:
+    load_var _37
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _39
+    jump L44
 
-  L36:
-    load_var _4
+  L35:
+    load_var _37
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _39
+    jump L44
 
-  L37:
+  L36:
     load_type int
     load_type void
     load_type void
-    load_var _4
+    load_var _37
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L45
+    store_var _39
+    jump L44
 
-  L38:
-    load_var _4
+  L37:
+    load_var _37
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _39
+    jump L44
+
+  L38:
+    load_type int
+    load_var _37
+    call baml.iter.Repeat.Iterator.next
+    store_var _39
+    jump L44
 
   L39:
     load_type int
-    load_var _4
-    call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L45
+    load_type void
+    load_type void
+    load_var _37
+    call baml.iter.Chain.Iterator.next
+    store_var _39
+    jump L44
 
   L40:
     load_type int
     load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L45
+    load_var _37
+    call baml.iter.StepBy.Iterator.next
+    store_var _39
+    jump L44
 
   L41:
     load_type int
-    load_type void
-    load_var _4
-    call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L45
+    load_var _37
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _39
+    jump L44
 
   L42:
-    load_type int
-    load_var _4
-    call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L45
+    load_var _37
+    call baml.iter.Range.Iterator.next
+    store_var _39
+    jump L44
 
   L43:
-    load_var _4
-    call baml.iter.Range.Iterator.next
-    store_var _36
-    jump L45
+    load_var _37
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _39
 
   L44:
-    load_var _4
-    make_bound_method baml.iter.Flatten.Iterator.next
-    call_indirect
-    store_var _36
+    load_var _39
+    is_type baml.iter.Done
+    pop_jump_if_false L45
+    jump L0
 
   L45:
-    load_var _36
-    is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L94
-
-  L46:
-    load_var _36
-    store_var a
-    load_var arr_b
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L47
-    jump L70
-
-  L47:
-    load_var arr_b
-    is_type baml.iter.Range
-    pop_jump_if_false L48
-    jump L69
-
-  L48:
-    load_var arr_b
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L49
-    jump L68
-
-  L49:
-    load_var arr_b
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L50
-    jump L67
-
-  L50:
-    load_var arr_b
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L51
-    jump L66
-
-  L51:
-    load_var arr_b
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L52
-    jump L65
-
-  L52:
-    load_var arr_b
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L53
-    jump L64
-
-  L53:
-    load_var arr_b
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L54
-    jump L63
-
-  L54:
-    load_var arr_b
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L55
-    jump L62
-
-  L55:
-    load_var arr_b
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L56
-    jump L61
-
-  L56:
-    load_var arr_b
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L57
-    jump L60
-
-  L57:
-    load_var arr_b
-    is_type unknown[]
-    pop_jump_if_false L58
-    jump L59
-
-  L58:
-    load_var arr_b
-    is_type int[]
-    pop_jump_if_false L95
-    load_type int
-    load_var arr_b
-    call baml.iter.Iterable$for$T[].iter
-    store_var _67
-    jump L71
-
-  L59:
-    load_type int
-    load_var arr_b
-    call baml.iter.Iterable$for$T[].iter
-    store_var _67
-    jump L71
-
-  L60:
-    load_type int
-    load_type void
-    load_var arr_b
-    call baml.iter.Peekable.Iterable.iter
-    store_var _67
-    jump L71
-
-  L61:
-    load_var arr_b
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _67
-    jump L71
-
-  L62:
-    load_var arr_b
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _67
-    jump L71
-
-  L63:
-    load_type int
-    load_type void
-    load_type void
-    load_var arr_b
-    call baml.iter.Filter.Iterable.iter
-    store_var _67
-    jump L71
-
-  L64:
-    load_var arr_b
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _67
-    jump L71
-
-  L65:
-    load_type int
-    load_var arr_b
-    call baml.iter.Repeat.Iterable.iter
-    store_var _67
-    jump L71
-
-  L66:
-    load_type int
-    load_type void
-    load_type void
-    load_var arr_b
-    call baml.iter.Chain.Iterable.iter
-    store_var _67
-    jump L71
-
-  L67:
-    load_type int
-    load_type void
-    load_var arr_b
-    call baml.iter.StepBy.Iterable.iter
-    store_var _67
-    jump L71
-
-  L68:
-    load_type int
-    load_var arr_b
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _67
-    jump L71
-
-  L69:
-    load_var arr_b
-    call baml.iter.Range.Iterable.iter
-    store_var _67
-    jump L71
-
-  L70:
-    load_var arr_b
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _67
-
-  L71:
-    load_var _67
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L72
-    jump L91
-
-  L72:
-    load_var _67
-    is_type baml.iter.Range
-    pop_jump_if_false L73
-    jump L90
-
-  L73:
-    load_var _67
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L74
-    jump L89
-
-  L74:
-    load_var _67
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L75
-    jump L88
-
-  L75:
-    load_var _67
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L76
-    jump L87
-
-  L76:
-    load_var _67
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L77
-    jump L86
-
-  L77:
-    load_var _67
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L78
-    jump L85
-
-  L78:
-    load_var _67
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L79
-    jump L84
-
-  L79:
-    load_var _67
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L80
-    jump L83
-
-  L80:
-    load_var _67
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L81
-    jump L82
-
-  L81:
-    load_var _67
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L95
-    load_type int
-    load_type void
-    load_var _67
-    call baml.iter.Peekable.Iterator.next
-    store_var _99
-    jump L92
-
-  L82:
-    load_var _67
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _99
-    jump L92
-
-  L83:
-    load_var _67
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _99
-    jump L92
-
-  L84:
-    load_type int
-    load_type void
-    load_type void
-    load_var _67
-    call baml.iter.Filter.Iterator.next
-    store_var _99
-    jump L92
-
-  L85:
-    load_var _67
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _99
-    jump L92
-
-  L86:
-    load_type int
-    load_var _67
-    call baml.iter.Repeat.Iterator.next
-    store_var _99
-    jump L92
-
-  L87:
-    load_type int
-    load_type void
-    load_type void
-    load_var _67
-    call baml.iter.Chain.Iterator.next
-    store_var _99
-    jump L92
-
-  L88:
-    load_type int
-    load_type void
-    load_var _67
-    call baml.iter.StepBy.Iterator.next
-    store_var _99
-    jump L92
-
-  L89:
-    load_type int
-    load_var _67
-    call baml.iter.ArrayIterator.Iterator.next
-    store_var _99
-    jump L92
-
-  L90:
-    load_var _67
-    call baml.iter.Range.Iterator.next
-    store_var _99
-    jump L92
-
-  L91:
-    load_var _67
-    make_bound_method baml.iter.Flatten.Iterator.next
-    call_indirect
-    store_var _99
-
-  L92:
-    load_var _99
-    is_type baml.iter.Done
-    pop_jump_if_false L93
-    jump L24
-
-  L93:
     load_var2 3 6
-    load_var _99
+    load_var _39
     mul_int
     add_int
     store_var result
-    jump L71
+    jump L23
 
-  L94:
+  L46:
     load_var result
     return
 
-  L95:
+  L47:
     unreachable
 }
 
 function for_loops.for_loops_render(xs: string[]) -> string {
     load_const ""
     store_var result
+    load_type string
     load_var xs
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var xs
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var xs
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var xs
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var xs
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var xs
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var xs
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var xs
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var xs
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var xs
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var xs
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var xs
-    is_type string[]
-    pop_jump_if_false L46
-    load_type string
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L22
-
-  L11:
-    load_type string
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L22
-
-  L12:
-    load_type string
-    load_type void
-    load_var xs
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L22
-
-  L13:
-    load_var xs
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L14:
-    load_var xs
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L15:
-    load_type string
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L22
-
-  L16:
-    load_var xs
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L17:
-    load_type string
-    load_var xs
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L22
-
-  L18:
-    load_type string
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L22
-
-  L19:
-    load_type string
-    load_type void
-    load_var xs
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L22
-
-  L20:
-    load_type string
-    load_var xs
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L22
-
-  L21:
-    load_var xs
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L22:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L46
+    pop_jump_if_false L24
     load_type string
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L32:
+  L10:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L33:
+  L11:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L34:
+  L12:
     load_type string
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L35:
+  L13:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L36:
+  L14:
     load_type string
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L37:
+  L15:
     load_type string
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L38:
+  L16:
     load_type string
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L39:
+  L17:
     load_type string
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L40:
+  L18:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _34
+    store_var _5
 
-  L41:
-    load_var _34
+  L19:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L45
+    pop_jump_if_false L20
+    jump L23
 
-  L42:
-    load_var _34
+  L20:
+    load_var _5
     store_var_load_var x
     load_const ""
     cmp_op ==
-    pop_jump_if_false L43
-    jump L44
+    pop_jump_if_false L21
+    jump L22
 
-  L43:
+  L21:
     load_var2 2 5
     bin_op +
     store_var result
-    jump L22
+    jump L0
 
-  L44:
+  L22:
     load_var result
     load_const "."
     bin_op +
     store_var result
-    jump L22
+    jump L0
 
-  L45:
+  L23:
     load_var result
     return
 
-  L46:
+  L24:
     unreachable
 }
 
 function for_loops.for_loops_sum(xs: int[]) -> int {
     load_const 0
     store_var result
+    load_type int
     load_var xs
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var xs
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var xs
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var xs
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var xs
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var xs
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var xs
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var xs
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var xs
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var xs
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var xs
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var xs
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var xs
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var xs
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var xs
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var xs
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var xs
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var xs
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var xs
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var xs
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var xs
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var xs
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var xs
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var xs
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
+  L22:
     load_var2 2 4
     add_int
     store_var result
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var result
     return
 
-  L48:
+  L24:
     unreachable
 }
 
 function for_loops.for_loops_sum_let_var() -> int {
     load_const 0
     store_var sum
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _3
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L24
-
-  L12:
-    load_type int
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L24
-
-  L14:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L15:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L24
-
-  L17:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L18:
-    load_type int
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L24
-
-  L21:
-    load_type int
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L24
-
-  L22:
-    load_var _3
-    call baml.iter.Range.Iterable.iter
-    store_var _4
-    jump L24
-
-  L23:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L24:
     load_var _4
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _4
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _4
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _4
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _4
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _4
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _4
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _4
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _4
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _4
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _4
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _4
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L35:
+  L11:
     load_var _4
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L36:
+  L12:
     load_var _4
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _4
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L38:
+  L14:
     load_var _4
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _4
     call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L43:
+  L19:
     load_var _4
     call baml.iter.Range.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L44:
+  L20:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _36
+    store_var _6
 
-  L45:
-    load_var _36
+  L21:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var2 1 4
+  L22:
+    load_var2 1 3
     add_int
     store_var sum
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var sum
     return
 
-  L48:
+  L24:
     unreachable
 }
 
 function for_loops.for_loops_sum_let_var_no_parens() -> int {
     load_const 0
     store_var sum
+    load_type int
     load_const 10
     load_const 20
     load_const 30
     alloc_array 3
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _3
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L24
-
-  L12:
-    load_type int
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L24
-
-  L14:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L15:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L24
-
-  L17:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L18:
-    load_type int
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L24
-
-  L21:
-    load_type int
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L24
-
-  L22:
-    load_var _3
-    call baml.iter.Range.Iterable.iter
-    store_var _4
-    jump L24
-
-  L23:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L24:
     load_var _4
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _4
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _4
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _4
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _4
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _4
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _4
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _4
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _4
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _4
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _4
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _4
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L35:
+  L11:
     load_var _4
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L36:
+  L12:
     load_var _4
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _4
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L38:
+  L14:
     load_var _4
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _4
     call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L43:
+  L19:
     load_var _4
     call baml.iter.Range.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L44:
+  L20:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _36
+    store_var _6
 
-  L45:
-    load_var _36
+  L21:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var2 1 4
+  L22:
+    load_var2 1 3
     add_int
     store_var sum
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var sum
     return
 
-  L48:
+  L24:
     unreachable
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/iter.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/iter.snap
@@ -2365,322 +2365,155 @@ function iter.iter_array_for_each() -> int[] {
 }
 
 function iter.iter_array_iter() -> int[] {
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
-
-  L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L46
-    load_type int
-    load_var _2
     call baml.iter.Iterable$for$T[].iter
     store_var _1
-    jump L24
+    load_var _1
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L0
+    jump L19
+
+  L0:
+    load_var _1
+    is_type baml.iter.Range
+    pop_jump_if_false L1
+    jump L18
+
+  L1:
+    load_var _1
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L2
+    jump L17
+
+  L2:
+    load_var _1
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L3
+    jump L16
+
+  L3:
+    load_var _1
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L4
+    jump L15
+
+  L4:
+    load_var _1
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L5
+    jump L14
+
+  L5:
+    load_var _1
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L6
+    jump L13
+
+  L6:
+    load_var _1
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L7
+    jump L12
+
+  L7:
+    load_var _1
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L8
+    jump L11
+
+  L8:
+    load_var _1
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L9
+    jump L10
+
+  L9:
+    load_var _1
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L21
+    load_type int
+    load_type void
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
+
+  L10:
+    load_type int
+    load_type void
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
+
+  L11:
+    load_type int
+    load_type void
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
 
   L12:
     load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _1
-    jump L24
+    load_type void
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
 
   L13:
     load_type int
     load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _1
-    jump L24
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
 
   L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _1
-    jump L24
+    load_type int
+    load_type void
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
 
   L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _1
-    jump L24
+    load_type int
+    load_type void
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
 
   L16:
     load_type int
     load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _1
-    jump L24
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
 
   L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _1
-    jump L24
+    load_type int
+    load_type void
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
 
   L18:
     load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _1
-    jump L24
+    load_type void
+    load_var _1
+    call baml.iter.Iterator.collect
+    jump L20
 
   L19:
     load_type int
     load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _1
-    jump L24
+    load_var _1
+    call baml.iter.Iterator.collect
 
   L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _1
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _1
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _1
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _1
-
-  L24:
-    load_var _1
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
-
-  L25:
-    load_var _1
-    is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
-
-  L26:
-    load_var _1
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
-
-  L27:
-    load_var _1
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
-
-  L28:
-    load_var _1
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
-
-  L29:
-    load_var _1
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
-
-  L30:
-    load_var _1
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
-
-  L31:
-    load_var _1
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
-
-  L32:
-    load_var _1
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
-
-  L33:
-    load_var _1
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
-
-  L34:
-    load_var _1
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L46
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L35:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L36:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L37:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L38:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L39:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L40:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L41:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L42:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L43:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-    jump L45
-
-  L44:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Iterator.collect
-
-  L45:
     return
 
-  L46:
+  L21:
     unreachable
 }
 
@@ -6260,991 +6093,520 @@ function iter.iter_for_in_array_iterator() -> int[] {
 function iter.iter_for_in_array_literal() -> int[] {
     alloc_array 0
     store_var out
+    load_type int
     load_const 10
     load_const 12
     alloc_array 2
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var2 1 4
+  L22:
+    load_var2 1 3
     call baml.Array.push
     pop 1
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var out
     return
 
-  L48:
+  L24:
     unreachable
 }
 
 function iter.iter_for_in_array_of_classes() -> int {
     load_const 0
     store_var total
+    load_type iter.IterLoopBox
     load_const 3
     init_instance user.iter.IterLoopBox .value
     load_const 8
     init_instance user.iter.IterLoopBox .value
     alloc_array 2
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _5
 
   L0:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _2
-    is_type iter.IterLoopBox[]
-    pop_jump_if_false L44
-    load_type iter.IterLoopBox
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L22
-
-  L11:
-    load_type iter.IterLoopBox
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L22
-
-  L12:
-    load_type iter.IterLoopBox
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _5
-    jump L22
-
-  L13:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L15:
-    load_type iter.IterLoopBox
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _5
-    jump L22
-
-  L16:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L17:
-    load_type iter.IterLoopBox
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _5
-    jump L22
-
-  L18:
-    load_type iter.IterLoopBox
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _5
-    jump L22
-
-  L19:
-    load_type iter.IterLoopBox
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _5
-    jump L22
-
-  L20:
-    load_type iter.IterLoopBox
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _5
-    jump L22
-
-  L21:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _5
-
-  L22:
     load_var _5
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _5
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _5
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _5
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _5
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _5
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _5
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _5
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _5
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _5
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type iter.IterLoopBox
     load_type void
     load_var _5
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L32:
+  L10:
     load_var _5
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L33:
+  L11:
     load_var _5
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L34:
+  L12:
     load_type iter.IterLoopBox
     load_type void
     load_type void
     load_var _5
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L35:
+  L13:
     load_var _5
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L36:
+  L14:
     load_type iter.IterLoopBox
     load_var _5
     call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L37:
+  L15:
     load_type iter.IterLoopBox
     load_type void
     load_type void
     load_var _5
     call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L38:
+  L16:
     load_type iter.IterLoopBox
     load_type void
     load_var _5
     call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L39:
+  L17:
     load_type iter.IterLoopBox
     load_var _5
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L40:
+  L18:
     load_var _5
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _36
+    store_var _7
 
-  L41:
-    load_var _36
+  L19:
+    load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var2 1 4
+  L20:
+    load_var2 1 3
     load_field .value
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var total
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function iter.iter_for_in_array_of_unions() -> int {
     load_const 0
     store_var total
+    load_type int | string
     load_const 1
     load_const "two"
     load_const 3
     alloc_array 3
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _3
-    is_type (int | string)[]
-    pop_jump_if_false L46
-    load_type int | string
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L11:
-    load_type int | string
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L12:
-    load_type int | string
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
-
-  L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L15:
-    load_type int | string
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
-
-  L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L17:
-    load_type int | string
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
-
-  L18:
-    load_type int | string
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
-
-  L19:
-    load_type int | string
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
-
-  L20:
-    load_type int | string
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
-
-  L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L22:
     load_var _4
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _4
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _4
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _4
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _4
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _4
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _4
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _4
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _4
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _4
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L46
+    pop_jump_if_false L24
     load_type int | string
     load_type void
     load_var _4
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L32:
+  L10:
     load_var _4
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L33:
+  L11:
     load_var _4
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L34:
+  L12:
     load_type int | string
     load_type void
     load_type void
     load_var _4
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L35:
+  L13:
     load_var _4
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L36:
+  L14:
     load_type int | string
     load_var _4
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L37:
+  L15:
     load_type int | string
     load_type void
     load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L38:
+  L16:
     load_type int | string
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L39:
+  L17:
     load_type int | string
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L40:
+  L18:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _6
 
-  L41:
-    load_var _35
+  L19:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L45
+    pop_jump_if_false L20
+    jump L23
 
-  L42:
-    load_var _35
+  L20:
+    load_var _6
     store_var_load_var x
     is_type int
-    pop_jump_if_false L43
-    jump L44
+    pop_jump_if_false L21
+    jump L22
 
-  L43:
+  L21:
     load_var x
     load_const "two"
     cmp_op ==
-    pop_jump_if_false L22
+    pop_jump_if_false L0
     load_var total
     load_const 20
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L44:
-    load_var2 1 5
+  L22:
+    load_var2 1 4
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L45:
+  L23:
     load_var total
     return
 
-  L46:
+  L24:
     unreachable
 }
 
@@ -9544,315 +8906,162 @@ function iter.iter_repeat() -> int[] {
 function iter.iter_shadowed_param_for_in(source: baml.iter.Iterable<Item = int, Error = void>) -> string[] {
     alloc_array 0
     store_var out
+    load_type string
     load_const "a"
     load_const "b"
     alloc_array 2
-    store_var_load_var _4
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _5
 
   L0:
-    load_var _4
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _4
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _4
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _4
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _4
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _4
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _4
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _4
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _4
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _4
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _4
-    is_type string[]
-    pop_jump_if_false L44
-    load_type string
-    load_var _4
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L22
-
-  L11:
-    load_type string
-    load_var _4
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L22
-
-  L12:
-    load_type string
-    load_type void
-    load_var _4
-    call baml.iter.Peekable.Iterable.iter
-    store_var _5
-    jump L22
-
-  L13:
-    load_var _4
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L14:
-    load_var _4
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L15:
-    load_type string
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Filter.Iterable.iter
-    store_var _5
-    jump L22
-
-  L16:
-    load_var _4
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L17:
-    load_type string
-    load_var _4
-    call baml.iter.Repeat.Iterable.iter
-    store_var _5
-    jump L22
-
-  L18:
-    load_type string
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Chain.Iterable.iter
-    store_var _5
-    jump L22
-
-  L19:
-    load_type string
-    load_type void
-    load_var _4
-    call baml.iter.StepBy.Iterable.iter
-    store_var _5
-    jump L22
-
-  L20:
-    load_type string
-    load_var _4
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _5
-    jump L22
-
-  L21:
-    load_var _4
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _5
-
-  L22:
     load_var _5
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _5
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _5
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _5
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _5
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _5
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _5
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _5
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _5
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _5
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type string
     load_type void
     load_var _5
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L32:
+  L10:
     load_var _5
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L33:
+  L11:
     load_var _5
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L34:
+  L12:
     load_type string
     load_type void
     load_type void
     load_var _5
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L35:
+  L13:
     load_var _5
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L36:
+  L14:
     load_type string
     load_var _5
     call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L37:
+  L15:
     load_type string
     load_type void
     load_type void
     load_var _5
     call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L38:
+  L16:
     load_type string
     load_type void
     load_var _5
     call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L39:
+  L17:
     load_type string
     load_var _5
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L40:
+  L18:
     load_var _5
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _36
+    store_var _7
 
-  L41:
-    load_var _36
+  L19:
+    load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var2 2 5
+  L20:
+    load_var2 2 4
     call baml.Array.push
     pop 1
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var out
     return
 
-  L44:
+  L22:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/iter_impl_generics_only.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/iter_impl_generics_only.snap
@@ -133,323 +133,155 @@ function iter_impl_generics_only.$init_test_ns_iter_impl_generics_only_iter(regi
 }
 
 function iter_impl_generics_only.iter_array_iter() -> int[] {
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type iter_impl_generics_only.core.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
-
-  L0:
-    load_var _2
-    is_type iter_impl_generics_only.core.StepBy<...>
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type iter_impl_generics_only.core.Repeat<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type iter_impl_generics_only.core.FlatMap<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type iter_impl_generics_only.core.FilterMap<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type iter_impl_generics_only.core.Range
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type iter_impl_generics_only.core.ArrayIterator<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type iter_impl_generics_only.core.Map<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type iter_impl_generics_only.core.Chain<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type iter_impl_generics_only.core.Filter<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type iter_impl_generics_only.core.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L46
-    load_type int
-    load_var _2
     call user.iter_impl_generics_only.core.Iterable<T, never>$for$T[].iter
     store_var _1
-    jump L24
+    load_var _1
+    is_type iter_impl_generics_only.core.Flatten<...>
+    pop_jump_if_false L0
+    jump L19
+
+  L0:
+    load_var _1
+    is_type iter_impl_generics_only.core.StepBy<...>
+    pop_jump_if_false L1
+    jump L18
+
+  L1:
+    load_var _1
+    is_type iter_impl_generics_only.core.Repeat<...>
+    pop_jump_if_false L2
+    jump L17
+
+  L2:
+    load_var _1
+    is_type iter_impl_generics_only.core.FlatMap<...>
+    pop_jump_if_false L3
+    jump L16
+
+  L3:
+    load_var _1
+    is_type iter_impl_generics_only.core.FilterMap<...>
+    pop_jump_if_false L4
+    jump L15
+
+  L4:
+    load_var _1
+    is_type iter_impl_generics_only.core.Range
+    pop_jump_if_false L5
+    jump L14
+
+  L5:
+    load_var _1
+    is_type iter_impl_generics_only.core.ArrayIterator<...>
+    pop_jump_if_false L6
+    jump L13
+
+  L6:
+    load_var _1
+    is_type iter_impl_generics_only.core.Map<...>
+    pop_jump_if_false L7
+    jump L12
+
+  L7:
+    load_var _1
+    is_type iter_impl_generics_only.core.Chain<...>
+    pop_jump_if_false L8
+    jump L11
+
+  L8:
+    load_var _1
+    is_type iter_impl_generics_only.core.Filter<...>
+    pop_jump_if_false L9
+    jump L10
+
+  L9:
+    load_var _1
+    is_type iter_impl_generics_only.core.Peekable<...>
+    pop_jump_if_false L21
+    load_type int
+    load_type void
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
+
+  L10:
+    load_type int
+    load_type void
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
+
+  L11:
+    load_type int
+    load_type void
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
 
   L12:
     load_type int
-    load_var _2
-    call user.iter_impl_generics_only.core.Iterable<T, never>$for$T[].iter
-    store_var _1
-    jump L24
+    load_type void
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
 
   L13:
     load_type int
     load_type void
-    load_var _2
-    call user.iter_impl_generics_only.core.Peekable.Iterable<T, E>.iter
-    store_var _1
-    jump L24
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
 
   L14:
     load_type int
     load_type void
-    load_type void
-    load_var _2
-    call user.iter_impl_generics_only.core.Filter.Iterable<T, E | E2>.iter
-    store_var _1
-    jump L24
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
 
   L15:
     load_type int
     load_type void
-    load_var _2
-    call user.iter_impl_generics_only.core.Chain.Iterable<T, E>.iter
-    store_var _1
-    jump L24
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
 
   L16:
-    load_var _2
-    make_bound_method user.iter_impl_generics_only.core.Map.Iterable<R, E | E2>.iter
-    call_indirect
-    store_var _1
-    jump L24
+    load_type int
+    load_type void
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
 
   L17:
     load_type int
-    load_var _2
-    call user.iter_impl_generics_only.core.ArrayIterator.Iterable<T, never>.iter
-    store_var _1
-    jump L24
+    load_type void
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
 
   L18:
-    load_var _2
-    call user.iter_impl_generics_only.core.Range.Iterable<int, never>.iter
-    store_var _1
-    jump L24
+    load_type int
+    load_type void
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
+    jump L20
 
   L19:
-    load_var _2
-    make_bound_method user.iter_impl_generics_only.core.FilterMap.Iterable<R, E | E2>.iter
-    call_indirect
-    store_var _1
-    jump L24
+    load_type int
+    load_type void
+    load_var _1
+    call user.iter_impl_generics_only.core.Iterator.collect
 
   L20:
-    load_var _2
-    make_bound_method user.iter_impl_generics_only.core.FlatMap.Iterable<R, E | E2 | E3>.iter
-    call_indirect
-    store_var _1
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call user.iter_impl_generics_only.core.Repeat.Iterable<T, never>.iter
-    store_var _1
-    jump L24
-
-  L22:
-    load_type int
-    load_type void
-    load_var _2
-    call user.iter_impl_generics_only.core.StepBy.Iterable<T, E>.iter
-    store_var _1
-    jump L24
-
-  L23:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call user.iter_impl_generics_only.core.Flatten.Iterable<R, E | E3>.iter
-    store_var _1
-
-  L24:
-    load_var _1
-    is_type iter_impl_generics_only.core.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
-
-  L25:
-    load_var _1
-    is_type iter_impl_generics_only.core.StepBy<...>
-    pop_jump_if_false L26
-    jump L43
-
-  L26:
-    load_var _1
-    is_type iter_impl_generics_only.core.Repeat<...>
-    pop_jump_if_false L27
-    jump L42
-
-  L27:
-    load_var _1
-    is_type iter_impl_generics_only.core.FlatMap<...>
-    pop_jump_if_false L28
-    jump L41
-
-  L28:
-    load_var _1
-    is_type iter_impl_generics_only.core.FilterMap<...>
-    pop_jump_if_false L29
-    jump L40
-
-  L29:
-    load_var _1
-    is_type iter_impl_generics_only.core.Range
-    pop_jump_if_false L30
-    jump L39
-
-  L30:
-    load_var _1
-    is_type iter_impl_generics_only.core.ArrayIterator<...>
-    pop_jump_if_false L31
-    jump L38
-
-  L31:
-    load_var _1
-    is_type iter_impl_generics_only.core.Map<...>
-    pop_jump_if_false L32
-    jump L37
-
-  L32:
-    load_var _1
-    is_type iter_impl_generics_only.core.Chain<...>
-    pop_jump_if_false L33
-    jump L36
-
-  L33:
-    load_var _1
-    is_type iter_impl_generics_only.core.Filter<...>
-    pop_jump_if_false L34
-    jump L35
-
-  L34:
-    load_var _1
-    is_type iter_impl_generics_only.core.Peekable<...>
-    pop_jump_if_false L46
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L35:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L36:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L37:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L38:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L39:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L40:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L41:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L42:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L43:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-    jump L45
-
-  L44:
-    load_type int
-    load_type void
-    load_var _1
-    call user.iter_impl_generics_only.core.Iterator.collect
-
-  L45:
     return
 
-  L46:
+  L21:
     unreachable
 }
 
@@ -5834,14 +5666,8 @@ function iter_impl_generics_only.out_of_body_inferred_ctor_dispatch() -> int {
     load_const 11
     call user.iter_impl_generics_only.core.OutOfBodyBox.new
     store_var value
-    load_var value
-    is_type iter_impl_generics_only.core.OutOfBodyBox<...>
-    pop_jump_if_false L0
     load_type int
     load_var value
     call user.iter_impl_generics_only.core.OutOfBodyValue<T>$for$OutOfBodyBox<T>.get
     return
-
-  L0:
-    unreachable
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -212,341 +212,176 @@ function lambdas.lambdas_captures_loop_variable_accumulation() -> int {
     store_var ?1
     load_const 0
     store_deref ?1
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _4
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _5
 
   L0:
-    load_var _4
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _4
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _4
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _4
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _4
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _4
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _4
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _4
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _4
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _4
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _4
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _4
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _4
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L24
-
-  L12:
-    load_type int
-    load_var _4
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _4
-    call baml.iter.Peekable.Iterable.iter
-    store_var _5
-    jump L24
-
-  L14:
-    load_var _4
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L24
-
-  L15:
-    load_var _4
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Filter.Iterable.iter
-    store_var _5
-    jump L24
-
-  L17:
-    load_var _4
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L24
-
-  L18:
-    load_type int
-    load_var _4
-    call baml.iter.Repeat.Iterable.iter
-    store_var _5
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Chain.Iterable.iter
-    store_var _5
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _4
-    call baml.iter.StepBy.Iterable.iter
-    store_var _5
-    jump L24
-
-  L21:
-    load_type int
-    load_var _4
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _5
-    jump L24
-
-  L22:
-    load_var _4
-    call baml.iter.Range.Iterable.iter
-    store_var _5
-    jump L24
-
-  L23:
-    load_var _4
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _5
-
-  L24:
     load_var _5
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _5
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _5
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _5
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _5
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _5
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _5
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _5
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _5
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _5
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _5
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _5
     call baml.iter.Peekable.Iterator.next
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L35:
+  L11:
     load_var _5
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L36:
+  L12:
     load_var _5
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _5
     call baml.iter.Filter.Iterator.next
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L38:
+  L14:
     load_var _5
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _5
     call baml.iter.Repeat.Iterator.next
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _5
     call baml.iter.Chain.Iterator.next
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _5
     call baml.iter.StepBy.Iterator.next
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _5
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L43:
+  L19:
     load_var _5
     call baml.iter.Range.Iterator.next
-    store_var _37
-    jump L45
+    store_var _7
+    jump L21
 
-  L44:
+  L20:
     load_var _5
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _37
+    store_var _7
 
-  L45:
-    load_var _37
+  L21:
+    load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var2 4 1
+  L22:
+    load_var2 3 1
     make_closure .<lambda(lambdas_captures_loop_variable_accumulation, 0)>, 1
     call_indirect
     pop 1
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_deref ?1
     return
 
-  L48:
+  L24:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
@@ -249,338 +249,173 @@ function lexical_scoping.fail() -> int {
 }
 
 function lexical_scoping.for_loop_restores_outer() -> int {
+    load_type int
     load_const 2
     load_const 3
     alloc_array 2
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var _35
+  L22:
+    load_var _5
     store_var x
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_const 1
     return
 
-  L48:
+  L24:
     unreachable
 }
 
@@ -751,325 +586,160 @@ function lexical_scoping.rule2_block_outer_mutation_escapes() -> int {
 function lexical_scoping.rule2_for_outer_mutation_escapes() -> int {
     load_const 1
     store_var x
+    load_type int
     load_const 1
     alloc_array 1
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    jump L45
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    jump L45
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    jump L45
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    jump L45
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    jump L45
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    jump L45
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    jump L45
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    jump L45
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    jump L45
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    jump L45
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
 
-  L45:
+  L21:
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
+  L22:
     load_const 2
     store_var x
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var x
     return
 
-  L48:
+  L24:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -800,313 +800,161 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
 function patterns_new_runtime.from_array_boxes(boxes: patterns_new_runtime.BoxT<int>[]) -> int {
     load_const 0
     store_var total
+    load_type patterns_new_runtime.BoxT<int>
     load_var boxes
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var boxes
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var boxes
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var boxes
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var boxes
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var boxes
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var boxes
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var boxes
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var boxes
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var boxes
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var boxes
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var boxes
-    is_type patterns_new_runtime.BoxT<int>[]
-    pop_jump_if_false L44
-    load_type patterns_new_runtime.BoxT<int>
-    load_var boxes
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L22
-
-  L11:
-    load_type patterns_new_runtime.BoxT<int>
-    load_var boxes
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L22
-
-  L12:
-    load_type patterns_new_runtime.BoxT<int>
-    load_type void
-    load_var boxes
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L22
-
-  L13:
-    load_var boxes
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L14:
-    load_var boxes
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L15:
-    load_type patterns_new_runtime.BoxT<int>
-    load_type void
-    load_type void
-    load_var boxes
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L22
-
-  L16:
-    load_var boxes
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L17:
-    load_type patterns_new_runtime.BoxT<int>
-    load_var boxes
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L22
-
-  L18:
-    load_type patterns_new_runtime.BoxT<int>
-    load_type void
-    load_type void
-    load_var boxes
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L22
-
-  L19:
-    load_type patterns_new_runtime.BoxT<int>
-    load_type void
-    load_var boxes
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L22
-
-  L20:
-    load_type patterns_new_runtime.BoxT<int>
-    load_var boxes
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L22
-
-  L21:
-    load_var boxes
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L22:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type patterns_new_runtime.BoxT<int>
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L32:
+  L10:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L33:
+  L11:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L34:
+  L12:
     load_type patterns_new_runtime.BoxT<int>
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L35:
+  L13:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L36:
+  L14:
     load_type patterns_new_runtime.BoxT<int>
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L37:
+  L15:
     load_type patterns_new_runtime.BoxT<int>
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L38:
+  L16:
     load_type patterns_new_runtime.BoxT<int>
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L39:
+  L17:
     load_type patterns_new_runtime.BoxT<int>
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L40:
+  L18:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _34
+    store_var _5
 
-  L41:
-    load_var _34
+  L19:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
+  L20:
     load_var2 2 4
     load_field .value
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var total
     return
 
-  L44:
+  L22:
     unreachable
 }
 
@@ -3249,6 +3097,7 @@ function patterns_new_runtime.test_five_levels_or_flipped() -> int {
 function patterns_new_runtime.test_for_class_binds_inner_zip() -> int {
     load_const 1
     store_var product
+    load_type patterns_new_runtime.UserCoord
     load_const 4
     init_instance user.patterns_new_runtime.Coord .zip
     init_instance user.patterns_new_runtime.Addr .coordinate
@@ -3262,324 +3111,171 @@ function patterns_new_runtime.test_for_class_binds_inner_zip() -> int {
     init_instance user.patterns_new_runtime.Addr .coordinate
     init_instance user.patterns_new_runtime.UserCoord .address
     alloc_array 3
-    store_var_load_var _12
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _13
 
   L0:
-    load_var _12
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _12
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _12
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _12
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _12
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _12
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _12
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _12
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _12
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _12
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _12
-    is_type patterns_new_runtime.UserCoord[]
-    pop_jump_if_false L44
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Iterable$for$T[].iter
-    store_var _13
-    jump L22
-
-  L11:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Iterable$for$T[].iter
-    store_var _13
-    jump L22
-
-  L12:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_var _12
-    call baml.iter.Peekable.Iterable.iter
-    store_var _13
-    jump L22
-
-  L13:
-    load_var _12
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L14:
-    load_var _12
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L15:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_type void
-    load_var _12
-    call baml.iter.Filter.Iterable.iter
-    store_var _13
-    jump L22
-
-  L16:
-    load_var _12
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L17:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Repeat.Iterable.iter
-    store_var _13
-    jump L22
-
-  L18:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_type void
-    load_var _12
-    call baml.iter.Chain.Iterable.iter
-    store_var _13
-    jump L22
-
-  L19:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_var _12
-    call baml.iter.StepBy.Iterable.iter
-    store_var _13
-    jump L22
-
-  L20:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _13
-    jump L22
-
-  L21:
-    load_var _12
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _13
-
-  L22:
     load_var _13
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _13
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _13
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _13
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _13
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _13
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _13
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _13
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _13
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _13
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_var _13
     call baml.iter.Peekable.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L32:
+  L10:
     load_var _13
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L33:
+  L11:
     load_var _13
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L34:
+  L12:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_type void
     load_var _13
     call baml.iter.Filter.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L35:
+  L13:
     load_var _13
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L36:
+  L14:
     load_type patterns_new_runtime.UserCoord
     load_var _13
     call baml.iter.Repeat.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L37:
+  L15:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_type void
     load_var _13
     call baml.iter.Chain.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L38:
+  L16:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_var _13
     call baml.iter.StepBy.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L39:
+  L17:
     load_type patterns_new_runtime.UserCoord
     load_var _13
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L40:
+  L18:
     load_var _13
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _44
+    store_var _15
 
-  L41:
-    load_var _44
+  L19:
+    load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var2 1 4
+  L20:
+    load_var2 1 3
     load_field .address
     load_field .coordinate
     load_field .zip
     mul_int
     store_var product
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var product
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
-    load_var ?5
+    load_var ?4
     make_cell
-    store_var ?5
+    store_var ?4
     alloc_array 0
     store_var funcs
+    load_type patterns_new_runtime.UserCoord
     load_const 1
     init_instance user.patterns_new_runtime.Coord .zip
     init_instance user.patterns_new_runtime.Addr .coordinate
@@ -3593,350 +3289,197 @@ function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
     init_instance user.patterns_new_runtime.Addr .coordinate
     init_instance user.patterns_new_runtime.UserCoord .address
     alloc_array 3
-    store_var_load_var _12
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _13
 
   L0:
-    load_var _12
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _12
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _12
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _12
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _12
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _12
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _12
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _12
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _12
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _12
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _12
-    is_type patterns_new_runtime.UserCoord[]
-    pop_jump_if_false L44
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Iterable$for$T[].iter
-    store_var _13
-    jump L22
-
-  L11:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Iterable$for$T[].iter
-    store_var _13
-    jump L22
-
-  L12:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_var _12
-    call baml.iter.Peekable.Iterable.iter
-    store_var _13
-    jump L22
-
-  L13:
-    load_var _12
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L14:
-    load_var _12
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L15:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_type void
-    load_var _12
-    call baml.iter.Filter.Iterable.iter
-    store_var _13
-    jump L22
-
-  L16:
-    load_var _12
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L17:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Repeat.Iterable.iter
-    store_var _13
-    jump L22
-
-  L18:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_type void
-    load_var _12
-    call baml.iter.Chain.Iterable.iter
-    store_var _13
-    jump L22
-
-  L19:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_var _12
-    call baml.iter.StepBy.Iterable.iter
-    store_var _13
-    jump L22
-
-  L20:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _13
-    jump L22
-
-  L21:
-    load_var _12
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _13
-
-  L22:
     load_var _13
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _13
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _13
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _13
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _13
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _13
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _13
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _13
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _13
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _13
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_var _13
     call baml.iter.Peekable.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L32:
+  L10:
     load_var _13
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L33:
+  L11:
     load_var _13
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L34:
+  L12:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_type void
     load_var _13
     call baml.iter.Filter.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L35:
+  L13:
     load_var _13
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L36:
+  L14:
     load_type patterns_new_runtime.UserCoord
     load_var _13
     call baml.iter.Repeat.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L37:
+  L15:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_type void
     load_var _13
     call baml.iter.Chain.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L38:
+  L16:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_var _13
     call baml.iter.StepBy.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L39:
+  L17:
     load_type patterns_new_runtime.UserCoord
     load_var _13
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L40:
+  L18:
     load_var _13
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _44
+    store_var _15
 
-  L41:
-    load_var _44
+  L19:
+    load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
+  L20:
     load_const null
     make_cell
     store_var zip
-    load_var _44
+    load_var _15
     load_field .address
     load_field .coordinate
     load_field .zip
-    store_deref ?5
-    load_var2 1 5
+    store_deref ?4
+    load_var2 1 4
     make_closure .<lambda(test_for_deep_class_capture_fresh, 0)>, 1
     call baml.Array.push
     pop 1
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var funcs
     load_const 0
     load_array_element
     call_indirect
-    store_var _81
+    store_var _52
     load_var funcs
     load_const 1
     load_array_element
     call_indirect
-    store_var _86
+    store_var _57
     load_var funcs
     load_const 2
     load_array_element
     call_indirect
-    store_var _90
-    load_var _81
+    store_var _61
+    load_var _52
     load_const 100
     mul_int
-    load_var _86
+    load_var _57
     load_const 10
     mul_int
     add_int
-    load_var _90
+    load_var _61
     add_int
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function patterns_new_runtime.test_for_deep_class_sums() -> int {
     load_const 0
     store_var total
+    load_type patterns_new_runtime.UserCoord
     load_const 1
     init_instance user.patterns_new_runtime.Coord .zip
     init_instance user.patterns_new_runtime.Addr .coordinate
@@ -3950,321 +3493,168 @@ function patterns_new_runtime.test_for_deep_class_sums() -> int {
     init_instance user.patterns_new_runtime.Addr .coordinate
     init_instance user.patterns_new_runtime.UserCoord .address
     alloc_array 3
-    store_var_load_var _12
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _13
 
   L0:
-    load_var _12
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _12
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _12
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _12
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _12
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _12
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _12
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _12
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _12
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _12
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _12
-    is_type patterns_new_runtime.UserCoord[]
-    pop_jump_if_false L44
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Iterable$for$T[].iter
-    store_var _13
-    jump L22
-
-  L11:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Iterable$for$T[].iter
-    store_var _13
-    jump L22
-
-  L12:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_var _12
-    call baml.iter.Peekable.Iterable.iter
-    store_var _13
-    jump L22
-
-  L13:
-    load_var _12
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L14:
-    load_var _12
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L15:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_type void
-    load_var _12
-    call baml.iter.Filter.Iterable.iter
-    store_var _13
-    jump L22
-
-  L16:
-    load_var _12
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _13
-    jump L22
-
-  L17:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.Repeat.Iterable.iter
-    store_var _13
-    jump L22
-
-  L18:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_type void
-    load_var _12
-    call baml.iter.Chain.Iterable.iter
-    store_var _13
-    jump L22
-
-  L19:
-    load_type patterns_new_runtime.UserCoord
-    load_type void
-    load_var _12
-    call baml.iter.StepBy.Iterable.iter
-    store_var _13
-    jump L22
-
-  L20:
-    load_type patterns_new_runtime.UserCoord
-    load_var _12
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _13
-    jump L22
-
-  L21:
-    load_var _12
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _13
-
-  L22:
     load_var _13
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _13
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _13
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _13
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _13
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _13
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _13
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _13
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _13
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _13
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_var _13
     call baml.iter.Peekable.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L32:
+  L10:
     load_var _13
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L33:
+  L11:
     load_var _13
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L34:
+  L12:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_type void
     load_var _13
     call baml.iter.Filter.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L35:
+  L13:
     load_var _13
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L36:
+  L14:
     load_type patterns_new_runtime.UserCoord
     load_var _13
     call baml.iter.Repeat.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L37:
+  L15:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_type void
     load_var _13
     call baml.iter.Chain.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L38:
+  L16:
     load_type patterns_new_runtime.UserCoord
     load_type void
     load_var _13
     call baml.iter.StepBy.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L39:
+  L17:
     load_type patterns_new_runtime.UserCoord
     load_var _13
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _44
-    jump L41
+    store_var _15
+    jump L19
 
-  L40:
+  L18:
     load_var _13
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _44
+    store_var _15
 
-  L41:
-    load_var _44
+  L19:
+    load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var2 1 4
+  L20:
+    load_var2 1 3
     load_field .address
     load_field .coordinate
     load_field .zip
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var total
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     load_const 0
     store_var total
+    load_type patterns_new_runtime.Team1
     load_const 1
     load_const 2
     alloc_array 2
@@ -4275,1042 +3665,559 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     alloc_array 1
     init_instance user.patterns_new_runtime.Team1 .scores
     alloc_array 3
-    store_var_load_var _9
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _10
 
   L0:
-    load_var _9
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _9
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _9
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _9
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _9
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _9
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _9
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _9
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _9
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _9
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _9
-    is_type patterns_new_runtime.Team1[]
-    pop_jump_if_false L44
-    load_type patterns_new_runtime.Team1
-    load_var _9
-    call baml.iter.Iterable$for$T[].iter
-    store_var _10
-    jump L22
-
-  L11:
-    load_type patterns_new_runtime.Team1
-    load_var _9
-    call baml.iter.Iterable$for$T[].iter
-    store_var _10
-    jump L22
-
-  L12:
-    load_type patterns_new_runtime.Team1
-    load_type void
-    load_var _9
-    call baml.iter.Peekable.Iterable.iter
-    store_var _10
-    jump L22
-
-  L13:
-    load_var _9
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _10
-    jump L22
-
-  L14:
-    load_var _9
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _10
-    jump L22
-
-  L15:
-    load_type patterns_new_runtime.Team1
-    load_type void
-    load_type void
-    load_var _9
-    call baml.iter.Filter.Iterable.iter
-    store_var _10
-    jump L22
-
-  L16:
-    load_var _9
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _10
-    jump L22
-
-  L17:
-    load_type patterns_new_runtime.Team1
-    load_var _9
-    call baml.iter.Repeat.Iterable.iter
-    store_var _10
-    jump L22
-
-  L18:
-    load_type patterns_new_runtime.Team1
-    load_type void
-    load_type void
-    load_var _9
-    call baml.iter.Chain.Iterable.iter
-    store_var _10
-    jump L22
-
-  L19:
-    load_type patterns_new_runtime.Team1
-    load_type void
-    load_var _9
-    call baml.iter.StepBy.Iterable.iter
-    store_var _10
-    jump L22
-
-  L20:
-    load_type patterns_new_runtime.Team1
-    load_var _9
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _10
-    jump L22
-
-  L21:
-    load_var _9
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _10
-
-  L22:
     load_var _10
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _10
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _10
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _10
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _10
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _10
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _10
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _10
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _10
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _10
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type patterns_new_runtime.Team1
     load_type void
     load_var _10
     call baml.iter.Peekable.Iterator.next
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L32:
+  L10:
     load_var _10
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L33:
+  L11:
     load_var _10
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L34:
+  L12:
     load_type patterns_new_runtime.Team1
     load_type void
     load_type void
     load_var _10
     call baml.iter.Filter.Iterator.next
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L35:
+  L13:
     load_var _10
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L36:
+  L14:
     load_type patterns_new_runtime.Team1
     load_var _10
     call baml.iter.Repeat.Iterator.next
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L37:
+  L15:
     load_type patterns_new_runtime.Team1
     load_type void
     load_type void
     load_var _10
     call baml.iter.Chain.Iterator.next
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L38:
+  L16:
     load_type patterns_new_runtime.Team1
     load_type void
     load_var _10
     call baml.iter.StepBy.Iterator.next
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L39:
+  L17:
     load_type patterns_new_runtime.Team1
     load_var _10
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _41
-    jump L41
+    store_var _12
+    jump L19
 
-  L40:
+  L18:
     load_var _10
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _41
+    store_var _12
 
-  L41:
-    load_var _41
+  L19:
+    load_var _12
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _41
+  L20:
+    load_var _12
     load_field .scores
     container_len
-    store_var _72
-    load_var2 1 5
+    store_var _43
+    load_var2 1 4
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var total
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
-    load_var ?7
+    load_var ?6
     make_cell
-    store_var ?7
+    store_var ?6
     alloc_array 0
     store_var funcs
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var _35
-    store_var _64
-    load_var _64
+  L22:
+    load_var _5
+    store_var _34
+    load_var _34
     store_var a
     load_const null
     make_cell
     store_var b
-    load_var _64
-    store_deref ?7
-    load_var2 1 7
+    load_var _34
+    store_deref ?6
+    load_var2 1 6
     make_closure .<lambda(test_for_let_chain_alias_capture, 0)>, 1
     call baml.Array.push
     pop 1
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var funcs
     load_const 0
     load_array_element
     call_indirect
-    store_var _71
+    store_var _41
     load_var funcs
     load_const 1
     load_array_element
     call_indirect
-    store_var _76
+    store_var _46
     load_var funcs
     load_const 2
     load_array_element
     call_indirect
-    store_var _80
-    load_var _71
+    store_var _50
+    load_var _41
     load_const 100
     mul_int
-    load_var _76
+    load_var _46
     load_const 10
     mul_int
     add_int
-    load_var _80
+    load_var _50
     add_int
     return
 
-  L48:
+  L24:
     unreachable
 }
 
 function patterns_new_runtime.test_for_let_chain_of_bindings() -> int {
     load_const 0
     store_var total
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var _35
-    store_var _64
-    load_var2 1 5
-    load_var _64
+  L22:
+    load_var _5
+    store_var _34
+    load_var2 1 4
+    load_var _34
     add_int
     add_int
     store_var total
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var total
     return
 
-  L48:
+  L24:
     unreachable
 }
 
 function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     load_const 0
     store_var total
+    load_type int[]
     load_const 4
     load_const 5
     alloc_array 2
@@ -5319,308 +4226,154 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     load_const 8
     alloc_array 3
     alloc_array 2
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _5
 
   L0:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _2
-    is_type int[][]
-    pop_jump_if_false L44
-    load_type int[]
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L22
-
-  L11:
-    load_type int[]
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L22
-
-  L12:
-    load_type int[]
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _5
-    jump L22
-
-  L13:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L15:
-    load_type int[]
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _5
-    jump L22
-
-  L16:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L17:
-    load_type int[]
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _5
-    jump L22
-
-  L18:
-    load_type int[]
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _5
-    jump L22
-
-  L19:
-    load_type int[]
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _5
-    jump L22
-
-  L20:
-    load_type int[]
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _5
-    jump L22
-
-  L21:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _5
-
-  L22:
     load_var _5
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _5
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _5
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _5
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _5
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _5
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _5
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _5
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _5
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _5
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type int[]
     load_type void
     load_var _5
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L32:
+  L10:
     load_var _5
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L33:
+  L11:
     load_var _5
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L34:
+  L12:
     load_type int[]
     load_type void
     load_type void
     load_var _5
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L35:
+  L13:
     load_var _5
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L36:
+  L14:
     load_type int[]
     load_var _5
     call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L37:
+  L15:
     load_type int[]
     load_type void
     load_type void
     load_var _5
     call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L38:
+  L16:
     load_type int[]
     load_type void
     load_var _5
     call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L39:
+  L17:
     load_type int[]
     load_var _5
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L40:
+  L18:
     load_var _5
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _36
+    store_var _7
 
-  L41:
-    load_var _36
+  L19:
+    load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _36
+  L20:
+    load_var _7
     store_var row
     load_var row
     container_len
-    store_var _69
-    load_var2 1 6
+    store_var _40
+    load_var2 1 5
     load_const 100
     mul_int
     load_var row
@@ -5634,704 +4387,375 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     add_int
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var total
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function patterns_new_runtime.test_for_let_or_same_binding() -> int {
     load_const 0
     store_var total
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     load_const 4
     alloc_array 4
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var _35
-    store_var _64
-    load_var2 1 5
+  L22:
+    load_var _5
+    store_var _34
+    load_var2 1 4
     add_int
     store_var total
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var total
     return
 
-  L48:
+  L24:
     unreachable
 }
 
 function patterns_new_runtime.test_for_let_or_six_bindings() -> int {
     load_const 0
     store_var total
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var _35
-    store_var _64
-    load_var2 1 5
+  L22:
+    load_var _5
+    store_var _34
+    load_var2 1 4
     add_int
     store_var total
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var total
     return
 
-  L48:
+  L24:
     unreachable
 }
 
 function patterns_new_runtime.test_for_nested_rest_irrefutable() -> int {
     load_const 0
     store_var total
+    load_type int[] | void[]
     load_const 1
     alloc_array 1
     load_const 2
@@ -6339,311 +4763,158 @@ function patterns_new_runtime.test_for_nested_rest_irrefutable() -> int {
     alloc_array 2
     alloc_array 0
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _6
 
   L0:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _2
-    is_type (int[] | void[])[]
-    pop_jump_if_false L44
-    load_type int[] | void[]
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _6
-    jump L22
-
-  L11:
-    load_type int[] | void[]
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _6
-    jump L22
-
-  L12:
-    load_type int[] | void[]
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _6
-    jump L22
-
-  L13:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _6
-    jump L22
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _6
-    jump L22
-
-  L15:
-    load_type int[] | void[]
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _6
-    jump L22
-
-  L16:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _6
-    jump L22
-
-  L17:
-    load_type int[] | void[]
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _6
-    jump L22
-
-  L18:
-    load_type int[] | void[]
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _6
-    jump L22
-
-  L19:
-    load_type int[] | void[]
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _6
-    jump L22
-
-  L20:
-    load_type int[] | void[]
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _6
-    jump L22
-
-  L21:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _6
-
-  L22:
     load_var _6
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _6
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _6
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _6
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _6
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _6
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _6
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _6
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _6
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _6
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type int[] | void[]
     load_type void
     load_var _6
     call baml.iter.Peekable.Iterator.next
-    jump L41
+    jump L19
 
-  L32:
+  L10:
     load_var _6
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    jump L41
+    jump L19
 
-  L33:
+  L11:
     load_var _6
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    jump L41
+    jump L19
 
-  L34:
+  L12:
     load_type int[] | void[]
     load_type void
     load_type void
     load_var _6
     call baml.iter.Filter.Iterator.next
-    jump L41
+    jump L19
 
-  L35:
+  L13:
     load_var _6
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    jump L41
+    jump L19
 
-  L36:
+  L14:
     load_type int[] | void[]
     load_var _6
     call baml.iter.Repeat.Iterator.next
-    jump L41
+    jump L19
 
-  L37:
+  L15:
     load_type int[] | void[]
     load_type void
     load_type void
     load_var _6
     call baml.iter.Chain.Iterator.next
-    jump L41
+    jump L19
 
-  L38:
+  L16:
     load_type int[] | void[]
     load_type void
     load_var _6
     call baml.iter.StepBy.Iterator.next
-    jump L41
+    jump L19
 
-  L39:
+  L17:
     load_type int[] | void[]
     load_var _6
     call baml.iter.ArrayIterator.Iterator.next
-    jump L41
+    jump L19
 
-  L40:
+  L18:
     load_var _6
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
 
-  L41:
+  L19:
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
+  L20:
     load_var total
     load_const 1
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var total
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
-    load_var ?5
+    load_var ?4
     make_cell
-    store_var ?5
+    store_var ?4
     alloc_array 0
     store_var funcs
+    load_type int[]
     load_const 1
     alloc_array 1
     load_const 2
@@ -6654,347 +4925,194 @@ function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
     load_const 6
     alloc_array 3
     alloc_array 3
-    store_var_load_var _6
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _7
 
   L0:
-    load_var _6
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _6
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _6
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _6
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _6
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _6
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _6
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _6
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _6
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _6
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _6
-    is_type int[][]
-    pop_jump_if_false L44
-    load_type int[]
-    load_var _6
-    call baml.iter.Iterable$for$T[].iter
-    store_var _7
-    jump L22
-
-  L11:
-    load_type int[]
-    load_var _6
-    call baml.iter.Iterable$for$T[].iter
-    store_var _7
-    jump L22
-
-  L12:
-    load_type int[]
-    load_type void
-    load_var _6
-    call baml.iter.Peekable.Iterable.iter
-    store_var _7
-    jump L22
-
-  L13:
-    load_var _6
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L14:
-    load_var _6
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L15:
-    load_type int[]
-    load_type void
-    load_type void
-    load_var _6
-    call baml.iter.Filter.Iterable.iter
-    store_var _7
-    jump L22
-
-  L16:
-    load_var _6
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L17:
-    load_type int[]
-    load_var _6
-    call baml.iter.Repeat.Iterable.iter
-    store_var _7
-    jump L22
-
-  L18:
-    load_type int[]
-    load_type void
-    load_type void
-    load_var _6
-    call baml.iter.Chain.Iterable.iter
-    store_var _7
-    jump L22
-
-  L19:
-    load_type int[]
-    load_type void
-    load_var _6
-    call baml.iter.StepBy.Iterable.iter
-    store_var _7
-    jump L22
-
-  L20:
-    load_type int[]
-    load_var _6
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _7
-    jump L22
-
-  L21:
-    load_var _6
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _7
-
-  L22:
     load_var _7
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _7
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _7
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _7
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _7
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _7
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _7
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _7
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _7
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _7
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type int[]
     load_type void
     load_var _7
     call baml.iter.Peekable.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L32:
+  L10:
     load_var _7
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L33:
+  L11:
     load_var _7
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L34:
+  L12:
     load_type int[]
     load_type void
     load_type void
     load_var _7
     call baml.iter.Filter.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L35:
+  L13:
     load_var _7
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L36:
+  L14:
     load_type int[]
     load_var _7
     call baml.iter.Repeat.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L37:
+  L15:
     load_type int[]
     load_type void
     load_type void
     load_var _7
     call baml.iter.Chain.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L38:
+  L16:
     load_type int[]
     load_type void
     load_var _7
     call baml.iter.StepBy.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L39:
+  L17:
     load_type int[]
     load_var _7
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L40:
+  L18:
     load_var _7
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _38
+    store_var _9
 
-  L41:
-    load_var _38
+  L19:
+    load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
+  L20:
     load_const null
     make_cell
     store_var row
-    load_var _38
-    store_deref ?5
-    load_var2 1 5
+    load_var _9
+    store_deref ?4
+    load_var2 1 4
     make_closure .<lambda(test_for_rest_capture_fresh_cell, 0)>, 1
     call baml.Array.push
     pop 1
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var funcs
     load_const 0
     load_array_element
     call_indirect
-    store_var _72
+    store_var _43
     load_var funcs
     load_const 1
     load_array_element
     call_indirect
-    store_var _77
+    store_var _48
     load_var funcs
     load_const 2
     load_array_element
     call_indirect
-    store_var _81
-    load_var _72
+    store_var _52
+    load_var _43
     load_const 100
     mul_int
-    load_var _77
+    load_var _48
     load_const 10
     mul_int
     add_int
-    load_var _81
+    load_var _52
     add_int
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     load_const 0
     store_var total
+    load_type int[]
     load_const 1
     load_const 2
     load_const 3
@@ -7003,321 +5121,168 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     load_const 4
     alloc_array 1
     alloc_array 3
-    store_var_load_var _6
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _7
 
   L0:
-    load_var _6
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _6
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _6
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _6
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _6
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _6
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _6
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _6
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _6
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _6
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _6
-    is_type int[][]
-    pop_jump_if_false L44
-    load_type int[]
-    load_var _6
-    call baml.iter.Iterable$for$T[].iter
-    store_var _7
-    jump L22
-
-  L11:
-    load_type int[]
-    load_var _6
-    call baml.iter.Iterable$for$T[].iter
-    store_var _7
-    jump L22
-
-  L12:
-    load_type int[]
-    load_type void
-    load_var _6
-    call baml.iter.Peekable.Iterable.iter
-    store_var _7
-    jump L22
-
-  L13:
-    load_var _6
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L14:
-    load_var _6
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L15:
-    load_type int[]
-    load_type void
-    load_type void
-    load_var _6
-    call baml.iter.Filter.Iterable.iter
-    store_var _7
-    jump L22
-
-  L16:
-    load_var _6
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L17:
-    load_type int[]
-    load_var _6
-    call baml.iter.Repeat.Iterable.iter
-    store_var _7
-    jump L22
-
-  L18:
-    load_type int[]
-    load_type void
-    load_type void
-    load_var _6
-    call baml.iter.Chain.Iterable.iter
-    store_var _7
-    jump L22
-
-  L19:
-    load_type int[]
-    load_type void
-    load_var _6
-    call baml.iter.StepBy.Iterable.iter
-    store_var _7
-    jump L22
-
-  L20:
-    load_type int[]
-    load_var _6
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _7
-    jump L22
-
-  L21:
-    load_var _6
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _7
-
-  L22:
     load_var _7
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _7
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _7
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _7
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _7
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _7
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _7
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _7
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _7
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _7
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type int[]
     load_type void
     load_var _7
     call baml.iter.Peekable.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L32:
+  L10:
     load_var _7
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L33:
+  L11:
     load_var _7
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L34:
+  L12:
     load_type int[]
     load_type void
     load_type void
     load_var _7
     call baml.iter.Filter.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L35:
+  L13:
     load_var _7
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L36:
+  L14:
     load_type int[]
     load_var _7
     call baml.iter.Repeat.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L37:
+  L15:
     load_type int[]
     load_type void
     load_type void
     load_var _7
     call baml.iter.Chain.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L38:
+  L16:
     load_type int[]
     load_type void
     load_var _7
     call baml.iter.StepBy.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L39:
+  L17:
     load_type int[]
     load_var _7
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _38
-    jump L41
+    store_var _9
+    jump L19
 
-  L40:
+  L18:
     load_var _7
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _38
+    store_var _9
 
-  L41:
-    load_var _38
+  L19:
+    load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _38
+  L20:
+    load_var _9
     container_len
-    store_var _68
-    load_var2 1 5
+    store_var _39
+    load_var2 1 4
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var total
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function patterns_new_runtime.test_for_rest_wildcard_irrefutable() -> int {
     load_const 0
     store_var count
+    load_type int[]
     load_const 1
     alloc_array 1
     alloc_array 0
@@ -7325,302 +5290,148 @@ function patterns_new_runtime.test_for_rest_wildcard_irrefutable() -> int {
     load_const 3
     alloc_array 2
     alloc_array 3
-    store_var_load_var _6
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _7
 
   L0:
-    load_var _6
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _6
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _6
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _6
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _6
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _6
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _6
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _6
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _6
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _6
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _6
-    is_type int[][]
-    pop_jump_if_false L44
-    load_type int[]
-    load_var _6
-    call baml.iter.Iterable$for$T[].iter
-    store_var _7
-    jump L22
-
-  L11:
-    load_type int[]
-    load_var _6
-    call baml.iter.Iterable$for$T[].iter
-    store_var _7
-    jump L22
-
-  L12:
-    load_type int[]
-    load_type void
-    load_var _6
-    call baml.iter.Peekable.Iterable.iter
-    store_var _7
-    jump L22
-
-  L13:
-    load_var _6
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L14:
-    load_var _6
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L15:
-    load_type int[]
-    load_type void
-    load_type void
-    load_var _6
-    call baml.iter.Filter.Iterable.iter
-    store_var _7
-    jump L22
-
-  L16:
-    load_var _6
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L22
-
-  L17:
-    load_type int[]
-    load_var _6
-    call baml.iter.Repeat.Iterable.iter
-    store_var _7
-    jump L22
-
-  L18:
-    load_type int[]
-    load_type void
-    load_type void
-    load_var _6
-    call baml.iter.Chain.Iterable.iter
-    store_var _7
-    jump L22
-
-  L19:
-    load_type int[]
-    load_type void
-    load_var _6
-    call baml.iter.StepBy.Iterable.iter
-    store_var _7
-    jump L22
-
-  L20:
-    load_type int[]
-    load_var _6
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _7
-    jump L22
-
-  L21:
-    load_var _6
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _7
-
-  L22:
     load_var _7
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _7
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _7
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _7
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _7
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _7
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _7
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _7
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _7
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _7
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type int[]
     load_type void
     load_var _7
     call baml.iter.Peekable.Iterator.next
-    jump L41
+    jump L19
 
-  L32:
+  L10:
     load_var _7
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    jump L41
+    jump L19
 
-  L33:
+  L11:
     load_var _7
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    jump L41
+    jump L19
 
-  L34:
+  L12:
     load_type int[]
     load_type void
     load_type void
     load_var _7
     call baml.iter.Filter.Iterator.next
-    jump L41
+    jump L19
 
-  L35:
+  L13:
     load_var _7
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    jump L41
+    jump L19
 
-  L36:
+  L14:
     load_type int[]
     load_var _7
     call baml.iter.Repeat.Iterator.next
-    jump L41
+    jump L19
 
-  L37:
+  L15:
     load_type int[]
     load_type void
     load_type void
     load_var _7
     call baml.iter.Chain.Iterator.next
-    jump L41
+    jump L19
 
-  L38:
+  L16:
     load_type int[]
     load_type void
     load_var _7
     call baml.iter.StepBy.Iterator.next
-    jump L41
+    jump L19
 
-  L39:
+  L17:
     load_type int[]
     load_var _7
     call baml.iter.ArrayIterator.Iterator.next
-    jump L41
+    jump L19
 
-  L40:
+  L18:
     load_var _7
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
 
-  L41:
+  L19:
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
+  L20:
     load_var count
     load_const 1
     add_int
     store_var count
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var count
     return
 
-  L44:
+  L22:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
@@ -145,335 +145,171 @@ function typed_inputs.negate(b: bool) -> bool {
 function typed_inputs.sum(arr: int[]) -> int {
     load_const 0
     store_var total
+    load_type int
     load_var arr
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var arr
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var arr
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var arr
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var arr
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var arr
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var arr
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var arr
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var arr
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var arr
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var arr
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var arr
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var arr
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var arr
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var arr
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var arr
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var arr
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var arr
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var arr
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var arr
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var arr
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var arr
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var arr
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var arr
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var arr
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var arr
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
+  L22:
     load_var2 2 4
     add_int
     store_var total
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var total
     return
 
-  L48:
+  L24:
     unreachable
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/watch.snap
@@ -330,331 +330,166 @@ function watch.watch_alias_nested_scope_fn() -> int {
 function watch.watch_break_unwatches_fn() -> int {
     load_const 0
     store_var total
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L50
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L50
+    pop_jump_if_false L26
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L49
+    pop_jump_if_false L22
+    jump L25
 
-  L46:
-    load_var _35
+  L22:
+    load_var _5
     store_var x
     load_const "x"
     load_const null
@@ -662,28 +497,28 @@ function watch.watch_break_unwatches_fn() -> int {
     load_var x
     load_const 1
     cmp_int_op >
-    pop_jump_if_false L47
-    jump L48
+    pop_jump_if_false L23
+    jump L24
 
-  L47:
+  L23:
     load_var x
     load_const 9
     add_int
     store_var x
-    load_var2 1 5
+    load_var2 1 4
     add_int
     store_var total
     unwatch x
-    jump L24
+    jump L0
 
-  L48:
+  L24:
     unwatch x
 
-  L49:
+  L25:
     load_var total
     return
 
-  L50:
+  L26:
     unreachable
 }
 
@@ -781,331 +616,166 @@ function watch.watch_class_destructure_fn() -> int {
 function watch.watch_continue_unwatches_fn() -> int {
     load_const 0
     store_var total
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L50
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L50
+    pop_jump_if_false L26
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L49
+    pop_jump_if_false L22
+    jump L25
 
-  L46:
-    load_var _35
+  L22:
+    load_var _5
     store_var x
     load_const "x"
     load_const null
@@ -1113,29 +783,29 @@ function watch.watch_continue_unwatches_fn() -> int {
     load_var x
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L47
-    jump L48
+    pop_jump_if_false L23
+    jump L24
 
-  L47:
+  L23:
     load_var x
     load_const 10
     add_int
     store_var x
-    load_var2 1 5
+    load_var2 1 4
     add_int
     store_var total
     unwatch x
-    jump L24
+    jump L0
 
-  L48:
+  L24:
     unwatch x
-    jump L24
+    jump L0
 
-  L49:
+  L25:
     load_var total
     return
 
-  L50:
+  L26:
     unreachable
 }
 
@@ -1232,331 +902,166 @@ function watch.watch_early_return_unwatches_fn() -> int {
 }
 
 function watch.watch_for_throw_fails() -> int {
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _1
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _2
 
   L0:
-    load_var _1
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _1
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _1
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _1
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _1
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _1
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _1
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _1
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _1
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _1
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _1
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _1
-    is_type int[]
-    pop_jump_if_false L50
-    load_type int
-    load_var _1
-    call baml.iter.Iterable$for$T[].iter
-    store_var _2
-    jump L24
-
-  L12:
-    load_type int
-    load_var _1
-    call baml.iter.Iterable$for$T[].iter
-    store_var _2
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.Peekable.Iterable.iter
-    store_var _2
-    jump L24
-
-  L14:
-    load_var _1
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _2
-    jump L24
-
-  L15:
-    load_var _1
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _2
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _1
-    call baml.iter.Filter.Iterable.iter
-    store_var _2
-    jump L24
-
-  L17:
-    load_var _1
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _2
-    jump L24
-
-  L18:
-    load_type int
-    load_var _1
-    call baml.iter.Repeat.Iterable.iter
-    store_var _2
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _1
-    call baml.iter.Chain.Iterable.iter
-    store_var _2
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _1
-    call baml.iter.StepBy.Iterable.iter
-    store_var _2
-    jump L24
-
-  L21:
-    load_type int
-    load_var _1
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _2
-    jump L24
-
-  L22:
-    load_var _1
-    call baml.iter.Range.Iterable.iter
-    store_var _2
-    jump L24
-
-  L23:
-    load_var _1
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _2
-
-  L24:
     load_var _2
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _2
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _2
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _2
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _2
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _2
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _2
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _2
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _2
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _2
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _2
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L50
+    pop_jump_if_false L26
     load_type int
     load_type void
     load_var _2
     call baml.iter.Peekable.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L35:
+  L11:
     load_var _2
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L36:
+  L12:
     load_var _2
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _2
     call baml.iter.Filter.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L38:
+  L14:
     load_var _2
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _2
     call baml.iter.Repeat.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _2
     call baml.iter.Chain.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _2
     call baml.iter.StepBy.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _2
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L43:
+  L19:
     load_var _2
     call baml.iter.Range.Iterator.next
-    store_var _34
-    jump L45
+    store_var _4
+    jump L21
 
-  L44:
+  L20:
     load_var _2
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _34
+    store_var _4
 
-  L45:
-    load_var _34
+  L21:
+    load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L49
+    pop_jump_if_false L22
+    jump L25
 
-  L46:
-    load_var _34
+  L22:
+    load_var _4
     store_var x
     load_const "x"
     load_const null
@@ -1564,27 +1069,27 @@ function watch.watch_for_throw_fails() -> int {
     load_var x
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L47
-    jump L48
+    pop_jump_if_false L23
+    jump L24
 
-  L47:
+  L23:
     load_var x
     load_const 9
     add_int
     store_var x
     unwatch x
-    jump L24
+    jump L0
 
-  L48:
+  L24:
     unwatch x
     load_const "boom"
     throw
 
-  L49:
+  L25:
     load_const 0
     return
 
-  L50:
+  L26:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -30,6 +30,27 @@ function baml.from_json(j: baml.json.json) -> baml.Bool  [expr] {
 }
 function baml.to_json(self: ?) -> baml.json.json  [builtin]
 
+--- <builtin>/baml/comparable.baml ---
+function baml._compare_shim(a: T, b: T) -> int  [builtin]
+function baml._float_total_cmp(a: float, b: float) -> int  [builtin]
+function baml._is_primitive_array(arr: T[]) -> bool  [builtin]
+function baml._rust_sort(arr: A) -> A  [builtin]
+function baml.compare(self: ?, other: Self) -> int  [expr] {
+  {  } if (self Lt other) {  } Neg 1 else if (self Gt other) {  } 1 else {  } 0
+}
+function baml.compare(self: ?, other: Self) -> int  [expr] {
+  {  } root._float_total_cmp(self, other)
+}
+function baml.compare(self: ?, other: Self) -> int  [expr] {
+  {  } if (self Lt other) {  } Neg 1 else if (self Gt other) {  } 1 else {  } 0
+}
+function baml.compare(self: ?, other: Self) -> int  [expr] {
+  {  } if (self Lt other) {  } Neg 1 else if (self Gt other) {  } 1 else {  } 0
+}
+function baml.sort(self: ?) -> Self  [expr] {
+  {  } if (root._is_primitive_array(self)) {  } root._rust_sort(self) else {  } self.sort_by((a: T, b: T) -> int throws T.CmpError { {  } root._compare_shim(a, b) })
+}
+
 --- <builtin>/baml/containers.baml ---
 class baml.Array {
 }
@@ -93,9 +114,10 @@ function baml.set(self: ?, key: K, value: V) -> V?  [builtin]
 function baml.shift(self: ?) -> T?  [builtin]
 function baml.slice(self: ?, start: int, end: int) -> T[]  [builtin]
 function baml.some(self: ?, predicate: (T) -> bool throws E) -> bool  [builtin]
-function baml.sort(self: ?) -> T[]  [builtin]
 function baml.sort_by(self: ?, compare: (T, T) -> int throws E) -> T[]  [builtin]
-function baml.sort_by_key(self: ?, key: (T) -> U throws E) -> T[]  [builtin]
+function baml.sort_by_key(self: ?, key: (T) -> U throws E) -> T[]  [expr] {
+  { let n = self.length(); if (n Le 1) { return self }; let items = self.slice(0, n); let keys: U[] = []; for x in items { keys.push(key(x)) }; let order: int[] = []; let p = 0; while p Lt n { order.push(p); p Add= 1 }; order.sort_by((i: int, j: int) -> int throws U.CmpError { {  } match (keys.at(i)) { null => 0, ki: U => match (keys.at(j)) { null => 0, kj: U => ki.compare(kj) } } }); let sorted: T[] = []; for i in order {  } match (items.at(i)) { null => {  }, item: T => { sorted.push(item) } }; self.clear(); for s in sorted { self.push(s) }; return self }
+}
 function baml.splice(self: ?, start: int, count: int, replace: T[]) -> null  [builtin]
 function baml.step_by(self: ?, n: int) -> baml.iter.Iterator<Item = T, Error = never>  [expr] {
   {  } baml.iter.ArrayIterator.new(self.slice(0, self.length())).step_by(n)
@@ -104,6 +126,9 @@ function baml.to_json(self: ?) -> baml.json.json  [builtin]
 function baml.to_json(self: ?) -> baml.json.json  [builtin]
 function baml.unshift(self: ?, item: T) -> int  [builtin]
 function baml.values(self: ?) -> V[]  [builtin]
+
+--- captures ---
+lambda (i, j) in sort_by_key: captures [keys]
 
 --- <builtin>/baml/core.baml ---
 function baml.deep_copy(value: T) -> T  [builtin]

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -56,6 +56,196 @@ fn baml.Bool.from_json(j: baml.json.json) -> baml.Bool {
 
 fn baml.Bool.to_json = builtin(vm)
 
+fn baml._compare_shim = builtin(vm)
+
+fn baml._float_total_cmp = builtin(vm)
+
+fn baml._is_primitive_array = builtin(vm)
+
+fn baml._rust_sort = builtin(vm)
+
+fn baml.Comparable$for$int.compare(self: int, other: void) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: int // self // param
+    let _2: void // other // param
+    let _3: bool
+    let _4: bool
+
+    bb0: {
+        _3 = copy _1 < copy _2;
+        branch copy _3 -> [bb4, bb1];
+    }
+
+    bb1: {
+        _4 = copy _1 > copy _2;
+        branch copy _4 -> [bb3, bb2];
+    }
+
+    bb2: {
+        _0 = const 0_i64;
+        goto -> bb5;
+    }
+
+    bb3: {
+        _0 = const 1_i64;
+        goto -> bb5;
+    }
+
+    bb4: {
+        _0 = const -1_i64;
+        goto -> bb5;
+    }
+
+    bb5: {
+        return;
+    }
+}
+
+fn baml.Comparable$for$float.compare(self: float, other: void) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: float // self // param
+    let _2: void // other // param
+
+    bb0: {
+        _0 = call const fn baml._float_total_cmp(copy _1, copy _2) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.Comparable$for$string.compare(self: string, other: void) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: string // self // param
+    let _2: void // other // param
+    let _3: bool
+    let _4: bool
+
+    bb0: {
+        _3 = copy _1 < copy _2;
+        branch copy _3 -> [bb4, bb1];
+    }
+
+    bb1: {
+        _4 = copy _1 > copy _2;
+        branch copy _4 -> [bb3, bb2];
+    }
+
+    bb2: {
+        _0 = const 0_i64;
+        goto -> bb5;
+    }
+
+    bb3: {
+        _0 = const 1_i64;
+        goto -> bb5;
+    }
+
+    bb4: {
+        _0 = const -1_i64;
+        goto -> bb5;
+    }
+
+    bb5: {
+        return;
+    }
+}
+
+fn baml.Comparable$for$bigint.compare(self: bigint, other: void) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: bigint // self // param
+    let _2: void // other // param
+    let _3: bool
+    let _4: bool
+
+    bb0: {
+        _3 = copy _1 < copy _2;
+        branch copy _3 -> [bb4, bb1];
+    }
+
+    bb1: {
+        _4 = copy _1 > copy _2;
+        branch copy _4 -> [bb3, bb2];
+    }
+
+    bb2: {
+        _0 = const 0_i64;
+        goto -> bb5;
+    }
+
+    bb3: {
+        _0 = const 1_i64;
+        goto -> bb5;
+    }
+
+    bb4: {
+        _0 = const -1_i64;
+        goto -> bb5;
+    }
+
+    bb5: {
+        return;
+    }
+}
+
+fn baml.Sortable$for$T[].sort(self: unknown[]) -> void {
+    // Locals:
+    let _0: void // _0 // return
+    let _1: unknown[] // self // param
+    let _2: bool
+    let _3: type
+    let _4: type
+    let _5: (unknown, unknown) -> int throws unknown
+    let _6: type
+    let _7: type
+
+    bb0: {
+        _3 = load_type(#0);
+        _2 = call const fn baml._is_primitive_array<copy _3>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        branch copy _2 -> [bb3, bb2];
+    }
+
+    bb2: {
+        _5 = make_closure lambda[0]<1 type_args>();
+        _6 = load_type(unknown);
+        _7 = load_type(#0);
+        _0 = call const fn baml.Array.sort_by<copy _7, copy _6>(copy _1, copy _5) -> [bb4];
+    }
+
+    bb3: {
+        _4 = load_type(#0[]);
+        _0 = call const fn baml._rust_sort<copy _4>(copy _1) -> [bb4];
+    }
+
+    bb4: {
+        return;
+    }
+}
+
+// lambda[0]
+fn .<lambda(sort, 0)>(a: unknown, b: unknown) -> null {
+    // Locals:
+    let _0: null // _0 // return
+    let _1: unknown // a // param
+    let _2: unknown // b // param
+
+    bb0: {
+        _0 = call const fn baml._compare_shim(copy _1, copy _2) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
 fn baml.Array.at = builtin(vm)
 
 fn baml.Array.chain(self: baml.Array, other: baml.iter.Iterable<Item = unknown, Error = unknown>) -> baml.iter.Iterator<Item = void, Error = void | void> {
@@ -699,68 +889,40 @@ fn baml.Array.for_each(self: baml.Array, fn: (unknown) -> void throws unknown) -
     let _4: int
     let _5: type
     let _6: baml.iter.Iterator<Item = unknown, Error = void>
-    let _7: bool
+    let _7: type
     let _8: unknown
     let _9: bool
-    let _10: bool
-    let _11: type
+    let _10: unknown
+    let _11: bool
     let _12: bool
     let _13: type
-    let _14: type
-    let _15: bool
+    let _14: bool
+    let _15: type
     let _16: type
-    let _17: type
+    let _17: bool
     let _18: type
-    let _19: bool
+    let _19: type
     let _20: type
     let _21: bool
-    let _22: unknown
+    let _22: type
     let _23: bool
-    let _24: type
-    let _25: type
+    let _24: unknown
+    let _25: bool
     let _26: type
-    let _27: bool
-    let _28: unknown
+    let _27: type
+    let _28: type
     let _29: bool
     let _30: unknown
     let _31: bool
-    let _32: type
-    let _33: type
-    let _34: bool
+    let _32: unknown
+    let _33: bool
+    let _34: type
     let _35: type
-    let _36: unknown
-    let _37: bool
-    let _38: unknown
-    let _39: bool
-    let _40: bool
-    let _41: type
-    let _42: bool
-    let _43: type
-    let _44: type
-    let _45: bool
-    let _46: type
-    let _47: type
-    let _48: type
-    let _49: bool
-    let _50: type
-    let _51: bool
-    let _52: unknown
-    let _53: bool
-    let _54: type
-    let _55: type
-    let _56: type
-    let _57: bool
-    let _58: unknown
-    let _59: bool
-    let _60: unknown
-    let _61: bool
-    let _62: type
-    let _63: type
-    let _64: bool
-    let _65: unknown
-    let _66: unknown // x
-    let _67: void
-    let _68: unknown
+    let _36: bool
+    let _37: unknown
+    let _38: unknown // x
+    let _39: void
+    let _40: unknown
 
     bb0: {
         _4 = len(_1);
@@ -773,63 +935,63 @@ fn baml.Array.for_each(self: baml.Array, fn: (unknown) -> void throws unknown) -
     }
 
     bb2: {
-        _7 = is_type(copy _3, baml.iter.Flatten<_, #0?, void, void>);
-        branch copy _7 -> [bb26, bb3];
+        _7 = load_type(#0);
+        _6 = call const fn baml.iter.Iterable$for$T[].iter<copy _7>(copy _3) -> [bb3];
     }
 
     bb3: {
-        _9 = is_type(copy _3, baml.iter.Range);
+        _9 = is_type(copy _6, baml.iter.Flatten<_, #0?, void, void>);
         branch copy _9 -> [bb25, bb4];
     }
 
     bb4: {
-        _10 = is_type(copy _3, baml.iter.ArrayIterator<#0?>);
-        branch copy _10 -> [bb24, bb5];
+        _11 = is_type(copy _6, baml.iter.Range);
+        branch copy _11 -> [bb24, bb5];
     }
 
     bb5: {
-        _12 = is_type(copy _3, baml.iter.StepBy<#0?, void>);
+        _12 = is_type(copy _6, baml.iter.ArrayIterator<#0?>);
         branch copy _12 -> [bb23, bb6];
     }
 
     bb6: {
-        _15 = is_type(copy _3, baml.iter.Chain<#0?, void, void>);
-        branch copy _15 -> [bb22, bb7];
+        _14 = is_type(copy _6, baml.iter.StepBy<#0?, void>);
+        branch copy _14 -> [bb22, bb7];
     }
 
     bb7: {
-        _19 = is_type(copy _3, baml.iter.Repeat<#0?>);
-        branch copy _19 -> [bb21, bb8];
+        _17 = is_type(copy _6, baml.iter.Chain<#0?, void, void>);
+        branch copy _17 -> [bb21, bb8];
     }
 
     bb8: {
-        _21 = is_type(copy _3, baml.iter.Map<_, #0?, void, void>);
+        _21 = is_type(copy _6, baml.iter.Repeat<#0?>);
         branch copy _21 -> [bb20, bb9];
     }
 
     bb9: {
-        _23 = is_type(copy _3, baml.iter.Filter<#0?, void, void>);
+        _23 = is_type(copy _6, baml.iter.Map<_, #0?, void, void>);
         branch copy _23 -> [bb19, bb10];
     }
 
     bb10: {
-        _27 = is_type(copy _3, baml.iter.FilterMap<_, #0?, void, void>);
-        branch copy _27 -> [bb18, bb11];
+        _25 = is_type(copy _6, baml.iter.Filter<#0?, void, void>);
+        branch copy _25 -> [bb18, bb11];
     }
 
     bb11: {
-        _29 = is_type(copy _3, baml.iter.FlatMap<_, #0?, void, void, void>);
+        _29 = is_type(copy _6, baml.iter.FilterMap<_, #0?, void, void>);
         branch copy _29 -> [bb17, bb12];
     }
 
     bb12: {
-        _31 = is_type(copy _3, baml.iter.Peekable<#0?, void>);
+        _31 = is_type(copy _6, baml.iter.FlatMap<_, #0?, void, void, void>);
         branch copy _31 -> [bb16, bb13];
     }
 
     bb13: {
-        _34 = is_type(copy _3, unknown[]);
-        branch copy _34 -> [bb15, bb14];
+        _33 = is_type(copy _6, baml.iter.Peekable<#0?, void>);
+        branch copy _33 -> [bb15, bb14];
     }
 
     bb14: {
@@ -837,208 +999,84 @@ fn baml.Array.for_each(self: baml.Array, fn: (unknown) -> void throws unknown) -
     }
 
     bb15: {
-        _35 = load_type(#0);
-        _6 = call const fn baml.iter.Iterable$for$T[].iter<copy _35>(copy _3) -> [bb27];
+        _34 = load_type(#0);
+        _35 = load_type(void);
+        _8 = call const fn baml.iter.Peekable.Iterator.next<copy _34, copy _35>(copy _6) -> [bb26];
     }
 
     bb16: {
-        _32 = load_type(#0);
-        _33 = load_type(void);
-        _6 = call const fn baml.iter.Peekable.Iterable.iter<copy _32, copy _33>(copy _3) -> [bb27];
+        _32 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _6);
+        _8 = call copy _32() -> [bb26];
     }
 
     bb17: {
-        _30 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _3);
-        _6 = call copy _30() -> [bb27];
+        _30 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _6);
+        _8 = call copy _30() -> [bb26];
     }
 
     bb18: {
-        _28 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _3);
-        _6 = call copy _28() -> [bb27];
+        _26 = load_type(#0);
+        _27 = load_type(void);
+        _28 = load_type(void);
+        _8 = call const fn baml.iter.Filter.Iterator.next<copy _26, copy _27, copy _28>(copy _6) -> [bb26];
     }
 
     bb19: {
-        _24 = load_type(#0);
-        _25 = load_type(void);
-        _26 = load_type(void);
-        _6 = call const fn baml.iter.Filter.Iterable.iter<copy _24, copy _25, copy _26>(copy _3) -> [bb27];
+        _24 = make_bound_method baml.iter.Map.Iterator.next(copy _6);
+        _8 = call copy _24() -> [bb26];
     }
 
     bb20: {
-        _22 = make_bound_method baml.iter.Map.Iterable.iter(copy _3);
-        _6 = call copy _22() -> [bb27];
+        _22 = load_type(#0);
+        _8 = call const fn baml.iter.Repeat.Iterator.next<copy _22>(copy _6) -> [bb26];
     }
 
     bb21: {
-        _20 = load_type(#0);
-        _6 = call const fn baml.iter.Repeat.Iterable.iter<copy _20>(copy _3) -> [bb27];
+        _18 = load_type(#0);
+        _19 = load_type(void);
+        _20 = load_type(void);
+        _8 = call const fn baml.iter.Chain.Iterator.next<copy _18, copy _19, copy _20>(copy _6) -> [bb26];
     }
 
     bb22: {
-        _16 = load_type(#0);
-        _17 = load_type(void);
-        _18 = load_type(void);
-        _6 = call const fn baml.iter.Chain.Iterable.iter<copy _16, copy _17, copy _18>(copy _3) -> [bb27];
+        _15 = load_type(#0);
+        _16 = load_type(void);
+        _8 = call const fn baml.iter.StepBy.Iterator.next<copy _15, copy _16>(copy _6) -> [bb26];
     }
 
     bb23: {
         _13 = load_type(#0);
-        _14 = load_type(void);
-        _6 = call const fn baml.iter.StepBy.Iterable.iter<copy _13, copy _14>(copy _3) -> [bb27];
+        _8 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _13>(copy _6) -> [bb26];
     }
 
     bb24: {
-        _11 = load_type(#0);
-        _6 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _11>(copy _3) -> [bb27];
+        _8 = call const fn baml.iter.Range.Iterator.next(copy _6) -> [bb26];
     }
 
     bb25: {
-        _6 = call const fn baml.iter.Range.Iterable.iter(copy _3) -> [bb27];
+        _10 = make_bound_method baml.iter.Flatten.Iterator.next(copy _6);
+        _8 = call copy _10() -> [bb26];
     }
 
     bb26: {
-        _8 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _3);
-        _6 = call copy _8() -> [bb27];
+        _36 = is_type(copy _8, baml.iter.Done);
+        branch copy _36 -> [bb28, bb27];
     }
 
     bb27: {
-        _37 = is_type(copy _6, baml.iter.Flatten<_, #0?, void, void>);
-        branch copy _37 -> [bb49, bb28];
+        _37 = copy _8;
+        fresh_cell(_38);
+        _38 = copy _37;
+        _40 = copy _38;
+        _39 = call copy _2(copy _40) -> [bb3];
     }
 
     bb28: {
-        _39 = is_type(copy _6, baml.iter.Range);
-        branch copy _39 -> [bb48, bb29];
+        _0 = const null;
+        goto -> bb29;
     }
 
     bb29: {
-        _40 = is_type(copy _6, baml.iter.ArrayIterator<#0?>);
-        branch copy _40 -> [bb47, bb30];
-    }
-
-    bb30: {
-        _42 = is_type(copy _6, baml.iter.StepBy<#0?, void>);
-        branch copy _42 -> [bb46, bb31];
-    }
-
-    bb31: {
-        _45 = is_type(copy _6, baml.iter.Chain<#0?, void, void>);
-        branch copy _45 -> [bb45, bb32];
-    }
-
-    bb32: {
-        _49 = is_type(copy _6, baml.iter.Repeat<#0?>);
-        branch copy _49 -> [bb44, bb33];
-    }
-
-    bb33: {
-        _51 = is_type(copy _6, baml.iter.Map<_, #0?, void, void>);
-        branch copy _51 -> [bb43, bb34];
-    }
-
-    bb34: {
-        _53 = is_type(copy _6, baml.iter.Filter<#0?, void, void>);
-        branch copy _53 -> [bb42, bb35];
-    }
-
-    bb35: {
-        _57 = is_type(copy _6, baml.iter.FilterMap<_, #0?, void, void>);
-        branch copy _57 -> [bb41, bb36];
-    }
-
-    bb36: {
-        _59 = is_type(copy _6, baml.iter.FlatMap<_, #0?, void, void, void>);
-        branch copy _59 -> [bb40, bb37];
-    }
-
-    bb37: {
-        _61 = is_type(copy _6, baml.iter.Peekable<#0?, void>);
-        branch copy _61 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _62 = load_type(#0);
-        _63 = load_type(void);
-        _36 = call const fn baml.iter.Peekable.Iterator.next<copy _62, copy _63>(copy _6) -> [bb50];
-    }
-
-    bb40: {
-        _60 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _6);
-        _36 = call copy _60() -> [bb50];
-    }
-
-    bb41: {
-        _58 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _6);
-        _36 = call copy _58() -> [bb50];
-    }
-
-    bb42: {
-        _54 = load_type(#0);
-        _55 = load_type(void);
-        _56 = load_type(void);
-        _36 = call const fn baml.iter.Filter.Iterator.next<copy _54, copy _55, copy _56>(copy _6) -> [bb50];
-    }
-
-    bb43: {
-        _52 = make_bound_method baml.iter.Map.Iterator.next(copy _6);
-        _36 = call copy _52() -> [bb50];
-    }
-
-    bb44: {
-        _50 = load_type(#0);
-        _36 = call const fn baml.iter.Repeat.Iterator.next<copy _50>(copy _6) -> [bb50];
-    }
-
-    bb45: {
-        _46 = load_type(#0);
-        _47 = load_type(void);
-        _48 = load_type(void);
-        _36 = call const fn baml.iter.Chain.Iterator.next<copy _46, copy _47, copy _48>(copy _6) -> [bb50];
-    }
-
-    bb46: {
-        _43 = load_type(#0);
-        _44 = load_type(void);
-        _36 = call const fn baml.iter.StepBy.Iterator.next<copy _43, copy _44>(copy _6) -> [bb50];
-    }
-
-    bb47: {
-        _41 = load_type(#0);
-        _36 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _41>(copy _6) -> [bb50];
-    }
-
-    bb48: {
-        _36 = call const fn baml.iter.Range.Iterator.next(copy _6) -> [bb50];
-    }
-
-    bb49: {
-        _38 = make_bound_method baml.iter.Flatten.Iterator.next(copy _6);
-        _36 = call copy _38() -> [bb50];
-    }
-
-    bb50: {
-        _64 = is_type(copy _36, baml.iter.Done);
-        branch copy _64 -> [bb52, bb51];
-    }
-
-    bb51: {
-        _65 = copy _36;
-        fresh_cell(_66);
-        _66 = copy _65;
-        _68 = copy _66;
-        _67 = call copy _2(copy _68) -> [bb27];
-    }
-
-    bb52: {
-        _0 = const null;
-        goto -> bb53;
-    }
-
-    bb53: {
         return;
     }
 }
@@ -1150,11 +1188,757 @@ fn baml.Array.slice = builtin(vm)
 
 fn baml.Array.some = builtin(vm)
 
-fn baml.Array.sort = builtin(vm)
-
 fn baml.Array.sort_by = builtin(vm)
 
-fn baml.Array.sort_by_key = builtin(vm)
+fn baml.Array.sort_by_key(self: baml.Array, key: (unknown) -> unknown throws unknown) -> void[] {
+    // Locals:
+    let _0: void[] // _0 // return
+    let _1: baml.Array // self // param
+    let _2: (unknown) -> unknown throws unknown // key // param
+    let _3: int // n
+    let _4: bool
+    let _5: int
+    let _6: unknown[] // items
+    let _7: int
+    let _8: type
+    let _9: unknown[] // keys [captured]
+    let _10: unknown[]
+    let _11: baml.iter.Iterator<Item = unknown, Error = void>
+    let _12: type
+    let _13: unknown
+    let _14: bool
+    let _15: unknown
+    let _16: bool
+    let _17: bool
+    let _18: type
+    let _19: bool
+    let _20: type
+    let _21: type
+    let _22: bool
+    let _23: type
+    let _24: type
+    let _25: type
+    let _26: bool
+    let _27: type
+    let _28: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
+    let _32: type
+    let _33: type
+    let _34: bool
+    let _35: unknown
+    let _36: bool
+    let _37: unknown
+    let _38: bool
+    let _39: type
+    let _40: type
+    let _41: bool
+    let _42: unknown
+    let _43: unknown // x
+    let _44: int
+    let _45: unknown
+    let _46: unknown
+    let _47: int[] // order
+    let _48: int // p
+    let _49: bool
+    let _50: int
+    let _51: int
+    let _52: int
+    let _53: int
+    let _54: int[]
+    let _55: (int, int) -> int throws unknown
+    let _56: type
+    let _57: type
+    let _58: unknown[] // sorted
+    let _59: int[]
+    let _60: baml.iter.Iterator<Item = int, Error = void>
+    let _61: type
+    let _62: unknown
+    let _63: bool
+    let _64: unknown
+    let _65: bool
+    let _66: bool
+    let _67: type
+    let _68: bool
+    let _69: type
+    let _70: type
+    let _71: bool
+    let _72: type
+    let _73: type
+    let _74: type
+    let _75: bool
+    let _76: type
+    let _77: bool
+    let _78: unknown
+    let _79: bool
+    let _80: type
+    let _81: type
+    let _82: type
+    let _83: bool
+    let _84: unknown
+    let _85: bool
+    let _86: unknown
+    let _87: bool
+    let _88: type
+    let _89: type
+    let _90: bool
+    let _91: int
+    let _92: int // i
+    let _93: unknown | null
+    let _94: int
+    let _95: type
+    let _96: bool
+    let _97: void // item
+    let _98: int
+    let _99: unknown
+    let _100: null
+    let _101: type
+    let _102: unknown[]
+    let _103: baml.iter.Iterator<Item = unknown, Error = void>
+    let _104: type
+    let _105: unknown
+    let _106: bool
+    let _107: unknown
+    let _108: bool
+    let _109: bool
+    let _110: type
+    let _111: bool
+    let _112: type
+    let _113: type
+    let _114: bool
+    let _115: type
+    let _116: type
+    let _117: type
+    let _118: bool
+    let _119: type
+    let _120: bool
+    let _121: unknown
+    let _122: bool
+    let _123: type
+    let _124: type
+    let _125: type
+    let _126: bool
+    let _127: unknown
+    let _128: bool
+    let _129: unknown
+    let _130: bool
+    let _131: type
+    let _132: type
+    let _133: bool
+    let _134: unknown
+    let _135: unknown // s
+    let _136: int
+    let _137: unknown
+
+    bb0: {
+        _3 = len(_1);
+        goto -> bb1;
+    }
+
+    bb1: {
+        _5 = copy _3;
+        _4 = copy _5 <= const 1_i64;
+        branch copy _4 -> [bb94, bb2];
+    }
+
+    bb2: {
+        _7 = copy _3;
+        _8 = load_type(#0);
+        _6 = call const fn baml.Array.slice<copy _8>(copy _1, const 0_i64, copy _7) -> [bb3];
+    }
+
+    bb3: {
+        _9 = [];
+        _10 = copy _6;
+        goto -> bb4;
+    }
+
+    bb4: {
+        _12 = load_type(#0);
+        _11 = call const fn baml.iter.Iterable$for$T[].iter<copy _12>(copy _10) -> [bb5];
+    }
+
+    bb5: {
+        _14 = is_type(copy _11, baml.iter.Flatten<_, #0?, void, void>);
+        branch copy _14 -> [bb27, bb6];
+    }
+
+    bb6: {
+        _16 = is_type(copy _11, baml.iter.Range);
+        branch copy _16 -> [bb26, bb7];
+    }
+
+    bb7: {
+        _17 = is_type(copy _11, baml.iter.ArrayIterator<#0?>);
+        branch copy _17 -> [bb25, bb8];
+    }
+
+    bb8: {
+        _19 = is_type(copy _11, baml.iter.StepBy<#0?, void>);
+        branch copy _19 -> [bb24, bb9];
+    }
+
+    bb9: {
+        _22 = is_type(copy _11, baml.iter.Chain<#0?, void, void>);
+        branch copy _22 -> [bb23, bb10];
+    }
+
+    bb10: {
+        _26 = is_type(copy _11, baml.iter.Repeat<#0?>);
+        branch copy _26 -> [bb22, bb11];
+    }
+
+    bb11: {
+        _28 = is_type(copy _11, baml.iter.Map<_, #0?, void, void>);
+        branch copy _28 -> [bb21, bb12];
+    }
+
+    bb12: {
+        _30 = is_type(copy _11, baml.iter.Filter<#0?, void, void>);
+        branch copy _30 -> [bb20, bb13];
+    }
+
+    bb13: {
+        _34 = is_type(copy _11, baml.iter.FilterMap<_, #0?, void, void>);
+        branch copy _34 -> [bb19, bb14];
+    }
+
+    bb14: {
+        _36 = is_type(copy _11, baml.iter.FlatMap<_, #0?, void, void, void>);
+        branch copy _36 -> [bb18, bb15];
+    }
+
+    bb15: {
+        _38 = is_type(copy _11, baml.iter.Peekable<#0?, void>);
+        branch copy _38 -> [bb17, bb16];
+    }
+
+    bb16: {
+        unreachable;
+    }
+
+    bb17: {
+        _39 = load_type(#0);
+        _40 = load_type(void);
+        _13 = call const fn baml.iter.Peekable.Iterator.next<copy _39, copy _40>(copy _11) -> [bb28];
+    }
+
+    bb18: {
+        _37 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _11);
+        _13 = call copy _37() -> [bb28];
+    }
+
+    bb19: {
+        _35 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _11);
+        _13 = call copy _35() -> [bb28];
+    }
+
+    bb20: {
+        _31 = load_type(#0);
+        _32 = load_type(void);
+        _33 = load_type(void);
+        _13 = call const fn baml.iter.Filter.Iterator.next<copy _31, copy _32, copy _33>(copy _11) -> [bb28];
+    }
+
+    bb21: {
+        _29 = make_bound_method baml.iter.Map.Iterator.next(copy _11);
+        _13 = call copy _29() -> [bb28];
+    }
+
+    bb22: {
+        _27 = load_type(#0);
+        _13 = call const fn baml.iter.Repeat.Iterator.next<copy _27>(copy _11) -> [bb28];
+    }
+
+    bb23: {
+        _23 = load_type(#0);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _13 = call const fn baml.iter.Chain.Iterator.next<copy _23, copy _24, copy _25>(copy _11) -> [bb28];
+    }
+
+    bb24: {
+        _20 = load_type(#0);
+        _21 = load_type(void);
+        _13 = call const fn baml.iter.StepBy.Iterator.next<copy _20, copy _21>(copy _11) -> [bb28];
+    }
+
+    bb25: {
+        _18 = load_type(#0);
+        _13 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _18>(copy _11) -> [bb28];
+    }
+
+    bb26: {
+        _13 = call const fn baml.iter.Range.Iterator.next(copy _11) -> [bb28];
+    }
+
+    bb27: {
+        _15 = make_bound_method baml.iter.Flatten.Iterator.next(copy _11);
+        _13 = call copy _15() -> [bb28];
+    }
+
+    bb28: {
+        _41 = is_type(copy _13, baml.iter.Done);
+        branch copy _41 -> [bb31, bb29];
+    }
+
+    bb29: {
+        _42 = copy _13;
+        fresh_cell(_43);
+        _43 = copy _42;
+        _46 = copy _43;
+        _45 = call copy _2(copy _46) -> [bb30];
+    }
+
+    bb30: {
+        _44 = call const fn baml.Array.push(copy _9, copy _45) -> [bb5];
+    }
+
+    bb31: {
+        _47 = [];
+        _48 = const 0_i64;
+        goto -> bb32;
+    }
+
+    bb32: {
+        _50 = copy _48;
+        _51 = copy _3;
+        _49 = copy _50 < copy _51;
+        branch copy _49 -> [bb92, bb33];
+    }
+
+    bb33: {
+        _55 = make_closure lambda[0]<3 type_args>(copy _9);
+        _56 = load_type(unknown);
+        _57 = load_type(int);
+        _54 = call const fn baml.Array.sort_by<copy _57, copy _56>(copy _47, copy _55) -> [bb34];
+    }
+
+    bb34: {
+        _58 = [];
+        _59 = copy _47;
+        goto -> bb35;
+    }
+
+    bb35: {
+        _61 = load_type(int);
+        _60 = call const fn baml.iter.Iterable$for$T[].iter<copy _61>(copy _59) -> [bb36];
+    }
+
+    bb36: {
+        _63 = is_type(copy _60, baml.iter.Flatten<_, int, void, void>);
+        branch copy _63 -> [bb58, bb37];
+    }
+
+    bb37: {
+        _65 = is_type(copy _60, baml.iter.Range);
+        branch copy _65 -> [bb57, bb38];
+    }
+
+    bb38: {
+        _66 = is_type(copy _60, baml.iter.ArrayIterator<int>);
+        branch copy _66 -> [bb56, bb39];
+    }
+
+    bb39: {
+        _68 = is_type(copy _60, baml.iter.StepBy<int, void>);
+        branch copy _68 -> [bb55, bb40];
+    }
+
+    bb40: {
+        _71 = is_type(copy _60, baml.iter.Chain<int, void, void>);
+        branch copy _71 -> [bb54, bb41];
+    }
+
+    bb41: {
+        _75 = is_type(copy _60, baml.iter.Repeat<int>);
+        branch copy _75 -> [bb53, bb42];
+    }
+
+    bb42: {
+        _77 = is_type(copy _60, baml.iter.Map<_, int, void, void>);
+        branch copy _77 -> [bb52, bb43];
+    }
+
+    bb43: {
+        _79 = is_type(copy _60, baml.iter.Filter<int, void, void>);
+        branch copy _79 -> [bb51, bb44];
+    }
+
+    bb44: {
+        _83 = is_type(copy _60, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _83 -> [bb50, bb45];
+    }
+
+    bb45: {
+        _85 = is_type(copy _60, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _85 -> [bb49, bb46];
+    }
+
+    bb46: {
+        _87 = is_type(copy _60, baml.iter.Peekable<int, void>);
+        branch copy _87 -> [bb48, bb47];
+    }
+
+    bb47: {
+        unreachable;
+    }
+
+    bb48: {
+        _88 = load_type(int);
+        _89 = load_type(void);
+        _62 = call const fn baml.iter.Peekable.Iterator.next<copy _88, copy _89>(copy _60) -> [bb59];
+    }
+
+    bb49: {
+        _86 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _60);
+        _62 = call copy _86() -> [bb59];
+    }
+
+    bb50: {
+        _84 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _60);
+        _62 = call copy _84() -> [bb59];
+    }
+
+    bb51: {
+        _80 = load_type(int);
+        _81 = load_type(void);
+        _82 = load_type(void);
+        _62 = call const fn baml.iter.Filter.Iterator.next<copy _80, copy _81, copy _82>(copy _60) -> [bb59];
+    }
+
+    bb52: {
+        _78 = make_bound_method baml.iter.Map.Iterator.next(copy _60);
+        _62 = call copy _78() -> [bb59];
+    }
+
+    bb53: {
+        _76 = load_type(int);
+        _62 = call const fn baml.iter.Repeat.Iterator.next<copy _76>(copy _60) -> [bb59];
+    }
+
+    bb54: {
+        _72 = load_type(int);
+        _73 = load_type(void);
+        _74 = load_type(void);
+        _62 = call const fn baml.iter.Chain.Iterator.next<copy _72, copy _73, copy _74>(copy _60) -> [bb59];
+    }
+
+    bb55: {
+        _69 = load_type(int);
+        _70 = load_type(void);
+        _62 = call const fn baml.iter.StepBy.Iterator.next<copy _69, copy _70>(copy _60) -> [bb59];
+    }
+
+    bb56: {
+        _67 = load_type(int);
+        _62 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _67>(copy _60) -> [bb59];
+    }
+
+    bb57: {
+        _62 = call const fn baml.iter.Range.Iterator.next(copy _60) -> [bb59];
+    }
+
+    bb58: {
+        _64 = make_bound_method baml.iter.Flatten.Iterator.next(copy _60);
+        _62 = call copy _64() -> [bb59];
+    }
+
+    bb59: {
+        _90 = is_type(copy _62, baml.iter.Done);
+        branch copy _90 -> [bb63, bb60];
+    }
+
+    bb60: {
+        _91 = copy _62;
+        fresh_cell(_92);
+        _92 = copy _91;
+        _94 = copy _92;
+        _95 = load_type(#0);
+        _93 = call const fn baml.Array.at<copy _95>(copy _6, copy _94) -> [bb61];
+    }
+
+    bb61: {
+        _96 = copy _93 == const null;
+        branch copy _96 -> [bb36, bb62];
+    }
+
+    bb62: {
+        _97 = copy _93;
+        _99 = copy _97;
+        _98 = call const fn baml.Array.push(copy _58, copy _99) -> [bb36];
+    }
+
+    bb63: {
+        _101 = load_type(#0);
+        _100 = call const fn baml.Array.clear<copy _101>(copy _1) -> [bb64];
+    }
+
+    bb64: {
+        _102 = copy _58;
+        goto -> bb65;
+    }
+
+    bb65: {
+        _104 = load_type(#0);
+        _103 = call const fn baml.iter.Iterable$for$T[].iter<copy _104>(copy _102) -> [bb66];
+    }
+
+    bb66: {
+        _106 = is_type(copy _103, baml.iter.Flatten<_, #0?, void, void>);
+        branch copy _106 -> [bb88, bb67];
+    }
+
+    bb67: {
+        _108 = is_type(copy _103, baml.iter.Range);
+        branch copy _108 -> [bb87, bb68];
+    }
+
+    bb68: {
+        _109 = is_type(copy _103, baml.iter.ArrayIterator<#0?>);
+        branch copy _109 -> [bb86, bb69];
+    }
+
+    bb69: {
+        _111 = is_type(copy _103, baml.iter.StepBy<#0?, void>);
+        branch copy _111 -> [bb85, bb70];
+    }
+
+    bb70: {
+        _114 = is_type(copy _103, baml.iter.Chain<#0?, void, void>);
+        branch copy _114 -> [bb84, bb71];
+    }
+
+    bb71: {
+        _118 = is_type(copy _103, baml.iter.Repeat<#0?>);
+        branch copy _118 -> [bb83, bb72];
+    }
+
+    bb72: {
+        _120 = is_type(copy _103, baml.iter.Map<_, #0?, void, void>);
+        branch copy _120 -> [bb82, bb73];
+    }
+
+    bb73: {
+        _122 = is_type(copy _103, baml.iter.Filter<#0?, void, void>);
+        branch copy _122 -> [bb81, bb74];
+    }
+
+    bb74: {
+        _126 = is_type(copy _103, baml.iter.FilterMap<_, #0?, void, void>);
+        branch copy _126 -> [bb80, bb75];
+    }
+
+    bb75: {
+        _128 = is_type(copy _103, baml.iter.FlatMap<_, #0?, void, void, void>);
+        branch copy _128 -> [bb79, bb76];
+    }
+
+    bb76: {
+        _130 = is_type(copy _103, baml.iter.Peekable<#0?, void>);
+        branch copy _130 -> [bb78, bb77];
+    }
+
+    bb77: {
+        unreachable;
+    }
+
+    bb78: {
+        _131 = load_type(#0);
+        _132 = load_type(void);
+        _105 = call const fn baml.iter.Peekable.Iterator.next<copy _131, copy _132>(copy _103) -> [bb89];
+    }
+
+    bb79: {
+        _129 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _103);
+        _105 = call copy _129() -> [bb89];
+    }
+
+    bb80: {
+        _127 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _103);
+        _105 = call copy _127() -> [bb89];
+    }
+
+    bb81: {
+        _123 = load_type(#0);
+        _124 = load_type(void);
+        _125 = load_type(void);
+        _105 = call const fn baml.iter.Filter.Iterator.next<copy _123, copy _124, copy _125>(copy _103) -> [bb89];
+    }
+
+    bb82: {
+        _121 = make_bound_method baml.iter.Map.Iterator.next(copy _103);
+        _105 = call copy _121() -> [bb89];
+    }
+
+    bb83: {
+        _119 = load_type(#0);
+        _105 = call const fn baml.iter.Repeat.Iterator.next<copy _119>(copy _103) -> [bb89];
+    }
+
+    bb84: {
+        _115 = load_type(#0);
+        _116 = load_type(void);
+        _117 = load_type(void);
+        _105 = call const fn baml.iter.Chain.Iterator.next<copy _115, copy _116, copy _117>(copy _103) -> [bb89];
+    }
+
+    bb85: {
+        _112 = load_type(#0);
+        _113 = load_type(void);
+        _105 = call const fn baml.iter.StepBy.Iterator.next<copy _112, copy _113>(copy _103) -> [bb89];
+    }
+
+    bb86: {
+        _110 = load_type(#0);
+        _105 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _110>(copy _103) -> [bb89];
+    }
+
+    bb87: {
+        _105 = call const fn baml.iter.Range.Iterator.next(copy _103) -> [bb89];
+    }
+
+    bb88: {
+        _107 = make_bound_method baml.iter.Flatten.Iterator.next(copy _103);
+        _105 = call copy _107() -> [bb89];
+    }
+
+    bb89: {
+        _133 = is_type(copy _105, baml.iter.Done);
+        branch copy _133 -> [bb91, bb90];
+    }
+
+    bb90: {
+        _134 = copy _105;
+        fresh_cell(_135);
+        _135 = copy _134;
+        _137 = copy _135;
+        _136 = call const fn baml.Array.push(copy _1, copy _137) -> [bb66];
+    }
+
+    bb91: {
+        _0 = copy _1;
+        goto -> bb95;
+    }
+
+    bb92: {
+        _53 = copy _48;
+        _52 = call const fn baml.Array.push(copy _47, copy _53) -> [bb93];
+    }
+
+    bb93: {
+        _48 = copy _48 + const 1_i64;
+        goto -> bb32;
+    }
+
+    bb94: {
+        _0 = copy _1;
+        goto -> bb95;
+    }
+
+    bb95: {
+        return;
+    }
+}
+
+// lambda[0]
+fn .<lambda(Array.sort_by_key, 0)>(i: int, j: int) -> null {
+    // Locals:
+    let _0: null // _0 // return
+    let _1: int // i // param
+    let _2: int // j // param
+    let _3: unknown | null
+    let _4: type
+    let _5: bool
+    let _6: void // ki
+    let _7: unknown | null
+    let _8: type
+    let _9: bool
+    let _10: void // kj
+    let _11: unknown
+    let _12: bool
+    let _13: bool
+    let _14: bool
+    let _15: bool
+
+    bb0: {
+        _4 = load_type(#1);
+        _3 = call const fn baml.Array.at<copy _4>(copy capture[0], copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _5 = copy _3 == const null;
+        branch copy _5 -> [bb14, bb2];
+    }
+
+    bb2: {
+        _6 = copy _3;
+        _8 = load_type(#1);
+        _7 = call const fn baml.Array.at<copy _8>(copy capture[0], copy _2) -> [bb3];
+    }
+
+    bb3: {
+        _9 = copy _7 == const null;
+        branch copy _9 -> [bb13, bb4];
+    }
+
+    bb4: {
+        _10 = copy _7;
+        _11 = copy _10;
+        _12 = is_type(copy _6, int);
+        branch copy _12 -> [bb12, bb5];
+    }
+
+    bb5: {
+        _13 = is_type(copy _6, bigint);
+        branch copy _13 -> [bb11, bb6];
+    }
+
+    bb6: {
+        _14 = is_type(copy _6, string);
+        branch copy _14 -> [bb10, bb7];
+    }
+
+    bb7: {
+        _15 = is_type(copy _6, float);
+        branch copy _15 -> [bb9, bb8];
+    }
+
+    bb8: {
+        unreachable;
+    }
+
+    bb9: {
+        _0 = call const fn baml.Comparable$for$float.compare(copy _6, copy _11) -> [bb15];
+    }
+
+    bb10: {
+        _0 = call const fn baml.Comparable$for$string.compare(copy _6, copy _11) -> [bb15];
+    }
+
+    bb11: {
+        _0 = call const fn baml.Comparable$for$bigint.compare(copy _6, copy _11) -> [bb15];
+    }
+
+    bb12: {
+        _0 = call const fn baml.Comparable$for$int.compare(copy _6, copy _11) -> [bb15];
+    }
+
+    bb13: {
+        _0 = const 0_i64;
+        goto -> bb15;
+    }
+
+    bb14: {
+        _0 = const 0_i64;
+        goto -> bb15;
+    }
+
+    bb15: {
+        return;
+    }
+}
 
 fn baml.Array.splice = builtin(vm)
 
@@ -12331,129 +13115,99 @@ fn baml.llm.PlannerState.rr_local_offset(self: baml.llm.PlannerState, client_nam
     let _3: int // offset
     let _4: string[]
     let _5: baml.iter.Iterator<Item = string, Error = void>
-    let _6: bool
+    let _6: type
     let _7: unknown
     let _8: bool
-    let _9: type
+    let _9: unknown
     let _10: bool
     let _11: type
-    let _12: type
-    let _13: bool
+    let _12: bool
+    let _13: type
     let _14: type
-    let _15: type
+    let _15: bool
     let _16: type
-    let _17: bool
+    let _17: type
     let _18: type
     let _19: bool
-    let _20: unknown
+    let _20: type
     let _21: bool
-    let _22: type
-    let _23: type
+    let _22: unknown
+    let _23: bool
     let _24: type
-    let _25: bool
-    let _26: unknown
+    let _25: type
+    let _26: type
     let _27: bool
     let _28: unknown
     let _29: bool
-    let _30: type
-    let _31: type
-    let _32: bool
+    let _30: unknown
+    let _31: bool
+    let _32: type
     let _33: type
     let _34: bool
-    let _35: type
-    let _36: unknown
+    let _35: string
+    let _36: string // seen_name
     let _37: bool
-    let _38: unknown
-    let _39: bool
-    let _40: type
-    let _41: bool
-    let _42: type
-    let _43: type
-    let _44: bool
-    let _45: type
-    let _46: type
-    let _47: type
-    let _48: bool
-    let _49: type
-    let _50: bool
-    let _51: unknown
-    let _52: bool
-    let _53: type
-    let _54: type
-    let _55: type
-    let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: unknown
-    let _60: bool
-    let _61: type
-    let _62: type
-    let _63: bool
-    let _64: string
-    let _65: string // seen_name
-    let _66: bool
-    let _67: string
+    let _38: string
 
     bb0: {
         _3 = const 0_i64;
         _4 = copy _1.0;
-        _6 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
-        branch copy _6 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _8 = is_type(copy _4, baml.iter.ArrayIterator<string>);
-        branch copy _8 -> [bb23, bb2];
+        _6 = load_type(string);
+        _5 = call const fn baml.iter.Iterable$for$T[].iter<copy _6>(copy _4) -> [bb2];
     }
 
     bb2: {
-        _10 = is_type(copy _4, baml.iter.StepBy<string, void>);
-        branch copy _10 -> [bb22, bb3];
+        _8 = is_type(copy _5, baml.iter.Flatten<_, string, void, void>);
+        branch copy _8 -> [bb22, bb3];
     }
 
     bb3: {
-        _13 = is_type(copy _4, baml.iter.Chain<string, void, void>);
-        branch copy _13 -> [bb21, bb4];
+        _10 = is_type(copy _5, baml.iter.ArrayIterator<string>);
+        branch copy _10 -> [bb21, bb4];
     }
 
     bb4: {
-        _17 = is_type(copy _4, baml.iter.Repeat<string>);
-        branch copy _17 -> [bb20, bb5];
+        _12 = is_type(copy _5, baml.iter.StepBy<string, void>);
+        branch copy _12 -> [bb20, bb5];
     }
 
     bb5: {
-        _19 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
-        branch copy _19 -> [bb19, bb6];
+        _15 = is_type(copy _5, baml.iter.Chain<string, void, void>);
+        branch copy _15 -> [bb19, bb6];
     }
 
     bb6: {
-        _21 = is_type(copy _4, baml.iter.Filter<string, void, void>);
-        branch copy _21 -> [bb18, bb7];
+        _19 = is_type(copy _5, baml.iter.Repeat<string>);
+        branch copy _19 -> [bb18, bb7];
     }
 
     bb7: {
-        _25 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _25 -> [bb17, bb8];
+        _21 = is_type(copy _5, baml.iter.Map<_, string, void, void>);
+        branch copy _21 -> [bb17, bb8];
     }
 
     bb8: {
-        _27 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _27 -> [bb16, bb9];
+        _23 = is_type(copy _5, baml.iter.Filter<string, void, void>);
+        branch copy _23 -> [bb16, bb9];
     }
 
     bb9: {
-        _29 = is_type(copy _4, baml.iter.Peekable<string, void>);
-        branch copy _29 -> [bb15, bb10];
+        _27 = is_type(copy _5, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _27 -> [bb15, bb10];
     }
 
     bb10: {
-        _32 = is_type(copy _4, unknown[]);
-        branch copy _32 -> [bb14, bb11];
+        _29 = is_type(copy _5, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _29 -> [bb14, bb11];
     }
 
     bb11: {
-        _34 = is_type(copy _4, string[]);
-        branch copy _34 -> [bb13, bb12];
+        _31 = is_type(copy _5, baml.iter.Peekable<string, void>);
+        branch copy _31 -> [bb13, bb12];
     }
 
     bb12: {
@@ -12461,206 +13215,86 @@ fn baml.llm.PlannerState.rr_local_offset(self: baml.llm.PlannerState, client_nam
     }
 
     bb13: {
-        _35 = load_type(string);
-        _5 = call const fn baml.iter.Iterable$for$T[].iter<copy _35>(copy _4) -> [bb25];
+        _32 = load_type(string);
+        _33 = load_type(void);
+        _7 = call const fn baml.iter.Peekable.Iterator.next<copy _32, copy _33>(copy _5) -> [bb23];
     }
 
     bb14: {
-        _33 = load_type(string);
-        _5 = call const fn baml.iter.Iterable$for$T[].iter<copy _33>(copy _4) -> [bb25];
+        _30 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _5);
+        _7 = call copy _30() -> [bb23];
     }
 
     bb15: {
-        _30 = load_type(string);
-        _31 = load_type(void);
-        _5 = call const fn baml.iter.Peekable.Iterable.iter<copy _30, copy _31>(copy _4) -> [bb25];
+        _28 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _5);
+        _7 = call copy _28() -> [bb23];
     }
 
     bb16: {
-        _28 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _4);
-        _5 = call copy _28() -> [bb25];
+        _24 = load_type(string);
+        _25 = load_type(void);
+        _26 = load_type(void);
+        _7 = call const fn baml.iter.Filter.Iterator.next<copy _24, copy _25, copy _26>(copy _5) -> [bb23];
     }
 
     bb17: {
-        _26 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _4);
-        _5 = call copy _26() -> [bb25];
+        _22 = make_bound_method baml.iter.Map.Iterator.next(copy _5);
+        _7 = call copy _22() -> [bb23];
     }
 
     bb18: {
-        _22 = load_type(string);
-        _23 = load_type(void);
-        _24 = load_type(void);
-        _5 = call const fn baml.iter.Filter.Iterable.iter<copy _22, copy _23, copy _24>(copy _4) -> [bb25];
+        _20 = load_type(string);
+        _7 = call const fn baml.iter.Repeat.Iterator.next<copy _20>(copy _5) -> [bb23];
     }
 
     bb19: {
-        _20 = make_bound_method baml.iter.Map.Iterable.iter(copy _4);
-        _5 = call copy _20() -> [bb25];
+        _16 = load_type(string);
+        _17 = load_type(void);
+        _18 = load_type(void);
+        _7 = call const fn baml.iter.Chain.Iterator.next<copy _16, copy _17, copy _18>(copy _5) -> [bb23];
     }
 
     bb20: {
-        _18 = load_type(string);
-        _5 = call const fn baml.iter.Repeat.Iterable.iter<copy _18>(copy _4) -> [bb25];
+        _13 = load_type(string);
+        _14 = load_type(void);
+        _7 = call const fn baml.iter.StepBy.Iterator.next<copy _13, copy _14>(copy _5) -> [bb23];
     }
 
     bb21: {
-        _14 = load_type(string);
-        _15 = load_type(void);
-        _16 = load_type(void);
-        _5 = call const fn baml.iter.Chain.Iterable.iter<copy _14, copy _15, copy _16>(copy _4) -> [bb25];
+        _11 = load_type(string);
+        _7 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _11>(copy _5) -> [bb23];
     }
 
     bb22: {
-        _11 = load_type(string);
-        _12 = load_type(void);
-        _5 = call const fn baml.iter.StepBy.Iterable.iter<copy _11, copy _12>(copy _4) -> [bb25];
+        _9 = make_bound_method baml.iter.Flatten.Iterator.next(copy _5);
+        _7 = call copy _9() -> [bb23];
     }
 
     bb23: {
-        _9 = load_type(string);
-        _5 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _9>(copy _4) -> [bb25];
+        _34 = is_type(copy _7, baml.iter.Done);
+        branch copy _34 -> [bb26, bb24];
     }
 
     bb24: {
-        _7 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _4);
-        _5 = call copy _7() -> [bb25];
+        _35 = copy _7;
+        fresh_cell(_36);
+        _36 = copy _35;
+        _38 = copy _36;
+        _37 = copy _38 == copy _2;
+        branch copy _37 -> [bb25, bb2];
     }
 
     bb25: {
-        _37 = is_type(copy _5, baml.iter.Flatten<_, string, void, void>);
-        branch copy _37 -> [bb45, bb26];
+        _3 = copy _3 + const 1_i64;
+        goto -> bb2;
     }
 
     bb26: {
-        _39 = is_type(copy _5, baml.iter.ArrayIterator<string>);
-        branch copy _39 -> [bb44, bb27];
+        _0 = copy _3;
+        goto -> bb27;
     }
 
     bb27: {
-        _41 = is_type(copy _5, baml.iter.StepBy<string, void>);
-        branch copy _41 -> [bb43, bb28];
-    }
-
-    bb28: {
-        _44 = is_type(copy _5, baml.iter.Chain<string, void, void>);
-        branch copy _44 -> [bb42, bb29];
-    }
-
-    bb29: {
-        _48 = is_type(copy _5, baml.iter.Repeat<string>);
-        branch copy _48 -> [bb41, bb30];
-    }
-
-    bb30: {
-        _50 = is_type(copy _5, baml.iter.Map<_, string, void, void>);
-        branch copy _50 -> [bb40, bb31];
-    }
-
-    bb31: {
-        _52 = is_type(copy _5, baml.iter.Filter<string, void, void>);
-        branch copy _52 -> [bb39, bb32];
-    }
-
-    bb32: {
-        _56 = is_type(copy _5, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _56 -> [bb38, bb33];
-    }
-
-    bb33: {
-        _58 = is_type(copy _5, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _58 -> [bb37, bb34];
-    }
-
-    bb34: {
-        _60 = is_type(copy _5, baml.iter.Peekable<string, void>);
-        branch copy _60 -> [bb36, bb35];
-    }
-
-    bb35: {
-        unreachable;
-    }
-
-    bb36: {
-        _61 = load_type(string);
-        _62 = load_type(void);
-        _36 = call const fn baml.iter.Peekable.Iterator.next<copy _61, copy _62>(copy _5) -> [bb46];
-    }
-
-    bb37: {
-        _59 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _5);
-        _36 = call copy _59() -> [bb46];
-    }
-
-    bb38: {
-        _57 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _5);
-        _36 = call copy _57() -> [bb46];
-    }
-
-    bb39: {
-        _53 = load_type(string);
-        _54 = load_type(void);
-        _55 = load_type(void);
-        _36 = call const fn baml.iter.Filter.Iterator.next<copy _53, copy _54, copy _55>(copy _5) -> [bb46];
-    }
-
-    bb40: {
-        _51 = make_bound_method baml.iter.Map.Iterator.next(copy _5);
-        _36 = call copy _51() -> [bb46];
-    }
-
-    bb41: {
-        _49 = load_type(string);
-        _36 = call const fn baml.iter.Repeat.Iterator.next<copy _49>(copy _5) -> [bb46];
-    }
-
-    bb42: {
-        _45 = load_type(string);
-        _46 = load_type(void);
-        _47 = load_type(void);
-        _36 = call const fn baml.iter.Chain.Iterator.next<copy _45, copy _46, copy _47>(copy _5) -> [bb46];
-    }
-
-    bb43: {
-        _42 = load_type(string);
-        _43 = load_type(void);
-        _36 = call const fn baml.iter.StepBy.Iterator.next<copy _42, copy _43>(copy _5) -> [bb46];
-    }
-
-    bb44: {
-        _40 = load_type(string);
-        _36 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _40>(copy _5) -> [bb46];
-    }
-
-    bb45: {
-        _38 = make_bound_method baml.iter.Flatten.Iterator.next(copy _5);
-        _36 = call copy _38() -> [bb46];
-    }
-
-    bb46: {
-        _63 = is_type(copy _36, baml.iter.Done);
-        branch copy _63 -> [bb49, bb47];
-    }
-
-    bb47: {
-        _64 = copy _36;
-        fresh_cell(_65);
-        _65 = copy _64;
-        _67 = copy _65;
-        _66 = copy _67 == copy _2;
-        branch copy _66 -> [bb48, bb25];
-    }
-
-    bb48: {
-        _3 = copy _3 + const 1_i64;
-        goto -> bb25;
-    }
-
-    bb49: {
-        _0 = copy _3;
-        goto -> bb50;
-    }
-
-    bb50: {
         return;
     }
 }
@@ -12909,146 +13543,88 @@ fn baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner_state
     let _8: baml.llm.OrchestrationStep[] // steps
     let _9: baml.llm.Client[]
     let _10: baml.iter.Iterator<Item = baml.llm.Client, Error = void>
-    let _11: bool
+    let _11: type
     let _12: unknown
     let _13: bool
-    let _14: type
+    let _14: unknown
     let _15: bool
     let _16: type
-    let _17: type
-    let _18: bool
+    let _17: bool
+    let _18: type
     let _19: type
-    let _20: type
+    let _20: bool
     let _21: type
-    let _22: bool
+    let _22: type
     let _23: type
     let _24: bool
-    let _25: unknown
+    let _25: type
     let _26: bool
-    let _27: type
-    let _28: type
+    let _27: unknown
+    let _28: bool
     let _29: type
-    let _30: bool
-    let _31: unknown
+    let _30: type
+    let _31: type
     let _32: bool
     let _33: unknown
     let _34: bool
-    let _35: type
-    let _36: type
-    let _37: bool
+    let _35: unknown
+    let _36: bool
+    let _37: type
     let _38: type
     let _39: bool
-    let _40: type
-    let _41: unknown
-    let _42: bool
-    let _43: unknown
-    let _44: bool
-    let _45: type
+    let _40: baml.llm.Client
+    let _41: baml.llm.Client // sub
+    let _42: baml.llm.OrchestrationStep[]
+    let _43: baml.iter.Iterator<Item = baml.llm.OrchestrationStep, Error = void>
+    let _44: type
+    let _45: unknown
     let _46: bool
-    let _47: type
-    let _48: type
-    let _49: bool
-    let _50: type
+    let _47: unknown
+    let _48: bool
+    let _49: type
+    let _50: bool
     let _51: type
     let _52: type
     let _53: bool
     let _54: type
-    let _55: bool
-    let _56: unknown
+    let _55: type
+    let _56: type
     let _57: bool
     let _58: type
-    let _59: type
-    let _60: type
+    let _59: bool
+    let _60: unknown
     let _61: bool
-    let _62: unknown
-    let _63: bool
-    let _64: unknown
+    let _62: type
+    let _63: type
+    let _64: type
     let _65: bool
-    let _66: type
-    let _67: type
-    let _68: bool
-    let _69: baml.llm.Client
-    let _70: baml.llm.Client // sub
-    let _71: baml.llm.OrchestrationStep[]
-    let _72: baml.iter.Iterator<Item = baml.llm.OrchestrationStep, Error = void>
-    let _73: bool
-    let _74: unknown
-    let _75: bool
-    let _76: type
+    let _66: unknown
+    let _67: bool
+    let _68: unknown
+    let _69: bool
+    let _70: type
+    let _71: type
+    let _72: bool
+    let _73: baml.llm.OrchestrationStep
+    let _74: baml.llm.OrchestrationStep // step
+    let _75: void
+    let _76: baml.llm.OrchestrationStep
     let _77: bool
-    let _78: type
-    let _79: type
-    let _80: bool
-    let _81: type
-    let _82: type
-    let _83: type
-    let _84: bool
-    let _85: type
-    let _86: bool
-    let _87: unknown
-    let _88: bool
-    let _89: type
-    let _90: type
-    let _91: type
-    let _92: bool
-    let _93: unknown
-    let _94: bool
-    let _95: unknown
-    let _96: bool
-    let _97: type
-    let _98: type
-    let _99: bool
-    let _100: type
-    let _101: bool
-    let _102: type
-    let _103: unknown
-    let _104: bool
-    let _105: unknown
-    let _106: bool
-    let _107: type
-    let _108: bool
-    let _109: type
-    let _110: type
-    let _111: bool
-    let _112: type
-    let _113: type
-    let _114: type
-    let _115: bool
-    let _116: type
-    let _117: bool
-    let _118: unknown
-    let _119: bool
-    let _120: type
-    let _121: type
-    let _122: type
-    let _123: bool
-    let _124: unknown
-    let _125: bool
-    let _126: unknown
-    let _127: bool
-    let _128: type
-    let _129: type
-    let _130: bool
-    let _131: baml.llm.OrchestrationStep
-    let _132: baml.llm.OrchestrationStep // step
-    let _133: void
-    let _134: baml.llm.OrchestrationStep
-    let _135: bool
-    let _136: int
-    let _137: (baml.llm.Client[]) -> int throws never
-    let _138: int // idx
-    let _139: string
-    let _140: int
-    let _141: int
-    let _142: (baml.llm.Client[]) -> int throws never
-    let _143: baml.llm.Client
-    let _144: baml.llm.Client[]
-    let _145: int
+    let _78: int
+    let _79: (baml.llm.Client[]) -> int throws never
+    let _80: int // idx
+    let _81: string
+    let _82: int
+    let _83: int
+    let _84: (baml.llm.Client[]) -> int throws never
+    let _85: baml.llm.Client
+    let _86: baml.llm.Client[]
+    let _87: int
 
     bb0: {
         _3 = copy _1.1;
         _4 = discriminant(_3);
-        switch copy _4 [ClientType.Primitive: bb105, ClientType.Fallback: bb8, ClientType.RoundRobin: bb2, otherwise: bb1] (exhaustive);
+        switch copy _4 [ClientType.Primitive: bb58, ClientType.Fallback: bb8, ClientType.RoundRobin: bb2, otherwise: bb1] (exhaustive);
     }
 
     bb1: {
@@ -13056,100 +13632,99 @@ fn baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner_state
     }
 
     bb2: {
-        _137 = copy _1.2;
-        _136 = len(_137);
+        _79 = copy _1.2;
+        _78 = len(_79);
         goto -> bb3;
     }
 
     bb3: {
-        _135 = copy _136 == const 0_i64;
-        branch copy _135 -> [bb7, bb4];
+        _77 = copy _78 == const 0_i64;
+        branch copy _77 -> [bb7, bb4];
     }
 
     bb4: {
-        _139 = copy _1.0;
-        _140 = copy _1.4;
-        _142 = copy _1.2;
-        _141 = len(_142);
+        _81 = copy _1.0;
+        _82 = copy _1.4;
+        _84 = copy _1.2;
+        _83 = len(_84);
         goto -> bb5;
     }
 
     bb5: {
-        _138 = call const fn baml.llm.PlannerState.rr_pick_index(copy _2, copy _139, copy _140, copy _141) -> [bb6];
+        _80 = call const fn baml.llm.PlannerState.rr_pick_index(copy _2, copy _81, copy _82, copy _83) -> [bb6];
     }
 
     bb6: {
-        _144 = copy _1.2;
-        _145 = copy _138;
-        _143 = copy _144[_145];
-        _0 = call const fn baml.llm.Client.build_plan_with_state(copy _143, copy _2) -> [bb107];
+        _86 = copy _1.2;
+        _87 = copy _80;
+        _85 = copy _86[_87];
+        _0 = call const fn baml.llm.Client.build_plan_with_state(copy _85, copy _2) -> [bb60];
     }
 
     bb7: {
         _0 = [];
-        goto -> bb107;
+        goto -> bb60;
     }
 
     bb8: {
         _8 = [];
         _9 = copy _1.2;
-        _11 = is_type(copy _9, baml.iter.Flatten<_, baml.llm.Client, void, void>);
-        branch copy _11 -> [bb32, bb9];
+        goto -> bb9;
     }
 
     bb9: {
-        _13 = is_type(copy _9, baml.iter.ArrayIterator<baml.llm.Client>);
-        branch copy _13 -> [bb31, bb10];
+        _11 = load_type(baml.llm.Client);
+        _10 = call const fn baml.iter.Iterable$for$T[].iter<copy _11>(copy _9) -> [bb10];
     }
 
     bb10: {
-        _15 = is_type(copy _9, baml.iter.StepBy<baml.llm.Client, void>);
-        branch copy _15 -> [bb30, bb11];
+        _13 = is_type(copy _10, baml.iter.Flatten<_, baml.llm.Client, void, void>);
+        branch copy _13 -> [bb30, bb11];
     }
 
     bb11: {
-        _18 = is_type(copy _9, baml.iter.Chain<baml.llm.Client, void, void>);
-        branch copy _18 -> [bb29, bb12];
+        _15 = is_type(copy _10, baml.iter.ArrayIterator<baml.llm.Client>);
+        branch copy _15 -> [bb29, bb12];
     }
 
     bb12: {
-        _22 = is_type(copy _9, baml.iter.Repeat<baml.llm.Client>);
-        branch copy _22 -> [bb28, bb13];
+        _17 = is_type(copy _10, baml.iter.StepBy<baml.llm.Client, void>);
+        branch copy _17 -> [bb28, bb13];
     }
 
     bb13: {
-        _24 = is_type(copy _9, baml.iter.Map<_, baml.llm.Client, void, void>);
-        branch copy _24 -> [bb27, bb14];
+        _20 = is_type(copy _10, baml.iter.Chain<baml.llm.Client, void, void>);
+        branch copy _20 -> [bb27, bb14];
     }
 
     bb14: {
-        _26 = is_type(copy _9, baml.iter.Filter<baml.llm.Client, void, void>);
-        branch copy _26 -> [bb26, bb15];
+        _24 = is_type(copy _10, baml.iter.Repeat<baml.llm.Client>);
+        branch copy _24 -> [bb26, bb15];
     }
 
     bb15: {
-        _30 = is_type(copy _9, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
-        branch copy _30 -> [bb25, bb16];
+        _26 = is_type(copy _10, baml.iter.Map<_, baml.llm.Client, void, void>);
+        branch copy _26 -> [bb25, bb16];
     }
 
     bb16: {
-        _32 = is_type(copy _9, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
-        branch copy _32 -> [bb24, bb17];
+        _28 = is_type(copy _10, baml.iter.Filter<baml.llm.Client, void, void>);
+        branch copy _28 -> [bb24, bb17];
     }
 
     bb17: {
-        _34 = is_type(copy _9, baml.iter.Peekable<baml.llm.Client, void>);
-        branch copy _34 -> [bb23, bb18];
+        _32 = is_type(copy _10, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
+        branch copy _32 -> [bb23, bb18];
     }
 
     bb18: {
-        _37 = is_type(copy _9, unknown[]);
-        branch copy _37 -> [bb22, bb19];
+        _34 = is_type(copy _10, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
+        branch copy _34 -> [bb22, bb19];
     }
 
     bb19: {
-        _39 = is_type(copy _9, baml.llm.Client[]);
-        branch copy _39 -> [bb21, bb20];
+        _36 = is_type(copy _10, baml.iter.Peekable<baml.llm.Client, void>);
+        branch copy _36 -> [bb21, bb20];
     }
 
     bb20: {
@@ -13157,463 +13732,218 @@ fn baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner_state
     }
 
     bb21: {
-        _40 = load_type(baml.llm.Client);
-        _10 = call const fn baml.iter.Iterable$for$T[].iter<copy _40>(copy _9) -> [bb33];
+        _37 = load_type(baml.llm.Client);
+        _38 = load_type(void);
+        _12 = call const fn baml.iter.Peekable.Iterator.next<copy _37, copy _38>(copy _10) -> [bb31];
     }
 
     bb22: {
-        _38 = load_type(baml.llm.Client);
-        _10 = call const fn baml.iter.Iterable$for$T[].iter<copy _38>(copy _9) -> [bb33];
+        _35 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _10);
+        _12 = call copy _35() -> [bb31];
     }
 
     bb23: {
-        _35 = load_type(baml.llm.Client);
-        _36 = load_type(void);
-        _10 = call const fn baml.iter.Peekable.Iterable.iter<copy _35, copy _36>(copy _9) -> [bb33];
+        _33 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _10);
+        _12 = call copy _33() -> [bb31];
     }
 
     bb24: {
-        _33 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _9);
-        _10 = call copy _33() -> [bb33];
+        _29 = load_type(baml.llm.Client);
+        _30 = load_type(void);
+        _31 = load_type(void);
+        _12 = call const fn baml.iter.Filter.Iterator.next<copy _29, copy _30, copy _31>(copy _10) -> [bb31];
     }
 
     bb25: {
-        _31 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _9);
-        _10 = call copy _31() -> [bb33];
+        _27 = make_bound_method baml.iter.Map.Iterator.next(copy _10);
+        _12 = call copy _27() -> [bb31];
     }
 
     bb26: {
-        _27 = load_type(baml.llm.Client);
-        _28 = load_type(void);
-        _29 = load_type(void);
-        _10 = call const fn baml.iter.Filter.Iterable.iter<copy _27, copy _28, copy _29>(copy _9) -> [bb33];
+        _25 = load_type(baml.llm.Client);
+        _12 = call const fn baml.iter.Repeat.Iterator.next<copy _25>(copy _10) -> [bb31];
     }
 
     bb27: {
-        _25 = make_bound_method baml.iter.Map.Iterable.iter(copy _9);
-        _10 = call copy _25() -> [bb33];
+        _21 = load_type(baml.llm.Client);
+        _22 = load_type(void);
+        _23 = load_type(void);
+        _12 = call const fn baml.iter.Chain.Iterator.next<copy _21, copy _22, copy _23>(copy _10) -> [bb31];
     }
 
     bb28: {
-        _23 = load_type(baml.llm.Client);
-        _10 = call const fn baml.iter.Repeat.Iterable.iter<copy _23>(copy _9) -> [bb33];
+        _18 = load_type(baml.llm.Client);
+        _19 = load_type(void);
+        _12 = call const fn baml.iter.StepBy.Iterator.next<copy _18, copy _19>(copy _10) -> [bb31];
     }
 
     bb29: {
-        _19 = load_type(baml.llm.Client);
-        _20 = load_type(void);
-        _21 = load_type(void);
-        _10 = call const fn baml.iter.Chain.Iterable.iter<copy _19, copy _20, copy _21>(copy _9) -> [bb33];
+        _16 = load_type(baml.llm.Client);
+        _12 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _16>(copy _10) -> [bb31];
     }
 
     bb30: {
-        _16 = load_type(baml.llm.Client);
-        _17 = load_type(void);
-        _10 = call const fn baml.iter.StepBy.Iterable.iter<copy _16, copy _17>(copy _9) -> [bb33];
+        _14 = make_bound_method baml.iter.Flatten.Iterator.next(copy _10);
+        _12 = call copy _14() -> [bb31];
     }
 
     bb31: {
-        _14 = load_type(baml.llm.Client);
-        _10 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _14>(copy _9) -> [bb33];
+        _39 = is_type(copy _12, baml.iter.Done);
+        branch copy _39 -> [bb57, bb32];
     }
 
     bb32: {
-        _12 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _9);
-        _10 = call copy _12() -> [bb33];
+        _40 = copy _12;
+        fresh_cell(_41);
+        _41 = copy _40;
+        _42 = call const fn baml.llm.Client.build_plan_with_state(copy _41, copy _2) -> [bb33];
     }
 
     bb33: {
-        _42 = is_type(copy _10, baml.iter.Flatten<_, baml.llm.Client, void, void>);
-        branch copy _42 -> [bb53, bb34];
+        _44 = load_type(baml.llm.OrchestrationStep);
+        _43 = call const fn baml.iter.Iterable$for$T[].iter<copy _44>(copy _42) -> [bb34];
     }
 
     bb34: {
-        _44 = is_type(copy _10, baml.iter.ArrayIterator<baml.llm.Client>);
-        branch copy _44 -> [bb52, bb35];
+        _46 = is_type(copy _43, baml.iter.Flatten<_, baml.llm.OrchestrationStep, void, void>);
+        branch copy _46 -> [bb54, bb35];
     }
 
     bb35: {
-        _46 = is_type(copy _10, baml.iter.StepBy<baml.llm.Client, void>);
-        branch copy _46 -> [bb51, bb36];
+        _48 = is_type(copy _43, baml.iter.ArrayIterator<baml.llm.OrchestrationStep>);
+        branch copy _48 -> [bb53, bb36];
     }
 
     bb36: {
-        _49 = is_type(copy _10, baml.iter.Chain<baml.llm.Client, void, void>);
-        branch copy _49 -> [bb50, bb37];
+        _50 = is_type(copy _43, baml.iter.StepBy<baml.llm.OrchestrationStep, void>);
+        branch copy _50 -> [bb52, bb37];
     }
 
     bb37: {
-        _53 = is_type(copy _10, baml.iter.Repeat<baml.llm.Client>);
-        branch copy _53 -> [bb49, bb38];
+        _53 = is_type(copy _43, baml.iter.Chain<baml.llm.OrchestrationStep, void, void>);
+        branch copy _53 -> [bb51, bb38];
     }
 
     bb38: {
-        _55 = is_type(copy _10, baml.iter.Map<_, baml.llm.Client, void, void>);
-        branch copy _55 -> [bb48, bb39];
+        _57 = is_type(copy _43, baml.iter.Repeat<baml.llm.OrchestrationStep>);
+        branch copy _57 -> [bb50, bb39];
     }
 
     bb39: {
-        _57 = is_type(copy _10, baml.iter.Filter<baml.llm.Client, void, void>);
-        branch copy _57 -> [bb47, bb40];
+        _59 = is_type(copy _43, baml.iter.Map<_, baml.llm.OrchestrationStep, void, void>);
+        branch copy _59 -> [bb49, bb40];
     }
 
     bb40: {
-        _61 = is_type(copy _10, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
-        branch copy _61 -> [bb46, bb41];
+        _61 = is_type(copy _43, baml.iter.Filter<baml.llm.OrchestrationStep, void, void>);
+        branch copy _61 -> [bb48, bb41];
     }
 
     bb41: {
-        _63 = is_type(copy _10, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
-        branch copy _63 -> [bb45, bb42];
+        _65 = is_type(copy _43, baml.iter.FilterMap<_, baml.llm.OrchestrationStep, void, void>);
+        branch copy _65 -> [bb47, bb42];
     }
 
     bb42: {
-        _65 = is_type(copy _10, baml.iter.Peekable<baml.llm.Client, void>);
-        branch copy _65 -> [bb44, bb43];
+        _67 = is_type(copy _43, baml.iter.FlatMap<_, baml.llm.OrchestrationStep, void, void, void>);
+        branch copy _67 -> [bb46, bb43];
     }
 
     bb43: {
-        unreachable;
+        _69 = is_type(copy _43, baml.iter.Peekable<baml.llm.OrchestrationStep, void>);
+        branch copy _69 -> [bb45, bb44];
     }
 
     bb44: {
-        _66 = load_type(baml.llm.Client);
-        _67 = load_type(void);
-        _41 = call const fn baml.iter.Peekable.Iterator.next<copy _66, copy _67>(copy _10) -> [bb54];
+        unreachable;
     }
 
     bb45: {
-        _64 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _10);
-        _41 = call copy _64() -> [bb54];
+        _70 = load_type(baml.llm.OrchestrationStep);
+        _71 = load_type(void);
+        _45 = call const fn baml.iter.Peekable.Iterator.next<copy _70, copy _71>(copy _43) -> [bb55];
     }
 
     bb46: {
-        _62 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _10);
-        _41 = call copy _62() -> [bb54];
+        _68 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _43);
+        _45 = call copy _68() -> [bb55];
     }
 
     bb47: {
-        _58 = load_type(baml.llm.Client);
-        _59 = load_type(void);
-        _60 = load_type(void);
-        _41 = call const fn baml.iter.Filter.Iterator.next<copy _58, copy _59, copy _60>(copy _10) -> [bb54];
+        _66 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _43);
+        _45 = call copy _66() -> [bb55];
     }
 
     bb48: {
-        _56 = make_bound_method baml.iter.Map.Iterator.next(copy _10);
-        _41 = call copy _56() -> [bb54];
+        _62 = load_type(baml.llm.OrchestrationStep);
+        _63 = load_type(void);
+        _64 = load_type(void);
+        _45 = call const fn baml.iter.Filter.Iterator.next<copy _62, copy _63, copy _64>(copy _43) -> [bb55];
     }
 
     bb49: {
-        _54 = load_type(baml.llm.Client);
-        _41 = call const fn baml.iter.Repeat.Iterator.next<copy _54>(copy _10) -> [bb54];
+        _60 = make_bound_method baml.iter.Map.Iterator.next(copy _43);
+        _45 = call copy _60() -> [bb55];
     }
 
     bb50: {
-        _50 = load_type(baml.llm.Client);
-        _51 = load_type(void);
-        _52 = load_type(void);
-        _41 = call const fn baml.iter.Chain.Iterator.next<copy _50, copy _51, copy _52>(copy _10) -> [bb54];
+        _58 = load_type(baml.llm.OrchestrationStep);
+        _45 = call const fn baml.iter.Repeat.Iterator.next<copy _58>(copy _43) -> [bb55];
     }
 
     bb51: {
-        _47 = load_type(baml.llm.Client);
-        _48 = load_type(void);
-        _41 = call const fn baml.iter.StepBy.Iterator.next<copy _47, copy _48>(copy _10) -> [bb54];
+        _54 = load_type(baml.llm.OrchestrationStep);
+        _55 = load_type(void);
+        _56 = load_type(void);
+        _45 = call const fn baml.iter.Chain.Iterator.next<copy _54, copy _55, copy _56>(copy _43) -> [bb55];
     }
 
     bb52: {
-        _45 = load_type(baml.llm.Client);
-        _41 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _45>(copy _10) -> [bb54];
+        _51 = load_type(baml.llm.OrchestrationStep);
+        _52 = load_type(void);
+        _45 = call const fn baml.iter.StepBy.Iterator.next<copy _51, copy _52>(copy _43) -> [bb55];
     }
 
     bb53: {
-        _43 = make_bound_method baml.iter.Flatten.Iterator.next(copy _10);
-        _41 = call copy _43() -> [bb54];
+        _49 = load_type(baml.llm.OrchestrationStep);
+        _45 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _49>(copy _43) -> [bb55];
     }
 
     bb54: {
-        _68 = is_type(copy _41, baml.iter.Done);
-        branch copy _68 -> [bb104, bb55];
+        _47 = make_bound_method baml.iter.Flatten.Iterator.next(copy _43);
+        _45 = call copy _47() -> [bb55];
     }
 
     bb55: {
-        _69 = copy _41;
-        fresh_cell(_70);
-        _70 = copy _69;
-        _71 = call const fn baml.llm.Client.build_plan_with_state(copy _70, copy _2) -> [bb56];
+        _72 = is_type(copy _45, baml.iter.Done);
+        branch copy _72 -> [bb10, bb56];
     }
 
     bb56: {
-        _73 = is_type(copy _71, baml.iter.Flatten<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _73 -> [bb80, bb57];
+        _73 = copy _45;
+        fresh_cell(_74);
+        _74 = copy _73;
+        _76 = copy _74;
+        _75 = call const fn baml.Array.push(copy _8, copy _76) -> [bb34];
     }
 
     bb57: {
-        _75 = is_type(copy _71, baml.iter.ArrayIterator<baml.llm.OrchestrationStep>);
-        branch copy _75 -> [bb79, bb58];
+        _0 = copy _8;
+        goto -> bb60;
     }
 
     bb58: {
-        _77 = is_type(copy _71, baml.iter.StepBy<baml.llm.OrchestrationStep, void>);
-        branch copy _77 -> [bb78, bb59];
+        _5 = call const fn baml.llm.Client.to_primitive_client(copy _1) -> [bb59];
     }
 
     bb59: {
-        _80 = is_type(copy _71, baml.iter.Chain<baml.llm.OrchestrationStep, void, void>);
-        branch copy _80 -> [bb77, bb60];
-    }
-
-    bb60: {
-        _84 = is_type(copy _71, baml.iter.Repeat<baml.llm.OrchestrationStep>);
-        branch copy _84 -> [bb76, bb61];
-    }
-
-    bb61: {
-        _86 = is_type(copy _71, baml.iter.Map<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _86 -> [bb75, bb62];
-    }
-
-    bb62: {
-        _88 = is_type(copy _71, baml.iter.Filter<baml.llm.OrchestrationStep, void, void>);
-        branch copy _88 -> [bb74, bb63];
-    }
-
-    bb63: {
-        _92 = is_type(copy _71, baml.iter.FilterMap<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _92 -> [bb73, bb64];
-    }
-
-    bb64: {
-        _94 = is_type(copy _71, baml.iter.FlatMap<_, baml.llm.OrchestrationStep, void, void, void>);
-        branch copy _94 -> [bb72, bb65];
-    }
-
-    bb65: {
-        _96 = is_type(copy _71, baml.iter.Peekable<baml.llm.OrchestrationStep, void>);
-        branch copy _96 -> [bb71, bb66];
-    }
-
-    bb66: {
-        _99 = is_type(copy _71, unknown[]);
-        branch copy _99 -> [bb70, bb67];
-    }
-
-    bb67: {
-        _101 = is_type(copy _71, baml.llm.OrchestrationStep[]);
-        branch copy _101 -> [bb69, bb68];
-    }
-
-    bb68: {
-        unreachable;
-    }
-
-    bb69: {
-        _102 = load_type(baml.llm.OrchestrationStep);
-        _72 = call const fn baml.iter.Iterable$for$T[].iter<copy _102>(copy _71) -> [bb81];
-    }
-
-    bb70: {
-        _100 = load_type(baml.llm.OrchestrationStep);
-        _72 = call const fn baml.iter.Iterable$for$T[].iter<copy _100>(copy _71) -> [bb81];
-    }
-
-    bb71: {
-        _97 = load_type(baml.llm.OrchestrationStep);
-        _98 = load_type(void);
-        _72 = call const fn baml.iter.Peekable.Iterable.iter<copy _97, copy _98>(copy _71) -> [bb81];
-    }
-
-    bb72: {
-        _95 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _71);
-        _72 = call copy _95() -> [bb81];
-    }
-
-    bb73: {
-        _93 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _71);
-        _72 = call copy _93() -> [bb81];
-    }
-
-    bb74: {
-        _89 = load_type(baml.llm.OrchestrationStep);
-        _90 = load_type(void);
-        _91 = load_type(void);
-        _72 = call const fn baml.iter.Filter.Iterable.iter<copy _89, copy _90, copy _91>(copy _71) -> [bb81];
-    }
-
-    bb75: {
-        _87 = make_bound_method baml.iter.Map.Iterable.iter(copy _71);
-        _72 = call copy _87() -> [bb81];
-    }
-
-    bb76: {
-        _85 = load_type(baml.llm.OrchestrationStep);
-        _72 = call const fn baml.iter.Repeat.Iterable.iter<copy _85>(copy _71) -> [bb81];
-    }
-
-    bb77: {
-        _81 = load_type(baml.llm.OrchestrationStep);
-        _82 = load_type(void);
-        _83 = load_type(void);
-        _72 = call const fn baml.iter.Chain.Iterable.iter<copy _81, copy _82, copy _83>(copy _71) -> [bb81];
-    }
-
-    bb78: {
-        _78 = load_type(baml.llm.OrchestrationStep);
-        _79 = load_type(void);
-        _72 = call const fn baml.iter.StepBy.Iterable.iter<copy _78, copy _79>(copy _71) -> [bb81];
-    }
-
-    bb79: {
-        _76 = load_type(baml.llm.OrchestrationStep);
-        _72 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _76>(copy _71) -> [bb81];
-    }
-
-    bb80: {
-        _74 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _71);
-        _72 = call copy _74() -> [bb81];
-    }
-
-    bb81: {
-        _104 = is_type(copy _72, baml.iter.Flatten<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _104 -> [bb101, bb82];
-    }
-
-    bb82: {
-        _106 = is_type(copy _72, baml.iter.ArrayIterator<baml.llm.OrchestrationStep>);
-        branch copy _106 -> [bb100, bb83];
-    }
-
-    bb83: {
-        _108 = is_type(copy _72, baml.iter.StepBy<baml.llm.OrchestrationStep, void>);
-        branch copy _108 -> [bb99, bb84];
-    }
-
-    bb84: {
-        _111 = is_type(copy _72, baml.iter.Chain<baml.llm.OrchestrationStep, void, void>);
-        branch copy _111 -> [bb98, bb85];
-    }
-
-    bb85: {
-        _115 = is_type(copy _72, baml.iter.Repeat<baml.llm.OrchestrationStep>);
-        branch copy _115 -> [bb97, bb86];
-    }
-
-    bb86: {
-        _117 = is_type(copy _72, baml.iter.Map<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _117 -> [bb96, bb87];
-    }
-
-    bb87: {
-        _119 = is_type(copy _72, baml.iter.Filter<baml.llm.OrchestrationStep, void, void>);
-        branch copy _119 -> [bb95, bb88];
-    }
-
-    bb88: {
-        _123 = is_type(copy _72, baml.iter.FilterMap<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _123 -> [bb94, bb89];
-    }
-
-    bb89: {
-        _125 = is_type(copy _72, baml.iter.FlatMap<_, baml.llm.OrchestrationStep, void, void, void>);
-        branch copy _125 -> [bb93, bb90];
-    }
-
-    bb90: {
-        _127 = is_type(copy _72, baml.iter.Peekable<baml.llm.OrchestrationStep, void>);
-        branch copy _127 -> [bb92, bb91];
-    }
-
-    bb91: {
-        unreachable;
-    }
-
-    bb92: {
-        _128 = load_type(baml.llm.OrchestrationStep);
-        _129 = load_type(void);
-        _103 = call const fn baml.iter.Peekable.Iterator.next<copy _128, copy _129>(copy _72) -> [bb102];
-    }
-
-    bb93: {
-        _126 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _72);
-        _103 = call copy _126() -> [bb102];
-    }
-
-    bb94: {
-        _124 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _72);
-        _103 = call copy _124() -> [bb102];
-    }
-
-    bb95: {
-        _120 = load_type(baml.llm.OrchestrationStep);
-        _121 = load_type(void);
-        _122 = load_type(void);
-        _103 = call const fn baml.iter.Filter.Iterator.next<copy _120, copy _121, copy _122>(copy _72) -> [bb102];
-    }
-
-    bb96: {
-        _118 = make_bound_method baml.iter.Map.Iterator.next(copy _72);
-        _103 = call copy _118() -> [bb102];
-    }
-
-    bb97: {
-        _116 = load_type(baml.llm.OrchestrationStep);
-        _103 = call const fn baml.iter.Repeat.Iterator.next<copy _116>(copy _72) -> [bb102];
-    }
-
-    bb98: {
-        _112 = load_type(baml.llm.OrchestrationStep);
-        _113 = load_type(void);
-        _114 = load_type(void);
-        _103 = call const fn baml.iter.Chain.Iterator.next<copy _112, copy _113, copy _114>(copy _72) -> [bb102];
-    }
-
-    bb99: {
-        _109 = load_type(baml.llm.OrchestrationStep);
-        _110 = load_type(void);
-        _103 = call const fn baml.iter.StepBy.Iterator.next<copy _109, copy _110>(copy _72) -> [bb102];
-    }
-
-    bb100: {
-        _107 = load_type(baml.llm.OrchestrationStep);
-        _103 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _107>(copy _72) -> [bb102];
-    }
-
-    bb101: {
-        _105 = make_bound_method baml.iter.Flatten.Iterator.next(copy _72);
-        _103 = call copy _105() -> [bb102];
-    }
-
-    bb102: {
-        _130 = is_type(copy _103, baml.iter.Done);
-        branch copy _130 -> [bb33, bb103];
-    }
-
-    bb103: {
-        _131 = copy _103;
-        fresh_cell(_132);
-        _132 = copy _131;
-        _134 = copy _132;
-        _133 = call const fn baml.Array.push(copy _8, copy _134) -> [bb81];
-    }
-
-    bb104: {
-        _0 = copy _8;
-        goto -> bb107;
-    }
-
-    bb105: {
-        _5 = call const fn baml.llm.Client.to_primitive_client(copy _1) -> [bb106];
-    }
-
-    bb106: {
         _7 = copy _5;
         _6 = baml.llm.OrchestrationStep { copy _7, const 0_i64 };
         _0 = [copy _6];
-        goto -> bb107;
+        goto -> bb60;
     }
 
-    bb107: {
+    bb60: {
         return;
     }
 }
@@ -13668,70 +13998,41 @@ fn baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_state: b
     let _25: baml.llm.OrchestrationStep[] // inner
     let _26: baml.llm.OrchestrationStep[]
     let _27: baml.iter.Iterator<Item = baml.llm.OrchestrationStep, Error = void>
-    let _28: bool
+    let _28: type
     let _29: unknown
     let _30: bool
-    let _31: type
+    let _31: unknown
     let _32: bool
     let _33: type
-    let _34: type
-    let _35: bool
+    let _34: bool
+    let _35: type
     let _36: type
-    let _37: type
+    let _37: bool
     let _38: type
-    let _39: bool
+    let _39: type
     let _40: type
     let _41: bool
-    let _42: unknown
+    let _42: type
     let _43: bool
-    let _44: type
-    let _45: type
+    let _44: unknown
+    let _45: bool
     let _46: type
-    let _47: bool
-    let _48: unknown
+    let _47: type
+    let _48: type
     let _49: bool
     let _50: unknown
     let _51: bool
-    let _52: type
-    let _53: type
-    let _54: bool
+    let _52: unknown
+    let _53: bool
+    let _54: type
     let _55: type
     let _56: bool
-    let _57: type
-    let _58: unknown
-    let _59: bool
-    let _60: unknown
-    let _61: bool
-    let _62: type
-    let _63: bool
-    let _64: type
-    let _65: type
-    let _66: bool
-    let _67: type
-    let _68: type
-    let _69: type
-    let _70: bool
-    let _71: type
-    let _72: bool
-    let _73: unknown
-    let _74: bool
-    let _75: type
-    let _76: type
-    let _77: type
-    let _78: bool
-    let _79: unknown
-    let _80: bool
-    let _81: unknown
-    let _82: bool
-    let _83: type
-    let _84: type
-    let _85: bool
-    let _86: baml.llm.OrchestrationStep
-    let _87: baml.llm.OrchestrationStep // step
-    let _88: int
-    let _89: baml.llm.OrchestrationStep
-    let _90: baml.llm.PrimitiveClient
-    let _91: int
+    let _57: baml.llm.OrchestrationStep
+    let _58: baml.llm.OrchestrationStep // step
+    let _59: int
+    let _60: baml.llm.OrchestrationStep
+    let _61: baml.llm.PrimitiveClient
+    let _62: int
 
     bb0: {
         _3 = copy _1.3;
@@ -13808,63 +14109,62 @@ fn baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_state: b
 
     bb12: {
         _26 = copy _25;
-        _28 = is_type(copy _26, baml.iter.Flatten<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _28 -> [bb36, bb13];
+        goto -> bb13;
     }
 
     bb13: {
-        _30 = is_type(copy _26, baml.iter.ArrayIterator<baml.llm.OrchestrationStep>);
-        branch copy _30 -> [bb35, bb14];
+        _28 = load_type(baml.llm.OrchestrationStep);
+        _27 = call const fn baml.iter.Iterable$for$T[].iter<copy _28>(copy _26) -> [bb14];
     }
 
     bb14: {
-        _32 = is_type(copy _26, baml.iter.StepBy<baml.llm.OrchestrationStep, void>);
-        branch copy _32 -> [bb34, bb15];
+        _30 = is_type(copy _27, baml.iter.Flatten<_, baml.llm.OrchestrationStep, void, void>);
+        branch copy _30 -> [bb34, bb15];
     }
 
     bb15: {
-        _35 = is_type(copy _26, baml.iter.Chain<baml.llm.OrchestrationStep, void, void>);
-        branch copy _35 -> [bb33, bb16];
+        _32 = is_type(copy _27, baml.iter.ArrayIterator<baml.llm.OrchestrationStep>);
+        branch copy _32 -> [bb33, bb16];
     }
 
     bb16: {
-        _39 = is_type(copy _26, baml.iter.Repeat<baml.llm.OrchestrationStep>);
-        branch copy _39 -> [bb32, bb17];
+        _34 = is_type(copy _27, baml.iter.StepBy<baml.llm.OrchestrationStep, void>);
+        branch copy _34 -> [bb32, bb17];
     }
 
     bb17: {
-        _41 = is_type(copy _26, baml.iter.Map<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _41 -> [bb31, bb18];
+        _37 = is_type(copy _27, baml.iter.Chain<baml.llm.OrchestrationStep, void, void>);
+        branch copy _37 -> [bb31, bb18];
     }
 
     bb18: {
-        _43 = is_type(copy _26, baml.iter.Filter<baml.llm.OrchestrationStep, void, void>);
-        branch copy _43 -> [bb30, bb19];
+        _41 = is_type(copy _27, baml.iter.Repeat<baml.llm.OrchestrationStep>);
+        branch copy _41 -> [bb30, bb19];
     }
 
     bb19: {
-        _47 = is_type(copy _26, baml.iter.FilterMap<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _47 -> [bb29, bb20];
+        _43 = is_type(copy _27, baml.iter.Map<_, baml.llm.OrchestrationStep, void, void>);
+        branch copy _43 -> [bb29, bb20];
     }
 
     bb20: {
-        _49 = is_type(copy _26, baml.iter.FlatMap<_, baml.llm.OrchestrationStep, void, void, void>);
-        branch copy _49 -> [bb28, bb21];
+        _45 = is_type(copy _27, baml.iter.Filter<baml.llm.OrchestrationStep, void, void>);
+        branch copy _45 -> [bb28, bb21];
     }
 
     bb21: {
-        _51 = is_type(copy _26, baml.iter.Peekable<baml.llm.OrchestrationStep, void>);
-        branch copy _51 -> [bb27, bb22];
+        _49 = is_type(copy _27, baml.iter.FilterMap<_, baml.llm.OrchestrationStep, void, void>);
+        branch copy _49 -> [bb27, bb22];
     }
 
     bb22: {
-        _54 = is_type(copy _26, unknown[]);
-        branch copy _54 -> [bb26, bb23];
+        _51 = is_type(copy _27, baml.iter.FlatMap<_, baml.llm.OrchestrationStep, void, void, void>);
+        branch copy _51 -> [bb26, bb23];
     }
 
     bb23: {
-        _56 = is_type(copy _26, baml.llm.OrchestrationStep[]);
-        branch copy _56 -> [bb25, bb24];
+        _53 = is_type(copy _27, baml.iter.Peekable<baml.llm.OrchestrationStep, void>);
+        branch copy _53 -> [bb25, bb24];
     }
 
     bb24: {
@@ -13872,197 +14172,77 @@ fn baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_state: b
     }
 
     bb25: {
-        _57 = load_type(baml.llm.OrchestrationStep);
-        _27 = call const fn baml.iter.Iterable$for$T[].iter<copy _57>(copy _26) -> [bb37];
+        _54 = load_type(baml.llm.OrchestrationStep);
+        _55 = load_type(void);
+        _29 = call const fn baml.iter.Peekable.Iterator.next<copy _54, copy _55>(copy _27) -> [bb35];
     }
 
     bb26: {
-        _55 = load_type(baml.llm.OrchestrationStep);
-        _27 = call const fn baml.iter.Iterable$for$T[].iter<copy _55>(copy _26) -> [bb37];
+        _52 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _27);
+        _29 = call copy _52() -> [bb35];
     }
 
     bb27: {
-        _52 = load_type(baml.llm.OrchestrationStep);
-        _53 = load_type(void);
-        _27 = call const fn baml.iter.Peekable.Iterable.iter<copy _52, copy _53>(copy _26) -> [bb37];
+        _50 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _27);
+        _29 = call copy _50() -> [bb35];
     }
 
     bb28: {
-        _50 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _26);
-        _27 = call copy _50() -> [bb37];
+        _46 = load_type(baml.llm.OrchestrationStep);
+        _47 = load_type(void);
+        _48 = load_type(void);
+        _29 = call const fn baml.iter.Filter.Iterator.next<copy _46, copy _47, copy _48>(copy _27) -> [bb35];
     }
 
     bb29: {
-        _48 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _26);
-        _27 = call copy _48() -> [bb37];
+        _44 = make_bound_method baml.iter.Map.Iterator.next(copy _27);
+        _29 = call copy _44() -> [bb35];
     }
 
     bb30: {
-        _44 = load_type(baml.llm.OrchestrationStep);
-        _45 = load_type(void);
-        _46 = load_type(void);
-        _27 = call const fn baml.iter.Filter.Iterable.iter<copy _44, copy _45, copy _46>(copy _26) -> [bb37];
+        _42 = load_type(baml.llm.OrchestrationStep);
+        _29 = call const fn baml.iter.Repeat.Iterator.next<copy _42>(copy _27) -> [bb35];
     }
 
     bb31: {
-        _42 = make_bound_method baml.iter.Map.Iterable.iter(copy _26);
-        _27 = call copy _42() -> [bb37];
+        _38 = load_type(baml.llm.OrchestrationStep);
+        _39 = load_type(void);
+        _40 = load_type(void);
+        _29 = call const fn baml.iter.Chain.Iterator.next<copy _38, copy _39, copy _40>(copy _27) -> [bb35];
     }
 
     bb32: {
-        _40 = load_type(baml.llm.OrchestrationStep);
-        _27 = call const fn baml.iter.Repeat.Iterable.iter<copy _40>(copy _26) -> [bb37];
+        _35 = load_type(baml.llm.OrchestrationStep);
+        _36 = load_type(void);
+        _29 = call const fn baml.iter.StepBy.Iterator.next<copy _35, copy _36>(copy _27) -> [bb35];
     }
 
     bb33: {
-        _36 = load_type(baml.llm.OrchestrationStep);
-        _37 = load_type(void);
-        _38 = load_type(void);
-        _27 = call const fn baml.iter.Chain.Iterable.iter<copy _36, copy _37, copy _38>(copy _26) -> [bb37];
+        _33 = load_type(baml.llm.OrchestrationStep);
+        _29 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _33>(copy _27) -> [bb35];
     }
 
     bb34: {
-        _33 = load_type(baml.llm.OrchestrationStep);
-        _34 = load_type(void);
-        _27 = call const fn baml.iter.StepBy.Iterable.iter<copy _33, copy _34>(copy _26) -> [bb37];
+        _31 = make_bound_method baml.iter.Flatten.Iterator.next(copy _27);
+        _29 = call copy _31() -> [bb35];
     }
 
     bb35: {
-        _31 = load_type(baml.llm.OrchestrationStep);
-        _27 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _31>(copy _26) -> [bb37];
+        _56 = is_type(copy _29, baml.iter.Done);
+        branch copy _56 -> [bb37, bb36];
     }
 
     bb36: {
-        _29 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _26);
-        _27 = call copy _29() -> [bb37];
+        _57 = copy _29;
+        fresh_cell(_58);
+        _58 = copy _57;
+        _61 = copy _58.0;
+        _62 = copy _13;
+        _60 = baml.llm.OrchestrationStep { copy _61, copy _62 };
+        _59 = call const fn baml.Array.push(copy _6, copy _60) -> [bb14];
     }
 
     bb37: {
-        _59 = is_type(copy _27, baml.iter.Flatten<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _59 -> [bb57, bb38];
-    }
-
-    bb38: {
-        _61 = is_type(copy _27, baml.iter.ArrayIterator<baml.llm.OrchestrationStep>);
-        branch copy _61 -> [bb56, bb39];
-    }
-
-    bb39: {
-        _63 = is_type(copy _27, baml.iter.StepBy<baml.llm.OrchestrationStep, void>);
-        branch copy _63 -> [bb55, bb40];
-    }
-
-    bb40: {
-        _66 = is_type(copy _27, baml.iter.Chain<baml.llm.OrchestrationStep, void, void>);
-        branch copy _66 -> [bb54, bb41];
-    }
-
-    bb41: {
-        _70 = is_type(copy _27, baml.iter.Repeat<baml.llm.OrchestrationStep>);
-        branch copy _70 -> [bb53, bb42];
-    }
-
-    bb42: {
-        _72 = is_type(copy _27, baml.iter.Map<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _72 -> [bb52, bb43];
-    }
-
-    bb43: {
-        _74 = is_type(copy _27, baml.iter.Filter<baml.llm.OrchestrationStep, void, void>);
-        branch copy _74 -> [bb51, bb44];
-    }
-
-    bb44: {
-        _78 = is_type(copy _27, baml.iter.FilterMap<_, baml.llm.OrchestrationStep, void, void>);
-        branch copy _78 -> [bb50, bb45];
-    }
-
-    bb45: {
-        _80 = is_type(copy _27, baml.iter.FlatMap<_, baml.llm.OrchestrationStep, void, void, void>);
-        branch copy _80 -> [bb49, bb46];
-    }
-
-    bb46: {
-        _82 = is_type(copy _27, baml.iter.Peekable<baml.llm.OrchestrationStep, void>);
-        branch copy _82 -> [bb48, bb47];
-    }
-
-    bb47: {
-        unreachable;
-    }
-
-    bb48: {
-        _83 = load_type(baml.llm.OrchestrationStep);
-        _84 = load_type(void);
-        _58 = call const fn baml.iter.Peekable.Iterator.next<copy _83, copy _84>(copy _27) -> [bb58];
-    }
-
-    bb49: {
-        _81 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _27);
-        _58 = call copy _81() -> [bb58];
-    }
-
-    bb50: {
-        _79 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _27);
-        _58 = call copy _79() -> [bb58];
-    }
-
-    bb51: {
-        _75 = load_type(baml.llm.OrchestrationStep);
-        _76 = load_type(void);
-        _77 = load_type(void);
-        _58 = call const fn baml.iter.Filter.Iterator.next<copy _75, copy _76, copy _77>(copy _27) -> [bb58];
-    }
-
-    bb52: {
-        _73 = make_bound_method baml.iter.Map.Iterator.next(copy _27);
-        _58 = call copy _73() -> [bb58];
-    }
-
-    bb53: {
-        _71 = load_type(baml.llm.OrchestrationStep);
-        _58 = call const fn baml.iter.Repeat.Iterator.next<copy _71>(copy _27) -> [bb58];
-    }
-
-    bb54: {
-        _67 = load_type(baml.llm.OrchestrationStep);
-        _68 = load_type(void);
-        _69 = load_type(void);
-        _58 = call const fn baml.iter.Chain.Iterator.next<copy _67, copy _68, copy _69>(copy _27) -> [bb58];
-    }
-
-    bb55: {
-        _64 = load_type(baml.llm.OrchestrationStep);
-        _65 = load_type(void);
-        _58 = call const fn baml.iter.StepBy.Iterator.next<copy _64, copy _65>(copy _27) -> [bb58];
-    }
-
-    bb56: {
-        _62 = load_type(baml.llm.OrchestrationStep);
-        _58 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _62>(copy _27) -> [bb58];
-    }
-
-    bb57: {
-        _60 = make_bound_method baml.iter.Flatten.Iterator.next(copy _27);
-        _58 = call copy _60() -> [bb58];
-    }
-
-    bb58: {
-        _85 = is_type(copy _58, baml.iter.Done);
-        branch copy _85 -> [bb60, bb59];
-    }
-
-    bb59: {
-        _86 = copy _58;
-        fresh_cell(_87);
-        _87 = copy _86;
-        _90 = copy _87.0;
-        _91 = copy _13;
-        _89 = baml.llm.OrchestrationStep { copy _90, copy _91 };
-        _88 = call const fn baml.Array.push(copy _6, copy _89) -> [bb37];
-    }
-
-    bb60: {
         _9 = copy _9 + const 1_i64;
         goto -> bb3;
     }
@@ -14113,88 +14293,59 @@ fn baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: baml.llm
     let _34: string
     let _35: baml.llm.Client[]
     let _36: baml.iter.Iterator<Item = baml.llm.Client, Error = void>
-    let _37: bool
+    let _37: type
     let _38: unknown
     let _39: bool
-    let _40: type
+    let _40: unknown
     let _41: bool
     let _42: type
-    let _43: type
-    let _44: bool
+    let _43: bool
+    let _44: type
     let _45: type
-    let _46: type
+    let _46: bool
     let _47: type
-    let _48: bool
+    let _48: type
     let _49: type
     let _50: bool
-    let _51: unknown
+    let _51: type
     let _52: bool
-    let _53: type
-    let _54: type
+    let _53: unknown
+    let _54: bool
     let _55: type
-    let _56: bool
-    let _57: unknown
+    let _56: type
+    let _57: type
     let _58: bool
     let _59: unknown
     let _60: bool
-    let _61: type
-    let _62: type
-    let _63: bool
+    let _61: unknown
+    let _62: bool
+    let _63: type
     let _64: type
     let _65: bool
-    let _66: type
-    let _67: unknown
-    let _68: bool
-    let _69: unknown
-    let _70: bool
-    let _71: type
+    let _66: baml.llm.Client
+    let _67: baml.llm.Client // sub
+    let _68: unknown // result2
+    let _69: unknown // e
+    let _70: type
+    let _71: baml.errors.DevOther
     let _72: bool
-    let _73: type
-    let _74: type
-    let _75: bool
-    let _76: type
-    let _77: type
-    let _78: type
-    let _79: bool
-    let _80: type
-    let _81: bool
-    let _82: unknown
-    let _83: bool
+    let _73: int
+    let _74: (baml.llm.Client[]) -> int throws never
+    let _75: baml.errors.DevOther
+    let _76: int // idx
+    let _77: int
+    let _78: int
+    let _79: (baml.llm.Client[]) -> int throws never
+    let _80: unknown // result3
+    let _81: baml.llm.Client
+    let _82: baml.llm.Client[]
+    let _83: int
     let _84: type
-    let _85: type
-    let _86: type
-    let _87: bool
-    let _88: unknown
-    let _89: bool
-    let _90: unknown
-    let _91: bool
-    let _92: type
-    let _93: type
-    let _94: bool
-    let _95: baml.llm.Client
-    let _96: baml.llm.Client // sub
-    let _97: unknown // result2
-    let _98: unknown // e
-    let _99: type
-    let _100: baml.errors.DevOther
-    let _101: bool
-    let _102: int
-    let _103: (baml.llm.Client[]) -> int throws never
-    let _104: baml.errors.DevOther
-    let _105: int // idx
-    let _106: int
-    let _107: int
-    let _108: (baml.llm.Client[]) -> int throws never
-    let _109: unknown // result3
-    let _110: baml.llm.Client
-    let _111: baml.llm.Client[]
-    let _112: int
-    let _113: type
 
     bb0: {
         _4 = copy _1.1;
         _5 = discriminant(_4);
-        switch copy _5 [ClientType.Primitive: bb33, ClientType.Fallback: bb8, ClientType.RoundRobin: bb2, otherwise: bb1] (exhaustive);
+        switch copy _5 [ClientType.Primitive: bb10, ClientType.Fallback: bb8, ClientType.RoundRobin: bb2, otherwise: bb1] (exhaustive);
     }
 
     bb1: {
@@ -14202,425 +14353,304 @@ fn baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: baml.llm
     }
 
     bb2: {
-        _103 = copy _1.2;
-        _102 = len(_103);
+        _74 = copy _1.2;
+        _73 = len(_74);
         goto -> bb3;
     }
 
     bb3: {
-        _101 = copy _102 == const 0_i64;
-        branch copy _101 -> [bb7, bb4];
+        _72 = copy _73 == const 0_i64;
+        branch copy _72 -> [bb7, bb4];
     }
 
     bb4: {
-        _106 = copy _1.4;
-        _108 = copy _1.2;
-        _107 = len(_108);
+        _77 = copy _1.4;
+        _79 = copy _1.2;
+        _78 = len(_79);
         goto -> bb5;
     }
 
     bb5: {
-        _105 = copy _106 % copy _107;
+        _76 = copy _77 % copy _78;
         _1.4 = copy _1.4 + const 1_i64;
-        _111 = copy _1.2;
-        _112 = copy _105;
-        _110 = copy _111[_112];
-        _113 = load_type(#0);
-        _109 = call const fn baml.llm.Client.execute_oneshot<copy _113>(copy _110, copy _2, copy _3) -> [bb6];
+        _82 = copy _1.2;
+        _83 = copy _76;
+        _81 = copy _82[_83];
+        _84 = load_type(#0);
+        _80 = call const fn baml.llm.Client.execute_oneshot<copy _84>(copy _81, copy _2, copy _3) -> [bb6];
     }
 
     bb6: {
-        _0 = copy _109;
-        goto -> bb81;
+        _0 = copy _80;
+        goto -> bb58;
     }
 
     bb7: {
-        _104 = baml.errors.DevOther { const "RoundRobin client has no sub-clients" };
-        throw copy _104;
+        _75 = baml.errors.DevOther { const "RoundRobin client has no sub-clients" };
+        throw copy _75;
     }
 
     bb8: {
         _35 = copy _1.2;
-        _37 = is_type(copy _35, baml.iter.Flatten<_, baml.llm.Client, void, void>);
-        branch copy _37 -> [bb32, bb9];
+        goto -> bb9;
     }
 
     bb9: {
-        _39 = is_type(copy _35, baml.iter.ArrayIterator<baml.llm.Client>);
-        branch copy _39 -> [bb31, bb10];
+        _37 = load_type(baml.llm.Client);
+        _36 = call const fn baml.iter.Iterable$for$T[].iter<copy _37>(copy _35) -> [bb34];
     }
 
     bb10: {
-        _41 = is_type(copy _35, baml.iter.StepBy<baml.llm.Client, void>);
-        branch copy _41 -> [bb30, bb11];
+        _6 = call const fn baml.llm.Client.to_primitive_client(copy _1) -> [bb11];
     }
 
     bb11: {
-        _44 = is_type(copy _35, baml.iter.Chain<baml.llm.Client, void, void>);
-        branch copy _44 -> [bb29, bb12];
+        _7 = load_type(#0);
+        goto -> bb12;
     }
 
     bb12: {
-        _48 = is_type(copy _35, baml.iter.Repeat<baml.llm.Client>);
-        branch copy _48 -> [bb28, bb13];
-    }
-
-    bb13: {
-        _50 = is_type(copy _35, baml.iter.Map<_, baml.llm.Client, void, void>);
-        branch copy _50 -> [bb27, bb14];
-    }
-
-    bb14: {
-        _52 = is_type(copy _35, baml.iter.Filter<baml.llm.Client, void, void>);
-        branch copy _52 -> [bb26, bb15];
-    }
-
-    bb15: {
-        _56 = is_type(copy _35, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
-        branch copy _56 -> [bb25, bb16];
-    }
-
-    bb16: {
-        _58 = is_type(copy _35, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
-        branch copy _58 -> [bb24, bb17];
-    }
-
-    bb17: {
-        _60 = is_type(copy _35, baml.iter.Peekable<baml.llm.Client, void>);
-        branch copy _60 -> [bb23, bb18];
-    }
-
-    bb18: {
-        _63 = is_type(copy _35, unknown[]);
-        branch copy _63 -> [bb22, bb19];
-    }
-
-    bb19: {
-        _65 = is_type(copy _35, baml.llm.Client[]);
-        branch copy _65 -> [bb21, bb20];
-    }
-
-    bb20: {
-        unreachable;
-    }
-
-    bb21: {
-        _66 = load_type(baml.llm.Client);
-        _36 = call const fn baml.iter.Iterable$for$T[].iter<copy _66>(copy _35) -> [bb57];
-    }
-
-    bb22: {
-        _64 = load_type(baml.llm.Client);
-        _36 = call const fn baml.iter.Iterable$for$T[].iter<copy _64>(copy _35) -> [bb57];
-    }
-
-    bb23: {
-        _61 = load_type(baml.llm.Client);
-        _62 = load_type(void);
-        _36 = call const fn baml.iter.Peekable.Iterable.iter<copy _61, copy _62>(copy _35) -> [bb57];
-    }
-
-    bb24: {
-        _59 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _35);
-        _36 = call copy _59() -> [bb57];
-    }
-
-    bb25: {
-        _57 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _35);
-        _36 = call copy _57() -> [bb57];
-    }
-
-    bb26: {
-        _53 = load_type(baml.llm.Client);
-        _54 = load_type(void);
-        _55 = load_type(void);
-        _36 = call const fn baml.iter.Filter.Iterable.iter<copy _53, copy _54, copy _55>(copy _35) -> [bb57];
-    }
-
-    bb27: {
-        _51 = make_bound_method baml.iter.Map.Iterable.iter(copy _35);
-        _36 = call copy _51() -> [bb57];
-    }
-
-    bb28: {
-        _49 = load_type(baml.llm.Client);
-        _36 = call const fn baml.iter.Repeat.Iterable.iter<copy _49>(copy _35) -> [bb57];
-    }
-
-    bb29: {
-        _45 = load_type(baml.llm.Client);
-        _46 = load_type(void);
-        _47 = load_type(void);
-        _36 = call const fn baml.iter.Chain.Iterable.iter<copy _45, copy _46, copy _47>(copy _35) -> [bb57];
-    }
-
-    bb30: {
-        _42 = load_type(baml.llm.Client);
-        _43 = load_type(void);
-        _36 = call const fn baml.iter.StepBy.Iterable.iter<copy _42, copy _43>(copy _35) -> [bb57];
-    }
-
-    bb31: {
-        _40 = load_type(baml.llm.Client);
-        _36 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _40>(copy _35) -> [bb57];
-    }
-
-    bb32: {
-        _38 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _35);
-        _36 = call copy _38() -> [bb57];
-    }
-
-    bb33: {
-        _6 = call const fn baml.llm.Client.to_primitive_client(copy _1) -> [bb34];
-    }
-
-    bb34: {
-        _7 = load_type(#0);
-        goto -> bb35;
-    }
-
-    bb35: {
         _9 = copy _2.0;
         _10 = copy _2.1;
         _11 = copy _7;
-        _8 = sys_op const fn baml.llm.PrimitiveClient.render_prompt(copy _6, copy _9, copy _10, copy _11) -> bb36;
+        _8 = sys_op const fn baml.llm.PrimitiveClient.render_prompt(copy _6, copy _9, copy _10, copy _11) -> bb13;
     }
 
-    bb36: {
+    bb13: {
         _13 = copy _8;
-        _12 = sys_op const fn baml.llm.PrimitiveClient.specialize_prompt(copy _6, copy _13) -> bb37;
+        _12 = sys_op const fn baml.llm.PrimitiveClient.specialize_prompt(copy _6, copy _13) -> bb14;
     }
 
-    bb37: {
+    bb14: {
         _15 = copy _12;
         _16 = copy _7;
-        _14 = sys_op const fn baml.llm.PrimitiveClient.build_request(copy _6, copy _15, copy _16) -> bb38;
+        _14 = sys_op const fn baml.llm.PrimitiveClient.build_request(copy _6, copy _15, copy _16) -> bb15;
     }
 
-    bb38: {
+    bb15: {
         _18 = copy _14;
-        _17 = sys_op const fn baml.http.send(copy _18) -> bb39;
+        _17 = sys_op const fn baml.http.send(copy _18) -> bb16;
     }
 
-    bb39: {
-        _19 = call const fn baml.http.Response.ok(copy _17) -> [bb40];
+    bb16: {
+        _19 = call const fn baml.http.Response.ok(copy _17) -> [bb17];
     }
 
-    bb40: {
-        branch copy _19 -> [bb42, bb41];
+    bb17: {
+        branch copy _19 -> [bb19, bb18];
     }
 
-    bb41: {
-        _28 = sys_op const fn baml.http.Response.text(copy _17) -> bb52 unwind bb50;
+    bb18: {
+        _28 = sys_op const fn baml.http.Response.text(copy _17) -> bb29 unwind bb27;
     }
 
-    bb42: {
-        _20 = sys_op const fn baml.http.Response.text(copy _17) -> bb43;
+    bb19: {
+        _20 = sys_op const fn baml.http.Response.text(copy _17) -> bb20;
     }
 
-    bb43: {
+    bb20: {
         _23 = copy _20;
         _24 = load_type(#0);
-        _21 = sys_op const fn baml.llm.PrimitiveClient.parse(copy _6, copy _23, copy _24) -> bb44 unwind bb45;
+        _21 = sys_op const fn baml.llm.PrimitiveClient.parse(copy _6, copy _23, copy _24) -> bb21 unwind bb22;
     }
 
-    bb44: {
+    bb21: {
         _0 = copy _21;
-        goto -> bb81;
+        goto -> bb58;
     }
 
-    bb45: {
-        throw_if_panic copy _22 -> bb46;
+    bb22: {
+        throw_if_panic copy _22 -> bb23;
     }
 
-    bb46: {
+    bb23: {
         _26 = copy _3 > const 0_i64;
-        branch copy _26 -> [bb48, bb47];
+        branch copy _26 -> [bb25, bb24];
     }
 
-    bb47: {
+    bb24: {
         _25 = const null;
-        goto -> bb49;
+        goto -> bb26;
     }
 
-    bb48: {
-        _25 = sys_op const fn baml.sys.sleep(copy _3) -> bb49;
+    bb25: {
+        _25 = sys_op const fn baml.sys.sleep(copy _3) -> bb26;
     }
 
-    bb49: {
+    bb26: {
         _27 = copy _22;
         throw copy _27;
     }
 
-    bb50: {
-        throw_if_panic copy _29 -> bb51;
+    bb27: {
+        throw_if_panic copy _29 -> bb28;
     }
 
-    bb51: {
+    bb28: {
         _28 = const "";
-        goto -> bb52;
+        goto -> bb29;
     }
 
-    bb52: {
+    bb29: {
         _31 = copy _3 > const 0_i64;
-        branch copy _31 -> [bb54, bb53];
+        branch copy _31 -> [bb31, bb30];
     }
 
-    bb53: {
+    bb30: {
         _30 = const null;
-        goto -> bb55;
+        goto -> bb32;
     }
 
-    bb54: {
-        _30 = sys_op const fn baml.sys.sleep(copy _3) -> bb55;
+    bb31: {
+        _30 = sys_op const fn baml.sys.sleep(copy _3) -> bb32;
     }
 
-    bb55: {
+    bb32: {
         _34 = copy _28;
         _33 = const "HTTP request failed: " + copy _34;
         _32 = baml.errors.DevOther { copy _33 };
         throw copy _32;
     }
 
-    bb56: {
-        throw_if_panic copy _98 -> bb57;
+    bb33: {
+        throw_if_panic copy _69 -> bb34;
     }
 
-    bb57: {
-        _68 = is_type(copy _36, baml.iter.Flatten<_, baml.llm.Client, void, void>);
-        branch copy _68 -> [bb77, bb58];
+    bb34: {
+        _39 = is_type(copy _36, baml.iter.Flatten<_, baml.llm.Client, void, void>);
+        branch copy _39 -> [bb54, bb35];
     }
 
-    bb58: {
-        _70 = is_type(copy _36, baml.iter.ArrayIterator<baml.llm.Client>);
-        branch copy _70 -> [bb76, bb59];
+    bb35: {
+        _41 = is_type(copy _36, baml.iter.ArrayIterator<baml.llm.Client>);
+        branch copy _41 -> [bb53, bb36];
     }
 
-    bb59: {
-        _72 = is_type(copy _36, baml.iter.StepBy<baml.llm.Client, void>);
-        branch copy _72 -> [bb75, bb60];
+    bb36: {
+        _43 = is_type(copy _36, baml.iter.StepBy<baml.llm.Client, void>);
+        branch copy _43 -> [bb52, bb37];
     }
 
-    bb60: {
-        _75 = is_type(copy _36, baml.iter.Chain<baml.llm.Client, void, void>);
-        branch copy _75 -> [bb74, bb61];
+    bb37: {
+        _46 = is_type(copy _36, baml.iter.Chain<baml.llm.Client, void, void>);
+        branch copy _46 -> [bb51, bb38];
     }
 
-    bb61: {
-        _79 = is_type(copy _36, baml.iter.Repeat<baml.llm.Client>);
-        branch copy _79 -> [bb73, bb62];
+    bb38: {
+        _50 = is_type(copy _36, baml.iter.Repeat<baml.llm.Client>);
+        branch copy _50 -> [bb50, bb39];
     }
 
-    bb62: {
-        _81 = is_type(copy _36, baml.iter.Map<_, baml.llm.Client, void, void>);
-        branch copy _81 -> [bb72, bb63];
+    bb39: {
+        _52 = is_type(copy _36, baml.iter.Map<_, baml.llm.Client, void, void>);
+        branch copy _52 -> [bb49, bb40];
     }
 
-    bb63: {
-        _83 = is_type(copy _36, baml.iter.Filter<baml.llm.Client, void, void>);
-        branch copy _83 -> [bb71, bb64];
+    bb40: {
+        _54 = is_type(copy _36, baml.iter.Filter<baml.llm.Client, void, void>);
+        branch copy _54 -> [bb48, bb41];
     }
 
-    bb64: {
-        _87 = is_type(copy _36, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
-        branch copy _87 -> [bb70, bb65];
+    bb41: {
+        _58 = is_type(copy _36, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
+        branch copy _58 -> [bb47, bb42];
     }
 
-    bb65: {
-        _89 = is_type(copy _36, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
-        branch copy _89 -> [bb69, bb66];
+    bb42: {
+        _60 = is_type(copy _36, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
+        branch copy _60 -> [bb46, bb43];
     }
 
-    bb66: {
-        _91 = is_type(copy _36, baml.iter.Peekable<baml.llm.Client, void>);
-        branch copy _91 -> [bb68, bb67];
+    bb43: {
+        _62 = is_type(copy _36, baml.iter.Peekable<baml.llm.Client, void>);
+        branch copy _62 -> [bb45, bb44];
     }
 
-    bb67: {
+    bb44: {
         unreachable;
     }
 
-    bb68: {
-        _92 = load_type(baml.llm.Client);
-        _93 = load_type(void);
-        _67 = call const fn baml.iter.Peekable.Iterator.next<copy _92, copy _93>(copy _36) -> [bb78];
+    bb45: {
+        _63 = load_type(baml.llm.Client);
+        _64 = load_type(void);
+        _38 = call const fn baml.iter.Peekable.Iterator.next<copy _63, copy _64>(copy _36) -> [bb55];
     }
 
-    bb69: {
-        _90 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _36);
-        _67 = call copy _90() -> [bb78];
+    bb46: {
+        _61 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _36);
+        _38 = call copy _61() -> [bb55];
     }
 
-    bb70: {
-        _88 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _36);
-        _67 = call copy _88() -> [bb78];
+    bb47: {
+        _59 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _36);
+        _38 = call copy _59() -> [bb55];
     }
 
-    bb71: {
-        _84 = load_type(baml.llm.Client);
-        _85 = load_type(void);
-        _86 = load_type(void);
-        _67 = call const fn baml.iter.Filter.Iterator.next<copy _84, copy _85, copy _86>(copy _36) -> [bb78];
+    bb48: {
+        _55 = load_type(baml.llm.Client);
+        _56 = load_type(void);
+        _57 = load_type(void);
+        _38 = call const fn baml.iter.Filter.Iterator.next<copy _55, copy _56, copy _57>(copy _36) -> [bb55];
     }
 
-    bb72: {
-        _82 = make_bound_method baml.iter.Map.Iterator.next(copy _36);
-        _67 = call copy _82() -> [bb78];
+    bb49: {
+        _53 = make_bound_method baml.iter.Map.Iterator.next(copy _36);
+        _38 = call copy _53() -> [bb55];
     }
 
-    bb73: {
-        _80 = load_type(baml.llm.Client);
-        _67 = call const fn baml.iter.Repeat.Iterator.next<copy _80>(copy _36) -> [bb78];
+    bb50: {
+        _51 = load_type(baml.llm.Client);
+        _38 = call const fn baml.iter.Repeat.Iterator.next<copy _51>(copy _36) -> [bb55];
     }
 
-    bb74: {
-        _76 = load_type(baml.llm.Client);
-        _77 = load_type(void);
-        _78 = load_type(void);
-        _67 = call const fn baml.iter.Chain.Iterator.next<copy _76, copy _77, copy _78>(copy _36) -> [bb78];
+    bb51: {
+        _47 = load_type(baml.llm.Client);
+        _48 = load_type(void);
+        _49 = load_type(void);
+        _38 = call const fn baml.iter.Chain.Iterator.next<copy _47, copy _48, copy _49>(copy _36) -> [bb55];
     }
 
-    bb75: {
-        _73 = load_type(baml.llm.Client);
-        _74 = load_type(void);
-        _67 = call const fn baml.iter.StepBy.Iterator.next<copy _73, copy _74>(copy _36) -> [bb78];
+    bb52: {
+        _44 = load_type(baml.llm.Client);
+        _45 = load_type(void);
+        _38 = call const fn baml.iter.StepBy.Iterator.next<copy _44, copy _45>(copy _36) -> [bb55];
     }
 
-    bb76: {
-        _71 = load_type(baml.llm.Client);
-        _67 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _71>(copy _36) -> [bb78];
+    bb53: {
+        _42 = load_type(baml.llm.Client);
+        _38 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _42>(copy _36) -> [bb55];
     }
 
-    bb77: {
-        _69 = make_bound_method baml.iter.Flatten.Iterator.next(copy _36);
-        _67 = call copy _69() -> [bb78];
+    bb54: {
+        _40 = make_bound_method baml.iter.Flatten.Iterator.next(copy _36);
+        _38 = call copy _40() -> [bb55];
     }
 
-    bb78: {
-        _94 = is_type(copy _67, baml.iter.Done);
-        branch copy _94 -> [bb82, bb79];
+    bb55: {
+        _65 = is_type(copy _38, baml.iter.Done);
+        branch copy _65 -> [bb59, bb56];
     }
 
-    bb79: {
-        _95 = copy _67;
-        fresh_cell(_96);
-        _96 = copy _95;
-        _99 = load_type(#0);
-        _97 = call const fn baml.llm.Client.execute_oneshot<copy _99>(copy _96, copy _2, copy _3) -> [bb80, unwind: bb56];
+    bb56: {
+        _66 = copy _38;
+        fresh_cell(_67);
+        _67 = copy _66;
+        _70 = load_type(#0);
+        _68 = call const fn baml.llm.Client.execute_oneshot<copy _70>(copy _67, copy _2, copy _3) -> [bb57, unwind: bb33];
     }
 
-    bb80: {
-        _0 = copy _97;
-        goto -> bb81;
+    bb57: {
+        _0 = copy _68;
+        goto -> bb58;
     }
 
-    bb81: {
+    bb58: {
         return;
     }
 
-    bb82: {
-        _100 = baml.errors.DevOther { const "All orchestration steps failed" };
-        throw copy _100;
+    bb59: {
+        _71 = baml.errors.DevOther { const "All orchestration steps failed" };
+        throw copy _71;
     }
 }
 
@@ -14652,90 +14682,61 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
     let _23: type
     let _24: baml.llm.Client[]
     let _25: baml.iter.Iterator<Item = baml.llm.Client, Error = void>
-    let _26: bool
+    let _26: type
     let _27: unknown
     let _28: bool
-    let _29: type
+    let _29: unknown
     let _30: bool
     let _31: type
-    let _32: type
-    let _33: bool
+    let _32: bool
+    let _33: type
     let _34: type
-    let _35: type
+    let _35: bool
     let _36: type
-    let _37: bool
+    let _37: type
     let _38: type
     let _39: bool
-    let _40: unknown
+    let _40: type
     let _41: bool
-    let _42: type
-    let _43: type
+    let _42: unknown
+    let _43: bool
     let _44: type
-    let _45: bool
-    let _46: unknown
+    let _45: type
+    let _46: type
     let _47: bool
     let _48: unknown
     let _49: bool
-    let _50: type
-    let _51: type
-    let _52: bool
+    let _50: unknown
+    let _51: bool
+    let _52: type
     let _53: type
     let _54: bool
-    let _55: type
-    let _56: unknown
-    let _57: bool
-    let _58: unknown
-    let _59: bool
+    let _55: baml.llm.Client
+    let _56: baml.llm.Client // sub
+    let _57: baml.llm.Stream<unknown, unknown> // result2
+    let _58: unknown // e
+    let _59: type
     let _60: type
-    let _61: bool
-    let _62: type
-    let _63: type
-    let _64: bool
-    let _65: type
-    let _66: type
-    let _67: type
-    let _68: bool
-    let _69: type
-    let _70: bool
-    let _71: unknown
-    let _72: bool
-    let _73: type
+    let _61: baml.errors.DevOther
+    let _62: bool
+    let _63: int
+    let _64: (baml.llm.Client[]) -> int throws never
+    let _65: baml.errors.DevOther
+    let _66: int // idx
+    let _67: int
+    let _68: int
+    let _69: (baml.llm.Client[]) -> int throws never
+    let _70: baml.llm.Stream<unknown, unknown> // result3
+    let _71: baml.llm.Client
+    let _72: baml.llm.Client[]
+    let _73: int
     let _74: type
     let _75: type
-    let _76: bool
-    let _77: unknown
-    let _78: bool
-    let _79: unknown
-    let _80: bool
-    let _81: type
-    let _82: type
-    let _83: bool
-    let _84: baml.llm.Client
-    let _85: baml.llm.Client // sub
-    let _86: baml.llm.Stream<unknown, unknown> // result2
-    let _87: unknown // e
-    let _88: type
-    let _89: type
-    let _90: baml.errors.DevOther
-    let _91: bool
-    let _92: int
-    let _93: (baml.llm.Client[]) -> int throws never
-    let _94: baml.errors.DevOther
-    let _95: int // idx
-    let _96: int
-    let _97: int
-    let _98: (baml.llm.Client[]) -> int throws never
-    let _99: baml.llm.Stream<unknown, unknown> // result3
-    let _100: baml.llm.Client
-    let _101: baml.llm.Client[]
-    let _102: int
-    let _103: type
-    let _104: type
 
     bb0: {
         _4 = copy _1.1;
         _5 = discriminant(_4);
-        switch copy _5 [ClientType.Primitive: bb33, ClientType.Fallback: bb8, ClientType.RoundRobin: bb2, otherwise: bb1] (exhaustive);
+        switch copy _5 [ClientType.Primitive: bb10, ClientType.Fallback: bb8, ClientType.RoundRobin: bb2, otherwise: bb1] (exhaustive);
     }
 
     bb1: {
@@ -14743,360 +14744,239 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
     }
 
     bb2: {
-        _93 = copy _1.2;
-        _92 = len(_93);
+        _64 = copy _1.2;
+        _63 = len(_64);
         goto -> bb3;
     }
 
     bb3: {
-        _91 = copy _92 == const 0_i64;
-        branch copy _91 -> [bb7, bb4];
+        _62 = copy _63 == const 0_i64;
+        branch copy _62 -> [bb7, bb4];
     }
 
     bb4: {
-        _96 = copy _1.4;
-        _98 = copy _1.2;
-        _97 = len(_98);
+        _67 = copy _1.4;
+        _69 = copy _1.2;
+        _68 = len(_69);
         goto -> bb5;
     }
 
     bb5: {
-        _95 = copy _96 % copy _97;
+        _66 = copy _67 % copy _68;
         _1.4 = copy _1.4 + const 1_i64;
-        _101 = copy _1.2;
-        _102 = copy _95;
-        _100 = copy _101[_102];
-        _103 = load_type(#0);
-        _104 = load_type(#1);
-        _99 = call const fn baml.llm.Client.execute_stream<copy _103, copy _104>(copy _100, copy _2, copy _3) -> [bb6];
+        _72 = copy _1.2;
+        _73 = copy _66;
+        _71 = copy _72[_73];
+        _74 = load_type(#0);
+        _75 = load_type(#1);
+        _70 = call const fn baml.llm.Client.execute_stream<copy _74, copy _75>(copy _71, copy _2, copy _3) -> [bb6];
     }
 
     bb6: {
-        _0 = copy _99;
-        goto -> bb66;
+        _0 = copy _70;
+        goto -> bb43;
     }
 
     bb7: {
-        _94 = baml.errors.DevOther { const "RoundRobin client has no sub-clients" };
-        throw copy _94;
+        _65 = baml.errors.DevOther { const "RoundRobin client has no sub-clients" };
+        throw copy _65;
     }
 
     bb8: {
         _24 = copy _1.2;
-        _26 = is_type(copy _24, baml.iter.Flatten<_, baml.llm.Client, void, void>);
-        branch copy _26 -> [bb32, bb9];
+        goto -> bb9;
     }
 
     bb9: {
-        _28 = is_type(copy _24, baml.iter.ArrayIterator<baml.llm.Client>);
-        branch copy _28 -> [bb31, bb10];
+        _26 = load_type(baml.llm.Client);
+        _25 = call const fn baml.iter.Iterable$for$T[].iter<copy _26>(copy _24) -> [bb19];
     }
 
     bb10: {
-        _30 = is_type(copy _24, baml.iter.StepBy<baml.llm.Client, void>);
-        branch copy _30 -> [bb30, bb11];
+        _6 = call const fn baml.llm.Client.to_primitive_client(copy _1) -> [bb11];
     }
 
     bb11: {
-        _33 = is_type(copy _24, baml.iter.Chain<baml.llm.Client, void, void>);
-        branch copy _33 -> [bb29, bb12];
+        _7 = load_type(#1);
+        goto -> bb12;
     }
 
     bb12: {
-        _37 = is_type(copy _24, baml.iter.Repeat<baml.llm.Client>);
-        branch copy _37 -> [bb28, bb13];
-    }
-
-    bb13: {
-        _39 = is_type(copy _24, baml.iter.Map<_, baml.llm.Client, void, void>);
-        branch copy _39 -> [bb27, bb14];
-    }
-
-    bb14: {
-        _41 = is_type(copy _24, baml.iter.Filter<baml.llm.Client, void, void>);
-        branch copy _41 -> [bb26, bb15];
-    }
-
-    bb15: {
-        _45 = is_type(copy _24, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
-        branch copy _45 -> [bb25, bb16];
-    }
-
-    bb16: {
-        _47 = is_type(copy _24, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
-        branch copy _47 -> [bb24, bb17];
-    }
-
-    bb17: {
-        _49 = is_type(copy _24, baml.iter.Peekable<baml.llm.Client, void>);
-        branch copy _49 -> [bb23, bb18];
-    }
-
-    bb18: {
-        _52 = is_type(copy _24, unknown[]);
-        branch copy _52 -> [bb22, bb19];
-    }
-
-    bb19: {
-        _54 = is_type(copy _24, baml.llm.Client[]);
-        branch copy _54 -> [bb21, bb20];
-    }
-
-    bb20: {
-        unreachable;
-    }
-
-    bb21: {
-        _55 = load_type(baml.llm.Client);
-        _25 = call const fn baml.iter.Iterable$for$T[].iter<copy _55>(copy _24) -> [bb42];
-    }
-
-    bb22: {
-        _53 = load_type(baml.llm.Client);
-        _25 = call const fn baml.iter.Iterable$for$T[].iter<copy _53>(copy _24) -> [bb42];
-    }
-
-    bb23: {
-        _50 = load_type(baml.llm.Client);
-        _51 = load_type(void);
-        _25 = call const fn baml.iter.Peekable.Iterable.iter<copy _50, copy _51>(copy _24) -> [bb42];
-    }
-
-    bb24: {
-        _48 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _24);
-        _25 = call copy _48() -> [bb42];
-    }
-
-    bb25: {
-        _46 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _24);
-        _25 = call copy _46() -> [bb42];
-    }
-
-    bb26: {
-        _42 = load_type(baml.llm.Client);
-        _43 = load_type(void);
-        _44 = load_type(void);
-        _25 = call const fn baml.iter.Filter.Iterable.iter<copy _42, copy _43, copy _44>(copy _24) -> [bb42];
-    }
-
-    bb27: {
-        _40 = make_bound_method baml.iter.Map.Iterable.iter(copy _24);
-        _25 = call copy _40() -> [bb42];
-    }
-
-    bb28: {
-        _38 = load_type(baml.llm.Client);
-        _25 = call const fn baml.iter.Repeat.Iterable.iter<copy _38>(copy _24) -> [bb42];
-    }
-
-    bb29: {
-        _34 = load_type(baml.llm.Client);
-        _35 = load_type(void);
-        _36 = load_type(void);
-        _25 = call const fn baml.iter.Chain.Iterable.iter<copy _34, copy _35, copy _36>(copy _24) -> [bb42];
-    }
-
-    bb30: {
-        _31 = load_type(baml.llm.Client);
-        _32 = load_type(void);
-        _25 = call const fn baml.iter.StepBy.Iterable.iter<copy _31, copy _32>(copy _24) -> [bb42];
-    }
-
-    bb31: {
-        _29 = load_type(baml.llm.Client);
-        _25 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _29>(copy _24) -> [bb42];
-    }
-
-    bb32: {
-        _27 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _24);
-        _25 = call copy _27() -> [bb42];
-    }
-
-    bb33: {
-        _6 = call const fn baml.llm.Client.to_primitive_client(copy _1) -> [bb34];
-    }
-
-    bb34: {
-        _7 = load_type(#1);
-        goto -> bb35;
-    }
-
-    bb35: {
         _9 = copy _2.0;
         _10 = copy _2.1;
         _11 = copy _7;
-        _8 = sys_op const fn baml.llm.PrimitiveClient.render_prompt(copy _6, copy _9, copy _10, copy _11) -> bb36;
+        _8 = sys_op const fn baml.llm.PrimitiveClient.render_prompt(copy _6, copy _9, copy _10, copy _11) -> bb13;
     }
 
-    bb36: {
+    bb13: {
         _13 = copy _8;
-        _12 = sys_op const fn baml.llm.PrimitiveClient.specialize_prompt(copy _6, copy _13) -> bb37;
+        _12 = sys_op const fn baml.llm.PrimitiveClient.specialize_prompt(copy _6, copy _13) -> bb14;
     }
 
-    bb37: {
+    bb14: {
         _15 = copy _12;
         _16 = copy _7;
-        _14 = sys_op const fn baml.llm.PrimitiveClient.build_request_stream(copy _6, copy _15, copy _16) -> bb38;
+        _14 = sys_op const fn baml.llm.PrimitiveClient.build_request_stream(copy _6, copy _15, copy _16) -> bb15;
     }
 
-    bb38: {
+    bb15: {
         _18 = copy _14;
-        _17 = sys_op const fn baml.http.fetch_sse(copy _18) -> bb39;
+        _17 = sys_op const fn baml.http.fetch_sse(copy _18) -> bb16;
     }
 
-    bb39: {
+    bb16: {
         _20 = copy _17;
         _21 = copy _2.2;
         _22 = load_type(#0);
         _23 = load_type(#1);
-        _19 = call const fn baml.llm.Client.__make_stream<copy _22, copy _23>(copy _1, copy _20, copy _21) -> [bb40];
+        _19 = call const fn baml.llm.Client.__make_stream<copy _22, copy _23>(copy _1, copy _20, copy _21) -> [bb17];
     }
 
-    bb40: {
+    bb17: {
         _0 = copy _19;
-        goto -> bb66;
+        goto -> bb43;
     }
 
-    bb41: {
-        throw_if_panic copy _87 -> bb42;
+    bb18: {
+        throw_if_panic copy _58 -> bb19;
     }
 
-    bb42: {
-        _57 = is_type(copy _25, baml.iter.Flatten<_, baml.llm.Client, void, void>);
-        branch copy _57 -> [bb62, bb43];
+    bb19: {
+        _28 = is_type(copy _25, baml.iter.Flatten<_, baml.llm.Client, void, void>);
+        branch copy _28 -> [bb39, bb20];
     }
 
-    bb43: {
-        _59 = is_type(copy _25, baml.iter.ArrayIterator<baml.llm.Client>);
-        branch copy _59 -> [bb61, bb44];
+    bb20: {
+        _30 = is_type(copy _25, baml.iter.ArrayIterator<baml.llm.Client>);
+        branch copy _30 -> [bb38, bb21];
     }
 
-    bb44: {
-        _61 = is_type(copy _25, baml.iter.StepBy<baml.llm.Client, void>);
-        branch copy _61 -> [bb60, bb45];
+    bb21: {
+        _32 = is_type(copy _25, baml.iter.StepBy<baml.llm.Client, void>);
+        branch copy _32 -> [bb37, bb22];
     }
 
-    bb45: {
-        _64 = is_type(copy _25, baml.iter.Chain<baml.llm.Client, void, void>);
-        branch copy _64 -> [bb59, bb46];
+    bb22: {
+        _35 = is_type(copy _25, baml.iter.Chain<baml.llm.Client, void, void>);
+        branch copy _35 -> [bb36, bb23];
     }
 
-    bb46: {
-        _68 = is_type(copy _25, baml.iter.Repeat<baml.llm.Client>);
-        branch copy _68 -> [bb58, bb47];
+    bb23: {
+        _39 = is_type(copy _25, baml.iter.Repeat<baml.llm.Client>);
+        branch copy _39 -> [bb35, bb24];
     }
 
-    bb47: {
-        _70 = is_type(copy _25, baml.iter.Map<_, baml.llm.Client, void, void>);
-        branch copy _70 -> [bb57, bb48];
+    bb24: {
+        _41 = is_type(copy _25, baml.iter.Map<_, baml.llm.Client, void, void>);
+        branch copy _41 -> [bb34, bb25];
     }
 
-    bb48: {
-        _72 = is_type(copy _25, baml.iter.Filter<baml.llm.Client, void, void>);
-        branch copy _72 -> [bb56, bb49];
+    bb25: {
+        _43 = is_type(copy _25, baml.iter.Filter<baml.llm.Client, void, void>);
+        branch copy _43 -> [bb33, bb26];
     }
 
-    bb49: {
-        _76 = is_type(copy _25, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
-        branch copy _76 -> [bb55, bb50];
+    bb26: {
+        _47 = is_type(copy _25, baml.iter.FilterMap<_, baml.llm.Client, void, void>);
+        branch copy _47 -> [bb32, bb27];
     }
 
-    bb50: {
-        _78 = is_type(copy _25, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
-        branch copy _78 -> [bb54, bb51];
+    bb27: {
+        _49 = is_type(copy _25, baml.iter.FlatMap<_, baml.llm.Client, void, void, void>);
+        branch copy _49 -> [bb31, bb28];
     }
 
-    bb51: {
-        _80 = is_type(copy _25, baml.iter.Peekable<baml.llm.Client, void>);
-        branch copy _80 -> [bb53, bb52];
+    bb28: {
+        _51 = is_type(copy _25, baml.iter.Peekable<baml.llm.Client, void>);
+        branch copy _51 -> [bb30, bb29];
     }
 
-    bb52: {
+    bb29: {
         unreachable;
     }
 
-    bb53: {
-        _81 = load_type(baml.llm.Client);
-        _82 = load_type(void);
-        _56 = call const fn baml.iter.Peekable.Iterator.next<copy _81, copy _82>(copy _25) -> [bb63];
+    bb30: {
+        _52 = load_type(baml.llm.Client);
+        _53 = load_type(void);
+        _27 = call const fn baml.iter.Peekable.Iterator.next<copy _52, copy _53>(copy _25) -> [bb40];
     }
 
-    bb54: {
-        _79 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _25);
-        _56 = call copy _79() -> [bb63];
+    bb31: {
+        _50 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _25);
+        _27 = call copy _50() -> [bb40];
     }
 
-    bb55: {
-        _77 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _25);
-        _56 = call copy _77() -> [bb63];
+    bb32: {
+        _48 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _25);
+        _27 = call copy _48() -> [bb40];
     }
 
-    bb56: {
-        _73 = load_type(baml.llm.Client);
-        _74 = load_type(void);
-        _75 = load_type(void);
-        _56 = call const fn baml.iter.Filter.Iterator.next<copy _73, copy _74, copy _75>(copy _25) -> [bb63];
+    bb33: {
+        _44 = load_type(baml.llm.Client);
+        _45 = load_type(void);
+        _46 = load_type(void);
+        _27 = call const fn baml.iter.Filter.Iterator.next<copy _44, copy _45, copy _46>(copy _25) -> [bb40];
     }
 
-    bb57: {
-        _71 = make_bound_method baml.iter.Map.Iterator.next(copy _25);
-        _56 = call copy _71() -> [bb63];
+    bb34: {
+        _42 = make_bound_method baml.iter.Map.Iterator.next(copy _25);
+        _27 = call copy _42() -> [bb40];
     }
 
-    bb58: {
-        _69 = load_type(baml.llm.Client);
-        _56 = call const fn baml.iter.Repeat.Iterator.next<copy _69>(copy _25) -> [bb63];
+    bb35: {
+        _40 = load_type(baml.llm.Client);
+        _27 = call const fn baml.iter.Repeat.Iterator.next<copy _40>(copy _25) -> [bb40];
     }
 
-    bb59: {
-        _65 = load_type(baml.llm.Client);
-        _66 = load_type(void);
-        _67 = load_type(void);
-        _56 = call const fn baml.iter.Chain.Iterator.next<copy _65, copy _66, copy _67>(copy _25) -> [bb63];
+    bb36: {
+        _36 = load_type(baml.llm.Client);
+        _37 = load_type(void);
+        _38 = load_type(void);
+        _27 = call const fn baml.iter.Chain.Iterator.next<copy _36, copy _37, copy _38>(copy _25) -> [bb40];
     }
 
-    bb60: {
-        _62 = load_type(baml.llm.Client);
-        _63 = load_type(void);
-        _56 = call const fn baml.iter.StepBy.Iterator.next<copy _62, copy _63>(copy _25) -> [bb63];
+    bb37: {
+        _33 = load_type(baml.llm.Client);
+        _34 = load_type(void);
+        _27 = call const fn baml.iter.StepBy.Iterator.next<copy _33, copy _34>(copy _25) -> [bb40];
     }
 
-    bb61: {
-        _60 = load_type(baml.llm.Client);
-        _56 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _60>(copy _25) -> [bb63];
+    bb38: {
+        _31 = load_type(baml.llm.Client);
+        _27 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _31>(copy _25) -> [bb40];
     }
 
-    bb62: {
-        _58 = make_bound_method baml.iter.Flatten.Iterator.next(copy _25);
-        _56 = call copy _58() -> [bb63];
+    bb39: {
+        _29 = make_bound_method baml.iter.Flatten.Iterator.next(copy _25);
+        _27 = call copy _29() -> [bb40];
     }
 
-    bb63: {
-        _83 = is_type(copy _56, baml.iter.Done);
-        branch copy _83 -> [bb67, bb64];
+    bb40: {
+        _54 = is_type(copy _27, baml.iter.Done);
+        branch copy _54 -> [bb44, bb41];
     }
 
-    bb64: {
-        _84 = copy _56;
-        fresh_cell(_85);
-        _85 = copy _84;
-        _88 = load_type(#0);
-        _89 = load_type(#1);
-        _86 = call const fn baml.llm.Client.execute_stream<copy _88, copy _89>(copy _85, copy _2, copy _3) -> [bb65, unwind: bb41];
+    bb41: {
+        _55 = copy _27;
+        fresh_cell(_56);
+        _56 = copy _55;
+        _59 = load_type(#0);
+        _60 = load_type(#1);
+        _57 = call const fn baml.llm.Client.execute_stream<copy _59, copy _60>(copy _56, copy _2, copy _3) -> [bb42, unwind: bb18];
     }
 
-    bb65: {
-        _0 = copy _86;
-        goto -> bb66;
+    bb42: {
+        _0 = copy _57;
+        goto -> bb43;
     }
 
-    bb66: {
+    bb43: {
         return;
     }
 
-    bb67: {
-        _90 = baml.errors.DevOther { const "All orchestration steps failed" };
-        throw copy _90;
+    bb44: {
+        _61 = baml.errors.DevOther { const "All orchestration steps failed" };
+        throw copy _61;
     }
 }
 
@@ -18763,10 +18643,10 @@ fn baml.spawn.options(group: baml.spawn.TaskGroup | null, cancel: baml.spawn.Can
 }
 
 // lambda[0]
-fn .<lambda(options, 0)>(params: baml.spawn.SpawnParams<void, void>) -> null {
+fn .<lambda(options, 0)>(params: baml.spawn.SpawnParams<unknown, unknown>) -> null {
     // Locals:
     let _0: null // _0 // return
-    let _1: baml.spawn.SpawnParams<void, void> // params // param
+    let _1: baml.spawn.SpawnParams<unknown, unknown> // params // param
     let _2: () -> unknown throws unknown
     let _3: string | null
     let _4: baml.spawn.TaskGroup | null
@@ -21835,76 +21715,47 @@ fn baml.toml.Table.from_json(json: baml.json.json) -> baml.toml.Table {
     let _5: type
     let _6: type
     let _7: baml.iter.Iterator<Item = string, Error = void>
-    let _8: bool
+    let _8: type
     let _9: unknown
     let _10: bool
-    let _11: type
+    let _11: unknown
     let _12: bool
     let _13: type
-    let _14: type
-    let _15: bool
+    let _14: bool
+    let _15: type
     let _16: type
-    let _17: type
+    let _17: bool
     let _18: type
-    let _19: bool
+    let _19: type
     let _20: type
     let _21: bool
-    let _22: unknown
+    let _22: type
     let _23: bool
-    let _24: type
-    let _25: type
+    let _24: unknown
+    let _25: bool
     let _26: type
-    let _27: bool
-    let _28: unknown
+    let _27: type
+    let _28: type
     let _29: bool
     let _30: unknown
     let _31: bool
-    let _32: type
-    let _33: type
-    let _34: bool
+    let _32: unknown
+    let _33: bool
+    let _34: type
     let _35: type
     let _36: bool
-    let _37: type
-    let _38: unknown
-    let _39: bool
-    let _40: unknown
-    let _41: bool
-    let _42: type
+    let _37: string
+    let _38: string // key
+    let _39: string
+    let _40: baml.json.json
+    let _41: map<string, baml.json.json>
+    let _42: string
     let _43: bool
-    let _44: type
-    let _45: type
-    let _46: bool
-    let _47: type
-    let _48: type
-    let _49: type
-    let _50: bool
-    let _51: type
-    let _52: bool
-    let _53: unknown
-    let _54: bool
-    let _55: type
-    let _56: type
-    let _57: type
-    let _58: bool
-    let _59: unknown
-    let _60: bool
-    let _61: unknown
-    let _62: bool
-    let _63: type
-    let _64: type
-    let _65: bool
-    let _66: string
-    let _67: string // key
-    let _68: string
-    let _69: baml.json.json
-    let _70: map<string, baml.json.json>
-    let _71: string
-    let _72: bool
-    let _73: baml.json.json // item
-    let _74: baml.json.json
-    let _75: baml.toml.Item
-    let _76: map<string, baml.toml.Item>
-    let _77: baml.json.JsonDecodeError
+    let _44: baml.json.json // item
+    let _45: baml.json.json
+    let _46: baml.toml.Item
+    let _47: map<string, baml.toml.Item>
+    let _48: baml.json.JsonDecodeError
 
     bb0: {
         _2 = is_type(copy _1, map<string, baml.json.json>);
@@ -21912,8 +21763,8 @@ fn baml.toml.Table.from_json(json: baml.json.json) -> baml.toml.Table {
     }
 
     bb1: {
-        _77 = baml.json.JsonDecodeError { const "expected map", const "" };
-        throw copy _77;
+        _48 = baml.json.JsonDecodeError { const "expected map", const "" };
+        throw copy _48;
     }
 
     bb2: {
@@ -21924,280 +21775,155 @@ fn baml.toml.Table.from_json(json: baml.json.json) -> baml.toml.Table {
     }
 
     bb3: {
-        _8 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
-        branch copy _8 -> [bb27, bb4];
+        _8 = load_type(string);
+        _7 = call const fn baml.iter.Iterable$for$T[].iter<copy _8>(copy _4) -> [bb4];
     }
 
     bb4: {
-        _10 = is_type(copy _4, baml.iter.ArrayIterator<string>);
-        branch copy _10 -> [bb26, bb5];
+        _10 = is_type(copy _7, baml.iter.Flatten<_, string, void, void>);
+        branch copy _10 -> [bb24, bb5];
     }
 
     bb5: {
-        _12 = is_type(copy _4, baml.iter.StepBy<string, void>);
-        branch copy _12 -> [bb25, bb6];
+        _12 = is_type(copy _7, baml.iter.ArrayIterator<string>);
+        branch copy _12 -> [bb23, bb6];
     }
 
     bb6: {
-        _15 = is_type(copy _4, baml.iter.Chain<string, void, void>);
-        branch copy _15 -> [bb24, bb7];
+        _14 = is_type(copy _7, baml.iter.StepBy<string, void>);
+        branch copy _14 -> [bb22, bb7];
     }
 
     bb7: {
-        _19 = is_type(copy _4, baml.iter.Repeat<string>);
-        branch copy _19 -> [bb23, bb8];
+        _17 = is_type(copy _7, baml.iter.Chain<string, void, void>);
+        branch copy _17 -> [bb21, bb8];
     }
 
     bb8: {
-        _21 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
-        branch copy _21 -> [bb22, bb9];
+        _21 = is_type(copy _7, baml.iter.Repeat<string>);
+        branch copy _21 -> [bb20, bb9];
     }
 
     bb9: {
-        _23 = is_type(copy _4, baml.iter.Filter<string, void, void>);
-        branch copy _23 -> [bb21, bb10];
+        _23 = is_type(copy _7, baml.iter.Map<_, string, void, void>);
+        branch copy _23 -> [bb19, bb10];
     }
 
     bb10: {
-        _27 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _27 -> [bb20, bb11];
+        _25 = is_type(copy _7, baml.iter.Filter<string, void, void>);
+        branch copy _25 -> [bb18, bb11];
     }
 
     bb11: {
-        _29 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _29 -> [bb19, bb12];
+        _29 = is_type(copy _7, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _29 -> [bb17, bb12];
     }
 
     bb12: {
-        _31 = is_type(copy _4, baml.iter.Peekable<string, void>);
-        branch copy _31 -> [bb18, bb13];
+        _31 = is_type(copy _7, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _31 -> [bb16, bb13];
     }
 
     bb13: {
-        _34 = is_type(copy _4, unknown[]);
-        branch copy _34 -> [bb17, bb14];
+        _33 = is_type(copy _7, baml.iter.Peekable<string, void>);
+        branch copy _33 -> [bb15, bb14];
     }
 
     bb14: {
-        _36 = is_type(copy _4, string[]);
-        branch copy _36 -> [bb16, bb15];
+        unreachable;
     }
 
     bb15: {
-        unreachable;
+        _34 = load_type(string);
+        _35 = load_type(void);
+        _9 = call const fn baml.iter.Peekable.Iterator.next<copy _34, copy _35>(copy _7) -> [bb25];
     }
 
     bb16: {
-        _37 = load_type(string);
-        _7 = call const fn baml.iter.Iterable$for$T[].iter<copy _37>(copy _4) -> [bb28];
+        _32 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _7);
+        _9 = call copy _32() -> [bb25];
     }
 
     bb17: {
-        _35 = load_type(string);
-        _7 = call const fn baml.iter.Iterable$for$T[].iter<copy _35>(copy _4) -> [bb28];
+        _30 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _7);
+        _9 = call copy _30() -> [bb25];
     }
 
     bb18: {
-        _32 = load_type(string);
-        _33 = load_type(void);
-        _7 = call const fn baml.iter.Peekable.Iterable.iter<copy _32, copy _33>(copy _4) -> [bb28];
+        _26 = load_type(string);
+        _27 = load_type(void);
+        _28 = load_type(void);
+        _9 = call const fn baml.iter.Filter.Iterator.next<copy _26, copy _27, copy _28>(copy _7) -> [bb25];
     }
 
     bb19: {
-        _30 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _4);
-        _7 = call copy _30() -> [bb28];
+        _24 = make_bound_method baml.iter.Map.Iterator.next(copy _7);
+        _9 = call copy _24() -> [bb25];
     }
 
     bb20: {
-        _28 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _4);
-        _7 = call copy _28() -> [bb28];
+        _22 = load_type(string);
+        _9 = call const fn baml.iter.Repeat.Iterator.next<copy _22>(copy _7) -> [bb25];
     }
 
     bb21: {
-        _24 = load_type(string);
-        _25 = load_type(void);
-        _26 = load_type(void);
-        _7 = call const fn baml.iter.Filter.Iterable.iter<copy _24, copy _25, copy _26>(copy _4) -> [bb28];
+        _18 = load_type(string);
+        _19 = load_type(void);
+        _20 = load_type(void);
+        _9 = call const fn baml.iter.Chain.Iterator.next<copy _18, copy _19, copy _20>(copy _7) -> [bb25];
     }
 
     bb22: {
-        _22 = make_bound_method baml.iter.Map.Iterable.iter(copy _4);
-        _7 = call copy _22() -> [bb28];
+        _15 = load_type(string);
+        _16 = load_type(void);
+        _9 = call const fn baml.iter.StepBy.Iterator.next<copy _15, copy _16>(copy _7) -> [bb25];
     }
 
     bb23: {
-        _20 = load_type(string);
-        _7 = call const fn baml.iter.Repeat.Iterable.iter<copy _20>(copy _4) -> [bb28];
+        _13 = load_type(string);
+        _9 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _13>(copy _7) -> [bb25];
     }
 
     bb24: {
-        _16 = load_type(string);
-        _17 = load_type(void);
-        _18 = load_type(void);
-        _7 = call const fn baml.iter.Chain.Iterable.iter<copy _16, copy _17, copy _18>(copy _4) -> [bb28];
+        _11 = make_bound_method baml.iter.Flatten.Iterator.next(copy _7);
+        _9 = call copy _11() -> [bb25];
     }
 
     bb25: {
-        _13 = load_type(string);
-        _14 = load_type(void);
-        _7 = call const fn baml.iter.StepBy.Iterable.iter<copy _13, copy _14>(copy _4) -> [bb28];
+        _36 = is_type(copy _9, baml.iter.Done);
+        branch copy _36 -> [bb29, bb26];
     }
 
     bb26: {
-        _11 = load_type(string);
-        _7 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _11>(copy _4) -> [bb28];
+        _37 = copy _9;
+        fresh_cell(_38);
+        _38 = copy _37;
+        _39 = copy _38;
+        _41 = copy _1;
+        _42 = copy _38;
+        _40 = copy _41[_42];
+        _43 = copy _40 == const null;
+        branch copy _43 -> [bb4, bb27];
     }
 
     bb27: {
-        _9 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _4);
-        _7 = call copy _9() -> [bb28];
+        _44 = copy _40;
+        _45 = copy _44;
+        _46 = call const fn baml.toml.item_from_json(copy _45) -> [bb28];
     }
 
     bb28: {
-        _39 = is_type(copy _7, baml.iter.Flatten<_, string, void, void>);
-        branch copy _39 -> [bb48, bb29];
+        _3[_39] = copy _46;
+        goto -> bb4;
     }
 
     bb29: {
-        _41 = is_type(copy _7, baml.iter.ArrayIterator<string>);
-        branch copy _41 -> [bb47, bb30];
+        _47 = copy _3;
+        _0 = baml.toml.Table { copy _47 };
+        goto -> bb30;
     }
 
     bb30: {
-        _43 = is_type(copy _7, baml.iter.StepBy<string, void>);
-        branch copy _43 -> [bb46, bb31];
-    }
-
-    bb31: {
-        _46 = is_type(copy _7, baml.iter.Chain<string, void, void>);
-        branch copy _46 -> [bb45, bb32];
-    }
-
-    bb32: {
-        _50 = is_type(copy _7, baml.iter.Repeat<string>);
-        branch copy _50 -> [bb44, bb33];
-    }
-
-    bb33: {
-        _52 = is_type(copy _7, baml.iter.Map<_, string, void, void>);
-        branch copy _52 -> [bb43, bb34];
-    }
-
-    bb34: {
-        _54 = is_type(copy _7, baml.iter.Filter<string, void, void>);
-        branch copy _54 -> [bb42, bb35];
-    }
-
-    bb35: {
-        _58 = is_type(copy _7, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _58 -> [bb41, bb36];
-    }
-
-    bb36: {
-        _60 = is_type(copy _7, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _60 -> [bb40, bb37];
-    }
-
-    bb37: {
-        _62 = is_type(copy _7, baml.iter.Peekable<string, void>);
-        branch copy _62 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _63 = load_type(string);
-        _64 = load_type(void);
-        _38 = call const fn baml.iter.Peekable.Iterator.next<copy _63, copy _64>(copy _7) -> [bb49];
-    }
-
-    bb40: {
-        _61 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _7);
-        _38 = call copy _61() -> [bb49];
-    }
-
-    bb41: {
-        _59 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _7);
-        _38 = call copy _59() -> [bb49];
-    }
-
-    bb42: {
-        _55 = load_type(string);
-        _56 = load_type(void);
-        _57 = load_type(void);
-        _38 = call const fn baml.iter.Filter.Iterator.next<copy _55, copy _56, copy _57>(copy _7) -> [bb49];
-    }
-
-    bb43: {
-        _53 = make_bound_method baml.iter.Map.Iterator.next(copy _7);
-        _38 = call copy _53() -> [bb49];
-    }
-
-    bb44: {
-        _51 = load_type(string);
-        _38 = call const fn baml.iter.Repeat.Iterator.next<copy _51>(copy _7) -> [bb49];
-    }
-
-    bb45: {
-        _47 = load_type(string);
-        _48 = load_type(void);
-        _49 = load_type(void);
-        _38 = call const fn baml.iter.Chain.Iterator.next<copy _47, copy _48, copy _49>(copy _7) -> [bb49];
-    }
-
-    bb46: {
-        _44 = load_type(string);
-        _45 = load_type(void);
-        _38 = call const fn baml.iter.StepBy.Iterator.next<copy _44, copy _45>(copy _7) -> [bb49];
-    }
-
-    bb47: {
-        _42 = load_type(string);
-        _38 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _42>(copy _7) -> [bb49];
-    }
-
-    bb48: {
-        _40 = make_bound_method baml.iter.Flatten.Iterator.next(copy _7);
-        _38 = call copy _40() -> [bb49];
-    }
-
-    bb49: {
-        _65 = is_type(copy _38, baml.iter.Done);
-        branch copy _65 -> [bb53, bb50];
-    }
-
-    bb50: {
-        _66 = copy _38;
-        fresh_cell(_67);
-        _67 = copy _66;
-        _68 = copy _67;
-        _70 = copy _1;
-        _71 = copy _67;
-        _69 = copy _70[_71];
-        _72 = copy _69 == const null;
-        branch copy _72 -> [bb28, bb51];
-    }
-
-    bb51: {
-        _73 = copy _69;
-        _74 = copy _73;
-        _75 = call const fn baml.toml.item_from_json(copy _74) -> [bb52];
-    }
-
-    bb52: {
-        _3[_68] = copy _75;
-        goto -> bb28;
-    }
-
-    bb53: {
-        _76 = copy _3;
-        _0 = baml.toml.Table { copy _76 };
-        goto -> bb54;
-    }
-
-    bb54: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -23,6 +23,82 @@ function baml.Bool.from_json(j: baml.json.json) -> baml.Bool throws baml.json.Js
 class baml.Bool$stream {
 }
 
+--- <builtin>/baml/comparable.baml ---
+function baml.compare(self: unknown, other: unknown) -> int throws never {
+  { : -1 | 1 | 0
+    if (self < other : bool) : -1 | 1 | 0
+      { : -1
+        Neg 1 : -1
+      }
+    else
+      if (self > other : bool) : 1 | 0
+        { : 1
+          1 : 1
+        }
+      else
+        { : 0
+          0 : 0
+        }
+  }
+}
+function baml.compare(self: unknown, other: unknown) -> int throws never {
+  { : -1 | 1 | 0
+    if (self < other : bool) : -1 | 1 | 0
+      { : -1
+        Neg 1 : -1
+      }
+    else
+      if (self > other : bool) : 1 | 0
+        { : 1
+          1 : 1
+        }
+      else
+        { : 0
+          0 : 0
+        }
+  }
+}
+function baml.compare(self: unknown, other: unknown) -> int throws never {
+  { : -1 | 1 | 0
+    if (self < other : bool) : -1 | 1 | 0
+      { : -1
+        Neg 1 : -1
+      }
+    else
+      if (self > other : bool) : 1 | 0
+        { : 1
+          1 : 1
+        }
+      else
+        { : 0
+          0 : 0
+        }
+  }
+}
+function baml.sort(self: unknown) -> unknown throws unknown {
+  { : T[]
+    if (root._is_primitive_array(self) : bool) : T[]
+      { : T[]
+        root._rust_sort<A>(self) : T[]
+      }
+    else
+      { : T[]
+        self.sort_by<T, E>((a: T, b: T) -> int throws T.CmpError { ... }) : T[]
+          (a: T, b: T) -> int throws T.CmpError { ... } : (a: T, b: T) -> int throws T.CmpError
+            {
+              root._compare_shim(a, b)
+            }
+      }
+  }
+}
+lambda baml.sort {
+}
+function baml.compare(self: unknown, other: unknown) -> int throws never {
+  { : int
+    root._float_total_cmp(self, other) : int
+  }
+}
+
 --- <builtin>/baml/containers.baml ---
 class baml.Array {
 }
@@ -66,8 +142,55 @@ function baml.Array.collect(self: baml.Array) -> unknown[] throws never {
 }
 function baml.Array.count(self: baml.Array) -> int throws never {
   { : int
-    self.length() : int
+    self.length<T>() : int
   }
+}
+function baml.Array.sort_by_key<U, E>(self: baml.Array, key: (unknown) -> U throws E) -> unknown[] throws E | U.CmpError {
+  { : never
+    let n = self.length<T>() : int
+    if (n <= 1 : bool) : void
+      { : never
+        return self : T[]
+      }
+    let items = self.slice<T>(0, n) : T[]
+    let keys: U[] = [] : U[]
+    for x in items
+      { : void
+        keys.push<U>(key(x)) : int
+      }
+    let order: int[] = [] : int[]
+    let p = 0 : 0 -> int
+    while p < n
+      { : void
+        order.push(p) : int
+        p Add= 1 : int
+      }
+    order.sort_by<E>((i: int, j: int) -> int throws U.CmpError { ... }) : int[]
+      (i: int, j: int) -> int throws U.CmpError { ... } : (i: int, j: int) -> int throws U.CmpError
+        {
+          match (keys.at(i)) { null => 0, ki: U => match (keys.at(j)) { null => 0, kj: U => ki.compare(kj) } }
+        }
+    let sorted: T[] = [] : T[]
+    for i in order
+      { : void
+        match (items.at(i) : T | null) : void
+          null =>
+            { : void
+            }
+          item: T =>
+            { : void
+              sorted.push<T>(item) : int
+            }
+      }
+    self.clear<T>() : null
+    for s in sorted
+      { : void
+        self.push<T>(s) : int
+      }
+    return self : T[]
+  }
+}
+lambda baml.Array.sort_by_key {
 }
 function baml.Array.from_json(j: baml.json.json) -> baml.Array<unknown> throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   Array {  } : baml.Array<T>

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -564,323 +564,172 @@ function baml.Array.for_each(self: baml.Array<unknown>, fn: (unknown) -> void th
     container_len
     call baml.Array.slice
     store_var _3
-    load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
-
-  L0:
-    load_var _3
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L46
     load_type #0
     load_var _3
     call baml.iter.Iterable$for$T[].iter
     store_var _6
-    jump L22
 
-  L11:
-    load_type #0
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _6
-    jump L22
-
-  L12:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _6
-    jump L22
-
-  L13:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _6
-    jump L22
-
-  L14:
-    load_type #0
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _6
-    jump L22
-
-  L15:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _6
-    jump L22
-
-  L16:
-    load_type #0
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _6
-    jump L22
-
-  L17:
-    load_type #0
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _6
-    jump L22
-
-  L18:
-    load_type #0
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _6
-    jump L22
-
-  L19:
-    load_type #0
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _6
-    jump L22
-
-  L20:
-    load_var _3
-    call baml.iter.Range.Iterable.iter
-    store_var _6
-    jump L22
-
-  L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _6
-
-  L22:
+  L0:
     load_var _6
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L42
+    pop_jump_if_false L1
+    jump L20
 
-  L23:
+  L1:
     load_var _6
     is_type baml.iter.Range
-    pop_jump_if_false L24
-    jump L41
+    pop_jump_if_false L2
+    jump L19
 
-  L24:
+  L2:
     load_var _6
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L25
-    jump L40
+    pop_jump_if_false L3
+    jump L18
 
-  L25:
+  L3:
     load_var _6
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L26
-    jump L39
+    pop_jump_if_false L4
+    jump L17
 
-  L26:
+  L4:
     load_var _6
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L27
-    jump L38
+    pop_jump_if_false L5
+    jump L16
 
-  L27:
+  L5:
     load_var _6
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L28
-    jump L37
+    pop_jump_if_false L6
+    jump L15
 
-  L28:
+  L6:
     load_var _6
     is_type baml.iter.Map<...>
-    pop_jump_if_false L29
-    jump L36
+    pop_jump_if_false L7
+    jump L14
 
-  L29:
+  L7:
     load_var _6
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L30
-    jump L35
+    pop_jump_if_false L8
+    jump L13
 
-  L30:
+  L8:
     load_var _6
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L31
-    jump L34
+    pop_jump_if_false L9
+    jump L12
 
-  L31:
+  L9:
     load_var _6
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L32
-    jump L33
+    pop_jump_if_false L10
+    jump L11
 
-  L32:
+  L10:
     load_var _6
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L46
+    pop_jump_if_false L24
     load_type #0
     load_type void
     load_var _6
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L33:
+  L11:
     load_var _6
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L34:
+  L12:
     load_var _6
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L35:
+  L13:
     load_type #0
     load_type void
     load_type void
     load_var _6
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L36:
+  L14:
     load_var _6
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L37:
+  L15:
     load_type #0
     load_var _6
     call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L38:
+  L16:
     load_type #0
     load_type void
     load_type void
     load_var _6
     call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L39:
+  L17:
     load_type #0
     load_type void
     load_var _6
     call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L40:
+  L18:
     load_type #0
     load_var _6
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L41:
+  L19:
     load_var _6
     call baml.iter.Range.Iterator.next
-    store_var _36
-    jump L43
+    store_var _8
+    jump L21
 
-  L42:
+  L20:
     load_var _6
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _36
+    store_var _8
 
-  L43:
-    load_var _36
+  L21:
+    load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L44
-    jump L45
+    pop_jump_if_false L22
+    jump L23
 
-  L44:
+  L22:
     load_var2 5 2
     call_indirect
     pop 1
-    jump L22
+    jump L0
 
-  L45:
+  L23:
     load_const null
     return
 
-  L46:
+  L24:
     unreachable
 }
 
@@ -953,13 +802,581 @@ function baml.Array.slice(self: baml.Array<unknown>, start: int, end: int) -> un
 function baml.Array.some(self: baml.Array<unknown>, predicate: (unknown) -> bool throws unknown) -> bool {
 }
 
-function baml.Array.sort(self: baml.Array<unknown>) -> unknown[] {
-}
-
 function baml.Array.sort_by(self: baml.Array<unknown>, compare: (unknown, unknown) -> int throws unknown) -> unknown[] {
 }
 
 function baml.Array.sort_by_key(self: baml.Array<unknown>, key: (unknown) -> unknown throws unknown) -> unknown[] {
+    load_var ?5
+    make_cell
+    store_var ?5
+    load_var self
+    container_len
+    store_var n
+    load_var n
+    load_const 1
+    cmp_int_op <=
+    pop_jump_if_false L0
+    jump L77
+
+  L0:
+    load_type #0
+    load_var self
+    load_const 0
+    load_var n
+    call baml.Array.slice
+    store_var items
+    alloc_array 0
+    store_deref ?5
+    load_type #0
+    load_var items
+    call baml.iter.Iterable$for$T[].iter
+    store_var _11
+
+  L1:
+    load_var _11
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L2
+    jump L21
+
+  L2:
+    load_var _11
+    is_type baml.iter.Range
+    pop_jump_if_false L3
+    jump L20
+
+  L3:
+    load_var _11
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L4
+    jump L19
+
+  L4:
+    load_var _11
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L5
+    jump L18
+
+  L5:
+    load_var _11
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L6
+    jump L17
+
+  L6:
+    load_var _11
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L7
+    jump L16
+
+  L7:
+    load_var _11
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L8
+    jump L15
+
+  L8:
+    load_var _11
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L9
+    jump L14
+
+  L9:
+    load_var _11
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L10
+    jump L13
+
+  L10:
+    load_var _11
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L11
+    jump L12
+
+  L11:
+    load_var _11
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L79
+    load_type #0
+    load_type void
+    load_var _11
+    call baml.iter.Peekable.Iterator.next
+    store_var _13
+    jump L22
+
+  L12:
+    load_var _11
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _13
+    jump L22
+
+  L13:
+    load_var _11
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _13
+    jump L22
+
+  L14:
+    load_type #0
+    load_type void
+    load_type void
+    load_var _11
+    call baml.iter.Filter.Iterator.next
+    store_var _13
+    jump L22
+
+  L15:
+    load_var _11
+    make_bound_method baml.iter.Map.Iterator.next
+    call_indirect
+    store_var _13
+    jump L22
+
+  L16:
+    load_type #0
+    load_var _11
+    call baml.iter.Repeat.Iterator.next
+    store_var _13
+    jump L22
+
+  L17:
+    load_type #0
+    load_type void
+    load_type void
+    load_var _11
+    call baml.iter.Chain.Iterator.next
+    store_var _13
+    jump L22
+
+  L18:
+    load_type #0
+    load_type void
+    load_var _11
+    call baml.iter.StepBy.Iterator.next
+    store_var _13
+    jump L22
+
+  L19:
+    load_type #0
+    load_var _11
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _13
+    jump L22
+
+  L20:
+    load_var _11
+    call baml.iter.Range.Iterator.next
+    store_var _13
+    jump L22
+
+  L21:
+    load_var _11
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _13
+
+  L22:
+    load_var _13
+    is_type baml.iter.Done
+    pop_jump_if_false L23
+    jump L24
+
+  L23:
+    load_var2 7 2
+    call_indirect
+    store_var _45
+    load_deref ?5
+    load_var _45
+    call baml.Array.push
+    pop 1
+    jump L1
+
+  L24:
+    alloc_array 0
+    store_var order
+    load_const 0
+    store_var p
+
+  L25:
+    load_var2 10 3
+    cmp_int_op <
+    pop_jump_if_false L26
+    jump L76
+
+  L26:
+    load_type int
+    load_type unknown
+    load_var order
+    load_type #0
+    load_type #1
+    load_type #2
+    load_var keys
+    make_closure .<lambda(Array.sort_by_key, 0)>, captures=1, ntypeargs=3
+    call baml.Array.sort_by
+    pop 1
+    alloc_array 0
+    store_var sorted
+    load_type int
+    load_var order
+    call baml.iter.Iterable$for$T[].iter
+    store_var _60
+
+  L27:
+    load_var _60
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L28
+    jump L47
+
+  L28:
+    load_var _60
+    is_type baml.iter.Range
+    pop_jump_if_false L29
+    jump L46
+
+  L29:
+    load_var _60
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L30
+    jump L45
+
+  L30:
+    load_var _60
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L31
+    jump L44
+
+  L31:
+    load_var _60
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L32
+    jump L43
+
+  L32:
+    load_var _60
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L33
+    jump L42
+
+  L33:
+    load_var _60
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L34
+    jump L41
+
+  L34:
+    load_var _60
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L35
+    jump L40
+
+  L35:
+    load_var _60
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L36
+    jump L39
+
+  L36:
+    load_var _60
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L37
+    jump L38
+
+  L37:
+    load_var _60
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L79
+    load_type int
+    load_type void
+    load_var _60
+    call baml.iter.Peekable.Iterator.next
+    store_var _62
+    jump L48
+
+  L38:
+    load_var _60
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _62
+    jump L48
+
+  L39:
+    load_var _60
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _62
+    jump L48
+
+  L40:
+    load_type int
+    load_type void
+    load_type void
+    load_var _60
+    call baml.iter.Filter.Iterator.next
+    store_var _62
+    jump L48
+
+  L41:
+    load_var _60
+    make_bound_method baml.iter.Map.Iterator.next
+    call_indirect
+    store_var _62
+    jump L48
+
+  L42:
+    load_type int
+    load_var _60
+    call baml.iter.Repeat.Iterator.next
+    store_var _62
+    jump L48
+
+  L43:
+    load_type int
+    load_type void
+    load_type void
+    load_var _60
+    call baml.iter.Chain.Iterator.next
+    store_var _62
+    jump L48
+
+  L44:
+    load_type int
+    load_type void
+    load_var _60
+    call baml.iter.StepBy.Iterator.next
+    store_var _62
+    jump L48
+
+  L45:
+    load_type int
+    load_var _60
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _62
+    jump L48
+
+  L46:
+    load_var _60
+    call baml.iter.Range.Iterator.next
+    store_var _62
+    jump L48
+
+  L47:
+    load_var _60
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _62
+
+  L48:
+    load_var _62
+    is_type baml.iter.Done
+    pop_jump_if_false L49
+    jump L51
+
+  L49:
+    load_type #0
+    load_var2 4 13
+    call baml.Array.at
+    store_var _93
+    load_var _93
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L50
+    jump L27
+
+  L50:
+    load_var2 11 14
+    call baml.Array.push
+    pop 1
+    jump L27
+
+  L51:
+    load_type #0
+    load_var self
+    call baml.Array.clear
+    pop 1
+    load_type #0
+    load_var sorted
+    call baml.iter.Iterable$for$T[].iter
+    store_var _103
+
+  L52:
+    load_var _103
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L53
+    jump L72
+
+  L53:
+    load_var _103
+    is_type baml.iter.Range
+    pop_jump_if_false L54
+    jump L71
+
+  L54:
+    load_var _103
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L55
+    jump L70
+
+  L55:
+    load_var _103
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L56
+    jump L69
+
+  L56:
+    load_var _103
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L57
+    jump L68
+
+  L57:
+    load_var _103
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L58
+    jump L67
+
+  L58:
+    load_var _103
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L59
+    jump L66
+
+  L59:
+    load_var _103
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L60
+    jump L65
+
+  L60:
+    load_var _103
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L61
+    jump L64
+
+  L61:
+    load_var _103
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L62
+    jump L63
+
+  L62:
+    load_var _103
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L79
+    load_type #0
+    load_type void
+    load_var _103
+    call baml.iter.Peekable.Iterator.next
+    store_var _105
+    jump L73
+
+  L63:
+    load_var _103
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _105
+    jump L73
+
+  L64:
+    load_var _103
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _105
+    jump L73
+
+  L65:
+    load_type #0
+    load_type void
+    load_type void
+    load_var _103
+    call baml.iter.Filter.Iterator.next
+    store_var _105
+    jump L73
+
+  L66:
+    load_var _103
+    make_bound_method baml.iter.Map.Iterator.next
+    call_indirect
+    store_var _105
+    jump L73
+
+  L67:
+    load_type #0
+    load_var _103
+    call baml.iter.Repeat.Iterator.next
+    store_var _105
+    jump L73
+
+  L68:
+    load_type #0
+    load_type void
+    load_type void
+    load_var _103
+    call baml.iter.Chain.Iterator.next
+    store_var _105
+    jump L73
+
+  L69:
+    load_type #0
+    load_type void
+    load_var _103
+    call baml.iter.StepBy.Iterator.next
+    store_var _105
+    jump L73
+
+  L70:
+    load_type #0
+    load_var _103
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _105
+    jump L73
+
+  L71:
+    load_var _103
+    call baml.iter.Range.Iterator.next
+    store_var _105
+    jump L73
+
+  L72:
+    load_var _103
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _105
+
+  L73:
+    load_var _105
+    is_type baml.iter.Done
+    pop_jump_if_false L74
+    jump L75
+
+  L74:
+    load_var2 1 16
+    call baml.Array.push
+    pop 1
+    jump L52
+
+  L75:
+    load_var self
+    jump L78
+
+  L76:
+    load_var2 9 10
+    call baml.Array.push
+    pop 1
+    load_var p
+    load_const 1
+    add_int
+    store_var p
+    jump L25
+
+  L77:
+    load_var self
+
+  L78:
+    return
+
+  L79:
+    unreachable
 }
 
 function baml.Array.splice(self: baml.Array<unknown>, start: int, count: int, replace: unknown[]) -> null {
@@ -1169,6 +1586,93 @@ function baml.Bool.from_json(j: baml.json.json) -> baml.Bool {
 }
 
 function baml.Bool.to_json(self: baml.Bool) -> baml.json.json {
+}
+
+function baml.Comparable$for$bigint.compare(self: bigint, other: bigint) -> int {
+    load_var2 1 2
+    cmp_op <
+    pop_jump_if_false L0
+    jump L3
+
+  L0:
+    load_var2 1 2
+    cmp_op >
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_const 0
+    jump L4
+
+  L2:
+    load_const 1
+    jump L4
+
+  L3:
+    load_const -1
+
+  L4:
+    return
+}
+
+function baml.Comparable$for$float.compare(self: float, other: float) -> int {
+    load_var2 1 2
+    call baml._float_total_cmp
+    return
+}
+
+function baml.Comparable$for$int.compare(self: int, other: int) -> int {
+    load_var2 1 2
+    cmp_op <
+    pop_jump_if_false L0
+    jump L3
+
+  L0:
+    load_var2 1 2
+    cmp_op >
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_const 0
+    jump L4
+
+  L2:
+    load_const 1
+    jump L4
+
+  L3:
+    load_const -1
+
+  L4:
+    return
+}
+
+function baml.Comparable$for$string.compare(self: string, other: string) -> int {
+    load_var2 1 2
+    cmp_op <
+    pop_jump_if_false L0
+    jump L3
+
+  L0:
+    load_var2 1 2
+    cmp_op >
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_const 0
+    jump L4
+
+  L2:
+    load_const 1
+    jump L4
+
+  L3:
+    load_const -1
+
+  L4:
+    return
 }
 
 function baml.Float.abs(self: baml.Float) -> float {
@@ -1439,6 +1943,31 @@ function baml.Null.from_json(j: baml.json.json) -> baml.Null {
 function baml.Null.to_json(self: baml.Null) -> baml.json.json {
 }
 
+function baml.Sortable$for$T[].sort(self: unknown[]) -> unknown[] {
+    load_type #0
+    load_var self
+    call baml._is_primitive_array
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_type #0
+    load_type unknown
+    load_var self
+    load_type #0
+    make_closure .<lambda(sort, 0)>, captures=0, ntypeargs=1
+    call baml.Array.sort_by
+    jump L2
+
+  L1:
+    load_type #0[]
+    load_var self
+    call baml._rust_sort
+
+  L2:
+    return
+}
+
 function baml.String.byte_length(self: baml.String) -> int {
 }
 
@@ -1649,6 +2178,18 @@ function baml.Uint8Array.to_string(self: baml.Uint8Array) -> string {
 }
 
 function baml.Uint8Array.zeroes(size: int) -> uint8array {
+}
+
+function baml._compare_shim(a: unknown, b: unknown) -> int {
+}
+
+function baml._float_total_cmp(a: float, b: float) -> int {
+}
+
+function baml._is_primitive_array(arr: unknown[]) -> bool {
+}
+
+function baml._rust_sort(arr: unknown) -> unknown {
 }
 
 function baml.deep_copy(value: unknown) -> unknown {
@@ -13094,7 +13635,7 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     load_const ClientType.Primitive
     cmp_int_op ==
     pop_jump_if_false L0
-    jump L92
+    jump L48
 
   L0:
     load_var self
@@ -13117,10 +13658,10 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
   L2:
     load_var self
     load_field .name
-    store_var _139
+    store_var _81
     load_var self
     load_field .counter
-    store_var _140
+    store_var _82
     load_var2 2 12
     load_var2 13 1
     load_field .sub_clients
@@ -13133,622 +13674,319 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     load_array_element
     load_var planner_state
     call baml.llm.Client.build_plan_with_state
-    jump L93
+    jump L49
 
   L3:
     alloc_array 0
-    jump L93
+    jump L49
 
   L4:
     alloc_array 0
     store_var steps
     load_var self
     load_field .sub_clients
-    store_var_load_var _9
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L5
-    jump L26
+    store_var _9
+    load_type baml.llm.Client
+    load_var _9
+    call baml.iter.Iterable$for$T[].iter
+    store_var _10
 
   L5:
-    load_var _9
-    is_type baml.iter.ArrayIterator<...>
+    load_var _10
+    is_type baml.iter.Flatten<...>
     pop_jump_if_false L6
-    jump L25
-
-  L6:
-    load_var _9
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L7
-    jump L24
-
-  L7:
-    load_var _9
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L8
     jump L23
 
-  L8:
-    load_var _9
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L9
+  L6:
+    load_var _10
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L7
     jump L22
 
-  L9:
-    load_var _9
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L10
+  L7:
+    load_var _10
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L8
     jump L21
 
-  L10:
-    load_var _9
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L11
+  L8:
+    load_var _10
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L9
     jump L20
 
-  L11:
-    load_var _9
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L12
+  L9:
+    load_var _10
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L10
     jump L19
 
-  L12:
-    load_var _9
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L13
+  L10:
+    load_var _10
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L11
     jump L18
 
-  L13:
-    load_var _9
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L14
+  L11:
+    load_var _10
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L12
     jump L17
 
-  L14:
-    load_var _9
-    is_type unknown[]
-    pop_jump_if_false L15
+  L12:
+    load_var _10
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L13
     jump L16
 
-  L15:
-    load_var _9
-    is_type baml.llm.Client[]
-    pop_jump_if_false L94
+  L13:
+    load_var _10
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L14
+    jump L15
+
+  L14:
+    load_var _10
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L50
     load_type baml.llm.Client
-    load_var _9
-    call baml.iter.Iterable$for$T[].iter
-    store_var _10
-    jump L27
+    load_type void
+    load_var _10
+    call baml.iter.Peekable.Iterator.next
+    store_var _12
+    jump L24
+
+  L15:
+    load_var _10
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _12
+    jump L24
 
   L16:
-    load_type baml.llm.Client
-    load_var _9
-    call baml.iter.Iterable$for$T[].iter
-    store_var _10
-    jump L27
+    load_var _10
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _12
+    jump L24
 
   L17:
     load_type baml.llm.Client
     load_type void
-    load_var _9
-    call baml.iter.Peekable.Iterable.iter
-    store_var _10
-    jump L27
+    load_type void
+    load_var _10
+    call baml.iter.Filter.Iterator.next
+    store_var _12
+    jump L24
 
   L18:
-    load_var _9
-    make_bound_method baml.iter.FlatMap.Iterable.iter
+    load_var _10
+    make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _10
-    jump L27
+    store_var _12
+    jump L24
 
   L19:
-    load_var _9
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _10
-    jump L27
+    load_type baml.llm.Client
+    load_var _10
+    call baml.iter.Repeat.Iterator.next
+    store_var _12
+    jump L24
 
   L20:
     load_type baml.llm.Client
     load_type void
     load_type void
-    load_var _9
-    call baml.iter.Filter.Iterable.iter
-    store_var _10
-    jump L27
+    load_var _10
+    call baml.iter.Chain.Iterator.next
+    store_var _12
+    jump L24
 
   L21:
-    load_var _9
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _10
-    jump L27
+    load_type baml.llm.Client
+    load_type void
+    load_var _10
+    call baml.iter.StepBy.Iterator.next
+    store_var _12
+    jump L24
 
   L22:
     load_type baml.llm.Client
-    load_var _9
-    call baml.iter.Repeat.Iterable.iter
-    store_var _10
-    jump L27
+    load_var _10
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _12
+    jump L24
 
   L23:
-    load_type baml.llm.Client
-    load_type void
-    load_type void
-    load_var _9
-    call baml.iter.Chain.Iterable.iter
-    store_var _10
-    jump L27
+    load_var _10
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _12
 
   L24:
-    load_type baml.llm.Client
-    load_type void
-    load_var _9
-    call baml.iter.StepBy.Iterable.iter
-    store_var _10
-    jump L27
+    load_var _12
+    is_type baml.iter.Done
+    pop_jump_if_false L25
+    jump L47
 
   L25:
-    load_type baml.llm.Client
-    load_var _9
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _10
-    jump L27
-
-  L26:
-    load_var _9
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _10
-
-  L27:
-    load_var _10
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L28
-    jump L45
-
-  L28:
-    load_var _10
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L29
-    jump L44
-
-  L29:
-    load_var _10
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L30
-    jump L43
-
-  L30:
-    load_var _10
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L31
-    jump L42
-
-  L31:
-    load_var _10
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L32
-    jump L41
-
-  L32:
-    load_var _10
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L33
-    jump L40
-
-  L33:
-    load_var _10
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L34
-    jump L39
-
-  L34:
-    load_var _10
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L35
-    jump L38
-
-  L35:
-    load_var _10
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L36
-    jump L37
-
-  L36:
-    load_var _10
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L94
-    load_type baml.llm.Client
-    load_type void
-    load_var _10
-    call baml.iter.Peekable.Iterator.next
-    store_var _41
-    jump L46
-
-  L37:
-    load_var _10
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _41
-    jump L46
-
-  L38:
-    load_var _10
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _41
-    jump L46
-
-  L39:
-    load_type baml.llm.Client
-    load_type void
-    load_type void
-    load_var _10
-    call baml.iter.Filter.Iterator.next
-    store_var _41
-    jump L46
-
-  L40:
-    load_var _10
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _41
-    jump L46
-
-  L41:
-    load_type baml.llm.Client
-    load_var _10
-    call baml.iter.Repeat.Iterator.next
-    store_var _41
-    jump L46
-
-  L42:
-    load_type baml.llm.Client
-    load_type void
-    load_type void
-    load_var _10
-    call baml.iter.Chain.Iterator.next
-    store_var _41
-    jump L46
-
-  L43:
-    load_type baml.llm.Client
-    load_type void
-    load_var _10
-    call baml.iter.StepBy.Iterator.next
-    store_var _41
-    jump L46
-
-  L44:
-    load_type baml.llm.Client
-    load_var _10
-    call baml.iter.ArrayIterator.Iterator.next
-    store_var _41
-    jump L46
-
-  L45:
-    load_var _10
-    make_bound_method baml.iter.Flatten.Iterator.next
-    call_indirect
-    store_var _41
-
-  L46:
-    load_var _41
-    is_type baml.iter.Done
-    pop_jump_if_false L47
-    jump L91
-
-  L47:
     load_var2 7 2
     call baml.llm.Client.build_plan_with_state
-    store_var _71
-    load_var _71
+    store_var _42
+    load_type baml.llm.OrchestrationStep
+    load_var _42
+    call baml.iter.Iterable$for$T[].iter
+    store_var _43
+
+  L26:
+    load_var _43
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L48
-    jump L69
+    pop_jump_if_false L27
+    jump L44
 
-  L48:
-    load_var _71
+  L27:
+    load_var _43
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L49
-    jump L68
+    pop_jump_if_false L28
+    jump L43
 
-  L49:
-    load_var _71
+  L28:
+    load_var _43
     is_type baml.iter.StepBy<...>
+    pop_jump_if_false L29
+    jump L42
+
+  L29:
+    load_var _43
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L30
+    jump L41
+
+  L30:
+    load_var _43
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L31
+    jump L40
+
+  L31:
+    load_var _43
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L32
+    jump L39
+
+  L32:
+    load_var _43
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L33
+    jump L38
+
+  L33:
+    load_var _43
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L34
+    jump L37
+
+  L34:
+    load_var _43
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L35
+    jump L36
+
+  L35:
+    load_var _43
+    is_type baml.iter.Peekable<...>
     pop_jump_if_false L50
-    jump L67
-
-  L50:
-    load_var _71
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L51
-    jump L66
-
-  L51:
-    load_var _71
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L52
-    jump L65
-
-  L52:
-    load_var _71
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L53
-    jump L64
-
-  L53:
-    load_var _71
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L54
-    jump L63
-
-  L54:
-    load_var _71
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L55
-    jump L62
-
-  L55:
-    load_var _71
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L56
-    jump L61
-
-  L56:
-    load_var _71
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L57
-    jump L60
-
-  L57:
-    load_var _71
-    is_type unknown[]
-    pop_jump_if_false L58
-    jump L59
-
-  L58:
-    load_var _71
-    is_type baml.llm.OrchestrationStep[]
-    pop_jump_if_false L94
-    load_type baml.llm.OrchestrationStep
-    load_var _71
-    call baml.iter.Iterable$for$T[].iter
-    store_var _72
-    jump L70
-
-  L59:
-    load_type baml.llm.OrchestrationStep
-    load_var _71
-    call baml.iter.Iterable$for$T[].iter
-    store_var _72
-    jump L70
-
-  L60:
     load_type baml.llm.OrchestrationStep
     load_type void
-    load_var _71
-    call baml.iter.Peekable.Iterable.iter
-    store_var _72
-    jump L70
-
-  L61:
-    load_var _71
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _72
-    jump L70
-
-  L62:
-    load_var _71
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _72
-    jump L70
-
-  L63:
-    load_type baml.llm.OrchestrationStep
-    load_type void
-    load_type void
-    load_var _71
-    call baml.iter.Filter.Iterable.iter
-    store_var _72
-    jump L70
-
-  L64:
-    load_var _71
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _72
-    jump L70
-
-  L65:
-    load_type baml.llm.OrchestrationStep
-    load_var _71
-    call baml.iter.Repeat.Iterable.iter
-    store_var _72
-    jump L70
-
-  L66:
-    load_type baml.llm.OrchestrationStep
-    load_type void
-    load_type void
-    load_var _71
-    call baml.iter.Chain.Iterable.iter
-    store_var _72
-    jump L70
-
-  L67:
-    load_type baml.llm.OrchestrationStep
-    load_type void
-    load_var _71
-    call baml.iter.StepBy.Iterable.iter
-    store_var _72
-    jump L70
-
-  L68:
-    load_type baml.llm.OrchestrationStep
-    load_var _71
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _72
-    jump L70
-
-  L69:
-    load_var _71
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _72
-
-  L70:
-    load_var _72
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L71
-    jump L88
-
-  L71:
-    load_var _72
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L72
-    jump L87
-
-  L72:
-    load_var _72
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L73
-    jump L86
-
-  L73:
-    load_var _72
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L74
-    jump L85
-
-  L74:
-    load_var _72
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L75
-    jump L84
-
-  L75:
-    load_var _72
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L76
-    jump L83
-
-  L76:
-    load_var _72
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L77
-    jump L82
-
-  L77:
-    load_var _72
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L78
-    jump L81
-
-  L78:
-    load_var _72
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L79
-    jump L80
-
-  L79:
-    load_var _72
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L94
-    load_type baml.llm.OrchestrationStep
-    load_type void
-    load_var _72
+    load_var _43
     call baml.iter.Peekable.Iterator.next
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L80:
-    load_var _72
+  L36:
+    load_var _43
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L81:
-    load_var _72
+  L37:
+    load_var _43
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L82:
+  L38:
     load_type baml.llm.OrchestrationStep
     load_type void
     load_type void
-    load_var _72
+    load_var _43
     call baml.iter.Filter.Iterator.next
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L83:
-    load_var _72
+  L39:
+    load_var _43
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L84:
+  L40:
     load_type baml.llm.OrchestrationStep
-    load_var _72
+    load_var _43
     call baml.iter.Repeat.Iterator.next
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L85:
+  L41:
     load_type baml.llm.OrchestrationStep
     load_type void
     load_type void
-    load_var _72
+    load_var _43
     call baml.iter.Chain.Iterator.next
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L86:
+  L42:
     load_type baml.llm.OrchestrationStep
     load_type void
-    load_var _72
+    load_var _43
     call baml.iter.StepBy.Iterator.next
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L87:
+  L43:
     load_type baml.llm.OrchestrationStep
-    load_var _72
+    load_var _43
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _103
-    jump L89
+    store_var _45
+    jump L45
 
-  L88:
-    load_var _72
+  L44:
+    load_var _43
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _103
+    store_var _45
 
-  L89:
-    load_var _103
+  L45:
+    load_var _45
     is_type baml.iter.Done
-    pop_jump_if_false L90
-    jump L27
+    pop_jump_if_false L46
+    jump L5
 
-  L90:
+  L46:
     load_var2 4 10
     call baml.Array.push
     pop 1
-    jump L70
+    jump L26
 
-  L91:
+  L47:
     load_var steps
-    jump L93
+    jump L49
 
-  L92:
+  L48:
     load_var self
     call baml.llm.Client.to_primitive_client
     store_var primitive
@@ -13757,10 +13995,10 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     init_instance baml.llm.OrchestrationStep .primitive_client, .delay_ms
     alloc_array 1
 
-  L93:
+  L49:
     return
 
-  L94:
+  L50:
     unreachable
 }
 
@@ -13848,318 +14086,167 @@ function baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_st
   L8:
     load_var2 1 2
     call baml.llm.Client.build_attempt_with_state
-    store_var_load_var _26
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L9
-    jump L30
+    store_var inner
+    load_type baml.llm.OrchestrationStep
+    load_var inner
+    call baml.iter.Iterable$for$T[].iter
+    store_var _27
 
   L9:
-    load_var _26
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L10
-    jump L29
-
-  L10:
-    load_var _26
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L11
-    jump L28
-
-  L11:
-    load_var _26
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L12
-    jump L27
-
-  L12:
-    load_var _26
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L13
-    jump L26
-
-  L13:
-    load_var _26
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L14
-    jump L25
-
-  L14:
-    load_var _26
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L15
-    jump L24
-
-  L15:
-    load_var _26
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L16
-    jump L23
-
-  L16:
-    load_var _26
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L17
-    jump L22
-
-  L17:
-    load_var _26
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L18
-    jump L21
-
-  L18:
-    load_var _26
-    is_type unknown[]
-    pop_jump_if_false L19
-    jump L20
-
-  L19:
-    load_var _26
-    is_type baml.llm.OrchestrationStep[]
-    pop_jump_if_false L53
-    load_type baml.llm.OrchestrationStep
-    load_var _26
-    call baml.iter.Iterable$for$T[].iter
-    store_var _27
-    jump L31
-
-  L20:
-    load_type baml.llm.OrchestrationStep
-    load_var _26
-    call baml.iter.Iterable$for$T[].iter
-    store_var _27
-    jump L31
-
-  L21:
-    load_type baml.llm.OrchestrationStep
-    load_type void
-    load_var _26
-    call baml.iter.Peekable.Iterable.iter
-    store_var _27
-    jump L31
-
-  L22:
-    load_var _26
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _27
-    jump L31
-
-  L23:
-    load_var _26
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _27
-    jump L31
-
-  L24:
-    load_type baml.llm.OrchestrationStep
-    load_type void
-    load_type void
-    load_var _26
-    call baml.iter.Filter.Iterable.iter
-    store_var _27
-    jump L31
-
-  L25:
-    load_var _26
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _27
-    jump L31
-
-  L26:
-    load_type baml.llm.OrchestrationStep
-    load_var _26
-    call baml.iter.Repeat.Iterable.iter
-    store_var _27
-    jump L31
-
-  L27:
-    load_type baml.llm.OrchestrationStep
-    load_type void
-    load_type void
-    load_var _26
-    call baml.iter.Chain.Iterable.iter
-    store_var _27
-    jump L31
-
-  L28:
-    load_type baml.llm.OrchestrationStep
-    load_type void
-    load_var _26
-    call baml.iter.StepBy.Iterable.iter
-    store_var _27
-    jump L31
-
-  L29:
-    load_type baml.llm.OrchestrationStep
-    load_var _26
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _27
-    jump L31
-
-  L30:
-    load_var _26
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _27
-
-  L31:
     load_var _27
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L32
-    jump L49
+    pop_jump_if_false L10
+    jump L27
 
-  L32:
+  L10:
     load_var _27
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L33
-    jump L48
+    pop_jump_if_false L11
+    jump L26
 
-  L33:
+  L11:
     load_var _27
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L34
-    jump L47
+    pop_jump_if_false L12
+    jump L25
 
-  L34:
+  L12:
     load_var _27
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L35
-    jump L46
+    pop_jump_if_false L13
+    jump L24
 
-  L35:
+  L13:
     load_var _27
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L36
-    jump L45
+    pop_jump_if_false L14
+    jump L23
 
-  L36:
+  L14:
     load_var _27
     is_type baml.iter.Map<...>
-    pop_jump_if_false L37
-    jump L44
+    pop_jump_if_false L15
+    jump L22
 
-  L37:
+  L15:
     load_var _27
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L38
-    jump L43
+    pop_jump_if_false L16
+    jump L21
 
-  L38:
+  L16:
     load_var _27
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L39
-    jump L42
+    pop_jump_if_false L17
+    jump L20
 
-  L39:
+  L17:
     load_var _27
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L40
-    jump L41
+    pop_jump_if_false L18
+    jump L19
 
-  L40:
+  L18:
     load_var _27
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L53
+    pop_jump_if_false L31
     load_type baml.llm.OrchestrationStep
     load_type void
     load_var _27
     call baml.iter.Peekable.Iterator.next
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L41:
+  L19:
     load_var _27
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L42:
+  L20:
     load_var _27
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L43:
+  L21:
     load_type baml.llm.OrchestrationStep
     load_type void
     load_type void
     load_var _27
     call baml.iter.Filter.Iterator.next
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L44:
+  L22:
     load_var _27
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L45:
+  L23:
     load_type baml.llm.OrchestrationStep
     load_var _27
     call baml.iter.Repeat.Iterator.next
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L46:
+  L24:
     load_type baml.llm.OrchestrationStep
     load_type void
     load_type void
     load_var _27
     call baml.iter.Chain.Iterator.next
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L47:
+  L25:
     load_type baml.llm.OrchestrationStep
     load_type void
     load_var _27
     call baml.iter.StepBy.Iterator.next
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L48:
+  L26:
     load_type baml.llm.OrchestrationStep
     load_var _27
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _58
-    jump L50
+    store_var _29
+    jump L28
 
-  L49:
+  L27:
     load_var _27
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _58
+    store_var _29
 
-  L50:
-    load_var _58
+  L28:
+    load_var _29
     is_type baml.iter.Done
-    pop_jump_if_false L51
-    jump L52
+    pop_jump_if_false L29
+    jump L30
 
-  L51:
+  L29:
     load_var2 5 12
     load_field .primitive_client
     load_var delay
     init_instance baml.llm.OrchestrationStep .primitive_client, .delay_ms
     call baml.Array.push
     pop 1
-    jump L31
+    jump L9
 
-  L52:
+  L30:
     load_var attempt
     load_const 1
     add_int
     store_var attempt
     jump L2
 
-  L53:
+  L31:
     unreachable
 }
 
@@ -14170,7 +14257,7 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
     load_const ClientType.Primitive
     cmp_int_op ==
     pop_jump_if_false L0
-    jump L50
+    jump L28
 
   L0:
     load_var self
@@ -14193,7 +14280,7 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
   L2:
     load_var self
     load_field .counter
-    store_var _106
+    store_var _77
     load_var self
     copy 0
     load_field .counter
@@ -14210,7 +14297,7 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
     load_array_element
     load_var2 2 3
     call baml.llm.Client.execute_oneshot
-    jump L56
+    jump L34
 
   L3:
     load_const "RoundRobin client has no sub-clients"
@@ -14220,320 +14307,169 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
   L4:
     load_var self
     load_field .sub_clients
-    store_var_load_var _35
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L5
-    jump L26
+    store_var _35
+    load_type baml.llm.Client
+    load_var _35
+    call baml.iter.Iterable$for$T[].iter
+    store_var _36
 
   L5:
-    load_var _35
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L6
-    jump L25
-
-  L6:
-    load_var _35
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L7
-    jump L24
-
-  L7:
-    load_var _35
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L8
-    jump L23
-
-  L8:
-    load_var _35
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L9
-    jump L22
-
-  L9:
-    load_var _35
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L10
-    jump L21
-
-  L10:
-    load_var _35
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L11
-    jump L20
-
-  L11:
-    load_var _35
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L12
-    jump L19
-
-  L12:
-    load_var _35
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L13
-    jump L18
-
-  L13:
-    load_var _35
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L14
-    jump L17
-
-  L14:
-    load_var _35
-    is_type unknown[]
-    pop_jump_if_false L15
-    jump L16
-
-  L15:
-    load_var _35
-    is_type baml.llm.Client[]
-    pop_jump_if_false L57
-    load_type baml.llm.Client
-    load_var _35
-    call baml.iter.Iterable$for$T[].iter
-    store_var _36
-    jump L27
-
-  L16:
-    load_type baml.llm.Client
-    load_var _35
-    call baml.iter.Iterable$for$T[].iter
-    store_var _36
-    jump L27
-
-  L17:
-    load_type baml.llm.Client
-    load_type void
-    load_var _35
-    call baml.iter.Peekable.Iterable.iter
-    store_var _36
-    jump L27
-
-  L18:
-    load_var _35
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _36
-    jump L27
-
-  L19:
-    load_var _35
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _36
-    jump L27
-
-  L20:
-    load_type baml.llm.Client
-    load_type void
-    load_type void
-    load_var _35
-    call baml.iter.Filter.Iterable.iter
-    store_var _36
-    jump L27
-
-  L21:
-    load_var _35
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _36
-    jump L27
-
-  L22:
-    load_type baml.llm.Client
-    load_var _35
-    call baml.iter.Repeat.Iterable.iter
-    store_var _36
-    jump L27
-
-  L23:
-    load_type baml.llm.Client
-    load_type void
-    load_type void
-    load_var _35
-    call baml.iter.Chain.Iterable.iter
-    store_var _36
-    jump L27
-
-  L24:
-    load_type baml.llm.Client
-    load_type void
-    load_var _35
-    call baml.iter.StepBy.Iterable.iter
-    store_var _36
-    jump L27
-
-  L25:
-    load_type baml.llm.Client
-    load_var _35
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _36
-    jump L27
-
-  L26:
-    load_var _35
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _36
-
-  L27:
     load_var _36
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L28
-    jump L45
+    pop_jump_if_false L6
+    jump L23
 
-  L28:
+  L6:
     load_var _36
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L29
-    jump L44
+    pop_jump_if_false L7
+    jump L22
 
-  L29:
+  L7:
     load_var _36
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L30
-    jump L43
+    pop_jump_if_false L8
+    jump L21
 
-  L30:
+  L8:
     load_var _36
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L31
-    jump L42
+    pop_jump_if_false L9
+    jump L20
 
-  L31:
+  L9:
     load_var _36
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L32
-    jump L41
+    pop_jump_if_false L10
+    jump L19
 
-  L32:
+  L10:
     load_var _36
     is_type baml.iter.Map<...>
-    pop_jump_if_false L33
-    jump L40
+    pop_jump_if_false L11
+    jump L18
 
-  L33:
+  L11:
     load_var _36
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L34
-    jump L39
+    pop_jump_if_false L12
+    jump L17
 
-  L34:
+  L12:
     load_var _36
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L35
-    jump L38
+    pop_jump_if_false L13
+    jump L16
 
-  L35:
+  L13:
     load_var _36
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L36
-    jump L37
+    pop_jump_if_false L14
+    jump L15
 
-  L36:
+  L14:
     load_var _36
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L57
+    pop_jump_if_false L35
     load_type baml.llm.Client
     load_type void
     load_var _36
     call baml.iter.Peekable.Iterator.next
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L37:
+  L15:
     load_var _36
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L38:
+  L16:
     load_var _36
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L39:
+  L17:
     load_type baml.llm.Client
     load_type void
     load_type void
     load_var _36
     call baml.iter.Filter.Iterator.next
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L40:
+  L18:
     load_var _36
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L41:
+  L19:
     load_type baml.llm.Client
     load_var _36
     call baml.iter.Repeat.Iterator.next
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L42:
+  L20:
     load_type baml.llm.Client
     load_type void
     load_type void
     load_var _36
     call baml.iter.Chain.Iterator.next
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L43:
+  L21:
     load_type baml.llm.Client
     load_type void
     load_var _36
     call baml.iter.StepBy.Iterator.next
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L44:
+  L22:
     load_type baml.llm.Client
     load_var _36
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _67
-    jump L46
+    store_var _38
+    jump L24
 
-  L45:
+  L23:
     load_var _36
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _67
+    store_var _38
 
-  L46:
-    load_var _67
+  L24:
+    load_var _38
     is_type baml.iter.Done
-    pop_jump_if_false L47
-    jump L49
+    pop_jump_if_false L25
+    jump L27
 
-  L47:
+  L25:
     load_type #0
     load_var2 15 2
     load_var active_delay_ms
     call baml.llm.Client.execute_oneshot
-    jump L48
+    jump L26
     load_var e
     throw_if_panic
-    jump L27
+    jump L5
 
-  L48:
-    jump L56
+  L26:
+    jump L34
 
-  L49:
+  L27:
     load_const "All orchestration steps failed"
     init_instance baml.errors.DevOther .message
     throw
 
-  L50:
+  L28:
     load_var self
     call baml.llm.Client.to_primitive_client
     store_var primitive
@@ -14556,61 +14492,61 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
     store_var http_response
     load_var http_response
     call baml.http.Response.ok
-    pop_jump_if_false L51
-    jump L54
+    pop_jump_if_false L29
+    jump L32
 
-  L51:
+  L29:
     load_var http_response
     sys_op baml.http.Response.text
     store_var error_body
-    jump L52
+    jump L30
     load_var e
     throw_if_panic
     load_const ""
     store_var error_body
 
-  L52:
+  L30:
     load_var active_delay_ms
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L53
+    pop_jump_if_false L31
     load_var active_delay_ms
     sys_op baml.sys.sleep
     pop 1
 
-  L53:
+  L31:
     load_const "HTTP request failed: "
     load_var error_body
     bin_op +
     init_instance baml.errors.DevOther .message
     throw
 
-  L54:
+  L32:
     load_var http_response
     sys_op baml.http.Response.text
     store_var body
     load_var2 4 9
     load_type #0
     sys_op baml.llm.PrimitiveClient.parse
-    jump L56
+    jump L34
     load_var e
     throw_if_panic
     load_var active_delay_ms
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L55
+    pop_jump_if_false L33
     load_var active_delay_ms
     sys_op baml.sys.sleep
     pop 1
 
-  L55:
+  L33:
     load_var e
     throw
 
-  L56:
+  L34:
     return
 
-  L57:
+  L35:
     unreachable
 }
 
@@ -14621,7 +14557,7 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
     load_const ClientType.Primitive
     cmp_int_op ==
     pop_jump_if_false L0
-    jump L50
+    jump L28
 
   L0:
     load_var self
@@ -14644,7 +14580,7 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
   L2:
     load_var self
     load_field .counter
-    store_var _96
+    store_var _67
     load_var self
     copy 0
     load_field .counter
@@ -14662,7 +14598,7 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
     load_array_element
     load_var2 2 3
     call baml.llm.Client.execute_stream
-    jump L51
+    jump L29
 
   L3:
     load_const "RoundRobin client has no sub-clients"
@@ -14672,321 +14608,170 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
   L4:
     load_var self
     load_field .sub_clients
-    store_var_load_var _24
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L5
-    jump L26
+    store_var _24
+    load_type baml.llm.Client
+    load_var _24
+    call baml.iter.Iterable$for$T[].iter
+    store_var _25
 
   L5:
-    load_var _24
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L6
-    jump L25
-
-  L6:
-    load_var _24
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L7
-    jump L24
-
-  L7:
-    load_var _24
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L8
-    jump L23
-
-  L8:
-    load_var _24
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L9
-    jump L22
-
-  L9:
-    load_var _24
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L10
-    jump L21
-
-  L10:
-    load_var _24
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L11
-    jump L20
-
-  L11:
-    load_var _24
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L12
-    jump L19
-
-  L12:
-    load_var _24
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L13
-    jump L18
-
-  L13:
-    load_var _24
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L14
-    jump L17
-
-  L14:
-    load_var _24
-    is_type unknown[]
-    pop_jump_if_false L15
-    jump L16
-
-  L15:
-    load_var _24
-    is_type baml.llm.Client[]
-    pop_jump_if_false L52
-    load_type baml.llm.Client
-    load_var _24
-    call baml.iter.Iterable$for$T[].iter
-    store_var _25
-    jump L27
-
-  L16:
-    load_type baml.llm.Client
-    load_var _24
-    call baml.iter.Iterable$for$T[].iter
-    store_var _25
-    jump L27
-
-  L17:
-    load_type baml.llm.Client
-    load_type void
-    load_var _24
-    call baml.iter.Peekable.Iterable.iter
-    store_var _25
-    jump L27
-
-  L18:
-    load_var _24
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _25
-    jump L27
-
-  L19:
-    load_var _24
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _25
-    jump L27
-
-  L20:
-    load_type baml.llm.Client
-    load_type void
-    load_type void
-    load_var _24
-    call baml.iter.Filter.Iterable.iter
-    store_var _25
-    jump L27
-
-  L21:
-    load_var _24
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _25
-    jump L27
-
-  L22:
-    load_type baml.llm.Client
-    load_var _24
-    call baml.iter.Repeat.Iterable.iter
-    store_var _25
-    jump L27
-
-  L23:
-    load_type baml.llm.Client
-    load_type void
-    load_type void
-    load_var _24
-    call baml.iter.Chain.Iterable.iter
-    store_var _25
-    jump L27
-
-  L24:
-    load_type baml.llm.Client
-    load_type void
-    load_var _24
-    call baml.iter.StepBy.Iterable.iter
-    store_var _25
-    jump L27
-
-  L25:
-    load_type baml.llm.Client
-    load_var _24
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _25
-    jump L27
-
-  L26:
-    load_var _24
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _25
-
-  L27:
     load_var _25
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L28
-    jump L45
+    pop_jump_if_false L6
+    jump L23
 
-  L28:
+  L6:
     load_var _25
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L29
-    jump L44
+    pop_jump_if_false L7
+    jump L22
 
-  L29:
+  L7:
     load_var _25
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L30
-    jump L43
+    pop_jump_if_false L8
+    jump L21
 
-  L30:
+  L8:
     load_var _25
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L31
-    jump L42
+    pop_jump_if_false L9
+    jump L20
 
-  L31:
+  L9:
     load_var _25
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L32
-    jump L41
+    pop_jump_if_false L10
+    jump L19
 
-  L32:
+  L10:
     load_var _25
     is_type baml.iter.Map<...>
-    pop_jump_if_false L33
-    jump L40
+    pop_jump_if_false L11
+    jump L18
 
-  L33:
+  L11:
     load_var _25
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L34
-    jump L39
+    pop_jump_if_false L12
+    jump L17
 
-  L34:
+  L12:
     load_var _25
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L35
-    jump L38
+    pop_jump_if_false L13
+    jump L16
 
-  L35:
+  L13:
     load_var _25
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L36
-    jump L37
+    pop_jump_if_false L14
+    jump L15
 
-  L36:
+  L14:
     load_var _25
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L52
+    pop_jump_if_false L30
     load_type baml.llm.Client
     load_type void
     load_var _25
     call baml.iter.Peekable.Iterator.next
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L37:
+  L15:
     load_var _25
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L38:
+  L16:
     load_var _25
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L39:
+  L17:
     load_type baml.llm.Client
     load_type void
     load_type void
     load_var _25
     call baml.iter.Filter.Iterator.next
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L40:
+  L18:
     load_var _25
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L41:
+  L19:
     load_type baml.llm.Client
     load_var _25
     call baml.iter.Repeat.Iterator.next
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L42:
+  L20:
     load_type baml.llm.Client
     load_type void
     load_type void
     load_var _25
     call baml.iter.Chain.Iterator.next
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L43:
+  L21:
     load_type baml.llm.Client
     load_type void
     load_var _25
     call baml.iter.StepBy.Iterator.next
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L44:
+  L22:
     load_type baml.llm.Client
     load_var _25
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _56
-    jump L46
+    store_var _27
+    jump L24
 
-  L45:
+  L23:
     load_var _25
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _56
+    store_var _27
 
-  L46:
-    load_var _56
+  L24:
+    load_var _27
     is_type baml.iter.Done
-    pop_jump_if_false L47
-    jump L49
+    pop_jump_if_false L25
+    jump L27
 
-  L47:
+  L25:
     load_type #0
     load_type #1
     load_var2 11 2
     load_var active_delay_ms
     call baml.llm.Client.execute_stream
-    jump L48
+    jump L26
     load_var e
     throw_if_panic
-    jump L27
+    jump L5
 
-  L48:
-    jump L51
+  L26:
+    jump L29
 
-  L49:
+  L27:
     load_const "All orchestration steps failed"
     init_instance baml.errors.DevOther .message
     throw
 
-  L50:
+  L28:
     load_var self
     call baml.llm.Client.to_primitive_client
     store_var primitive
@@ -15014,10 +14799,10 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
     load_field .function_name
     call baml.llm.Client.__make_stream
 
-  L51:
+  L29:
     return
 
-  L52:
+  L30:
     unreachable
 }
 
@@ -15526,316 +15311,165 @@ function baml.llm.PlannerState.rr_local_offset(self: baml.llm.PlannerState, clie
     store_var offset
     load_var self
     load_field .rr_client_names
-    store_var_load_var _4
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _4
+    load_type string
+    load_var _4
+    call baml.iter.Iterable$for$T[].iter
+    store_var _5
 
   L0:
-    load_var _4
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _4
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _4
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _4
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _4
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _4
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _4
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _4
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _4
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _4
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _4
-    is_type string[]
-    pop_jump_if_false L44
-    load_type string
-    load_var _4
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L22
-
-  L11:
-    load_type string
-    load_var _4
-    call baml.iter.Iterable$for$T[].iter
-    store_var _5
-    jump L22
-
-  L12:
-    load_type string
-    load_type void
-    load_var _4
-    call baml.iter.Peekable.Iterable.iter
-    store_var _5
-    jump L22
-
-  L13:
-    load_var _4
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L14:
-    load_var _4
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L15:
-    load_type string
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Filter.Iterable.iter
-    store_var _5
-    jump L22
-
-  L16:
-    load_var _4
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _5
-    jump L22
-
-  L17:
-    load_type string
-    load_var _4
-    call baml.iter.Repeat.Iterable.iter
-    store_var _5
-    jump L22
-
-  L18:
-    load_type string
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Chain.Iterable.iter
-    store_var _5
-    jump L22
-
-  L19:
-    load_type string
-    load_type void
-    load_var _4
-    call baml.iter.StepBy.Iterable.iter
-    store_var _5
-    jump L22
-
-  L20:
-    load_type string
-    load_var _4
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _5
-    jump L22
-
-  L21:
-    load_var _4
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _5
-
-  L22:
     load_var _5
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _5
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _5
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _5
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _5
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _5
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _5
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _5
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _5
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _5
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type string
     load_type void
     load_var _5
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L32:
+  L10:
     load_var _5
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L33:
+  L11:
     load_var _5
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L34:
+  L12:
     load_type string
     load_type void
     load_type void
     load_var _5
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L35:
+  L13:
     load_var _5
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L36:
+  L14:
     load_type string
     load_var _5
     call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L37:
+  L15:
     load_type string
     load_type void
     load_type void
     load_var _5
     call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L38:
+  L16:
     load_type string
     load_type void
     load_var _5
     call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L39:
+  L17:
     load_type string
     load_var _5
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L41
+    store_var _7
+    jump L19
 
-  L40:
+  L18:
     load_var _5
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _36
+    store_var _7
 
-  L41:
-    load_var _36
+  L19:
+    load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
+  L20:
     load_var2 6 2
     cmp_op ==
-    pop_jump_if_false L22
+    pop_jump_if_false L0
     load_var offset
     load_const 1
     add_int
     store_var offset
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var offset
     return
 
-  L44:
+  L22:
     unreachable
 }
 
@@ -19133,329 +18767,177 @@ function baml.toml.Table.from_json(json: baml.json.json) -> baml.toml.Table {
     load_var json
     call baml.Map.keys
     store_var _4
+    load_type string
     load_var _4
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L2
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _7
 
   L2:
-    load_var _4
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L3
-    jump L22
-
-  L3:
-    load_var _4
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L4
-    jump L21
-
-  L4:
-    load_var _4
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L5
-    jump L20
-
-  L5:
-    load_var _4
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L6
-    jump L19
-
-  L6:
-    load_var _4
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L7
-    jump L18
-
-  L7:
-    load_var _4
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L8
-    jump L17
-
-  L8:
-    load_var _4
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L9
-    jump L16
-
-  L9:
-    load_var _4
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L10
-    jump L15
-
-  L10:
-    load_var _4
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L11
-    jump L14
-
-  L11:
-    load_var _4
-    is_type unknown[]
-    pop_jump_if_false L12
-    jump L13
-
-  L12:
-    load_var _4
-    is_type string[]
-    pop_jump_if_false L47
-    load_type string
-    load_var _4
-    call baml.iter.Iterable$for$T[].iter
-    store_var _7
-    jump L24
-
-  L13:
-    load_type string
-    load_var _4
-    call baml.iter.Iterable$for$T[].iter
-    store_var _7
-    jump L24
-
-  L14:
-    load_type string
-    load_type void
-    load_var _4
-    call baml.iter.Peekable.Iterable.iter
-    store_var _7
-    jump L24
-
-  L15:
-    load_var _4
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L24
-
-  L16:
-    load_var _4
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L24
-
-  L17:
-    load_type string
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Filter.Iterable.iter
-    store_var _7
-    jump L24
-
-  L18:
-    load_var _4
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _7
-    jump L24
-
-  L19:
-    load_type string
-    load_var _4
-    call baml.iter.Repeat.Iterable.iter
-    store_var _7
-    jump L24
-
-  L20:
-    load_type string
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Chain.Iterable.iter
-    store_var _7
-    jump L24
-
-  L21:
-    load_type string
-    load_type void
-    load_var _4
-    call baml.iter.StepBy.Iterable.iter
-    store_var _7
-    jump L24
-
-  L22:
-    load_type string
-    load_var _4
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _7
-    jump L24
-
-  L23:
-    load_var _4
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _7
-
-  L24:
     load_var _7
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L42
+    pop_jump_if_false L3
+    jump L20
 
-  L25:
+  L3:
     load_var _7
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L26
-    jump L41
+    pop_jump_if_false L4
+    jump L19
 
-  L26:
+  L4:
     load_var _7
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L27
-    jump L40
+    pop_jump_if_false L5
+    jump L18
 
-  L27:
+  L5:
     load_var _7
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L28
-    jump L39
+    pop_jump_if_false L6
+    jump L17
 
-  L28:
+  L6:
     load_var _7
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L29
-    jump L38
+    pop_jump_if_false L7
+    jump L16
 
-  L29:
+  L7:
     load_var _7
     is_type baml.iter.Map<...>
-    pop_jump_if_false L30
-    jump L37
+    pop_jump_if_false L8
+    jump L15
 
-  L30:
+  L8:
     load_var _7
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L31
-    jump L36
+    pop_jump_if_false L9
+    jump L14
 
-  L31:
+  L9:
     load_var _7
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L32
-    jump L35
+    pop_jump_if_false L10
+    jump L13
 
-  L32:
+  L10:
     load_var _7
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L33
-    jump L34
+    pop_jump_if_false L11
+    jump L12
 
-  L33:
+  L11:
     load_var _7
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L47
+    pop_jump_if_false L25
     load_type string
     load_type void
     load_var _7
     call baml.iter.Peekable.Iterator.next
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L34:
+  L12:
     load_var _7
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L35:
+  L13:
     load_var _7
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L36:
+  L14:
     load_type string
     load_type void
     load_type void
     load_var _7
     call baml.iter.Filter.Iterator.next
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L37:
+  L15:
     load_var _7
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L38:
+  L16:
     load_type string
     load_var _7
     call baml.iter.Repeat.Iterator.next
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L39:
+  L17:
     load_type string
     load_type void
     load_type void
     load_var _7
     call baml.iter.Chain.Iterator.next
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L40:
+  L18:
     load_type string
     load_type void
     load_var _7
     call baml.iter.StepBy.Iterator.next
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L41:
+  L19:
     load_type string
     load_var _7
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _38
-    jump L43
+    store_var _9
+    jump L21
 
-  L42:
+  L20:
     load_var _7
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _38
+    store_var _9
 
-  L43:
-    load_var _38
+  L21:
+    load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L44
-    jump L46
+    pop_jump_if_false L22
+    jump L24
 
-  L44:
-    load_var _38
+  L22:
+    load_var _9
     store_var key
     load_var key
-    store_var _68
+    store_var _39
     load_var2 1 6
     load_map_element
-    store_var_load_var _69
+    store_var_load_var _40
     load_const null
     cmp_op ==
-    pop_jump_if_false L45
-    jump L24
+    pop_jump_if_false L23
+    jump L2
 
-  L45:
-    load_var _69
+  L23:
+    load_var _40
     call baml.toml.item_from_json
-    store_var _75
+    store_var _46
     load_var2 2 7
-    load_var _75
+    load_var _46
     store_map_element
-    jump L24
+    jump L2
 
-  L46:
+  L24:
     load_var items
     init_instance baml.toml.Table .items
     return
 
-  L47:
+  L25:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
@@ -26,219 +26,160 @@ fn testing.TestRegistry.expand_set(self: testing.TestRegistry, name: string) -> 
     let _2: string // name // param
     let _3: testing.TestSetRegistration[]
     let _4: baml.iter.Iterator<Item = testing.TestSetRegistration, Error = void>
-    let _5: bool
+    let _5: type
     let _6: unknown
     let _7: bool
-    let _8: type
+    let _8: unknown
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
+    let _34: testing.TestSetRegistration
+    let _35: testing.TestSetRegistration // ts
     let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: type
-    let _40: bool
-    let _41: type
-    let _42: type
-    let _43: bool
-    let _44: type
-    let _45: type
-    let _46: type
-    let _47: bool
-    let _48: type
-    let _49: bool
-    let _50: unknown
-    let _51: bool
-    let _52: type
-    let _53: type
-    let _54: type
-    let _55: bool
-    let _56: unknown
-    let _57: bool
-    let _58: unknown
-    let _59: bool
+    let _37: string
+    let _38: int // start
+    let _39: testing.TestCollector // sub_collector
+    let _40: testing.TestRegistration[]
+    let _41: testing.TestSetRegistration[]
+    let _42: void
+    let _43: (testing.TestCollector) -> void throws unknown
+    let _44: testing.TestCollector
+    let _45: int // elapsed
+    let _46: int
+    let _47: int
+    let _48: testing.TestRegistry // sub_registry
+    let _49: testing.TestCollector
+    let _50: map<string, testing.TestRegistry>
+    let _51: int
+    let _52: testing.TestRegistry | null
+    let _53: (map<string, testing.TestRegistry>, string, testing.TestRegistry) -> testing.TestRegistry | null throws never
+    let _54: testing.TestRegistry
+    let _55: type
+    let _56: type
+    let _57: string[]
+    let _58: (map<string, testing.TestRegistry>) -> string[] throws never
+    let _59: type
     let _60: type
-    let _61: type
-    let _62: bool
-    let _63: testing.TestSetRegistration
-    let _64: testing.TestSetRegistration // ts
-    let _65: bool
-    let _66: string
-    let _67: int // start
-    let _68: testing.TestCollector // sub_collector
-    let _69: testing.TestRegistration[]
-    let _70: testing.TestSetRegistration[]
-    let _71: void
-    let _72: (testing.TestCollector) -> void throws unknown
-    let _73: testing.TestCollector
-    let _74: int // elapsed
-    let _75: int
-    let _76: int
-    let _77: testing.TestRegistry // sub_registry
-    let _78: testing.TestCollector
-    let _79: map<string, testing.TestRegistry>
-    let _80: int
-    let _81: testing.TestRegistry | null
-    let _82: (map<string, testing.TestRegistry>, string, testing.TestRegistry) -> testing.TestRegistry | null throws never
-    let _83: testing.TestRegistry
-    let _84: type
-    let _85: type
-    let _86: string[]
-    let _87: (map<string, testing.TestRegistry>) -> string[] throws never
+    let _61: baml.iter.Iterator<Item = string, Error = void>
+    let _62: type
+    let _63: unknown
+    let _64: bool
+    let _65: unknown
+    let _66: bool
+    let _67: type
+    let _68: bool
+    let _69: type
+    let _70: type
+    let _71: bool
+    let _72: type
+    let _73: type
+    let _74: type
+    let _75: bool
+    let _76: type
+    let _77: bool
+    let _78: unknown
+    let _79: bool
+    let _80: type
+    let _81: type
+    let _82: type
+    let _83: bool
+    let _84: unknown
+    let _85: bool
+    let _86: unknown
+    let _87: bool
     let _88: type
     let _89: type
-    let _90: baml.iter.Iterator<Item = string, Error = void>
-    let _91: bool
-    let _92: unknown
-    let _93: bool
-    let _94: type
-    let _95: bool
-    let _96: type
-    let _97: type
-    let _98: bool
-    let _99: type
-    let _100: type
-    let _101: type
-    let _102: bool
-    let _103: type
-    let _104: bool
-    let _105: unknown
-    let _106: bool
-    let _107: type
-    let _108: type
-    let _109: type
-    let _110: bool
-    let _111: unknown
-    let _112: bool
-    let _113: unknown
-    let _114: bool
-    let _115: type
-    let _116: type
-    let _117: bool
-    let _118: type
-    let _119: bool
-    let _120: type
-    let _121: unknown
-    let _122: bool
-    let _123: unknown
-    let _124: bool
-    let _125: type
-    let _126: bool
-    let _127: type
-    let _128: type
-    let _129: bool
-    let _130: type
-    let _131: type
-    let _132: type
-    let _133: bool
-    let _134: type
-    let _135: bool
-    let _136: unknown
-    let _137: bool
-    let _138: type
-    let _139: type
-    let _140: type
-    let _141: bool
-    let _142: unknown
-    let _143: bool
-    let _144: unknown
-    let _145: bool
-    let _146: type
-    let _147: type
-    let _148: bool
-    let _149: string
-    let _150: string // k
-    let _151: testing.TestRegistry // sub
-    let _152: map<string, testing.TestRegistry>
-    let _153: string
-    let _154: bool
-    let _155: string
-    let _156: string
-    let _157: string
+    let _90: bool
+    let _91: string
+    let _92: string // k
+    let _93: testing.TestRegistry // sub
+    let _94: map<string, testing.TestRegistry>
+    let _95: string
+    let _96: bool
+    let _97: string
+    let _98: string
+    let _99: string
 
     bb0: {
         _3 = copy _1.0.2;
-        _5 = is_type(copy _3, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
-        branch copy _5 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _7 = is_type(copy _3, baml.iter.ArrayIterator<testing.TestSetRegistration>);
-        branch copy _7 -> [bb23, bb2];
+        _5 = load_type(testing.TestSetRegistration);
+        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _5>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _9 = is_type(copy _3, baml.iter.StepBy<testing.TestSetRegistration, void>);
-        branch copy _9 -> [bb22, bb3];
+        _7 = is_type(copy _4, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
+        branch copy _7 -> [bb22, bb3];
     }
 
     bb3: {
-        _12 = is_type(copy _3, baml.iter.Chain<testing.TestSetRegistration, void, void>);
-        branch copy _12 -> [bb21, bb4];
+        _9 = is_type(copy _4, baml.iter.ArrayIterator<testing.TestSetRegistration>);
+        branch copy _9 -> [bb21, bb4];
     }
 
     bb4: {
-        _16 = is_type(copy _3, baml.iter.Repeat<testing.TestSetRegistration>);
-        branch copy _16 -> [bb20, bb5];
+        _11 = is_type(copy _4, baml.iter.StepBy<testing.TestSetRegistration, void>);
+        branch copy _11 -> [bb20, bb5];
     }
 
     bb5: {
-        _18 = is_type(copy _3, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
-        branch copy _18 -> [bb19, bb6];
+        _14 = is_type(copy _4, baml.iter.Chain<testing.TestSetRegistration, void, void>);
+        branch copy _14 -> [bb19, bb6];
     }
 
     bb6: {
-        _20 = is_type(copy _3, baml.iter.Filter<testing.TestSetRegistration, void, void>);
-        branch copy _20 -> [bb18, bb7];
+        _18 = is_type(copy _4, baml.iter.Repeat<testing.TestSetRegistration>);
+        branch copy _18 -> [bb18, bb7];
     }
 
     bb7: {
-        _24 = is_type(copy _3, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
-        branch copy _24 -> [bb17, bb8];
+        _20 = is_type(copy _4, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
+        branch copy _20 -> [bb17, bb8];
     }
 
     bb8: {
-        _26 = is_type(copy _3, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
-        branch copy _26 -> [bb16, bb9];
+        _22 = is_type(copy _4, baml.iter.Filter<testing.TestSetRegistration, void, void>);
+        branch copy _22 -> [bb16, bb9];
     }
 
     bb9: {
-        _28 = is_type(copy _3, baml.iter.Peekable<testing.TestSetRegistration, void>);
-        branch copy _28 -> [bb15, bb10];
+        _26 = is_type(copy _4, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
+        branch copy _26 -> [bb15, bb10];
     }
 
     bb10: {
-        _31 = is_type(copy _3, unknown[]);
-        branch copy _31 -> [bb14, bb11];
+        _28 = is_type(copy _4, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
+        branch copy _28 -> [bb14, bb11];
     }
 
     bb11: {
-        _33 = is_type(copy _3, testing.TestSetRegistration[]);
-        branch copy _33 -> [bb13, bb12];
+        _30 = is_type(copy _4, baml.iter.Peekable<testing.TestSetRegistration, void>);
+        branch copy _30 -> [bb13, bb12];
     }
 
     bb12: {
@@ -246,509 +187,264 @@ fn testing.TestRegistry.expand_set(self: testing.TestRegistry, name: string) -> 
     }
 
     bb13: {
-        _34 = load_type(testing.TestSetRegistration);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _3) -> [bb25];
+        _31 = load_type(testing.TestSetRegistration);
+        _32 = load_type(void);
+        _6 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _4) -> [bb23];
     }
 
     bb14: {
-        _32 = load_type(testing.TestSetRegistration);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _3) -> [bb25];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
+        _6 = call copy _29() -> [bb23];
     }
 
     bb15: {
-        _29 = load_type(testing.TestSetRegistration);
-        _30 = load_type(void);
-        _4 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _3) -> [bb25];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
+        _6 = call copy _27() -> [bb23];
     }
 
     bb16: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _3);
-        _4 = call copy _27() -> [bb25];
+        _23 = load_type(testing.TestSetRegistration);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _6 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _4) -> [bb23];
     }
 
     bb17: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _3);
-        _4 = call copy _25() -> [bb25];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
+        _6 = call copy _21() -> [bb23];
     }
 
     bb18: {
-        _21 = load_type(testing.TestSetRegistration);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _4 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _3) -> [bb25];
+        _19 = load_type(testing.TestSetRegistration);
+        _6 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _4) -> [bb23];
     }
 
     bb19: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _3);
-        _4 = call copy _19() -> [bb25];
+        _15 = load_type(testing.TestSetRegistration);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _6 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _4) -> [bb23];
     }
 
     bb20: {
-        _17 = load_type(testing.TestSetRegistration);
-        _4 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _3) -> [bb25];
+        _12 = load_type(testing.TestSetRegistration);
+        _13 = load_type(void);
+        _6 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _4) -> [bb23];
     }
 
     bb21: {
-        _13 = load_type(testing.TestSetRegistration);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _4 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _3) -> [bb25];
+        _10 = load_type(testing.TestSetRegistration);
+        _6 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _4) -> [bb23];
     }
 
     bb22: {
-        _10 = load_type(testing.TestSetRegistration);
-        _11 = load_type(void);
-        _4 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _3) -> [bb25];
+        _8 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
+        _6 = call copy _8() -> [bb23];
     }
 
     bb23: {
-        _8 = load_type(testing.TestSetRegistration);
-        _4 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _3) -> [bb25];
+        _33 = is_type(copy _6, baml.iter.Done);
+        branch copy _33 -> [bb30, bb24];
     }
 
     bb24: {
-        _6 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _3);
-        _4 = call copy _6() -> [bb25];
+        _34 = copy _6;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _37 = copy _35.0;
+        _36 = copy _37 == copy _2;
+        branch copy _36 -> [bb25, bb2];
     }
 
     bb25: {
-        _36 = is_type(copy _4, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
-        branch copy _36 -> [bb45, bb26];
+        _38 = call const fn baml.sys.now_ms() -> [bb26];
     }
 
     bb26: {
-        _38 = is_type(copy _4, baml.iter.ArrayIterator<testing.TestSetRegistration>);
-        branch copy _38 -> [bb44, bb27];
+        _40 = [];
+        _41 = [];
+        _39 = testing.TestCollector { copy _2, copy _40, copy _41 };
+        _43 = copy _35.1;
+        _44 = copy _39;
+        _42 = call copy _43(copy _44) -> [bb27];
     }
 
     bb27: {
-        _40 = is_type(copy _4, baml.iter.StepBy<testing.TestSetRegistration, void>);
-        branch copy _40 -> [bb43, bb28];
+        _46 = call const fn baml.sys.now_ms() -> [bb28];
     }
 
     bb28: {
-        _43 = is_type(copy _4, baml.iter.Chain<testing.TestSetRegistration, void, void>);
-        branch copy _43 -> [bb42, bb29];
+        _47 = copy _38;
+        _45 = copy _46 - copy _47;
+        _49 = copy _39;
+        _50 = {  };
+        _51 = copy _45;
+        _48 = testing.TestRegistry { copy _49, copy _50, copy _51 };
+        _53 = copy _1.1;
+        _54 = copy _48;
+        _55 = load_type(string);
+        _56 = load_type(testing.TestRegistry);
+        _52 = call const fn baml.Map.set<copy _55, copy _56>(copy _53, copy _2, copy _54) -> [bb29];
     }
 
     bb29: {
-        _47 = is_type(copy _4, baml.iter.Repeat<testing.TestSetRegistration>);
-        branch copy _47 -> [bb41, bb30];
+        _0 = call const fn testing.TestRegistry.serialize(copy _1) -> [bb57];
     }
 
     bb30: {
-        _49 = is_type(copy _4, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
-        branch copy _49 -> [bb40, bb31];
+        _58 = copy _1.1;
+        _59 = load_type(string);
+        _60 = load_type(testing.TestRegistry);
+        _57 = call const fn baml.Map.keys<copy _59, copy _60>(copy _58) -> [bb31];
     }
 
     bb31: {
-        _51 = is_type(copy _4, baml.iter.Filter<testing.TestSetRegistration, void, void>);
-        branch copy _51 -> [bb39, bb32];
+        _62 = load_type(string);
+        _61 = call const fn baml.iter.Iterable$for$T[].iter<copy _62>(copy _57) -> [bb32];
     }
 
     bb32: {
-        _55 = is_type(copy _4, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
-        branch copy _55 -> [bb38, bb33];
+        _64 = is_type(copy _61, baml.iter.Flatten<_, string, void, void>);
+        branch copy _64 -> [bb52, bb33];
     }
 
     bb33: {
-        _57 = is_type(copy _4, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
-        branch copy _57 -> [bb37, bb34];
+        _66 = is_type(copy _61, baml.iter.ArrayIterator<string>);
+        branch copy _66 -> [bb51, bb34];
     }
 
     bb34: {
-        _59 = is_type(copy _4, baml.iter.Peekable<testing.TestSetRegistration, void>);
-        branch copy _59 -> [bb36, bb35];
+        _68 = is_type(copy _61, baml.iter.StepBy<string, void>);
+        branch copy _68 -> [bb50, bb35];
     }
 
     bb35: {
-        unreachable;
+        _71 = is_type(copy _61, baml.iter.Chain<string, void, void>);
+        branch copy _71 -> [bb49, bb36];
     }
 
     bb36: {
-        _60 = load_type(testing.TestSetRegistration);
-        _61 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _60, copy _61>(copy _4) -> [bb46];
+        _75 = is_type(copy _61, baml.iter.Repeat<string>);
+        branch copy _75 -> [bb48, bb37];
     }
 
     bb37: {
-        _58 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
-        _35 = call copy _58() -> [bb46];
+        _77 = is_type(copy _61, baml.iter.Map<_, string, void, void>);
+        branch copy _77 -> [bb47, bb38];
     }
 
     bb38: {
-        _56 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
-        _35 = call copy _56() -> [bb46];
+        _79 = is_type(copy _61, baml.iter.Filter<string, void, void>);
+        branch copy _79 -> [bb46, bb39];
     }
 
     bb39: {
-        _52 = load_type(testing.TestSetRegistration);
-        _53 = load_type(void);
-        _54 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _52, copy _53, copy _54>(copy _4) -> [bb46];
+        _83 = is_type(copy _61, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _83 -> [bb45, bb40];
     }
 
     bb40: {
-        _50 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
-        _35 = call copy _50() -> [bb46];
+        _85 = is_type(copy _61, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _85 -> [bb44, bb41];
     }
 
     bb41: {
-        _48 = load_type(testing.TestSetRegistration);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _48>(copy _4) -> [bb46];
+        _87 = is_type(copy _61, baml.iter.Peekable<string, void>);
+        branch copy _87 -> [bb43, bb42];
     }
 
     bb42: {
-        _44 = load_type(testing.TestSetRegistration);
-        _45 = load_type(void);
-        _46 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _44, copy _45, copy _46>(copy _4) -> [bb46];
+        unreachable;
     }
 
     bb43: {
-        _41 = load_type(testing.TestSetRegistration);
-        _42 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _41, copy _42>(copy _4) -> [bb46];
+        _88 = load_type(string);
+        _89 = load_type(void);
+        _63 = call const fn baml.iter.Peekable.Iterator.next<copy _88, copy _89>(copy _61) -> [bb53];
     }
 
     bb44: {
-        _39 = load_type(testing.TestSetRegistration);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _39>(copy _4) -> [bb46];
+        _86 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _61);
+        _63 = call copy _86() -> [bb53];
     }
 
     bb45: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
-        _35 = call copy _37() -> [bb46];
+        _84 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _61);
+        _63 = call copy _84() -> [bb53];
     }
 
     bb46: {
-        _62 = is_type(copy _35, baml.iter.Done);
-        branch copy _62 -> [bb53, bb47];
+        _80 = load_type(string);
+        _81 = load_type(void);
+        _82 = load_type(void);
+        _63 = call const fn baml.iter.Filter.Iterator.next<copy _80, copy _81, copy _82>(copy _61) -> [bb53];
     }
 
     bb47: {
-        _63 = copy _35;
-        fresh_cell(_64);
-        _64 = copy _63;
-        _66 = copy _64.0;
-        _65 = copy _66 == copy _2;
-        branch copy _65 -> [bb48, bb25];
+        _78 = make_bound_method baml.iter.Map.Iterator.next(copy _61);
+        _63 = call copy _78() -> [bb53];
     }
 
     bb48: {
-        _67 = call const fn baml.sys.now_ms() -> [bb49];
+        _76 = load_type(string);
+        _63 = call const fn baml.iter.Repeat.Iterator.next<copy _76>(copy _61) -> [bb53];
     }
 
     bb49: {
-        _69 = [];
-        _70 = [];
-        _68 = testing.TestCollector { copy _2, copy _69, copy _70 };
-        _72 = copy _64.1;
-        _73 = copy _68;
-        _71 = call copy _72(copy _73) -> [bb50];
+        _72 = load_type(string);
+        _73 = load_type(void);
+        _74 = load_type(void);
+        _63 = call const fn baml.iter.Chain.Iterator.next<copy _72, copy _73, copy _74>(copy _61) -> [bb53];
     }
 
     bb50: {
-        _75 = call const fn baml.sys.now_ms() -> [bb51];
+        _69 = load_type(string);
+        _70 = load_type(void);
+        _63 = call const fn baml.iter.StepBy.Iterator.next<copy _69, copy _70>(copy _61) -> [bb53];
     }
 
     bb51: {
-        _76 = copy _67;
-        _74 = copy _75 - copy _76;
-        _78 = copy _68;
-        _79 = {  };
-        _80 = copy _74;
-        _77 = testing.TestRegistry { copy _78, copy _79, copy _80 };
-        _82 = copy _1.1;
-        _83 = copy _77;
-        _84 = load_type(string);
-        _85 = load_type(testing.TestRegistry);
-        _81 = call const fn baml.Map.set<copy _84, copy _85>(copy _82, copy _2, copy _83) -> [bb52];
+        _67 = load_type(string);
+        _63 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _67>(copy _61) -> [bb53];
     }
 
     bb52: {
-        _0 = call const fn testing.TestRegistry.serialize(copy _1) -> [bb104];
+        _65 = make_bound_method baml.iter.Flatten.Iterator.next(copy _61);
+        _63 = call copy _65() -> [bb53];
     }
 
     bb53: {
-        _87 = copy _1.1;
-        _88 = load_type(string);
-        _89 = load_type(testing.TestRegistry);
-        _86 = call const fn baml.Map.keys<copy _88, copy _89>(copy _87) -> [bb54];
+        _90 = is_type(copy _63, baml.iter.Done);
+        branch copy _90 -> [bb58, bb54];
     }
 
     bb54: {
-        _91 = is_type(copy _86, baml.iter.Flatten<_, string, void, void>);
-        branch copy _91 -> [bb78, bb55];
+        _91 = copy _63;
+        fresh_cell(_92);
+        _92 = copy _91;
+        _94 = copy _1.1;
+        _95 = copy _92;
+        _93 = copy _94[_95];
+        _98 = copy _92;
+        _97 = copy _98 + const "/";
+        _96 = call const fn baml.String.starts_with(copy _2, copy _97) -> [bb55];
     }
 
     bb55: {
-        _93 = is_type(copy _86, baml.iter.ArrayIterator<string>);
-        branch copy _93 -> [bb77, bb56];
+        branch copy _96 -> [bb56, bb32];
     }
 
     bb56: {
-        _95 = is_type(copy _86, baml.iter.StepBy<string, void>);
-        branch copy _95 -> [bb76, bb57];
+        _0 = call const fn testing.TestRegistry.expand_set(copy _93, copy _2) -> [bb57];
     }
 
     bb57: {
-        _98 = is_type(copy _86, baml.iter.Chain<string, void, void>);
-        branch copy _98 -> [bb75, bb58];
-    }
-
-    bb58: {
-        _102 = is_type(copy _86, baml.iter.Repeat<string>);
-        branch copy _102 -> [bb74, bb59];
-    }
-
-    bb59: {
-        _104 = is_type(copy _86, baml.iter.Map<_, string, void, void>);
-        branch copy _104 -> [bb73, bb60];
-    }
-
-    bb60: {
-        _106 = is_type(copy _86, baml.iter.Filter<string, void, void>);
-        branch copy _106 -> [bb72, bb61];
-    }
-
-    bb61: {
-        _110 = is_type(copy _86, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _110 -> [bb71, bb62];
-    }
-
-    bb62: {
-        _112 = is_type(copy _86, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _112 -> [bb70, bb63];
-    }
-
-    bb63: {
-        _114 = is_type(copy _86, baml.iter.Peekable<string, void>);
-        branch copy _114 -> [bb69, bb64];
-    }
-
-    bb64: {
-        _117 = is_type(copy _86, unknown[]);
-        branch copy _117 -> [bb68, bb65];
-    }
-
-    bb65: {
-        _119 = is_type(copy _86, string[]);
-        branch copy _119 -> [bb67, bb66];
-    }
-
-    bb66: {
-        unreachable;
-    }
-
-    bb67: {
-        _120 = load_type(string);
-        _90 = call const fn baml.iter.Iterable$for$T[].iter<copy _120>(copy _86) -> [bb79];
-    }
-
-    bb68: {
-        _118 = load_type(string);
-        _90 = call const fn baml.iter.Iterable$for$T[].iter<copy _118>(copy _86) -> [bb79];
-    }
-
-    bb69: {
-        _115 = load_type(string);
-        _116 = load_type(void);
-        _90 = call const fn baml.iter.Peekable.Iterable.iter<copy _115, copy _116>(copy _86) -> [bb79];
-    }
-
-    bb70: {
-        _113 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _86);
-        _90 = call copy _113() -> [bb79];
-    }
-
-    bb71: {
-        _111 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _86);
-        _90 = call copy _111() -> [bb79];
-    }
-
-    bb72: {
-        _107 = load_type(string);
-        _108 = load_type(void);
-        _109 = load_type(void);
-        _90 = call const fn baml.iter.Filter.Iterable.iter<copy _107, copy _108, copy _109>(copy _86) -> [bb79];
-    }
-
-    bb73: {
-        _105 = make_bound_method baml.iter.Map.Iterable.iter(copy _86);
-        _90 = call copy _105() -> [bb79];
-    }
-
-    bb74: {
-        _103 = load_type(string);
-        _90 = call const fn baml.iter.Repeat.Iterable.iter<copy _103>(copy _86) -> [bb79];
-    }
-
-    bb75: {
-        _99 = load_type(string);
-        _100 = load_type(void);
-        _101 = load_type(void);
-        _90 = call const fn baml.iter.Chain.Iterable.iter<copy _99, copy _100, copy _101>(copy _86) -> [bb79];
-    }
-
-    bb76: {
-        _96 = load_type(string);
-        _97 = load_type(void);
-        _90 = call const fn baml.iter.StepBy.Iterable.iter<copy _96, copy _97>(copy _86) -> [bb79];
-    }
-
-    bb77: {
-        _94 = load_type(string);
-        _90 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _94>(copy _86) -> [bb79];
-    }
-
-    bb78: {
-        _92 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _86);
-        _90 = call copy _92() -> [bb79];
-    }
-
-    bb79: {
-        _122 = is_type(copy _90, baml.iter.Flatten<_, string, void, void>);
-        branch copy _122 -> [bb99, bb80];
-    }
-
-    bb80: {
-        _124 = is_type(copy _90, baml.iter.ArrayIterator<string>);
-        branch copy _124 -> [bb98, bb81];
-    }
-
-    bb81: {
-        _126 = is_type(copy _90, baml.iter.StepBy<string, void>);
-        branch copy _126 -> [bb97, bb82];
-    }
-
-    bb82: {
-        _129 = is_type(copy _90, baml.iter.Chain<string, void, void>);
-        branch copy _129 -> [bb96, bb83];
-    }
-
-    bb83: {
-        _133 = is_type(copy _90, baml.iter.Repeat<string>);
-        branch copy _133 -> [bb95, bb84];
-    }
-
-    bb84: {
-        _135 = is_type(copy _90, baml.iter.Map<_, string, void, void>);
-        branch copy _135 -> [bb94, bb85];
-    }
-
-    bb85: {
-        _137 = is_type(copy _90, baml.iter.Filter<string, void, void>);
-        branch copy _137 -> [bb93, bb86];
-    }
-
-    bb86: {
-        _141 = is_type(copy _90, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _141 -> [bb92, bb87];
-    }
-
-    bb87: {
-        _143 = is_type(copy _90, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _143 -> [bb91, bb88];
-    }
-
-    bb88: {
-        _145 = is_type(copy _90, baml.iter.Peekable<string, void>);
-        branch copy _145 -> [bb90, bb89];
-    }
-
-    bb89: {
-        unreachable;
-    }
-
-    bb90: {
-        _146 = load_type(string);
-        _147 = load_type(void);
-        _121 = call const fn baml.iter.Peekable.Iterator.next<copy _146, copy _147>(copy _90) -> [bb100];
-    }
-
-    bb91: {
-        _144 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _90);
-        _121 = call copy _144() -> [bb100];
-    }
-
-    bb92: {
-        _142 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _90);
-        _121 = call copy _142() -> [bb100];
-    }
-
-    bb93: {
-        _138 = load_type(string);
-        _139 = load_type(void);
-        _140 = load_type(void);
-        _121 = call const fn baml.iter.Filter.Iterator.next<copy _138, copy _139, copy _140>(copy _90) -> [bb100];
-    }
-
-    bb94: {
-        _136 = make_bound_method baml.iter.Map.Iterator.next(copy _90);
-        _121 = call copy _136() -> [bb100];
-    }
-
-    bb95: {
-        _134 = load_type(string);
-        _121 = call const fn baml.iter.Repeat.Iterator.next<copy _134>(copy _90) -> [bb100];
-    }
-
-    bb96: {
-        _130 = load_type(string);
-        _131 = load_type(void);
-        _132 = load_type(void);
-        _121 = call const fn baml.iter.Chain.Iterator.next<copy _130, copy _131, copy _132>(copy _90) -> [bb100];
-    }
-
-    bb97: {
-        _127 = load_type(string);
-        _128 = load_type(void);
-        _121 = call const fn baml.iter.StepBy.Iterator.next<copy _127, copy _128>(copy _90) -> [bb100];
-    }
-
-    bb98: {
-        _125 = load_type(string);
-        _121 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _125>(copy _90) -> [bb100];
-    }
-
-    bb99: {
-        _123 = make_bound_method baml.iter.Flatten.Iterator.next(copy _90);
-        _121 = call copy _123() -> [bb100];
-    }
-
-    bb100: {
-        _148 = is_type(copy _121, baml.iter.Done);
-        branch copy _148 -> [bb105, bb101];
-    }
-
-    bb101: {
-        _149 = copy _121;
-        fresh_cell(_150);
-        _150 = copy _149;
-        _152 = copy _1.1;
-        _153 = copy _150;
-        _151 = copy _152[_153];
-        _156 = copy _150;
-        _155 = copy _156 + const "/";
-        _154 = call const fn baml.String.starts_with(copy _2, copy _155) -> [bb102];
-    }
-
-    bb102: {
-        branch copy _154 -> [bb103, bb79];
-    }
-
-    bb103: {
-        _0 = call const fn testing.TestRegistry.expand_set(copy _151, copy _2) -> [bb104];
-    }
-
-    bb104: {
         return;
     }
 
-    bb105: {
-        _157 = const "TestSet not found for expansion: " + copy _2;
-        throw copy _157;
+    bb58: {
+        _99 = const "TestSet not found for expansion: " + copy _2;
+        throw copy _99;
     }
 }
 
@@ -759,129 +455,99 @@ fn testing.TestCollector.find_testset(self: testing.TestCollector, name: string)
     let _2: string // name // param
     let _3: testing.TestSetRegistration[]
     let _4: baml.iter.Iterator<Item = testing.TestSetRegistration, Error = void>
-    let _5: bool
+    let _5: type
     let _6: unknown
     let _7: bool
-    let _8: type
+    let _8: unknown
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
+    let _34: testing.TestSetRegistration
+    let _35: testing.TestSetRegistration // ts
     let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: type
-    let _40: bool
-    let _41: type
-    let _42: type
-    let _43: bool
-    let _44: type
-    let _45: type
-    let _46: type
-    let _47: bool
-    let _48: type
-    let _49: bool
-    let _50: unknown
-    let _51: bool
-    let _52: type
-    let _53: type
-    let _54: type
-    let _55: bool
-    let _56: unknown
-    let _57: bool
-    let _58: unknown
-    let _59: bool
-    let _60: type
-    let _61: type
-    let _62: bool
-    let _63: testing.TestSetRegistration
-    let _64: testing.TestSetRegistration // ts
-    let _65: bool
-    let _66: string
-    let _67: string
+    let _37: string
+    let _38: string
 
     bb0: {
         _3 = copy _1.2;
-        _5 = is_type(copy _3, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
-        branch copy _5 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _7 = is_type(copy _3, baml.iter.ArrayIterator<testing.TestSetRegistration>);
-        branch copy _7 -> [bb23, bb2];
+        _5 = load_type(testing.TestSetRegistration);
+        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _5>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _9 = is_type(copy _3, baml.iter.StepBy<testing.TestSetRegistration, void>);
-        branch copy _9 -> [bb22, bb3];
+        _7 = is_type(copy _4, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
+        branch copy _7 -> [bb22, bb3];
     }
 
     bb3: {
-        _12 = is_type(copy _3, baml.iter.Chain<testing.TestSetRegistration, void, void>);
-        branch copy _12 -> [bb21, bb4];
+        _9 = is_type(copy _4, baml.iter.ArrayIterator<testing.TestSetRegistration>);
+        branch copy _9 -> [bb21, bb4];
     }
 
     bb4: {
-        _16 = is_type(copy _3, baml.iter.Repeat<testing.TestSetRegistration>);
-        branch copy _16 -> [bb20, bb5];
+        _11 = is_type(copy _4, baml.iter.StepBy<testing.TestSetRegistration, void>);
+        branch copy _11 -> [bb20, bb5];
     }
 
     bb5: {
-        _18 = is_type(copy _3, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
-        branch copy _18 -> [bb19, bb6];
+        _14 = is_type(copy _4, baml.iter.Chain<testing.TestSetRegistration, void, void>);
+        branch copy _14 -> [bb19, bb6];
     }
 
     bb6: {
-        _20 = is_type(copy _3, baml.iter.Filter<testing.TestSetRegistration, void, void>);
-        branch copy _20 -> [bb18, bb7];
+        _18 = is_type(copy _4, baml.iter.Repeat<testing.TestSetRegistration>);
+        branch copy _18 -> [bb18, bb7];
     }
 
     bb7: {
-        _24 = is_type(copy _3, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
-        branch copy _24 -> [bb17, bb8];
+        _20 = is_type(copy _4, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
+        branch copy _20 -> [bb17, bb8];
     }
 
     bb8: {
-        _26 = is_type(copy _3, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
-        branch copy _26 -> [bb16, bb9];
+        _22 = is_type(copy _4, baml.iter.Filter<testing.TestSetRegistration, void, void>);
+        branch copy _22 -> [bb16, bb9];
     }
 
     bb9: {
-        _28 = is_type(copy _3, baml.iter.Peekable<testing.TestSetRegistration, void>);
-        branch copy _28 -> [bb15, bb10];
+        _26 = is_type(copy _4, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
+        branch copy _26 -> [bb15, bb10];
     }
 
     bb10: {
-        _31 = is_type(copy _3, unknown[]);
-        branch copy _31 -> [bb14, bb11];
+        _28 = is_type(copy _4, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
+        branch copy _28 -> [bb14, bb11];
     }
 
     bb11: {
-        _33 = is_type(copy _3, testing.TestSetRegistration[]);
-        branch copy _33 -> [bb13, bb12];
+        _30 = is_type(copy _4, baml.iter.Peekable<testing.TestSetRegistration, void>);
+        branch copy _30 -> [bb13, bb12];
     }
 
     bb12: {
@@ -889,207 +555,87 @@ fn testing.TestCollector.find_testset(self: testing.TestCollector, name: string)
     }
 
     bb13: {
-        _34 = load_type(testing.TestSetRegistration);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _3) -> [bb25];
+        _31 = load_type(testing.TestSetRegistration);
+        _32 = load_type(void);
+        _6 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _4) -> [bb23];
     }
 
     bb14: {
-        _32 = load_type(testing.TestSetRegistration);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _3) -> [bb25];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
+        _6 = call copy _29() -> [bb23];
     }
 
     bb15: {
-        _29 = load_type(testing.TestSetRegistration);
-        _30 = load_type(void);
-        _4 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _3) -> [bb25];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
+        _6 = call copy _27() -> [bb23];
     }
 
     bb16: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _3);
-        _4 = call copy _27() -> [bb25];
+        _23 = load_type(testing.TestSetRegistration);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _6 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _4) -> [bb23];
     }
 
     bb17: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _3);
-        _4 = call copy _25() -> [bb25];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
+        _6 = call copy _21() -> [bb23];
     }
 
     bb18: {
-        _21 = load_type(testing.TestSetRegistration);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _4 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _3) -> [bb25];
+        _19 = load_type(testing.TestSetRegistration);
+        _6 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _4) -> [bb23];
     }
 
     bb19: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _3);
-        _4 = call copy _19() -> [bb25];
+        _15 = load_type(testing.TestSetRegistration);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _6 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _4) -> [bb23];
     }
 
     bb20: {
-        _17 = load_type(testing.TestSetRegistration);
-        _4 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _3) -> [bb25];
+        _12 = load_type(testing.TestSetRegistration);
+        _13 = load_type(void);
+        _6 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _4) -> [bb23];
     }
 
     bb21: {
-        _13 = load_type(testing.TestSetRegistration);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _4 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _3) -> [bb25];
+        _10 = load_type(testing.TestSetRegistration);
+        _6 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _4) -> [bb23];
     }
 
     bb22: {
-        _10 = load_type(testing.TestSetRegistration);
-        _11 = load_type(void);
-        _4 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _3) -> [bb25];
+        _8 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
+        _6 = call copy _8() -> [bb23];
     }
 
     bb23: {
-        _8 = load_type(testing.TestSetRegistration);
-        _4 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _3) -> [bb25];
+        _33 = is_type(copy _6, baml.iter.Done);
+        branch copy _33 -> [bb27, bb24];
     }
 
     bb24: {
-        _6 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _3);
-        _4 = call copy _6() -> [bb25];
+        _34 = copy _6;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _37 = copy _35.0;
+        _36 = copy _37 == copy _2;
+        branch copy _36 -> [bb25, bb2];
     }
 
     bb25: {
-        _36 = is_type(copy _4, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
-        branch copy _36 -> [bb45, bb26];
+        _0 = copy _35;
+        goto -> bb26;
     }
 
     bb26: {
-        _38 = is_type(copy _4, baml.iter.ArrayIterator<testing.TestSetRegistration>);
-        branch copy _38 -> [bb44, bb27];
-    }
-
-    bb27: {
-        _40 = is_type(copy _4, baml.iter.StepBy<testing.TestSetRegistration, void>);
-        branch copy _40 -> [bb43, bb28];
-    }
-
-    bb28: {
-        _43 = is_type(copy _4, baml.iter.Chain<testing.TestSetRegistration, void, void>);
-        branch copy _43 -> [bb42, bb29];
-    }
-
-    bb29: {
-        _47 = is_type(copy _4, baml.iter.Repeat<testing.TestSetRegistration>);
-        branch copy _47 -> [bb41, bb30];
-    }
-
-    bb30: {
-        _49 = is_type(copy _4, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
-        branch copy _49 -> [bb40, bb31];
-    }
-
-    bb31: {
-        _51 = is_type(copy _4, baml.iter.Filter<testing.TestSetRegistration, void, void>);
-        branch copy _51 -> [bb39, bb32];
-    }
-
-    bb32: {
-        _55 = is_type(copy _4, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
-        branch copy _55 -> [bb38, bb33];
-    }
-
-    bb33: {
-        _57 = is_type(copy _4, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
-        branch copy _57 -> [bb37, bb34];
-    }
-
-    bb34: {
-        _59 = is_type(copy _4, baml.iter.Peekable<testing.TestSetRegistration, void>);
-        branch copy _59 -> [bb36, bb35];
-    }
-
-    bb35: {
-        unreachable;
-    }
-
-    bb36: {
-        _60 = load_type(testing.TestSetRegistration);
-        _61 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _60, copy _61>(copy _4) -> [bb46];
-    }
-
-    bb37: {
-        _58 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
-        _35 = call copy _58() -> [bb46];
-    }
-
-    bb38: {
-        _56 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
-        _35 = call copy _56() -> [bb46];
-    }
-
-    bb39: {
-        _52 = load_type(testing.TestSetRegistration);
-        _53 = load_type(void);
-        _54 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _52, copy _53, copy _54>(copy _4) -> [bb46];
-    }
-
-    bb40: {
-        _50 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
-        _35 = call copy _50() -> [bb46];
-    }
-
-    bb41: {
-        _48 = load_type(testing.TestSetRegistration);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _48>(copy _4) -> [bb46];
-    }
-
-    bb42: {
-        _44 = load_type(testing.TestSetRegistration);
-        _45 = load_type(void);
-        _46 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _44, copy _45, copy _46>(copy _4) -> [bb46];
-    }
-
-    bb43: {
-        _41 = load_type(testing.TestSetRegistration);
-        _42 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _41, copy _42>(copy _4) -> [bb46];
-    }
-
-    bb44: {
-        _39 = load_type(testing.TestSetRegistration);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _39>(copy _4) -> [bb46];
-    }
-
-    bb45: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
-        _35 = call copy _37() -> [bb46];
-    }
-
-    bb46: {
-        _62 = is_type(copy _35, baml.iter.Done);
-        branch copy _62 -> [bb50, bb47];
-    }
-
-    bb47: {
-        _63 = copy _35;
-        fresh_cell(_64);
-        _64 = copy _63;
-        _66 = copy _64.0;
-        _65 = copy _66 == copy _2;
-        branch copy _65 -> [bb48, bb25];
-    }
-
-    bb48: {
-        _0 = copy _64;
-        goto -> bb49;
-    }
-
-    bb49: {
         return;
     }
 
-    bb50: {
-        _67 = const "TestSet not found: " + copy _2;
-        throw copy _67;
+    bb27: {
+        _38 = const "TestSet not found: " + copy _2;
+        throw copy _38;
     }
 }
 
@@ -1440,86 +986,57 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
     let _12: string
     let _13: testing.TestRegistration[]
     let _14: baml.iter.Iterator<Item = testing.TestRegistration, Error = void>
-    let _15: bool
+    let _15: type
     let _16: unknown
     let _17: bool
-    let _18: type
+    let _18: unknown
     let _19: bool
     let _20: type
-    let _21: type
-    let _22: bool
+    let _21: bool
+    let _22: type
     let _23: type
-    let _24: type
+    let _24: bool
     let _25: type
-    let _26: bool
+    let _26: type
     let _27: type
     let _28: bool
-    let _29: unknown
+    let _29: type
     let _30: bool
-    let _31: type
-    let _32: type
+    let _31: unknown
+    let _32: bool
     let _33: type
-    let _34: bool
-    let _35: unknown
+    let _34: type
+    let _35: type
     let _36: bool
     let _37: unknown
     let _38: bool
-    let _39: type
-    let _40: type
-    let _41: bool
+    let _39: unknown
+    let _40: bool
+    let _41: type
     let _42: type
     let _43: bool
-    let _44: type
-    let _45: unknown
+    let _44: testing.TestRegistration
+    let _45: testing.TestRegistration // t
     let _46: bool
-    let _47: unknown
-    let _48: bool
-    let _49: type
-    let _50: bool
-    let _51: type
-    let _52: type
+    let _47: bool
+    let _48: string
+    let _49: string
+    let _50: (baml.String, string) -> bool throws never
+    let _51: string
+    let _52: string // final_name
     let _53: bool
-    let _54: type
-    let _55: type
-    let _56: type
-    let _57: bool
-    let _58: type
-    let _59: bool
-    let _60: unknown
-    let _61: bool
-    let _62: type
-    let _63: type
-    let _64: type
-    let _65: bool
-    let _66: unknown
-    let _67: bool
-    let _68: unknown
-    let _69: bool
-    let _70: type
-    let _71: type
-    let _72: bool
-    let _73: testing.TestRegistration
-    let _74: testing.TestRegistration // t
-    let _75: bool
-    let _76: bool
-    let _77: string
-    let _78: string
-    let _79: (baml.String, string) -> bool throws never
-    let _80: string
-    let _81: string // final_name
-    let _82: bool
-    let _83: int
-    let _84: string
-    let _85: string
-    let _86: string
-    let _87: int
-    let _88: int
-    let _89: type
-    let _90: int
-    let _91: (testing.TestRegistration[], testing.TestRegistration) -> int throws never
-    let _92: testing.TestRegistration
-    let _93: string
-    let _94: type
+    let _54: int
+    let _55: string
+    let _56: string
+    let _57: string
+    let _58: int
+    let _59: int
+    let _60: type
+    let _61: int
+    let _62: (testing.TestRegistration[], testing.TestRegistration) -> int throws never
+    let _63: testing.TestRegistration
+    let _64: string
+    let _65: type
 
     bb0: {
         _7 = copy _1.0;
@@ -1544,63 +1061,62 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
         _12 = copy _5;
         _11 = copy _12 + const "#";
         _13 = copy _1.1;
-        _15 = is_type(copy _13, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
-        branch copy _15 -> [bb27, bb4];
+        goto -> bb4;
     }
 
     bb4: {
-        _17 = is_type(copy _13, baml.iter.ArrayIterator<testing.TestRegistration>);
-        branch copy _17 -> [bb26, bb5];
+        _15 = load_type(testing.TestRegistration);
+        _14 = call const fn baml.iter.Iterable$for$T[].iter<copy _15>(copy _13) -> [bb5];
     }
 
     bb5: {
-        _19 = is_type(copy _13, baml.iter.StepBy<testing.TestRegistration, void>);
-        branch copy _19 -> [bb25, bb6];
+        _17 = is_type(copy _14, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
+        branch copy _17 -> [bb25, bb6];
     }
 
     bb6: {
-        _22 = is_type(copy _13, baml.iter.Chain<testing.TestRegistration, void, void>);
-        branch copy _22 -> [bb24, bb7];
+        _19 = is_type(copy _14, baml.iter.ArrayIterator<testing.TestRegistration>);
+        branch copy _19 -> [bb24, bb7];
     }
 
     bb7: {
-        _26 = is_type(copy _13, baml.iter.Repeat<testing.TestRegistration>);
-        branch copy _26 -> [bb23, bb8];
+        _21 = is_type(copy _14, baml.iter.StepBy<testing.TestRegistration, void>);
+        branch copy _21 -> [bb23, bb8];
     }
 
     bb8: {
-        _28 = is_type(copy _13, baml.iter.Map<_, testing.TestRegistration, void, void>);
-        branch copy _28 -> [bb22, bb9];
+        _24 = is_type(copy _14, baml.iter.Chain<testing.TestRegistration, void, void>);
+        branch copy _24 -> [bb22, bb9];
     }
 
     bb9: {
-        _30 = is_type(copy _13, baml.iter.Filter<testing.TestRegistration, void, void>);
-        branch copy _30 -> [bb21, bb10];
+        _28 = is_type(copy _14, baml.iter.Repeat<testing.TestRegistration>);
+        branch copy _28 -> [bb21, bb10];
     }
 
     bb10: {
-        _34 = is_type(copy _13, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
-        branch copy _34 -> [bb20, bb11];
+        _30 = is_type(copy _14, baml.iter.Map<_, testing.TestRegistration, void, void>);
+        branch copy _30 -> [bb20, bb11];
     }
 
     bb11: {
-        _36 = is_type(copy _13, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
-        branch copy _36 -> [bb19, bb12];
+        _32 = is_type(copy _14, baml.iter.Filter<testing.TestRegistration, void, void>);
+        branch copy _32 -> [bb19, bb12];
     }
 
     bb12: {
-        _38 = is_type(copy _13, baml.iter.Peekable<testing.TestRegistration, void>);
-        branch copy _38 -> [bb18, bb13];
+        _36 = is_type(copy _14, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
+        branch copy _36 -> [bb18, bb13];
     }
 
     bb13: {
-        _41 = is_type(copy _13, unknown[]);
-        branch copy _41 -> [bb17, bb14];
+        _38 = is_type(copy _14, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
+        branch copy _38 -> [bb17, bb14];
     }
 
     bb14: {
-        _43 = is_type(copy _13, testing.TestRegistration[]);
-        branch copy _43 -> [bb16, bb15];
+        _40 = is_type(copy _14, baml.iter.Peekable<testing.TestRegistration, void>);
+        branch copy _40 -> [bb16, bb15];
     }
 
     bb15: {
@@ -1608,250 +1124,130 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
     }
 
     bb16: {
-        _44 = load_type(testing.TestRegistration);
-        _14 = call const fn baml.iter.Iterable$for$T[].iter<copy _44>(copy _13) -> [bb28];
+        _41 = load_type(testing.TestRegistration);
+        _42 = load_type(void);
+        _16 = call const fn baml.iter.Peekable.Iterator.next<copy _41, copy _42>(copy _14) -> [bb26];
     }
 
     bb17: {
-        _42 = load_type(testing.TestRegistration);
-        _14 = call const fn baml.iter.Iterable$for$T[].iter<copy _42>(copy _13) -> [bb28];
+        _39 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _14);
+        _16 = call copy _39() -> [bb26];
     }
 
     bb18: {
-        _39 = load_type(testing.TestRegistration);
-        _40 = load_type(void);
-        _14 = call const fn baml.iter.Peekable.Iterable.iter<copy _39, copy _40>(copy _13) -> [bb28];
+        _37 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _14);
+        _16 = call copy _37() -> [bb26];
     }
 
     bb19: {
-        _37 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _13);
-        _14 = call copy _37() -> [bb28];
+        _33 = load_type(testing.TestRegistration);
+        _34 = load_type(void);
+        _35 = load_type(void);
+        _16 = call const fn baml.iter.Filter.Iterator.next<copy _33, copy _34, copy _35>(copy _14) -> [bb26];
     }
 
     bb20: {
-        _35 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _13);
-        _14 = call copy _35() -> [bb28];
+        _31 = make_bound_method baml.iter.Map.Iterator.next(copy _14);
+        _16 = call copy _31() -> [bb26];
     }
 
     bb21: {
-        _31 = load_type(testing.TestRegistration);
-        _32 = load_type(void);
-        _33 = load_type(void);
-        _14 = call const fn baml.iter.Filter.Iterable.iter<copy _31, copy _32, copy _33>(copy _13) -> [bb28];
+        _29 = load_type(testing.TestRegistration);
+        _16 = call const fn baml.iter.Repeat.Iterator.next<copy _29>(copy _14) -> [bb26];
     }
 
     bb22: {
-        _29 = make_bound_method baml.iter.Map.Iterable.iter(copy _13);
-        _14 = call copy _29() -> [bb28];
+        _25 = load_type(testing.TestRegistration);
+        _26 = load_type(void);
+        _27 = load_type(void);
+        _16 = call const fn baml.iter.Chain.Iterator.next<copy _25, copy _26, copy _27>(copy _14) -> [bb26];
     }
 
     bb23: {
-        _27 = load_type(testing.TestRegistration);
-        _14 = call const fn baml.iter.Repeat.Iterable.iter<copy _27>(copy _13) -> [bb28];
+        _22 = load_type(testing.TestRegistration);
+        _23 = load_type(void);
+        _16 = call const fn baml.iter.StepBy.Iterator.next<copy _22, copy _23>(copy _14) -> [bb26];
     }
 
     bb24: {
-        _23 = load_type(testing.TestRegistration);
-        _24 = load_type(void);
-        _25 = load_type(void);
-        _14 = call const fn baml.iter.Chain.Iterable.iter<copy _23, copy _24, copy _25>(copy _13) -> [bb28];
+        _20 = load_type(testing.TestRegistration);
+        _16 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _20>(copy _14) -> [bb26];
     }
 
     bb25: {
-        _20 = load_type(testing.TestRegistration);
-        _21 = load_type(void);
-        _14 = call const fn baml.iter.StepBy.Iterable.iter<copy _20, copy _21>(copy _13) -> [bb28];
+        _18 = make_bound_method baml.iter.Flatten.Iterator.next(copy _14);
+        _16 = call copy _18() -> [bb26];
     }
 
     bb26: {
-        _18 = load_type(testing.TestRegistration);
-        _14 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _18>(copy _13) -> [bb28];
+        _43 = is_type(copy _16, baml.iter.Done);
+        branch copy _43 -> [bb31, bb27];
     }
 
     bb27: {
-        _16 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _13);
-        _14 = call copy _16() -> [bb28];
+        _44 = copy _16;
+        fresh_cell(_45);
+        _45 = copy _44;
+        _48 = copy _45.0;
+        _49 = copy _5;
+        _47 = copy _48 == copy _49;
+        _46 = short_circuit(||) copy _47 -> [eval: bb28, join: bb29];
     }
 
     bb28: {
-        _46 = is_type(copy _14, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
-        branch copy _46 -> [bb48, bb29];
+        _50 = copy _45.0;
+        _51 = copy _11;
+        _46 = call const fn baml.String.starts_with(copy _50, copy _51) -> [bb29];
     }
 
     bb29: {
-        _48 = is_type(copy _14, baml.iter.ArrayIterator<testing.TestRegistration>);
-        branch copy _48 -> [bb47, bb30];
+        branch copy _46 -> [bb30, bb5];
     }
 
     bb30: {
-        _50 = is_type(copy _14, baml.iter.StepBy<testing.TestRegistration, void>);
-        branch copy _50 -> [bb46, bb31];
+        _10 = copy _10 + const 1_i64;
+        goto -> bb5;
     }
 
     bb31: {
-        _53 = is_type(copy _14, baml.iter.Chain<testing.TestRegistration, void, void>);
-        branch copy _53 -> [bb45, bb32];
+        _54 = copy _10;
+        _53 = copy _54 > const 0_i64;
+        branch copy _53 -> [bb33, bb32];
     }
 
     bb32: {
-        _57 = is_type(copy _14, baml.iter.Repeat<testing.TestRegistration>);
-        branch copy _57 -> [bb44, bb33];
+        _52 = copy _5;
+        goto -> bb35;
     }
 
     bb33: {
-        _59 = is_type(copy _14, baml.iter.Map<_, testing.TestRegistration, void, void>);
-        branch copy _59 -> [bb43, bb34];
+        _56 = copy _5;
+        _55 = copy _56 + const "#";
+        _59 = copy _10;
+        _58 = copy _59 + const 1_i64;
+        _60 = load_type(int);
+        _57 = call const fn baml.unstable.string<copy _60>(copy _58) -> [bb34];
     }
 
     bb34: {
-        _61 = is_type(copy _14, baml.iter.Filter<testing.TestRegistration, void, void>);
-        branch copy _61 -> [bb42, bb35];
+        _52 = copy _55 + copy _57;
+        goto -> bb35;
     }
 
     bb35: {
-        _65 = is_type(copy _14, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
-        branch copy _65 -> [bb41, bb36];
+        _62 = copy _1.1;
+        _64 = copy _52;
+        _63 = testing.TestRegistration { copy _64, copy _3, copy _4 };
+        _65 = load_type(testing.TestRegistration);
+        _61 = call const fn baml.Array.push<copy _65>(copy _62, copy _63) -> [bb36];
     }
 
     bb36: {
-        _67 = is_type(copy _14, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
-        branch copy _67 -> [bb40, bb37];
+        _0 = const null;
+        goto -> bb37;
     }
 
     bb37: {
-        _69 = is_type(copy _14, baml.iter.Peekable<testing.TestRegistration, void>);
-        branch copy _69 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _70 = load_type(testing.TestRegistration);
-        _71 = load_type(void);
-        _45 = call const fn baml.iter.Peekable.Iterator.next<copy _70, copy _71>(copy _14) -> [bb49];
-    }
-
-    bb40: {
-        _68 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _14);
-        _45 = call copy _68() -> [bb49];
-    }
-
-    bb41: {
-        _66 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _14);
-        _45 = call copy _66() -> [bb49];
-    }
-
-    bb42: {
-        _62 = load_type(testing.TestRegistration);
-        _63 = load_type(void);
-        _64 = load_type(void);
-        _45 = call const fn baml.iter.Filter.Iterator.next<copy _62, copy _63, copy _64>(copy _14) -> [bb49];
-    }
-
-    bb43: {
-        _60 = make_bound_method baml.iter.Map.Iterator.next(copy _14);
-        _45 = call copy _60() -> [bb49];
-    }
-
-    bb44: {
-        _58 = load_type(testing.TestRegistration);
-        _45 = call const fn baml.iter.Repeat.Iterator.next<copy _58>(copy _14) -> [bb49];
-    }
-
-    bb45: {
-        _54 = load_type(testing.TestRegistration);
-        _55 = load_type(void);
-        _56 = load_type(void);
-        _45 = call const fn baml.iter.Chain.Iterator.next<copy _54, copy _55, copy _56>(copy _14) -> [bb49];
-    }
-
-    bb46: {
-        _51 = load_type(testing.TestRegistration);
-        _52 = load_type(void);
-        _45 = call const fn baml.iter.StepBy.Iterator.next<copy _51, copy _52>(copy _14) -> [bb49];
-    }
-
-    bb47: {
-        _49 = load_type(testing.TestRegistration);
-        _45 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _49>(copy _14) -> [bb49];
-    }
-
-    bb48: {
-        _47 = make_bound_method baml.iter.Flatten.Iterator.next(copy _14);
-        _45 = call copy _47() -> [bb49];
-    }
-
-    bb49: {
-        _72 = is_type(copy _45, baml.iter.Done);
-        branch copy _72 -> [bb54, bb50];
-    }
-
-    bb50: {
-        _73 = copy _45;
-        fresh_cell(_74);
-        _74 = copy _73;
-        _77 = copy _74.0;
-        _78 = copy _5;
-        _76 = copy _77 == copy _78;
-        _75 = short_circuit(||) copy _76 -> [eval: bb51, join: bb52];
-    }
-
-    bb51: {
-        _79 = copy _74.0;
-        _80 = copy _11;
-        _75 = call const fn baml.String.starts_with(copy _79, copy _80) -> [bb52];
-    }
-
-    bb52: {
-        branch copy _75 -> [bb53, bb28];
-    }
-
-    bb53: {
-        _10 = copy _10 + const 1_i64;
-        goto -> bb28;
-    }
-
-    bb54: {
-        _83 = copy _10;
-        _82 = copy _83 > const 0_i64;
-        branch copy _82 -> [bb56, bb55];
-    }
-
-    bb55: {
-        _81 = copy _5;
-        goto -> bb58;
-    }
-
-    bb56: {
-        _85 = copy _5;
-        _84 = copy _85 + const "#";
-        _88 = copy _10;
-        _87 = copy _88 + const 1_i64;
-        _89 = load_type(int);
-        _86 = call const fn baml.unstable.string<copy _89>(copy _87) -> [bb57];
-    }
-
-    bb57: {
-        _81 = copy _84 + copy _86;
-        goto -> bb58;
-    }
-
-    bb58: {
-        _91 = copy _1.1;
-        _93 = copy _81;
-        _92 = testing.TestRegistration { copy _93, copy _3, copy _4 };
-        _94 = load_type(testing.TestRegistration);
-        _90 = call const fn baml.Array.push<copy _94>(copy _91, copy _92) -> [bb59];
-    }
-
-    bb59: {
-        _0 = const null;
-        goto -> bb60;
-    }
-
-    bb60: {
         return;
     }
 }
@@ -1873,86 +1269,57 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
     let _12: string
     let _13: testing.TestSetRegistration[]
     let _14: baml.iter.Iterator<Item = testing.TestSetRegistration, Error = void>
-    let _15: bool
+    let _15: type
     let _16: unknown
     let _17: bool
-    let _18: type
+    let _18: unknown
     let _19: bool
     let _20: type
-    let _21: type
-    let _22: bool
+    let _21: bool
+    let _22: type
     let _23: type
-    let _24: type
+    let _24: bool
     let _25: type
-    let _26: bool
+    let _26: type
     let _27: type
     let _28: bool
-    let _29: unknown
+    let _29: type
     let _30: bool
-    let _31: type
-    let _32: type
+    let _31: unknown
+    let _32: bool
     let _33: type
-    let _34: bool
-    let _35: unknown
+    let _34: type
+    let _35: type
     let _36: bool
     let _37: unknown
     let _38: bool
-    let _39: type
-    let _40: type
-    let _41: bool
+    let _39: unknown
+    let _40: bool
+    let _41: type
     let _42: type
     let _43: bool
-    let _44: type
-    let _45: unknown
+    let _44: testing.TestSetRegistration
+    let _45: testing.TestSetRegistration // ts
     let _46: bool
-    let _47: unknown
-    let _48: bool
-    let _49: type
-    let _50: bool
-    let _51: type
-    let _52: type
+    let _47: bool
+    let _48: string
+    let _49: string
+    let _50: (baml.String, string) -> bool throws never
+    let _51: string
+    let _52: string // final_name
     let _53: bool
-    let _54: type
-    let _55: type
-    let _56: type
-    let _57: bool
-    let _58: type
-    let _59: bool
-    let _60: unknown
-    let _61: bool
-    let _62: type
-    let _63: type
-    let _64: type
-    let _65: bool
-    let _66: unknown
-    let _67: bool
-    let _68: unknown
-    let _69: bool
-    let _70: type
-    let _71: type
-    let _72: bool
-    let _73: testing.TestSetRegistration
-    let _74: testing.TestSetRegistration // ts
-    let _75: bool
-    let _76: bool
-    let _77: string
-    let _78: string
-    let _79: (baml.String, string) -> bool throws never
-    let _80: string
-    let _81: string // final_name
-    let _82: bool
-    let _83: int
-    let _84: string
-    let _85: string
-    let _86: string
-    let _87: int
-    let _88: int
-    let _89: type
-    let _90: int
-    let _91: (testing.TestSetRegistration[], testing.TestSetRegistration) -> int throws never
-    let _92: testing.TestSetRegistration
-    let _93: string
-    let _94: type
+    let _54: int
+    let _55: string
+    let _56: string
+    let _57: string
+    let _58: int
+    let _59: int
+    let _60: type
+    let _61: int
+    let _62: (testing.TestSetRegistration[], testing.TestSetRegistration) -> int throws never
+    let _63: testing.TestSetRegistration
+    let _64: string
+    let _65: type
 
     bb0: {
         _7 = copy _1.0;
@@ -1977,63 +1344,62 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
         _12 = copy _5;
         _11 = copy _12 + const "#";
         _13 = copy _1.2;
-        _15 = is_type(copy _13, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
-        branch copy _15 -> [bb27, bb4];
+        goto -> bb4;
     }
 
     bb4: {
-        _17 = is_type(copy _13, baml.iter.ArrayIterator<testing.TestSetRegistration>);
-        branch copy _17 -> [bb26, bb5];
+        _15 = load_type(testing.TestSetRegistration);
+        _14 = call const fn baml.iter.Iterable$for$T[].iter<copy _15>(copy _13) -> [bb5];
     }
 
     bb5: {
-        _19 = is_type(copy _13, baml.iter.StepBy<testing.TestSetRegistration, void>);
-        branch copy _19 -> [bb25, bb6];
+        _17 = is_type(copy _14, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
+        branch copy _17 -> [bb25, bb6];
     }
 
     bb6: {
-        _22 = is_type(copy _13, baml.iter.Chain<testing.TestSetRegistration, void, void>);
-        branch copy _22 -> [bb24, bb7];
+        _19 = is_type(copy _14, baml.iter.ArrayIterator<testing.TestSetRegistration>);
+        branch copy _19 -> [bb24, bb7];
     }
 
     bb7: {
-        _26 = is_type(copy _13, baml.iter.Repeat<testing.TestSetRegistration>);
-        branch copy _26 -> [bb23, bb8];
+        _21 = is_type(copy _14, baml.iter.StepBy<testing.TestSetRegistration, void>);
+        branch copy _21 -> [bb23, bb8];
     }
 
     bb8: {
-        _28 = is_type(copy _13, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
-        branch copy _28 -> [bb22, bb9];
+        _24 = is_type(copy _14, baml.iter.Chain<testing.TestSetRegistration, void, void>);
+        branch copy _24 -> [bb22, bb9];
     }
 
     bb9: {
-        _30 = is_type(copy _13, baml.iter.Filter<testing.TestSetRegistration, void, void>);
-        branch copy _30 -> [bb21, bb10];
+        _28 = is_type(copy _14, baml.iter.Repeat<testing.TestSetRegistration>);
+        branch copy _28 -> [bb21, bb10];
     }
 
     bb10: {
-        _34 = is_type(copy _13, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
-        branch copy _34 -> [bb20, bb11];
+        _30 = is_type(copy _14, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
+        branch copy _30 -> [bb20, bb11];
     }
 
     bb11: {
-        _36 = is_type(copy _13, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
-        branch copy _36 -> [bb19, bb12];
+        _32 = is_type(copy _14, baml.iter.Filter<testing.TestSetRegistration, void, void>);
+        branch copy _32 -> [bb19, bb12];
     }
 
     bb12: {
-        _38 = is_type(copy _13, baml.iter.Peekable<testing.TestSetRegistration, void>);
-        branch copy _38 -> [bb18, bb13];
+        _36 = is_type(copy _14, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
+        branch copy _36 -> [bb18, bb13];
     }
 
     bb13: {
-        _41 = is_type(copy _13, unknown[]);
-        branch copy _41 -> [bb17, bb14];
+        _38 = is_type(copy _14, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
+        branch copy _38 -> [bb17, bb14];
     }
 
     bb14: {
-        _43 = is_type(copy _13, testing.TestSetRegistration[]);
-        branch copy _43 -> [bb16, bb15];
+        _40 = is_type(copy _14, baml.iter.Peekable<testing.TestSetRegistration, void>);
+        branch copy _40 -> [bb16, bb15];
     }
 
     bb15: {
@@ -2041,250 +1407,130 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
     }
 
     bb16: {
-        _44 = load_type(testing.TestSetRegistration);
-        _14 = call const fn baml.iter.Iterable$for$T[].iter<copy _44>(copy _13) -> [bb28];
+        _41 = load_type(testing.TestSetRegistration);
+        _42 = load_type(void);
+        _16 = call const fn baml.iter.Peekable.Iterator.next<copy _41, copy _42>(copy _14) -> [bb26];
     }
 
     bb17: {
-        _42 = load_type(testing.TestSetRegistration);
-        _14 = call const fn baml.iter.Iterable$for$T[].iter<copy _42>(copy _13) -> [bb28];
+        _39 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _14);
+        _16 = call copy _39() -> [bb26];
     }
 
     bb18: {
-        _39 = load_type(testing.TestSetRegistration);
-        _40 = load_type(void);
-        _14 = call const fn baml.iter.Peekable.Iterable.iter<copy _39, copy _40>(copy _13) -> [bb28];
+        _37 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _14);
+        _16 = call copy _37() -> [bb26];
     }
 
     bb19: {
-        _37 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _13);
-        _14 = call copy _37() -> [bb28];
+        _33 = load_type(testing.TestSetRegistration);
+        _34 = load_type(void);
+        _35 = load_type(void);
+        _16 = call const fn baml.iter.Filter.Iterator.next<copy _33, copy _34, copy _35>(copy _14) -> [bb26];
     }
 
     bb20: {
-        _35 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _13);
-        _14 = call copy _35() -> [bb28];
+        _31 = make_bound_method baml.iter.Map.Iterator.next(copy _14);
+        _16 = call copy _31() -> [bb26];
     }
 
     bb21: {
-        _31 = load_type(testing.TestSetRegistration);
-        _32 = load_type(void);
-        _33 = load_type(void);
-        _14 = call const fn baml.iter.Filter.Iterable.iter<copy _31, copy _32, copy _33>(copy _13) -> [bb28];
+        _29 = load_type(testing.TestSetRegistration);
+        _16 = call const fn baml.iter.Repeat.Iterator.next<copy _29>(copy _14) -> [bb26];
     }
 
     bb22: {
-        _29 = make_bound_method baml.iter.Map.Iterable.iter(copy _13);
-        _14 = call copy _29() -> [bb28];
+        _25 = load_type(testing.TestSetRegistration);
+        _26 = load_type(void);
+        _27 = load_type(void);
+        _16 = call const fn baml.iter.Chain.Iterator.next<copy _25, copy _26, copy _27>(copy _14) -> [bb26];
     }
 
     bb23: {
-        _27 = load_type(testing.TestSetRegistration);
-        _14 = call const fn baml.iter.Repeat.Iterable.iter<copy _27>(copy _13) -> [bb28];
+        _22 = load_type(testing.TestSetRegistration);
+        _23 = load_type(void);
+        _16 = call const fn baml.iter.StepBy.Iterator.next<copy _22, copy _23>(copy _14) -> [bb26];
     }
 
     bb24: {
-        _23 = load_type(testing.TestSetRegistration);
-        _24 = load_type(void);
-        _25 = load_type(void);
-        _14 = call const fn baml.iter.Chain.Iterable.iter<copy _23, copy _24, copy _25>(copy _13) -> [bb28];
+        _20 = load_type(testing.TestSetRegistration);
+        _16 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _20>(copy _14) -> [bb26];
     }
 
     bb25: {
-        _20 = load_type(testing.TestSetRegistration);
-        _21 = load_type(void);
-        _14 = call const fn baml.iter.StepBy.Iterable.iter<copy _20, copy _21>(copy _13) -> [bb28];
+        _18 = make_bound_method baml.iter.Flatten.Iterator.next(copy _14);
+        _16 = call copy _18() -> [bb26];
     }
 
     bb26: {
-        _18 = load_type(testing.TestSetRegistration);
-        _14 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _18>(copy _13) -> [bb28];
+        _43 = is_type(copy _16, baml.iter.Done);
+        branch copy _43 -> [bb31, bb27];
     }
 
     bb27: {
-        _16 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _13);
-        _14 = call copy _16() -> [bb28];
+        _44 = copy _16;
+        fresh_cell(_45);
+        _45 = copy _44;
+        _48 = copy _45.0;
+        _49 = copy _5;
+        _47 = copy _48 == copy _49;
+        _46 = short_circuit(||) copy _47 -> [eval: bb28, join: bb29];
     }
 
     bb28: {
-        _46 = is_type(copy _14, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
-        branch copy _46 -> [bb48, bb29];
+        _50 = copy _45.0;
+        _51 = copy _11;
+        _46 = call const fn baml.String.starts_with(copy _50, copy _51) -> [bb29];
     }
 
     bb29: {
-        _48 = is_type(copy _14, baml.iter.ArrayIterator<testing.TestSetRegistration>);
-        branch copy _48 -> [bb47, bb30];
+        branch copy _46 -> [bb30, bb5];
     }
 
     bb30: {
-        _50 = is_type(copy _14, baml.iter.StepBy<testing.TestSetRegistration, void>);
-        branch copy _50 -> [bb46, bb31];
+        _10 = copy _10 + const 1_i64;
+        goto -> bb5;
     }
 
     bb31: {
-        _53 = is_type(copy _14, baml.iter.Chain<testing.TestSetRegistration, void, void>);
-        branch copy _53 -> [bb45, bb32];
+        _54 = copy _10;
+        _53 = copy _54 > const 0_i64;
+        branch copy _53 -> [bb33, bb32];
     }
 
     bb32: {
-        _57 = is_type(copy _14, baml.iter.Repeat<testing.TestSetRegistration>);
-        branch copy _57 -> [bb44, bb33];
+        _52 = copy _5;
+        goto -> bb35;
     }
 
     bb33: {
-        _59 = is_type(copy _14, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
-        branch copy _59 -> [bb43, bb34];
+        _56 = copy _5;
+        _55 = copy _56 + const "#";
+        _59 = copy _10;
+        _58 = copy _59 + const 1_i64;
+        _60 = load_type(int);
+        _57 = call const fn baml.unstable.string<copy _60>(copy _58) -> [bb34];
     }
 
     bb34: {
-        _61 = is_type(copy _14, baml.iter.Filter<testing.TestSetRegistration, void, void>);
-        branch copy _61 -> [bb42, bb35];
+        _52 = copy _55 + copy _57;
+        goto -> bb35;
     }
 
     bb35: {
-        _65 = is_type(copy _14, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
-        branch copy _65 -> [bb41, bb36];
+        _62 = copy _1.2;
+        _64 = copy _52;
+        _63 = testing.TestSetRegistration { copy _64, copy _3, copy _4 };
+        _65 = load_type(testing.TestSetRegistration);
+        _61 = call const fn baml.Array.push<copy _65>(copy _62, copy _63) -> [bb36];
     }
 
     bb36: {
-        _67 = is_type(copy _14, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
-        branch copy _67 -> [bb40, bb37];
+        _0 = const null;
+        goto -> bb37;
     }
 
     bb37: {
-        _69 = is_type(copy _14, baml.iter.Peekable<testing.TestSetRegistration, void>);
-        branch copy _69 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _70 = load_type(testing.TestSetRegistration);
-        _71 = load_type(void);
-        _45 = call const fn baml.iter.Peekable.Iterator.next<copy _70, copy _71>(copy _14) -> [bb49];
-    }
-
-    bb40: {
-        _68 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _14);
-        _45 = call copy _68() -> [bb49];
-    }
-
-    bb41: {
-        _66 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _14);
-        _45 = call copy _66() -> [bb49];
-    }
-
-    bb42: {
-        _62 = load_type(testing.TestSetRegistration);
-        _63 = load_type(void);
-        _64 = load_type(void);
-        _45 = call const fn baml.iter.Filter.Iterator.next<copy _62, copy _63, copy _64>(copy _14) -> [bb49];
-    }
-
-    bb43: {
-        _60 = make_bound_method baml.iter.Map.Iterator.next(copy _14);
-        _45 = call copy _60() -> [bb49];
-    }
-
-    bb44: {
-        _58 = load_type(testing.TestSetRegistration);
-        _45 = call const fn baml.iter.Repeat.Iterator.next<copy _58>(copy _14) -> [bb49];
-    }
-
-    bb45: {
-        _54 = load_type(testing.TestSetRegistration);
-        _55 = load_type(void);
-        _56 = load_type(void);
-        _45 = call const fn baml.iter.Chain.Iterator.next<copy _54, copy _55, copy _56>(copy _14) -> [bb49];
-    }
-
-    bb46: {
-        _51 = load_type(testing.TestSetRegistration);
-        _52 = load_type(void);
-        _45 = call const fn baml.iter.StepBy.Iterator.next<copy _51, copy _52>(copy _14) -> [bb49];
-    }
-
-    bb47: {
-        _49 = load_type(testing.TestSetRegistration);
-        _45 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _49>(copy _14) -> [bb49];
-    }
-
-    bb48: {
-        _47 = make_bound_method baml.iter.Flatten.Iterator.next(copy _14);
-        _45 = call copy _47() -> [bb49];
-    }
-
-    bb49: {
-        _72 = is_type(copy _45, baml.iter.Done);
-        branch copy _72 -> [bb54, bb50];
-    }
-
-    bb50: {
-        _73 = copy _45;
-        fresh_cell(_74);
-        _74 = copy _73;
-        _77 = copy _74.0;
-        _78 = copy _5;
-        _76 = copy _77 == copy _78;
-        _75 = short_circuit(||) copy _76 -> [eval: bb51, join: bb52];
-    }
-
-    bb51: {
-        _79 = copy _74.0;
-        _80 = copy _11;
-        _75 = call const fn baml.String.starts_with(copy _79, copy _80) -> [bb52];
-    }
-
-    bb52: {
-        branch copy _75 -> [bb53, bb28];
-    }
-
-    bb53: {
-        _10 = copy _10 + const 1_i64;
-        goto -> bb28;
-    }
-
-    bb54: {
-        _83 = copy _10;
-        _82 = copy _83 > const 0_i64;
-        branch copy _82 -> [bb56, bb55];
-    }
-
-    bb55: {
-        _81 = copy _5;
-        goto -> bb58;
-    }
-
-    bb56: {
-        _85 = copy _5;
-        _84 = copy _85 + const "#";
-        _88 = copy _10;
-        _87 = copy _88 + const 1_i64;
-        _89 = load_type(int);
-        _86 = call const fn baml.unstable.string<copy _89>(copy _87) -> [bb57];
-    }
-
-    bb57: {
-        _81 = copy _84 + copy _86;
-        goto -> bb58;
-    }
-
-    bb58: {
-        _91 = copy _1.2;
-        _93 = copy _81;
-        _92 = testing.TestSetRegistration { copy _93, copy _3, copy _4 };
-        _94 = load_type(testing.TestSetRegistration);
-        _90 = call const fn baml.Array.push<copy _94>(copy _91, copy _92) -> [bb59];
-    }
-
-    bb59: {
-        _0 = const null;
-        goto -> bb60;
-    }
-
-    bb60: {
         return;
     }
 }
@@ -2296,202 +1542,143 @@ fn testing.TestRegistry.run_test(self: testing.TestRegistry, name: string) -> te
     let _2: string // name // param
     let _3: testing.TestRegistration[]
     let _4: baml.iter.Iterator<Item = testing.TestRegistration, Error = void>
-    let _5: bool
+    let _5: type
     let _6: unknown
     let _7: bool
-    let _8: type
+    let _8: unknown
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
+    let _34: testing.TestRegistration
+    let _35: testing.TestRegistration // t
     let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: type
-    let _40: bool
-    let _41: type
+    let _37: string
+    let _38: () -> void throws unknown
+    let _39: ((() -> testing.TestReport throws never) -> (() -> testing.TestReport throws never) throws never) | null
+    let _40: string[]
+    let _41: (map<string, testing.TestRegistry>) -> string[] throws never
     let _42: type
-    let _43: bool
-    let _44: type
+    let _43: type
+    let _44: baml.iter.Iterator<Item = string, Error = void>
     let _45: type
-    let _46: type
+    let _46: unknown
     let _47: bool
-    let _48: type
+    let _48: unknown
     let _49: bool
-    let _50: unknown
+    let _50: type
     let _51: bool
     let _52: type
     let _53: type
-    let _54: type
-    let _55: bool
-    let _56: unknown
-    let _57: bool
-    let _58: unknown
-    let _59: bool
-    let _60: type
-    let _61: type
+    let _54: bool
+    let _55: type
+    let _56: type
+    let _57: type
+    let _58: bool
+    let _59: type
+    let _60: bool
+    let _61: unknown
     let _62: bool
-    let _63: testing.TestRegistration
-    let _64: testing.TestRegistration // t
-    let _65: bool
-    let _66: string
-    let _67: () -> void throws unknown
-    let _68: ((() -> testing.TestReport throws never) -> (() -> testing.TestReport throws never) throws never) | null
-    let _69: string[]
-    let _70: (map<string, testing.TestRegistry>) -> string[] throws never
+    let _63: type
+    let _64: type
+    let _65: type
+    let _66: bool
+    let _67: unknown
+    let _68: bool
+    let _69: unknown
+    let _70: bool
     let _71: type
     let _72: type
-    let _73: baml.iter.Iterator<Item = string, Error = void>
-    let _74: bool
-    let _75: unknown
-    let _76: bool
-    let _77: type
-    let _78: bool
-    let _79: type
-    let _80: type
-    let _81: bool
-    let _82: type
-    let _83: type
-    let _84: type
-    let _85: bool
-    let _86: type
-    let _87: bool
-    let _88: unknown
-    let _89: bool
-    let _90: type
-    let _91: type
-    let _92: type
-    let _93: bool
-    let _94: unknown
-    let _95: bool
-    let _96: unknown
-    let _97: bool
-    let _98: type
-    let _99: type
-    let _100: bool
-    let _101: type
-    let _102: bool
-    let _103: type
-    let _104: unknown
-    let _105: bool
-    let _106: unknown
-    let _107: bool
-    let _108: type
-    let _109: bool
-    let _110: type
-    let _111: type
-    let _112: bool
-    let _113: type
-    let _114: type
-    let _115: type
-    let _116: bool
-    let _117: type
-    let _118: bool
-    let _119: unknown
-    let _120: bool
-    let _121: type
-    let _122: type
-    let _123: type
-    let _124: bool
-    let _125: unknown
-    let _126: bool
-    let _127: unknown
-    let _128: bool
-    let _129: type
-    let _130: type
-    let _131: bool
-    let _132: string
-    let _133: string // k
-    let _134: testing.TestRegistry // sub
-    let _135: map<string, testing.TestRegistry>
-    let _136: string
-    let _137: bool
-    let _138: string
-    let _139: string
-    let _140: string
+    let _73: bool
+    let _74: string
+    let _75: string // k
+    let _76: testing.TestRegistry // sub
+    let _77: map<string, testing.TestRegistry>
+    let _78: string
+    let _79: bool
+    let _80: string
+    let _81: string
+    let _82: string
 
     bb0: {
         _3 = copy _1.0.1;
-        _5 = is_type(copy _3, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
-        branch copy _5 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _7 = is_type(copy _3, baml.iter.ArrayIterator<testing.TestRegistration>);
-        branch copy _7 -> [bb23, bb2];
+        _5 = load_type(testing.TestRegistration);
+        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _5>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _9 = is_type(copy _3, baml.iter.StepBy<testing.TestRegistration, void>);
-        branch copy _9 -> [bb22, bb3];
+        _7 = is_type(copy _4, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
+        branch copy _7 -> [bb22, bb3];
     }
 
     bb3: {
-        _12 = is_type(copy _3, baml.iter.Chain<testing.TestRegistration, void, void>);
-        branch copy _12 -> [bb21, bb4];
+        _9 = is_type(copy _4, baml.iter.ArrayIterator<testing.TestRegistration>);
+        branch copy _9 -> [bb21, bb4];
     }
 
     bb4: {
-        _16 = is_type(copy _3, baml.iter.Repeat<testing.TestRegistration>);
-        branch copy _16 -> [bb20, bb5];
+        _11 = is_type(copy _4, baml.iter.StepBy<testing.TestRegistration, void>);
+        branch copy _11 -> [bb20, bb5];
     }
 
     bb5: {
-        _18 = is_type(copy _3, baml.iter.Map<_, testing.TestRegistration, void, void>);
-        branch copy _18 -> [bb19, bb6];
+        _14 = is_type(copy _4, baml.iter.Chain<testing.TestRegistration, void, void>);
+        branch copy _14 -> [bb19, bb6];
     }
 
     bb6: {
-        _20 = is_type(copy _3, baml.iter.Filter<testing.TestRegistration, void, void>);
-        branch copy _20 -> [bb18, bb7];
+        _18 = is_type(copy _4, baml.iter.Repeat<testing.TestRegistration>);
+        branch copy _18 -> [bb18, bb7];
     }
 
     bb7: {
-        _24 = is_type(copy _3, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
-        branch copy _24 -> [bb17, bb8];
+        _20 = is_type(copy _4, baml.iter.Map<_, testing.TestRegistration, void, void>);
+        branch copy _20 -> [bb17, bb8];
     }
 
     bb8: {
-        _26 = is_type(copy _3, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
-        branch copy _26 -> [bb16, bb9];
+        _22 = is_type(copy _4, baml.iter.Filter<testing.TestRegistration, void, void>);
+        branch copy _22 -> [bb16, bb9];
     }
 
     bb9: {
-        _28 = is_type(copy _3, baml.iter.Peekable<testing.TestRegistration, void>);
-        branch copy _28 -> [bb15, bb10];
+        _26 = is_type(copy _4, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
+        branch copy _26 -> [bb15, bb10];
     }
 
     bb10: {
-        _31 = is_type(copy _3, unknown[]);
-        branch copy _31 -> [bb14, bb11];
+        _28 = is_type(copy _4, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
+        branch copy _28 -> [bb14, bb11];
     }
 
     bb11: {
-        _33 = is_type(copy _3, testing.TestRegistration[]);
-        branch copy _33 -> [bb13, bb12];
+        _30 = is_type(copy _4, baml.iter.Peekable<testing.TestRegistration, void>);
+        branch copy _30 -> [bb13, bb12];
     }
 
     bb12: {
@@ -2499,480 +1686,235 @@ fn testing.TestRegistry.run_test(self: testing.TestRegistry, name: string) -> te
     }
 
     bb13: {
-        _34 = load_type(testing.TestRegistration);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _3) -> [bb25];
+        _31 = load_type(testing.TestRegistration);
+        _32 = load_type(void);
+        _6 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _4) -> [bb23];
     }
 
     bb14: {
-        _32 = load_type(testing.TestRegistration);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _3) -> [bb25];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
+        _6 = call copy _29() -> [bb23];
     }
 
     bb15: {
-        _29 = load_type(testing.TestRegistration);
-        _30 = load_type(void);
-        _4 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _3) -> [bb25];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
+        _6 = call copy _27() -> [bb23];
     }
 
     bb16: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _3);
-        _4 = call copy _27() -> [bb25];
+        _23 = load_type(testing.TestRegistration);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _6 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _4) -> [bb23];
     }
 
     bb17: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _3);
-        _4 = call copy _25() -> [bb25];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
+        _6 = call copy _21() -> [bb23];
     }
 
     bb18: {
-        _21 = load_type(testing.TestRegistration);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _4 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _3) -> [bb25];
+        _19 = load_type(testing.TestRegistration);
+        _6 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _4) -> [bb23];
     }
 
     bb19: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _3);
-        _4 = call copy _19() -> [bb25];
+        _15 = load_type(testing.TestRegistration);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _6 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _4) -> [bb23];
     }
 
     bb20: {
-        _17 = load_type(testing.TestRegistration);
-        _4 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _3) -> [bb25];
+        _12 = load_type(testing.TestRegistration);
+        _13 = load_type(void);
+        _6 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _4) -> [bb23];
     }
 
     bb21: {
-        _13 = load_type(testing.TestRegistration);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _4 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _3) -> [bb25];
+        _10 = load_type(testing.TestRegistration);
+        _6 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _4) -> [bb23];
     }
 
     bb22: {
-        _10 = load_type(testing.TestRegistration);
-        _11 = load_type(void);
-        _4 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _3) -> [bb25];
+        _8 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
+        _6 = call copy _8() -> [bb23];
     }
 
     bb23: {
-        _8 = load_type(testing.TestRegistration);
-        _4 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _3) -> [bb25];
+        _33 = is_type(copy _6, baml.iter.Done);
+        branch copy _33 -> [bb26, bb24];
     }
 
     bb24: {
-        _6 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _3);
-        _4 = call copy _6() -> [bb25];
+        _34 = copy _6;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _37 = copy _35.0;
+        _36 = copy _37 == copy _2;
+        branch copy _36 -> [bb25, bb2];
     }
 
     bb25: {
-        _36 = is_type(copy _4, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
-        branch copy _36 -> [bb45, bb26];
+        _38 = copy _35.1;
+        _39 = copy _35.2;
+        _0 = call const fn testing.run_test(copy _38, copy _39) -> [bb53];
     }
 
     bb26: {
-        _38 = is_type(copy _4, baml.iter.ArrayIterator<testing.TestRegistration>);
-        branch copy _38 -> [bb44, bb27];
+        _41 = copy _1.1;
+        _42 = load_type(string);
+        _43 = load_type(testing.TestRegistry);
+        _40 = call const fn baml.Map.keys<copy _42, copy _43>(copy _41) -> [bb27];
     }
 
     bb27: {
-        _40 = is_type(copy _4, baml.iter.StepBy<testing.TestRegistration, void>);
-        branch copy _40 -> [bb43, bb28];
+        _45 = load_type(string);
+        _44 = call const fn baml.iter.Iterable$for$T[].iter<copy _45>(copy _40) -> [bb28];
     }
 
     bb28: {
-        _43 = is_type(copy _4, baml.iter.Chain<testing.TestRegistration, void, void>);
-        branch copy _43 -> [bb42, bb29];
+        _47 = is_type(copy _44, baml.iter.Flatten<_, string, void, void>);
+        branch copy _47 -> [bb48, bb29];
     }
 
     bb29: {
-        _47 = is_type(copy _4, baml.iter.Repeat<testing.TestRegistration>);
-        branch copy _47 -> [bb41, bb30];
+        _49 = is_type(copy _44, baml.iter.ArrayIterator<string>);
+        branch copy _49 -> [bb47, bb30];
     }
 
     bb30: {
-        _49 = is_type(copy _4, baml.iter.Map<_, testing.TestRegistration, void, void>);
-        branch copy _49 -> [bb40, bb31];
+        _51 = is_type(copy _44, baml.iter.StepBy<string, void>);
+        branch copy _51 -> [bb46, bb31];
     }
 
     bb31: {
-        _51 = is_type(copy _4, baml.iter.Filter<testing.TestRegistration, void, void>);
-        branch copy _51 -> [bb39, bb32];
+        _54 = is_type(copy _44, baml.iter.Chain<string, void, void>);
+        branch copy _54 -> [bb45, bb32];
     }
 
     bb32: {
-        _55 = is_type(copy _4, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
-        branch copy _55 -> [bb38, bb33];
+        _58 = is_type(copy _44, baml.iter.Repeat<string>);
+        branch copy _58 -> [bb44, bb33];
     }
 
     bb33: {
-        _57 = is_type(copy _4, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
-        branch copy _57 -> [bb37, bb34];
+        _60 = is_type(copy _44, baml.iter.Map<_, string, void, void>);
+        branch copy _60 -> [bb43, bb34];
     }
 
     bb34: {
-        _59 = is_type(copy _4, baml.iter.Peekable<testing.TestRegistration, void>);
-        branch copy _59 -> [bb36, bb35];
+        _62 = is_type(copy _44, baml.iter.Filter<string, void, void>);
+        branch copy _62 -> [bb42, bb35];
     }
 
     bb35: {
-        unreachable;
+        _66 = is_type(copy _44, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _66 -> [bb41, bb36];
     }
 
     bb36: {
-        _60 = load_type(testing.TestRegistration);
-        _61 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _60, copy _61>(copy _4) -> [bb46];
+        _68 = is_type(copy _44, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _68 -> [bb40, bb37];
     }
 
     bb37: {
-        _58 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
-        _35 = call copy _58() -> [bb46];
+        _70 = is_type(copy _44, baml.iter.Peekable<string, void>);
+        branch copy _70 -> [bb39, bb38];
     }
 
     bb38: {
-        _56 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
-        _35 = call copy _56() -> [bb46];
+        unreachable;
     }
 
     bb39: {
-        _52 = load_type(testing.TestRegistration);
-        _53 = load_type(void);
-        _54 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _52, copy _53, copy _54>(copy _4) -> [bb46];
+        _71 = load_type(string);
+        _72 = load_type(void);
+        _46 = call const fn baml.iter.Peekable.Iterator.next<copy _71, copy _72>(copy _44) -> [bb49];
     }
 
     bb40: {
-        _50 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
-        _35 = call copy _50() -> [bb46];
+        _69 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _44);
+        _46 = call copy _69() -> [bb49];
     }
 
     bb41: {
-        _48 = load_type(testing.TestRegistration);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _48>(copy _4) -> [bb46];
+        _67 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _44);
+        _46 = call copy _67() -> [bb49];
     }
 
     bb42: {
-        _44 = load_type(testing.TestRegistration);
-        _45 = load_type(void);
-        _46 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _44, copy _45, copy _46>(copy _4) -> [bb46];
+        _63 = load_type(string);
+        _64 = load_type(void);
+        _65 = load_type(void);
+        _46 = call const fn baml.iter.Filter.Iterator.next<copy _63, copy _64, copy _65>(copy _44) -> [bb49];
     }
 
     bb43: {
-        _41 = load_type(testing.TestRegistration);
-        _42 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _41, copy _42>(copy _4) -> [bb46];
+        _61 = make_bound_method baml.iter.Map.Iterator.next(copy _44);
+        _46 = call copy _61() -> [bb49];
     }
 
     bb44: {
-        _39 = load_type(testing.TestRegistration);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _39>(copy _4) -> [bb46];
+        _59 = load_type(string);
+        _46 = call const fn baml.iter.Repeat.Iterator.next<copy _59>(copy _44) -> [bb49];
     }
 
     bb45: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
-        _35 = call copy _37() -> [bb46];
+        _55 = load_type(string);
+        _56 = load_type(void);
+        _57 = load_type(void);
+        _46 = call const fn baml.iter.Chain.Iterator.next<copy _55, copy _56, copy _57>(copy _44) -> [bb49];
     }
 
     bb46: {
-        _62 = is_type(copy _35, baml.iter.Done);
-        branch copy _62 -> [bb49, bb47];
+        _52 = load_type(string);
+        _53 = load_type(void);
+        _46 = call const fn baml.iter.StepBy.Iterator.next<copy _52, copy _53>(copy _44) -> [bb49];
     }
 
     bb47: {
-        _63 = copy _35;
-        fresh_cell(_64);
-        _64 = copy _63;
-        _66 = copy _64.0;
-        _65 = copy _66 == copy _2;
-        branch copy _65 -> [bb48, bb25];
+        _50 = load_type(string);
+        _46 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _50>(copy _44) -> [bb49];
     }
 
     bb48: {
-        _67 = copy _64.1;
-        _68 = copy _64.2;
-        _0 = call const fn testing.run_test(copy _67, copy _68) -> [bb100];
+        _48 = make_bound_method baml.iter.Flatten.Iterator.next(copy _44);
+        _46 = call copy _48() -> [bb49];
     }
 
     bb49: {
-        _70 = copy _1.1;
-        _71 = load_type(string);
-        _72 = load_type(testing.TestRegistry);
-        _69 = call const fn baml.Map.keys<copy _71, copy _72>(copy _70) -> [bb50];
+        _73 = is_type(copy _46, baml.iter.Done);
+        branch copy _73 -> [bb54, bb50];
     }
 
     bb50: {
-        _74 = is_type(copy _69, baml.iter.Flatten<_, string, void, void>);
-        branch copy _74 -> [bb74, bb51];
+        _74 = copy _46;
+        fresh_cell(_75);
+        _75 = copy _74;
+        _77 = copy _1.1;
+        _78 = copy _75;
+        _76 = copy _77[_78];
+        _81 = copy _75;
+        _80 = copy _81 + const "/";
+        _79 = call const fn baml.String.starts_with(copy _2, copy _80) -> [bb51];
     }
 
     bb51: {
-        _76 = is_type(copy _69, baml.iter.ArrayIterator<string>);
-        branch copy _76 -> [bb73, bb52];
+        branch copy _79 -> [bb52, bb28];
     }
 
     bb52: {
-        _78 = is_type(copy _69, baml.iter.StepBy<string, void>);
-        branch copy _78 -> [bb72, bb53];
+        _0 = call const fn testing.TestRegistry.run_test(copy _76, copy _2) -> [bb53];
     }
 
     bb53: {
-        _81 = is_type(copy _69, baml.iter.Chain<string, void, void>);
-        branch copy _81 -> [bb71, bb54];
-    }
-
-    bb54: {
-        _85 = is_type(copy _69, baml.iter.Repeat<string>);
-        branch copy _85 -> [bb70, bb55];
-    }
-
-    bb55: {
-        _87 = is_type(copy _69, baml.iter.Map<_, string, void, void>);
-        branch copy _87 -> [bb69, bb56];
-    }
-
-    bb56: {
-        _89 = is_type(copy _69, baml.iter.Filter<string, void, void>);
-        branch copy _89 -> [bb68, bb57];
-    }
-
-    bb57: {
-        _93 = is_type(copy _69, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _93 -> [bb67, bb58];
-    }
-
-    bb58: {
-        _95 = is_type(copy _69, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _95 -> [bb66, bb59];
-    }
-
-    bb59: {
-        _97 = is_type(copy _69, baml.iter.Peekable<string, void>);
-        branch copy _97 -> [bb65, bb60];
-    }
-
-    bb60: {
-        _100 = is_type(copy _69, unknown[]);
-        branch copy _100 -> [bb64, bb61];
-    }
-
-    bb61: {
-        _102 = is_type(copy _69, string[]);
-        branch copy _102 -> [bb63, bb62];
-    }
-
-    bb62: {
-        unreachable;
-    }
-
-    bb63: {
-        _103 = load_type(string);
-        _73 = call const fn baml.iter.Iterable$for$T[].iter<copy _103>(copy _69) -> [bb75];
-    }
-
-    bb64: {
-        _101 = load_type(string);
-        _73 = call const fn baml.iter.Iterable$for$T[].iter<copy _101>(copy _69) -> [bb75];
-    }
-
-    bb65: {
-        _98 = load_type(string);
-        _99 = load_type(void);
-        _73 = call const fn baml.iter.Peekable.Iterable.iter<copy _98, copy _99>(copy _69) -> [bb75];
-    }
-
-    bb66: {
-        _96 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _69);
-        _73 = call copy _96() -> [bb75];
-    }
-
-    bb67: {
-        _94 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _69);
-        _73 = call copy _94() -> [bb75];
-    }
-
-    bb68: {
-        _90 = load_type(string);
-        _91 = load_type(void);
-        _92 = load_type(void);
-        _73 = call const fn baml.iter.Filter.Iterable.iter<copy _90, copy _91, copy _92>(copy _69) -> [bb75];
-    }
-
-    bb69: {
-        _88 = make_bound_method baml.iter.Map.Iterable.iter(copy _69);
-        _73 = call copy _88() -> [bb75];
-    }
-
-    bb70: {
-        _86 = load_type(string);
-        _73 = call const fn baml.iter.Repeat.Iterable.iter<copy _86>(copy _69) -> [bb75];
-    }
-
-    bb71: {
-        _82 = load_type(string);
-        _83 = load_type(void);
-        _84 = load_type(void);
-        _73 = call const fn baml.iter.Chain.Iterable.iter<copy _82, copy _83, copy _84>(copy _69) -> [bb75];
-    }
-
-    bb72: {
-        _79 = load_type(string);
-        _80 = load_type(void);
-        _73 = call const fn baml.iter.StepBy.Iterable.iter<copy _79, copy _80>(copy _69) -> [bb75];
-    }
-
-    bb73: {
-        _77 = load_type(string);
-        _73 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _77>(copy _69) -> [bb75];
-    }
-
-    bb74: {
-        _75 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _69);
-        _73 = call copy _75() -> [bb75];
-    }
-
-    bb75: {
-        _105 = is_type(copy _73, baml.iter.Flatten<_, string, void, void>);
-        branch copy _105 -> [bb95, bb76];
-    }
-
-    bb76: {
-        _107 = is_type(copy _73, baml.iter.ArrayIterator<string>);
-        branch copy _107 -> [bb94, bb77];
-    }
-
-    bb77: {
-        _109 = is_type(copy _73, baml.iter.StepBy<string, void>);
-        branch copy _109 -> [bb93, bb78];
-    }
-
-    bb78: {
-        _112 = is_type(copy _73, baml.iter.Chain<string, void, void>);
-        branch copy _112 -> [bb92, bb79];
-    }
-
-    bb79: {
-        _116 = is_type(copy _73, baml.iter.Repeat<string>);
-        branch copy _116 -> [bb91, bb80];
-    }
-
-    bb80: {
-        _118 = is_type(copy _73, baml.iter.Map<_, string, void, void>);
-        branch copy _118 -> [bb90, bb81];
-    }
-
-    bb81: {
-        _120 = is_type(copy _73, baml.iter.Filter<string, void, void>);
-        branch copy _120 -> [bb89, bb82];
-    }
-
-    bb82: {
-        _124 = is_type(copy _73, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _124 -> [bb88, bb83];
-    }
-
-    bb83: {
-        _126 = is_type(copy _73, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _126 -> [bb87, bb84];
-    }
-
-    bb84: {
-        _128 = is_type(copy _73, baml.iter.Peekable<string, void>);
-        branch copy _128 -> [bb86, bb85];
-    }
-
-    bb85: {
-        unreachable;
-    }
-
-    bb86: {
-        _129 = load_type(string);
-        _130 = load_type(void);
-        _104 = call const fn baml.iter.Peekable.Iterator.next<copy _129, copy _130>(copy _73) -> [bb96];
-    }
-
-    bb87: {
-        _127 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _73);
-        _104 = call copy _127() -> [bb96];
-    }
-
-    bb88: {
-        _125 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _73);
-        _104 = call copy _125() -> [bb96];
-    }
-
-    bb89: {
-        _121 = load_type(string);
-        _122 = load_type(void);
-        _123 = load_type(void);
-        _104 = call const fn baml.iter.Filter.Iterator.next<copy _121, copy _122, copy _123>(copy _73) -> [bb96];
-    }
-
-    bb90: {
-        _119 = make_bound_method baml.iter.Map.Iterator.next(copy _73);
-        _104 = call copy _119() -> [bb96];
-    }
-
-    bb91: {
-        _117 = load_type(string);
-        _104 = call const fn baml.iter.Repeat.Iterator.next<copy _117>(copy _73) -> [bb96];
-    }
-
-    bb92: {
-        _113 = load_type(string);
-        _114 = load_type(void);
-        _115 = load_type(void);
-        _104 = call const fn baml.iter.Chain.Iterator.next<copy _113, copy _114, copy _115>(copy _73) -> [bb96];
-    }
-
-    bb93: {
-        _110 = load_type(string);
-        _111 = load_type(void);
-        _104 = call const fn baml.iter.StepBy.Iterator.next<copy _110, copy _111>(copy _73) -> [bb96];
-    }
-
-    bb94: {
-        _108 = load_type(string);
-        _104 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _108>(copy _73) -> [bb96];
-    }
-
-    bb95: {
-        _106 = make_bound_method baml.iter.Flatten.Iterator.next(copy _73);
-        _104 = call copy _106() -> [bb96];
-    }
-
-    bb96: {
-        _131 = is_type(copy _104, baml.iter.Done);
-        branch copy _131 -> [bb101, bb97];
-    }
-
-    bb97: {
-        _132 = copy _104;
-        fresh_cell(_133);
-        _133 = copy _132;
-        _135 = copy _1.1;
-        _136 = copy _133;
-        _134 = copy _135[_136];
-        _139 = copy _133;
-        _138 = copy _139 + const "/";
-        _137 = call const fn baml.String.starts_with(copy _2, copy _138) -> [bb98];
-    }
-
-    bb98: {
-        branch copy _137 -> [bb99, bb75];
-    }
-
-    bb99: {
-        _0 = call const fn testing.TestRegistry.run_test(copy _134, copy _2) -> [bb100];
-    }
-
-    bb100: {
         return;
     }
 
-    bb101: {
-        _140 = const "Test not found: " + copy _2;
-        throw copy _140;
+    bb54: {
+        _82 = const "Test not found: " + copy _2;
+        throw copy _82;
     }
 }
 
@@ -3121,206 +2063,147 @@ fn testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.Serial
     let _2: (testing.SerializedTest | testing.SerializedTestSet)[] // items
     let _3: testing.TestRegistration[]
     let _4: baml.iter.Iterator<Item = testing.TestRegistration, Error = void>
-    let _5: bool
+    let _5: type
     let _6: unknown
     let _7: bool
-    let _8: type
+    let _8: unknown
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: type
-    let _40: bool
+    let _34: testing.TestRegistration
+    let _35: testing.TestRegistration // t
+    let _36: void
+    let _37: testing.SerializedTest
+    let _38: string
+    let _39: testing.TestSetRegistration[]
+    let _40: baml.iter.Iterator<Item = testing.TestSetRegistration, Error = void>
     let _41: type
-    let _42: type
+    let _42: unknown
     let _43: bool
-    let _44: type
-    let _45: type
+    let _44: unknown
+    let _45: bool
     let _46: type
     let _47: bool
     let _48: type
-    let _49: bool
-    let _50: unknown
-    let _51: bool
+    let _49: type
+    let _50: bool
+    let _51: type
     let _52: type
     let _53: type
-    let _54: type
-    let _55: bool
-    let _56: unknown
-    let _57: bool
-    let _58: unknown
-    let _59: bool
+    let _54: bool
+    let _55: type
+    let _56: bool
+    let _57: unknown
+    let _58: bool
+    let _59: type
     let _60: type
     let _61: type
     let _62: bool
-    let _63: testing.TestRegistration
-    let _64: testing.TestRegistration // t
-    let _65: void
-    let _66: testing.SerializedTest
-    let _67: string
-    let _68: testing.TestSetRegistration[]
-    let _69: baml.iter.Iterator<Item = testing.TestSetRegistration, Error = void>
-    let _70: bool
-    let _71: unknown
-    let _72: bool
-    let _73: type
-    let _74: bool
-    let _75: type
+    let _63: unknown
+    let _64: bool
+    let _65: unknown
+    let _66: bool
+    let _67: type
+    let _68: type
+    let _69: bool
+    let _70: testing.TestSetRegistration
+    let _71: testing.TestSetRegistration // ts
+    let _72: void
+    let _73: testing.TestRegistry | null // expanded
+    let _74: (map<string, testing.TestRegistry>, string) -> testing.TestRegistry | null throws never
+    let _75: string
     let _76: type
-    let _77: bool
-    let _78: type
-    let _79: type
-    let _80: type
-    let _81: bool
-    let _82: type
-    let _83: bool
-    let _84: unknown
-    let _85: bool
-    let _86: type
-    let _87: type
-    let _88: type
-    let _89: bool
-    let _90: unknown
-    let _91: bool
-    let _92: unknown
-    let _93: bool
-    let _94: type
-    let _95: type
-    let _96: bool
-    let _97: type
-    let _98: bool
-    let _99: type
-    let _100: unknown
-    let _101: bool
-    let _102: unknown
-    let _103: bool
-    let _104: type
-    let _105: bool
-    let _106: type
-    let _107: type
-    let _108: bool
-    let _109: type
-    let _110: type
-    let _111: type
-    let _112: bool
-    let _113: type
-    let _114: bool
-    let _115: unknown
-    let _116: bool
-    let _117: type
-    let _118: type
-    let _119: type
-    let _120: bool
-    let _121: unknown
-    let _122: bool
-    let _123: unknown
-    let _124: bool
-    let _125: type
-    let _126: type
-    let _127: bool
-    let _128: testing.TestSetRegistration
-    let _129: testing.TestSetRegistration // ts
-    let _130: void
-    let _131: testing.TestRegistry | null // expanded
-    let _132: (map<string, testing.TestRegistry>, string) -> testing.TestRegistry | null throws never
-    let _133: string
-    let _134: type
-    let _135: type
-    let _136: bool
-    let _137: testing.TestRegistry // sub
-    let _138: testing.SerializedTestSet
-    let _139: string
-    let _140: (testing.SerializedTest | testing.SerializedTestSet)[]
-    let _141: int
-    let _142: testing.SerializedTest
-    let _143: string
+    let _77: type
+    let _78: bool
+    let _79: testing.TestRegistry // sub
+    let _80: testing.SerializedTestSet
+    let _81: string
+    let _82: (testing.SerializedTest | testing.SerializedTestSet)[]
+    let _83: int
+    let _84: testing.SerializedTest
+    let _85: string
 
     bb0: {
         _2 = [];
         _3 = copy _1.0.1;
-        _5 = is_type(copy _3, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
-        branch copy _5 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _7 = is_type(copy _3, baml.iter.ArrayIterator<testing.TestRegistration>);
-        branch copy _7 -> [bb23, bb2];
+        _5 = load_type(testing.TestRegistration);
+        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _5>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _9 = is_type(copy _3, baml.iter.StepBy<testing.TestRegistration, void>);
-        branch copy _9 -> [bb22, bb3];
+        _7 = is_type(copy _4, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
+        branch copy _7 -> [bb22, bb3];
     }
 
     bb3: {
-        _12 = is_type(copy _3, baml.iter.Chain<testing.TestRegistration, void, void>);
-        branch copy _12 -> [bb21, bb4];
+        _9 = is_type(copy _4, baml.iter.ArrayIterator<testing.TestRegistration>);
+        branch copy _9 -> [bb21, bb4];
     }
 
     bb4: {
-        _16 = is_type(copy _3, baml.iter.Repeat<testing.TestRegistration>);
-        branch copy _16 -> [bb20, bb5];
+        _11 = is_type(copy _4, baml.iter.StepBy<testing.TestRegistration, void>);
+        branch copy _11 -> [bb20, bb5];
     }
 
     bb5: {
-        _18 = is_type(copy _3, baml.iter.Map<_, testing.TestRegistration, void, void>);
-        branch copy _18 -> [bb19, bb6];
+        _14 = is_type(copy _4, baml.iter.Chain<testing.TestRegistration, void, void>);
+        branch copy _14 -> [bb19, bb6];
     }
 
     bb6: {
-        _20 = is_type(copy _3, baml.iter.Filter<testing.TestRegistration, void, void>);
-        branch copy _20 -> [bb18, bb7];
+        _18 = is_type(copy _4, baml.iter.Repeat<testing.TestRegistration>);
+        branch copy _18 -> [bb18, bb7];
     }
 
     bb7: {
-        _24 = is_type(copy _3, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
-        branch copy _24 -> [bb17, bb8];
+        _20 = is_type(copy _4, baml.iter.Map<_, testing.TestRegistration, void, void>);
+        branch copy _20 -> [bb17, bb8];
     }
 
     bb8: {
-        _26 = is_type(copy _3, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
-        branch copy _26 -> [bb16, bb9];
+        _22 = is_type(copy _4, baml.iter.Filter<testing.TestRegistration, void, void>);
+        branch copy _22 -> [bb16, bb9];
     }
 
     bb9: {
-        _28 = is_type(copy _3, baml.iter.Peekable<testing.TestRegistration, void>);
-        branch copy _28 -> [bb15, bb10];
+        _26 = is_type(copy _4, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
+        branch copy _26 -> [bb15, bb10];
     }
 
     bb10: {
-        _31 = is_type(copy _3, unknown[]);
-        branch copy _31 -> [bb14, bb11];
+        _28 = is_type(copy _4, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
+        branch copy _28 -> [bb14, bb11];
     }
 
     bb11: {
-        _33 = is_type(copy _3, testing.TestRegistration[]);
-        branch copy _33 -> [bb13, bb12];
+        _30 = is_type(copy _4, baml.iter.Peekable<testing.TestRegistration, void>);
+        branch copy _30 -> [bb13, bb12];
     }
 
     bb12: {
@@ -3328,481 +2211,240 @@ fn testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.Serial
     }
 
     bb13: {
-        _34 = load_type(testing.TestRegistration);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _3) -> [bb25];
+        _31 = load_type(testing.TestRegistration);
+        _32 = load_type(void);
+        _6 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _4) -> [bb23];
     }
 
     bb14: {
-        _32 = load_type(testing.TestRegistration);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _3) -> [bb25];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
+        _6 = call copy _29() -> [bb23];
     }
 
     bb15: {
-        _29 = load_type(testing.TestRegistration);
-        _30 = load_type(void);
-        _4 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _3) -> [bb25];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
+        _6 = call copy _27() -> [bb23];
     }
 
     bb16: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _3);
-        _4 = call copy _27() -> [bb25];
+        _23 = load_type(testing.TestRegistration);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _6 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _4) -> [bb23];
     }
 
     bb17: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _3);
-        _4 = call copy _25() -> [bb25];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
+        _6 = call copy _21() -> [bb23];
     }
 
     bb18: {
-        _21 = load_type(testing.TestRegistration);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _4 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _3) -> [bb25];
+        _19 = load_type(testing.TestRegistration);
+        _6 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _4) -> [bb23];
     }
 
     bb19: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _3);
-        _4 = call copy _19() -> [bb25];
+        _15 = load_type(testing.TestRegistration);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _6 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _4) -> [bb23];
     }
 
     bb20: {
-        _17 = load_type(testing.TestRegistration);
-        _4 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _3) -> [bb25];
+        _12 = load_type(testing.TestRegistration);
+        _13 = load_type(void);
+        _6 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _4) -> [bb23];
     }
 
     bb21: {
-        _13 = load_type(testing.TestRegistration);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _4 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _3) -> [bb25];
+        _10 = load_type(testing.TestRegistration);
+        _6 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _4) -> [bb23];
     }
 
     bb22: {
-        _10 = load_type(testing.TestRegistration);
-        _11 = load_type(void);
-        _4 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _3) -> [bb25];
+        _8 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
+        _6 = call copy _8() -> [bb23];
     }
 
     bb23: {
-        _8 = load_type(testing.TestRegistration);
-        _4 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _3) -> [bb25];
+        _33 = is_type(copy _6, baml.iter.Done);
+        branch copy _33 -> [bb25, bb24];
     }
 
     bb24: {
-        _6 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _3);
-        _4 = call copy _6() -> [bb25];
+        _34 = copy _6;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _38 = copy _35.0;
+        _37 = testing.SerializedTest { const "test", copy _38 };
+        _36 = call const fn baml.Array.push(copy _2, copy _37) -> [bb2];
     }
 
     bb25: {
-        _36 = is_type(copy _4, baml.iter.Flatten<_, testing.TestRegistration, void, void>);
-        branch copy _36 -> [bb45, bb26];
+        _39 = copy _1.0.2;
+        goto -> bb26;
     }
 
     bb26: {
-        _38 = is_type(copy _4, baml.iter.ArrayIterator<testing.TestRegistration>);
-        branch copy _38 -> [bb44, bb27];
+        _41 = load_type(testing.TestSetRegistration);
+        _40 = call const fn baml.iter.Iterable$for$T[].iter<copy _41>(copy _39) -> [bb27];
     }
 
     bb27: {
-        _40 = is_type(copy _4, baml.iter.StepBy<testing.TestRegistration, void>);
-        branch copy _40 -> [bb43, bb28];
+        _43 = is_type(copy _40, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
+        branch copy _43 -> [bb47, bb28];
     }
 
     bb28: {
-        _43 = is_type(copy _4, baml.iter.Chain<testing.TestRegistration, void, void>);
-        branch copy _43 -> [bb42, bb29];
+        _45 = is_type(copy _40, baml.iter.ArrayIterator<testing.TestSetRegistration>);
+        branch copy _45 -> [bb46, bb29];
     }
 
     bb29: {
-        _47 = is_type(copy _4, baml.iter.Repeat<testing.TestRegistration>);
-        branch copy _47 -> [bb41, bb30];
+        _47 = is_type(copy _40, baml.iter.StepBy<testing.TestSetRegistration, void>);
+        branch copy _47 -> [bb45, bb30];
     }
 
     bb30: {
-        _49 = is_type(copy _4, baml.iter.Map<_, testing.TestRegistration, void, void>);
-        branch copy _49 -> [bb40, bb31];
+        _50 = is_type(copy _40, baml.iter.Chain<testing.TestSetRegistration, void, void>);
+        branch copy _50 -> [bb44, bb31];
     }
 
     bb31: {
-        _51 = is_type(copy _4, baml.iter.Filter<testing.TestRegistration, void, void>);
-        branch copy _51 -> [bb39, bb32];
+        _54 = is_type(copy _40, baml.iter.Repeat<testing.TestSetRegistration>);
+        branch copy _54 -> [bb43, bb32];
     }
 
     bb32: {
-        _55 = is_type(copy _4, baml.iter.FilterMap<_, testing.TestRegistration, void, void>);
-        branch copy _55 -> [bb38, bb33];
+        _56 = is_type(copy _40, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
+        branch copy _56 -> [bb42, bb33];
     }
 
     bb33: {
-        _57 = is_type(copy _4, baml.iter.FlatMap<_, testing.TestRegistration, void, void, void>);
-        branch copy _57 -> [bb37, bb34];
+        _58 = is_type(copy _40, baml.iter.Filter<testing.TestSetRegistration, void, void>);
+        branch copy _58 -> [bb41, bb34];
     }
 
     bb34: {
-        _59 = is_type(copy _4, baml.iter.Peekable<testing.TestRegistration, void>);
-        branch copy _59 -> [bb36, bb35];
+        _62 = is_type(copy _40, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
+        branch copy _62 -> [bb40, bb35];
     }
 
     bb35: {
-        unreachable;
+        _64 = is_type(copy _40, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
+        branch copy _64 -> [bb39, bb36];
     }
 
     bb36: {
-        _60 = load_type(testing.TestRegistration);
-        _61 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _60, copy _61>(copy _4) -> [bb46];
+        _66 = is_type(copy _40, baml.iter.Peekable<testing.TestSetRegistration, void>);
+        branch copy _66 -> [bb38, bb37];
     }
 
     bb37: {
-        _58 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
-        _35 = call copy _58() -> [bb46];
+        unreachable;
     }
 
     bb38: {
-        _56 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
-        _35 = call copy _56() -> [bb46];
+        _67 = load_type(testing.TestSetRegistration);
+        _68 = load_type(void);
+        _42 = call const fn baml.iter.Peekable.Iterator.next<copy _67, copy _68>(copy _40) -> [bb48];
     }
 
     bb39: {
-        _52 = load_type(testing.TestRegistration);
-        _53 = load_type(void);
-        _54 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _52, copy _53, copy _54>(copy _4) -> [bb46];
+        _65 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _40);
+        _42 = call copy _65() -> [bb48];
     }
 
     bb40: {
-        _50 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
-        _35 = call copy _50() -> [bb46];
+        _63 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _40);
+        _42 = call copy _63() -> [bb48];
     }
 
     bb41: {
-        _48 = load_type(testing.TestRegistration);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _48>(copy _4) -> [bb46];
+        _59 = load_type(testing.TestSetRegistration);
+        _60 = load_type(void);
+        _61 = load_type(void);
+        _42 = call const fn baml.iter.Filter.Iterator.next<copy _59, copy _60, copy _61>(copy _40) -> [bb48];
     }
 
     bb42: {
-        _44 = load_type(testing.TestRegistration);
-        _45 = load_type(void);
-        _46 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _44, copy _45, copy _46>(copy _4) -> [bb46];
+        _57 = make_bound_method baml.iter.Map.Iterator.next(copy _40);
+        _42 = call copy _57() -> [bb48];
     }
 
     bb43: {
-        _41 = load_type(testing.TestRegistration);
-        _42 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _41, copy _42>(copy _4) -> [bb46];
+        _55 = load_type(testing.TestSetRegistration);
+        _42 = call const fn baml.iter.Repeat.Iterator.next<copy _55>(copy _40) -> [bb48];
     }
 
     bb44: {
-        _39 = load_type(testing.TestRegistration);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _39>(copy _4) -> [bb46];
+        _51 = load_type(testing.TestSetRegistration);
+        _52 = load_type(void);
+        _53 = load_type(void);
+        _42 = call const fn baml.iter.Chain.Iterator.next<copy _51, copy _52, copy _53>(copy _40) -> [bb48];
     }
 
     bb45: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
-        _35 = call copy _37() -> [bb46];
+        _48 = load_type(testing.TestSetRegistration);
+        _49 = load_type(void);
+        _42 = call const fn baml.iter.StepBy.Iterator.next<copy _48, copy _49>(copy _40) -> [bb48];
     }
 
     bb46: {
-        _62 = is_type(copy _35, baml.iter.Done);
-        branch copy _62 -> [bb48, bb47];
+        _46 = load_type(testing.TestSetRegistration);
+        _42 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _46>(copy _40) -> [bb48];
     }
 
     bb47: {
-        _63 = copy _35;
-        fresh_cell(_64);
-        _64 = copy _63;
-        _67 = copy _64.0;
-        _66 = testing.SerializedTest { const "test", copy _67 };
-        _65 = call const fn baml.Array.push(copy _2, copy _66) -> [bb25];
+        _44 = make_bound_method baml.iter.Flatten.Iterator.next(copy _40);
+        _42 = call copy _44() -> [bb48];
     }
 
     bb48: {
-        _68 = copy _1.0.2;
-        _70 = is_type(copy _68, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
-        branch copy _70 -> [bb72, bb49];
+        _69 = is_type(copy _42, baml.iter.Done);
+        branch copy _69 -> [bb54, bb49];
     }
 
     bb49: {
-        _72 = is_type(copy _68, baml.iter.ArrayIterator<testing.TestSetRegistration>);
-        branch copy _72 -> [bb71, bb50];
+        _70 = copy _42;
+        fresh_cell(_71);
+        _71 = copy _70;
+        _74 = copy _1.1;
+        _75 = copy _71.0;
+        _76 = load_type(string);
+        _77 = load_type(testing.TestRegistry);
+        _73 = call const fn baml.Map.get<copy _76, copy _77>(copy _74, copy _75) -> [bb50];
     }
 
     bb50: {
-        _74 = is_type(copy _68, baml.iter.StepBy<testing.TestSetRegistration, void>);
-        branch copy _74 -> [bb70, bb51];
+        _78 = is_type(copy _73, testing.TestRegistry);
+        branch copy _78 -> [bb52, bb51];
     }
 
     bb51: {
-        _77 = is_type(copy _68, baml.iter.Chain<testing.TestSetRegistration, void, void>);
-        branch copy _77 -> [bb69, bb52];
+        _85 = copy _71.0;
+        _84 = testing.SerializedTest { const "lazyTestSet", copy _85 };
+        _72 = call const fn baml.Array.push(copy _2, copy _84) -> [bb27];
     }
 
     bb52: {
-        _81 = is_type(copy _68, baml.iter.Repeat<testing.TestSetRegistration>);
-        branch copy _81 -> [bb68, bb53];
+        _79 = copy _73;
+        _81 = copy _71.0;
+        _82 = call const fn testing.TestRegistry.serialize(copy _79) -> [bb53];
     }
 
     bb53: {
-        _83 = is_type(copy _68, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
-        branch copy _83 -> [bb67, bb54];
+        _83 = copy _79.2;
+        _80 = testing.SerializedTestSet { copy _81, copy _82, copy _83 };
+        _72 = call const fn baml.Array.push(copy _2, copy _80) -> [bb27];
     }
 
     bb54: {
-        _85 = is_type(copy _68, baml.iter.Filter<testing.TestSetRegistration, void, void>);
-        branch copy _85 -> [bb66, bb55];
+        _0 = copy _2;
+        goto -> bb55;
     }
 
     bb55: {
-        _89 = is_type(copy _68, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
-        branch copy _89 -> [bb65, bb56];
-    }
-
-    bb56: {
-        _91 = is_type(copy _68, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
-        branch copy _91 -> [bb64, bb57];
-    }
-
-    bb57: {
-        _93 = is_type(copy _68, baml.iter.Peekable<testing.TestSetRegistration, void>);
-        branch copy _93 -> [bb63, bb58];
-    }
-
-    bb58: {
-        _96 = is_type(copy _68, unknown[]);
-        branch copy _96 -> [bb62, bb59];
-    }
-
-    bb59: {
-        _98 = is_type(copy _68, testing.TestSetRegistration[]);
-        branch copy _98 -> [bb61, bb60];
-    }
-
-    bb60: {
-        unreachable;
-    }
-
-    bb61: {
-        _99 = load_type(testing.TestSetRegistration);
-        _69 = call const fn baml.iter.Iterable$for$T[].iter<copy _99>(copy _68) -> [bb73];
-    }
-
-    bb62: {
-        _97 = load_type(testing.TestSetRegistration);
-        _69 = call const fn baml.iter.Iterable$for$T[].iter<copy _97>(copy _68) -> [bb73];
-    }
-
-    bb63: {
-        _94 = load_type(testing.TestSetRegistration);
-        _95 = load_type(void);
-        _69 = call const fn baml.iter.Peekable.Iterable.iter<copy _94, copy _95>(copy _68) -> [bb73];
-    }
-
-    bb64: {
-        _92 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _68);
-        _69 = call copy _92() -> [bb73];
-    }
-
-    bb65: {
-        _90 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _68);
-        _69 = call copy _90() -> [bb73];
-    }
-
-    bb66: {
-        _86 = load_type(testing.TestSetRegistration);
-        _87 = load_type(void);
-        _88 = load_type(void);
-        _69 = call const fn baml.iter.Filter.Iterable.iter<copy _86, copy _87, copy _88>(copy _68) -> [bb73];
-    }
-
-    bb67: {
-        _84 = make_bound_method baml.iter.Map.Iterable.iter(copy _68);
-        _69 = call copy _84() -> [bb73];
-    }
-
-    bb68: {
-        _82 = load_type(testing.TestSetRegistration);
-        _69 = call const fn baml.iter.Repeat.Iterable.iter<copy _82>(copy _68) -> [bb73];
-    }
-
-    bb69: {
-        _78 = load_type(testing.TestSetRegistration);
-        _79 = load_type(void);
-        _80 = load_type(void);
-        _69 = call const fn baml.iter.Chain.Iterable.iter<copy _78, copy _79, copy _80>(copy _68) -> [bb73];
-    }
-
-    bb70: {
-        _75 = load_type(testing.TestSetRegistration);
-        _76 = load_type(void);
-        _69 = call const fn baml.iter.StepBy.Iterable.iter<copy _75, copy _76>(copy _68) -> [bb73];
-    }
-
-    bb71: {
-        _73 = load_type(testing.TestSetRegistration);
-        _69 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _73>(copy _68) -> [bb73];
-    }
-
-    bb72: {
-        _71 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _68);
-        _69 = call copy _71() -> [bb73];
-    }
-
-    bb73: {
-        _101 = is_type(copy _69, baml.iter.Flatten<_, testing.TestSetRegistration, void, void>);
-        branch copy _101 -> [bb93, bb74];
-    }
-
-    bb74: {
-        _103 = is_type(copy _69, baml.iter.ArrayIterator<testing.TestSetRegistration>);
-        branch copy _103 -> [bb92, bb75];
-    }
-
-    bb75: {
-        _105 = is_type(copy _69, baml.iter.StepBy<testing.TestSetRegistration, void>);
-        branch copy _105 -> [bb91, bb76];
-    }
-
-    bb76: {
-        _108 = is_type(copy _69, baml.iter.Chain<testing.TestSetRegistration, void, void>);
-        branch copy _108 -> [bb90, bb77];
-    }
-
-    bb77: {
-        _112 = is_type(copy _69, baml.iter.Repeat<testing.TestSetRegistration>);
-        branch copy _112 -> [bb89, bb78];
-    }
-
-    bb78: {
-        _114 = is_type(copy _69, baml.iter.Map<_, testing.TestSetRegistration, void, void>);
-        branch copy _114 -> [bb88, bb79];
-    }
-
-    bb79: {
-        _116 = is_type(copy _69, baml.iter.Filter<testing.TestSetRegistration, void, void>);
-        branch copy _116 -> [bb87, bb80];
-    }
-
-    bb80: {
-        _120 = is_type(copy _69, baml.iter.FilterMap<_, testing.TestSetRegistration, void, void>);
-        branch copy _120 -> [bb86, bb81];
-    }
-
-    bb81: {
-        _122 = is_type(copy _69, baml.iter.FlatMap<_, testing.TestSetRegistration, void, void, void>);
-        branch copy _122 -> [bb85, bb82];
-    }
-
-    bb82: {
-        _124 = is_type(copy _69, baml.iter.Peekable<testing.TestSetRegistration, void>);
-        branch copy _124 -> [bb84, bb83];
-    }
-
-    bb83: {
-        unreachable;
-    }
-
-    bb84: {
-        _125 = load_type(testing.TestSetRegistration);
-        _126 = load_type(void);
-        _100 = call const fn baml.iter.Peekable.Iterator.next<copy _125, copy _126>(copy _69) -> [bb94];
-    }
-
-    bb85: {
-        _123 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _69);
-        _100 = call copy _123() -> [bb94];
-    }
-
-    bb86: {
-        _121 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _69);
-        _100 = call copy _121() -> [bb94];
-    }
-
-    bb87: {
-        _117 = load_type(testing.TestSetRegistration);
-        _118 = load_type(void);
-        _119 = load_type(void);
-        _100 = call const fn baml.iter.Filter.Iterator.next<copy _117, copy _118, copy _119>(copy _69) -> [bb94];
-    }
-
-    bb88: {
-        _115 = make_bound_method baml.iter.Map.Iterator.next(copy _69);
-        _100 = call copy _115() -> [bb94];
-    }
-
-    bb89: {
-        _113 = load_type(testing.TestSetRegistration);
-        _100 = call const fn baml.iter.Repeat.Iterator.next<copy _113>(copy _69) -> [bb94];
-    }
-
-    bb90: {
-        _109 = load_type(testing.TestSetRegistration);
-        _110 = load_type(void);
-        _111 = load_type(void);
-        _100 = call const fn baml.iter.Chain.Iterator.next<copy _109, copy _110, copy _111>(copy _69) -> [bb94];
-    }
-
-    bb91: {
-        _106 = load_type(testing.TestSetRegistration);
-        _107 = load_type(void);
-        _100 = call const fn baml.iter.StepBy.Iterator.next<copy _106, copy _107>(copy _69) -> [bb94];
-    }
-
-    bb92: {
-        _104 = load_type(testing.TestSetRegistration);
-        _100 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _104>(copy _69) -> [bb94];
-    }
-
-    bb93: {
-        _102 = make_bound_method baml.iter.Flatten.Iterator.next(copy _69);
-        _100 = call copy _102() -> [bb94];
-    }
-
-    bb94: {
-        _127 = is_type(copy _100, baml.iter.Done);
-        branch copy _127 -> [bb100, bb95];
-    }
-
-    bb95: {
-        _128 = copy _100;
-        fresh_cell(_129);
-        _129 = copy _128;
-        _132 = copy _1.1;
-        _133 = copy _129.0;
-        _134 = load_type(string);
-        _135 = load_type(testing.TestRegistry);
-        _131 = call const fn baml.Map.get<copy _134, copy _135>(copy _132, copy _133) -> [bb96];
-    }
-
-    bb96: {
-        _136 = is_type(copy _131, testing.TestRegistry);
-        branch copy _136 -> [bb98, bb97];
-    }
-
-    bb97: {
-        _143 = copy _129.0;
-        _142 = testing.SerializedTest { const "lazyTestSet", copy _143 };
-        _130 = call const fn baml.Array.push(copy _2, copy _142) -> [bb73];
-    }
-
-    bb98: {
-        _137 = copy _131;
-        _139 = copy _129.0;
-        _140 = call const fn testing.TestRegistry.serialize(copy _137) -> [bb99];
-    }
-
-    bb99: {
-        _141 = copy _137.2;
-        _138 = testing.SerializedTestSet { copy _139, copy _140, copy _141 };
-        _130 = call const fn baml.Array.push(copy _2, copy _138) -> [bb73];
-    }
-
-    bb100: {
-        _0 = copy _2;
-        goto -> bb101;
-    }
-
-    bb101: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
@@ -120,318 +120,167 @@ function testing.SerializedTestSet.to_json(self: testing.SerializedTestSet) -> b
 function testing.TestCollector.find_testset(self: testing.TestCollector, name: string) -> testing.TestSetRegistration {
     load_var self
     load_field .testsets
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _3
+    load_type testing.TestSetRegistration
+    load_var _3
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _3
-    is_type testing.TestSetRegistration[]
-    pop_jump_if_false L44
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L11:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L12:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
-
-  L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L15:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
-
-  L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L17:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
-
-  L18:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
-
-  L19:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
-
-  L20:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
-
-  L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L22:
     load_var _4
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _4
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _4
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _4
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _4
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _4
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _4
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _4
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _4
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _4
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type testing.TestSetRegistration
     load_type void
     load_var _4
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L32:
+  L10:
     load_var _4
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L33:
+  L11:
     load_var _4
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L34:
+  L12:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _4
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L35:
+  L13:
     load_var _4
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L36:
+  L14:
     load_type testing.TestSetRegistration
     load_var _4
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L37:
+  L15:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L38:
+  L16:
     load_type testing.TestSetRegistration
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L39:
+  L17:
     load_type testing.TestSetRegistration
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L40:
+  L18:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _6
 
-  L41:
-    load_var _35
+  L19:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _35
+  L20:
+    load_var _6
     store_var_load_var ts
     load_field .name
     load_var name
     cmp_op ==
-    pop_jump_if_false L22
+    pop_jump_if_false L0
     load_var ts
     return
 
-  L43:
+  L21:
     load_const "TestSet not found: "
     load_var name
     bin_op +
     throw
 
-  L44:
+  L22:
     unreachable
 }
 
@@ -500,353 +349,202 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     store_var hash_prefix
     load_var self
     load_field .tests
-    store_var_load_var _13
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L3
-    jump L24
+    store_var _13
+    load_type testing.TestRegistration
+    load_var _13
+    call baml.iter.Iterable$for$T[].iter
+    store_var _14
 
   L3:
-    load_var _13
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L4
-    jump L23
-
-  L4:
-    load_var _13
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L5
-    jump L22
-
-  L5:
-    load_var _13
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L6
-    jump L21
-
-  L6:
-    load_var _13
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L7
-    jump L20
-
-  L7:
-    load_var _13
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L8
-    jump L19
-
-  L8:
-    load_var _13
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L9
-    jump L18
-
-  L9:
-    load_var _13
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L10
-    jump L17
-
-  L10:
-    load_var _13
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L11
-    jump L16
-
-  L11:
-    load_var _13
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L12
-    jump L15
-
-  L12:
-    load_var _13
-    is_type unknown[]
-    pop_jump_if_false L13
-    jump L14
-
-  L13:
-    load_var _13
-    is_type testing.TestRegistration[]
-    pop_jump_if_false L52
-    load_type testing.TestRegistration
-    load_var _13
-    call baml.iter.Iterable$for$T[].iter
-    store_var _14
-    jump L25
-
-  L14:
-    load_type testing.TestRegistration
-    load_var _13
-    call baml.iter.Iterable$for$T[].iter
-    store_var _14
-    jump L25
-
-  L15:
-    load_type testing.TestRegistration
-    load_type void
-    load_var _13
-    call baml.iter.Peekable.Iterable.iter
-    store_var _14
-    jump L25
-
-  L16:
-    load_var _13
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L17:
-    load_var _13
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L18:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _13
-    call baml.iter.Filter.Iterable.iter
-    store_var _14
-    jump L25
-
-  L19:
-    load_var _13
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L20:
-    load_type testing.TestRegistration
-    load_var _13
-    call baml.iter.Repeat.Iterable.iter
-    store_var _14
-    jump L25
-
-  L21:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _13
-    call baml.iter.Chain.Iterable.iter
-    store_var _14
-    jump L25
-
-  L22:
-    load_type testing.TestRegistration
-    load_type void
-    load_var _13
-    call baml.iter.StepBy.Iterable.iter
-    store_var _14
-    jump L25
-
-  L23:
-    load_type testing.TestRegistration
-    load_var _13
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _14
-    jump L25
-
-  L24:
-    load_var _13
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _14
-
-  L25:
     load_var _14
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L4
+    jump L21
 
-  L26:
+  L4:
     load_var _14
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L5
+    jump L20
 
-  L27:
+  L5:
     load_var _14
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L6
+    jump L19
 
-  L28:
+  L6:
     load_var _14
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L7
+    jump L18
 
-  L29:
+  L7:
     load_var _14
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L8
+    jump L17
 
-  L30:
+  L8:
     load_var _14
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L9
+    jump L16
 
-  L31:
+  L9:
     load_var _14
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L10
+    jump L15
 
-  L32:
+  L10:
     load_var _14
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L11
+    jump L14
 
-  L33:
+  L11:
     load_var _14
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L12
+    jump L13
 
-  L34:
+  L12:
     load_var _14
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L52
+    pop_jump_if_false L30
     load_type testing.TestRegistration
     load_type void
     load_var _14
     call baml.iter.Peekable.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L35:
+  L13:
     load_var _14
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L36:
+  L14:
     load_var _14
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L37:
+  L15:
     load_type testing.TestRegistration
     load_type void
     load_type void
     load_var _14
     call baml.iter.Filter.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L38:
+  L16:
     load_var _14
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L39:
+  L17:
     load_type testing.TestRegistration
     load_var _14
     call baml.iter.Repeat.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L40:
+  L18:
     load_type testing.TestRegistration
     load_type void
     load_type void
     load_var _14
     call baml.iter.Chain.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L41:
+  L19:
     load_type testing.TestRegistration
     load_type void
     load_var _14
     call baml.iter.StepBy.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L42:
+  L20:
     load_type testing.TestRegistration
     load_var _14
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L43:
+  L21:
     load_var _14
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _45
+    store_var _16
 
-  L44:
-    load_var _45
+  L22:
+    load_var _16
     is_type baml.iter.Done
-    pop_jump_if_false L45
-    jump L48
+    pop_jump_if_false L23
+    jump L26
 
-  L45:
-    load_var _45
+  L23:
+    load_var _16
     store_var_load_var t
     load_field .name
     load_var full_name
     cmp_op ==
-    jump_if_false L46
-    jump L47
+    jump_if_false L24
+    jump L25
 
-  L46:
+  L24:
     pop 1
     load_var t
     load_field .name
     load_var hash_prefix
     call baml.String.starts_with
 
-  L47:
-    pop_jump_if_false L25
+  L25:
+    pop_jump_if_false L3
     load_var count
     load_const 1
     add_int
     store_var count
-    jump L25
+    jump L3
 
-  L48:
+  L26:
     load_var count
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L49
-    jump L50
+    pop_jump_if_false L27
+    jump L28
 
-  L49:
+  L27:
     load_var full_name
     store_var final_name
-    jump L51
+    jump L29
 
-  L50:
+  L28:
     load_var full_name
     load_const "#"
     bin_op +
-    store_var _84
+    store_var _55
     load_type int
     load_var count
     load_const 1
     add_int
     call baml.unstable.string
-    store_var _86
+    store_var _57
     load_var2 13 14
     bin_op +
     store_var final_name
 
-  L51:
+  L29:
     load_type testing.TestRegistration
     load_var self
     load_field .tests
@@ -858,7 +556,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     load_const null
     return
 
-  L52:
+  L30:
     unreachable
 }
 
@@ -893,353 +591,202 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     store_var hash_prefix
     load_var self
     load_field .testsets
-    store_var_load_var _13
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L3
-    jump L24
+    store_var _13
+    load_type testing.TestSetRegistration
+    load_var _13
+    call baml.iter.Iterable$for$T[].iter
+    store_var _14
 
   L3:
-    load_var _13
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L4
-    jump L23
-
-  L4:
-    load_var _13
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L5
-    jump L22
-
-  L5:
-    load_var _13
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L6
-    jump L21
-
-  L6:
-    load_var _13
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L7
-    jump L20
-
-  L7:
-    load_var _13
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L8
-    jump L19
-
-  L8:
-    load_var _13
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L9
-    jump L18
-
-  L9:
-    load_var _13
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L10
-    jump L17
-
-  L10:
-    load_var _13
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L11
-    jump L16
-
-  L11:
-    load_var _13
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L12
-    jump L15
-
-  L12:
-    load_var _13
-    is_type unknown[]
-    pop_jump_if_false L13
-    jump L14
-
-  L13:
-    load_var _13
-    is_type testing.TestSetRegistration[]
-    pop_jump_if_false L52
-    load_type testing.TestSetRegistration
-    load_var _13
-    call baml.iter.Iterable$for$T[].iter
-    store_var _14
-    jump L25
-
-  L14:
-    load_type testing.TestSetRegistration
-    load_var _13
-    call baml.iter.Iterable$for$T[].iter
-    store_var _14
-    jump L25
-
-  L15:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _13
-    call baml.iter.Peekable.Iterable.iter
-    store_var _14
-    jump L25
-
-  L16:
-    load_var _13
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L17:
-    load_var _13
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L18:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _13
-    call baml.iter.Filter.Iterable.iter
-    store_var _14
-    jump L25
-
-  L19:
-    load_var _13
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L20:
-    load_type testing.TestSetRegistration
-    load_var _13
-    call baml.iter.Repeat.Iterable.iter
-    store_var _14
-    jump L25
-
-  L21:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _13
-    call baml.iter.Chain.Iterable.iter
-    store_var _14
-    jump L25
-
-  L22:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _13
-    call baml.iter.StepBy.Iterable.iter
-    store_var _14
-    jump L25
-
-  L23:
-    load_type testing.TestSetRegistration
-    load_var _13
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _14
-    jump L25
-
-  L24:
-    load_var _13
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _14
-
-  L25:
     load_var _14
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L4
+    jump L21
 
-  L26:
+  L4:
     load_var _14
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L5
+    jump L20
 
-  L27:
+  L5:
     load_var _14
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L6
+    jump L19
 
-  L28:
+  L6:
     load_var _14
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L7
+    jump L18
 
-  L29:
+  L7:
     load_var _14
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L8
+    jump L17
 
-  L30:
+  L8:
     load_var _14
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L9
+    jump L16
 
-  L31:
+  L9:
     load_var _14
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L10
+    jump L15
 
-  L32:
+  L10:
     load_var _14
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L11
+    jump L14
 
-  L33:
+  L11:
     load_var _14
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L12
+    jump L13
 
-  L34:
+  L12:
     load_var _14
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L52
+    pop_jump_if_false L30
     load_type testing.TestSetRegistration
     load_type void
     load_var _14
     call baml.iter.Peekable.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L35:
+  L13:
     load_var _14
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L36:
+  L14:
     load_var _14
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L37:
+  L15:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _14
     call baml.iter.Filter.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L38:
+  L16:
     load_var _14
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L39:
+  L17:
     load_type testing.TestSetRegistration
     load_var _14
     call baml.iter.Repeat.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L40:
+  L18:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _14
     call baml.iter.Chain.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L41:
+  L19:
     load_type testing.TestSetRegistration
     load_type void
     load_var _14
     call baml.iter.StepBy.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L42:
+  L20:
     load_type testing.TestSetRegistration
     load_var _14
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L43:
+  L21:
     load_var _14
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _45
+    store_var _16
 
-  L44:
-    load_var _45
+  L22:
+    load_var _16
     is_type baml.iter.Done
-    pop_jump_if_false L45
-    jump L48
+    pop_jump_if_false L23
+    jump L26
 
-  L45:
-    load_var _45
+  L23:
+    load_var _16
     store_var_load_var ts
     load_field .name
     load_var full_name
     cmp_op ==
-    jump_if_false L46
-    jump L47
+    jump_if_false L24
+    jump L25
 
-  L46:
+  L24:
     pop 1
     load_var ts
     load_field .name
     load_var hash_prefix
     call baml.String.starts_with
 
-  L47:
-    pop_jump_if_false L25
+  L25:
+    pop_jump_if_false L3
     load_var count
     load_const 1
     add_int
     store_var count
-    jump L25
+    jump L3
 
-  L48:
+  L26:
     load_var count
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L49
-    jump L50
+    pop_jump_if_false L27
+    jump L28
 
-  L49:
+  L27:
     load_var full_name
     store_var final_name
-    jump L51
+    jump L29
 
-  L50:
+  L28:
     load_var full_name
     load_const "#"
     bin_op +
-    store_var _84
+    store_var _55
     load_type int
     load_var count
     load_const 1
     add_int
     call baml.unstable.string
-    store_var _86
+    store_var _57
     load_var2 13 14
     bin_op +
     store_var final_name
 
-  L51:
+  L29:
     load_type testing.TestSetRegistration
     load_var self
     load_field .testsets
@@ -1251,7 +798,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     load_const null
     return
 
-  L52:
+  L30:
     unreachable
 }
 
@@ -1312,308 +859,157 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_var self
     load_field .collector
     load_field .testsets
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _3
+    load_type testing.TestSetRegistration
+    load_var _3
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _3
-    is_type testing.TestSetRegistration[]
-    pop_jump_if_false L89
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L11:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L12:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
-
-  L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L15:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
-
-  L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L17:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
-
-  L18:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
-
-  L19:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
-
-  L20:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
-
-  L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L22:
     load_var _4
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _4
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _4
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _4
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _4
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _4
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _4
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _4
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _4
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _4
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L89
+    pop_jump_if_false L45
     load_type testing.TestSetRegistration
     load_type void
     load_var _4
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L32:
+  L10:
     load_var _4
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L33:
+  L11:
     load_var _4
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L34:
+  L12:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _4
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L35:
+  L13:
     load_var _4
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L36:
+  L14:
     load_type testing.TestSetRegistration
     load_var _4
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L37:
+  L15:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L38:
+  L16:
     load_type testing.TestSetRegistration
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L39:
+  L17:
     load_type testing.TestSetRegistration
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L40:
+  L18:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _6
 
-  L41:
-    load_var _35
+  L19:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _35
+  L20:
+    load_var _6
     store_var_load_var ts
     load_field .name
     load_var name
     cmp_op ==
-    pop_jump_if_false L22
+    pop_jump_if_false L0
     call baml.sys.now_ms
     store_var start
     load_var name
@@ -1626,7 +1022,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     call_indirect
     pop 1
     call baml.sys.now_ms
-    store_var _75
+    store_var _46
     load_type string
     load_type testing.TestRegistry
     load_var self
@@ -1640,312 +1036,160 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     pop 1
     load_var self
     call testing.TestRegistry.serialize
-    jump L87
+    jump L43
 
-  L43:
+  L21:
     load_type string
     load_type testing.TestRegistry
     load_var self
     load_field .expansions
     call baml.Map.keys
-    store_var _86
-    load_var _86
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L44
-    jump L65
+    store_var _57
+    load_type string
+    load_var _57
+    call baml.iter.Iterable$for$T[].iter
+    store_var _61
 
-  L44:
-    load_var _86
+  L22:
+    load_var _61
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L23
+    jump L40
+
+  L23:
+    load_var _61
     is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L24
+    jump L39
+
+  L24:
+    load_var _61
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L25
+    jump L38
+
+  L25:
+    load_var _61
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L26
+    jump L37
+
+  L26:
+    load_var _61
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L27
+    jump L36
+
+  L27:
+    load_var _61
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L28
+    jump L35
+
+  L28:
+    load_var _61
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L29
+    jump L34
+
+  L29:
+    load_var _61
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L30
+    jump L33
+
+  L30:
+    load_var _61
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L31
+    jump L32
+
+  L31:
+    load_var _61
+    is_type baml.iter.Peekable<...>
     pop_jump_if_false L45
-    jump L64
-
-  L45:
-    load_var _86
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L46
-    jump L63
-
-  L46:
-    load_var _86
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L47
-    jump L62
-
-  L47:
-    load_var _86
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L48
-    jump L61
-
-  L48:
-    load_var _86
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L49
-    jump L60
-
-  L49:
-    load_var _86
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L50
-    jump L59
-
-  L50:
-    load_var _86
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L51
-    jump L58
-
-  L51:
-    load_var _86
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L52
-    jump L57
-
-  L52:
-    load_var _86
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L53
-    jump L56
-
-  L53:
-    load_var _86
-    is_type unknown[]
-    pop_jump_if_false L54
-    jump L55
-
-  L54:
-    load_var _86
-    is_type string[]
-    pop_jump_if_false L89
-    load_type string
-    load_var _86
-    call baml.iter.Iterable$for$T[].iter
-    store_var _90
-    jump L66
-
-  L55:
-    load_type string
-    load_var _86
-    call baml.iter.Iterable$for$T[].iter
-    store_var _90
-    jump L66
-
-  L56:
     load_type string
     load_type void
-    load_var _86
-    call baml.iter.Peekable.Iterable.iter
-    store_var _90
-    jump L66
-
-  L57:
-    load_var _86
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _90
-    jump L66
-
-  L58:
-    load_var _86
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _90
-    jump L66
-
-  L59:
-    load_type string
-    load_type void
-    load_type void
-    load_var _86
-    call baml.iter.Filter.Iterable.iter
-    store_var _90
-    jump L66
-
-  L60:
-    load_var _86
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _90
-    jump L66
-
-  L61:
-    load_type string
-    load_var _86
-    call baml.iter.Repeat.Iterable.iter
-    store_var _90
-    jump L66
-
-  L62:
-    load_type string
-    load_type void
-    load_type void
-    load_var _86
-    call baml.iter.Chain.Iterable.iter
-    store_var _90
-    jump L66
-
-  L63:
-    load_type string
-    load_type void
-    load_var _86
-    call baml.iter.StepBy.Iterable.iter
-    store_var _90
-    jump L66
-
-  L64:
-    load_type string
-    load_var _86
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _90
-    jump L66
-
-  L65:
-    load_var _86
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _90
-
-  L66:
-    load_var _90
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L67
-    jump L84
-
-  L67:
-    load_var _90
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L68
-    jump L83
-
-  L68:
-    load_var _90
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L69
-    jump L82
-
-  L69:
-    load_var _90
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L70
-    jump L81
-
-  L70:
-    load_var _90
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L71
-    jump L80
-
-  L71:
-    load_var _90
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L72
-    jump L79
-
-  L72:
-    load_var _90
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L73
-    jump L78
-
-  L73:
-    load_var _90
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L74
-    jump L77
-
-  L74:
-    load_var _90
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L75
-    jump L76
-
-  L75:
-    load_var _90
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L89
-    load_type string
-    load_type void
-    load_var _90
+    load_var _61
     call baml.iter.Peekable.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L76:
-    load_var _90
+  L32:
+    load_var _61
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L77:
-    load_var _90
+  L33:
+    load_var _61
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L78:
+  L34:
     load_type string
     load_type void
     load_type void
-    load_var _90
+    load_var _61
     call baml.iter.Filter.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L79:
-    load_var _90
+  L35:
+    load_var _61
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L80:
+  L36:
     load_type string
-    load_var _90
+    load_var _61
     call baml.iter.Repeat.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L81:
+  L37:
     load_type string
     load_type void
     load_type void
-    load_var _90
+    load_var _61
     call baml.iter.Chain.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L82:
+  L38:
     load_type string
     load_type void
-    load_var _90
+    load_var _61
     call baml.iter.StepBy.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L83:
+  L39:
     load_type string
-    load_var _90
+    load_var _61
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L84:
-    load_var _90
+  L40:
+    load_var _61
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _121
+    store_var _63
 
-  L85:
-    load_var _121
+  L41:
+    load_var _63
     is_type baml.iter.Done
-    pop_jump_if_false L86
-    jump L88
+    pop_jump_if_false L42
+    jump L44
 
-  L86:
-    load_var _121
+  L42:
+    load_var _63
     store_var k
     load_var self
     load_field .expansions
@@ -1956,20 +1200,20 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_const "/"
     bin_op +
     call baml.String.starts_with
-    pop_jump_if_false L66
+    pop_jump_if_false L22
     load_var2 14 2
     call testing.TestRegistry.expand_set
 
-  L87:
+  L43:
     return
 
-  L88:
+  L44:
     load_const "TestSet not found for expansion: "
     load_var name
     bin_op +
     throw
 
-  L89:
+  L45:
     unreachable
 }
 
@@ -2011,619 +1255,316 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var self
     load_field .collector
     load_field .tests
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _3
+    load_type testing.TestRegistration
+    load_var _3
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
+    load_var _4
+    is_type baml.iter.Flatten<...>
     pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
     jump L18
 
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
+  L1:
+    load_var _4
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L2
     jump L17
 
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
+  L2:
+    load_var _4
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L3
     jump L16
 
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
+  L3:
+    load_var _4
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L4
     jump L15
 
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
+  L4:
+    load_var _4
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L5
     jump L14
 
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
+  L5:
+    load_var _4
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L6
     jump L13
 
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
+  L6:
+    load_var _4
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L7
     jump L12
 
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
+  L7:
+    load_var _4
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L8
     jump L11
 
-  L10:
-    load_var _3
-    is_type testing.TestRegistration[]
-    pop_jump_if_false L89
+  L8:
+    load_var _4
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L9
+    jump L10
+
+  L9:
+    load_var _4
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L45
     load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
+    load_type void
+    load_var _4
+    call baml.iter.Peekable.Iterator.next
+    store_var _6
+    jump L19
+
+  L10:
+    load_var _4
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L19
 
   L11:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
+    load_var _4
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L19
 
   L12:
     load_type testing.TestRegistration
     load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
+    load_type void
+    load_var _4
+    call baml.iter.Filter.Iterator.next
+    store_var _6
+    jump L19
 
   L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
+    load_var _4
+    make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _4
-    jump L22
+    store_var _6
+    jump L19
 
   L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
+    load_type testing.TestRegistration
+    load_var _4
+    call baml.iter.Repeat.Iterator.next
+    store_var _6
+    jump L19
 
   L15:
     load_type testing.TestRegistration
     load_type void
     load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
-
-  L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L17:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
-
-  L18:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
-
-  L19:
-    load_type testing.TestRegistration
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
-
-  L20:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
-
-  L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L22:
-    load_var _4
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
-
-  L23:
-    load_var _4
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
-
-  L24:
-    load_var _4
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
-
-  L25:
-    load_var _4
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
-
-  L26:
-    load_var _4
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
-
-  L27:
-    load_var _4
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
-
-  L28:
-    load_var _4
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
-
-  L29:
-    load_var _4
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
-
-  L30:
-    load_var _4
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
-
-  L31:
-    load_var _4
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L89
-    load_type testing.TestRegistration
-    load_type void
-    load_var _4
-    call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L41
-
-  L32:
-    load_var _4
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _35
-    jump L41
-
-  L33:
-    load_var _4
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _35
-    jump L41
-
-  L34:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L41
-
-  L35:
-    load_var _4
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _35
-    jump L41
-
-  L36:
-    load_type testing.TestRegistration
-    load_var _4
-    call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L41
-
-  L37:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L38:
+  L16:
     load_type testing.TestRegistration
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L39:
+  L17:
     load_type testing.TestRegistration
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L40:
+  L18:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _6
 
-  L41:
-    load_var _35
+  L19:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _35
+  L20:
+    load_var _6
     store_var_load_var t
     load_field .name
     load_var name
     cmp_op ==
-    pop_jump_if_false L22
+    pop_jump_if_false L0
     load_var t
     load_field .body
     load_var t
     load_field .runner
     call testing.run_test
-    jump L87
+    jump L43
 
-  L43:
+  L21:
     load_type string
     load_type testing.TestRegistry
     load_var self
     load_field .expansions
     call baml.Map.keys
-    store_var _69
-    load_var _69
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L44
-    jump L65
+    store_var _40
+    load_type string
+    load_var _40
+    call baml.iter.Iterable$for$T[].iter
+    store_var _44
 
-  L44:
-    load_var _69
+  L22:
+    load_var _44
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L23
+    jump L40
+
+  L23:
+    load_var _44
     is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L24
+    jump L39
+
+  L24:
+    load_var _44
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L25
+    jump L38
+
+  L25:
+    load_var _44
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L26
+    jump L37
+
+  L26:
+    load_var _44
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L27
+    jump L36
+
+  L27:
+    load_var _44
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L28
+    jump L35
+
+  L28:
+    load_var _44
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L29
+    jump L34
+
+  L29:
+    load_var _44
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L30
+    jump L33
+
+  L30:
+    load_var _44
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L31
+    jump L32
+
+  L31:
+    load_var _44
+    is_type baml.iter.Peekable<...>
     pop_jump_if_false L45
-    jump L64
-
-  L45:
-    load_var _69
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L46
-    jump L63
-
-  L46:
-    load_var _69
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L47
-    jump L62
-
-  L47:
-    load_var _69
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L48
-    jump L61
-
-  L48:
-    load_var _69
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L49
-    jump L60
-
-  L49:
-    load_var _69
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L50
-    jump L59
-
-  L50:
-    load_var _69
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L51
-    jump L58
-
-  L51:
-    load_var _69
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L52
-    jump L57
-
-  L52:
-    load_var _69
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L53
-    jump L56
-
-  L53:
-    load_var _69
-    is_type unknown[]
-    pop_jump_if_false L54
-    jump L55
-
-  L54:
-    load_var _69
-    is_type string[]
-    pop_jump_if_false L89
-    load_type string
-    load_var _69
-    call baml.iter.Iterable$for$T[].iter
-    store_var _73
-    jump L66
-
-  L55:
-    load_type string
-    load_var _69
-    call baml.iter.Iterable$for$T[].iter
-    store_var _73
-    jump L66
-
-  L56:
     load_type string
     load_type void
-    load_var _69
-    call baml.iter.Peekable.Iterable.iter
-    store_var _73
-    jump L66
-
-  L57:
-    load_var _69
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _73
-    jump L66
-
-  L58:
-    load_var _69
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _73
-    jump L66
-
-  L59:
-    load_type string
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Filter.Iterable.iter
-    store_var _73
-    jump L66
-
-  L60:
-    load_var _69
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _73
-    jump L66
-
-  L61:
-    load_type string
-    load_var _69
-    call baml.iter.Repeat.Iterable.iter
-    store_var _73
-    jump L66
-
-  L62:
-    load_type string
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Chain.Iterable.iter
-    store_var _73
-    jump L66
-
-  L63:
-    load_type string
-    load_type void
-    load_var _69
-    call baml.iter.StepBy.Iterable.iter
-    store_var _73
-    jump L66
-
-  L64:
-    load_type string
-    load_var _69
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _73
-    jump L66
-
-  L65:
-    load_var _69
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _73
-
-  L66:
-    load_var _73
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L67
-    jump L84
-
-  L67:
-    load_var _73
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L68
-    jump L83
-
-  L68:
-    load_var _73
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L69
-    jump L82
-
-  L69:
-    load_var _73
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L70
-    jump L81
-
-  L70:
-    load_var _73
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L71
-    jump L80
-
-  L71:
-    load_var _73
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L72
-    jump L79
-
-  L72:
-    load_var _73
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L73
-    jump L78
-
-  L73:
-    load_var _73
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L74
-    jump L77
-
-  L74:
-    load_var _73
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L75
-    jump L76
-
-  L75:
-    load_var _73
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L89
-    load_type string
-    load_type void
-    load_var _73
+    load_var _44
     call baml.iter.Peekable.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L76:
-    load_var _73
+  L32:
+    load_var _44
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L77:
-    load_var _73
+  L33:
+    load_var _44
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L78:
+  L34:
     load_type string
     load_type void
     load_type void
-    load_var _73
+    load_var _44
     call baml.iter.Filter.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L79:
-    load_var _73
+  L35:
+    load_var _44
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L80:
+  L36:
     load_type string
-    load_var _73
+    load_var _44
     call baml.iter.Repeat.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L81:
+  L37:
     load_type string
     load_type void
     load_type void
-    load_var _73
+    load_var _44
     call baml.iter.Chain.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L82:
+  L38:
     load_type string
     load_type void
-    load_var _73
+    load_var _44
     call baml.iter.StepBy.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L83:
+  L39:
     load_type string
-    load_var _73
+    load_var _44
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L84:
-    load_var _73
+  L40:
+    load_var _44
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _104
+    store_var _46
 
-  L85:
-    load_var _104
+  L41:
+    load_var _46
     is_type baml.iter.Done
-    pop_jump_if_false L86
-    jump L88
+    pop_jump_if_false L42
+    jump L44
 
-  L86:
-    load_var _104
+  L42:
+    load_var _46
     store_var k
     load_var self
     load_field .expansions
@@ -2634,20 +1575,20 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_const "/"
     bin_op +
     call baml.String.starts_with
-    pop_jump_if_false L66
+    pop_jump_if_false L22
     load_var2 11 2
     call testing.TestRegistry.run_test
 
-  L87:
+  L43:
     return
 
-  L88:
+  L44:
     load_const "Test not found: "
     load_var name
     bin_op +
     throw
 
-  L89:
+  L45:
     unreachable
 }
 
@@ -2657,612 +1598,310 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     load_var self
     load_field .collector
     load_field .tests
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _3
+    load_type testing.TestRegistration
+    load_var _3
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
+    load_var _4
+    is_type baml.iter.Flatten<...>
     pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
     jump L18
 
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
+  L1:
+    load_var _4
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L2
     jump L17
 
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
+  L2:
+    load_var _4
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L3
     jump L16
 
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
+  L3:
+    load_var _4
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L4
     jump L15
 
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
+  L4:
+    load_var _4
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L5
     jump L14
 
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
+  L5:
+    load_var _4
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L6
     jump L13
 
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
+  L6:
+    load_var _4
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L7
     jump L12
 
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
+  L7:
+    load_var _4
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L8
     jump L11
 
-  L10:
-    load_var _3
-    is_type testing.TestRegistration[]
-    pop_jump_if_false L90
+  L8:
+    load_var _4
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L9
+    jump L10
+
+  L9:
+    load_var _4
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L46
     load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
+    load_type void
+    load_var _4
+    call baml.iter.Peekable.Iterator.next
+    store_var _6
+    jump L19
+
+  L10:
+    load_var _4
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L19
 
   L11:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
+    load_var _4
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L19
 
   L12:
     load_type testing.TestRegistration
     load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
+    load_type void
+    load_var _4
+    call baml.iter.Filter.Iterator.next
+    store_var _6
+    jump L19
 
   L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
+    load_var _4
+    make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _4
-    jump L22
+    store_var _6
+    jump L19
 
   L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
+    load_type testing.TestRegistration
+    load_var _4
+    call baml.iter.Repeat.Iterator.next
+    store_var _6
+    jump L19
 
   L15:
     load_type testing.TestRegistration
     load_type void
     load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
+    load_var _4
+    call baml.iter.Chain.Iterator.next
+    store_var _6
+    jump L19
 
   L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
+    load_type testing.TestRegistration
+    load_type void
+    load_var _4
+    call baml.iter.StepBy.Iterator.next
+    store_var _6
+    jump L19
 
   L17:
     load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
+    load_var _4
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _6
+    jump L19
 
   L18:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
+    load_var _4
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _6
 
   L19:
-    load_type testing.TestRegistration
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
+    load_var _6
+    is_type baml.iter.Done
+    pop_jump_if_false L20
+    jump L21
 
   L20:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
+    load_var items
+    load_const "test"
+    load_var _6
+    load_field .name
+    init_instance testing.SerializedTest .type, .name
+    call baml.Array.push
+    pop 1
+    jump L0
 
   L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
+    load_var self
+    load_field .collector
+    load_field .testsets
+    store_var _39
+    load_type testing.TestSetRegistration
+    load_var _39
+    call baml.iter.Iterable$for$T[].iter
+    store_var _40
 
   L22:
-    load_var _4
+    load_var _40
     is_type baml.iter.Flatten<...>
     pop_jump_if_false L23
     jump L40
 
   L23:
-    load_var _4
+    load_var _40
     is_type baml.iter.ArrayIterator<...>
     pop_jump_if_false L24
     jump L39
 
   L24:
-    load_var _4
+    load_var _40
     is_type baml.iter.StepBy<...>
     pop_jump_if_false L25
     jump L38
 
   L25:
-    load_var _4
+    load_var _40
     is_type baml.iter.Chain<...>
     pop_jump_if_false L26
     jump L37
 
   L26:
-    load_var _4
+    load_var _40
     is_type baml.iter.Repeat<...>
     pop_jump_if_false L27
     jump L36
 
   L27:
-    load_var _4
+    load_var _40
     is_type baml.iter.Map<...>
     pop_jump_if_false L28
     jump L35
 
   L28:
-    load_var _4
+    load_var _40
     is_type baml.iter.Filter<...>
     pop_jump_if_false L29
     jump L34
 
   L29:
-    load_var _4
+    load_var _40
     is_type baml.iter.FilterMap<...>
     pop_jump_if_false L30
     jump L33
 
   L30:
-    load_var _4
+    load_var _40
     is_type baml.iter.FlatMap<...>
     pop_jump_if_false L31
     jump L32
 
   L31:
-    load_var _4
+    load_var _40
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L90
-    load_type testing.TestRegistration
+    pop_jump_if_false L46
+    load_type testing.TestSetRegistration
     load_type void
-    load_var _4
+    load_var _40
     call baml.iter.Peekable.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L32:
-    load_var _4
+    load_var _40
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
+    store_var _42
     jump L41
 
   L33:
-    load_var _4
+    load_var _40
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
+    store_var _42
     jump L41
 
   L34:
-    load_type testing.TestRegistration
+    load_type testing.TestSetRegistration
     load_type void
     load_type void
-    load_var _4
+    load_var _40
     call baml.iter.Filter.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L35:
-    load_var _4
+    load_var _40
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
+    store_var _42
     jump L41
 
   L36:
-    load_type testing.TestRegistration
-    load_var _4
+    load_type testing.TestSetRegistration
+    load_var _40
     call baml.iter.Repeat.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L37:
-    load_type testing.TestRegistration
+    load_type testing.TestSetRegistration
     load_type void
     load_type void
-    load_var _4
+    load_var _40
     call baml.iter.Chain.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L38:
-    load_type testing.TestRegistration
+    load_type testing.TestSetRegistration
     load_type void
-    load_var _4
+    load_var _40
     call baml.iter.StepBy.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L39:
-    load_type testing.TestRegistration
-    load_var _4
+    load_type testing.TestSetRegistration
+    load_var _40
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L40:
-    load_var _4
+    load_var _40
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _42
 
   L41:
-    load_var _35
+    load_var _42
     is_type baml.iter.Done
     pop_jump_if_false L42
-    jump L43
+    jump L45
 
   L42:
-    load_var items
-    load_const "test"
-    load_var _35
-    load_field .name
-    init_instance testing.SerializedTest .type, .name
-    call baml.Array.push
-    pop 1
-    jump L22
-
-  L43:
-    load_var self
-    load_field .collector
-    load_field .testsets
-    store_var_load_var _68
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L44
-    jump L65
-
-  L44:
-    load_var _68
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L45
-    jump L64
-
-  L45:
-    load_var _68
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L46
-    jump L63
-
-  L46:
-    load_var _68
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L47
-    jump L62
-
-  L47:
-    load_var _68
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L48
-    jump L61
-
-  L48:
-    load_var _68
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L49
-    jump L60
-
-  L49:
-    load_var _68
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L50
-    jump L59
-
-  L50:
-    load_var _68
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L51
-    jump L58
-
-  L51:
-    load_var _68
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L52
-    jump L57
-
-  L52:
-    load_var _68
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L53
-    jump L56
-
-  L53:
-    load_var _68
-    is_type unknown[]
-    pop_jump_if_false L54
-    jump L55
-
-  L54:
-    load_var _68
-    is_type testing.TestSetRegistration[]
-    pop_jump_if_false L90
-    load_type testing.TestSetRegistration
-    load_var _68
-    call baml.iter.Iterable$for$T[].iter
-    store_var _69
-    jump L66
-
-  L55:
-    load_type testing.TestSetRegistration
-    load_var _68
-    call baml.iter.Iterable$for$T[].iter
-    store_var _69
-    jump L66
-
-  L56:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _68
-    call baml.iter.Peekable.Iterable.iter
-    store_var _69
-    jump L66
-
-  L57:
-    load_var _68
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _69
-    jump L66
-
-  L58:
-    load_var _68
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _69
-    jump L66
-
-  L59:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _68
-    call baml.iter.Filter.Iterable.iter
-    store_var _69
-    jump L66
-
-  L60:
-    load_var _68
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _69
-    jump L66
-
-  L61:
-    load_type testing.TestSetRegistration
-    load_var _68
-    call baml.iter.Repeat.Iterable.iter
-    store_var _69
-    jump L66
-
-  L62:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _68
-    call baml.iter.Chain.Iterable.iter
-    store_var _69
-    jump L66
-
-  L63:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _68
-    call baml.iter.StepBy.Iterable.iter
-    store_var _69
-    jump L66
-
-  L64:
-    load_type testing.TestSetRegistration
-    load_var _68
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _69
-    jump L66
-
-  L65:
-    load_var _68
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _69
-
-  L66:
-    load_var _69
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L67
-    jump L84
-
-  L67:
-    load_var _69
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L68
-    jump L83
-
-  L68:
-    load_var _69
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L69
-    jump L82
-
-  L69:
-    load_var _69
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L70
-    jump L81
-
-  L70:
-    load_var _69
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L71
-    jump L80
-
-  L71:
-    load_var _69
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L72
-    jump L79
-
-  L72:
-    load_var _69
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L73
-    jump L78
-
-  L73:
-    load_var _69
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L74
-    jump L77
-
-  L74:
-    load_var _69
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L75
-    jump L76
-
-  L75:
-    load_var _69
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L90
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _69
-    call baml.iter.Peekable.Iterator.next
-    store_var _100
-    jump L85
-
-  L76:
-    load_var _69
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _100
-    jump L85
-
-  L77:
-    load_var _69
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _100
-    jump L85
-
-  L78:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Filter.Iterator.next
-    store_var _100
-    jump L85
-
-  L79:
-    load_var _69
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _100
-    jump L85
-
-  L80:
-    load_type testing.TestSetRegistration
-    load_var _69
-    call baml.iter.Repeat.Iterator.next
-    store_var _100
-    jump L85
-
-  L81:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Chain.Iterator.next
-    store_var _100
-    jump L85
-
-  L82:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _69
-    call baml.iter.StepBy.Iterator.next
-    store_var _100
-    jump L85
-
-  L83:
-    load_type testing.TestSetRegistration
-    load_var _69
-    call baml.iter.ArrayIterator.Iterator.next
-    store_var _100
-    jump L85
-
-  L84:
-    load_var _69
-    make_bound_method baml.iter.Flatten.Iterator.next
-    call_indirect
-    store_var _100
-
-  L85:
-    load_var _100
-    is_type baml.iter.Done
-    pop_jump_if_false L86
-    jump L89
-
-  L86:
-    load_var _100
+    load_var _42
     store_var ts
     load_type string
     load_type testing.TestRegistry
@@ -3274,10 +1913,10 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var expanded
     load_var expanded
     is_type testing.TestRegistry
-    pop_jump_if_false L87
-    jump L88
+    pop_jump_if_false L43
+    jump L44
 
-  L87:
+  L43:
     load_var items
     load_const "lazyTestSet"
     load_var ts
@@ -3285,30 +1924,30 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     init_instance testing.SerializedTest .type, .name
     call baml.Array.push
     pop 1
-    jump L66
+    jump L22
 
-  L88:
+  L44:
     load_var expanded
     store_var sub
     load_var ts
     load_field .name
-    store_var _139
+    store_var _81
     load_var sub
     call testing.TestRegistry.serialize
-    store_var _140
+    store_var _82
     load_var2 2 12
     load_var2 13 11
     load_field .loading_time_ms
     init_instance testing.SerializedTestSet .name, .items, .loadingTimeMs
     call baml.Array.push
     pop 1
-    jump L66
+    jump L22
 
-  L89:
+  L45:
     load_var items
     return
 
-  L90:
+  L46:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__04_5_mir.snap
@@ -9,200 +9,140 @@ fn user.sum_array(arr: int[]) -> int {
     let _2: int // sum [captured]
     let _3: (() -> void throws never)[] // total
     let _4: baml.iter.Iterator<Item = int, Error = void>
-    let _5: bool
+    let _5: type
     let _6: unknown
     let _7: bool
-    let _8: bool
-    let _9: type
+    let _8: unknown
+    let _9: bool
     let _10: bool
     let _11: type
-    let _12: type
-    let _13: bool
+    let _12: bool
+    let _13: type
     let _14: type
-    let _15: type
+    let _15: bool
     let _16: type
-    let _17: bool
+    let _17: type
     let _18: type
     let _19: bool
-    let _20: unknown
+    let _20: type
     let _21: bool
-    let _22: type
-    let _23: type
+    let _22: unknown
+    let _23: bool
     let _24: type
-    let _25: bool
-    let _26: unknown
+    let _25: type
+    let _26: type
     let _27: bool
     let _28: unknown
     let _29: bool
-    let _30: type
-    let _31: type
-    let _32: bool
+    let _30: unknown
+    let _31: bool
+    let _32: type
     let _33: type
     let _34: bool
-    let _35: type
-    let _36: unknown
-    let _37: bool
-    let _38: unknown
-    let _39: bool
-    let _40: bool
+    let _35: int
+    let _36: int // i [captured]
+    let _37: void
+    let _38: () -> void throws never
+    let _39: (() -> void throws never)[]
+    let _40: baml.iter.Iterator<Item = () -> void throws never, Error = void>
     let _41: type
-    let _42: bool
-    let _43: type
-    let _44: type
+    let _42: unknown
+    let _43: bool
+    let _44: unknown
     let _45: bool
     let _46: type
-    let _47: type
+    let _47: bool
     let _48: type
-    let _49: bool
-    let _50: type
-    let _51: bool
-    let _52: unknown
-    let _53: bool
-    let _54: type
+    let _49: type
+    let _50: bool
+    let _51: type
+    let _52: type
+    let _53: type
+    let _54: bool
     let _55: type
-    let _56: type
-    let _57: bool
-    let _58: unknown
-    let _59: bool
-    let _60: unknown
-    let _61: bool
-    let _62: type
-    let _63: type
+    let _56: bool
+    let _57: unknown
+    let _58: bool
+    let _59: type
+    let _60: type
+    let _61: type
+    let _62: bool
+    let _63: unknown
     let _64: bool
-    let _65: int
-    let _66: int // i [captured]
-    let _67: void
-    let _68: () -> void throws never
-    let _69: (() -> void throws never)[]
-    let _70: baml.iter.Iterator<Item = () -> void throws never, Error = void>
-    let _71: bool
-    let _72: unknown
-    let _73: bool
-    let _74: type
-    let _75: bool
-    let _76: type
-    let _77: type
-    let _78: bool
-    let _79: type
-    let _80: type
-    let _81: type
-    let _82: bool
-    let _83: type
-    let _84: bool
-    let _85: unknown
-    let _86: bool
-    let _87: type
-    let _88: type
-    let _89: type
-    let _90: bool
-    let _91: unknown
-    let _92: bool
-    let _93: unknown
-    let _94: bool
-    let _95: type
-    let _96: type
-    let _97: bool
-    let _98: type
-    let _99: bool
-    let _100: type
-    let _101: unknown
-    let _102: bool
-    let _103: unknown
-    let _104: bool
-    let _105: type
-    let _106: bool
-    let _107: type
-    let _108: type
-    let _109: bool
-    let _110: type
-    let _111: type
-    let _112: type
-    let _113: bool
-    let _114: type
-    let _115: bool
-    let _116: unknown
-    let _117: bool
-    let _118: type
-    let _119: type
-    let _120: type
-    let _121: bool
-    let _122: unknown
-    let _123: bool
-    let _124: unknown
-    let _125: bool
-    let _126: type
-    let _127: type
-    let _128: bool
-    let _129: () -> void throws never
-    let _130: () -> void throws never // cb
-    let _131: void
-    let _132: () -> void throws never
+    let _65: unknown
+    let _66: bool
+    let _67: type
+    let _68: type
+    let _69: bool
+    let _70: () -> void throws never
+    let _71: () -> void throws never // cb
+    let _72: void
+    let _73: () -> void throws never
 
     bb0: {
         _2 = const 0_i64;
         _3 = [];
-        _5 = is_type(copy _1, baml.iter.Flatten<_, int, void, void>);
-        branch copy _5 -> [bb26, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _7 = is_type(copy _1, baml.iter.Range);
-        branch copy _7 -> [bb25, bb2];
+        _5 = load_type(int);
+        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _5>(copy _1) -> [bb2];
     }
 
     bb2: {
-        _8 = is_type(copy _1, baml.iter.ArrayIterator<int>);
-        branch copy _8 -> [bb24, bb3];
+        _7 = is_type(copy _4, baml.iter.Flatten<_, int, void, void>);
+        branch copy _7 -> [bb24, bb3];
     }
 
     bb3: {
-        _10 = is_type(copy _1, baml.iter.StepBy<int, void>);
-        branch copy _10 -> [bb23, bb4];
+        _9 = is_type(copy _4, baml.iter.Range);
+        branch copy _9 -> [bb23, bb4];
     }
 
     bb4: {
-        _13 = is_type(copy _1, baml.iter.Chain<int, void, void>);
-        branch copy _13 -> [bb22, bb5];
+        _10 = is_type(copy _4, baml.iter.ArrayIterator<int>);
+        branch copy _10 -> [bb22, bb5];
     }
 
     bb5: {
-        _17 = is_type(copy _1, baml.iter.Repeat<int>);
-        branch copy _17 -> [bb21, bb6];
+        _12 = is_type(copy _4, baml.iter.StepBy<int, void>);
+        branch copy _12 -> [bb21, bb6];
     }
 
     bb6: {
-        _19 = is_type(copy _1, baml.iter.Map<_, int, void, void>);
-        branch copy _19 -> [bb20, bb7];
+        _15 = is_type(copy _4, baml.iter.Chain<int, void, void>);
+        branch copy _15 -> [bb20, bb7];
     }
 
     bb7: {
-        _21 = is_type(copy _1, baml.iter.Filter<int, void, void>);
-        branch copy _21 -> [bb19, bb8];
+        _19 = is_type(copy _4, baml.iter.Repeat<int>);
+        branch copy _19 -> [bb19, bb8];
     }
 
     bb8: {
-        _25 = is_type(copy _1, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _25 -> [bb18, bb9];
+        _21 = is_type(copy _4, baml.iter.Map<_, int, void, void>);
+        branch copy _21 -> [bb18, bb9];
     }
 
     bb9: {
-        _27 = is_type(copy _1, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _27 -> [bb17, bb10];
+        _23 = is_type(copy _4, baml.iter.Filter<int, void, void>);
+        branch copy _23 -> [bb17, bb10];
     }
 
     bb10: {
-        _29 = is_type(copy _1, baml.iter.Peekable<int, void>);
-        branch copy _29 -> [bb16, bb11];
+        _27 = is_type(copy _4, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _27 -> [bb16, bb11];
     }
 
     bb11: {
-        _32 = is_type(copy _1, unknown[]);
-        branch copy _32 -> [bb15, bb12];
+        _29 = is_type(copy _4, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _29 -> [bb15, bb12];
     }
 
     bb12: {
-        _34 = is_type(copy _1, int[]);
-        branch copy _34 -> [bb14, bb13];
+        _31 = is_type(copy _4, baml.iter.Peekable<int, void>);
+        branch copy _31 -> [bb14, bb13];
     }
 
     bb13: {
@@ -210,467 +150,217 @@ fn user.sum_array(arr: int[]) -> int {
     }
 
     bb14: {
-        _35 = load_type(int);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _35>(copy _1) -> [bb27];
+        _32 = load_type(int);
+        _33 = load_type(void);
+        _6 = call const fn baml.iter.Peekable.Iterator.next<copy _32, copy _33>(copy _4) -> [bb25];
     }
 
     bb15: {
-        _33 = load_type(int);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _33>(copy _1) -> [bb27];
+        _30 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
+        _6 = call copy _30() -> [bb25];
     }
 
     bb16: {
-        _30 = load_type(int);
-        _31 = load_type(void);
-        _4 = call const fn baml.iter.Peekable.Iterable.iter<copy _30, copy _31>(copy _1) -> [bb27];
+        _28 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
+        _6 = call copy _28() -> [bb25];
     }
 
     bb17: {
-        _28 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _1);
-        _4 = call copy _28() -> [bb27];
+        _24 = load_type(int);
+        _25 = load_type(void);
+        _26 = load_type(void);
+        _6 = call const fn baml.iter.Filter.Iterator.next<copy _24, copy _25, copy _26>(copy _4) -> [bb25];
     }
 
     bb18: {
-        _26 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _1);
-        _4 = call copy _26() -> [bb27];
+        _22 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
+        _6 = call copy _22() -> [bb25];
     }
 
     bb19: {
-        _22 = load_type(int);
-        _23 = load_type(void);
-        _24 = load_type(void);
-        _4 = call const fn baml.iter.Filter.Iterable.iter<copy _22, copy _23, copy _24>(copy _1) -> [bb27];
+        _20 = load_type(int);
+        _6 = call const fn baml.iter.Repeat.Iterator.next<copy _20>(copy _4) -> [bb25];
     }
 
     bb20: {
-        _20 = make_bound_method baml.iter.Map.Iterable.iter(copy _1);
-        _4 = call copy _20() -> [bb27];
+        _16 = load_type(int);
+        _17 = load_type(void);
+        _18 = load_type(void);
+        _6 = call const fn baml.iter.Chain.Iterator.next<copy _16, copy _17, copy _18>(copy _4) -> [bb25];
     }
 
     bb21: {
-        _18 = load_type(int);
-        _4 = call const fn baml.iter.Repeat.Iterable.iter<copy _18>(copy _1) -> [bb27];
+        _13 = load_type(int);
+        _14 = load_type(void);
+        _6 = call const fn baml.iter.StepBy.Iterator.next<copy _13, copy _14>(copy _4) -> [bb25];
     }
 
     bb22: {
-        _14 = load_type(int);
-        _15 = load_type(void);
-        _16 = load_type(void);
-        _4 = call const fn baml.iter.Chain.Iterable.iter<copy _14, copy _15, copy _16>(copy _1) -> [bb27];
+        _11 = load_type(int);
+        _6 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _11>(copy _4) -> [bb25];
     }
 
     bb23: {
-        _11 = load_type(int);
-        _12 = load_type(void);
-        _4 = call const fn baml.iter.StepBy.Iterable.iter<copy _11, copy _12>(copy _1) -> [bb27];
+        _6 = call const fn baml.iter.Range.Iterator.next(copy _4) -> [bb25];
     }
 
     bb24: {
-        _9 = load_type(int);
-        _4 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _9>(copy _1) -> [bb27];
+        _8 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
+        _6 = call copy _8() -> [bb25];
     }
 
     bb25: {
-        _4 = call const fn baml.iter.Range.Iterable.iter(copy _1) -> [bb27];
+        _34 = is_type(copy _6, baml.iter.Done);
+        branch copy _34 -> [bb27, bb26];
     }
 
     bb26: {
-        _6 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _1);
-        _4 = call copy _6() -> [bb27];
+        _35 = copy _6;
+        fresh_cell(_36);
+        _36 = copy _35;
+        _38 = make_closure lambda[0](copy _2, copy _36);
+        _37 = call const fn baml.Array.push(copy _3, copy _38) -> [bb2];
     }
 
     bb27: {
-        _37 = is_type(copy _4, baml.iter.Flatten<_, int, void, void>);
-        branch copy _37 -> [bb49, bb28];
+        _39 = copy _3;
+        goto -> bb28;
     }
 
     bb28: {
-        _39 = is_type(copy _4, baml.iter.Range);
-        branch copy _39 -> [bb48, bb29];
+        _41 = load_type(() -> void throws never);
+        _40 = call const fn baml.iter.Iterable$for$T[].iter<copy _41>(copy _39) -> [bb29];
     }
 
     bb29: {
-        _40 = is_type(copy _4, baml.iter.ArrayIterator<int>);
-        branch copy _40 -> [bb47, bb30];
+        _43 = is_type(copy _40, baml.iter.Flatten<_, () -> void throws never, void, void>);
+        branch copy _43 -> [bb49, bb30];
     }
 
     bb30: {
-        _42 = is_type(copy _4, baml.iter.StepBy<int, void>);
-        branch copy _42 -> [bb46, bb31];
+        _45 = is_type(copy _40, baml.iter.ArrayIterator<() -> void throws never>);
+        branch copy _45 -> [bb48, bb31];
     }
 
     bb31: {
-        _45 = is_type(copy _4, baml.iter.Chain<int, void, void>);
-        branch copy _45 -> [bb45, bb32];
+        _47 = is_type(copy _40, baml.iter.StepBy<() -> void throws never, void>);
+        branch copy _47 -> [bb47, bb32];
     }
 
     bb32: {
-        _49 = is_type(copy _4, baml.iter.Repeat<int>);
-        branch copy _49 -> [bb44, bb33];
+        _50 = is_type(copy _40, baml.iter.Chain<() -> void throws never, void, void>);
+        branch copy _50 -> [bb46, bb33];
     }
 
     bb33: {
-        _51 = is_type(copy _4, baml.iter.Map<_, int, void, void>);
-        branch copy _51 -> [bb43, bb34];
+        _54 = is_type(copy _40, baml.iter.Repeat<() -> void throws never>);
+        branch copy _54 -> [bb45, bb34];
     }
 
     bb34: {
-        _53 = is_type(copy _4, baml.iter.Filter<int, void, void>);
-        branch copy _53 -> [bb42, bb35];
+        _56 = is_type(copy _40, baml.iter.Map<_, () -> void throws never, void, void>);
+        branch copy _56 -> [bb44, bb35];
     }
 
     bb35: {
-        _57 = is_type(copy _4, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _57 -> [bb41, bb36];
+        _58 = is_type(copy _40, baml.iter.Filter<() -> void throws never, void, void>);
+        branch copy _58 -> [bb43, bb36];
     }
 
     bb36: {
-        _59 = is_type(copy _4, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _59 -> [bb40, bb37];
+        _62 = is_type(copy _40, baml.iter.FilterMap<_, () -> void throws never, void, void>);
+        branch copy _62 -> [bb42, bb37];
     }
 
     bb37: {
-        _61 = is_type(copy _4, baml.iter.Peekable<int, void>);
-        branch copy _61 -> [bb39, bb38];
+        _64 = is_type(copy _40, baml.iter.FlatMap<_, () -> void throws never, void, void, void>);
+        branch copy _64 -> [bb41, bb38];
     }
 
     bb38: {
-        unreachable;
+        _66 = is_type(copy _40, baml.iter.Peekable<() -> void throws never, void>);
+        branch copy _66 -> [bb40, bb39];
     }
 
     bb39: {
-        _62 = load_type(int);
-        _63 = load_type(void);
-        _36 = call const fn baml.iter.Peekable.Iterator.next<copy _62, copy _63>(copy _4) -> [bb50];
+        unreachable;
     }
 
     bb40: {
-        _60 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
-        _36 = call copy _60() -> [bb50];
+        _67 = load_type(() -> void throws never);
+        _68 = load_type(void);
+        _42 = call const fn baml.iter.Peekable.Iterator.next<copy _67, copy _68>(copy _40) -> [bb50];
     }
 
     bb41: {
-        _58 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
-        _36 = call copy _58() -> [bb50];
+        _65 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _40);
+        _42 = call copy _65() -> [bb50];
     }
 
     bb42: {
-        _54 = load_type(int);
-        _55 = load_type(void);
-        _56 = load_type(void);
-        _36 = call const fn baml.iter.Filter.Iterator.next<copy _54, copy _55, copy _56>(copy _4) -> [bb50];
+        _63 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _40);
+        _42 = call copy _63() -> [bb50];
     }
 
     bb43: {
-        _52 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
-        _36 = call copy _52() -> [bb50];
+        _59 = load_type(() -> void throws never);
+        _60 = load_type(void);
+        _61 = load_type(void);
+        _42 = call const fn baml.iter.Filter.Iterator.next<copy _59, copy _60, copy _61>(copy _40) -> [bb50];
     }
 
     bb44: {
-        _50 = load_type(int);
-        _36 = call const fn baml.iter.Repeat.Iterator.next<copy _50>(copy _4) -> [bb50];
+        _57 = make_bound_method baml.iter.Map.Iterator.next(copy _40);
+        _42 = call copy _57() -> [bb50];
     }
 
     bb45: {
-        _46 = load_type(int);
-        _47 = load_type(void);
-        _48 = load_type(void);
-        _36 = call const fn baml.iter.Chain.Iterator.next<copy _46, copy _47, copy _48>(copy _4) -> [bb50];
+        _55 = load_type(() -> void throws never);
+        _42 = call const fn baml.iter.Repeat.Iterator.next<copy _55>(copy _40) -> [bb50];
     }
 
     bb46: {
-        _43 = load_type(int);
-        _44 = load_type(void);
-        _36 = call const fn baml.iter.StepBy.Iterator.next<copy _43, copy _44>(copy _4) -> [bb50];
+        _51 = load_type(() -> void throws never);
+        _52 = load_type(void);
+        _53 = load_type(void);
+        _42 = call const fn baml.iter.Chain.Iterator.next<copy _51, copy _52, copy _53>(copy _40) -> [bb50];
     }
 
     bb47: {
-        _41 = load_type(int);
-        _36 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _41>(copy _4) -> [bb50];
+        _48 = load_type(() -> void throws never);
+        _49 = load_type(void);
+        _42 = call const fn baml.iter.StepBy.Iterator.next<copy _48, copy _49>(copy _40) -> [bb50];
     }
 
     bb48: {
-        _36 = call const fn baml.iter.Range.Iterator.next(copy _4) -> [bb50];
+        _46 = load_type(() -> void throws never);
+        _42 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _46>(copy _40) -> [bb50];
     }
 
     bb49: {
-        _38 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
-        _36 = call copy _38() -> [bb50];
+        _44 = make_bound_method baml.iter.Flatten.Iterator.next(copy _40);
+        _42 = call copy _44() -> [bb50];
     }
 
     bb50: {
-        _64 = is_type(copy _36, baml.iter.Done);
-        branch copy _64 -> [bb52, bb51];
+        _69 = is_type(copy _42, baml.iter.Done);
+        branch copy _69 -> [bb52, bb51];
     }
 
     bb51: {
-        _65 = copy _36;
-        fresh_cell(_66);
-        _66 = copy _65;
-        _68 = make_closure lambda[0](copy _2, copy _66);
-        _67 = call const fn baml.Array.push(copy _3, copy _68) -> [bb27];
+        _70 = copy _42;
+        fresh_cell(_71);
+        _71 = copy _70;
+        _73 = copy _71;
+        _72 = call copy _73() -> [bb29];
     }
 
     bb52: {
-        _69 = copy _3;
-        _71 = is_type(copy _69, baml.iter.Flatten<_, () -> void throws never, void, void>);
-        branch copy _71 -> [bb76, bb53];
+        _0 = copy _2;
+        goto -> bb53;
     }
 
     bb53: {
-        _73 = is_type(copy _69, baml.iter.ArrayIterator<() -> void throws never>);
-        branch copy _73 -> [bb75, bb54];
-    }
-
-    bb54: {
-        _75 = is_type(copy _69, baml.iter.StepBy<() -> void throws never, void>);
-        branch copy _75 -> [bb74, bb55];
-    }
-
-    bb55: {
-        _78 = is_type(copy _69, baml.iter.Chain<() -> void throws never, void, void>);
-        branch copy _78 -> [bb73, bb56];
-    }
-
-    bb56: {
-        _82 = is_type(copy _69, baml.iter.Repeat<() -> void throws never>);
-        branch copy _82 -> [bb72, bb57];
-    }
-
-    bb57: {
-        _84 = is_type(copy _69, baml.iter.Map<_, () -> void throws never, void, void>);
-        branch copy _84 -> [bb71, bb58];
-    }
-
-    bb58: {
-        _86 = is_type(copy _69, baml.iter.Filter<() -> void throws never, void, void>);
-        branch copy _86 -> [bb70, bb59];
-    }
-
-    bb59: {
-        _90 = is_type(copy _69, baml.iter.FilterMap<_, () -> void throws never, void, void>);
-        branch copy _90 -> [bb69, bb60];
-    }
-
-    bb60: {
-        _92 = is_type(copy _69, baml.iter.FlatMap<_, () -> void throws never, void, void, void>);
-        branch copy _92 -> [bb68, bb61];
-    }
-
-    bb61: {
-        _94 = is_type(copy _69, baml.iter.Peekable<() -> void throws never, void>);
-        branch copy _94 -> [bb67, bb62];
-    }
-
-    bb62: {
-        _97 = is_type(copy _69, unknown[]);
-        branch copy _97 -> [bb66, bb63];
-    }
-
-    bb63: {
-        _99 = is_type(copy _69, (() -> void throws never)[]);
-        branch copy _99 -> [bb65, bb64];
-    }
-
-    bb64: {
-        unreachable;
-    }
-
-    bb65: {
-        _100 = load_type(() -> void throws never);
-        _70 = call const fn baml.iter.Iterable$for$T[].iter<copy _100>(copy _69) -> [bb77];
-    }
-
-    bb66: {
-        _98 = load_type(() -> void throws never);
-        _70 = call const fn baml.iter.Iterable$for$T[].iter<copy _98>(copy _69) -> [bb77];
-    }
-
-    bb67: {
-        _95 = load_type(() -> void throws never);
-        _96 = load_type(void);
-        _70 = call const fn baml.iter.Peekable.Iterable.iter<copy _95, copy _96>(copy _69) -> [bb77];
-    }
-
-    bb68: {
-        _93 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _69);
-        _70 = call copy _93() -> [bb77];
-    }
-
-    bb69: {
-        _91 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _69);
-        _70 = call copy _91() -> [bb77];
-    }
-
-    bb70: {
-        _87 = load_type(() -> void throws never);
-        _88 = load_type(void);
-        _89 = load_type(void);
-        _70 = call const fn baml.iter.Filter.Iterable.iter<copy _87, copy _88, copy _89>(copy _69) -> [bb77];
-    }
-
-    bb71: {
-        _85 = make_bound_method baml.iter.Map.Iterable.iter(copy _69);
-        _70 = call copy _85() -> [bb77];
-    }
-
-    bb72: {
-        _83 = load_type(() -> void throws never);
-        _70 = call const fn baml.iter.Repeat.Iterable.iter<copy _83>(copy _69) -> [bb77];
-    }
-
-    bb73: {
-        _79 = load_type(() -> void throws never);
-        _80 = load_type(void);
-        _81 = load_type(void);
-        _70 = call const fn baml.iter.Chain.Iterable.iter<copy _79, copy _80, copy _81>(copy _69) -> [bb77];
-    }
-
-    bb74: {
-        _76 = load_type(() -> void throws never);
-        _77 = load_type(void);
-        _70 = call const fn baml.iter.StepBy.Iterable.iter<copy _76, copy _77>(copy _69) -> [bb77];
-    }
-
-    bb75: {
-        _74 = load_type(() -> void throws never);
-        _70 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _74>(copy _69) -> [bb77];
-    }
-
-    bb76: {
-        _72 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _69);
-        _70 = call copy _72() -> [bb77];
-    }
-
-    bb77: {
-        _102 = is_type(copy _70, baml.iter.Flatten<_, () -> void throws never, void, void>);
-        branch copy _102 -> [bb97, bb78];
-    }
-
-    bb78: {
-        _104 = is_type(copy _70, baml.iter.ArrayIterator<() -> void throws never>);
-        branch copy _104 -> [bb96, bb79];
-    }
-
-    bb79: {
-        _106 = is_type(copy _70, baml.iter.StepBy<() -> void throws never, void>);
-        branch copy _106 -> [bb95, bb80];
-    }
-
-    bb80: {
-        _109 = is_type(copy _70, baml.iter.Chain<() -> void throws never, void, void>);
-        branch copy _109 -> [bb94, bb81];
-    }
-
-    bb81: {
-        _113 = is_type(copy _70, baml.iter.Repeat<() -> void throws never>);
-        branch copy _113 -> [bb93, bb82];
-    }
-
-    bb82: {
-        _115 = is_type(copy _70, baml.iter.Map<_, () -> void throws never, void, void>);
-        branch copy _115 -> [bb92, bb83];
-    }
-
-    bb83: {
-        _117 = is_type(copy _70, baml.iter.Filter<() -> void throws never, void, void>);
-        branch copy _117 -> [bb91, bb84];
-    }
-
-    bb84: {
-        _121 = is_type(copy _70, baml.iter.FilterMap<_, () -> void throws never, void, void>);
-        branch copy _121 -> [bb90, bb85];
-    }
-
-    bb85: {
-        _123 = is_type(copy _70, baml.iter.FlatMap<_, () -> void throws never, void, void, void>);
-        branch copy _123 -> [bb89, bb86];
-    }
-
-    bb86: {
-        _125 = is_type(copy _70, baml.iter.Peekable<() -> void throws never, void>);
-        branch copy _125 -> [bb88, bb87];
-    }
-
-    bb87: {
-        unreachable;
-    }
-
-    bb88: {
-        _126 = load_type(() -> void throws never);
-        _127 = load_type(void);
-        _101 = call const fn baml.iter.Peekable.Iterator.next<copy _126, copy _127>(copy _70) -> [bb98];
-    }
-
-    bb89: {
-        _124 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _70);
-        _101 = call copy _124() -> [bb98];
-    }
-
-    bb90: {
-        _122 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _70);
-        _101 = call copy _122() -> [bb98];
-    }
-
-    bb91: {
-        _118 = load_type(() -> void throws never);
-        _119 = load_type(void);
-        _120 = load_type(void);
-        _101 = call const fn baml.iter.Filter.Iterator.next<copy _118, copy _119, copy _120>(copy _70) -> [bb98];
-    }
-
-    bb92: {
-        _116 = make_bound_method baml.iter.Map.Iterator.next(copy _70);
-        _101 = call copy _116() -> [bb98];
-    }
-
-    bb93: {
-        _114 = load_type(() -> void throws never);
-        _101 = call const fn baml.iter.Repeat.Iterator.next<copy _114>(copy _70) -> [bb98];
-    }
-
-    bb94: {
-        _110 = load_type(() -> void throws never);
-        _111 = load_type(void);
-        _112 = load_type(void);
-        _101 = call const fn baml.iter.Chain.Iterator.next<copy _110, copy _111, copy _112>(copy _70) -> [bb98];
-    }
-
-    bb95: {
-        _107 = load_type(() -> void throws never);
-        _108 = load_type(void);
-        _101 = call const fn baml.iter.StepBy.Iterator.next<copy _107, copy _108>(copy _70) -> [bb98];
-    }
-
-    bb96: {
-        _105 = load_type(() -> void throws never);
-        _101 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _105>(copy _70) -> [bb98];
-    }
-
-    bb97: {
-        _103 = make_bound_method baml.iter.Flatten.Iterator.next(copy _70);
-        _101 = call copy _103() -> [bb98];
-    }
-
-    bb98: {
-        _128 = is_type(copy _101, baml.iter.Done);
-        branch copy _128 -> [bb100, bb99];
-    }
-
-    bb99: {
-        _129 = copy _101;
-        fresh_cell(_130);
-        _130 = copy _129;
-        _132 = copy _130;
-        _131 = call copy _132() -> [bb77];
-    }
-
-    bb100: {
-        _0 = copy _2;
-        goto -> bb101;
-    }
-
-    bb101: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
@@ -12,645 +12,328 @@ function user.sum_array(arr: int[]) -> int {
     store_deref ?2
     alloc_array 0
     store_var total
+    load_type int
     load_var arr
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var arr
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var arr
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var arr
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var arr
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var arr
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var arr
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var arr
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var arr
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var arr
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var arr
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var arr
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var arr
-    is_type int[]
-    pop_jump_if_false L92
-    load_type int
-    load_var arr
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L24
-
-  L12:
-    load_type int
-    load_var arr
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var arr
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L24
-
-  L14:
-    load_var arr
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L15:
-    load_var arr
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var arr
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L24
-
-  L17:
-    load_var arr
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L24
-
-  L18:
-    load_type int
-    load_var arr
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var arr
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var arr
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L24
-
-  L21:
-    load_type int
-    load_var arr
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L24
-
-  L22:
-    load_var arr
-    call baml.iter.Range.Iterable.iter
-    store_var _4
-    jump L24
-
-  L23:
-    load_var arr
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L24:
     load_var _4
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _4
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _4
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _4
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _4
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _4
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _4
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _4
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _4
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _4
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _4
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L92
+    pop_jump_if_false L46
     load_type int
     load_type void
     load_var _4
     call baml.iter.Peekable.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L35:
+  L11:
     load_var _4
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L36:
+  L12:
     load_var _4
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _4
     call baml.iter.Filter.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L38:
+  L14:
     load_var _4
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _4
     call baml.iter.Repeat.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L43:
+  L19:
     load_var _4
     call baml.iter.Range.Iterator.next
-    store_var _36
-    jump L45
+    store_var _6
+    jump L21
 
-  L44:
+  L20:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _36
+    store_var _6
 
-  L45:
-    load_var _36
+  L21:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
+  L22:
     load_const null
     make_cell
     store_var i
-    load_var _36
+    load_var _6
     store_deref ?6
     load_var2 3 2
     load_var i
     make_closure .<lambda(sum_array, 0)>, 2
     call baml.Array.push
     pop 1
-    jump L24
+    jump L0
 
-  L47:
+  L23:
+    load_type () -> void throws never
     load_var total
-    store_var_load_var _69
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L48
-    jump L69
-
-  L48:
-    load_var _69
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L49
-    jump L68
-
-  L49:
-    load_var _69
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L50
-    jump L67
-
-  L50:
-    load_var _69
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L51
-    jump L66
-
-  L51:
-    load_var _69
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L52
-    jump L65
-
-  L52:
-    load_var _69
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L53
-    jump L64
-
-  L53:
-    load_var _69
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L54
-    jump L63
-
-  L54:
-    load_var _69
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L55
-    jump L62
-
-  L55:
-    load_var _69
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L56
-    jump L61
-
-  L56:
-    load_var _69
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L57
-    jump L60
-
-  L57:
-    load_var _69
-    is_type unknown[]
-    pop_jump_if_false L58
-    jump L59
-
-  L58:
-    load_var _69
-    is_type (() -> void throws never)[]
-    pop_jump_if_false L92
-    load_type () -> void throws never
-    load_var _69
     call baml.iter.Iterable$for$T[].iter
-    store_var _70
-    jump L70
+    store_var _40
 
-  L59:
-    load_type () -> void throws never
-    load_var _69
-    call baml.iter.Iterable$for$T[].iter
-    store_var _70
-    jump L70
-
-  L60:
-    load_type () -> void throws never
-    load_type void
-    load_var _69
-    call baml.iter.Peekable.Iterable.iter
-    store_var _70
-    jump L70
-
-  L61:
-    load_var _69
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _70
-    jump L70
-
-  L62:
-    load_var _69
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _70
-    jump L70
-
-  L63:
-    load_type () -> void throws never
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Filter.Iterable.iter
-    store_var _70
-    jump L70
-
-  L64:
-    load_var _69
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _70
-    jump L70
-
-  L65:
-    load_type () -> void throws never
-    load_var _69
-    call baml.iter.Repeat.Iterable.iter
-    store_var _70
-    jump L70
-
-  L66:
-    load_type () -> void throws never
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Chain.Iterable.iter
-    store_var _70
-    jump L70
-
-  L67:
-    load_type () -> void throws never
-    load_type void
-    load_var _69
-    call baml.iter.StepBy.Iterable.iter
-    store_var _70
-    jump L70
-
-  L68:
-    load_type () -> void throws never
-    load_var _69
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _70
-    jump L70
-
-  L69:
-    load_var _69
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _70
-
-  L70:
-    load_var _70
+  L24:
+    load_var _40
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L71
-    jump L88
+    pop_jump_if_false L25
+    jump L42
 
-  L71:
-    load_var _70
+  L25:
+    load_var _40
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L72
-    jump L87
+    pop_jump_if_false L26
+    jump L41
 
-  L72:
-    load_var _70
+  L26:
+    load_var _40
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L73
-    jump L86
+    pop_jump_if_false L27
+    jump L40
 
-  L73:
-    load_var _70
+  L27:
+    load_var _40
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L74
-    jump L85
+    pop_jump_if_false L28
+    jump L39
 
-  L74:
-    load_var _70
+  L28:
+    load_var _40
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L75
-    jump L84
+    pop_jump_if_false L29
+    jump L38
 
-  L75:
-    load_var _70
+  L29:
+    load_var _40
     is_type baml.iter.Map<...>
-    pop_jump_if_false L76
-    jump L83
+    pop_jump_if_false L30
+    jump L37
 
-  L76:
-    load_var _70
+  L30:
+    load_var _40
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L77
-    jump L82
+    pop_jump_if_false L31
+    jump L36
 
-  L77:
-    load_var _70
+  L31:
+    load_var _40
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L78
-    jump L81
+    pop_jump_if_false L32
+    jump L35
 
-  L78:
-    load_var _70
+  L32:
+    load_var _40
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L79
-    jump L80
+    pop_jump_if_false L33
+    jump L34
 
-  L79:
-    load_var _70
+  L33:
+    load_var _40
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L92
+    pop_jump_if_false L46
     load_type () -> void throws never
     load_type void
-    load_var _70
+    load_var _40
     call baml.iter.Peekable.Iterator.next
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L80:
-    load_var _70
+  L34:
+    load_var _40
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L81:
-    load_var _70
+  L35:
+    load_var _40
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L82:
+  L36:
     load_type () -> void throws never
     load_type void
     load_type void
-    load_var _70
+    load_var _40
     call baml.iter.Filter.Iterator.next
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L83:
-    load_var _70
+  L37:
+    load_var _40
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L84:
+  L38:
     load_type () -> void throws never
-    load_var _70
+    load_var _40
     call baml.iter.Repeat.Iterator.next
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L85:
+  L39:
     load_type () -> void throws never
     load_type void
     load_type void
-    load_var _70
+    load_var _40
     call baml.iter.Chain.Iterator.next
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L86:
+  L40:
     load_type () -> void throws never
     load_type void
-    load_var _70
+    load_var _40
     call baml.iter.StepBy.Iterator.next
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L87:
+  L41:
     load_type () -> void throws never
-    load_var _70
+    load_var _40
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _101
-    jump L89
+    store_var _42
+    jump L43
 
-  L88:
-    load_var _70
+  L42:
+    load_var _40
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _101
+    store_var _42
 
-  L89:
-    load_var _101
+  L43:
+    load_var _42
     is_type baml.iter.Done
-    pop_jump_if_false L90
-    jump L91
+    pop_jump_if_false L44
+    jump L45
 
-  L90:
-    load_var _101
+  L44:
+    load_var _42
     call_indirect
     pop 1
-    jump L70
+    jump L24
 
-  L91:
+  L45:
     load_deref ?2
     return
 
-  L92:
+  L46:
     unreachable
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__04_5_mir.snap
@@ -475,11 +475,11 @@ fn user.test_generic_apply_inferred() -> int {
 }
 
 // lambda[0]
-fn .<lambda(test_generic_apply_inferred, 0)>(f: (void) -> void throws never, x: void) -> null {
+fn .<lambda(test_generic_apply_inferred, 0)>(f: (unknown) -> unknown throws never, x: unknown) -> null {
     // Locals:
     let _0: null // _0 // return
-    let _1: (void) -> void throws never // f // param
-    let _2: void // x // param
+    let _1: (unknown) -> unknown throws never // f // param
+    let _2: unknown // x // param
 
     bb0: {
         _0 = call copy _1(copy _2) -> [bb1];
@@ -541,10 +541,10 @@ fn user.test_generic_multi_instantiation() -> int {
 }
 
 // lambda[0]
-fn .<lambda(test_generic_multi_instantiation, 0)>(x: void) -> null {
+fn .<lambda(test_generic_multi_instantiation, 0)>(x: unknown) -> null {
     // Locals:
     let _0: null // _0 // return
-    let _1: void // x // param
+    let _1: unknown // x // param
 
     bb0: {
         _0 = copy _1;
@@ -1430,72 +1430,42 @@ fn user.test_shadowing() -> string {
     let _7: type
     let _8: int[]
     let _9: baml.iter.Iterator<Item = int, Error = void>
-    let _10: bool
+    let _10: type
     let _11: unknown
     let _12: bool
-    let _13: bool
-    let _14: type
+    let _13: unknown
+    let _14: bool
     let _15: bool
     let _16: type
-    let _17: type
-    let _18: bool
+    let _17: bool
+    let _18: type
     let _19: type
-    let _20: type
+    let _20: bool
     let _21: type
-    let _22: bool
+    let _22: type
     let _23: type
     let _24: bool
-    let _25: unknown
+    let _25: type
     let _26: bool
-    let _27: type
-    let _28: type
+    let _27: unknown
+    let _28: bool
     let _29: type
-    let _30: bool
-    let _31: unknown
+    let _30: type
+    let _31: type
     let _32: bool
     let _33: unknown
     let _34: bool
-    let _35: type
-    let _36: type
-    let _37: bool
+    let _35: unknown
+    let _36: bool
+    let _37: type
     let _38: type
     let _39: bool
-    let _40: type
-    let _41: unknown
-    let _42: bool
-    let _43: unknown
-    let _44: bool
-    let _45: bool
-    let _46: type
-    let _47: bool
-    let _48: type
-    let _49: type
-    let _50: bool
-    let _51: type
-    let _52: type
-    let _53: type
-    let _54: bool
-    let _55: type
-    let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: type
-    let _60: type
-    let _61: type
-    let _62: bool
-    let _63: unknown
-    let _64: bool
-    let _65: unknown
-    let _66: bool
-    let _67: type
-    let _68: type
-    let _69: bool
-    let _70: int
-    let _71: int // y
-    let _72: int // i
-    let _73: bool
-    let _74: int
-    let _75: int
+    let _40: int
+    let _41: int // y
+    let _42: int // i
+    let _43: bool
+    let _44: int
+    let _45: int
 
     bb0: {
         _1 = const "999";
@@ -1509,68 +1479,67 @@ fn user.test_shadowing() -> string {
 
     bb1: {
         _8 = copy _3;
-        _10 = is_type(copy _8, baml.iter.Flatten<_, int, void, void>);
-        branch copy _10 -> [bb27, bb2];
+        goto -> bb2;
     }
 
     bb2: {
-        _12 = is_type(copy _8, baml.iter.Range);
-        branch copy _12 -> [bb26, bb3];
+        _10 = load_type(int);
+        _9 = call const fn baml.iter.Iterable$for$T[].iter<copy _10>(copy _8) -> [bb3];
     }
 
     bb3: {
-        _13 = is_type(copy _8, baml.iter.ArrayIterator<int>);
-        branch copy _13 -> [bb25, bb4];
+        _12 = is_type(copy _9, baml.iter.Flatten<_, int, void, void>);
+        branch copy _12 -> [bb25, bb4];
     }
 
     bb4: {
-        _15 = is_type(copy _8, baml.iter.StepBy<int, void>);
-        branch copy _15 -> [bb24, bb5];
+        _14 = is_type(copy _9, baml.iter.Range);
+        branch copy _14 -> [bb24, bb5];
     }
 
     bb5: {
-        _18 = is_type(copy _8, baml.iter.Chain<int, void, void>);
-        branch copy _18 -> [bb23, bb6];
+        _15 = is_type(copy _9, baml.iter.ArrayIterator<int>);
+        branch copy _15 -> [bb23, bb6];
     }
 
     bb6: {
-        _22 = is_type(copy _8, baml.iter.Repeat<int>);
-        branch copy _22 -> [bb22, bb7];
+        _17 = is_type(copy _9, baml.iter.StepBy<int, void>);
+        branch copy _17 -> [bb22, bb7];
     }
 
     bb7: {
-        _24 = is_type(copy _8, baml.iter.Map<_, int, void, void>);
-        branch copy _24 -> [bb21, bb8];
+        _20 = is_type(copy _9, baml.iter.Chain<int, void, void>);
+        branch copy _20 -> [bb21, bb8];
     }
 
     bb8: {
-        _26 = is_type(copy _8, baml.iter.Filter<int, void, void>);
-        branch copy _26 -> [bb20, bb9];
+        _24 = is_type(copy _9, baml.iter.Repeat<int>);
+        branch copy _24 -> [bb20, bb9];
     }
 
     bb9: {
-        _30 = is_type(copy _8, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _30 -> [bb19, bb10];
+        _26 = is_type(copy _9, baml.iter.Map<_, int, void, void>);
+        branch copy _26 -> [bb19, bb10];
     }
 
     bb10: {
-        _32 = is_type(copy _8, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _32 -> [bb18, bb11];
+        _28 = is_type(copy _9, baml.iter.Filter<int, void, void>);
+        branch copy _28 -> [bb18, bb11];
     }
 
     bb11: {
-        _34 = is_type(copy _8, baml.iter.Peekable<int, void>);
-        branch copy _34 -> [bb17, bb12];
+        _32 = is_type(copy _9, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _32 -> [bb17, bb12];
     }
 
     bb12: {
-        _37 = is_type(copy _8, unknown[]);
-        branch copy _37 -> [bb16, bb13];
+        _34 = is_type(copy _9, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _34 -> [bb16, bb13];
     }
 
     bb13: {
-        _39 = is_type(copy _8, int[]);
-        branch copy _39 -> [bb15, bb14];
+        _36 = is_type(copy _9, baml.iter.Peekable<int, void>);
+        branch copy _36 -> [bb15, bb14];
     }
 
     bb14: {
@@ -1578,226 +1547,97 @@ fn user.test_shadowing() -> string {
     }
 
     bb15: {
-        _40 = load_type(int);
-        _9 = call const fn baml.iter.Iterable$for$T[].iter<copy _40>(copy _8) -> [bb28];
+        _37 = load_type(int);
+        _38 = load_type(void);
+        _11 = call const fn baml.iter.Peekable.Iterator.next<copy _37, copy _38>(copy _9) -> [bb26];
     }
 
     bb16: {
-        _38 = load_type(int);
-        _9 = call const fn baml.iter.Iterable$for$T[].iter<copy _38>(copy _8) -> [bb28];
+        _35 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _9);
+        _11 = call copy _35() -> [bb26];
     }
 
     bb17: {
-        _35 = load_type(int);
-        _36 = load_type(void);
-        _9 = call const fn baml.iter.Peekable.Iterable.iter<copy _35, copy _36>(copy _8) -> [bb28];
+        _33 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _9);
+        _11 = call copy _33() -> [bb26];
     }
 
     bb18: {
-        _33 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _8);
-        _9 = call copy _33() -> [bb28];
+        _29 = load_type(int);
+        _30 = load_type(void);
+        _31 = load_type(void);
+        _11 = call const fn baml.iter.Filter.Iterator.next<copy _29, copy _30, copy _31>(copy _9) -> [bb26];
     }
 
     bb19: {
-        _31 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _8);
-        _9 = call copy _31() -> [bb28];
+        _27 = make_bound_method baml.iter.Map.Iterator.next(copy _9);
+        _11 = call copy _27() -> [bb26];
     }
 
     bb20: {
-        _27 = load_type(int);
-        _28 = load_type(void);
-        _29 = load_type(void);
-        _9 = call const fn baml.iter.Filter.Iterable.iter<copy _27, copy _28, copy _29>(copy _8) -> [bb28];
+        _25 = load_type(int);
+        _11 = call const fn baml.iter.Repeat.Iterator.next<copy _25>(copy _9) -> [bb26];
     }
 
     bb21: {
-        _25 = make_bound_method baml.iter.Map.Iterable.iter(copy _8);
-        _9 = call copy _25() -> [bb28];
+        _21 = load_type(int);
+        _22 = load_type(void);
+        _23 = load_type(void);
+        _11 = call const fn baml.iter.Chain.Iterator.next<copy _21, copy _22, copy _23>(copy _9) -> [bb26];
     }
 
     bb22: {
-        _23 = load_type(int);
-        _9 = call const fn baml.iter.Repeat.Iterable.iter<copy _23>(copy _8) -> [bb28];
+        _18 = load_type(int);
+        _19 = load_type(void);
+        _11 = call const fn baml.iter.StepBy.Iterator.next<copy _18, copy _19>(copy _9) -> [bb26];
     }
 
     bb23: {
-        _19 = load_type(int);
-        _20 = load_type(void);
-        _21 = load_type(void);
-        _9 = call const fn baml.iter.Chain.Iterable.iter<copy _19, copy _20, copy _21>(copy _8) -> [bb28];
+        _16 = load_type(int);
+        _11 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _16>(copy _9) -> [bb26];
     }
 
     bb24: {
-        _16 = load_type(int);
-        _17 = load_type(void);
-        _9 = call const fn baml.iter.StepBy.Iterable.iter<copy _16, copy _17>(copy _8) -> [bb28];
+        _11 = call const fn baml.iter.Range.Iterator.next(copy _9) -> [bb26];
     }
 
     bb25: {
-        _14 = load_type(int);
-        _9 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _14>(copy _8) -> [bb28];
+        _13 = make_bound_method baml.iter.Flatten.Iterator.next(copy _9);
+        _11 = call copy _13() -> [bb26];
     }
 
     bb26: {
-        _9 = call const fn baml.iter.Range.Iterable.iter(copy _8) -> [bb28];
+        _39 = is_type(copy _11, baml.iter.Done);
+        branch copy _39 -> [bb30, bb27];
     }
 
     bb27: {
-        _11 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _8);
-        _9 = call copy _11() -> [bb28];
+        _40 = copy _11;
+        fresh_cell(_41);
+        _41 = copy _40;
+        _42 = const 0_i64;
+        goto -> bb28;
     }
 
     bb28: {
-        _42 = is_type(copy _9, baml.iter.Flatten<_, int, void, void>);
-        branch copy _42 -> [bb50, bb29];
+        _44 = copy _42;
+        _45 = copy _41;
+        _43 = copy _44 < copy _45;
+        branch copy _43 -> [bb29, bb3];
     }
 
     bb29: {
-        _44 = is_type(copy _9, baml.iter.Range);
-        branch copy _44 -> [bb49, bb30];
+        _1 = copy _1 + const "1";
+        _42 = copy _42 + const 1_i64;
+        goto -> bb28;
     }
 
     bb30: {
-        _45 = is_type(copy _9, baml.iter.ArrayIterator<int>);
-        branch copy _45 -> [bb48, bb31];
+        _0 = copy _1;
+        goto -> bb31;
     }
 
     bb31: {
-        _47 = is_type(copy _9, baml.iter.StepBy<int, void>);
-        branch copy _47 -> [bb47, bb32];
-    }
-
-    bb32: {
-        _50 = is_type(copy _9, baml.iter.Chain<int, void, void>);
-        branch copy _50 -> [bb46, bb33];
-    }
-
-    bb33: {
-        _54 = is_type(copy _9, baml.iter.Repeat<int>);
-        branch copy _54 -> [bb45, bb34];
-    }
-
-    bb34: {
-        _56 = is_type(copy _9, baml.iter.Map<_, int, void, void>);
-        branch copy _56 -> [bb44, bb35];
-    }
-
-    bb35: {
-        _58 = is_type(copy _9, baml.iter.Filter<int, void, void>);
-        branch copy _58 -> [bb43, bb36];
-    }
-
-    bb36: {
-        _62 = is_type(copy _9, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _62 -> [bb42, bb37];
-    }
-
-    bb37: {
-        _64 = is_type(copy _9, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _64 -> [bb41, bb38];
-    }
-
-    bb38: {
-        _66 = is_type(copy _9, baml.iter.Peekable<int, void>);
-        branch copy _66 -> [bb40, bb39];
-    }
-
-    bb39: {
-        unreachable;
-    }
-
-    bb40: {
-        _67 = load_type(int);
-        _68 = load_type(void);
-        _41 = call const fn baml.iter.Peekable.Iterator.next<copy _67, copy _68>(copy _9) -> [bb51];
-    }
-
-    bb41: {
-        _65 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _9);
-        _41 = call copy _65() -> [bb51];
-    }
-
-    bb42: {
-        _63 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _9);
-        _41 = call copy _63() -> [bb51];
-    }
-
-    bb43: {
-        _59 = load_type(int);
-        _60 = load_type(void);
-        _61 = load_type(void);
-        _41 = call const fn baml.iter.Filter.Iterator.next<copy _59, copy _60, copy _61>(copy _9) -> [bb51];
-    }
-
-    bb44: {
-        _57 = make_bound_method baml.iter.Map.Iterator.next(copy _9);
-        _41 = call copy _57() -> [bb51];
-    }
-
-    bb45: {
-        _55 = load_type(int);
-        _41 = call const fn baml.iter.Repeat.Iterator.next<copy _55>(copy _9) -> [bb51];
-    }
-
-    bb46: {
-        _51 = load_type(int);
-        _52 = load_type(void);
-        _53 = load_type(void);
-        _41 = call const fn baml.iter.Chain.Iterator.next<copy _51, copy _52, copy _53>(copy _9) -> [bb51];
-    }
-
-    bb47: {
-        _48 = load_type(int);
-        _49 = load_type(void);
-        _41 = call const fn baml.iter.StepBy.Iterator.next<copy _48, copy _49>(copy _9) -> [bb51];
-    }
-
-    bb48: {
-        _46 = load_type(int);
-        _41 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _46>(copy _9) -> [bb51];
-    }
-
-    bb49: {
-        _41 = call const fn baml.iter.Range.Iterator.next(copy _9) -> [bb51];
-    }
-
-    bb50: {
-        _43 = make_bound_method baml.iter.Flatten.Iterator.next(copy _9);
-        _41 = call copy _43() -> [bb51];
-    }
-
-    bb51: {
-        _69 = is_type(copy _41, baml.iter.Done);
-        branch copy _69 -> [bb55, bb52];
-    }
-
-    bb52: {
-        _70 = copy _41;
-        fresh_cell(_71);
-        _71 = copy _70;
-        _72 = const 0_i64;
-        goto -> bb53;
-    }
-
-    bb53: {
-        _74 = copy _72;
-        _75 = copy _71;
-        _73 = copy _74 < copy _75;
-        branch copy _73 -> [bb54, bb28];
-    }
-
-    bb54: {
-        _1 = copy _1 + const "1";
-        _72 = copy _72 + const 1_i64;
-        goto -> bb53;
-    }
-
-    bb55: {
-        _0 = copy _1;
-        goto -> bb56;
-    }
-
-    bb56: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
@@ -371,335 +371,172 @@ function user.test_shadowing() -> string {
     alloc_array 3
     make_closure .<lambda(test_shadowing, 0)>, 0
     call baml.Array.map
-    store_var_load_var _8
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    store_var mapped
+    load_type int
+    load_var mapped
+    call baml.iter.Iterable$for$T[].iter
+    store_var _9
 
   L0:
-    load_var _8
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _8
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _8
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _8
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _8
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _8
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _8
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _8
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _8
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _8
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _8
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _8
-    is_type int[]
-    pop_jump_if_false L49
-    load_type int
-    load_var _8
-    call baml.iter.Iterable$for$T[].iter
-    store_var _9
-    jump L24
-
-  L12:
-    load_type int
-    load_var _8
-    call baml.iter.Iterable$for$T[].iter
-    store_var _9
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _8
-    call baml.iter.Peekable.Iterable.iter
-    store_var _9
-    jump L24
-
-  L14:
-    load_var _8
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _9
-    jump L24
-
-  L15:
-    load_var _8
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _9
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _8
-    call baml.iter.Filter.Iterable.iter
-    store_var _9
-    jump L24
-
-  L17:
-    load_var _8
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _9
-    jump L24
-
-  L18:
-    load_type int
-    load_var _8
-    call baml.iter.Repeat.Iterable.iter
-    store_var _9
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _8
-    call baml.iter.Chain.Iterable.iter
-    store_var _9
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _8
-    call baml.iter.StepBy.Iterable.iter
-    store_var _9
-    jump L24
-
-  L21:
-    load_type int
-    load_var _8
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _9
-    jump L24
-
-  L22:
-    load_var _8
-    call baml.iter.Range.Iterable.iter
-    store_var _9
-    jump L24
-
-  L23:
-    load_var _8
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _9
-
-  L24:
     load_var _9
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _9
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _9
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _9
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _9
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _9
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _9
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _9
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _9
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _9
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _9
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L49
+    pop_jump_if_false L25
     load_type int
     load_type void
     load_var _9
     call baml.iter.Peekable.Iterator.next
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L35:
+  L11:
     load_var _9
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L36:
+  L12:
     load_var _9
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _9
     call baml.iter.Filter.Iterator.next
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L38:
+  L14:
     load_var _9
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _9
     call baml.iter.Repeat.Iterator.next
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _9
     call baml.iter.Chain.Iterator.next
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _9
     call baml.iter.StepBy.Iterator.next
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _9
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L43:
+  L19:
     load_var _9
     call baml.iter.Range.Iterator.next
-    store_var _41
-    jump L45
+    store_var _11
+    jump L21
 
-  L44:
+  L20:
     load_var _9
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _41
+    store_var _11
 
-  L45:
-    load_var _41
+  L21:
+    load_var _11
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L48
+    pop_jump_if_false L22
+    jump L24
 
-  L46:
-    load_var _41
+  L22:
+    load_var _11
     store_var y
     load_const 0
     store_var i
 
-  L47:
+  L23:
     load_var2 6 5
     cmp_int_op <
-    pop_jump_if_false L24
+    pop_jump_if_false L0
     load_var x
     load_const "1"
     bin_op +
@@ -708,13 +545,13 @@ function user.test_shadowing() -> string {
     load_const 1
     add_int
     store_var i
-    jump L47
+    jump L23
 
-  L48:
+  L24:
     load_var x
     return
 
-  L49:
+  L25:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__04_5_mir.snap
@@ -92,10 +92,10 @@ fn user.test_generic_lambda() -> int {
 }
 
 // lambda[0]
-fn .<lambda(test_generic_lambda, 0)>(x: void) -> null {
+fn .<lambda(test_generic_lambda, 0)>(x: unknown) -> null {
     // Locals:
     let _0: null // _0 // return
-    let _1: void // x // param
+    let _1: unknown // x // param
 
     bb0: {
         _0 = copy _1;

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__04_5_mir.snap
@@ -55,10 +55,10 @@ fn user.test_generic() -> int {
 }
 
 // lambda[0]
-fn .<lambda(test_generic, 0)>(x: void) -> null {
+fn .<lambda(test_generic, 0)>(x: unknown) -> null {
     // Locals:
     let _0: null // _0 // return
-    let _1: void // x // param
+    let _1: unknown // x // param
 
     bb0: {
         _0 = copy _1;

--- a/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__04_5_mir.snap
@@ -120,134 +120,103 @@ fn user.for_loop_restores_outer() -> int {
     let _1: int // x
     let _2: int[]
     let _3: baml.iter.Iterator<Item = int, Error = void>
-    let _4: bool
+    let _4: type
     let _5: unknown
     let _6: bool
-    let _7: bool
-    let _8: type
+    let _7: unknown
+    let _8: bool
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: bool
-    let _40: type
-    let _41: bool
-    let _42: type
-    let _43: type
-    let _44: bool
-    let _45: type
-    let _46: type
-    let _47: type
-    let _48: bool
-    let _49: type
-    let _50: bool
-    let _51: unknown
-    let _52: bool
-    let _53: type
-    let _54: type
-    let _55: type
-    let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: unknown
-    let _60: bool
-    let _61: type
-    let _62: type
-    let _63: bool
-    let _64: int
-    let _65: int // x
+    let _34: int
+    let _35: int // x
 
     bb0: {
         _1 = const 1_i64;
         _2 = [const 2_i64, const 3_i64];
-        _4 = is_type(copy _2, baml.iter.Flatten<_, int, void, void>);
-        branch copy _4 -> [bb26, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _6 = is_type(copy _2, baml.iter.Range);
-        branch copy _6 -> [bb25, bb2];
+        _4 = load_type(int);
+        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _4>(copy _2) -> [bb2];
     }
 
     bb2: {
-        _7 = is_type(copy _2, baml.iter.ArrayIterator<int>);
-        branch copy _7 -> [bb24, bb3];
+        _6 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
+        branch copy _6 -> [bb24, bb3];
     }
 
     bb3: {
-        _9 = is_type(copy _2, baml.iter.StepBy<int, void>);
-        branch copy _9 -> [bb23, bb4];
+        _8 = is_type(copy _3, baml.iter.Range);
+        branch copy _8 -> [bb23, bb4];
     }
 
     bb4: {
-        _12 = is_type(copy _2, baml.iter.Chain<int, void, void>);
-        branch copy _12 -> [bb22, bb5];
+        _9 = is_type(copy _3, baml.iter.ArrayIterator<int>);
+        branch copy _9 -> [bb22, bb5];
     }
 
     bb5: {
-        _16 = is_type(copy _2, baml.iter.Repeat<int>);
-        branch copy _16 -> [bb21, bb6];
+        _11 = is_type(copy _3, baml.iter.StepBy<int, void>);
+        branch copy _11 -> [bb21, bb6];
     }
 
     bb6: {
-        _18 = is_type(copy _2, baml.iter.Map<_, int, void, void>);
-        branch copy _18 -> [bb20, bb7];
+        _14 = is_type(copy _3, baml.iter.Chain<int, void, void>);
+        branch copy _14 -> [bb20, bb7];
     }
 
     bb7: {
-        _20 = is_type(copy _2, baml.iter.Filter<int, void, void>);
-        branch copy _20 -> [bb19, bb8];
+        _18 = is_type(copy _3, baml.iter.Repeat<int>);
+        branch copy _18 -> [bb19, bb8];
     }
 
     bb8: {
-        _24 = is_type(copy _2, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _24 -> [bb18, bb9];
+        _20 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
+        branch copy _20 -> [bb18, bb9];
     }
 
     bb9: {
-        _26 = is_type(copy _2, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _26 -> [bb17, bb10];
+        _22 = is_type(copy _3, baml.iter.Filter<int, void, void>);
+        branch copy _22 -> [bb17, bb10];
     }
 
     bb10: {
-        _28 = is_type(copy _2, baml.iter.Peekable<int, void>);
-        branch copy _28 -> [bb16, bb11];
+        _26 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _26 -> [bb16, bb11];
     }
 
     bb11: {
-        _31 = is_type(copy _2, unknown[]);
-        branch copy _31 -> [bb15, bb12];
+        _28 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _28 -> [bb15, bb12];
     }
 
     bb12: {
-        _33 = is_type(copy _2, int[]);
-        branch copy _33 -> [bb14, bb13];
+        _30 = is_type(copy _3, baml.iter.Peekable<int, void>);
+        branch copy _30 -> [bb14, bb13];
     }
 
     bb13: {
@@ -255,212 +224,83 @@ fn user.for_loop_restores_outer() -> int {
     }
 
     bb14: {
-        _34 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _2) -> [bb27];
+        _31 = load_type(int);
+        _32 = load_type(void);
+        _5 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _3) -> [bb25];
     }
 
     bb15: {
-        _32 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _2) -> [bb27];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
+        _5 = call copy _29() -> [bb25];
     }
 
     bb16: {
-        _29 = load_type(int);
-        _30 = load_type(void);
-        _3 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _2) -> [bb27];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
+        _5 = call copy _27() -> [bb25];
     }
 
     bb17: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _2);
-        _3 = call copy _27() -> [bb27];
+        _23 = load_type(int);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _5 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _3) -> [bb25];
     }
 
     bb18: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _2);
-        _3 = call copy _25() -> [bb27];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
+        _5 = call copy _21() -> [bb25];
     }
 
     bb19: {
-        _21 = load_type(int);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _3 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _2) -> [bb27];
+        _19 = load_type(int);
+        _5 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _3) -> [bb25];
     }
 
     bb20: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _2);
-        _3 = call copy _19() -> [bb27];
+        _15 = load_type(int);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _5 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _3) -> [bb25];
     }
 
     bb21: {
-        _17 = load_type(int);
-        _3 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _2) -> [bb27];
+        _12 = load_type(int);
+        _13 = load_type(void);
+        _5 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _3) -> [bb25];
     }
 
     bb22: {
-        _13 = load_type(int);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _3 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _2) -> [bb27];
+        _10 = load_type(int);
+        _5 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _3) -> [bb25];
     }
 
     bb23: {
-        _10 = load_type(int);
-        _11 = load_type(void);
-        _3 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _2) -> [bb27];
+        _5 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb25];
     }
 
     bb24: {
-        _8 = load_type(int);
-        _3 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _2) -> [bb27];
+        _7 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
+        _5 = call copy _7() -> [bb25];
     }
 
     bb25: {
-        _3 = call const fn baml.iter.Range.Iterable.iter(copy _2) -> [bb27];
+        _33 = is_type(copy _5, baml.iter.Done);
+        branch copy _33 -> [bb27, bb26];
     }
 
     bb26: {
-        _5 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _2);
-        _3 = call copy _5() -> [bb27];
+        _34 = copy _5;
+        fresh_cell(_35);
+        _35 = copy _34;
+        goto -> bb2;
     }
 
     bb27: {
-        _36 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
-        branch copy _36 -> [bb49, bb28];
+        _0 = copy _1;
+        goto -> bb28;
     }
 
     bb28: {
-        _38 = is_type(copy _3, baml.iter.Range);
-        branch copy _38 -> [bb48, bb29];
-    }
-
-    bb29: {
-        _39 = is_type(copy _3, baml.iter.ArrayIterator<int>);
-        branch copy _39 -> [bb47, bb30];
-    }
-
-    bb30: {
-        _41 = is_type(copy _3, baml.iter.StepBy<int, void>);
-        branch copy _41 -> [bb46, bb31];
-    }
-
-    bb31: {
-        _44 = is_type(copy _3, baml.iter.Chain<int, void, void>);
-        branch copy _44 -> [bb45, bb32];
-    }
-
-    bb32: {
-        _48 = is_type(copy _3, baml.iter.Repeat<int>);
-        branch copy _48 -> [bb44, bb33];
-    }
-
-    bb33: {
-        _50 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
-        branch copy _50 -> [bb43, bb34];
-    }
-
-    bb34: {
-        _52 = is_type(copy _3, baml.iter.Filter<int, void, void>);
-        branch copy _52 -> [bb42, bb35];
-    }
-
-    bb35: {
-        _56 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _56 -> [bb41, bb36];
-    }
-
-    bb36: {
-        _58 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _58 -> [bb40, bb37];
-    }
-
-    bb37: {
-        _60 = is_type(copy _3, baml.iter.Peekable<int, void>);
-        branch copy _60 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _61 = load_type(int);
-        _62 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _61, copy _62>(copy _3) -> [bb50];
-    }
-
-    bb40: {
-        _59 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
-        _35 = call copy _59() -> [bb50];
-    }
-
-    bb41: {
-        _57 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
-        _35 = call copy _57() -> [bb50];
-    }
-
-    bb42: {
-        _53 = load_type(int);
-        _54 = load_type(void);
-        _55 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _53, copy _54, copy _55>(copy _3) -> [bb50];
-    }
-
-    bb43: {
-        _51 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
-        _35 = call copy _51() -> [bb50];
-    }
-
-    bb44: {
-        _49 = load_type(int);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _49>(copy _3) -> [bb50];
-    }
-
-    bb45: {
-        _45 = load_type(int);
-        _46 = load_type(void);
-        _47 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _45, copy _46, copy _47>(copy _3) -> [bb50];
-    }
-
-    bb46: {
-        _42 = load_type(int);
-        _43 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _42, copy _43>(copy _3) -> [bb50];
-    }
-
-    bb47: {
-        _40 = load_type(int);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _40>(copy _3) -> [bb50];
-    }
-
-    bb48: {
-        _35 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb50];
-    }
-
-    bb49: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
-        _35 = call copy _37() -> [bb50];
-    }
-
-    bb50: {
-        _63 = is_type(copy _35, baml.iter.Done);
-        branch copy _63 -> [bb52, bb51];
-    }
-
-    bb51: {
-        _64 = copy _35;
-        fresh_cell(_65);
-        _65 = copy _64;
-        goto -> bb27;
-    }
-
-    bb52: {
-        _0 = copy _1;
-        goto -> bb53;
-    }
-
-    bb53: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
@@ -50,338 +50,173 @@ function user.declared_type_restored() -> string {
 }
 
 function user.for_loop_restores_outer() -> int {
+    load_type int
     load_const 2
     load_const 3
     alloc_array 2
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var _35
+  L22:
+    load_var _5
     store_var x
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_const 1
     return
 
-  L48:
+  L24:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__04_5_mir.snap
@@ -603,135 +603,104 @@ fn user.iterator_style_for_loop() -> int {
     let _1: int // result
     let _2: int[]
     let _3: baml.iter.Iterator<Item = int, Error = void>
-    let _4: bool
+    let _4: type
     let _5: unknown
     let _6: bool
-    let _7: bool
-    let _8: type
+    let _7: unknown
+    let _8: bool
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: bool
-    let _40: type
-    let _41: bool
-    let _42: type
-    let _43: type
-    let _44: bool
-    let _45: type
-    let _46: type
-    let _47: type
-    let _48: bool
-    let _49: type
-    let _50: bool
-    let _51: unknown
-    let _52: bool
-    let _53: type
-    let _54: type
-    let _55: type
-    let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: unknown
-    let _60: bool
-    let _61: type
-    let _62: type
-    let _63: bool
-    let _64: int
-    let _65: int // i
-    let _66: int
+    let _34: int
+    let _35: int // i
+    let _36: int
 
     bb0: {
         _1 = const 0_i64;
         _2 = [const 1_i64, const 2_i64, const 3_i64];
-        _4 = is_type(copy _2, baml.iter.Flatten<_, int, void, void>);
-        branch copy _4 -> [bb26, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _6 = is_type(copy _2, baml.iter.Range);
-        branch copy _6 -> [bb25, bb2];
+        _4 = load_type(int);
+        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _4>(copy _2) -> [bb2];
     }
 
     bb2: {
-        _7 = is_type(copy _2, baml.iter.ArrayIterator<int>);
-        branch copy _7 -> [bb24, bb3];
+        _6 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
+        branch copy _6 -> [bb24, bb3];
     }
 
     bb3: {
-        _9 = is_type(copy _2, baml.iter.StepBy<int, void>);
-        branch copy _9 -> [bb23, bb4];
+        _8 = is_type(copy _3, baml.iter.Range);
+        branch copy _8 -> [bb23, bb4];
     }
 
     bb4: {
-        _12 = is_type(copy _2, baml.iter.Chain<int, void, void>);
-        branch copy _12 -> [bb22, bb5];
+        _9 = is_type(copy _3, baml.iter.ArrayIterator<int>);
+        branch copy _9 -> [bb22, bb5];
     }
 
     bb5: {
-        _16 = is_type(copy _2, baml.iter.Repeat<int>);
-        branch copy _16 -> [bb21, bb6];
+        _11 = is_type(copy _3, baml.iter.StepBy<int, void>);
+        branch copy _11 -> [bb21, bb6];
     }
 
     bb6: {
-        _18 = is_type(copy _2, baml.iter.Map<_, int, void, void>);
-        branch copy _18 -> [bb20, bb7];
+        _14 = is_type(copy _3, baml.iter.Chain<int, void, void>);
+        branch copy _14 -> [bb20, bb7];
     }
 
     bb7: {
-        _20 = is_type(copy _2, baml.iter.Filter<int, void, void>);
-        branch copy _20 -> [bb19, bb8];
+        _18 = is_type(copy _3, baml.iter.Repeat<int>);
+        branch copy _18 -> [bb19, bb8];
     }
 
     bb8: {
-        _24 = is_type(copy _2, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _24 -> [bb18, bb9];
+        _20 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
+        branch copy _20 -> [bb18, bb9];
     }
 
     bb9: {
-        _26 = is_type(copy _2, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _26 -> [bb17, bb10];
+        _22 = is_type(copy _3, baml.iter.Filter<int, void, void>);
+        branch copy _22 -> [bb17, bb10];
     }
 
     bb10: {
-        _28 = is_type(copy _2, baml.iter.Peekable<int, void>);
-        branch copy _28 -> [bb16, bb11];
+        _26 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _26 -> [bb16, bb11];
     }
 
     bb11: {
-        _31 = is_type(copy _2, unknown[]);
-        branch copy _31 -> [bb15, bb12];
+        _28 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _28 -> [bb15, bb12];
     }
 
     bb12: {
-        _33 = is_type(copy _2, int[]);
-        branch copy _33 -> [bb14, bb13];
+        _30 = is_type(copy _3, baml.iter.Peekable<int, void>);
+        branch copy _30 -> [bb14, bb13];
     }
 
     bb13: {
@@ -739,214 +708,85 @@ fn user.iterator_style_for_loop() -> int {
     }
 
     bb14: {
-        _34 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _2) -> [bb27];
+        _31 = load_type(int);
+        _32 = load_type(void);
+        _5 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _3) -> [bb25];
     }
 
     bb15: {
-        _32 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _2) -> [bb27];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
+        _5 = call copy _29() -> [bb25];
     }
 
     bb16: {
-        _29 = load_type(int);
-        _30 = load_type(void);
-        _3 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _2) -> [bb27];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
+        _5 = call copy _27() -> [bb25];
     }
 
     bb17: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _2);
-        _3 = call copy _27() -> [bb27];
+        _23 = load_type(int);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _5 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _3) -> [bb25];
     }
 
     bb18: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _2);
-        _3 = call copy _25() -> [bb27];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
+        _5 = call copy _21() -> [bb25];
     }
 
     bb19: {
-        _21 = load_type(int);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _3 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _2) -> [bb27];
+        _19 = load_type(int);
+        _5 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _3) -> [bb25];
     }
 
     bb20: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _2);
-        _3 = call copy _19() -> [bb27];
+        _15 = load_type(int);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _5 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _3) -> [bb25];
     }
 
     bb21: {
-        _17 = load_type(int);
-        _3 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _2) -> [bb27];
+        _12 = load_type(int);
+        _13 = load_type(void);
+        _5 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _3) -> [bb25];
     }
 
     bb22: {
-        _13 = load_type(int);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _3 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _2) -> [bb27];
+        _10 = load_type(int);
+        _5 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _3) -> [bb25];
     }
 
     bb23: {
-        _10 = load_type(int);
-        _11 = load_type(void);
-        _3 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _2) -> [bb27];
+        _5 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb25];
     }
 
     bb24: {
-        _8 = load_type(int);
-        _3 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _2) -> [bb27];
+        _7 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
+        _5 = call copy _7() -> [bb25];
     }
 
     bb25: {
-        _3 = call const fn baml.iter.Range.Iterable.iter(copy _2) -> [bb27];
+        _33 = is_type(copy _5, baml.iter.Done);
+        branch copy _33 -> [bb27, bb26];
     }
 
     bb26: {
-        _5 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _2);
-        _3 = call copy _5() -> [bb27];
+        _34 = copy _5;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _36 = copy _35;
+        _1 = copy _1 + copy _36;
+        goto -> bb2;
     }
 
     bb27: {
-        _36 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
-        branch copy _36 -> [bb49, bb28];
+        _0 = copy _1;
+        goto -> bb28;
     }
 
     bb28: {
-        _38 = is_type(copy _3, baml.iter.Range);
-        branch copy _38 -> [bb48, bb29];
-    }
-
-    bb29: {
-        _39 = is_type(copy _3, baml.iter.ArrayIterator<int>);
-        branch copy _39 -> [bb47, bb30];
-    }
-
-    bb30: {
-        _41 = is_type(copy _3, baml.iter.StepBy<int, void>);
-        branch copy _41 -> [bb46, bb31];
-    }
-
-    bb31: {
-        _44 = is_type(copy _3, baml.iter.Chain<int, void, void>);
-        branch copy _44 -> [bb45, bb32];
-    }
-
-    bb32: {
-        _48 = is_type(copy _3, baml.iter.Repeat<int>);
-        branch copy _48 -> [bb44, bb33];
-    }
-
-    bb33: {
-        _50 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
-        branch copy _50 -> [bb43, bb34];
-    }
-
-    bb34: {
-        _52 = is_type(copy _3, baml.iter.Filter<int, void, void>);
-        branch copy _52 -> [bb42, bb35];
-    }
-
-    bb35: {
-        _56 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _56 -> [bb41, bb36];
-    }
-
-    bb36: {
-        _58 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _58 -> [bb40, bb37];
-    }
-
-    bb37: {
-        _60 = is_type(copy _3, baml.iter.Peekable<int, void>);
-        branch copy _60 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _61 = load_type(int);
-        _62 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _61, copy _62>(copy _3) -> [bb50];
-    }
-
-    bb40: {
-        _59 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
-        _35 = call copy _59() -> [bb50];
-    }
-
-    bb41: {
-        _57 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
-        _35 = call copy _57() -> [bb50];
-    }
-
-    bb42: {
-        _53 = load_type(int);
-        _54 = load_type(void);
-        _55 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _53, copy _54, copy _55>(copy _3) -> [bb50];
-    }
-
-    bb43: {
-        _51 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
-        _35 = call copy _51() -> [bb50];
-    }
-
-    bb44: {
-        _49 = load_type(int);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _49>(copy _3) -> [bb50];
-    }
-
-    bb45: {
-        _45 = load_type(int);
-        _46 = load_type(void);
-        _47 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _45, copy _46, copy _47>(copy _3) -> [bb50];
-    }
-
-    bb46: {
-        _42 = load_type(int);
-        _43 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _42, copy _43>(copy _3) -> [bb50];
-    }
-
-    bb47: {
-        _40 = load_type(int);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _40>(copy _3) -> [bb50];
-    }
-
-    bb48: {
-        _35 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb50];
-    }
-
-    bb49: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
-        _35 = call copy _37() -> [bb50];
-    }
-
-    bb50: {
-        _63 = is_type(copy _35, baml.iter.Done);
-        branch copy _63 -> [bb52, bb51];
-    }
-
-    bb51: {
-        _64 = copy _35;
-        fresh_cell(_65);
-        _65 = copy _64;
-        _66 = copy _65;
-        _1 = copy _1 + copy _66;
-        goto -> bb27;
-    }
-
-    bb52: {
-        _0 = copy _1;
-        goto -> bb53;
-    }
-
-    bb53: {
         return;
     }
 }
@@ -957,201 +797,140 @@ fn user.nested_for_loop() -> int {
     let _1: int // result
     let _2: int[]
     let _3: baml.iter.Iterator<Item = int, Error = void>
-    let _4: bool
+    let _4: type
     let _5: unknown
     let _6: bool
-    let _7: bool
-    let _8: type
+    let _7: unknown
+    let _8: bool
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: bool
-    let _40: type
-    let _41: bool
-    let _42: type
-    let _43: type
-    let _44: bool
-    let _45: type
+    let _34: int
+    let _35: int // i
+    let _36: int[]
+    let _37: baml.iter.Iterator<Item = int, Error = void>
+    let _38: type
+    let _39: unknown
+    let _40: bool
+    let _41: unknown
+    let _42: bool
+    let _43: bool
+    let _44: type
+    let _45: bool
     let _46: type
     let _47: type
     let _48: bool
     let _49: type
-    let _50: bool
-    let _51: unknown
+    let _50: type
+    let _51: type
     let _52: bool
     let _53: type
-    let _54: type
-    let _55: type
+    let _54: bool
+    let _55: unknown
     let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: unknown
+    let _57: type
+    let _58: type
+    let _59: type
     let _60: bool
-    let _61: type
-    let _62: type
-    let _63: bool
-    let _64: int
-    let _65: int // i
-    let _66: int[]
-    let _67: baml.iter.Iterator<Item = int, Error = void>
-    let _68: bool
-    let _69: unknown
-    let _70: bool
-    let _71: bool
-    let _72: type
-    let _73: bool
-    let _74: type
-    let _75: type
-    let _76: bool
-    let _77: type
-    let _78: type
-    let _79: type
-    let _80: bool
-    let _81: type
-    let _82: bool
-    let _83: unknown
-    let _84: bool
-    let _85: type
-    let _86: type
-    let _87: type
-    let _88: bool
-    let _89: unknown
-    let _90: bool
-    let _91: unknown
-    let _92: bool
-    let _93: type
-    let _94: type
-    let _95: bool
-    let _96: type
-    let _97: bool
-    let _98: type
-    let _99: unknown
-    let _100: bool
-    let _101: unknown
-    let _102: bool
-    let _103: bool
-    let _104: type
-    let _105: bool
-    let _106: type
-    let _107: type
-    let _108: bool
-    let _109: type
-    let _110: type
-    let _111: type
-    let _112: bool
-    let _113: type
-    let _114: bool
-    let _115: unknown
-    let _116: bool
-    let _117: type
-    let _118: type
-    let _119: type
-    let _120: bool
-    let _121: unknown
-    let _122: bool
-    let _123: unknown
-    let _124: bool
-    let _125: type
-    let _126: type
-    let _127: bool
-    let _128: int
-    let _129: int // j
-    let _130: int
-    let _131: int
-    let _132: int
+    let _61: unknown
+    let _62: bool
+    let _63: unknown
+    let _64: bool
+    let _65: type
+    let _66: type
+    let _67: bool
+    let _68: int
+    let _69: int // j
+    let _70: int
+    let _71: int
+    let _72: int
 
     bb0: {
         _1 = const 0_i64;
         _2 = [const 1_i64, const 2_i64, const 3_i64];
-        _4 = is_type(copy _2, baml.iter.Flatten<_, int, void, void>);
-        branch copy _4 -> [bb26, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _6 = is_type(copy _2, baml.iter.Range);
-        branch copy _6 -> [bb25, bb2];
+        _4 = load_type(int);
+        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _4>(copy _2) -> [bb2];
     }
 
     bb2: {
-        _7 = is_type(copy _2, baml.iter.ArrayIterator<int>);
-        branch copy _7 -> [bb24, bb3];
+        _6 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
+        branch copy _6 -> [bb24, bb3];
     }
 
     bb3: {
-        _9 = is_type(copy _2, baml.iter.StepBy<int, void>);
-        branch copy _9 -> [bb23, bb4];
+        _8 = is_type(copy _3, baml.iter.Range);
+        branch copy _8 -> [bb23, bb4];
     }
 
     bb4: {
-        _12 = is_type(copy _2, baml.iter.Chain<int, void, void>);
-        branch copy _12 -> [bb22, bb5];
+        _9 = is_type(copy _3, baml.iter.ArrayIterator<int>);
+        branch copy _9 -> [bb22, bb5];
     }
 
     bb5: {
-        _16 = is_type(copy _2, baml.iter.Repeat<int>);
-        branch copy _16 -> [bb21, bb6];
+        _11 = is_type(copy _3, baml.iter.StepBy<int, void>);
+        branch copy _11 -> [bb21, bb6];
     }
 
     bb6: {
-        _18 = is_type(copy _2, baml.iter.Map<_, int, void, void>);
-        branch copy _18 -> [bb20, bb7];
+        _14 = is_type(copy _3, baml.iter.Chain<int, void, void>);
+        branch copy _14 -> [bb20, bb7];
     }
 
     bb7: {
-        _20 = is_type(copy _2, baml.iter.Filter<int, void, void>);
-        branch copy _20 -> [bb19, bb8];
+        _18 = is_type(copy _3, baml.iter.Repeat<int>);
+        branch copy _18 -> [bb19, bb8];
     }
 
     bb8: {
-        _24 = is_type(copy _2, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _24 -> [bb18, bb9];
+        _20 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
+        branch copy _20 -> [bb18, bb9];
     }
 
     bb9: {
-        _26 = is_type(copy _2, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _26 -> [bb17, bb10];
+        _22 = is_type(copy _3, baml.iter.Filter<int, void, void>);
+        branch copy _22 -> [bb17, bb10];
     }
 
     bb10: {
-        _28 = is_type(copy _2, baml.iter.Peekable<int, void>);
-        branch copy _28 -> [bb16, bb11];
+        _26 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _26 -> [bb16, bb11];
     }
 
     bb11: {
-        _31 = is_type(copy _2, unknown[]);
-        branch copy _31 -> [bb15, bb12];
+        _28 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _28 -> [bb15, bb12];
     }
 
     bb12: {
-        _33 = is_type(copy _2, int[]);
-        branch copy _33 -> [bb14, bb13];
+        _30 = is_type(copy _3, baml.iter.Peekable<int, void>);
+        branch copy _30 -> [bb14, bb13];
     }
 
     bb13: {
@@ -1159,483 +938,224 @@ fn user.nested_for_loop() -> int {
     }
 
     bb14: {
-        _34 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _2) -> [bb27];
+        _31 = load_type(int);
+        _32 = load_type(void);
+        _5 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _3) -> [bb25];
     }
 
     bb15: {
-        _32 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _2) -> [bb27];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
+        _5 = call copy _29() -> [bb25];
     }
 
     bb16: {
-        _29 = load_type(int);
-        _30 = load_type(void);
-        _3 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _2) -> [bb27];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
+        _5 = call copy _27() -> [bb25];
     }
 
     bb17: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _2);
-        _3 = call copy _27() -> [bb27];
+        _23 = load_type(int);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _5 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _3) -> [bb25];
     }
 
     bb18: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _2);
-        _3 = call copy _25() -> [bb27];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
+        _5 = call copy _21() -> [bb25];
     }
 
     bb19: {
-        _21 = load_type(int);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _3 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _2) -> [bb27];
+        _19 = load_type(int);
+        _5 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _3) -> [bb25];
     }
 
     bb20: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _2);
-        _3 = call copy _19() -> [bb27];
+        _15 = load_type(int);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _5 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _3) -> [bb25];
     }
 
     bb21: {
-        _17 = load_type(int);
-        _3 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _2) -> [bb27];
+        _12 = load_type(int);
+        _13 = load_type(void);
+        _5 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _3) -> [bb25];
     }
 
     bb22: {
-        _13 = load_type(int);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _3 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _2) -> [bb27];
+        _10 = load_type(int);
+        _5 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _3) -> [bb25];
     }
 
     bb23: {
-        _10 = load_type(int);
-        _11 = load_type(void);
-        _3 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _2) -> [bb27];
+        _5 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb25];
     }
 
     bb24: {
-        _8 = load_type(int);
-        _3 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _2) -> [bb27];
+        _7 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
+        _5 = call copy _7() -> [bb25];
     }
 
     bb25: {
-        _3 = call const fn baml.iter.Range.Iterable.iter(copy _2) -> [bb27];
+        _33 = is_type(copy _5, baml.iter.Done);
+        branch copy _33 -> [bb53, bb26];
     }
 
     bb26: {
-        _5 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _2);
-        _3 = call copy _5() -> [bb27];
+        _34 = copy _5;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _36 = [const 4_i64, const 5_i64, const 6_i64];
+        goto -> bb27;
     }
 
     bb27: {
-        _36 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
-        branch copy _36 -> [bb49, bb28];
+        _38 = load_type(int);
+        _37 = call const fn baml.iter.Iterable$for$T[].iter<copy _38>(copy _36) -> [bb28];
     }
 
     bb28: {
-        _38 = is_type(copy _3, baml.iter.Range);
-        branch copy _38 -> [bb48, bb29];
+        _40 = is_type(copy _37, baml.iter.Flatten<_, int, void, void>);
+        branch copy _40 -> [bb50, bb29];
     }
 
     bb29: {
-        _39 = is_type(copy _3, baml.iter.ArrayIterator<int>);
-        branch copy _39 -> [bb47, bb30];
+        _42 = is_type(copy _37, baml.iter.Range);
+        branch copy _42 -> [bb49, bb30];
     }
 
     bb30: {
-        _41 = is_type(copy _3, baml.iter.StepBy<int, void>);
-        branch copy _41 -> [bb46, bb31];
+        _43 = is_type(copy _37, baml.iter.ArrayIterator<int>);
+        branch copy _43 -> [bb48, bb31];
     }
 
     bb31: {
-        _44 = is_type(copy _3, baml.iter.Chain<int, void, void>);
-        branch copy _44 -> [bb45, bb32];
+        _45 = is_type(copy _37, baml.iter.StepBy<int, void>);
+        branch copy _45 -> [bb47, bb32];
     }
 
     bb32: {
-        _48 = is_type(copy _3, baml.iter.Repeat<int>);
-        branch copy _48 -> [bb44, bb33];
+        _48 = is_type(copy _37, baml.iter.Chain<int, void, void>);
+        branch copy _48 -> [bb46, bb33];
     }
 
     bb33: {
-        _50 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
-        branch copy _50 -> [bb43, bb34];
+        _52 = is_type(copy _37, baml.iter.Repeat<int>);
+        branch copy _52 -> [bb45, bb34];
     }
 
     bb34: {
-        _52 = is_type(copy _3, baml.iter.Filter<int, void, void>);
-        branch copy _52 -> [bb42, bb35];
+        _54 = is_type(copy _37, baml.iter.Map<_, int, void, void>);
+        branch copy _54 -> [bb44, bb35];
     }
 
     bb35: {
-        _56 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _56 -> [bb41, bb36];
+        _56 = is_type(copy _37, baml.iter.Filter<int, void, void>);
+        branch copy _56 -> [bb43, bb36];
     }
 
     bb36: {
-        _58 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _58 -> [bb40, bb37];
+        _60 = is_type(copy _37, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _60 -> [bb42, bb37];
     }
 
     bb37: {
-        _60 = is_type(copy _3, baml.iter.Peekable<int, void>);
-        branch copy _60 -> [bb39, bb38];
+        _62 = is_type(copy _37, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _62 -> [bb41, bb38];
     }
 
     bb38: {
-        unreachable;
+        _64 = is_type(copy _37, baml.iter.Peekable<int, void>);
+        branch copy _64 -> [bb40, bb39];
     }
 
     bb39: {
-        _61 = load_type(int);
-        _62 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _61, copy _62>(copy _3) -> [bb50];
+        unreachable;
     }
 
     bb40: {
-        _59 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
-        _35 = call copy _59() -> [bb50];
+        _65 = load_type(int);
+        _66 = load_type(void);
+        _39 = call const fn baml.iter.Peekable.Iterator.next<copy _65, copy _66>(copy _37) -> [bb51];
     }
 
     bb41: {
-        _57 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
-        _35 = call copy _57() -> [bb50];
+        _63 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _37);
+        _39 = call copy _63() -> [bb51];
     }
 
     bb42: {
-        _53 = load_type(int);
-        _54 = load_type(void);
-        _55 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _53, copy _54, copy _55>(copy _3) -> [bb50];
+        _61 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _37);
+        _39 = call copy _61() -> [bb51];
     }
 
     bb43: {
-        _51 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
-        _35 = call copy _51() -> [bb50];
+        _57 = load_type(int);
+        _58 = load_type(void);
+        _59 = load_type(void);
+        _39 = call const fn baml.iter.Filter.Iterator.next<copy _57, copy _58, copy _59>(copy _37) -> [bb51];
     }
 
     bb44: {
-        _49 = load_type(int);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _49>(copy _3) -> [bb50];
+        _55 = make_bound_method baml.iter.Map.Iterator.next(copy _37);
+        _39 = call copy _55() -> [bb51];
     }
 
     bb45: {
-        _45 = load_type(int);
-        _46 = load_type(void);
-        _47 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _45, copy _46, copy _47>(copy _3) -> [bb50];
+        _53 = load_type(int);
+        _39 = call const fn baml.iter.Repeat.Iterator.next<copy _53>(copy _37) -> [bb51];
     }
 
     bb46: {
-        _42 = load_type(int);
-        _43 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _42, copy _43>(copy _3) -> [bb50];
+        _49 = load_type(int);
+        _50 = load_type(void);
+        _51 = load_type(void);
+        _39 = call const fn baml.iter.Chain.Iterator.next<copy _49, copy _50, copy _51>(copy _37) -> [bb51];
     }
 
     bb47: {
-        _40 = load_type(int);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _40>(copy _3) -> [bb50];
+        _46 = load_type(int);
+        _47 = load_type(void);
+        _39 = call const fn baml.iter.StepBy.Iterator.next<copy _46, copy _47>(copy _37) -> [bb51];
     }
 
     bb48: {
-        _35 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb50];
+        _44 = load_type(int);
+        _39 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _44>(copy _37) -> [bb51];
     }
 
     bb49: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
-        _35 = call copy _37() -> [bb50];
+        _39 = call const fn baml.iter.Range.Iterator.next(copy _37) -> [bb51];
     }
 
     bb50: {
-        _63 = is_type(copy _35, baml.iter.Done);
-        branch copy _63 -> [bb103, bb51];
+        _41 = make_bound_method baml.iter.Flatten.Iterator.next(copy _37);
+        _39 = call copy _41() -> [bb51];
     }
 
     bb51: {
-        _64 = copy _35;
-        fresh_cell(_65);
-        _65 = copy _64;
-        _66 = [const 4_i64, const 5_i64, const 6_i64];
-        _68 = is_type(copy _66, baml.iter.Flatten<_, int, void, void>);
-        branch copy _68 -> [bb77, bb52];
+        _67 = is_type(copy _39, baml.iter.Done);
+        branch copy _67 -> [bb2, bb52];
     }
 
     bb52: {
-        _70 = is_type(copy _66, baml.iter.Range);
-        branch copy _70 -> [bb76, bb53];
+        _68 = copy _39;
+        fresh_cell(_69);
+        _69 = copy _68;
+        _71 = copy _35;
+        _72 = copy _69;
+        _70 = copy _71 * copy _72;
+        _1 = copy _1 + copy _70;
+        goto -> bb28;
     }
 
     bb53: {
-        _71 = is_type(copy _66, baml.iter.ArrayIterator<int>);
-        branch copy _71 -> [bb75, bb54];
+        _0 = copy _1;
+        goto -> bb54;
     }
 
     bb54: {
-        _73 = is_type(copy _66, baml.iter.StepBy<int, void>);
-        branch copy _73 -> [bb74, bb55];
-    }
-
-    bb55: {
-        _76 = is_type(copy _66, baml.iter.Chain<int, void, void>);
-        branch copy _76 -> [bb73, bb56];
-    }
-
-    bb56: {
-        _80 = is_type(copy _66, baml.iter.Repeat<int>);
-        branch copy _80 -> [bb72, bb57];
-    }
-
-    bb57: {
-        _82 = is_type(copy _66, baml.iter.Map<_, int, void, void>);
-        branch copy _82 -> [bb71, bb58];
-    }
-
-    bb58: {
-        _84 = is_type(copy _66, baml.iter.Filter<int, void, void>);
-        branch copy _84 -> [bb70, bb59];
-    }
-
-    bb59: {
-        _88 = is_type(copy _66, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _88 -> [bb69, bb60];
-    }
-
-    bb60: {
-        _90 = is_type(copy _66, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _90 -> [bb68, bb61];
-    }
-
-    bb61: {
-        _92 = is_type(copy _66, baml.iter.Peekable<int, void>);
-        branch copy _92 -> [bb67, bb62];
-    }
-
-    bb62: {
-        _95 = is_type(copy _66, unknown[]);
-        branch copy _95 -> [bb66, bb63];
-    }
-
-    bb63: {
-        _97 = is_type(copy _66, int[]);
-        branch copy _97 -> [bb65, bb64];
-    }
-
-    bb64: {
-        unreachable;
-    }
-
-    bb65: {
-        _98 = load_type(int);
-        _67 = call const fn baml.iter.Iterable$for$T[].iter<copy _98>(copy _66) -> [bb78];
-    }
-
-    bb66: {
-        _96 = load_type(int);
-        _67 = call const fn baml.iter.Iterable$for$T[].iter<copy _96>(copy _66) -> [bb78];
-    }
-
-    bb67: {
-        _93 = load_type(int);
-        _94 = load_type(void);
-        _67 = call const fn baml.iter.Peekable.Iterable.iter<copy _93, copy _94>(copy _66) -> [bb78];
-    }
-
-    bb68: {
-        _91 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _66);
-        _67 = call copy _91() -> [bb78];
-    }
-
-    bb69: {
-        _89 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _66);
-        _67 = call copy _89() -> [bb78];
-    }
-
-    bb70: {
-        _85 = load_type(int);
-        _86 = load_type(void);
-        _87 = load_type(void);
-        _67 = call const fn baml.iter.Filter.Iterable.iter<copy _85, copy _86, copy _87>(copy _66) -> [bb78];
-    }
-
-    bb71: {
-        _83 = make_bound_method baml.iter.Map.Iterable.iter(copy _66);
-        _67 = call copy _83() -> [bb78];
-    }
-
-    bb72: {
-        _81 = load_type(int);
-        _67 = call const fn baml.iter.Repeat.Iterable.iter<copy _81>(copy _66) -> [bb78];
-    }
-
-    bb73: {
-        _77 = load_type(int);
-        _78 = load_type(void);
-        _79 = load_type(void);
-        _67 = call const fn baml.iter.Chain.Iterable.iter<copy _77, copy _78, copy _79>(copy _66) -> [bb78];
-    }
-
-    bb74: {
-        _74 = load_type(int);
-        _75 = load_type(void);
-        _67 = call const fn baml.iter.StepBy.Iterable.iter<copy _74, copy _75>(copy _66) -> [bb78];
-    }
-
-    bb75: {
-        _72 = load_type(int);
-        _67 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _72>(copy _66) -> [bb78];
-    }
-
-    bb76: {
-        _67 = call const fn baml.iter.Range.Iterable.iter(copy _66) -> [bb78];
-    }
-
-    bb77: {
-        _69 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _66);
-        _67 = call copy _69() -> [bb78];
-    }
-
-    bb78: {
-        _100 = is_type(copy _67, baml.iter.Flatten<_, int, void, void>);
-        branch copy _100 -> [bb100, bb79];
-    }
-
-    bb79: {
-        _102 = is_type(copy _67, baml.iter.Range);
-        branch copy _102 -> [bb99, bb80];
-    }
-
-    bb80: {
-        _103 = is_type(copy _67, baml.iter.ArrayIterator<int>);
-        branch copy _103 -> [bb98, bb81];
-    }
-
-    bb81: {
-        _105 = is_type(copy _67, baml.iter.StepBy<int, void>);
-        branch copy _105 -> [bb97, bb82];
-    }
-
-    bb82: {
-        _108 = is_type(copy _67, baml.iter.Chain<int, void, void>);
-        branch copy _108 -> [bb96, bb83];
-    }
-
-    bb83: {
-        _112 = is_type(copy _67, baml.iter.Repeat<int>);
-        branch copy _112 -> [bb95, bb84];
-    }
-
-    bb84: {
-        _114 = is_type(copy _67, baml.iter.Map<_, int, void, void>);
-        branch copy _114 -> [bb94, bb85];
-    }
-
-    bb85: {
-        _116 = is_type(copy _67, baml.iter.Filter<int, void, void>);
-        branch copy _116 -> [bb93, bb86];
-    }
-
-    bb86: {
-        _120 = is_type(copy _67, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _120 -> [bb92, bb87];
-    }
-
-    bb87: {
-        _122 = is_type(copy _67, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _122 -> [bb91, bb88];
-    }
-
-    bb88: {
-        _124 = is_type(copy _67, baml.iter.Peekable<int, void>);
-        branch copy _124 -> [bb90, bb89];
-    }
-
-    bb89: {
-        unreachable;
-    }
-
-    bb90: {
-        _125 = load_type(int);
-        _126 = load_type(void);
-        _99 = call const fn baml.iter.Peekable.Iterator.next<copy _125, copy _126>(copy _67) -> [bb101];
-    }
-
-    bb91: {
-        _123 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _67);
-        _99 = call copy _123() -> [bb101];
-    }
-
-    bb92: {
-        _121 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _67);
-        _99 = call copy _121() -> [bb101];
-    }
-
-    bb93: {
-        _117 = load_type(int);
-        _118 = load_type(void);
-        _119 = load_type(void);
-        _99 = call const fn baml.iter.Filter.Iterator.next<copy _117, copy _118, copy _119>(copy _67) -> [bb101];
-    }
-
-    bb94: {
-        _115 = make_bound_method baml.iter.Map.Iterator.next(copy _67);
-        _99 = call copy _115() -> [bb101];
-    }
-
-    bb95: {
-        _113 = load_type(int);
-        _99 = call const fn baml.iter.Repeat.Iterator.next<copy _113>(copy _67) -> [bb101];
-    }
-
-    bb96: {
-        _109 = load_type(int);
-        _110 = load_type(void);
-        _111 = load_type(void);
-        _99 = call const fn baml.iter.Chain.Iterator.next<copy _109, copy _110, copy _111>(copy _67) -> [bb101];
-    }
-
-    bb97: {
-        _106 = load_type(int);
-        _107 = load_type(void);
-        _99 = call const fn baml.iter.StepBy.Iterator.next<copy _106, copy _107>(copy _67) -> [bb101];
-    }
-
-    bb98: {
-        _104 = load_type(int);
-        _99 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _104>(copy _67) -> [bb101];
-    }
-
-    bb99: {
-        _99 = call const fn baml.iter.Range.Iterator.next(copy _67) -> [bb101];
-    }
-
-    bb100: {
-        _101 = make_bound_method baml.iter.Flatten.Iterator.next(copy _67);
-        _99 = call copy _101() -> [bb101];
-    }
-
-    bb101: {
-        _127 = is_type(copy _99, baml.iter.Done);
-        branch copy _127 -> [bb27, bb102];
-    }
-
-    bb102: {
-        _128 = copy _99;
-        fresh_cell(_129);
-        _129 = copy _128;
-        _131 = copy _65;
-        _132 = copy _129;
-        _130 = copy _131 * copy _132;
-        _1 = copy _1 + copy _130;
-        goto -> bb78;
-    }
-
-    bb103: {
-        _0 = copy _1;
-        goto -> bb104;
-    }
-
-    bb104: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
@@ -265,340 +265,175 @@ function user.edge_type_then_object() -> int {
 function user.iterator_style_for_loop() -> int {
     load_const 0
     store_var result
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var2 1 4
+  L22:
+    load_var2 1 3
     add_int
     store_var result
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var result
     return
 
-  L48:
+  L24:
     unreachable
 }
 
@@ -672,668 +507,338 @@ function user.nested_break() -> int {
 function user.nested_for_loop() -> int {
     load_const 0
     store_var result
+    load_type int
     load_const 1
     load_const 2
     load_const 3
     alloc_array 3
-    store_var_load_var _2
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var _2
-    is_type baml.iter.Range
+    load_var _3
+    is_type baml.iter.Flatten<...>
     pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var _2
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var _2
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
     jump L20
 
-  L3:
-    load_var _2
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
+  L1:
+    load_var _3
+    is_type baml.iter.Range
+    pop_jump_if_false L2
     jump L19
 
-  L4:
-    load_var _2
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
+  L2:
+    load_var _3
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L3
     jump L18
 
-  L5:
-    load_var _2
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
+  L3:
+    load_var _3
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L4
     jump L17
 
-  L6:
-    load_var _2
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
+  L4:
+    load_var _3
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L5
     jump L16
 
-  L7:
-    load_var _2
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
+  L5:
+    load_var _3
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L6
     jump L15
 
-  L8:
-    load_var _2
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
+  L6:
+    load_var _3
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L7
     jump L14
 
-  L9:
-    load_var _2
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
+  L7:
+    load_var _3
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L8
     jump L13
 
-  L10:
-    load_var _2
-    is_type unknown[]
-    pop_jump_if_false L11
+  L8:
+    load_var _3
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L9
     jump L12
 
-  L11:
-    load_var _2
-    is_type int[]
-    pop_jump_if_false L95
+  L9:
+    load_var _3
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L10
+    jump L11
+
+  L10:
+    load_var _3
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L47
     load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
+    load_type void
+    load_var _3
+    call baml.iter.Peekable.Iterator.next
+    store_var _5
+    jump L21
+
+  L11:
+    load_var _3
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _5
+    jump L21
 
   L12:
-    load_type int
-    load_var _2
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
+    load_var _3
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _5
+    jump L21
 
   L13:
     load_type int
     load_type void
-    load_var _2
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
+    load_type void
+    load_var _3
+    call baml.iter.Filter.Iterator.next
+    store_var _5
+    jump L21
 
   L14:
-    load_var _2
-    make_bound_method baml.iter.FlatMap.Iterable.iter
+    load_var _3
+    make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _3
-    jump L24
+    store_var _5
+    jump L21
 
   L15:
-    load_var _2
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
+    load_type int
+    load_var _3
+    call baml.iter.Repeat.Iterator.next
+    store_var _5
+    jump L21
 
   L16:
     load_type int
     load_type void
     load_type void
-    load_var _2
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var _2
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var _2
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var _2
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var _2
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var _2
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var _2
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var _2
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
-    load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
-
-  L25:
-    load_var _3
-    is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
-
-  L26:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
-
-  L27:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
-
-  L28:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
-
-  L29:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
-
-  L30:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
-
-  L31:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
-
-  L32:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
-
-  L33:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
-
-  L34:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L95
-    load_type int
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
-
-  L35:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _35
-    jump L45
-
-  L36:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _35
-    jump L45
-
-  L37:
-    load_type int
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
-
-  L38:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _35
-    jump L45
-
-  L39:
-    load_type int
-    load_var _3
-    call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
-
-  L40:
-    load_type int
-    load_type void
-    load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L94
+    pop_jump_if_false L22
+    jump L46
 
-  L46:
-    load_var _35
+  L22:
+    load_var _5
     store_var i
+    load_type int
     load_const 4
     load_const 5
     load_const 6
     alloc_array 3
-    store_var_load_var _66
+    call baml.iter.Iterable$for$T[].iter
+    store_var _37
+
+  L23:
+    load_var _37
     is_type baml.iter.Flatten<...>
+    pop_jump_if_false L24
+    jump L43
+
+  L24:
+    load_var _37
+    is_type baml.iter.Range
+    pop_jump_if_false L25
+    jump L42
+
+  L25:
+    load_var _37
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L26
+    jump L41
+
+  L26:
+    load_var _37
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L27
+    jump L40
+
+  L27:
+    load_var _37
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L28
+    jump L39
+
+  L28:
+    load_var _37
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L29
+    jump L38
+
+  L29:
+    load_var _37
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L30
+    jump L37
+
+  L30:
+    load_var _37
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L31
+    jump L36
+
+  L31:
+    load_var _37
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L32
+    jump L35
+
+  L32:
+    load_var _37
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L33
+    jump L34
+
+  L33:
+    load_var _37
+    is_type baml.iter.Peekable<...>
     pop_jump_if_false L47
-    jump L70
-
-  L47:
-    load_var _66
-    is_type baml.iter.Range
-    pop_jump_if_false L48
-    jump L69
-
-  L48:
-    load_var _66
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L49
-    jump L68
-
-  L49:
-    load_var _66
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L50
-    jump L67
-
-  L50:
-    load_var _66
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L51
-    jump L66
-
-  L51:
-    load_var _66
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L52
-    jump L65
-
-  L52:
-    load_var _66
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L53
-    jump L64
-
-  L53:
-    load_var _66
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L54
-    jump L63
-
-  L54:
-    load_var _66
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L55
-    jump L62
-
-  L55:
-    load_var _66
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L56
-    jump L61
-
-  L56:
-    load_var _66
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L57
-    jump L60
-
-  L57:
-    load_var _66
-    is_type unknown[]
-    pop_jump_if_false L58
-    jump L59
-
-  L58:
-    load_var _66
-    is_type int[]
-    pop_jump_if_false L95
-    load_type int
-    load_var _66
-    call baml.iter.Iterable$for$T[].iter
-    store_var _67
-    jump L71
-
-  L59:
-    load_type int
-    load_var _66
-    call baml.iter.Iterable$for$T[].iter
-    store_var _67
-    jump L71
-
-  L60:
     load_type int
     load_type void
-    load_var _66
-    call baml.iter.Peekable.Iterable.iter
-    store_var _67
-    jump L71
-
-  L61:
-    load_var _66
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _67
-    jump L71
-
-  L62:
-    load_var _66
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _67
-    jump L71
-
-  L63:
-    load_type int
-    load_type void
-    load_type void
-    load_var _66
-    call baml.iter.Filter.Iterable.iter
-    store_var _67
-    jump L71
-
-  L64:
-    load_var _66
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _67
-    jump L71
-
-  L65:
-    load_type int
-    load_var _66
-    call baml.iter.Repeat.Iterable.iter
-    store_var _67
-    jump L71
-
-  L66:
-    load_type int
-    load_type void
-    load_type void
-    load_var _66
-    call baml.iter.Chain.Iterable.iter
-    store_var _67
-    jump L71
-
-  L67:
-    load_type int
-    load_type void
-    load_var _66
-    call baml.iter.StepBy.Iterable.iter
-    store_var _67
-    jump L71
-
-  L68:
-    load_type int
-    load_var _66
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _67
-    jump L71
-
-  L69:
-    load_var _66
-    call baml.iter.Range.Iterable.iter
-    store_var _67
-    jump L71
-
-  L70:
-    load_var _66
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _67
-
-  L71:
-    load_var _67
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L72
-    jump L91
-
-  L72:
-    load_var _67
-    is_type baml.iter.Range
-    pop_jump_if_false L73
-    jump L90
-
-  L73:
-    load_var _67
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L74
-    jump L89
-
-  L74:
-    load_var _67
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L75
-    jump L88
-
-  L75:
-    load_var _67
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L76
-    jump L87
-
-  L76:
-    load_var _67
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L77
-    jump L86
-
-  L77:
-    load_var _67
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L78
-    jump L85
-
-  L78:
-    load_var _67
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L79
-    jump L84
-
-  L79:
-    load_var _67
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L80
-    jump L83
-
-  L80:
-    load_var _67
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L81
-    jump L82
-
-  L81:
-    load_var _67
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L95
-    load_type int
-    load_type void
-    load_var _67
+    load_var _37
     call baml.iter.Peekable.Iterator.next
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L82:
-    load_var _67
+  L34:
+    load_var _37
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L83:
-    load_var _67
+  L35:
+    load_var _37
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L84:
+  L36:
     load_type int
     load_type void
     load_type void
-    load_var _67
+    load_var _37
     call baml.iter.Filter.Iterator.next
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L85:
-    load_var _67
+  L37:
+    load_var _37
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L86:
+  L38:
     load_type int
-    load_var _67
+    load_var _37
     call baml.iter.Repeat.Iterator.next
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L87:
+  L39:
     load_type int
     load_type void
     load_type void
-    load_var _67
+    load_var _37
     call baml.iter.Chain.Iterator.next
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L88:
+  L40:
     load_type int
     load_type void
-    load_var _67
+    load_var _37
     call baml.iter.StepBy.Iterator.next
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L89:
+  L41:
     load_type int
-    load_var _67
+    load_var _37
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L90:
-    load_var _67
+  L42:
+    load_var _37
     call baml.iter.Range.Iterator.next
-    store_var _99
-    jump L92
+    store_var _39
+    jump L44
 
-  L91:
-    load_var _67
+  L43:
+    load_var _37
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _99
+    store_var _39
 
-  L92:
-    load_var _99
+  L44:
+    load_var _39
     is_type baml.iter.Done
-    pop_jump_if_false L93
-    jump L24
+    pop_jump_if_false L45
+    jump L0
 
-  L93:
-    load_var2 1 5
-    load_var _99
+  L45:
+    load_var2 1 4
+    load_var _39
     mul_int
     add_int
     store_var result
-    jump L71
+    jump L23
 
-  L94:
+  L46:
     load_var result
     return
 
-  L95:
+  L47:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__04_5_mir.snap
@@ -392,133 +392,102 @@ fn user.for_let_ascription(items: int[]) -> int {
     let _1: int[] // items // param
     let _2: int // sum
     let _3: baml.iter.Iterator<Item = int, Error = void>
-    let _4: bool
+    let _4: type
     let _5: unknown
     let _6: bool
-    let _7: bool
-    let _8: type
+    let _7: unknown
+    let _8: bool
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: bool
-    let _40: type
-    let _41: bool
-    let _42: type
-    let _43: type
-    let _44: bool
-    let _45: type
-    let _46: type
-    let _47: type
-    let _48: bool
-    let _49: type
-    let _50: bool
-    let _51: unknown
-    let _52: bool
-    let _53: type
-    let _54: type
-    let _55: type
-    let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: unknown
-    let _60: bool
-    let _61: type
-    let _62: type
-    let _63: bool
-    let _64: int
-    let _65: int | string // n
+    let _34: int
+    let _35: int | string // n
 
     bb0: {
         _2 = const 0_i64;
-        _4 = is_type(copy _1, baml.iter.Flatten<_, int, void, void>);
-        branch copy _4 -> [bb26, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _6 = is_type(copy _1, baml.iter.Range);
-        branch copy _6 -> [bb25, bb2];
+        _4 = load_type(int);
+        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _4>(copy _1) -> [bb2];
     }
 
     bb2: {
-        _7 = is_type(copy _1, baml.iter.ArrayIterator<int>);
-        branch copy _7 -> [bb24, bb3];
+        _6 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
+        branch copy _6 -> [bb24, bb3];
     }
 
     bb3: {
-        _9 = is_type(copy _1, baml.iter.StepBy<int, void>);
-        branch copy _9 -> [bb23, bb4];
+        _8 = is_type(copy _3, baml.iter.Range);
+        branch copy _8 -> [bb23, bb4];
     }
 
     bb4: {
-        _12 = is_type(copy _1, baml.iter.Chain<int, void, void>);
-        branch copy _12 -> [bb22, bb5];
+        _9 = is_type(copy _3, baml.iter.ArrayIterator<int>);
+        branch copy _9 -> [bb22, bb5];
     }
 
     bb5: {
-        _16 = is_type(copy _1, baml.iter.Repeat<int>);
-        branch copy _16 -> [bb21, bb6];
+        _11 = is_type(copy _3, baml.iter.StepBy<int, void>);
+        branch copy _11 -> [bb21, bb6];
     }
 
     bb6: {
-        _18 = is_type(copy _1, baml.iter.Map<_, int, void, void>);
-        branch copy _18 -> [bb20, bb7];
+        _14 = is_type(copy _3, baml.iter.Chain<int, void, void>);
+        branch copy _14 -> [bb20, bb7];
     }
 
     bb7: {
-        _20 = is_type(copy _1, baml.iter.Filter<int, void, void>);
-        branch copy _20 -> [bb19, bb8];
+        _18 = is_type(copy _3, baml.iter.Repeat<int>);
+        branch copy _18 -> [bb19, bb8];
     }
 
     bb8: {
-        _24 = is_type(copy _1, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _24 -> [bb18, bb9];
+        _20 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
+        branch copy _20 -> [bb18, bb9];
     }
 
     bb9: {
-        _26 = is_type(copy _1, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _26 -> [bb17, bb10];
+        _22 = is_type(copy _3, baml.iter.Filter<int, void, void>);
+        branch copy _22 -> [bb17, bb10];
     }
 
     bb10: {
-        _28 = is_type(copy _1, baml.iter.Peekable<int, void>);
-        branch copy _28 -> [bb16, bb11];
+        _26 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _26 -> [bb16, bb11];
     }
 
     bb11: {
-        _31 = is_type(copy _1, unknown[]);
-        branch copy _31 -> [bb15, bb12];
+        _28 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _28 -> [bb15, bb12];
     }
 
     bb12: {
-        _33 = is_type(copy _1, int[]);
-        branch copy _33 -> [bb14, bb13];
+        _30 = is_type(copy _3, baml.iter.Peekable<int, void>);
+        branch copy _30 -> [bb14, bb13];
     }
 
     bb13: {
@@ -526,213 +495,84 @@ fn user.for_let_ascription(items: int[]) -> int {
     }
 
     bb14: {
-        _34 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _1) -> [bb27];
+        _31 = load_type(int);
+        _32 = load_type(void);
+        _5 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _3) -> [bb25];
     }
 
     bb15: {
-        _32 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _1) -> [bb27];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
+        _5 = call copy _29() -> [bb25];
     }
 
     bb16: {
-        _29 = load_type(int);
-        _30 = load_type(void);
-        _3 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _1) -> [bb27];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
+        _5 = call copy _27() -> [bb25];
     }
 
     bb17: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _1);
-        _3 = call copy _27() -> [bb27];
+        _23 = load_type(int);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _5 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _3) -> [bb25];
     }
 
     bb18: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _1);
-        _3 = call copy _25() -> [bb27];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
+        _5 = call copy _21() -> [bb25];
     }
 
     bb19: {
-        _21 = load_type(int);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _3 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _1) -> [bb27];
+        _19 = load_type(int);
+        _5 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _3) -> [bb25];
     }
 
     bb20: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _1);
-        _3 = call copy _19() -> [bb27];
+        _15 = load_type(int);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _5 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _3) -> [bb25];
     }
 
     bb21: {
-        _17 = load_type(int);
-        _3 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _1) -> [bb27];
+        _12 = load_type(int);
+        _13 = load_type(void);
+        _5 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _3) -> [bb25];
     }
 
     bb22: {
-        _13 = load_type(int);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _3 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _1) -> [bb27];
+        _10 = load_type(int);
+        _5 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _3) -> [bb25];
     }
 
     bb23: {
-        _10 = load_type(int);
-        _11 = load_type(void);
-        _3 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _1) -> [bb27];
+        _5 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb25];
     }
 
     bb24: {
-        _8 = load_type(int);
-        _3 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _1) -> [bb27];
+        _7 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
+        _5 = call copy _7() -> [bb25];
     }
 
     bb25: {
-        _3 = call const fn baml.iter.Range.Iterable.iter(copy _1) -> [bb27];
+        _33 = is_type(copy _5, baml.iter.Done);
+        branch copy _33 -> [bb27, bb26];
     }
 
     bb26: {
-        _5 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _1);
-        _3 = call copy _5() -> [bb27];
+        _34 = copy _5;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _2 = copy _2 + const 1_i64;
+        goto -> bb2;
     }
 
     bb27: {
-        _36 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
-        branch copy _36 -> [bb49, bb28];
+        _0 = copy _2;
+        goto -> bb28;
     }
 
     bb28: {
-        _38 = is_type(copy _3, baml.iter.Range);
-        branch copy _38 -> [bb48, bb29];
-    }
-
-    bb29: {
-        _39 = is_type(copy _3, baml.iter.ArrayIterator<int>);
-        branch copy _39 -> [bb47, bb30];
-    }
-
-    bb30: {
-        _41 = is_type(copy _3, baml.iter.StepBy<int, void>);
-        branch copy _41 -> [bb46, bb31];
-    }
-
-    bb31: {
-        _44 = is_type(copy _3, baml.iter.Chain<int, void, void>);
-        branch copy _44 -> [bb45, bb32];
-    }
-
-    bb32: {
-        _48 = is_type(copy _3, baml.iter.Repeat<int>);
-        branch copy _48 -> [bb44, bb33];
-    }
-
-    bb33: {
-        _50 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
-        branch copy _50 -> [bb43, bb34];
-    }
-
-    bb34: {
-        _52 = is_type(copy _3, baml.iter.Filter<int, void, void>);
-        branch copy _52 -> [bb42, bb35];
-    }
-
-    bb35: {
-        _56 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _56 -> [bb41, bb36];
-    }
-
-    bb36: {
-        _58 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _58 -> [bb40, bb37];
-    }
-
-    bb37: {
-        _60 = is_type(copy _3, baml.iter.Peekable<int, void>);
-        branch copy _60 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _61 = load_type(int);
-        _62 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _61, copy _62>(copy _3) -> [bb50];
-    }
-
-    bb40: {
-        _59 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
-        _35 = call copy _59() -> [bb50];
-    }
-
-    bb41: {
-        _57 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
-        _35 = call copy _57() -> [bb50];
-    }
-
-    bb42: {
-        _53 = load_type(int);
-        _54 = load_type(void);
-        _55 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _53, copy _54, copy _55>(copy _3) -> [bb50];
-    }
-
-    bb43: {
-        _51 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
-        _35 = call copy _51() -> [bb50];
-    }
-
-    bb44: {
-        _49 = load_type(int);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _49>(copy _3) -> [bb50];
-    }
-
-    bb45: {
-        _45 = load_type(int);
-        _46 = load_type(void);
-        _47 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _45, copy _46, copy _47>(copy _3) -> [bb50];
-    }
-
-    bb46: {
-        _42 = load_type(int);
-        _43 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _42, copy _43>(copy _3) -> [bb50];
-    }
-
-    bb47: {
-        _40 = load_type(int);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _40>(copy _3) -> [bb50];
-    }
-
-    bb48: {
-        _35 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb50];
-    }
-
-    bb49: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
-        _35 = call copy _37() -> [bb50];
-    }
-
-    bb50: {
-        _63 = is_type(copy _35, baml.iter.Done);
-        branch copy _63 -> [bb52, bb51];
-    }
-
-    bb51: {
-        _64 = copy _35;
-        fresh_cell(_65);
-        _65 = copy _64;
-        _2 = copy _2 + const 1_i64;
-        goto -> bb27;
-    }
-
-    bb52: {
-        _0 = copy _2;
-        goto -> bb53;
-    }
-
-    bb53: {
         return;
     }
 }
@@ -743,128 +583,98 @@ fn user.for_let_fn_narrow(items: ((int) -> int throws never)[]) -> int {
     let _1: ((int) -> int throws never)[] // items // param
     let _2: int // total
     let _3: baml.iter.Iterator<Item = (int) -> int throws never, Error = void>
-    let _4: bool
+    let _4: type
     let _5: unknown
     let _6: bool
-    let _7: type
+    let _7: unknown
     let _8: bool
     let _9: type
-    let _10: type
-    let _11: bool
+    let _10: bool
+    let _11: type
     let _12: type
-    let _13: type
+    let _13: bool
     let _14: type
-    let _15: bool
+    let _15: type
     let _16: type
     let _17: bool
-    let _18: unknown
+    let _18: type
     let _19: bool
-    let _20: type
-    let _21: type
+    let _20: unknown
+    let _21: bool
     let _22: type
-    let _23: bool
-    let _24: unknown
+    let _23: type
+    let _24: type
     let _25: bool
     let _26: unknown
     let _27: bool
-    let _28: type
-    let _29: type
-    let _30: bool
+    let _28: unknown
+    let _29: bool
+    let _30: type
     let _31: type
     let _32: bool
-    let _33: type
-    let _34: unknown
-    let _35: bool
-    let _36: unknown
-    let _37: bool
-    let _38: type
-    let _39: bool
-    let _40: type
-    let _41: type
-    let _42: bool
-    let _43: type
-    let _44: type
-    let _45: type
-    let _46: bool
-    let _47: type
-    let _48: bool
-    let _49: unknown
-    let _50: bool
-    let _51: type
-    let _52: type
-    let _53: type
-    let _54: bool
-    let _55: unknown
-    let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: type
-    let _60: type
-    let _61: bool
-    let _62: (int) -> int throws never
-    let _63: (int) -> int throws never // f
-    let _64: int
-    let _65: (int) -> int throws never
+    let _33: (int) -> int throws never
+    let _34: (int) -> int throws never // f
+    let _35: int
+    let _36: (int) -> int throws never
 
     bb0: {
         _2 = const 0_i64;
-        _4 = is_type(copy _1, baml.iter.Flatten<_, (int) -> int throws never, void, void>);
-        branch copy _4 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _6 = is_type(copy _1, baml.iter.ArrayIterator<(int) -> int throws never>);
-        branch copy _6 -> [bb23, bb2];
+        _4 = load_type((int) -> int throws never);
+        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _4>(copy _1) -> [bb2];
     }
 
     bb2: {
-        _8 = is_type(copy _1, baml.iter.StepBy<(int) -> int throws never, void>);
-        branch copy _8 -> [bb22, bb3];
+        _6 = is_type(copy _3, baml.iter.Flatten<_, (int) -> int throws never, void, void>);
+        branch copy _6 -> [bb22, bb3];
     }
 
     bb3: {
-        _11 = is_type(copy _1, baml.iter.Chain<(int) -> int throws never, void, void>);
-        branch copy _11 -> [bb21, bb4];
+        _8 = is_type(copy _3, baml.iter.ArrayIterator<(int) -> int throws never>);
+        branch copy _8 -> [bb21, bb4];
     }
 
     bb4: {
-        _15 = is_type(copy _1, baml.iter.Repeat<(int) -> int throws never>);
-        branch copy _15 -> [bb20, bb5];
+        _10 = is_type(copy _3, baml.iter.StepBy<(int) -> int throws never, void>);
+        branch copy _10 -> [bb20, bb5];
     }
 
     bb5: {
-        _17 = is_type(copy _1, baml.iter.Map<_, (int) -> int throws never, void, void>);
-        branch copy _17 -> [bb19, bb6];
+        _13 = is_type(copy _3, baml.iter.Chain<(int) -> int throws never, void, void>);
+        branch copy _13 -> [bb19, bb6];
     }
 
     bb6: {
-        _19 = is_type(copy _1, baml.iter.Filter<(int) -> int throws never, void, void>);
-        branch copy _19 -> [bb18, bb7];
+        _17 = is_type(copy _3, baml.iter.Repeat<(int) -> int throws never>);
+        branch copy _17 -> [bb18, bb7];
     }
 
     bb7: {
-        _23 = is_type(copy _1, baml.iter.FilterMap<_, (int) -> int throws never, void, void>);
-        branch copy _23 -> [bb17, bb8];
+        _19 = is_type(copy _3, baml.iter.Map<_, (int) -> int throws never, void, void>);
+        branch copy _19 -> [bb17, bb8];
     }
 
     bb8: {
-        _25 = is_type(copy _1, baml.iter.FlatMap<_, (int) -> int throws never, void, void, void>);
-        branch copy _25 -> [bb16, bb9];
+        _21 = is_type(copy _3, baml.iter.Filter<(int) -> int throws never, void, void>);
+        branch copy _21 -> [bb16, bb9];
     }
 
     bb9: {
-        _27 = is_type(copy _1, baml.iter.Peekable<(int) -> int throws never, void>);
-        branch copy _27 -> [bb15, bb10];
+        _25 = is_type(copy _3, baml.iter.FilterMap<_, (int) -> int throws never, void, void>);
+        branch copy _25 -> [bb15, bb10];
     }
 
     bb10: {
-        _30 = is_type(copy _1, unknown[]);
-        branch copy _30 -> [bb14, bb11];
+        _27 = is_type(copy _3, baml.iter.FlatMap<_, (int) -> int throws never, void, void, void>);
+        branch copy _27 -> [bb14, bb11];
     }
 
     bb11: {
-        _32 = is_type(copy _1, ((int) -> int throws never)[]);
-        branch copy _32 -> [bb13, bb12];
+        _29 = is_type(copy _3, baml.iter.Peekable<(int) -> int throws never, void>);
+        branch copy _29 -> [bb13, bb12];
     }
 
     bb12: {
@@ -872,205 +682,85 @@ fn user.for_let_fn_narrow(items: ((int) -> int throws never)[]) -> int {
     }
 
     bb13: {
-        _33 = load_type((int) -> int throws never);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _33>(copy _1) -> [bb25];
+        _30 = load_type((int) -> int throws never);
+        _31 = load_type(void);
+        _5 = call const fn baml.iter.Peekable.Iterator.next<copy _30, copy _31>(copy _3) -> [bb23];
     }
 
     bb14: {
-        _31 = load_type((int) -> int throws never);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _31>(copy _1) -> [bb25];
+        _28 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
+        _5 = call copy _28() -> [bb23];
     }
 
     bb15: {
-        _28 = load_type((int) -> int throws never);
-        _29 = load_type(void);
-        _3 = call const fn baml.iter.Peekable.Iterable.iter<copy _28, copy _29>(copy _1) -> [bb25];
+        _26 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
+        _5 = call copy _26() -> [bb23];
     }
 
     bb16: {
-        _26 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _1);
-        _3 = call copy _26() -> [bb25];
+        _22 = load_type((int) -> int throws never);
+        _23 = load_type(void);
+        _24 = load_type(void);
+        _5 = call const fn baml.iter.Filter.Iterator.next<copy _22, copy _23, copy _24>(copy _3) -> [bb23];
     }
 
     bb17: {
-        _24 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _1);
-        _3 = call copy _24() -> [bb25];
+        _20 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
+        _5 = call copy _20() -> [bb23];
     }
 
     bb18: {
-        _20 = load_type((int) -> int throws never);
-        _21 = load_type(void);
-        _22 = load_type(void);
-        _3 = call const fn baml.iter.Filter.Iterable.iter<copy _20, copy _21, copy _22>(copy _1) -> [bb25];
+        _18 = load_type((int) -> int throws never);
+        _5 = call const fn baml.iter.Repeat.Iterator.next<copy _18>(copy _3) -> [bb23];
     }
 
     bb19: {
-        _18 = make_bound_method baml.iter.Map.Iterable.iter(copy _1);
-        _3 = call copy _18() -> [bb25];
+        _14 = load_type((int) -> int throws never);
+        _15 = load_type(void);
+        _16 = load_type(void);
+        _5 = call const fn baml.iter.Chain.Iterator.next<copy _14, copy _15, copy _16>(copy _3) -> [bb23];
     }
 
     bb20: {
-        _16 = load_type((int) -> int throws never);
-        _3 = call const fn baml.iter.Repeat.Iterable.iter<copy _16>(copy _1) -> [bb25];
+        _11 = load_type((int) -> int throws never);
+        _12 = load_type(void);
+        _5 = call const fn baml.iter.StepBy.Iterator.next<copy _11, copy _12>(copy _3) -> [bb23];
     }
 
     bb21: {
-        _12 = load_type((int) -> int throws never);
-        _13 = load_type(void);
-        _14 = load_type(void);
-        _3 = call const fn baml.iter.Chain.Iterable.iter<copy _12, copy _13, copy _14>(copy _1) -> [bb25];
+        _9 = load_type((int) -> int throws never);
+        _5 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _9>(copy _3) -> [bb23];
     }
 
     bb22: {
-        _9 = load_type((int) -> int throws never);
-        _10 = load_type(void);
-        _3 = call const fn baml.iter.StepBy.Iterable.iter<copy _9, copy _10>(copy _1) -> [bb25];
+        _7 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
+        _5 = call copy _7() -> [bb23];
     }
 
     bb23: {
-        _7 = load_type((int) -> int throws never);
-        _3 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _7>(copy _1) -> [bb25];
+        _32 = is_type(copy _5, baml.iter.Done);
+        branch copy _32 -> [bb26, bb24];
     }
 
     bb24: {
-        _5 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _1);
-        _3 = call copy _5() -> [bb25];
+        _33 = copy _5;
+        fresh_cell(_34);
+        _34 = copy _33;
+        _36 = copy _34;
+        _35 = call copy _36(const 0_i64) -> [bb25];
     }
 
     bb25: {
-        _35 = is_type(copy _3, baml.iter.Flatten<_, (int) -> int throws never, void, void>);
-        branch copy _35 -> [bb45, bb26];
+        _2 = copy _2 + copy _35;
+        goto -> bb2;
     }
 
     bb26: {
-        _37 = is_type(copy _3, baml.iter.ArrayIterator<(int) -> int throws never>);
-        branch copy _37 -> [bb44, bb27];
+        _0 = copy _2;
+        goto -> bb27;
     }
 
     bb27: {
-        _39 = is_type(copy _3, baml.iter.StepBy<(int) -> int throws never, void>);
-        branch copy _39 -> [bb43, bb28];
-    }
-
-    bb28: {
-        _42 = is_type(copy _3, baml.iter.Chain<(int) -> int throws never, void, void>);
-        branch copy _42 -> [bb42, bb29];
-    }
-
-    bb29: {
-        _46 = is_type(copy _3, baml.iter.Repeat<(int) -> int throws never>);
-        branch copy _46 -> [bb41, bb30];
-    }
-
-    bb30: {
-        _48 = is_type(copy _3, baml.iter.Map<_, (int) -> int throws never, void, void>);
-        branch copy _48 -> [bb40, bb31];
-    }
-
-    bb31: {
-        _50 = is_type(copy _3, baml.iter.Filter<(int) -> int throws never, void, void>);
-        branch copy _50 -> [bb39, bb32];
-    }
-
-    bb32: {
-        _54 = is_type(copy _3, baml.iter.FilterMap<_, (int) -> int throws never, void, void>);
-        branch copy _54 -> [bb38, bb33];
-    }
-
-    bb33: {
-        _56 = is_type(copy _3, baml.iter.FlatMap<_, (int) -> int throws never, void, void, void>);
-        branch copy _56 -> [bb37, bb34];
-    }
-
-    bb34: {
-        _58 = is_type(copy _3, baml.iter.Peekable<(int) -> int throws never, void>);
-        branch copy _58 -> [bb36, bb35];
-    }
-
-    bb35: {
-        unreachable;
-    }
-
-    bb36: {
-        _59 = load_type((int) -> int throws never);
-        _60 = load_type(void);
-        _34 = call const fn baml.iter.Peekable.Iterator.next<copy _59, copy _60>(copy _3) -> [bb46];
-    }
-
-    bb37: {
-        _57 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
-        _34 = call copy _57() -> [bb46];
-    }
-
-    bb38: {
-        _55 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
-        _34 = call copy _55() -> [bb46];
-    }
-
-    bb39: {
-        _51 = load_type((int) -> int throws never);
-        _52 = load_type(void);
-        _53 = load_type(void);
-        _34 = call const fn baml.iter.Filter.Iterator.next<copy _51, copy _52, copy _53>(copy _3) -> [bb46];
-    }
-
-    bb40: {
-        _49 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
-        _34 = call copy _49() -> [bb46];
-    }
-
-    bb41: {
-        _47 = load_type((int) -> int throws never);
-        _34 = call const fn baml.iter.Repeat.Iterator.next<copy _47>(copy _3) -> [bb46];
-    }
-
-    bb42: {
-        _43 = load_type((int) -> int throws never);
-        _44 = load_type(void);
-        _45 = load_type(void);
-        _34 = call const fn baml.iter.Chain.Iterator.next<copy _43, copy _44, copy _45>(copy _3) -> [bb46];
-    }
-
-    bb43: {
-        _40 = load_type((int) -> int throws never);
-        _41 = load_type(void);
-        _34 = call const fn baml.iter.StepBy.Iterator.next<copy _40, copy _41>(copy _3) -> [bb46];
-    }
-
-    bb44: {
-        _38 = load_type((int) -> int throws never);
-        _34 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _38>(copy _3) -> [bb46];
-    }
-
-    bb45: {
-        _36 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
-        _34 = call copy _36() -> [bb46];
-    }
-
-    bb46: {
-        _61 = is_type(copy _34, baml.iter.Done);
-        branch copy _61 -> [bb49, bb47];
-    }
-
-    bb47: {
-        _62 = copy _34;
-        fresh_cell(_63);
-        _63 = copy _62;
-        _65 = copy _63;
-        _64 = call copy _65(const 0_i64) -> [bb48];
-    }
-
-    bb48: {
-        _2 = copy _2 + copy _64;
-        goto -> bb25;
-    }
-
-    bb49: {
-        _0 = copy _2;
-        goto -> bb50;
-    }
-
-    bb50: {
         return;
     }
 }
@@ -1081,134 +771,103 @@ fn user.for_let_with_narrow(items: int[]) -> int {
     let _1: int[] // items // param
     let _2: int // sum
     let _3: baml.iter.Iterator<Item = int, Error = void>
-    let _4: bool
+    let _4: type
     let _5: unknown
     let _6: bool
-    let _7: bool
-    let _8: type
+    let _7: unknown
+    let _8: bool
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: bool
-    let _40: type
-    let _41: bool
-    let _42: type
-    let _43: type
-    let _44: bool
-    let _45: type
-    let _46: type
-    let _47: type
-    let _48: bool
-    let _49: type
-    let _50: bool
-    let _51: unknown
-    let _52: bool
-    let _53: type
-    let _54: type
-    let _55: type
-    let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: unknown
-    let _60: bool
-    let _61: type
-    let _62: type
-    let _63: bool
-    let _64: int
-    let _65: int // n
-    let _66: int
+    let _34: int
+    let _35: int // n
+    let _36: int
 
     bb0: {
         _2 = const 0_i64;
-        _4 = is_type(copy _1, baml.iter.Flatten<_, int, void, void>);
-        branch copy _4 -> [bb26, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _6 = is_type(copy _1, baml.iter.Range);
-        branch copy _6 -> [bb25, bb2];
+        _4 = load_type(int);
+        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _4>(copy _1) -> [bb2];
     }
 
     bb2: {
-        _7 = is_type(copy _1, baml.iter.ArrayIterator<int>);
-        branch copy _7 -> [bb24, bb3];
+        _6 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
+        branch copy _6 -> [bb24, bb3];
     }
 
     bb3: {
-        _9 = is_type(copy _1, baml.iter.StepBy<int, void>);
-        branch copy _9 -> [bb23, bb4];
+        _8 = is_type(copy _3, baml.iter.Range);
+        branch copy _8 -> [bb23, bb4];
     }
 
     bb4: {
-        _12 = is_type(copy _1, baml.iter.Chain<int, void, void>);
-        branch copy _12 -> [bb22, bb5];
+        _9 = is_type(copy _3, baml.iter.ArrayIterator<int>);
+        branch copy _9 -> [bb22, bb5];
     }
 
     bb5: {
-        _16 = is_type(copy _1, baml.iter.Repeat<int>);
-        branch copy _16 -> [bb21, bb6];
+        _11 = is_type(copy _3, baml.iter.StepBy<int, void>);
+        branch copy _11 -> [bb21, bb6];
     }
 
     bb6: {
-        _18 = is_type(copy _1, baml.iter.Map<_, int, void, void>);
-        branch copy _18 -> [bb20, bb7];
+        _14 = is_type(copy _3, baml.iter.Chain<int, void, void>);
+        branch copy _14 -> [bb20, bb7];
     }
 
     bb7: {
-        _20 = is_type(copy _1, baml.iter.Filter<int, void, void>);
-        branch copy _20 -> [bb19, bb8];
+        _18 = is_type(copy _3, baml.iter.Repeat<int>);
+        branch copy _18 -> [bb19, bb8];
     }
 
     bb8: {
-        _24 = is_type(copy _1, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _24 -> [bb18, bb9];
+        _20 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
+        branch copy _20 -> [bb18, bb9];
     }
 
     bb9: {
-        _26 = is_type(copy _1, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _26 -> [bb17, bb10];
+        _22 = is_type(copy _3, baml.iter.Filter<int, void, void>);
+        branch copy _22 -> [bb17, bb10];
     }
 
     bb10: {
-        _28 = is_type(copy _1, baml.iter.Peekable<int, void>);
-        branch copy _28 -> [bb16, bb11];
+        _26 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
+        branch copy _26 -> [bb16, bb11];
     }
 
     bb11: {
-        _31 = is_type(copy _1, unknown[]);
-        branch copy _31 -> [bb15, bb12];
+        _28 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
+        branch copy _28 -> [bb15, bb12];
     }
 
     bb12: {
-        _33 = is_type(copy _1, int[]);
-        branch copy _33 -> [bb14, bb13];
+        _30 = is_type(copy _3, baml.iter.Peekable<int, void>);
+        branch copy _30 -> [bb14, bb13];
     }
 
     bb13: {
@@ -1216,214 +875,85 @@ fn user.for_let_with_narrow(items: int[]) -> int {
     }
 
     bb14: {
-        _34 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _1) -> [bb27];
+        _31 = load_type(int);
+        _32 = load_type(void);
+        _5 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _3) -> [bb25];
     }
 
     bb15: {
-        _32 = load_type(int);
-        _3 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _1) -> [bb27];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
+        _5 = call copy _29() -> [bb25];
     }
 
     bb16: {
-        _29 = load_type(int);
-        _30 = load_type(void);
-        _3 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _1) -> [bb27];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
+        _5 = call copy _27() -> [bb25];
     }
 
     bb17: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _1);
-        _3 = call copy _27() -> [bb27];
+        _23 = load_type(int);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _5 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _3) -> [bb25];
     }
 
     bb18: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _1);
-        _3 = call copy _25() -> [bb27];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
+        _5 = call copy _21() -> [bb25];
     }
 
     bb19: {
-        _21 = load_type(int);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _3 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _1) -> [bb27];
+        _19 = load_type(int);
+        _5 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _3) -> [bb25];
     }
 
     bb20: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _1);
-        _3 = call copy _19() -> [bb27];
+        _15 = load_type(int);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _5 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _3) -> [bb25];
     }
 
     bb21: {
-        _17 = load_type(int);
-        _3 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _1) -> [bb27];
+        _12 = load_type(int);
+        _13 = load_type(void);
+        _5 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _3) -> [bb25];
     }
 
     bb22: {
-        _13 = load_type(int);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _3 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _1) -> [bb27];
+        _10 = load_type(int);
+        _5 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _3) -> [bb25];
     }
 
     bb23: {
-        _10 = load_type(int);
-        _11 = load_type(void);
-        _3 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _1) -> [bb27];
+        _5 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb25];
     }
 
     bb24: {
-        _8 = load_type(int);
-        _3 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _1) -> [bb27];
+        _7 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
+        _5 = call copy _7() -> [bb25];
     }
 
     bb25: {
-        _3 = call const fn baml.iter.Range.Iterable.iter(copy _1) -> [bb27];
+        _33 = is_type(copy _5, baml.iter.Done);
+        branch copy _33 -> [bb27, bb26];
     }
 
     bb26: {
-        _5 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _1);
-        _3 = call copy _5() -> [bb27];
+        _34 = copy _5;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _36 = copy _35;
+        _2 = copy _2 + copy _36;
+        goto -> bb2;
     }
 
     bb27: {
-        _36 = is_type(copy _3, baml.iter.Flatten<_, int, void, void>);
-        branch copy _36 -> [bb49, bb28];
+        _0 = copy _2;
+        goto -> bb28;
     }
 
     bb28: {
-        _38 = is_type(copy _3, baml.iter.Range);
-        branch copy _38 -> [bb48, bb29];
-    }
-
-    bb29: {
-        _39 = is_type(copy _3, baml.iter.ArrayIterator<int>);
-        branch copy _39 -> [bb47, bb30];
-    }
-
-    bb30: {
-        _41 = is_type(copy _3, baml.iter.StepBy<int, void>);
-        branch copy _41 -> [bb46, bb31];
-    }
-
-    bb31: {
-        _44 = is_type(copy _3, baml.iter.Chain<int, void, void>);
-        branch copy _44 -> [bb45, bb32];
-    }
-
-    bb32: {
-        _48 = is_type(copy _3, baml.iter.Repeat<int>);
-        branch copy _48 -> [bb44, bb33];
-    }
-
-    bb33: {
-        _50 = is_type(copy _3, baml.iter.Map<_, int, void, void>);
-        branch copy _50 -> [bb43, bb34];
-    }
-
-    bb34: {
-        _52 = is_type(copy _3, baml.iter.Filter<int, void, void>);
-        branch copy _52 -> [bb42, bb35];
-    }
-
-    bb35: {
-        _56 = is_type(copy _3, baml.iter.FilterMap<_, int, void, void>);
-        branch copy _56 -> [bb41, bb36];
-    }
-
-    bb36: {
-        _58 = is_type(copy _3, baml.iter.FlatMap<_, int, void, void, void>);
-        branch copy _58 -> [bb40, bb37];
-    }
-
-    bb37: {
-        _60 = is_type(copy _3, baml.iter.Peekable<int, void>);
-        branch copy _60 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _61 = load_type(int);
-        _62 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _61, copy _62>(copy _3) -> [bb50];
-    }
-
-    bb40: {
-        _59 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _3);
-        _35 = call copy _59() -> [bb50];
-    }
-
-    bb41: {
-        _57 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _3);
-        _35 = call copy _57() -> [bb50];
-    }
-
-    bb42: {
-        _53 = load_type(int);
-        _54 = load_type(void);
-        _55 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _53, copy _54, copy _55>(copy _3) -> [bb50];
-    }
-
-    bb43: {
-        _51 = make_bound_method baml.iter.Map.Iterator.next(copy _3);
-        _35 = call copy _51() -> [bb50];
-    }
-
-    bb44: {
-        _49 = load_type(int);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _49>(copy _3) -> [bb50];
-    }
-
-    bb45: {
-        _45 = load_type(int);
-        _46 = load_type(void);
-        _47 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _45, copy _46, copy _47>(copy _3) -> [bb50];
-    }
-
-    bb46: {
-        _42 = load_type(int);
-        _43 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _42, copy _43>(copy _3) -> [bb50];
-    }
-
-    bb47: {
-        _40 = load_type(int);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _40>(copy _3) -> [bb50];
-    }
-
-    bb48: {
-        _35 = call const fn baml.iter.Range.Iterator.next(copy _3) -> [bb50];
-    }
-
-    bb49: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _3);
-        _35 = call copy _37() -> [bb50];
-    }
-
-    bb50: {
-        _63 = is_type(copy _35, baml.iter.Done);
-        branch copy _63 -> [bb52, bb51];
-    }
-
-    bb51: {
-        _64 = copy _35;
-        fresh_cell(_65);
-        _65 = copy _64;
-        _66 = copy _65;
-        _2 = copy _2 + copy _66;
-        goto -> bb27;
-    }
-
-    bb52: {
-        _0 = copy _2;
-        goto -> bb53;
-    }
-
-    bb53: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
@@ -294,990 +294,510 @@ function user.fn_return_widens(cb: (int) -> int | string throws never) -> int {
 function user.for_let_ascription(items: int[]) -> int {
     load_const 0
     store_var sum
+    load_type int
     load_var items
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var items
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var items
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var items
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var items
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var items
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var items
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var items
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var items
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var items
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var items
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var items
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var items
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var items
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var items
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var items
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var items
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var items
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var items
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var items
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var items
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var items
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var items
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var items
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var items
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var items
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
-    load_var _35
+  L22:
+    load_var _5
     store_var n
     load_var sum
     load_const 1
     add_int
     store_var sum
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var sum
     return
 
-  L48:
+  L24:
     unreachable
 }
 
 function user.for_let_fn_narrow(items: ((int) -> int throws never)[]) -> int {
     load_const 0
     store_var total
+    load_type (int) -> int throws never
     load_var items
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var items
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var items
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var items
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var items
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var items
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var items
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var items
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var items
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var items
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var items
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var items
-    is_type ((int) -> int throws never)[]
-    pop_jump_if_false L44
-    load_type (int) -> int throws never
-    load_var items
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L22
-
-  L11:
-    load_type (int) -> int throws never
-    load_var items
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L22
-
-  L12:
-    load_type (int) -> int throws never
-    load_type void
-    load_var items
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L22
-
-  L13:
-    load_var items
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L14:
-    load_var items
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L15:
-    load_type (int) -> int throws never
-    load_type void
-    load_type void
-    load_var items
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L22
-
-  L16:
-    load_var items
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L22
-
-  L17:
-    load_type (int) -> int throws never
-    load_var items
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L22
-
-  L18:
-    load_type (int) -> int throws never
-    load_type void
-    load_type void
-    load_var items
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L22
-
-  L19:
-    load_type (int) -> int throws never
-    load_type void
-    load_var items
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L22
-
-  L20:
-    load_type (int) -> int throws never
-    load_var items
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L22
-
-  L21:
-    load_var items
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L22:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type (int) -> int throws never
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L32:
+  L10:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L33:
+  L11:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L34:
+  L12:
     load_type (int) -> int throws never
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L35:
+  L13:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L36:
+  L14:
     load_type (int) -> int throws never
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L37:
+  L15:
     load_type (int) -> int throws never
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L38:
+  L16:
     load_type (int) -> int throws never
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L39:
+  L17:
     load_type (int) -> int throws never
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _34
-    jump L41
+    store_var _5
+    jump L19
 
-  L40:
+  L18:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _34
+    store_var _5
 
-  L41:
-    load_var _34
+  L19:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
+  L20:
     load_const 0
-    load_var _34
+    load_var _5
     call_indirect
     load_var total
     add_int
     store_var total
-    jump L22
+    jump L0
 
-  L43:
+  L21:
     load_var total
     return
 
-  L44:
+  L22:
     unreachable
 }
 
 function user.for_let_with_narrow(items: int[]) -> int {
     load_const 0
     store_var sum
+    load_type int
     load_var items
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L23
+    call baml.iter.Iterable$for$T[].iter
+    store_var _3
 
   L0:
-    load_var items
-    is_type baml.iter.Range
-    pop_jump_if_false L1
-    jump L22
-
-  L1:
-    load_var items
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L2
-    jump L21
-
-  L2:
-    load_var items
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L3
-    jump L20
-
-  L3:
-    load_var items
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
-    load_var items
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L5
-    jump L18
-
-  L5:
-    load_var items
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
-    load_var items
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
-    load_var items
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L8
-    jump L15
-
-  L8:
-    load_var items
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L9
-    jump L14
-
-  L9:
-    load_var items
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
-    load_var items
-    is_type unknown[]
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
-    load_var items
-    is_type int[]
-    pop_jump_if_false L48
-    load_type int
-    load_var items
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L12:
-    load_type int
-    load_var items
-    call baml.iter.Iterable$for$T[].iter
-    store_var _3
-    jump L24
-
-  L13:
-    load_type int
-    load_type void
-    load_var items
-    call baml.iter.Peekable.Iterable.iter
-    store_var _3
-    jump L24
-
-  L14:
-    load_var items
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L15:
-    load_var items
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L16:
-    load_type int
-    load_type void
-    load_type void
-    load_var items
-    call baml.iter.Filter.Iterable.iter
-    store_var _3
-    jump L24
-
-  L17:
-    load_var items
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _3
-    jump L24
-
-  L18:
-    load_type int
-    load_var items
-    call baml.iter.Repeat.Iterable.iter
-    store_var _3
-    jump L24
-
-  L19:
-    load_type int
-    load_type void
-    load_type void
-    load_var items
-    call baml.iter.Chain.Iterable.iter
-    store_var _3
-    jump L24
-
-  L20:
-    load_type int
-    load_type void
-    load_var items
-    call baml.iter.StepBy.Iterable.iter
-    store_var _3
-    jump L24
-
-  L21:
-    load_type int
-    load_var items
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _3
-    jump L24
-
-  L22:
-    load_var items
-    call baml.iter.Range.Iterable.iter
-    store_var _3
-    jump L24
-
-  L23:
-    load_var items
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _3
-
-  L24:
     load_var _3
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L25
-    jump L44
+    pop_jump_if_false L1
+    jump L20
 
-  L25:
+  L1:
     load_var _3
     is_type baml.iter.Range
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L2
+    jump L19
 
-  L26:
+  L2:
     load_var _3
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L3
+    jump L18
 
-  L27:
+  L3:
     load_var _3
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L4
+    jump L17
 
-  L28:
+  L4:
     load_var _3
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L5
+    jump L16
 
-  L29:
+  L5:
     load_var _3
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L6
+    jump L15
 
-  L30:
+  L6:
     load_var _3
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L7
+    jump L14
 
-  L31:
+  L7:
     load_var _3
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L8
+    jump L13
 
-  L32:
+  L8:
     load_var _3
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L9
+    jump L12
 
-  L33:
+  L9:
     load_var _3
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L10
+    jump L11
 
-  L34:
+  L10:
     load_var _3
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L48
+    pop_jump_if_false L24
     load_type int
     load_type void
     load_var _3
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L35:
+  L11:
     load_var _3
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L36:
+  L12:
     load_var _3
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L37:
+  L13:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L38:
+  L14:
     load_var _3
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L39:
+  L15:
     load_type int
     load_var _3
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L40:
+  L16:
     load_type int
     load_type void
     load_type void
     load_var _3
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L41:
+  L17:
     load_type int
     load_type void
     load_var _3
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L42:
+  L18:
     load_type int
     load_var _3
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L43:
+  L19:
     load_var _3
     call baml.iter.Range.Iterator.next
-    store_var _35
-    jump L45
+    store_var _5
+    jump L21
 
-  L44:
+  L20:
     load_var _3
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _5
 
-  L45:
-    load_var _35
+  L21:
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L46
-    jump L47
+    pop_jump_if_false L22
+    jump L23
 
-  L46:
+  L22:
     load_var2 2 4
     add_int
     store_var sum
-    jump L24
+    jump L0
 
-  L47:
+  L23:
     load_var sum
     return
 
-  L48:
+  L24:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__04_5_mir.snap
@@ -39,129 +39,99 @@ fn .<lambda($init_test_main, 0)>(testset: testing.TestCollector) -> null {
     let _2: string[] // cases
     let _3: string[]
     let _4: baml.iter.Iterator<Item = string, Error = void>
-    let _5: bool
+    let _5: type
     let _6: unknown
     let _7: bool
-    let _8: type
+    let _8: unknown
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: type
-    let _40: bool
-    let _41: type
-    let _42: type
-    let _43: bool
-    let _44: type
-    let _45: type
-    let _46: type
-    let _47: bool
-    let _48: type
-    let _49: bool
-    let _50: unknown
-    let _51: bool
-    let _52: type
-    let _53: type
-    let _54: type
-    let _55: bool
-    let _56: unknown
-    let _57: bool
-    let _58: unknown
-    let _59: bool
-    let _60: type
-    let _61: type
-    let _62: bool
-    let _63: string
-    let _64: string // case [captured]
-    let _65: void
-    let _66: () -> void throws unknown
+    let _34: string
+    let _35: string // case [captured]
+    let _36: void
+    let _37: () -> void throws unknown
 
     bb0: {
         _2 = [const "hello", const "world", const "foo"];
         _3 = copy _2;
-        _5 = is_type(copy _3, baml.iter.Flatten<_, string, void, void>);
-        branch copy _5 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _7 = is_type(copy _3, baml.iter.ArrayIterator<string>);
-        branch copy _7 -> [bb23, bb2];
+        _5 = load_type(string);
+        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _5>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _9 = is_type(copy _3, baml.iter.StepBy<string, void>);
-        branch copy _9 -> [bb22, bb3];
+        _7 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
+        branch copy _7 -> [bb22, bb3];
     }
 
     bb3: {
-        _12 = is_type(copy _3, baml.iter.Chain<string, void, void>);
-        branch copy _12 -> [bb21, bb4];
+        _9 = is_type(copy _4, baml.iter.ArrayIterator<string>);
+        branch copy _9 -> [bb21, bb4];
     }
 
     bb4: {
-        _16 = is_type(copy _3, baml.iter.Repeat<string>);
-        branch copy _16 -> [bb20, bb5];
+        _11 = is_type(copy _4, baml.iter.StepBy<string, void>);
+        branch copy _11 -> [bb20, bb5];
     }
 
     bb5: {
-        _18 = is_type(copy _3, baml.iter.Map<_, string, void, void>);
-        branch copy _18 -> [bb19, bb6];
+        _14 = is_type(copy _4, baml.iter.Chain<string, void, void>);
+        branch copy _14 -> [bb19, bb6];
     }
 
     bb6: {
-        _20 = is_type(copy _3, baml.iter.Filter<string, void, void>);
-        branch copy _20 -> [bb18, bb7];
+        _18 = is_type(copy _4, baml.iter.Repeat<string>);
+        branch copy _18 -> [bb18, bb7];
     }
 
     bb7: {
-        _24 = is_type(copy _3, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _24 -> [bb17, bb8];
+        _20 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
+        branch copy _20 -> [bb17, bb8];
     }
 
     bb8: {
-        _26 = is_type(copy _3, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _26 -> [bb16, bb9];
+        _22 = is_type(copy _4, baml.iter.Filter<string, void, void>);
+        branch copy _22 -> [bb16, bb9];
     }
 
     bb9: {
-        _28 = is_type(copy _3, baml.iter.Peekable<string, void>);
-        branch copy _28 -> [bb15, bb10];
+        _26 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _26 -> [bb15, bb10];
     }
 
     bb10: {
-        _31 = is_type(copy _3, unknown[]);
-        branch copy _31 -> [bb14, bb11];
+        _28 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _28 -> [bb14, bb11];
     }
 
     bb11: {
-        _33 = is_type(copy _3, string[]);
-        branch copy _33 -> [bb13, bb12];
+        _30 = is_type(copy _4, baml.iter.Peekable<string, void>);
+        branch copy _30 -> [bb13, bb12];
     }
 
     bb12: {
@@ -169,200 +139,80 @@ fn .<lambda($init_test_main, 0)>(testset: testing.TestCollector) -> null {
     }
 
     bb13: {
-        _34 = load_type(string);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _3) -> [bb25];
+        _31 = load_type(string);
+        _32 = load_type(void);
+        _6 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _4) -> [bb23];
     }
 
     bb14: {
-        _32 = load_type(string);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _3) -> [bb25];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
+        _6 = call copy _29() -> [bb23];
     }
 
     bb15: {
-        _29 = load_type(string);
-        _30 = load_type(void);
-        _4 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _3) -> [bb25];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
+        _6 = call copy _27() -> [bb23];
     }
 
     bb16: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _3);
-        _4 = call copy _27() -> [bb25];
+        _23 = load_type(string);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _6 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _4) -> [bb23];
     }
 
     bb17: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _3);
-        _4 = call copy _25() -> [bb25];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
+        _6 = call copy _21() -> [bb23];
     }
 
     bb18: {
-        _21 = load_type(string);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _4 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _3) -> [bb25];
+        _19 = load_type(string);
+        _6 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _4) -> [bb23];
     }
 
     bb19: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _3);
-        _4 = call copy _19() -> [bb25];
+        _15 = load_type(string);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _6 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _4) -> [bb23];
     }
 
     bb20: {
-        _17 = load_type(string);
-        _4 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _3) -> [bb25];
+        _12 = load_type(string);
+        _13 = load_type(void);
+        _6 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _4) -> [bb23];
     }
 
     bb21: {
-        _13 = load_type(string);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _4 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _3) -> [bb25];
+        _10 = load_type(string);
+        _6 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _4) -> [bb23];
     }
 
     bb22: {
-        _10 = load_type(string);
-        _11 = load_type(void);
-        _4 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _3) -> [bb25];
+        _8 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
+        _6 = call copy _8() -> [bb23];
     }
 
     bb23: {
-        _8 = load_type(string);
-        _4 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _3) -> [bb25];
+        _33 = is_type(copy _6, baml.iter.Done);
+        branch copy _33 -> [bb25, bb24];
     }
 
     bb24: {
-        _6 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _3);
-        _4 = call copy _6() -> [bb25];
+        _34 = copy _6;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _37 = make_closure lambda[0](copy _35);
+        _36 = call const fn testing.TestCollector.register_test(copy _1, const "check case", copy _37, const null) -> [bb2];
     }
 
     bb25: {
-        _36 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
-        branch copy _36 -> [bb45, bb26];
+        _0 = const null;
+        goto -> bb26;
     }
 
     bb26: {
-        _38 = is_type(copy _4, baml.iter.ArrayIterator<string>);
-        branch copy _38 -> [bb44, bb27];
-    }
-
-    bb27: {
-        _40 = is_type(copy _4, baml.iter.StepBy<string, void>);
-        branch copy _40 -> [bb43, bb28];
-    }
-
-    bb28: {
-        _43 = is_type(copy _4, baml.iter.Chain<string, void, void>);
-        branch copy _43 -> [bb42, bb29];
-    }
-
-    bb29: {
-        _47 = is_type(copy _4, baml.iter.Repeat<string>);
-        branch copy _47 -> [bb41, bb30];
-    }
-
-    bb30: {
-        _49 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
-        branch copy _49 -> [bb40, bb31];
-    }
-
-    bb31: {
-        _51 = is_type(copy _4, baml.iter.Filter<string, void, void>);
-        branch copy _51 -> [bb39, bb32];
-    }
-
-    bb32: {
-        _55 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _55 -> [bb38, bb33];
-    }
-
-    bb33: {
-        _57 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _57 -> [bb37, bb34];
-    }
-
-    bb34: {
-        _59 = is_type(copy _4, baml.iter.Peekable<string, void>);
-        branch copy _59 -> [bb36, bb35];
-    }
-
-    bb35: {
-        unreachable;
-    }
-
-    bb36: {
-        _60 = load_type(string);
-        _61 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _60, copy _61>(copy _4) -> [bb46];
-    }
-
-    bb37: {
-        _58 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
-        _35 = call copy _58() -> [bb46];
-    }
-
-    bb38: {
-        _56 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
-        _35 = call copy _56() -> [bb46];
-    }
-
-    bb39: {
-        _52 = load_type(string);
-        _53 = load_type(void);
-        _54 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _52, copy _53, copy _54>(copy _4) -> [bb46];
-    }
-
-    bb40: {
-        _50 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
-        _35 = call copy _50() -> [bb46];
-    }
-
-    bb41: {
-        _48 = load_type(string);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _48>(copy _4) -> [bb46];
-    }
-
-    bb42: {
-        _44 = load_type(string);
-        _45 = load_type(void);
-        _46 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _44, copy _45, copy _46>(copy _4) -> [bb46];
-    }
-
-    bb43: {
-        _41 = load_type(string);
-        _42 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _41, copy _42>(copy _4) -> [bb46];
-    }
-
-    bb44: {
-        _39 = load_type(string);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _39>(copy _4) -> [bb46];
-    }
-
-    bb45: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
-        _35 = call copy _37() -> [bb46];
-    }
-
-    bb46: {
-        _62 = is_type(copy _35, baml.iter.Done);
-        branch copy _62 -> [bb48, bb47];
-    }
-
-    bb47: {
-        _63 = copy _35;
-        fresh_cell(_64);
-        _64 = copy _63;
-        _66 = make_closure lambda[0](copy _64);
-        _65 = call const fn testing.TestCollector.register_test(copy _1, const "check case", copy _66, const null) -> [bb25];
-    }
-
-    bb48: {
-        _0 = const null;
-        goto -> bb49;
-    }
-
-    bb49: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
@@ -32,132 +32,102 @@ fn .<lambda($init_test_main, 0)>(testset: testing.TestCollector) -> null {
     let _2: string[] // topics
     let _3: string[]
     let _4: baml.iter.Iterator<Item = string, Error = void>
-    let _5: bool
+    let _5: type
     let _6: unknown
     let _7: bool
-    let _8: type
+    let _8: unknown
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: type
-    let _40: bool
-    let _41: type
-    let _42: type
-    let _43: bool
-    let _44: type
-    let _45: type
-    let _46: type
-    let _47: bool
-    let _48: type
-    let _49: bool
-    let _50: unknown
-    let _51: bool
-    let _52: type
-    let _53: type
-    let _54: type
-    let _55: bool
-    let _56: unknown
-    let _57: bool
-    let _58: unknown
-    let _59: bool
-    let _60: type
-    let _61: type
-    let _62: bool
-    let _63: string
-    let _64: string // sentiments [captured]
-    let _65: void
-    let _66: string
-    let _67: (testing.TestCollector) -> void throws unknown
-    let _68: void
-    let _69: (testing.TestCollector) -> void throws unknown
+    let _34: string
+    let _35: string // sentiments [captured]
+    let _36: void
+    let _37: string
+    let _38: (testing.TestCollector) -> void throws unknown
+    let _39: void
+    let _40: (testing.TestCollector) -> void throws unknown
 
     bb0: {
         _2 = [const "happy", const "sad"];
         _3 = copy _2;
-        _5 = is_type(copy _3, baml.iter.Flatten<_, string, void, void>);
-        branch copy _5 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _7 = is_type(copy _3, baml.iter.ArrayIterator<string>);
-        branch copy _7 -> [bb23, bb2];
+        _5 = load_type(string);
+        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _5>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _9 = is_type(copy _3, baml.iter.StepBy<string, void>);
-        branch copy _9 -> [bb22, bb3];
+        _7 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
+        branch copy _7 -> [bb22, bb3];
     }
 
     bb3: {
-        _12 = is_type(copy _3, baml.iter.Chain<string, void, void>);
-        branch copy _12 -> [bb21, bb4];
+        _9 = is_type(copy _4, baml.iter.ArrayIterator<string>);
+        branch copy _9 -> [bb21, bb4];
     }
 
     bb4: {
-        _16 = is_type(copy _3, baml.iter.Repeat<string>);
-        branch copy _16 -> [bb20, bb5];
+        _11 = is_type(copy _4, baml.iter.StepBy<string, void>);
+        branch copy _11 -> [bb20, bb5];
     }
 
     bb5: {
-        _18 = is_type(copy _3, baml.iter.Map<_, string, void, void>);
-        branch copy _18 -> [bb19, bb6];
+        _14 = is_type(copy _4, baml.iter.Chain<string, void, void>);
+        branch copy _14 -> [bb19, bb6];
     }
 
     bb6: {
-        _20 = is_type(copy _3, baml.iter.Filter<string, void, void>);
-        branch copy _20 -> [bb18, bb7];
+        _18 = is_type(copy _4, baml.iter.Repeat<string>);
+        branch copy _18 -> [bb18, bb7];
     }
 
     bb7: {
-        _24 = is_type(copy _3, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _24 -> [bb17, bb8];
+        _20 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
+        branch copy _20 -> [bb17, bb8];
     }
 
     bb8: {
-        _26 = is_type(copy _3, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _26 -> [bb16, bb9];
+        _22 = is_type(copy _4, baml.iter.Filter<string, void, void>);
+        branch copy _22 -> [bb16, bb9];
     }
 
     bb9: {
-        _28 = is_type(copy _3, baml.iter.Peekable<string, void>);
-        branch copy _28 -> [bb15, bb10];
+        _26 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _26 -> [bb15, bb10];
     }
 
     bb10: {
-        _31 = is_type(copy _3, unknown[]);
-        branch copy _31 -> [bb14, bb11];
+        _28 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _28 -> [bb14, bb11];
     }
 
     bb11: {
-        _33 = is_type(copy _3, string[]);
-        branch copy _33 -> [bb13, bb12];
+        _30 = is_type(copy _4, baml.iter.Peekable<string, void>);
+        branch copy _30 -> [bb13, bb12];
     }
 
     bb12: {
@@ -165,206 +135,86 @@ fn .<lambda($init_test_main, 0)>(testset: testing.TestCollector) -> null {
     }
 
     bb13: {
-        _34 = load_type(string);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _3) -> [bb25];
+        _31 = load_type(string);
+        _32 = load_type(void);
+        _6 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _4) -> [bb23];
     }
 
     bb14: {
-        _32 = load_type(string);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _3) -> [bb25];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
+        _6 = call copy _29() -> [bb23];
     }
 
     bb15: {
-        _29 = load_type(string);
-        _30 = load_type(void);
-        _4 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _3) -> [bb25];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
+        _6 = call copy _27() -> [bb23];
     }
 
     bb16: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _3);
-        _4 = call copy _27() -> [bb25];
+        _23 = load_type(string);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _6 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _4) -> [bb23];
     }
 
     bb17: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _3);
-        _4 = call copy _25() -> [bb25];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
+        _6 = call copy _21() -> [bb23];
     }
 
     bb18: {
-        _21 = load_type(string);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _4 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _3) -> [bb25];
+        _19 = load_type(string);
+        _6 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _4) -> [bb23];
     }
 
     bb19: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _3);
-        _4 = call copy _19() -> [bb25];
+        _15 = load_type(string);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _6 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _4) -> [bb23];
     }
 
     bb20: {
-        _17 = load_type(string);
-        _4 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _3) -> [bb25];
+        _12 = load_type(string);
+        _13 = load_type(void);
+        _6 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _4) -> [bb23];
     }
 
     bb21: {
-        _13 = load_type(string);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _4 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _3) -> [bb25];
+        _10 = load_type(string);
+        _6 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _4) -> [bb23];
     }
 
     bb22: {
-        _10 = load_type(string);
-        _11 = load_type(void);
-        _4 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _3) -> [bb25];
+        _8 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
+        _6 = call copy _8() -> [bb23];
     }
 
     bb23: {
-        _8 = load_type(string);
-        _4 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _3) -> [bb25];
+        _33 = is_type(copy _6, baml.iter.Done);
+        branch copy _33 -> [bb25, bb24];
     }
 
     bb24: {
-        _6 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _3);
-        _4 = call copy _6() -> [bb25];
+        _34 = copy _6;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _37 = copy _35;
+        _38 = make_closure lambda[0](copy _35);
+        _36 = call const fn testing.TestCollector.register_test_set(copy _1, copy _37, copy _38, const null) -> [bb2];
     }
 
     bb25: {
-        _36 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
-        branch copy _36 -> [bb45, bb26];
+        _40 = make_closure lambda[1]();
+        _39 = call const fn testing.TestCollector.register_test_set(copy _1, const "vibes", copy _40, const null) -> [bb26];
     }
 
     bb26: {
-        _38 = is_type(copy _4, baml.iter.ArrayIterator<string>);
-        branch copy _38 -> [bb44, bb27];
+        _0 = const null;
+        goto -> bb27;
     }
 
     bb27: {
-        _40 = is_type(copy _4, baml.iter.StepBy<string, void>);
-        branch copy _40 -> [bb43, bb28];
-    }
-
-    bb28: {
-        _43 = is_type(copy _4, baml.iter.Chain<string, void, void>);
-        branch copy _43 -> [bb42, bb29];
-    }
-
-    bb29: {
-        _47 = is_type(copy _4, baml.iter.Repeat<string>);
-        branch copy _47 -> [bb41, bb30];
-    }
-
-    bb30: {
-        _49 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
-        branch copy _49 -> [bb40, bb31];
-    }
-
-    bb31: {
-        _51 = is_type(copy _4, baml.iter.Filter<string, void, void>);
-        branch copy _51 -> [bb39, bb32];
-    }
-
-    bb32: {
-        _55 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _55 -> [bb38, bb33];
-    }
-
-    bb33: {
-        _57 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _57 -> [bb37, bb34];
-    }
-
-    bb34: {
-        _59 = is_type(copy _4, baml.iter.Peekable<string, void>);
-        branch copy _59 -> [bb36, bb35];
-    }
-
-    bb35: {
-        unreachable;
-    }
-
-    bb36: {
-        _60 = load_type(string);
-        _61 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _60, copy _61>(copy _4) -> [bb46];
-    }
-
-    bb37: {
-        _58 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
-        _35 = call copy _58() -> [bb46];
-    }
-
-    bb38: {
-        _56 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
-        _35 = call copy _56() -> [bb46];
-    }
-
-    bb39: {
-        _52 = load_type(string);
-        _53 = load_type(void);
-        _54 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _52, copy _53, copy _54>(copy _4) -> [bb46];
-    }
-
-    bb40: {
-        _50 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
-        _35 = call copy _50() -> [bb46];
-    }
-
-    bb41: {
-        _48 = load_type(string);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _48>(copy _4) -> [bb46];
-    }
-
-    bb42: {
-        _44 = load_type(string);
-        _45 = load_type(void);
-        _46 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _44, copy _45, copy _46>(copy _4) -> [bb46];
-    }
-
-    bb43: {
-        _41 = load_type(string);
-        _42 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _41, copy _42>(copy _4) -> [bb46];
-    }
-
-    bb44: {
-        _39 = load_type(string);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _39>(copy _4) -> [bb46];
-    }
-
-    bb45: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
-        _35 = call copy _37() -> [bb46];
-    }
-
-    bb46: {
-        _62 = is_type(copy _35, baml.iter.Done);
-        branch copy _62 -> [bb48, bb47];
-    }
-
-    bb47: {
-        _63 = copy _35;
-        fresh_cell(_64);
-        _64 = copy _63;
-        _66 = copy _64;
-        _67 = make_closure lambda[0](copy _64);
-        _65 = call const fn testing.TestCollector.register_test_set(copy _1, copy _66, copy _67, const null) -> [bb25];
-    }
-
-    bb48: {
-        _69 = make_closure lambda[1]();
-        _68 = call const fn testing.TestCollector.register_test_set(copy _1, const "vibes", copy _69, const null) -> [bb49];
-    }
-
-    bb49: {
-        _0 = const null;
-        goto -> bb50;
-    }
-
-    bb50: {
         return;
     }
 }
@@ -382,69 +232,40 @@ fn .<lambda(<lambda($init_test_main, 0)>, 1)>(testset: testing.TestCollector) ->
     let _7: string
     let _8: string[]
     let _9: baml.iter.Iterator<Item = string, Error = void>
-    let _10: bool
+    let _10: type
     let _11: unknown
     let _12: bool
-    let _13: type
+    let _13: unknown
     let _14: bool
     let _15: type
-    let _16: type
-    let _17: bool
+    let _16: bool
+    let _17: type
     let _18: type
-    let _19: type
+    let _19: bool
     let _20: type
-    let _21: bool
+    let _21: type
     let _22: type
     let _23: bool
-    let _24: unknown
+    let _24: type
     let _25: bool
-    let _26: type
-    let _27: type
+    let _26: unknown
+    let _27: bool
     let _28: type
-    let _29: bool
-    let _30: unknown
+    let _29: type
+    let _30: type
     let _31: bool
     let _32: unknown
     let _33: bool
-    let _34: type
-    let _35: type
-    let _36: bool
+    let _34: unknown
+    let _35: bool
+    let _36: type
     let _37: type
     let _38: bool
-    let _39: type
-    let _40: unknown
-    let _41: bool
-    let _42: unknown
-    let _43: bool
-    let _44: type
-    let _45: bool
-    let _46: type
-    let _47: type
-    let _48: bool
-    let _49: type
-    let _50: type
-    let _51: type
-    let _52: bool
-    let _53: type
-    let _54: bool
-    let _55: unknown
-    let _56: bool
-    let _57: type
-    let _58: type
-    let _59: type
-    let _60: bool
-    let _61: unknown
-    let _62: bool
-    let _63: unknown
-    let _64: bool
-    let _65: type
-    let _66: type
-    let _67: bool
-    let _68: string
-    let _69: string // ex
-    let _70: void
-    let _71: string
-    let _72: () -> void throws unknown
+    let _39: string
+    let _40: string // ex
+    let _41: void
+    let _42: string
+    let _43: () -> void throws unknown
 
     bb0: {
         _4 = copy capture[0];
@@ -463,63 +284,62 @@ fn .<lambda(<lambda($init_test_main, 0)>, 1)>(testset: testing.TestCollector) ->
 
     bb3: {
         _8 = copy _6;
-        _10 = is_type(copy _8, baml.iter.Flatten<_, string, void, void>);
-        branch copy _10 -> [bb27, bb4];
+        goto -> bb4;
     }
 
     bb4: {
-        _12 = is_type(copy _8, baml.iter.ArrayIterator<string>);
-        branch copy _12 -> [bb26, bb5];
+        _10 = load_type(string);
+        _9 = call const fn baml.iter.Iterable$for$T[].iter<copy _10>(copy _8) -> [bb5];
     }
 
     bb5: {
-        _14 = is_type(copy _8, baml.iter.StepBy<string, void>);
-        branch copy _14 -> [bb25, bb6];
+        _12 = is_type(copy _9, baml.iter.Flatten<_, string, void, void>);
+        branch copy _12 -> [bb25, bb6];
     }
 
     bb6: {
-        _17 = is_type(copy _8, baml.iter.Chain<string, void, void>);
-        branch copy _17 -> [bb24, bb7];
+        _14 = is_type(copy _9, baml.iter.ArrayIterator<string>);
+        branch copy _14 -> [bb24, bb7];
     }
 
     bb7: {
-        _21 = is_type(copy _8, baml.iter.Repeat<string>);
-        branch copy _21 -> [bb23, bb8];
+        _16 = is_type(copy _9, baml.iter.StepBy<string, void>);
+        branch copy _16 -> [bb23, bb8];
     }
 
     bb8: {
-        _23 = is_type(copy _8, baml.iter.Map<_, string, void, void>);
-        branch copy _23 -> [bb22, bb9];
+        _19 = is_type(copy _9, baml.iter.Chain<string, void, void>);
+        branch copy _19 -> [bb22, bb9];
     }
 
     bb9: {
-        _25 = is_type(copy _8, baml.iter.Filter<string, void, void>);
-        branch copy _25 -> [bb21, bb10];
+        _23 = is_type(copy _9, baml.iter.Repeat<string>);
+        branch copy _23 -> [bb21, bb10];
     }
 
     bb10: {
-        _29 = is_type(copy _8, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _29 -> [bb20, bb11];
+        _25 = is_type(copy _9, baml.iter.Map<_, string, void, void>);
+        branch copy _25 -> [bb20, bb11];
     }
 
     bb11: {
-        _31 = is_type(copy _8, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _31 -> [bb19, bb12];
+        _27 = is_type(copy _9, baml.iter.Filter<string, void, void>);
+        branch copy _27 -> [bb19, bb12];
     }
 
     bb12: {
-        _33 = is_type(copy _8, baml.iter.Peekable<string, void>);
-        branch copy _33 -> [bb18, bb13];
+        _31 = is_type(copy _9, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _31 -> [bb18, bb13];
     }
 
     bb13: {
-        _36 = is_type(copy _8, unknown[]);
-        branch copy _36 -> [bb17, bb14];
+        _33 = is_type(copy _9, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _33 -> [bb17, bb14];
     }
 
     bb14: {
-        _38 = is_type(copy _8, string[]);
-        branch copy _38 -> [bb16, bb15];
+        _35 = is_type(copy _9, baml.iter.Peekable<string, void>);
+        branch copy _35 -> [bb16, bb15];
     }
 
     bb15: {
@@ -527,201 +347,81 @@ fn .<lambda(<lambda($init_test_main, 0)>, 1)>(testset: testing.TestCollector) ->
     }
 
     bb16: {
-        _39 = load_type(string);
-        _9 = call const fn baml.iter.Iterable$for$T[].iter<copy _39>(copy _8) -> [bb28];
+        _36 = load_type(string);
+        _37 = load_type(void);
+        _11 = call const fn baml.iter.Peekable.Iterator.next<copy _36, copy _37>(copy _9) -> [bb26];
     }
 
     bb17: {
-        _37 = load_type(string);
-        _9 = call const fn baml.iter.Iterable$for$T[].iter<copy _37>(copy _8) -> [bb28];
+        _34 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _9);
+        _11 = call copy _34() -> [bb26];
     }
 
     bb18: {
-        _34 = load_type(string);
-        _35 = load_type(void);
-        _9 = call const fn baml.iter.Peekable.Iterable.iter<copy _34, copy _35>(copy _8) -> [bb28];
+        _32 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _9);
+        _11 = call copy _32() -> [bb26];
     }
 
     bb19: {
-        _32 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _8);
-        _9 = call copy _32() -> [bb28];
+        _28 = load_type(string);
+        _29 = load_type(void);
+        _30 = load_type(void);
+        _11 = call const fn baml.iter.Filter.Iterator.next<copy _28, copy _29, copy _30>(copy _9) -> [bb26];
     }
 
     bb20: {
-        _30 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _8);
-        _9 = call copy _30() -> [bb28];
+        _26 = make_bound_method baml.iter.Map.Iterator.next(copy _9);
+        _11 = call copy _26() -> [bb26];
     }
 
     bb21: {
-        _26 = load_type(string);
-        _27 = load_type(void);
-        _28 = load_type(void);
-        _9 = call const fn baml.iter.Filter.Iterable.iter<copy _26, copy _27, copy _28>(copy _8) -> [bb28];
+        _24 = load_type(string);
+        _11 = call const fn baml.iter.Repeat.Iterator.next<copy _24>(copy _9) -> [bb26];
     }
 
     bb22: {
-        _24 = make_bound_method baml.iter.Map.Iterable.iter(copy _8);
-        _9 = call copy _24() -> [bb28];
+        _20 = load_type(string);
+        _21 = load_type(void);
+        _22 = load_type(void);
+        _11 = call const fn baml.iter.Chain.Iterator.next<copy _20, copy _21, copy _22>(copy _9) -> [bb26];
     }
 
     bb23: {
-        _22 = load_type(string);
-        _9 = call const fn baml.iter.Repeat.Iterable.iter<copy _22>(copy _8) -> [bb28];
+        _17 = load_type(string);
+        _18 = load_type(void);
+        _11 = call const fn baml.iter.StepBy.Iterator.next<copy _17, copy _18>(copy _9) -> [bb26];
     }
 
     bb24: {
-        _18 = load_type(string);
-        _19 = load_type(void);
-        _20 = load_type(void);
-        _9 = call const fn baml.iter.Chain.Iterable.iter<copy _18, copy _19, copy _20>(copy _8) -> [bb28];
+        _15 = load_type(string);
+        _11 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _15>(copy _9) -> [bb26];
     }
 
     bb25: {
-        _15 = load_type(string);
-        _16 = load_type(void);
-        _9 = call const fn baml.iter.StepBy.Iterable.iter<copy _15, copy _16>(copy _8) -> [bb28];
+        _13 = make_bound_method baml.iter.Flatten.Iterator.next(copy _9);
+        _11 = call copy _13() -> [bb26];
     }
 
     bb26: {
-        _13 = load_type(string);
-        _9 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _13>(copy _8) -> [bb28];
+        _38 = is_type(copy _11, baml.iter.Done);
+        branch copy _38 -> [bb28, bb27];
     }
 
     bb27: {
-        _11 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _8);
-        _9 = call copy _11() -> [bb28];
+        _39 = copy _11;
+        fresh_cell(_40);
+        _40 = copy _39;
+        _42 = copy _40;
+        _43 = make_closure lambda[0]();
+        _41 = call const fn testing.TestCollector.register_test(copy _1, copy _42, copy _43, const null) -> [bb5];
     }
 
     bb28: {
-        _41 = is_type(copy _9, baml.iter.Flatten<_, string, void, void>);
-        branch copy _41 -> [bb48, bb29];
+        _0 = const null;
+        goto -> bb29;
     }
 
     bb29: {
-        _43 = is_type(copy _9, baml.iter.ArrayIterator<string>);
-        branch copy _43 -> [bb47, bb30];
-    }
-
-    bb30: {
-        _45 = is_type(copy _9, baml.iter.StepBy<string, void>);
-        branch copy _45 -> [bb46, bb31];
-    }
-
-    bb31: {
-        _48 = is_type(copy _9, baml.iter.Chain<string, void, void>);
-        branch copy _48 -> [bb45, bb32];
-    }
-
-    bb32: {
-        _52 = is_type(copy _9, baml.iter.Repeat<string>);
-        branch copy _52 -> [bb44, bb33];
-    }
-
-    bb33: {
-        _54 = is_type(copy _9, baml.iter.Map<_, string, void, void>);
-        branch copy _54 -> [bb43, bb34];
-    }
-
-    bb34: {
-        _56 = is_type(copy _9, baml.iter.Filter<string, void, void>);
-        branch copy _56 -> [bb42, bb35];
-    }
-
-    bb35: {
-        _60 = is_type(copy _9, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _60 -> [bb41, bb36];
-    }
-
-    bb36: {
-        _62 = is_type(copy _9, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _62 -> [bb40, bb37];
-    }
-
-    bb37: {
-        _64 = is_type(copy _9, baml.iter.Peekable<string, void>);
-        branch copy _64 -> [bb39, bb38];
-    }
-
-    bb38: {
-        unreachable;
-    }
-
-    bb39: {
-        _65 = load_type(string);
-        _66 = load_type(void);
-        _40 = call const fn baml.iter.Peekable.Iterator.next<copy _65, copy _66>(copy _9) -> [bb49];
-    }
-
-    bb40: {
-        _63 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _9);
-        _40 = call copy _63() -> [bb49];
-    }
-
-    bb41: {
-        _61 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _9);
-        _40 = call copy _61() -> [bb49];
-    }
-
-    bb42: {
-        _57 = load_type(string);
-        _58 = load_type(void);
-        _59 = load_type(void);
-        _40 = call const fn baml.iter.Filter.Iterator.next<copy _57, copy _58, copy _59>(copy _9) -> [bb49];
-    }
-
-    bb43: {
-        _55 = make_bound_method baml.iter.Map.Iterator.next(copy _9);
-        _40 = call copy _55() -> [bb49];
-    }
-
-    bb44: {
-        _53 = load_type(string);
-        _40 = call const fn baml.iter.Repeat.Iterator.next<copy _53>(copy _9) -> [bb49];
-    }
-
-    bb45: {
-        _49 = load_type(string);
-        _50 = load_type(void);
-        _51 = load_type(void);
-        _40 = call const fn baml.iter.Chain.Iterator.next<copy _49, copy _50, copy _51>(copy _9) -> [bb49];
-    }
-
-    bb46: {
-        _46 = load_type(string);
-        _47 = load_type(void);
-        _40 = call const fn baml.iter.StepBy.Iterator.next<copy _46, copy _47>(copy _9) -> [bb49];
-    }
-
-    bb47: {
-        _44 = load_type(string);
-        _40 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _44>(copy _9) -> [bb49];
-    }
-
-    bb48: {
-        _42 = make_bound_method baml.iter.Flatten.Iterator.next(copy _9);
-        _40 = call copy _42() -> [bb49];
-    }
-
-    bb49: {
-        _67 = is_type(copy _40, baml.iter.Done);
-        branch copy _67 -> [bb51, bb50];
-    }
-
-    bb50: {
-        _68 = copy _40;
-        fresh_cell(_69);
-        _69 = copy _68;
-        _71 = copy _69;
-        _72 = make_closure lambda[0]();
-        _70 = call const fn testing.TestCollector.register_test(copy _1, copy _71, copy _72, const null) -> [bb28];
-    }
-
-    bb51: {
-        _0 = const null;
-        goto -> bb52;
-    }
-
-    bb52: {
         return;
     }
 }
@@ -761,130 +461,100 @@ fn .<lambda(<lambda($init_test_main, 0)>, 3)>(testset: testing.TestCollector) ->
     let _2: string[] // topics
     let _3: string[]
     let _4: baml.iter.Iterator<Item = string, Error = void>
-    let _5: bool
+    let _5: type
     let _6: unknown
     let _7: bool
-    let _8: type
+    let _8: unknown
     let _9: bool
     let _10: type
-    let _11: type
-    let _12: bool
+    let _11: bool
+    let _12: type
     let _13: type
-    let _14: type
+    let _14: bool
     let _15: type
-    let _16: bool
+    let _16: type
     let _17: type
     let _18: bool
-    let _19: unknown
+    let _19: type
     let _20: bool
-    let _21: type
-    let _22: type
+    let _21: unknown
+    let _22: bool
     let _23: type
-    let _24: bool
-    let _25: unknown
+    let _24: type
+    let _25: type
     let _26: bool
     let _27: unknown
     let _28: bool
-    let _29: type
-    let _30: type
-    let _31: bool
+    let _29: unknown
+    let _30: bool
+    let _31: type
     let _32: type
     let _33: bool
-    let _34: type
-    let _35: unknown
-    let _36: bool
-    let _37: unknown
-    let _38: bool
-    let _39: type
-    let _40: bool
-    let _41: type
-    let _42: type
-    let _43: bool
-    let _44: type
-    let _45: type
-    let _46: type
-    let _47: bool
-    let _48: type
-    let _49: bool
-    let _50: unknown
-    let _51: bool
-    let _52: type
-    let _53: type
-    let _54: type
-    let _55: bool
-    let _56: unknown
-    let _57: bool
-    let _58: unknown
-    let _59: bool
-    let _60: type
-    let _61: type
-    let _62: bool
-    let _63: string
-    let _64: string // sentiments [captured]
-    let _65: void
-    let _66: string
-    let _67: (testing.TestCollector) -> void throws unknown
+    let _34: string
+    let _35: string // sentiments [captured]
+    let _36: void
+    let _37: string
+    let _38: (testing.TestCollector) -> void throws unknown
 
     bb0: {
         _2 = [const "happy", const "sad"];
         _3 = copy _2;
-        _5 = is_type(copy _3, baml.iter.Flatten<_, string, void, void>);
-        branch copy _5 -> [bb24, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _7 = is_type(copy _3, baml.iter.ArrayIterator<string>);
-        branch copy _7 -> [bb23, bb2];
+        _5 = load_type(string);
+        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _5>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _9 = is_type(copy _3, baml.iter.StepBy<string, void>);
-        branch copy _9 -> [bb22, bb3];
+        _7 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
+        branch copy _7 -> [bb22, bb3];
     }
 
     bb3: {
-        _12 = is_type(copy _3, baml.iter.Chain<string, void, void>);
-        branch copy _12 -> [bb21, bb4];
+        _9 = is_type(copy _4, baml.iter.ArrayIterator<string>);
+        branch copy _9 -> [bb21, bb4];
     }
 
     bb4: {
-        _16 = is_type(copy _3, baml.iter.Repeat<string>);
-        branch copy _16 -> [bb20, bb5];
+        _11 = is_type(copy _4, baml.iter.StepBy<string, void>);
+        branch copy _11 -> [bb20, bb5];
     }
 
     bb5: {
-        _18 = is_type(copy _3, baml.iter.Map<_, string, void, void>);
-        branch copy _18 -> [bb19, bb6];
+        _14 = is_type(copy _4, baml.iter.Chain<string, void, void>);
+        branch copy _14 -> [bb19, bb6];
     }
 
     bb6: {
-        _20 = is_type(copy _3, baml.iter.Filter<string, void, void>);
-        branch copy _20 -> [bb18, bb7];
+        _18 = is_type(copy _4, baml.iter.Repeat<string>);
+        branch copy _18 -> [bb18, bb7];
     }
 
     bb7: {
-        _24 = is_type(copy _3, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _24 -> [bb17, bb8];
+        _20 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
+        branch copy _20 -> [bb17, bb8];
     }
 
     bb8: {
-        _26 = is_type(copy _3, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _26 -> [bb16, bb9];
+        _22 = is_type(copy _4, baml.iter.Filter<string, void, void>);
+        branch copy _22 -> [bb16, bb9];
     }
 
     bb9: {
-        _28 = is_type(copy _3, baml.iter.Peekable<string, void>);
-        branch copy _28 -> [bb15, bb10];
+        _26 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _26 -> [bb15, bb10];
     }
 
     bb10: {
-        _31 = is_type(copy _3, unknown[]);
-        branch copy _31 -> [bb14, bb11];
+        _28 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _28 -> [bb14, bb11];
     }
 
     bb11: {
-        _33 = is_type(copy _3, string[]);
-        branch copy _33 -> [bb13, bb12];
+        _30 = is_type(copy _4, baml.iter.Peekable<string, void>);
+        branch copy _30 -> [bb13, bb12];
     }
 
     bb12: {
@@ -892,201 +562,81 @@ fn .<lambda(<lambda($init_test_main, 0)>, 3)>(testset: testing.TestCollector) ->
     }
 
     bb13: {
-        _34 = load_type(string);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _34>(copy _3) -> [bb25];
+        _31 = load_type(string);
+        _32 = load_type(void);
+        _6 = call const fn baml.iter.Peekable.Iterator.next<copy _31, copy _32>(copy _4) -> [bb23];
     }
 
     bb14: {
-        _32 = load_type(string);
-        _4 = call const fn baml.iter.Iterable$for$T[].iter<copy _32>(copy _3) -> [bb25];
+        _29 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
+        _6 = call copy _29() -> [bb23];
     }
 
     bb15: {
-        _29 = load_type(string);
-        _30 = load_type(void);
-        _4 = call const fn baml.iter.Peekable.Iterable.iter<copy _29, copy _30>(copy _3) -> [bb25];
+        _27 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
+        _6 = call copy _27() -> [bb23];
     }
 
     bb16: {
-        _27 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _3);
-        _4 = call copy _27() -> [bb25];
+        _23 = load_type(string);
+        _24 = load_type(void);
+        _25 = load_type(void);
+        _6 = call const fn baml.iter.Filter.Iterator.next<copy _23, copy _24, copy _25>(copy _4) -> [bb23];
     }
 
     bb17: {
-        _25 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _3);
-        _4 = call copy _25() -> [bb25];
+        _21 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
+        _6 = call copy _21() -> [bb23];
     }
 
     bb18: {
-        _21 = load_type(string);
-        _22 = load_type(void);
-        _23 = load_type(void);
-        _4 = call const fn baml.iter.Filter.Iterable.iter<copy _21, copy _22, copy _23>(copy _3) -> [bb25];
+        _19 = load_type(string);
+        _6 = call const fn baml.iter.Repeat.Iterator.next<copy _19>(copy _4) -> [bb23];
     }
 
     bb19: {
-        _19 = make_bound_method baml.iter.Map.Iterable.iter(copy _3);
-        _4 = call copy _19() -> [bb25];
+        _15 = load_type(string);
+        _16 = load_type(void);
+        _17 = load_type(void);
+        _6 = call const fn baml.iter.Chain.Iterator.next<copy _15, copy _16, copy _17>(copy _4) -> [bb23];
     }
 
     bb20: {
-        _17 = load_type(string);
-        _4 = call const fn baml.iter.Repeat.Iterable.iter<copy _17>(copy _3) -> [bb25];
+        _12 = load_type(string);
+        _13 = load_type(void);
+        _6 = call const fn baml.iter.StepBy.Iterator.next<copy _12, copy _13>(copy _4) -> [bb23];
     }
 
     bb21: {
-        _13 = load_type(string);
-        _14 = load_type(void);
-        _15 = load_type(void);
-        _4 = call const fn baml.iter.Chain.Iterable.iter<copy _13, copy _14, copy _15>(copy _3) -> [bb25];
+        _10 = load_type(string);
+        _6 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _10>(copy _4) -> [bb23];
     }
 
     bb22: {
-        _10 = load_type(string);
-        _11 = load_type(void);
-        _4 = call const fn baml.iter.StepBy.Iterable.iter<copy _10, copy _11>(copy _3) -> [bb25];
+        _8 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
+        _6 = call copy _8() -> [bb23];
     }
 
     bb23: {
-        _8 = load_type(string);
-        _4 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _8>(copy _3) -> [bb25];
+        _33 = is_type(copy _6, baml.iter.Done);
+        branch copy _33 -> [bb25, bb24];
     }
 
     bb24: {
-        _6 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _3);
-        _4 = call copy _6() -> [bb25];
+        _34 = copy _6;
+        fresh_cell(_35);
+        _35 = copy _34;
+        _37 = copy _35;
+        _38 = make_closure lambda[0](copy _35);
+        _36 = call const fn testing.TestCollector.register_test_set(copy _1, copy _37, copy _38, const null) -> [bb2];
     }
 
     bb25: {
-        _36 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
-        branch copy _36 -> [bb45, bb26];
+        _0 = const null;
+        goto -> bb26;
     }
 
     bb26: {
-        _38 = is_type(copy _4, baml.iter.ArrayIterator<string>);
-        branch copy _38 -> [bb44, bb27];
-    }
-
-    bb27: {
-        _40 = is_type(copy _4, baml.iter.StepBy<string, void>);
-        branch copy _40 -> [bb43, bb28];
-    }
-
-    bb28: {
-        _43 = is_type(copy _4, baml.iter.Chain<string, void, void>);
-        branch copy _43 -> [bb42, bb29];
-    }
-
-    bb29: {
-        _47 = is_type(copy _4, baml.iter.Repeat<string>);
-        branch copy _47 -> [bb41, bb30];
-    }
-
-    bb30: {
-        _49 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
-        branch copy _49 -> [bb40, bb31];
-    }
-
-    bb31: {
-        _51 = is_type(copy _4, baml.iter.Filter<string, void, void>);
-        branch copy _51 -> [bb39, bb32];
-    }
-
-    bb32: {
-        _55 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _55 -> [bb38, bb33];
-    }
-
-    bb33: {
-        _57 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _57 -> [bb37, bb34];
-    }
-
-    bb34: {
-        _59 = is_type(copy _4, baml.iter.Peekable<string, void>);
-        branch copy _59 -> [bb36, bb35];
-    }
-
-    bb35: {
-        unreachable;
-    }
-
-    bb36: {
-        _60 = load_type(string);
-        _61 = load_type(void);
-        _35 = call const fn baml.iter.Peekable.Iterator.next<copy _60, copy _61>(copy _4) -> [bb46];
-    }
-
-    bb37: {
-        _58 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _4);
-        _35 = call copy _58() -> [bb46];
-    }
-
-    bb38: {
-        _56 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _4);
-        _35 = call copy _56() -> [bb46];
-    }
-
-    bb39: {
-        _52 = load_type(string);
-        _53 = load_type(void);
-        _54 = load_type(void);
-        _35 = call const fn baml.iter.Filter.Iterator.next<copy _52, copy _53, copy _54>(copy _4) -> [bb46];
-    }
-
-    bb40: {
-        _50 = make_bound_method baml.iter.Map.Iterator.next(copy _4);
-        _35 = call copy _50() -> [bb46];
-    }
-
-    bb41: {
-        _48 = load_type(string);
-        _35 = call const fn baml.iter.Repeat.Iterator.next<copy _48>(copy _4) -> [bb46];
-    }
-
-    bb42: {
-        _44 = load_type(string);
-        _45 = load_type(void);
-        _46 = load_type(void);
-        _35 = call const fn baml.iter.Chain.Iterator.next<copy _44, copy _45, copy _46>(copy _4) -> [bb46];
-    }
-
-    bb43: {
-        _41 = load_type(string);
-        _42 = load_type(void);
-        _35 = call const fn baml.iter.StepBy.Iterator.next<copy _41, copy _42>(copy _4) -> [bb46];
-    }
-
-    bb44: {
-        _39 = load_type(string);
-        _35 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _39>(copy _4) -> [bb46];
-    }
-
-    bb45: {
-        _37 = make_bound_method baml.iter.Flatten.Iterator.next(copy _4);
-        _35 = call copy _37() -> [bb46];
-    }
-
-    bb46: {
-        _62 = is_type(copy _35, baml.iter.Done);
-        branch copy _62 -> [bb48, bb47];
-    }
-
-    bb47: {
-        _63 = copy _35;
-        fresh_cell(_64);
-        _64 = copy _63;
-        _66 = copy _64;
-        _67 = make_closure lambda[0](copy _64);
-        _65 = call const fn testing.TestCollector.register_test_set(copy _1, copy _66, copy _67, const null) -> [bb25];
-    }
-
-    bb48: {
-        _0 = const null;
-        goto -> bb49;
-    }
-
-    bb49: {
         return;
     }
 }
@@ -1100,69 +650,40 @@ fn .<lambda(<lambda(<lambda($init_test_main, 0)>, 3)>, 4)>(testset: testing.Test
     let _3: string
     let _4: string[]
     let _5: baml.iter.Iterator<Item = string, Error = void>
-    let _6: bool
+    let _6: type
     let _7: unknown
     let _8: bool
-    let _9: type
+    let _9: unknown
     let _10: bool
     let _11: type
-    let _12: type
-    let _13: bool
+    let _12: bool
+    let _13: type
     let _14: type
-    let _15: type
+    let _15: bool
     let _16: type
-    let _17: bool
+    let _17: type
     let _18: type
     let _19: bool
-    let _20: unknown
+    let _20: type
     let _21: bool
-    let _22: type
-    let _23: type
+    let _22: unknown
+    let _23: bool
     let _24: type
-    let _25: bool
-    let _26: unknown
+    let _25: type
+    let _26: type
     let _27: bool
     let _28: unknown
     let _29: bool
-    let _30: type
-    let _31: type
-    let _32: bool
+    let _30: unknown
+    let _31: bool
+    let _32: type
     let _33: type
     let _34: bool
-    let _35: type
-    let _36: unknown
-    let _37: bool
-    let _38: unknown
-    let _39: bool
-    let _40: type
-    let _41: bool
-    let _42: type
-    let _43: type
-    let _44: bool
-    let _45: type
-    let _46: type
-    let _47: type
-    let _48: bool
-    let _49: type
-    let _50: bool
-    let _51: unknown
-    let _52: bool
-    let _53: type
-    let _54: type
-    let _55: type
-    let _56: bool
-    let _57: unknown
-    let _58: bool
-    let _59: unknown
-    let _60: bool
-    let _61: type
-    let _62: type
-    let _63: bool
-    let _64: string
-    let _65: string // ex
-    let _66: void
-    let _67: string
-    let _68: () -> void throws unknown
+    let _35: string
+    let _36: string // ex
+    let _37: void
+    let _38: string
+    let _39: () -> void throws unknown
 
     bb0: {
         _3 = copy capture[0];
@@ -1171,63 +692,62 @@ fn .<lambda(<lambda(<lambda($init_test_main, 0)>, 3)>, 4)>(testset: testing.Test
 
     bb1: {
         _4 = copy _2;
-        _6 = is_type(copy _4, baml.iter.Flatten<_, string, void, void>);
-        branch copy _6 -> [bb25, bb2];
+        goto -> bb2;
     }
 
     bb2: {
-        _8 = is_type(copy _4, baml.iter.ArrayIterator<string>);
-        branch copy _8 -> [bb24, bb3];
+        _6 = load_type(string);
+        _5 = call const fn baml.iter.Iterable$for$T[].iter<copy _6>(copy _4) -> [bb3];
     }
 
     bb3: {
-        _10 = is_type(copy _4, baml.iter.StepBy<string, void>);
-        branch copy _10 -> [bb23, bb4];
+        _8 = is_type(copy _5, baml.iter.Flatten<_, string, void, void>);
+        branch copy _8 -> [bb23, bb4];
     }
 
     bb4: {
-        _13 = is_type(copy _4, baml.iter.Chain<string, void, void>);
-        branch copy _13 -> [bb22, bb5];
+        _10 = is_type(copy _5, baml.iter.ArrayIterator<string>);
+        branch copy _10 -> [bb22, bb5];
     }
 
     bb5: {
-        _17 = is_type(copy _4, baml.iter.Repeat<string>);
-        branch copy _17 -> [bb21, bb6];
+        _12 = is_type(copy _5, baml.iter.StepBy<string, void>);
+        branch copy _12 -> [bb21, bb6];
     }
 
     bb6: {
-        _19 = is_type(copy _4, baml.iter.Map<_, string, void, void>);
-        branch copy _19 -> [bb20, bb7];
+        _15 = is_type(copy _5, baml.iter.Chain<string, void, void>);
+        branch copy _15 -> [bb20, bb7];
     }
 
     bb7: {
-        _21 = is_type(copy _4, baml.iter.Filter<string, void, void>);
-        branch copy _21 -> [bb19, bb8];
+        _19 = is_type(copy _5, baml.iter.Repeat<string>);
+        branch copy _19 -> [bb19, bb8];
     }
 
     bb8: {
-        _25 = is_type(copy _4, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _25 -> [bb18, bb9];
+        _21 = is_type(copy _5, baml.iter.Map<_, string, void, void>);
+        branch copy _21 -> [bb18, bb9];
     }
 
     bb9: {
-        _27 = is_type(copy _4, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _27 -> [bb17, bb10];
+        _23 = is_type(copy _5, baml.iter.Filter<string, void, void>);
+        branch copy _23 -> [bb17, bb10];
     }
 
     bb10: {
-        _29 = is_type(copy _4, baml.iter.Peekable<string, void>);
-        branch copy _29 -> [bb16, bb11];
+        _27 = is_type(copy _5, baml.iter.FilterMap<_, string, void, void>);
+        branch copy _27 -> [bb16, bb11];
     }
 
     bb11: {
-        _32 = is_type(copy _4, unknown[]);
-        branch copy _32 -> [bb15, bb12];
+        _29 = is_type(copy _5, baml.iter.FlatMap<_, string, void, void, void>);
+        branch copy _29 -> [bb15, bb12];
     }
 
     bb12: {
-        _34 = is_type(copy _4, string[]);
-        branch copy _34 -> [bb14, bb13];
+        _31 = is_type(copy _5, baml.iter.Peekable<string, void>);
+        branch copy _31 -> [bb14, bb13];
     }
 
     bb13: {
@@ -1235,201 +755,81 @@ fn .<lambda(<lambda(<lambda($init_test_main, 0)>, 3)>, 4)>(testset: testing.Test
     }
 
     bb14: {
-        _35 = load_type(string);
-        _5 = call const fn baml.iter.Iterable$for$T[].iter<copy _35>(copy _4) -> [bb26];
+        _32 = load_type(string);
+        _33 = load_type(void);
+        _7 = call const fn baml.iter.Peekable.Iterator.next<copy _32, copy _33>(copy _5) -> [bb24];
     }
 
     bb15: {
-        _33 = load_type(string);
-        _5 = call const fn baml.iter.Iterable$for$T[].iter<copy _33>(copy _4) -> [bb26];
+        _30 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _5);
+        _7 = call copy _30() -> [bb24];
     }
 
     bb16: {
-        _30 = load_type(string);
-        _31 = load_type(void);
-        _5 = call const fn baml.iter.Peekable.Iterable.iter<copy _30, copy _31>(copy _4) -> [bb26];
+        _28 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _5);
+        _7 = call copy _28() -> [bb24];
     }
 
     bb17: {
-        _28 = make_bound_method baml.iter.FlatMap.Iterable.iter(copy _4);
-        _5 = call copy _28() -> [bb26];
+        _24 = load_type(string);
+        _25 = load_type(void);
+        _26 = load_type(void);
+        _7 = call const fn baml.iter.Filter.Iterator.next<copy _24, copy _25, copy _26>(copy _5) -> [bb24];
     }
 
     bb18: {
-        _26 = make_bound_method baml.iter.FilterMap.Iterable.iter(copy _4);
-        _5 = call copy _26() -> [bb26];
+        _22 = make_bound_method baml.iter.Map.Iterator.next(copy _5);
+        _7 = call copy _22() -> [bb24];
     }
 
     bb19: {
-        _22 = load_type(string);
-        _23 = load_type(void);
-        _24 = load_type(void);
-        _5 = call const fn baml.iter.Filter.Iterable.iter<copy _22, copy _23, copy _24>(copy _4) -> [bb26];
+        _20 = load_type(string);
+        _7 = call const fn baml.iter.Repeat.Iterator.next<copy _20>(copy _5) -> [bb24];
     }
 
     bb20: {
-        _20 = make_bound_method baml.iter.Map.Iterable.iter(copy _4);
-        _5 = call copy _20() -> [bb26];
+        _16 = load_type(string);
+        _17 = load_type(void);
+        _18 = load_type(void);
+        _7 = call const fn baml.iter.Chain.Iterator.next<copy _16, copy _17, copy _18>(copy _5) -> [bb24];
     }
 
     bb21: {
-        _18 = load_type(string);
-        _5 = call const fn baml.iter.Repeat.Iterable.iter<copy _18>(copy _4) -> [bb26];
+        _13 = load_type(string);
+        _14 = load_type(void);
+        _7 = call const fn baml.iter.StepBy.Iterator.next<copy _13, copy _14>(copy _5) -> [bb24];
     }
 
     bb22: {
-        _14 = load_type(string);
-        _15 = load_type(void);
-        _16 = load_type(void);
-        _5 = call const fn baml.iter.Chain.Iterable.iter<copy _14, copy _15, copy _16>(copy _4) -> [bb26];
+        _11 = load_type(string);
+        _7 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _11>(copy _5) -> [bb24];
     }
 
     bb23: {
-        _11 = load_type(string);
-        _12 = load_type(void);
-        _5 = call const fn baml.iter.StepBy.Iterable.iter<copy _11, copy _12>(copy _4) -> [bb26];
+        _9 = make_bound_method baml.iter.Flatten.Iterator.next(copy _5);
+        _7 = call copy _9() -> [bb24];
     }
 
     bb24: {
-        _9 = load_type(string);
-        _5 = call const fn baml.iter.ArrayIterator.Iterable.iter<copy _9>(copy _4) -> [bb26];
+        _34 = is_type(copy _7, baml.iter.Done);
+        branch copy _34 -> [bb26, bb25];
     }
 
     bb25: {
-        _7 = make_bound_method baml.iter.Flatten.Iterable.iter(copy _4);
-        _5 = call copy _7() -> [bb26];
+        _35 = copy _7;
+        fresh_cell(_36);
+        _36 = copy _35;
+        _38 = copy _36;
+        _39 = make_closure lambda[0]();
+        _37 = call const fn testing.TestCollector.register_test(copy _1, copy _38, copy _39, const null) -> [bb3];
     }
 
     bb26: {
-        _37 = is_type(copy _5, baml.iter.Flatten<_, string, void, void>);
-        branch copy _37 -> [bb46, bb27];
+        _0 = const null;
+        goto -> bb27;
     }
 
     bb27: {
-        _39 = is_type(copy _5, baml.iter.ArrayIterator<string>);
-        branch copy _39 -> [bb45, bb28];
-    }
-
-    bb28: {
-        _41 = is_type(copy _5, baml.iter.StepBy<string, void>);
-        branch copy _41 -> [bb44, bb29];
-    }
-
-    bb29: {
-        _44 = is_type(copy _5, baml.iter.Chain<string, void, void>);
-        branch copy _44 -> [bb43, bb30];
-    }
-
-    bb30: {
-        _48 = is_type(copy _5, baml.iter.Repeat<string>);
-        branch copy _48 -> [bb42, bb31];
-    }
-
-    bb31: {
-        _50 = is_type(copy _5, baml.iter.Map<_, string, void, void>);
-        branch copy _50 -> [bb41, bb32];
-    }
-
-    bb32: {
-        _52 = is_type(copy _5, baml.iter.Filter<string, void, void>);
-        branch copy _52 -> [bb40, bb33];
-    }
-
-    bb33: {
-        _56 = is_type(copy _5, baml.iter.FilterMap<_, string, void, void>);
-        branch copy _56 -> [bb39, bb34];
-    }
-
-    bb34: {
-        _58 = is_type(copy _5, baml.iter.FlatMap<_, string, void, void, void>);
-        branch copy _58 -> [bb38, bb35];
-    }
-
-    bb35: {
-        _60 = is_type(copy _5, baml.iter.Peekable<string, void>);
-        branch copy _60 -> [bb37, bb36];
-    }
-
-    bb36: {
-        unreachable;
-    }
-
-    bb37: {
-        _61 = load_type(string);
-        _62 = load_type(void);
-        _36 = call const fn baml.iter.Peekable.Iterator.next<copy _61, copy _62>(copy _5) -> [bb47];
-    }
-
-    bb38: {
-        _59 = make_bound_method baml.iter.FlatMap.Iterator.next(copy _5);
-        _36 = call copy _59() -> [bb47];
-    }
-
-    bb39: {
-        _57 = make_bound_method baml.iter.FilterMap.Iterator.next(copy _5);
-        _36 = call copy _57() -> [bb47];
-    }
-
-    bb40: {
-        _53 = load_type(string);
-        _54 = load_type(void);
-        _55 = load_type(void);
-        _36 = call const fn baml.iter.Filter.Iterator.next<copy _53, copy _54, copy _55>(copy _5) -> [bb47];
-    }
-
-    bb41: {
-        _51 = make_bound_method baml.iter.Map.Iterator.next(copy _5);
-        _36 = call copy _51() -> [bb47];
-    }
-
-    bb42: {
-        _49 = load_type(string);
-        _36 = call const fn baml.iter.Repeat.Iterator.next<copy _49>(copy _5) -> [bb47];
-    }
-
-    bb43: {
-        _45 = load_type(string);
-        _46 = load_type(void);
-        _47 = load_type(void);
-        _36 = call const fn baml.iter.Chain.Iterator.next<copy _45, copy _46, copy _47>(copy _5) -> [bb47];
-    }
-
-    bb44: {
-        _42 = load_type(string);
-        _43 = load_type(void);
-        _36 = call const fn baml.iter.StepBy.Iterator.next<copy _42, copy _43>(copy _5) -> [bb47];
-    }
-
-    bb45: {
-        _40 = load_type(string);
-        _36 = call const fn baml.iter.ArrayIterator.Iterator.next<copy _40>(copy _5) -> [bb47];
-    }
-
-    bb46: {
-        _38 = make_bound_method baml.iter.Flatten.Iterator.next(copy _5);
-        _36 = call copy _38() -> [bb47];
-    }
-
-    bb47: {
-        _63 = is_type(copy _36, baml.iter.Done);
-        branch copy _63 -> [bb49, bb48];
-    }
-
-    bb48: {
-        _64 = copy _36;
-        fresh_cell(_65);
-        _65 = copy _64;
-        _67 = copy _65;
-        _68 = make_closure lambda[0]();
-        _66 = call const fn testing.TestCollector.register_test(copy _1, copy _67, copy _68, const null) -> [bb26];
-    }
-
-    bb49: {
-        _0 = const null;
-        goto -> bb50;
-    }
-
-    bb50: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -3,16 +3,22 @@ source: crates/baml_tests/src/compiler2_tir/phase5.rs
 expression: output
 ---
 namespace baml:
-  class Array<T> { methods: [length, at, push, pop, concat, for_each, filter, filter_map, step_by, chain, peekable, collect, count, reverse, sort, sort_by, sort_by_key, slice, join, map, to_json, some, every, find, find_index, find_last, find_last_index, includes, index_of, last_index_of, reduce, flat_map, clear, shift, unshift, insert, splice, from_json] }
+  class Array<T> { methods: [length, at, push, pop, concat, for_each, filter, filter_map, step_by, chain, peekable, collect, count, reverse, sort_by, sort_by_key, slice, join, map, to_json, some, every, find, find_index, find_last, find_last_index, includes, index_of, last_index_of, reduce, flat_map, clear, shift, unshift, insert, splice, from_json] }
   class Bigint { methods: [to_json, abs, min, max, clamp, isqrt, pow, ilog, parse, random, from_json] }
   class Bool { methods: [to_json, from_json] }
+  type Comparable
   class Float { methods: [to_json, is_nan, is_infinite, is_finite, abs, min, max, clamp, floor, ceil, round, trunc, fract, ifloor, iceil, iround, itrunc, sqrt, pow, log, hypot, sin, cos, tan, asin, acos, atan, atan2, sinh, cosh, tanh, asinh, acosh, atanh, to_radians, to_degrees, parse, random, pi, e, golden_ratio, nan, inf, from_json] }
   class Int { methods: [to_json, abs, min, max, clamp, isqrt, pow, ilog, leading_zeros, leading_ones, trailing_zeros, trailing_ones, count_zeros, count_ones, parse, random, max_value, min_value, from_json] }
   class Map<K, V> { methods: [length, has, keys, values, set, get, to_json, delete, get_or_insert, clear, from_json] }
   class Null { methods: [to_json, from_json] }
+  type Sortable
   class String { methods: [to_json, length, char_count, byte_length, to_lower_case, to_upper_case, trim, trim_start, trim_end, includes, starts_with, ends_with, split, lines, substring, replace, index_of, char_at, repeat, matches, replace_all, is_numeric, is_alphabetic, is_alphanumeric, is_uppercase, is_lowercase, is_whitespace, is_control, is_graphic, is_ascii, is_ascii_numeric, is_ascii_alphabetic, is_ascii_alphanumeric, is_ascii_uppercase, is_ascii_lowercase, is_ascii_whitespace, is_ascii_control, is_ascii_graphic, is_ascii_hex, to_utf8, from_utf8, from_code_points, from_json] }
   class TypeValue { methods: [to_string, implements, implemented_by, implementors, to_json, from_json] }
   class Uint8Array { methods: [to_json, length, at, push, pop, concat, includes, reverse, slice, zeroes, from_array, to_array, from_hex, to_hex, from_base64, to_base64, to_string, sort, from_json] }
+  function _compare_shim<T>
+  function _float_total_cmp
+  function _is_primitive_array<T>
+  function _rust_sort<A>
   function deep_copy<T>
   function deep_equals<T>
 namespace baml.env:

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -3,7 +3,7 @@ source: crates/baml_tests/tests/bytecode_format/main.rs
 ---
 function assert.contains(haystack: string, needle: string) -> null {
   32   0   load_var2 1 2          
-       1   call 179 ntypeargs=0   (baml.String.includes)
+       1   call 187 ntypeargs=0   (baml.String.includes)
        2   unary_op !             
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
@@ -13,7 +13,7 @@ function assert.contains(haystack: string, needle: string) -> null {
   32   6   jump +3                (to 9)
 
   33   7   load_const 1           ("assertion failed: string does not contain expected substring")
-       8   call 305 ntypeargs=0   (baml.sys.panic)
+       8   call 313 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -28,7 +28,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   23   5   jump +3                (to 8)
 
   24   6   load_const 1           ("assertion failed: expected equal values")
-       7   call 305 ntypeargs=0   (baml.sys.panic)
+       7   call 313 ntypeargs=0   (baml.sys.panic)
        8   return                 
 }
 
@@ -43,7 +43,7 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 305 ntypeargs=0   (baml.sys.panic)
+      7   call 313 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
@@ -59,7 +59,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 305 ntypeargs=0   (baml.sys.panic)
+       8   call 313 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -72,18 +72,18 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
   7   0    load_var 1             (j)
       1    load_const 0           ("outcome")
-      2    call 407 ntypeargs=0   (baml.json.field)
+      2    call 415 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 399 ntypeargs=1   (baml.json.from_json)
+      6    call 407 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("duration_ms")
-      9    call 407 ntypeargs=0   (baml.json.field)
+      9    call 415 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 399 ntypeargs=1   (baml.json.from_json)
+      13   call 407 ntypeargs=1   (baml.json.from_json)
       14   init_instance 0        (testing.RunReport .outcome, .duration_ms)
       15   return                 
 }
@@ -96,7 +96,7 @@ function testing.RunReport.to_json(self: testing.RunReport) -> baml.json.json {
       4    call_indirect         
       5    load_var 1            (self)
       6    load_field 1          (duration_ms)
-      7    call 63 ntypeargs=0   (baml.Int.to_json)
+      7    call 71 ntypeargs=0   (baml.Int.to_json)
       8    load_const 1          ("outcome")
       9    load_const 2          ("duration_ms")
       10   alloc_map 2           
@@ -106,18 +106,18 @@ function testing.RunReport.to_json(self: testing.RunReport) -> baml.json.json {
 function testing.SerializedTest.from_json(j: baml.json.json) -> testing.SerializedTest {
   78   0    load_var 1             (j)
        1    load_const 0           ("type")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("name")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 1            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.SerializedTest .type, .name)
        15   return                 
 }
@@ -125,10 +125,10 @@ function testing.SerializedTest.from_json(j: baml.json.json) -> testing.Serializ
 function testing.SerializedTest.to_json(self: testing.SerializedTest) -> baml.json.json {
   78   0   load_var 1             (self)
        1   load_field 0           (type)
-       2   call 164 ntypeargs=0   (baml.String.to_json)
+       2   call 172 ntypeargs=0   (baml.String.to_json)
        3   load_var 1             (self)
        4   load_field 1           (name)
-       5   call 164 ntypeargs=0   (baml.String.to_json)
+       5   call 172 ntypeargs=0   (baml.String.to_json)
        6   load_const 0           ("type")
        7   load_const 1           ("name")
        8   alloc_map 2            
@@ -138,25 +138,25 @@ function testing.SerializedTest.to_json(self: testing.SerializedTest) -> baml.js
 function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.SerializedTestSet {
   83   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("items")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loadingTimeMs")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
        22   return                 
 }
@@ -164,14 +164,14 @@ function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.Seria
 function testing.SerializedTestSet.to_json(self: testing.SerializedTestSet) -> baml.json.json {
   83   0    load_var 1             (self)
        1    load_field 0           (name)
-       2    call 164 ntypeargs=0   (baml.String.to_json)
+       2    call 172 ntypeargs=0   (baml.String.to_json)
        3    load_type 0            
        4    load_var 1             (self)
        5    load_field 1           (items)
-       6    call 38 ntypeargs=1    (baml.Array.to_json)
+       6    call 37 ntypeargs=1    (baml.Array.to_json)
        7    load_var 1             (self)
        8    load_field 2           (loadingTimeMs)
-       9    call 63 ntypeargs=0    (baml.Int.to_json)
+       9    call 71 ntypeargs=0    (baml.Int.to_json)
        10   load_const 1           ("name")
        11   load_const 2           ("items")
        12   load_const 3           ("loadingTimeMs")
@@ -182,256 +182,149 @@ function testing.SerializedTestSet.to_json(self: testing.SerializedTestSet) -> b
 function testing.TestCollector.find_testset(self: testing.TestCollector, name: string) -> testing.TestSetRegistration {
   61   0     load_var 1               (self)
        1     load_field 2             (testsets)
-       2     store_var_load_var 3     (_3)
-       3     is_type 0                
-       4     pop_jump_if_false +2     (to 6)
-       5     jump +105                (to 110)
-       6     load_var 3               (_3)
-       7     is_type 1                
-       8     pop_jump_if_false +2     (to 10)
-       9     jump +96                 (to 105)
-       10    load_var 3               (_3)
-       11    is_type 2                
-       12    pop_jump_if_false +2     (to 14)
-       13    jump +86                 (to 99)
-       14    load_var 3               (_3)
-       15    is_type 3                
-       16    pop_jump_if_false +2     (to 18)
-       17    jump +75                 (to 92)
-       18    load_var 3               (_3)
-       19    is_type 4                
-       20    pop_jump_if_false +2     (to 22)
-       21    jump +66                 (to 87)
-       22    load_var 3               (_3)
-       23    is_type 5                
-       24    pop_jump_if_false +2     (to 26)
-       25    jump +57                 (to 82)
-       26    load_var 3               (_3)
-       27    is_type 6                
-       28    pop_jump_if_false +2     (to 30)
-       29    jump +46                 (to 75)
-       30    load_var 3               (_3)
-       31    is_type 7                
-       32    pop_jump_if_false +2     (to 34)
-       33    jump +37                 (to 70)
-       34    load_var 3               (_3)
-       35    is_type 8                
-       36    pop_jump_if_false +2     (to 38)
-       37    jump +28                 (to 65)
-       38    load_var 3               (_3)
-       39    is_type 9                
-       40    pop_jump_if_false +2     (to 42)
-       41    jump +18                 (to 59)
-       42    load_var 3               (_3)
-       43    is_type 10               
-       44    pop_jump_if_false +2     (to 46)
-       45    jump +9                  (to 54)
-       46    load_var 3               (_3)
-       47    is_type 10               
-       48    pop_jump_if_false +176   (to 224)
-       49    load_type 11             
-       50    load_var 3               (_3)
-       51    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       52    store_var 4              (_4)
-       53    jump +61                 (to 114)
-       54    load_type 11             
-       55    load_var 3               (_3)
-       56    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       57    store_var 4              (_4)
-       58    jump +56                 (to 114)
-       59    load_type 11             
-       60    load_type 12             
-       61    load_var 3               (_3)
-       62    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       63    store_var 4              (_4)
-       64    jump +50                 (to 114)
-       65    load_var 3               (_3)
-       66    make_bound_method 514    
-       67    call_indirect            
-       68    store_var 4              (_4)
-       69    jump +45                 (to 114)
-       70    load_var 3               (_3)
-       71    make_bound_method 527    
-       72    call_indirect            
-       73    store_var 4              (_4)
-       74    jump +40                 (to 114)
-       75    load_type 11             
-       76    load_type 12             
-       77    load_type 12             
-       78    load_var 3               (_3)
-       79    call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       80    store_var 4              (_4)
-       81    jump +33                 (to 114)
-       82    load_var 3               (_3)
-       83    make_bound_method 557    
-       84    call_indirect            
-       85    store_var 4              (_4)
-       86    jump +28                 (to 114)
+       2     store_var 3              (_3)
+       3     load_type 0              
+       4     load_var 3               (_3)
+       5     call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       6     store_var 4              (_4)
+       7     load_var 4               (_4)
+       8     is_type 1                
+       9     pop_jump_if_false +2     (to 11)
+       10    jump +87                 (to 97)
+       11    load_var 4               (_4)
+       12    is_type 2                
+       13    pop_jump_if_false +2     (to 15)
+       14    jump +78                 (to 92)
+       15    load_var 4               (_4)
+       16    is_type 3                
+       17    pop_jump_if_false +2     (to 19)
+       18    jump +68                 (to 86)
+       19    load_var 4               (_4)
+       20    is_type 4                
+       21    pop_jump_if_false +2     (to 23)
+       22    jump +57                 (to 79)
+       23    load_var 4               (_4)
+       24    is_type 5                
+       25    pop_jump_if_false +2     (to 27)
+       26    jump +48                 (to 74)
+       27    load_var 4               (_4)
+       28    is_type 6                
+       29    pop_jump_if_false +2     (to 31)
+       30    jump +39                 (to 69)
+       31    load_var 4               (_4)
+       32    is_type 7                
+       33    pop_jump_if_false +2     (to 35)
+       34    jump +28                 (to 62)
+       35    load_var 4               (_4)
+       36    is_type 8                
+       37    pop_jump_if_false +2     (to 39)
+       38    jump +19                 (to 57)
+       39    load_var 4               (_4)
+       40    is_type 9                
+       41    pop_jump_if_false +2     (to 43)
+       42    jump +10                 (to 52)
+       43    load_var 4               (_4)
+       44    is_type 10               
+       45    pop_jump_if_false +72    (to 117)
+       46    load_type 0              
+       47    load_type 11             
+       48    load_var 4               (_4)
+       49    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       50    store_var 5              (_6)
+       51    jump +50                 (to 101)
+       52    load_var 4               (_4)
+       53    make_bound_method 576    
+       54    call_indirect            
+       55    store_var 5              (_6)
+       56    jump +45                 (to 101)
+       57    load_var 4               (_4)
+       58    make_bound_method 589    
+       59    call_indirect            
+       60    store_var 5              (_6)
+       61    jump +40                 (to 101)
+       62    load_type 0              
+       63    load_type 11             
+       64    load_type 11             
+       65    load_var 4               (_4)
+       66    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       67    store_var 5              (_6)
+       68    jump +33                 (to 101)
+       69    load_var 4               (_4)
+       70    make_bound_method 525    
+       71    call_indirect            
+       72    store_var 5              (_6)
+       73    jump +28                 (to 101)
+       74    load_type 0              
+       75    load_var 4               (_4)
+       76    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       77    store_var 5              (_6)
+       78    jump +23                 (to 101)
+       79    load_type 0              
+       80    load_type 11             
+       81    load_type 11             
+       82    load_var 4               (_4)
+       83    call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       84    store_var 5              (_6)
+       85    jump +16                 (to 101)
+       86    load_type 0              
        87    load_type 11             
-       88    load_var 3               (_3)
-       89    call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       90    store_var 4              (_4)
-       91    jump +23                 (to 114)
-       92    load_type 11             
-       93    load_type 12             
-       94    load_type 12             
-       95    load_var 3               (_3)
-       96    call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       97    store_var 4              (_4)
-       98    jump +16                 (to 114)
-       99    load_type 11             
-       100   load_type 12             
-       101   load_var 3               (_3)
-       102   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       103   store_var 4              (_4)
-       104   jump +10                 (to 114)
-       105   load_type 11             
-       106   load_var 3               (_3)
-       107   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       108   store_var 4              (_4)
-       109   jump +5                  (to 114)
-       110   load_var 3               (_3)
-       111   make_bound_method 588    
-       112   call_indirect            
-       113   store_var 4              (_4)
-       114   load_var 4               (_4)
-       115   is_type 0                
-       116   pop_jump_if_false +2     (to 118)
-       117   jump +87                 (to 204)
-       118   load_var 4               (_4)
-       119   is_type 1                
-       120   pop_jump_if_false +2     (to 122)
-       121   jump +78                 (to 199)
-       122   load_var 4               (_4)
-       123   is_type 2                
-       124   pop_jump_if_false +2     (to 126)
-       125   jump +68                 (to 193)
-       126   load_var 4               (_4)
-       127   is_type 3                
-       128   pop_jump_if_false +2     (to 130)
-       129   jump +57                 (to 186)
-       130   load_var 4               (_4)
-       131   is_type 4                
-       132   pop_jump_if_false +2     (to 134)
-       133   jump +48                 (to 181)
-       134   load_var 4               (_4)
-       135   is_type 5                
-       136   pop_jump_if_false +2     (to 138)
-       137   jump +39                 (to 176)
-       138   load_var 4               (_4)
-       139   is_type 6                
-       140   pop_jump_if_false +2     (to 142)
-       141   jump +28                 (to 169)
-       142   load_var 4               (_4)
-       143   is_type 7                
-       144   pop_jump_if_false +2     (to 146)
-       145   jump +19                 (to 164)
-       146   load_var 4               (_4)
-       147   is_type 8                
-       148   pop_jump_if_false +2     (to 150)
-       149   jump +10                 (to 159)
-       150   load_var 4               (_4)
-       151   is_type 9                
-       152   pop_jump_if_false +72    (to 224)
-       153   load_type 11             
-       154   load_type 12             
-       155   load_var 4               (_4)
-       156   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       157   store_var 5              (_35)
-       158   jump +50                 (to 208)
-       159   load_var 4               (_4)
-       160   make_bound_method 568    
-       161   call_indirect            
-       162   store_var 5              (_35)
-       163   jump +45                 (to 208)
-       164   load_var 4               (_4)
-       165   make_bound_method 581    
-       166   call_indirect            
-       167   store_var 5              (_35)
-       168   jump +40                 (to 208)
-       169   load_type 11             
-       170   load_type 12             
-       171   load_type 12             
-       172   load_var 4               (_4)
-       173   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       174   store_var 5              (_35)
-       175   jump +33                 (to 208)
-       176   load_var 4               (_4)
-       177   make_bound_method 517    
-       178   call_indirect            
-       179   store_var 5              (_35)
-       180   jump +28                 (to 208)
-       181   load_type 11             
-       182   load_var 4               (_4)
-       183   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       184   store_var 5              (_35)
-       185   jump +23                 (to 208)
-       186   load_type 11             
-       187   load_type 12             
-       188   load_type 12             
-       189   load_var 4               (_4)
-       190   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       191   store_var 5              (_35)
-       192   jump +16                 (to 208)
-       193   load_type 11             
-       194   load_type 12             
-       195   load_var 4               (_4)
-       196   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       197   store_var 5              (_35)
-       198   jump +10                 (to 208)
-       199   load_type 11             
-       200   load_var 4               (_4)
-       201   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       202   store_var 5              (_35)
-       203   jump +5                  (to 208)
-       204   load_var 4               (_4)
-       205   make_bound_method 552    
-       206   call_indirect            
-       207   store_var 5              (_35)
-       208   load_var 5               (_35)
-       209   is_type 13               
-       210   pop_jump_if_false +2     (to 212)
-       211   jump +9                  (to 220)
-       212   load_var 5               (_35)
-       213   store_var_load_var 6     (ts)
+       88    load_var 4               (_4)
+       89    call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       90    store_var 5              (_6)
+       91    jump +10                 (to 101)
+       92    load_type 0              
+       93    load_var 4               (_4)
+       94    call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       95    store_var 5              (_6)
+       96    jump +5                  (to 101)
+       97    load_var 4               (_4)
+       98    make_bound_method 560    
+       99    call_indirect            
+       100   store_var 5              (_6)
+       101   load_var 5               (_6)
+       102   is_type 12               
+       103   pop_jump_if_false +2     (to 105)
+       104   jump +9                  (to 113)
+       105   load_var 5               (_6)
+       106   store_var_load_var 6     (ts)
 
-  62   214   load_field 0             (name)
-       215   load_var 2               (name)
-       216   cmp_op ==                
-       217   pop_jump_if_false -103   (to 114)
+  62   107   load_field 0             (name)
+       108   load_var 2               (name)
+       109   cmp_op ==                
+       110   pop_jump_if_false -103   (to 7)
 
-  63   218   load_var 6               (ts)
-       219   return                   
+  63   111   load_var 6               (ts)
+       112   return                   
 
-  66   220   load_const 14            ("TestSet not found: ")
-       221   load_var 2               (name)
-       222   bin_op +                 
-       223   throw                    
-       224   unreachable              
+  66   113   load_const 13            ("TestSet not found: ")
+       114   load_var 2               (name)
+       115   bin_op +                 
+       116   throw                    
+       117   unreachable              
 }
 
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
   29   0    load_var 1             (j)
        1    load_const 0           ("prefix")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("tests")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("testsets")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        22   return                 
 }
@@ -472,270 +365,163 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
 
   42   22    load_var 1               (self)
        23    load_field 1             (tests)
-       24    store_var_load_var 8     (_13)
-       25    is_type 4                
-       26    pop_jump_if_false +2     (to 28)
-       27    jump +105                (to 132)
-       28    load_var 8               (_13)
-       29    is_type 5                
-       30    pop_jump_if_false +2     (to 32)
-       31    jump +96                 (to 127)
-       32    load_var 8               (_13)
-       33    is_type 6                
-       34    pop_jump_if_false +2     (to 36)
-       35    jump +86                 (to 121)
-       36    load_var 8               (_13)
-       37    is_type 7                
-       38    pop_jump_if_false +2     (to 40)
-       39    jump +75                 (to 114)
-       40    load_var 8               (_13)
-       41    is_type 8                
-       42    pop_jump_if_false +2     (to 44)
-       43    jump +66                 (to 109)
-       44    load_var 8               (_13)
-       45    is_type 9                
-       46    pop_jump_if_false +2     (to 48)
-       47    jump +57                 (to 104)
-       48    load_var 8               (_13)
-       49    is_type 10               
-       50    pop_jump_if_false +2     (to 52)
-       51    jump +46                 (to 97)
-       52    load_var 8               (_13)
-       53    is_type 11               
-       54    pop_jump_if_false +2     (to 56)
-       55    jump +37                 (to 92)
-       56    load_var 8               (_13)
-       57    is_type 12               
-       58    pop_jump_if_false +2     (to 60)
-       59    jump +28                 (to 87)
-       60    load_var 8               (_13)
-       61    is_type 13               
-       62    pop_jump_if_false +2     (to 64)
-       63    jump +18                 (to 81)
-       64    load_var 8               (_13)
-       65    is_type 14               
-       66    pop_jump_if_false +2     (to 68)
-       67    jump +9                  (to 76)
-       68    load_var 8               (_13)
-       69    is_type 14               
-       70    pop_jump_if_false +213   (to 283)
-       71    load_type 15             
-       72    load_var 8               (_13)
-       73    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       74    store_var 9              (_14)
-       75    jump +61                 (to 136)
-       76    load_type 15             
-       77    load_var 8               (_13)
-       78    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       79    store_var 9              (_14)
-       80    jump +56                 (to 136)
-       81    load_type 15             
-       82    load_type 16             
-       83    load_var 8               (_13)
-       84    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       85    store_var 9              (_14)
-       86    jump +50                 (to 136)
-       87    load_var 8               (_13)
-       88    make_bound_method 514    
-       89    call_indirect            
-       90    store_var 9              (_14)
-       91    jump +45                 (to 136)
-       92    load_var 8               (_13)
-       93    make_bound_method 527    
-       94    call_indirect            
-       95    store_var 9              (_14)
-       96    jump +40                 (to 136)
-       97    load_type 15             
-       98    load_type 16             
-       99    load_type 16             
-       100   load_var 8               (_13)
-       101   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       102   store_var 9              (_14)
-       103   jump +33                 (to 136)
-       104   load_var 8               (_13)
-       105   make_bound_method 557    
-       106   call_indirect            
-       107   store_var 9              (_14)
-       108   jump +28                 (to 136)
+       24    store_var 8              (_13)
+       25    load_type 4              
+       26    load_var 8               (_13)
+       27    call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       28    store_var 9              (_14)
+       29    load_var 9               (_14)
+       30    is_type 5                
+       31    pop_jump_if_false +2     (to 33)
+       32    jump +87                 (to 119)
+       33    load_var 9               (_14)
+       34    is_type 6                
+       35    pop_jump_if_false +2     (to 37)
+       36    jump +78                 (to 114)
+       37    load_var 9               (_14)
+       38    is_type 7                
+       39    pop_jump_if_false +2     (to 41)
+       40    jump +68                 (to 108)
+       41    load_var 9               (_14)
+       42    is_type 8                
+       43    pop_jump_if_false +2     (to 45)
+       44    jump +57                 (to 101)
+       45    load_var 9               (_14)
+       46    is_type 9                
+       47    pop_jump_if_false +2     (to 49)
+       48    jump +48                 (to 96)
+       49    load_var 9               (_14)
+       50    is_type 10               
+       51    pop_jump_if_false +2     (to 53)
+       52    jump +39                 (to 91)
+       53    load_var 9               (_14)
+       54    is_type 11               
+       55    pop_jump_if_false +2     (to 57)
+       56    jump +28                 (to 84)
+       57    load_var 9               (_14)
+       58    is_type 12               
+       59    pop_jump_if_false +2     (to 61)
+       60    jump +19                 (to 79)
+       61    load_var 9               (_14)
+       62    is_type 13               
+       63    pop_jump_if_false +2     (to 65)
+       64    jump +10                 (to 74)
+       65    load_var 9               (_14)
+       66    is_type 14               
+       67    pop_jump_if_false +109   (to 176)
+       68    load_type 4              
+       69    load_type 15             
+       70    load_var 9               (_14)
+       71    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       72    store_var 10             (_16)
+       73    jump +50                 (to 123)
+       74    load_var 9               (_14)
+       75    make_bound_method 576    
+       76    call_indirect            
+       77    store_var 10             (_16)
+       78    jump +45                 (to 123)
+       79    load_var 9               (_14)
+       80    make_bound_method 589    
+       81    call_indirect            
+       82    store_var 10             (_16)
+       83    jump +40                 (to 123)
+       84    load_type 4              
+       85    load_type 15             
+       86    load_type 15             
+       87    load_var 9               (_14)
+       88    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       89    store_var 10             (_16)
+       90    jump +33                 (to 123)
+       91    load_var 9               (_14)
+       92    make_bound_method 525    
+       93    call_indirect            
+       94    store_var 10             (_16)
+       95    jump +28                 (to 123)
+       96    load_type 4              
+       97    load_var 9               (_14)
+       98    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       99    store_var 10             (_16)
+       100   jump +23                 (to 123)
+       101   load_type 4              
+       102   load_type 15             
+       103   load_type 15             
+       104   load_var 9               (_14)
+       105   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       106   store_var 10             (_16)
+       107   jump +16                 (to 123)
+       108   load_type 4              
        109   load_type 15             
-       110   load_var 8               (_13)
-       111   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       112   store_var 9              (_14)
-       113   jump +23                 (to 136)
-       114   load_type 15             
-       115   load_type 16             
-       116   load_type 16             
-       117   load_var 8               (_13)
-       118   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       119   store_var 9              (_14)
-       120   jump +16                 (to 136)
-       121   load_type 15             
-       122   load_type 16             
-       123   load_var 8               (_13)
-       124   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       125   store_var 9              (_14)
-       126   jump +10                 (to 136)
-       127   load_type 15             
-       128   load_var 8               (_13)
-       129   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       130   store_var 9              (_14)
-       131   jump +5                  (to 136)
-       132   load_var 8               (_13)
-       133   make_bound_method 588    
-       134   call_indirect            
-       135   store_var 9              (_14)
-       136   load_var 9               (_14)
-       137   is_type 4                
-       138   pop_jump_if_false +2     (to 140)
-       139   jump +87                 (to 226)
-       140   load_var 9               (_14)
-       141   is_type 5                
-       142   pop_jump_if_false +2     (to 144)
-       143   jump +78                 (to 221)
-       144   load_var 9               (_14)
-       145   is_type 6                
-       146   pop_jump_if_false +2     (to 148)
-       147   jump +68                 (to 215)
-       148   load_var 9               (_14)
-       149   is_type 7                
-       150   pop_jump_if_false +2     (to 152)
-       151   jump +57                 (to 208)
-       152   load_var 9               (_14)
-       153   is_type 8                
-       154   pop_jump_if_false +2     (to 156)
-       155   jump +48                 (to 203)
-       156   load_var 9               (_14)
-       157   is_type 9                
-       158   pop_jump_if_false +2     (to 160)
-       159   jump +39                 (to 198)
-       160   load_var 9               (_14)
-       161   is_type 10               
-       162   pop_jump_if_false +2     (to 164)
-       163   jump +28                 (to 191)
-       164   load_var 9               (_14)
-       165   is_type 11               
-       166   pop_jump_if_false +2     (to 168)
-       167   jump +19                 (to 186)
-       168   load_var 9               (_14)
-       169   is_type 12               
-       170   pop_jump_if_false +2     (to 172)
-       171   jump +10                 (to 181)
-       172   load_var 9               (_14)
-       173   is_type 13               
-       174   pop_jump_if_false +109   (to 283)
-       175   load_type 15             
-       176   load_type 16             
-       177   load_var 9               (_14)
-       178   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       179   store_var 10             (_45)
-       180   jump +50                 (to 230)
-       181   load_var 9               (_14)
-       182   make_bound_method 568    
-       183   call_indirect            
-       184   store_var 10             (_45)
-       185   jump +45                 (to 230)
-       186   load_var 9               (_14)
-       187   make_bound_method 581    
-       188   call_indirect            
-       189   store_var 10             (_45)
-       190   jump +40                 (to 230)
-       191   load_type 15             
-       192   load_type 16             
-       193   load_type 16             
-       194   load_var 9               (_14)
-       195   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       196   store_var 10             (_45)
-       197   jump +33                 (to 230)
-       198   load_var 9               (_14)
-       199   make_bound_method 517    
-       200   call_indirect            
-       201   store_var 10             (_45)
-       202   jump +28                 (to 230)
-       203   load_type 15             
-       204   load_var 9               (_14)
-       205   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       206   store_var 10             (_45)
-       207   jump +23                 (to 230)
-       208   load_type 15             
-       209   load_type 16             
-       210   load_type 16             
-       211   load_var 9               (_14)
-       212   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       213   store_var 10             (_45)
-       214   jump +16                 (to 230)
-       215   load_type 15             
-       216   load_type 16             
-       217   load_var 9               (_14)
-       218   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       219   store_var 10             (_45)
-       220   jump +10                 (to 230)
-       221   load_type 15             
-       222   load_var 9               (_14)
-       223   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       224   store_var 10             (_45)
-       225   jump +5                  (to 230)
-       226   load_var 9               (_14)
-       227   make_bound_method 552    
-       228   call_indirect            
-       229   store_var 10             (_45)
-       230   load_var 10              (_45)
-       231   is_type 17               
-       232   pop_jump_if_false +2     (to 234)
-       233   jump +19                 (to 252)
-       234   load_var 10              (_45)
-       235   store_var_load_var 11    (t)
+       110   load_var 9               (_14)
+       111   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       112   store_var 10             (_16)
+       113   jump +10                 (to 123)
+       114   load_type 4              
+       115   load_var 9               (_14)
+       116   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       117   store_var 10             (_16)
+       118   jump +5                  (to 123)
+       119   load_var 9               (_14)
+       120   make_bound_method 560    
+       121   call_indirect            
+       122   store_var 10             (_16)
+       123   load_var 10              (_16)
+       124   is_type 16               
+       125   pop_jump_if_false +2     (to 127)
+       126   jump +19                 (to 145)
+       127   load_var 10              (_16)
+       128   store_var_load_var 11    (t)
 
-  43   236   load_field 0             (name)
-       237   load_var 5               (full_name)
-       238   cmp_op ==                
-       239   jump_if_false +2         (to 241)
-       240   jump +6                  (to 246)
-       241   pop 1                    
-       242   load_var 11              (t)
-       243   load_field 0             (name)
-       244   load_var 7               (hash_prefix)
-       245   call 152 ntypeargs=0     (baml.String.starts_with)
-       246   pop_jump_if_false -110   (to 136)
-       247   load_var 6               (count)
-       248   load_const 18            (1)
-       249   add_int                  
-       250   store_var 6              (count)
-       251   jump -115                (to 136)
+  43   129   load_field 0             (name)
+       130   load_var 5               (full_name)
+       131   cmp_op ==                
+       132   jump_if_false +2         (to 134)
+       133   jump +6                  (to 139)
+       134   pop 1                    
+       135   load_var 11              (t)
+       136   load_field 0             (name)
+       137   load_var 7               (hash_prefix)
+       138   call 160 ntypeargs=0     (baml.String.starts_with)
+       139   pop_jump_if_false -110   (to 29)
+       140   load_var 6               (count)
+       141   load_const 17            (1)
+       142   add_int                  
+       143   store_var 6              (count)
+       144   jump -115                (to 29)
 
-  45   252   load_var 6               (count)
-       253   load_const 2             (0)
-       254   cmp_int_op >             
-       255   pop_jump_if_false +2     (to 257)
-       256   jump +4                  (to 260)
-       257   load_var 5               (full_name)
-       258   store_var 12             (final_name)
-       259   jump +14                 (to 273)
-       260   load_var 5               (full_name)
-       261   load_const 19            ("#")
-       262   bin_op +                 
-       263   store_var 13             (_84)
-       264   load_type 20             
-       265   load_var 6               (count)
-       266   load_const 18            (1)
-       267   add_int                  
-       268   call 423 ntypeargs=1     (baml.unstable.string)
-       269   store_var 14             (_86)
-       270   load_var2 13 14          
-       271   bin_op +                 
-       272   store_var 12             (final_name)
+  45   145   load_var 6               (count)
+       146   load_const 2             (0)
+       147   cmp_int_op >             
+       148   pop_jump_if_false +2     (to 150)
+       149   jump +4                  (to 153)
+       150   load_var 5               (full_name)
+       151   store_var 12             (final_name)
+       152   jump +14                 (to 166)
+       153   load_var 5               (full_name)
+       154   load_const 18            ("#")
+       155   bin_op +                 
+       156   store_var 13             (_55)
+       157   load_type 19             
+       158   load_var 6               (count)
+       159   load_const 17            (1)
+       160   add_int                  
+       161   call 431 ntypeargs=1     (baml.unstable.string)
+       162   store_var 14             (_57)
+       163   load_var2 13 14          
+       164   bin_op +                 
+       165   store_var 12             (final_name)
 
-  46   273   load_type 15             
-       274   load_var 1               (self)
-       275   load_field 1             (tests)
-       276   load_var2 12 3           
-       277   load_var 4               (runner)
-       278   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
-       280   pop 1                    
+  46   166   load_type 4              
+       167   load_var 1               (self)
+       168   load_field 1             (tests)
+       169   load_var2 12 3           
+       170   load_var 4               (runner)
+       171   init_instance 0          (testing.TestRegistration .name, .body, .runner)
+       172   call 17 ntypeargs=1      (baml.Array.push)
+       173   pop 1                    
 
-  38   281   load_const 21            (null)
-       282   return                   
-       283   unreachable              
+  38   174   load_const 20            (null)
+       175   return                   
+       176   unreachable              
 }
 
 function testing.TestCollector.register_test_set(self: testing.TestCollector, name: string, collector: (testing.TestCollector) -> void throws unknown, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never) | null) -> void {
@@ -766,284 +552,177 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
 
   53   22    load_var 1               (self)
        23    load_field 2             (testsets)
-       24    store_var_load_var 8     (_13)
-       25    is_type 4                
-       26    pop_jump_if_false +2     (to 28)
-       27    jump +105                (to 132)
-       28    load_var 8               (_13)
-       29    is_type 5                
-       30    pop_jump_if_false +2     (to 32)
-       31    jump +96                 (to 127)
-       32    load_var 8               (_13)
-       33    is_type 6                
-       34    pop_jump_if_false +2     (to 36)
-       35    jump +86                 (to 121)
-       36    load_var 8               (_13)
-       37    is_type 7                
-       38    pop_jump_if_false +2     (to 40)
-       39    jump +75                 (to 114)
-       40    load_var 8               (_13)
-       41    is_type 8                
-       42    pop_jump_if_false +2     (to 44)
-       43    jump +66                 (to 109)
-       44    load_var 8               (_13)
-       45    is_type 9                
-       46    pop_jump_if_false +2     (to 48)
-       47    jump +57                 (to 104)
-       48    load_var 8               (_13)
-       49    is_type 10               
-       50    pop_jump_if_false +2     (to 52)
-       51    jump +46                 (to 97)
-       52    load_var 8               (_13)
-       53    is_type 11               
-       54    pop_jump_if_false +2     (to 56)
-       55    jump +37                 (to 92)
-       56    load_var 8               (_13)
-       57    is_type 12               
-       58    pop_jump_if_false +2     (to 60)
-       59    jump +28                 (to 87)
-       60    load_var 8               (_13)
-       61    is_type 13               
-       62    pop_jump_if_false +2     (to 64)
-       63    jump +18                 (to 81)
-       64    load_var 8               (_13)
-       65    is_type 14               
-       66    pop_jump_if_false +2     (to 68)
-       67    jump +9                  (to 76)
-       68    load_var 8               (_13)
-       69    is_type 14               
-       70    pop_jump_if_false +213   (to 283)
-       71    load_type 15             
-       72    load_var 8               (_13)
-       73    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       74    store_var 9              (_14)
-       75    jump +61                 (to 136)
-       76    load_type 15             
-       77    load_var 8               (_13)
-       78    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       79    store_var 9              (_14)
-       80    jump +56                 (to 136)
-       81    load_type 15             
-       82    load_type 16             
-       83    load_var 8               (_13)
-       84    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       85    store_var 9              (_14)
-       86    jump +50                 (to 136)
-       87    load_var 8               (_13)
-       88    make_bound_method 514    
-       89    call_indirect            
-       90    store_var 9              (_14)
-       91    jump +45                 (to 136)
-       92    load_var 8               (_13)
-       93    make_bound_method 527    
-       94    call_indirect            
-       95    store_var 9              (_14)
-       96    jump +40                 (to 136)
-       97    load_type 15             
-       98    load_type 16             
-       99    load_type 16             
-       100   load_var 8               (_13)
-       101   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       102   store_var 9              (_14)
-       103   jump +33                 (to 136)
-       104   load_var 8               (_13)
-       105   make_bound_method 557    
-       106   call_indirect            
-       107   store_var 9              (_14)
-       108   jump +28                 (to 136)
+       24    store_var 8              (_13)
+       25    load_type 4              
+       26    load_var 8               (_13)
+       27    call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       28    store_var 9              (_14)
+       29    load_var 9               (_14)
+       30    is_type 5                
+       31    pop_jump_if_false +2     (to 33)
+       32    jump +87                 (to 119)
+       33    load_var 9               (_14)
+       34    is_type 6                
+       35    pop_jump_if_false +2     (to 37)
+       36    jump +78                 (to 114)
+       37    load_var 9               (_14)
+       38    is_type 7                
+       39    pop_jump_if_false +2     (to 41)
+       40    jump +68                 (to 108)
+       41    load_var 9               (_14)
+       42    is_type 8                
+       43    pop_jump_if_false +2     (to 45)
+       44    jump +57                 (to 101)
+       45    load_var 9               (_14)
+       46    is_type 9                
+       47    pop_jump_if_false +2     (to 49)
+       48    jump +48                 (to 96)
+       49    load_var 9               (_14)
+       50    is_type 10               
+       51    pop_jump_if_false +2     (to 53)
+       52    jump +39                 (to 91)
+       53    load_var 9               (_14)
+       54    is_type 11               
+       55    pop_jump_if_false +2     (to 57)
+       56    jump +28                 (to 84)
+       57    load_var 9               (_14)
+       58    is_type 12               
+       59    pop_jump_if_false +2     (to 61)
+       60    jump +19                 (to 79)
+       61    load_var 9               (_14)
+       62    is_type 13               
+       63    pop_jump_if_false +2     (to 65)
+       64    jump +10                 (to 74)
+       65    load_var 9               (_14)
+       66    is_type 14               
+       67    pop_jump_if_false +109   (to 176)
+       68    load_type 4              
+       69    load_type 15             
+       70    load_var 9               (_14)
+       71    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       72    store_var 10             (_16)
+       73    jump +50                 (to 123)
+       74    load_var 9               (_14)
+       75    make_bound_method 576    
+       76    call_indirect            
+       77    store_var 10             (_16)
+       78    jump +45                 (to 123)
+       79    load_var 9               (_14)
+       80    make_bound_method 589    
+       81    call_indirect            
+       82    store_var 10             (_16)
+       83    jump +40                 (to 123)
+       84    load_type 4              
+       85    load_type 15             
+       86    load_type 15             
+       87    load_var 9               (_14)
+       88    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       89    store_var 10             (_16)
+       90    jump +33                 (to 123)
+       91    load_var 9               (_14)
+       92    make_bound_method 525    
+       93    call_indirect            
+       94    store_var 10             (_16)
+       95    jump +28                 (to 123)
+       96    load_type 4              
+       97    load_var 9               (_14)
+       98    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       99    store_var 10             (_16)
+       100   jump +23                 (to 123)
+       101   load_type 4              
+       102   load_type 15             
+       103   load_type 15             
+       104   load_var 9               (_14)
+       105   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       106   store_var 10             (_16)
+       107   jump +16                 (to 123)
+       108   load_type 4              
        109   load_type 15             
-       110   load_var 8               (_13)
-       111   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       112   store_var 9              (_14)
-       113   jump +23                 (to 136)
-       114   load_type 15             
-       115   load_type 16             
-       116   load_type 16             
-       117   load_var 8               (_13)
-       118   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       119   store_var 9              (_14)
-       120   jump +16                 (to 136)
-       121   load_type 15             
-       122   load_type 16             
-       123   load_var 8               (_13)
-       124   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       125   store_var 9              (_14)
-       126   jump +10                 (to 136)
-       127   load_type 15             
-       128   load_var 8               (_13)
-       129   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       130   store_var 9              (_14)
-       131   jump +5                  (to 136)
-       132   load_var 8               (_13)
-       133   make_bound_method 588    
-       134   call_indirect            
-       135   store_var 9              (_14)
-       136   load_var 9               (_14)
-       137   is_type 4                
-       138   pop_jump_if_false +2     (to 140)
-       139   jump +87                 (to 226)
-       140   load_var 9               (_14)
-       141   is_type 5                
-       142   pop_jump_if_false +2     (to 144)
-       143   jump +78                 (to 221)
-       144   load_var 9               (_14)
-       145   is_type 6                
-       146   pop_jump_if_false +2     (to 148)
-       147   jump +68                 (to 215)
-       148   load_var 9               (_14)
-       149   is_type 7                
-       150   pop_jump_if_false +2     (to 152)
-       151   jump +57                 (to 208)
-       152   load_var 9               (_14)
-       153   is_type 8                
-       154   pop_jump_if_false +2     (to 156)
-       155   jump +48                 (to 203)
-       156   load_var 9               (_14)
-       157   is_type 9                
-       158   pop_jump_if_false +2     (to 160)
-       159   jump +39                 (to 198)
-       160   load_var 9               (_14)
-       161   is_type 10               
-       162   pop_jump_if_false +2     (to 164)
-       163   jump +28                 (to 191)
-       164   load_var 9               (_14)
-       165   is_type 11               
-       166   pop_jump_if_false +2     (to 168)
-       167   jump +19                 (to 186)
-       168   load_var 9               (_14)
-       169   is_type 12               
-       170   pop_jump_if_false +2     (to 172)
-       171   jump +10                 (to 181)
-       172   load_var 9               (_14)
-       173   is_type 13               
-       174   pop_jump_if_false +109   (to 283)
-       175   load_type 15             
-       176   load_type 16             
-       177   load_var 9               (_14)
-       178   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       179   store_var 10             (_45)
-       180   jump +50                 (to 230)
-       181   load_var 9               (_14)
-       182   make_bound_method 568    
-       183   call_indirect            
-       184   store_var 10             (_45)
-       185   jump +45                 (to 230)
-       186   load_var 9               (_14)
-       187   make_bound_method 581    
-       188   call_indirect            
-       189   store_var 10             (_45)
-       190   jump +40                 (to 230)
-       191   load_type 15             
-       192   load_type 16             
-       193   load_type 16             
-       194   load_var 9               (_14)
-       195   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       196   store_var 10             (_45)
-       197   jump +33                 (to 230)
-       198   load_var 9               (_14)
-       199   make_bound_method 517    
-       200   call_indirect            
-       201   store_var 10             (_45)
-       202   jump +28                 (to 230)
-       203   load_type 15             
-       204   load_var 9               (_14)
-       205   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       206   store_var 10             (_45)
-       207   jump +23                 (to 230)
-       208   load_type 15             
-       209   load_type 16             
-       210   load_type 16             
-       211   load_var 9               (_14)
-       212   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       213   store_var 10             (_45)
-       214   jump +16                 (to 230)
-       215   load_type 15             
-       216   load_type 16             
-       217   load_var 9               (_14)
-       218   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       219   store_var 10             (_45)
-       220   jump +10                 (to 230)
-       221   load_type 15             
-       222   load_var 9               (_14)
-       223   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       224   store_var 10             (_45)
-       225   jump +5                  (to 230)
-       226   load_var 9               (_14)
-       227   make_bound_method 552    
-       228   call_indirect            
-       229   store_var 10             (_45)
-       230   load_var 10              (_45)
-       231   is_type 17               
-       232   pop_jump_if_false +2     (to 234)
-       233   jump +19                 (to 252)
-       234   load_var 10              (_45)
-       235   store_var_load_var 11    (ts)
+       110   load_var 9               (_14)
+       111   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       112   store_var 10             (_16)
+       113   jump +10                 (to 123)
+       114   load_type 4              
+       115   load_var 9               (_14)
+       116   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       117   store_var 10             (_16)
+       118   jump +5                  (to 123)
+       119   load_var 9               (_14)
+       120   make_bound_method 560    
+       121   call_indirect            
+       122   store_var 10             (_16)
+       123   load_var 10              (_16)
+       124   is_type 16               
+       125   pop_jump_if_false +2     (to 127)
+       126   jump +19                 (to 145)
+       127   load_var 10              (_16)
+       128   store_var_load_var 11    (ts)
 
-  54   236   load_field 0             (name)
-       237   load_var 5               (full_name)
-       238   cmp_op ==                
-       239   jump_if_false +2         (to 241)
-       240   jump +6                  (to 246)
-       241   pop 1                    
-       242   load_var 11              (ts)
-       243   load_field 0             (name)
-       244   load_var 7               (hash_prefix)
-       245   call 152 ntypeargs=0     (baml.String.starts_with)
-       246   pop_jump_if_false -110   (to 136)
-       247   load_var 6               (count)
-       248   load_const 18            (1)
-       249   add_int                  
-       250   store_var 6              (count)
-       251   jump -115                (to 136)
+  54   129   load_field 0             (name)
+       130   load_var 5               (full_name)
+       131   cmp_op ==                
+       132   jump_if_false +2         (to 134)
+       133   jump +6                  (to 139)
+       134   pop 1                    
+       135   load_var 11              (ts)
+       136   load_field 0             (name)
+       137   load_var 7               (hash_prefix)
+       138   call 160 ntypeargs=0     (baml.String.starts_with)
+       139   pop_jump_if_false -110   (to 29)
+       140   load_var 6               (count)
+       141   load_const 17            (1)
+       142   add_int                  
+       143   store_var 6              (count)
+       144   jump -115                (to 29)
 
-  56   252   load_var 6               (count)
-       253   load_const 2             (0)
-       254   cmp_int_op >             
-       255   pop_jump_if_false +2     (to 257)
-       256   jump +4                  (to 260)
-       257   load_var 5               (full_name)
-       258   store_var 12             (final_name)
-       259   jump +14                 (to 273)
-       260   load_var 5               (full_name)
-       261   load_const 19            ("#")
-       262   bin_op +                 
-       263   store_var 13             (_84)
-       264   load_type 20             
-       265   load_var 6               (count)
-       266   load_const 18            (1)
-       267   add_int                  
-       268   call 423 ntypeargs=1     (baml.unstable.string)
-       269   store_var 14             (_86)
-       270   load_var2 13 14          
-       271   bin_op +                 
-       272   store_var 12             (final_name)
+  56   145   load_var 6               (count)
+       146   load_const 2             (0)
+       147   cmp_int_op >             
+       148   pop_jump_if_false +2     (to 150)
+       149   jump +4                  (to 153)
+       150   load_var 5               (full_name)
+       151   store_var 12             (final_name)
+       152   jump +14                 (to 166)
+       153   load_var 5               (full_name)
+       154   load_const 18            ("#")
+       155   bin_op +                 
+       156   store_var 13             (_55)
+       157   load_type 19             
+       158   load_var 6               (count)
+       159   load_const 17            (1)
+       160   add_int                  
+       161   call 431 ntypeargs=1     (baml.unstable.string)
+       162   store_var 14             (_57)
+       163   load_var2 13 14          
+       164   bin_op +                 
+       165   store_var 12             (final_name)
 
-  57   273   load_type 15             
-       274   load_var 1               (self)
-       275   load_field 2             (testsets)
-       276   load_var2 12 3           
-       277   load_var 4               (runner)
-       278   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
-       280   pop 1                    
+  57   166   load_type 4              
+       167   load_var 1               (self)
+       168   load_field 2             (testsets)
+       169   load_var2 12 3           
+       170   load_var 4               (runner)
+       171   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
+       172   call 17 ntypeargs=1      (baml.Array.push)
+       173   pop 1                    
 
-  49   281   load_const 21            (null)
-       282   return                   
-       283   unreachable              
+  49   174   load_const 20            (null)
+       175   return                   
+       176   unreachable              
 }
 
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {
   29   0    load_var 1             (self)
        1    load_field 0           (prefix)
-       2    call 164 ntypeargs=0   (baml.String.to_json)
+       2    call 172 ntypeargs=0   (baml.String.to_json)
        3    load_type 0            
        4    load_var 1             (self)
        5    load_field 1           (tests)
-       6    call 38 ntypeargs=1    (baml.Array.to_json)
+       6    call 37 ntypeargs=1    (baml.Array.to_json)
        7    load_type 1            
        8    load_var 1             (self)
        9    load_field 2           (testsets)
-       10   call 38 ntypeargs=1    (baml.Array.to_json)
+       10   call 37 ntypeargs=1    (baml.Array.to_json)
        11   load_const 2           ("prefix")
        12   load_const 3           ("tests")
        13   load_const 4           ("testsets")
@@ -1054,25 +733,25 @@ function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json
 function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRegistration {
   5   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 407 ntypeargs=0   (baml.json.field)
+      2    call 415 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 399 ntypeargs=1   (baml.json.from_json)
+      6    call 407 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("body")
-      9    call 407 ntypeargs=0   (baml.json.field)
+      9    call 415 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 399 ntypeargs=1   (baml.json.from_json)
+      13   call 407 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("runner")
-      16   call 407 ntypeargs=0   (baml.json.field)
+      16   call 415 ntypeargs=0   (baml.json.field)
       17   store_var 4            (_9)
       18   load_type 5            
       19   load_var 4             (_9)
-      20   call 399 ntypeargs=1   (baml.json.from_json)
+      20   call 407 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (testing.TestRegistration .name, .body, .runner)
       22   return                 
 }
@@ -1080,8 +759,8 @@ function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRe
 function testing.TestRegistration.to_json(self: testing.TestRegistration) -> baml.json.json {
   13   0   load_type 0            
        1   load_var 1             (self)
-       2   call 409 ntypeargs=1   (baml.json.to_string)
-       3   call 404 ntypeargs=0   (baml.json.parse)
+       2   call 417 ntypeargs=1   (baml.json.to_string)
+       3   call 412 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
@@ -1089,525 +768,310 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   157   0     load_var 1               (self)
         1     load_field 0             (collector)
         2     load_field 2             (testsets)
-        3     store_var_load_var 3     (_3)
+        3     store_var 3              (_3)
 
-  156   4     is_type 0                
-        5     pop_jump_if_false +2     (to 7)
-        6     jump +105                (to 111)
-        7     load_var 3               (_3)
-        8     is_type 1                
-        9     pop_jump_if_false +2     (to 11)
-        10    jump +96                 (to 106)
-        11    load_var 3               (_3)
-        12    is_type 2                
-        13    pop_jump_if_false +2     (to 15)
-        14    jump +86                 (to 100)
-        15    load_var 3               (_3)
-        16    is_type 3                
-        17    pop_jump_if_false +2     (to 19)
-        18    jump +75                 (to 93)
-        19    load_var 3               (_3)
-        20    is_type 4                
-        21    pop_jump_if_false +2     (to 23)
-        22    jump +66                 (to 88)
-        23    load_var 3               (_3)
-        24    is_type 5                
-        25    pop_jump_if_false +2     (to 27)
-        26    jump +57                 (to 83)
-        27    load_var 3               (_3)
-        28    is_type 6                
-        29    pop_jump_if_false +2     (to 31)
-        30    jump +46                 (to 76)
-        31    load_var 3               (_3)
-        32    is_type 7                
-        33    pop_jump_if_false +2     (to 35)
-        34    jump +37                 (to 71)
-        35    load_var 3               (_3)
-        36    is_type 8                
-        37    pop_jump_if_false +2     (to 39)
-        38    jump +28                 (to 66)
-        39    load_var 3               (_3)
-        40    is_type 9                
-        41    pop_jump_if_false +2     (to 43)
-        42    jump +18                 (to 60)
-        43    load_var 3               (_3)
-        44    is_type 10               
-        45    pop_jump_if_false +2     (to 47)
-        46    jump +9                  (to 55)
-        47    load_var 3               (_3)
-        48    is_type 10               
-        49    pop_jump_if_false +432   (to 481)
-        50    load_type 11             
-        51    load_var 3               (_3)
-        52    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        53    store_var 4              (_4)
-        54    jump +61                 (to 115)
-        55    load_type 11             
-        56    load_var 3               (_3)
-        57    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        58    store_var 4              (_4)
-        59    jump +56                 (to 115)
-        60    load_type 11             
-        61    load_type 12             
-        62    load_var 3               (_3)
-        63    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        64    store_var 4              (_4)
-        65    jump +50                 (to 115)
-        66    load_var 3               (_3)
-        67    make_bound_method 514    
-        68    call_indirect            
-        69    store_var 4              (_4)
-        70    jump +45                 (to 115)
-        71    load_var 3               (_3)
-        72    make_bound_method 527    
-        73    call_indirect            
-        74    store_var 4              (_4)
-        75    jump +40                 (to 115)
-        76    load_type 11             
-        77    load_type 12             
-        78    load_type 12             
-        79    load_var 3               (_3)
-        80    call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        81    store_var 4              (_4)
-        82    jump +33                 (to 115)
-        83    load_var 3               (_3)
-        84    make_bound_method 557    
-        85    call_indirect            
-        86    store_var 4              (_4)
-        87    jump +28                 (to 115)
+  156   4     load_type 0              
+        5     load_var 3               (_3)
+        6     call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        7     store_var 4              (_4)
+        8     load_var 4               (_4)
+        9     is_type 1                
+        10    pop_jump_if_false +2     (to 12)
+        11    jump +87                 (to 98)
+        12    load_var 4               (_4)
+        13    is_type 2                
+        14    pop_jump_if_false +2     (to 16)
+        15    jump +78                 (to 93)
+        16    load_var 4               (_4)
+        17    is_type 3                
+        18    pop_jump_if_false +2     (to 20)
+        19    jump +68                 (to 87)
+        20    load_var 4               (_4)
+        21    is_type 4                
+        22    pop_jump_if_false +2     (to 24)
+        23    jump +57                 (to 80)
+        24    load_var 4               (_4)
+        25    is_type 5                
+        26    pop_jump_if_false +2     (to 28)
+        27    jump +48                 (to 75)
+        28    load_var 4               (_4)
+        29    is_type 6                
+        30    pop_jump_if_false +2     (to 32)
+        31    jump +39                 (to 70)
+        32    load_var 4               (_4)
+        33    is_type 7                
+        34    pop_jump_if_false +2     (to 36)
+        35    jump +28                 (to 63)
+        36    load_var 4               (_4)
+        37    is_type 8                
+        38    pop_jump_if_false +2     (to 40)
+        39    jump +19                 (to 58)
+        40    load_var 4               (_4)
+        41    is_type 9                
+        42    pop_jump_if_false +2     (to 44)
+        43    jump +10                 (to 53)
+        44    load_var 4               (_4)
+        45    is_type 10               
+        46    pop_jump_if_false +220   (to 266)
+        47    load_type 0              
+        48    load_type 11             
+        49    load_var 4               (_4)
+        50    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        51    store_var 5              (_6)
+        52    jump +50                 (to 102)
+        53    load_var 4               (_4)
+        54    make_bound_method 576    
+        55    call_indirect            
+        56    store_var 5              (_6)
+        57    jump +45                 (to 102)
+        58    load_var 4               (_4)
+        59    make_bound_method 589    
+        60    call_indirect            
+        61    store_var 5              (_6)
+        62    jump +40                 (to 102)
+        63    load_type 0              
+        64    load_type 11             
+        65    load_type 11             
+        66    load_var 4               (_4)
+        67    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        68    store_var 5              (_6)
+        69    jump +33                 (to 102)
+        70    load_var 4               (_4)
+        71    make_bound_method 525    
+        72    call_indirect            
+        73    store_var 5              (_6)
+        74    jump +28                 (to 102)
+        75    load_type 0              
+        76    load_var 4               (_4)
+        77    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        78    store_var 5              (_6)
+        79    jump +23                 (to 102)
+        80    load_type 0              
+        81    load_type 11             
+        82    load_type 11             
+        83    load_var 4               (_4)
+        84    call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        85    store_var 5              (_6)
+        86    jump +16                 (to 102)
+        87    load_type 0              
         88    load_type 11             
-        89    load_var 3               (_3)
-        90    call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        91    store_var 4              (_4)
-        92    jump +23                 (to 115)
-        93    load_type 11             
-        94    load_type 12             
-        95    load_type 12             
-        96    load_var 3               (_3)
-        97    call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        98    store_var 4              (_4)
-        99    jump +16                 (to 115)
-        100   load_type 11             
-        101   load_type 12             
-        102   load_var 3               (_3)
-        103   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        104   store_var 4              (_4)
-        105   jump +10                 (to 115)
-        106   load_type 11             
-        107   load_var 3               (_3)
-        108   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        109   store_var 4              (_4)
-        110   jump +5                  (to 115)
-        111   load_var 3               (_3)
-        112   make_bound_method 588    
-        113   call_indirect            
-        114   store_var 4              (_4)
-        115   load_var 4               (_4)
-        116   is_type 0                
-        117   pop_jump_if_false +2     (to 119)
-        118   jump +87                 (to 205)
-        119   load_var 4               (_4)
-        120   is_type 1                
-        121   pop_jump_if_false +2     (to 123)
-        122   jump +78                 (to 200)
-        123   load_var 4               (_4)
-        124   is_type 2                
-        125   pop_jump_if_false +2     (to 127)
-        126   jump +68                 (to 194)
-        127   load_var 4               (_4)
-        128   is_type 3                
-        129   pop_jump_if_false +2     (to 131)
-        130   jump +57                 (to 187)
-        131   load_var 4               (_4)
-        132   is_type 4                
-        133   pop_jump_if_false +2     (to 135)
-        134   jump +48                 (to 182)
-        135   load_var 4               (_4)
-        136   is_type 5                
-        137   pop_jump_if_false +2     (to 139)
-        138   jump +39                 (to 177)
-        139   load_var 4               (_4)
-        140   is_type 6                
-        141   pop_jump_if_false +2     (to 143)
-        142   jump +28                 (to 170)
-        143   load_var 4               (_4)
-        144   is_type 7                
-        145   pop_jump_if_false +2     (to 147)
-        146   jump +19                 (to 165)
-        147   load_var 4               (_4)
-        148   is_type 8                
-        149   pop_jump_if_false +2     (to 151)
-        150   jump +10                 (to 160)
-        151   load_var 4               (_4)
-        152   is_type 9                
-        153   pop_jump_if_false +328   (to 481)
-        154   load_type 11             
-        155   load_type 12             
-        156   load_var 4               (_4)
-        157   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        158   store_var 5              (_35)
-        159   jump +50                 (to 209)
-        160   load_var 4               (_4)
-        161   make_bound_method 568    
-        162   call_indirect            
-        163   store_var 5              (_35)
-        164   jump +45                 (to 209)
-        165   load_var 4               (_4)
-        166   make_bound_method 581    
-        167   call_indirect            
-        168   store_var 5              (_35)
-        169   jump +40                 (to 209)
-        170   load_type 11             
-        171   load_type 12             
-        172   load_type 12             
-        173   load_var 4               (_4)
-        174   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        175   store_var 5              (_35)
-        176   jump +33                 (to 209)
-        177   load_var 4               (_4)
-        178   make_bound_method 517    
-        179   call_indirect            
-        180   store_var 5              (_35)
-        181   jump +28                 (to 209)
-        182   load_type 11             
-        183   load_var 4               (_4)
-        184   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        185   store_var 5              (_35)
-        186   jump +23                 (to 209)
-        187   load_type 11             
-        188   load_type 12             
-        189   load_type 12             
-        190   load_var 4               (_4)
-        191   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        192   store_var 5              (_35)
-        193   jump +16                 (to 209)
-        194   load_type 11             
-        195   load_type 12             
-        196   load_var 4               (_4)
-        197   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        198   store_var 5              (_35)
-        199   jump +10                 (to 209)
-        200   load_type 11             
-        201   load_var 4               (_4)
-        202   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        203   store_var 5              (_35)
-        204   jump +5                  (to 209)
-        205   load_var 4               (_4)
-        206   make_bound_method 552    
-        207   call_indirect            
-        208   store_var 5              (_35)
-        209   load_var 5               (_35)
-        210   is_type 13               
-        211   pop_jump_if_false +2     (to 213)
-        212   jump +34                 (to 246)
-        213   load_var 5               (_35)
-        214   store_var_load_var 6     (ts)
+        89    load_var 4               (_4)
+        90    call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        91    store_var 5              (_6)
+        92    jump +10                 (to 102)
+        93    load_type 0              
+        94    load_var 4               (_4)
+        95    call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        96    store_var 5              (_6)
+        97    jump +5                  (to 102)
+        98    load_var 4               (_4)
+        99    make_bound_method 560    
+        100   call_indirect            
+        101   store_var 5              (_6)
+        102   load_var 5               (_6)
+        103   is_type 12               
+        104   pop_jump_if_false +2     (to 106)
+        105   jump +34                 (to 139)
+        106   load_var 5               (_6)
+        107   store_var_load_var 6     (ts)
 
-  158   215   load_field 0             (name)
-        216   load_var 2               (name)
-        217   cmp_op ==                
-        218   pop_jump_if_false -103   (to 115)
+  158   108   load_field 0             (name)
+        109   load_var 2               (name)
+        110   cmp_op ==                
+        111   pop_jump_if_false -103   (to 8)
 
-  159   219   call 301 ntypeargs=0     (baml.sys.now_ms)
-        220   store_var 7              (start)
+  159   112   call 309 ntypeargs=0     (baml.sys.now_ms)
+        113   store_var 7              (start)
 
-  160   221   load_var 2               (name)
-        222   alloc_array 0            
-        223   alloc_array 0            
-        224   init_instance 0          (testing.TestCollector .prefix, .tests, .testsets)
-        225   store_var_load_var 8     (sub_collector)
+  160   114   load_var 2               (name)
+        115   alloc_array 0            
+        116   alloc_array 0            
+        117   init_instance 0          (testing.TestCollector .prefix, .tests, .testsets)
+        118   store_var_load_var 8     (sub_collector)
 
-  161   226   load_var 6               (ts)
-        227   load_field 1             (collector)
-        228   call_indirect            
-        229   pop 1                    
+  161   119   load_var 6               (ts)
+        120   load_field 1             (collector)
+        121   call_indirect            
+        122   pop 1                    
 
-  162   230   call 301 ntypeargs=0     (baml.sys.now_ms)
-        231   store_var 9              (_75)
+  162   123   call 309 ntypeargs=0     (baml.sys.now_ms)
+        124   store_var 9              (_46)
 
-  168   232   load_type 14             
-        233   load_type 15             
-        234   load_var 1               (self)
-        235   load_field 1             (expansions)
-        236   load_var2 2 8            
+  168   125   load_type 13             
+        126   load_type 14             
+        127   load_var 1               (self)
+        128   load_field 1             (expansions)
+        129   load_var2 2 8            
 
-  165   237   alloc_map 0              
+  165   130   alloc_map 0              
 
-  162   238   load_var2 9 7            
-        239   sub_int                  
-        240   init_instance 1          (testing.TestRegistry .collector, .expansions, .loading_time_ms)
-        241   call 22 ntypeargs=2      (baml.Map.set)
-        242   pop 1                    
+  162   131   load_var2 9 7            
+        132   sub_int                  
+        133   init_instance 1          (testing.TestRegistry .collector, .expansions, .loading_time_ms)
+        134   call 22 ntypeargs=2      (baml.Map.set)
+        135   pop 1                    
 
-  169   243   load_var 1               (self)
-        244   call 746 ntypeargs=0     (testing.TestRegistry.serialize)
-        245   jump +231                (to 476)
+  169   136   load_var 1               (self)
+        137   call 754 ntypeargs=0     (testing.TestRegistry.serialize)
+        138   jump +123                (to 261)
 
-  173   246   load_type 14             
-        247   load_type 15             
-        248   load_var 1               (self)
-        249   load_field 1             (expansions)
-        250   call 20 ntypeargs=2      (baml.Map.keys)
-        251   store_var 10             (_86)
+  173   139   load_type 13             
+        140   load_type 14             
+        141   load_var 1               (self)
+        142   load_field 1             (expansions)
+        143   call 20 ntypeargs=2      (baml.Map.keys)
+        144   store_var 10             (_57)
 
-  172   252   load_var 10              (_86)
-        253   is_type 16               
-        254   pop_jump_if_false +2     (to 256)
-        255   jump +105                (to 360)
-        256   load_var 10              (_86)
-        257   is_type 17               
-        258   pop_jump_if_false +2     (to 260)
-        259   jump +96                 (to 355)
-        260   load_var 10              (_86)
-        261   is_type 18               
-        262   pop_jump_if_false +2     (to 264)
-        263   jump +86                 (to 349)
-        264   load_var 10              (_86)
-        265   is_type 19               
-        266   pop_jump_if_false +2     (to 268)
-        267   jump +75                 (to 342)
-        268   load_var 10              (_86)
-        269   is_type 20               
-        270   pop_jump_if_false +2     (to 272)
-        271   jump +66                 (to 337)
-        272   load_var 10              (_86)
-        273   is_type 21               
-        274   pop_jump_if_false +2     (to 276)
-        275   jump +57                 (to 332)
-        276   load_var 10              (_86)
-        277   is_type 22               
-        278   pop_jump_if_false +2     (to 280)
-        279   jump +46                 (to 325)
-        280   load_var 10              (_86)
-        281   is_type 23               
-        282   pop_jump_if_false +2     (to 284)
-        283   jump +37                 (to 320)
-        284   load_var 10              (_86)
-        285   is_type 24               
-        286   pop_jump_if_false +2     (to 288)
-        287   jump +28                 (to 315)
-        288   load_var 10              (_86)
-        289   is_type 25               
-        290   pop_jump_if_false +2     (to 292)
-        291   jump +18                 (to 309)
-        292   load_var 10              (_86)
-        293   is_type 10               
-        294   pop_jump_if_false +2     (to 296)
-        295   jump +9                  (to 304)
-        296   load_var 10              (_86)
-        297   is_type 10               
-        298   pop_jump_if_false +183   (to 481)
-        299   load_type 14             
-        300   load_var 10              (_86)
-        301   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        302   store_var 11             (_90)
-        303   jump +61                 (to 364)
-        304   load_type 14             
-        305   load_var 10              (_86)
-        306   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        307   store_var 11             (_90)
-        308   jump +56                 (to 364)
-        309   load_type 14             
-        310   load_type 12             
-        311   load_var 10              (_86)
-        312   call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        313   store_var 11             (_90)
-        314   jump +50                 (to 364)
-        315   load_var 10              (_86)
-        316   make_bound_method 514    
-        317   call_indirect            
-        318   store_var 11             (_90)
-        319   jump +45                 (to 364)
-        320   load_var 10              (_86)
-        321   make_bound_method 527    
-        322   call_indirect            
-        323   store_var 11             (_90)
-        324   jump +40                 (to 364)
-        325   load_type 14             
-        326   load_type 12             
-        327   load_type 12             
-        328   load_var 10              (_86)
-        329   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        330   store_var 11             (_90)
-        331   jump +33                 (to 364)
-        332   load_var 10              (_86)
-        333   make_bound_method 557    
-        334   call_indirect            
-        335   store_var 11             (_90)
-        336   jump +28                 (to 364)
-        337   load_type 14             
-        338   load_var 10              (_86)
-        339   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        340   store_var 11             (_90)
-        341   jump +23                 (to 364)
-        342   load_type 14             
-        343   load_type 12             
-        344   load_type 12             
-        345   load_var 10              (_86)
-        346   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        347   store_var 11             (_90)
-        348   jump +16                 (to 364)
-        349   load_type 14             
-        350   load_type 12             
-        351   load_var 10              (_86)
-        352   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        353   store_var 11             (_90)
-        354   jump +10                 (to 364)
-        355   load_type 14             
-        356   load_var 10              (_86)
-        357   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        358   store_var 11             (_90)
-        359   jump +5                  (to 364)
-        360   load_var 10              (_86)
-        361   make_bound_method 588    
-        362   call_indirect            
-        363   store_var 11             (_90)
-        364   load_var 11              (_90)
-        365   is_type 16               
-        366   pop_jump_if_false +2     (to 368)
-        367   jump +87                 (to 454)
-        368   load_var 11              (_90)
-        369   is_type 17               
-        370   pop_jump_if_false +2     (to 372)
-        371   jump +78                 (to 449)
-        372   load_var 11              (_90)
-        373   is_type 18               
-        374   pop_jump_if_false +2     (to 376)
-        375   jump +68                 (to 443)
-        376   load_var 11              (_90)
-        377   is_type 19               
-        378   pop_jump_if_false +2     (to 380)
-        379   jump +57                 (to 436)
-        380   load_var 11              (_90)
-        381   is_type 20               
-        382   pop_jump_if_false +2     (to 384)
-        383   jump +48                 (to 431)
-        384   load_var 11              (_90)
-        385   is_type 21               
-        386   pop_jump_if_false +2     (to 388)
-        387   jump +39                 (to 426)
-        388   load_var 11              (_90)
-        389   is_type 22               
-        390   pop_jump_if_false +2     (to 392)
-        391   jump +28                 (to 419)
-        392   load_var 11              (_90)
-        393   is_type 23               
-        394   pop_jump_if_false +2     (to 396)
-        395   jump +19                 (to 414)
-        396   load_var 11              (_90)
-        397   is_type 24               
-        398   pop_jump_if_false +2     (to 400)
-        399   jump +10                 (to 409)
-        400   load_var 11              (_90)
-        401   is_type 25               
-        402   pop_jump_if_false +79    (to 481)
-        403   load_type 14             
-        404   load_type 12             
-        405   load_var 11              (_90)
-        406   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        407   store_var 12             (_121)
-        408   jump +50                 (to 458)
-        409   load_var 11              (_90)
-        410   make_bound_method 568    
-        411   call_indirect            
-        412   store_var 12             (_121)
-        413   jump +45                 (to 458)
-        414   load_var 11              (_90)
-        415   make_bound_method 581    
-        416   call_indirect            
-        417   store_var 12             (_121)
-        418   jump +40                 (to 458)
-        419   load_type 14             
-        420   load_type 12             
-        421   load_type 12             
-        422   load_var 11              (_90)
-        423   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        424   store_var 12             (_121)
-        425   jump +33                 (to 458)
-        426   load_var 11              (_90)
-        427   make_bound_method 517    
-        428   call_indirect            
-        429   store_var 12             (_121)
-        430   jump +28                 (to 458)
-        431   load_type 14             
-        432   load_var 11              (_90)
-        433   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        434   store_var 12             (_121)
-        435   jump +23                 (to 458)
-        436   load_type 14             
-        437   load_type 12             
-        438   load_type 12             
-        439   load_var 11              (_90)
-        440   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        441   store_var 12             (_121)
-        442   jump +16                 (to 458)
-        443   load_type 14             
-        444   load_type 12             
-        445   load_var 11              (_90)
-        446   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        447   store_var 12             (_121)
-        448   jump +10                 (to 458)
-        449   load_type 14             
-        450   load_var 11              (_90)
-        451   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        452   store_var 12             (_121)
-        453   jump +5                  (to 458)
-        454   load_var 11              (_90)
-        455   make_bound_method 552    
-        456   call_indirect            
-        457   store_var 12             (_121)
-        458   load_var 12              (_121)
-        459   is_type 13               
-        460   pop_jump_if_false +2     (to 462)
-        461   jump +16                 (to 477)
-        462   load_var 12              (_121)
-        463   store_var 13             (k)
+  172   145   load_type 13             
+        146   load_var 10              (_57)
+        147   call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        148   store_var 11             (_61)
+        149   load_var 11              (_61)
+        150   is_type 15               
+        151   pop_jump_if_false +2     (to 153)
+        152   jump +87                 (to 239)
+        153   load_var 11              (_61)
+        154   is_type 16               
+        155   pop_jump_if_false +2     (to 157)
+        156   jump +78                 (to 234)
+        157   load_var 11              (_61)
+        158   is_type 17               
+        159   pop_jump_if_false +2     (to 161)
+        160   jump +68                 (to 228)
+        161   load_var 11              (_61)
+        162   is_type 18               
+        163   pop_jump_if_false +2     (to 165)
+        164   jump +57                 (to 221)
+        165   load_var 11              (_61)
+        166   is_type 19               
+        167   pop_jump_if_false +2     (to 169)
+        168   jump +48                 (to 216)
+        169   load_var 11              (_61)
+        170   is_type 20               
+        171   pop_jump_if_false +2     (to 173)
+        172   jump +39                 (to 211)
+        173   load_var 11              (_61)
+        174   is_type 21               
+        175   pop_jump_if_false +2     (to 177)
+        176   jump +28                 (to 204)
+        177   load_var 11              (_61)
+        178   is_type 22               
+        179   pop_jump_if_false +2     (to 181)
+        180   jump +19                 (to 199)
+        181   load_var 11              (_61)
+        182   is_type 23               
+        183   pop_jump_if_false +2     (to 185)
+        184   jump +10                 (to 194)
+        185   load_var 11              (_61)
+        186   is_type 24               
+        187   pop_jump_if_false +79    (to 266)
+        188   load_type 13             
+        189   load_type 11             
+        190   load_var 11              (_61)
+        191   call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        192   store_var 12             (_63)
+        193   jump +50                 (to 243)
+        194   load_var 11              (_61)
+        195   make_bound_method 576    
+        196   call_indirect            
+        197   store_var 12             (_63)
+        198   jump +45                 (to 243)
+        199   load_var 11              (_61)
+        200   make_bound_method 589    
+        201   call_indirect            
+        202   store_var 12             (_63)
+        203   jump +40                 (to 243)
+        204   load_type 13             
+        205   load_type 11             
+        206   load_type 11             
+        207   load_var 11              (_61)
+        208   call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        209   store_var 12             (_63)
+        210   jump +33                 (to 243)
+        211   load_var 11              (_61)
+        212   make_bound_method 525    
+        213   call_indirect            
+        214   store_var 12             (_63)
+        215   jump +28                 (to 243)
+        216   load_type 13             
+        217   load_var 11              (_61)
+        218   call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        219   store_var 12             (_63)
+        220   jump +23                 (to 243)
+        221   load_type 13             
+        222   load_type 11             
+        223   load_type 11             
+        224   load_var 11              (_61)
+        225   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        226   store_var 12             (_63)
+        227   jump +16                 (to 243)
+        228   load_type 13             
+        229   load_type 11             
+        230   load_var 11              (_61)
+        231   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        232   store_var 12             (_63)
+        233   jump +10                 (to 243)
+        234   load_type 13             
+        235   load_var 11              (_61)
+        236   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        237   store_var 12             (_63)
+        238   jump +5                  (to 243)
+        239   load_var 11              (_61)
+        240   make_bound_method 560    
+        241   call_indirect            
+        242   store_var 12             (_63)
+        243   load_var 12              (_63)
+        244   is_type 12               
+        245   pop_jump_if_false +2     (to 247)
+        246   jump +16                 (to 262)
+        247   load_var 12              (_63)
+        248   store_var 13             (k)
 
-  174   464   load_var 1               (self)
-        465   load_field 1             (expansions)
-        466   load_var 13              (k)
-        467   load_map_element         
-        468   store_var 14             (sub)
+  174   249   load_var 1               (self)
+        250   load_field 1             (expansions)
+        251   load_var 13              (k)
+        252   load_map_element         
+        253   store_var 14             (sub)
 
-  175   469   load_var2 2 13           
-        470   load_const 26            ("/")
-        471   bin_op +                 
-        472   call 152 ntypeargs=0     (baml.String.starts_with)
-        473   pop_jump_if_false -109   (to 364)
+  175   254   load_var2 2 13           
+        255   load_const 25            ("/")
+        256   bin_op +                 
+        257   call 160 ntypeargs=0     (baml.String.starts_with)
+        258   pop_jump_if_false -109   (to 149)
 
-  176   474   load_var2 14 2           
-        475   call 751 ntypeargs=0     (testing.TestRegistry.expand_set)
-        476   return                   
+  176   259   load_var2 14 2           
+        260   call 759 ntypeargs=0     (testing.TestRegistry.expand_set)
+        261   return                   
 
-  179   477   load_const 27            ("TestSet not found for expansion: ")
-        478   load_var 2               (name)
-        479   bin_op +                 
-        480   throw                    
-        481   unreachable              
+  179   262   load_const 26            ("TestSet not found for expansion: ")
+        263   load_var 2               (name)
+        264   bin_op +                 
+        265   throw                    
+        266   unreachable              
 }
 
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
   93   0    load_var 1             (j)
        1    load_const 0           ("collector")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("expansions")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loading_time_ms")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
        22   return                 
 }
@@ -1625,474 +1089,259 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
   137   0     load_var 1               (self)
         1     load_field 0             (collector)
         2     load_field 1             (tests)
-        3     store_var_load_var 3     (_3)
+        3     store_var 3              (_3)
 
-  136   4     is_type 0                
-        5     pop_jump_if_false +2     (to 7)
-        6     jump +105                (to 111)
-        7     load_var 3               (_3)
-        8     is_type 1                
-        9     pop_jump_if_false +2     (to 11)
-        10    jump +96                 (to 106)
-        11    load_var 3               (_3)
-        12    is_type 2                
-        13    pop_jump_if_false +2     (to 15)
-        14    jump +86                 (to 100)
-        15    load_var 3               (_3)
-        16    is_type 3                
-        17    pop_jump_if_false +2     (to 19)
-        18    jump +75                 (to 93)
-        19    load_var 3               (_3)
-        20    is_type 4                
-        21    pop_jump_if_false +2     (to 23)
-        22    jump +66                 (to 88)
-        23    load_var 3               (_3)
-        24    is_type 5                
-        25    pop_jump_if_false +2     (to 27)
-        26    jump +57                 (to 83)
-        27    load_var 3               (_3)
-        28    is_type 6                
-        29    pop_jump_if_false +2     (to 31)
-        30    jump +46                 (to 76)
-        31    load_var 3               (_3)
-        32    is_type 7                
-        33    pop_jump_if_false +2     (to 35)
-        34    jump +37                 (to 71)
-        35    load_var 3               (_3)
-        36    is_type 8                
-        37    pop_jump_if_false +2     (to 39)
-        38    jump +28                 (to 66)
-        39    load_var 3               (_3)
-        40    is_type 9                
-        41    pop_jump_if_false +2     (to 43)
-        42    jump +18                 (to 60)
-        43    load_var 3               (_3)
-        44    is_type 10               
-        45    pop_jump_if_false +2     (to 47)
-        46    jump +9                  (to 55)
-        47    load_var 3               (_3)
-        48    is_type 10               
-        49    pop_jump_if_false +411   (to 460)
-        50    load_type 11             
-        51    load_var 3               (_3)
-        52    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        53    store_var 4              (_4)
-        54    jump +61                 (to 115)
-        55    load_type 11             
-        56    load_var 3               (_3)
-        57    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        58    store_var 4              (_4)
-        59    jump +56                 (to 115)
-        60    load_type 11             
-        61    load_type 12             
-        62    load_var 3               (_3)
-        63    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        64    store_var 4              (_4)
-        65    jump +50                 (to 115)
-        66    load_var 3               (_3)
-        67    make_bound_method 514    
-        68    call_indirect            
-        69    store_var 4              (_4)
-        70    jump +45                 (to 115)
-        71    load_var 3               (_3)
-        72    make_bound_method 527    
-        73    call_indirect            
-        74    store_var 4              (_4)
-        75    jump +40                 (to 115)
-        76    load_type 11             
-        77    load_type 12             
-        78    load_type 12             
-        79    load_var 3               (_3)
-        80    call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        81    store_var 4              (_4)
-        82    jump +33                 (to 115)
-        83    load_var 3               (_3)
-        84    make_bound_method 557    
-        85    call_indirect            
-        86    store_var 4              (_4)
-        87    jump +28                 (to 115)
+  136   4     load_type 0              
+        5     load_var 3               (_3)
+        6     call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        7     store_var 4              (_4)
+        8     load_var 4               (_4)
+        9     is_type 1                
+        10    pop_jump_if_false +2     (to 12)
+        11    jump +87                 (to 98)
+        12    load_var 4               (_4)
+        13    is_type 2                
+        14    pop_jump_if_false +2     (to 16)
+        15    jump +78                 (to 93)
+        16    load_var 4               (_4)
+        17    is_type 3                
+        18    pop_jump_if_false +2     (to 20)
+        19    jump +68                 (to 87)
+        20    load_var 4               (_4)
+        21    is_type 4                
+        22    pop_jump_if_false +2     (to 24)
+        23    jump +57                 (to 80)
+        24    load_var 4               (_4)
+        25    is_type 5                
+        26    pop_jump_if_false +2     (to 28)
+        27    jump +48                 (to 75)
+        28    load_var 4               (_4)
+        29    is_type 6                
+        30    pop_jump_if_false +2     (to 32)
+        31    jump +39                 (to 70)
+        32    load_var 4               (_4)
+        33    is_type 7                
+        34    pop_jump_if_false +2     (to 36)
+        35    jump +28                 (to 63)
+        36    load_var 4               (_4)
+        37    is_type 8                
+        38    pop_jump_if_false +2     (to 40)
+        39    jump +19                 (to 58)
+        40    load_var 4               (_4)
+        41    is_type 9                
+        42    pop_jump_if_false +2     (to 44)
+        43    jump +10                 (to 53)
+        44    load_var 4               (_4)
+        45    is_type 10               
+        46    pop_jump_if_false +199   (to 245)
+        47    load_type 0              
+        48    load_type 11             
+        49    load_var 4               (_4)
+        50    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        51    store_var 5              (_6)
+        52    jump +50                 (to 102)
+        53    load_var 4               (_4)
+        54    make_bound_method 576    
+        55    call_indirect            
+        56    store_var 5              (_6)
+        57    jump +45                 (to 102)
+        58    load_var 4               (_4)
+        59    make_bound_method 589    
+        60    call_indirect            
+        61    store_var 5              (_6)
+        62    jump +40                 (to 102)
+        63    load_type 0              
+        64    load_type 11             
+        65    load_type 11             
+        66    load_var 4               (_4)
+        67    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        68    store_var 5              (_6)
+        69    jump +33                 (to 102)
+        70    load_var 4               (_4)
+        71    make_bound_method 525    
+        72    call_indirect            
+        73    store_var 5              (_6)
+        74    jump +28                 (to 102)
+        75    load_type 0              
+        76    load_var 4               (_4)
+        77    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        78    store_var 5              (_6)
+        79    jump +23                 (to 102)
+        80    load_type 0              
+        81    load_type 11             
+        82    load_type 11             
+        83    load_var 4               (_4)
+        84    call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        85    store_var 5              (_6)
+        86    jump +16                 (to 102)
+        87    load_type 0              
         88    load_type 11             
-        89    load_var 3               (_3)
-        90    call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        91    store_var 4              (_4)
-        92    jump +23                 (to 115)
-        93    load_type 11             
-        94    load_type 12             
-        95    load_type 12             
-        96    load_var 3               (_3)
-        97    call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        98    store_var 4              (_4)
-        99    jump +16                 (to 115)
-        100   load_type 11             
-        101   load_type 12             
-        102   load_var 3               (_3)
-        103   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        104   store_var 4              (_4)
-        105   jump +10                 (to 115)
-        106   load_type 11             
-        107   load_var 3               (_3)
-        108   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        109   store_var 4              (_4)
-        110   jump +5                  (to 115)
-        111   load_var 3               (_3)
-        112   make_bound_method 588    
-        113   call_indirect            
-        114   store_var 4              (_4)
-        115   load_var 4               (_4)
-        116   is_type 0                
-        117   pop_jump_if_false +2     (to 119)
-        118   jump +87                 (to 205)
-        119   load_var 4               (_4)
-        120   is_type 1                
-        121   pop_jump_if_false +2     (to 123)
-        122   jump +78                 (to 200)
-        123   load_var 4               (_4)
-        124   is_type 2                
-        125   pop_jump_if_false +2     (to 127)
-        126   jump +68                 (to 194)
-        127   load_var 4               (_4)
-        128   is_type 3                
-        129   pop_jump_if_false +2     (to 131)
-        130   jump +57                 (to 187)
-        131   load_var 4               (_4)
-        132   is_type 4                
-        133   pop_jump_if_false +2     (to 135)
-        134   jump +48                 (to 182)
-        135   load_var 4               (_4)
-        136   is_type 5                
-        137   pop_jump_if_false +2     (to 139)
-        138   jump +39                 (to 177)
-        139   load_var 4               (_4)
-        140   is_type 6                
-        141   pop_jump_if_false +2     (to 143)
-        142   jump +28                 (to 170)
-        143   load_var 4               (_4)
-        144   is_type 7                
-        145   pop_jump_if_false +2     (to 147)
-        146   jump +19                 (to 165)
-        147   load_var 4               (_4)
-        148   is_type 8                
-        149   pop_jump_if_false +2     (to 151)
-        150   jump +10                 (to 160)
-        151   load_var 4               (_4)
-        152   is_type 9                
-        153   pop_jump_if_false +307   (to 460)
-        154   load_type 11             
-        155   load_type 12             
-        156   load_var 4               (_4)
-        157   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        158   store_var 5              (_35)
-        159   jump +50                 (to 209)
-        160   load_var 4               (_4)
-        161   make_bound_method 568    
-        162   call_indirect            
-        163   store_var 5              (_35)
-        164   jump +45                 (to 209)
-        165   load_var 4               (_4)
-        166   make_bound_method 581    
-        167   call_indirect            
-        168   store_var 5              (_35)
-        169   jump +40                 (to 209)
-        170   load_type 11             
-        171   load_type 12             
-        172   load_type 12             
-        173   load_var 4               (_4)
-        174   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        175   store_var 5              (_35)
-        176   jump +33                 (to 209)
-        177   load_var 4               (_4)
-        178   make_bound_method 517    
-        179   call_indirect            
-        180   store_var 5              (_35)
-        181   jump +28                 (to 209)
-        182   load_type 11             
-        183   load_var 4               (_4)
-        184   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        185   store_var 5              (_35)
-        186   jump +23                 (to 209)
-        187   load_type 11             
-        188   load_type 12             
-        189   load_type 12             
-        190   load_var 4               (_4)
-        191   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        192   store_var 5              (_35)
-        193   jump +16                 (to 209)
-        194   load_type 11             
-        195   load_type 12             
-        196   load_var 4               (_4)
-        197   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        198   store_var 5              (_35)
-        199   jump +10                 (to 209)
-        200   load_type 11             
-        201   load_var 4               (_4)
-        202   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        203   store_var 5              (_35)
-        204   jump +5                  (to 209)
-        205   load_var 4               (_4)
-        206   make_bound_method 552    
-        207   call_indirect            
-        208   store_var 5              (_35)
-        209   load_var 5               (_35)
-        210   is_type 13               
-        211   pop_jump_if_false +2     (to 213)
-        212   jump +13                 (to 225)
-        213   load_var 5               (_35)
-        214   store_var_load_var 6     (t)
+        89    load_var 4               (_4)
+        90    call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        91    store_var 5              (_6)
+        92    jump +10                 (to 102)
+        93    load_type 0              
+        94    load_var 4               (_4)
+        95    call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        96    store_var 5              (_6)
+        97    jump +5                  (to 102)
+        98    load_var 4               (_4)
+        99    make_bound_method 560    
+        100   call_indirect            
+        101   store_var 5              (_6)
+        102   load_var 5               (_6)
+        103   is_type 12               
+        104   pop_jump_if_false +2     (to 106)
+        105   jump +13                 (to 118)
+        106   load_var 5               (_6)
+        107   store_var_load_var 6     (t)
 
-  138   215   load_field 0             (name)
-        216   load_var 2               (name)
-        217   cmp_op ==                
-        218   pop_jump_if_false -103   (to 115)
+  138   108   load_field 0             (name)
+        109   load_var 2               (name)
+        110   cmp_op ==                
+        111   pop_jump_if_false -103   (to 8)
 
-  139   219   load_var 6               (t)
-        220   load_field 1             (body)
-        221   load_var 6               (t)
-        222   load_field 2             (runner)
-        223   call 757 ntypeargs=0     (testing.run_test)
-        224   jump +231                (to 455)
+  139   112   load_var 6               (t)
+        113   load_field 1             (body)
+        114   load_var 6               (t)
+        115   load_field 2             (runner)
+        116   call 765 ntypeargs=0     (testing.run_test)
+        117   jump +123                (to 240)
 
-  143   225   load_type 14             
-        226   load_type 15             
-        227   load_var 1               (self)
-        228   load_field 1             (expansions)
-        229   call 20 ntypeargs=2      (baml.Map.keys)
-        230   store_var 7              (_69)
+  143   118   load_type 13             
+        119   load_type 14             
+        120   load_var 1               (self)
+        121   load_field 1             (expansions)
+        122   call 20 ntypeargs=2      (baml.Map.keys)
+        123   store_var 7              (_40)
 
-  142   231   load_var 7               (_69)
-        232   is_type 16               
-        233   pop_jump_if_false +2     (to 235)
-        234   jump +105                (to 339)
-        235   load_var 7               (_69)
-        236   is_type 17               
-        237   pop_jump_if_false +2     (to 239)
-        238   jump +96                 (to 334)
-        239   load_var 7               (_69)
-        240   is_type 18               
-        241   pop_jump_if_false +2     (to 243)
-        242   jump +86                 (to 328)
-        243   load_var 7               (_69)
-        244   is_type 19               
-        245   pop_jump_if_false +2     (to 247)
-        246   jump +75                 (to 321)
-        247   load_var 7               (_69)
-        248   is_type 20               
-        249   pop_jump_if_false +2     (to 251)
-        250   jump +66                 (to 316)
-        251   load_var 7               (_69)
-        252   is_type 21               
-        253   pop_jump_if_false +2     (to 255)
-        254   jump +57                 (to 311)
-        255   load_var 7               (_69)
-        256   is_type 22               
-        257   pop_jump_if_false +2     (to 259)
-        258   jump +46                 (to 304)
-        259   load_var 7               (_69)
-        260   is_type 23               
-        261   pop_jump_if_false +2     (to 263)
-        262   jump +37                 (to 299)
-        263   load_var 7               (_69)
-        264   is_type 24               
-        265   pop_jump_if_false +2     (to 267)
-        266   jump +28                 (to 294)
-        267   load_var 7               (_69)
-        268   is_type 25               
-        269   pop_jump_if_false +2     (to 271)
-        270   jump +18                 (to 288)
-        271   load_var 7               (_69)
-        272   is_type 10               
-        273   pop_jump_if_false +2     (to 275)
-        274   jump +9                  (to 283)
-        275   load_var 7               (_69)
-        276   is_type 10               
-        277   pop_jump_if_false +183   (to 460)
-        278   load_type 14             
-        279   load_var 7               (_69)
-        280   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        281   store_var 8              (_73)
-        282   jump +61                 (to 343)
-        283   load_type 14             
-        284   load_var 7               (_69)
-        285   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        286   store_var 8              (_73)
-        287   jump +56                 (to 343)
-        288   load_type 14             
-        289   load_type 12             
-        290   load_var 7               (_69)
-        291   call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        292   store_var 8              (_73)
-        293   jump +50                 (to 343)
-        294   load_var 7               (_69)
-        295   make_bound_method 514    
-        296   call_indirect            
-        297   store_var 8              (_73)
-        298   jump +45                 (to 343)
-        299   load_var 7               (_69)
-        300   make_bound_method 527    
-        301   call_indirect            
-        302   store_var 8              (_73)
-        303   jump +40                 (to 343)
-        304   load_type 14             
-        305   load_type 12             
-        306   load_type 12             
-        307   load_var 7               (_69)
-        308   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        309   store_var 8              (_73)
-        310   jump +33                 (to 343)
-        311   load_var 7               (_69)
-        312   make_bound_method 557    
-        313   call_indirect            
-        314   store_var 8              (_73)
-        315   jump +28                 (to 343)
-        316   load_type 14             
-        317   load_var 7               (_69)
-        318   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        319   store_var 8              (_73)
-        320   jump +23                 (to 343)
-        321   load_type 14             
-        322   load_type 12             
-        323   load_type 12             
-        324   load_var 7               (_69)
-        325   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        326   store_var 8              (_73)
-        327   jump +16                 (to 343)
-        328   load_type 14             
-        329   load_type 12             
-        330   load_var 7               (_69)
-        331   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        332   store_var 8              (_73)
-        333   jump +10                 (to 343)
-        334   load_type 14             
-        335   load_var 7               (_69)
-        336   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        337   store_var 8              (_73)
-        338   jump +5                  (to 343)
-        339   load_var 7               (_69)
-        340   make_bound_method 588    
-        341   call_indirect            
-        342   store_var 8              (_73)
-        343   load_var 8               (_73)
-        344   is_type 16               
-        345   pop_jump_if_false +2     (to 347)
-        346   jump +87                 (to 433)
-        347   load_var 8               (_73)
-        348   is_type 17               
-        349   pop_jump_if_false +2     (to 351)
-        350   jump +78                 (to 428)
-        351   load_var 8               (_73)
-        352   is_type 18               
-        353   pop_jump_if_false +2     (to 355)
-        354   jump +68                 (to 422)
-        355   load_var 8               (_73)
-        356   is_type 19               
-        357   pop_jump_if_false +2     (to 359)
-        358   jump +57                 (to 415)
-        359   load_var 8               (_73)
-        360   is_type 20               
-        361   pop_jump_if_false +2     (to 363)
-        362   jump +48                 (to 410)
-        363   load_var 8               (_73)
-        364   is_type 21               
-        365   pop_jump_if_false +2     (to 367)
-        366   jump +39                 (to 405)
-        367   load_var 8               (_73)
-        368   is_type 22               
-        369   pop_jump_if_false +2     (to 371)
-        370   jump +28                 (to 398)
-        371   load_var 8               (_73)
-        372   is_type 23               
-        373   pop_jump_if_false +2     (to 375)
-        374   jump +19                 (to 393)
-        375   load_var 8               (_73)
-        376   is_type 24               
-        377   pop_jump_if_false +2     (to 379)
-        378   jump +10                 (to 388)
-        379   load_var 8               (_73)
-        380   is_type 25               
-        381   pop_jump_if_false +79    (to 460)
-        382   load_type 14             
-        383   load_type 12             
-        384   load_var 8               (_73)
-        385   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        386   store_var 9              (_104)
-        387   jump +50                 (to 437)
-        388   load_var 8               (_73)
-        389   make_bound_method 568    
-        390   call_indirect            
-        391   store_var 9              (_104)
-        392   jump +45                 (to 437)
-        393   load_var 8               (_73)
-        394   make_bound_method 581    
-        395   call_indirect            
-        396   store_var 9              (_104)
-        397   jump +40                 (to 437)
-        398   load_type 14             
-        399   load_type 12             
-        400   load_type 12             
-        401   load_var 8               (_73)
-        402   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        403   store_var 9              (_104)
-        404   jump +33                 (to 437)
-        405   load_var 8               (_73)
-        406   make_bound_method 517    
-        407   call_indirect            
-        408   store_var 9              (_104)
-        409   jump +28                 (to 437)
-        410   load_type 14             
-        411   load_var 8               (_73)
-        412   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        413   store_var 9              (_104)
-        414   jump +23                 (to 437)
-        415   load_type 14             
-        416   load_type 12             
-        417   load_type 12             
-        418   load_var 8               (_73)
-        419   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        420   store_var 9              (_104)
-        421   jump +16                 (to 437)
-        422   load_type 14             
-        423   load_type 12             
-        424   load_var 8               (_73)
-        425   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        426   store_var 9              (_104)
-        427   jump +10                 (to 437)
-        428   load_type 14             
-        429   load_var 8               (_73)
-        430   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        431   store_var 9              (_104)
-        432   jump +5                  (to 437)
-        433   load_var 8               (_73)
-        434   make_bound_method 552    
-        435   call_indirect            
-        436   store_var 9              (_104)
-        437   load_var 9               (_104)
-        438   is_type 13               
-        439   pop_jump_if_false +2     (to 441)
-        440   jump +16                 (to 456)
-        441   load_var 9               (_104)
-        442   store_var 10             (k)
+  142   124   load_type 13             
+        125   load_var 7               (_40)
+        126   call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   store_var 8              (_44)
+        128   load_var 8               (_44)
+        129   is_type 15               
+        130   pop_jump_if_false +2     (to 132)
+        131   jump +87                 (to 218)
+        132   load_var 8               (_44)
+        133   is_type 16               
+        134   pop_jump_if_false +2     (to 136)
+        135   jump +78                 (to 213)
+        136   load_var 8               (_44)
+        137   is_type 17               
+        138   pop_jump_if_false +2     (to 140)
+        139   jump +68                 (to 207)
+        140   load_var 8               (_44)
+        141   is_type 18               
+        142   pop_jump_if_false +2     (to 144)
+        143   jump +57                 (to 200)
+        144   load_var 8               (_44)
+        145   is_type 19               
+        146   pop_jump_if_false +2     (to 148)
+        147   jump +48                 (to 195)
+        148   load_var 8               (_44)
+        149   is_type 20               
+        150   pop_jump_if_false +2     (to 152)
+        151   jump +39                 (to 190)
+        152   load_var 8               (_44)
+        153   is_type 21               
+        154   pop_jump_if_false +2     (to 156)
+        155   jump +28                 (to 183)
+        156   load_var 8               (_44)
+        157   is_type 22               
+        158   pop_jump_if_false +2     (to 160)
+        159   jump +19                 (to 178)
+        160   load_var 8               (_44)
+        161   is_type 23               
+        162   pop_jump_if_false +2     (to 164)
+        163   jump +10                 (to 173)
+        164   load_var 8               (_44)
+        165   is_type 24               
+        166   pop_jump_if_false +79    (to 245)
+        167   load_type 13             
+        168   load_type 11             
+        169   load_var 8               (_44)
+        170   call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   store_var 9              (_46)
+        172   jump +50                 (to 222)
+        173   load_var 8               (_44)
+        174   make_bound_method 576    
+        175   call_indirect            
+        176   store_var 9              (_46)
+        177   jump +45                 (to 222)
+        178   load_var 8               (_44)
+        179   make_bound_method 589    
+        180   call_indirect            
+        181   store_var 9              (_46)
+        182   jump +40                 (to 222)
+        183   load_type 13             
+        184   load_type 11             
+        185   load_type 11             
+        186   load_var 8               (_44)
+        187   call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   store_var 9              (_46)
+        189   jump +33                 (to 222)
+        190   load_var 8               (_44)
+        191   make_bound_method 525    
+        192   call_indirect            
+        193   store_var 9              (_46)
+        194   jump +28                 (to 222)
+        195   load_type 13             
+        196   load_var 8               (_44)
+        197   call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   store_var 9              (_46)
+        199   jump +23                 (to 222)
+        200   load_type 13             
+        201   load_type 11             
+        202   load_type 11             
+        203   load_var 8               (_44)
+        204   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   store_var 9              (_46)
+        206   jump +16                 (to 222)
+        207   load_type 13             
+        208   load_type 11             
+        209   load_var 8               (_44)
+        210   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   store_var 9              (_46)
+        212   jump +10                 (to 222)
+        213   load_type 13             
+        214   load_var 8               (_44)
+        215   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   store_var 9              (_46)
+        217   jump +5                  (to 222)
+        218   load_var 8               (_44)
+        219   make_bound_method 560    
+        220   call_indirect            
+        221   store_var 9              (_46)
+        222   load_var 9               (_46)
+        223   is_type 12               
+        224   pop_jump_if_false +2     (to 226)
+        225   jump +16                 (to 241)
+        226   load_var 9               (_46)
+        227   store_var 10             (k)
 
-  144   443   load_var 1               (self)
-        444   load_field 1             (expansions)
-        445   load_var 10              (k)
-        446   load_map_element         
-        447   store_var 11             (sub)
+  144   228   load_var 1               (self)
+        229   load_field 1             (expansions)
+        230   load_var 10              (k)
+        231   load_map_element         
+        232   store_var 11             (sub)
 
-  146   448   load_var2 2 10           
-        449   load_const 26            ("/")
-        450   bin_op +                 
-        451   call 152 ntypeargs=0     (baml.String.starts_with)
+  146   233   load_var2 2 10           
+        234   load_const 25            ("/")
+        235   bin_op +                 
+        236   call 160 ntypeargs=0     (baml.String.starts_with)
 
-  145   452   pop_jump_if_false -109   (to 343)
+  145   237   pop_jump_if_false -109   (to 128)
 
-  147   453   load_var2 11 2           
-        454   call 750 ntypeargs=0     (testing.TestRegistry.run_test)
-        455   return                   
+  147   238   load_var2 11 2           
+        239   call 758 ntypeargs=0     (testing.TestRegistry.run_test)
+        240   return                   
 
-  150   456   load_const 27            ("Test not found: ")
-        457   load_var 2               (name)
-        458   bin_op +                 
-        459   throw                    
-        460   unreachable              
+  150   241   load_const 26            ("Test not found: ")
+        242   load_var 2               (name)
+        243   bin_op +                 
+        244   throw                    
+        245   unreachable              
 }
 
 function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.SerializedTest | testing.SerializedTestSet)[] {
@@ -2102,495 +1351,281 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
   113   2     load_var 1               (self)
         3     load_field 0             (collector)
         4     load_field 1             (tests)
-        5     store_var_load_var 3     (_3)
-        6     is_type 0                
-        7     pop_jump_if_false +2     (to 9)
-        8     jump +105                (to 113)
-        9     load_var 3               (_3)
-        10    is_type 1                
-        11    pop_jump_if_false +2     (to 13)
-        12    jump +96                 (to 108)
-        13    load_var 3               (_3)
-        14    is_type 2                
-        15    pop_jump_if_false +2     (to 17)
-        16    jump +86                 (to 102)
-        17    load_var 3               (_3)
-        18    is_type 3                
-        19    pop_jump_if_false +2     (to 21)
-        20    jump +75                 (to 95)
-        21    load_var 3               (_3)
-        22    is_type 4                
-        23    pop_jump_if_false +2     (to 25)
-        24    jump +66                 (to 90)
-        25    load_var 3               (_3)
-        26    is_type 5                
-        27    pop_jump_if_false +2     (to 29)
-        28    jump +57                 (to 85)
-        29    load_var 3               (_3)
-        30    is_type 6                
-        31    pop_jump_if_false +2     (to 33)
-        32    jump +46                 (to 78)
-        33    load_var 3               (_3)
-        34    is_type 7                
-        35    pop_jump_if_false +2     (to 37)
-        36    jump +37                 (to 73)
-        37    load_var 3               (_3)
-        38    is_type 8                
-        39    pop_jump_if_false +2     (to 41)
-        40    jump +28                 (to 68)
-        41    load_var 3               (_3)
-        42    is_type 9                
-        43    pop_jump_if_false +2     (to 45)
-        44    jump +18                 (to 62)
-        45    load_var 3               (_3)
-        46    is_type 10               
-        47    pop_jump_if_false +2     (to 49)
-        48    jump +9                  (to 57)
-        49    load_var 3               (_3)
-        50    is_type 10               
-        51    pop_jump_if_false +424   (to 475)
-        52    load_type 11             
-        53    load_var 3               (_3)
-        54    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        55    store_var 4              (_4)
-        56    jump +61                 (to 117)
-        57    load_type 11             
-        58    load_var 3               (_3)
-        59    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        60    store_var 4              (_4)
-        61    jump +56                 (to 117)
-        62    load_type 11             
-        63    load_type 12             
-        64    load_var 3               (_3)
-        65    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        66    store_var 4              (_4)
-        67    jump +50                 (to 117)
-        68    load_var 3               (_3)
-        69    make_bound_method 514    
-        70    call_indirect            
-        71    store_var 4              (_4)
-        72    jump +45                 (to 117)
-        73    load_var 3               (_3)
-        74    make_bound_method 527    
-        75    call_indirect            
-        76    store_var 4              (_4)
-        77    jump +40                 (to 117)
-        78    load_type 11             
-        79    load_type 12             
-        80    load_type 12             
-        81    load_var 3               (_3)
-        82    call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        83    store_var 4              (_4)
-        84    jump +33                 (to 117)
-        85    load_var 3               (_3)
-        86    make_bound_method 557    
-        87    call_indirect            
-        88    store_var 4              (_4)
-        89    jump +28                 (to 117)
+        5     store_var 3              (_3)
+        6     load_type 0              
+        7     load_var 3               (_3)
+        8     call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     store_var 4              (_4)
+        10    load_var 4               (_4)
+        11    is_type 1                
+        12    pop_jump_if_false +2     (to 14)
+        13    jump +87                 (to 100)
+        14    load_var 4               (_4)
+        15    is_type 2                
+        16    pop_jump_if_false +2     (to 18)
+        17    jump +78                 (to 95)
+        18    load_var 4               (_4)
+        19    is_type 3                
+        20    pop_jump_if_false +2     (to 22)
+        21    jump +68                 (to 89)
+        22    load_var 4               (_4)
+        23    is_type 4                
+        24    pop_jump_if_false +2     (to 26)
+        25    jump +57                 (to 82)
+        26    load_var 4               (_4)
+        27    is_type 5                
+        28    pop_jump_if_false +2     (to 30)
+        29    jump +48                 (to 77)
+        30    load_var 4               (_4)
+        31    is_type 6                
+        32    pop_jump_if_false +2     (to 34)
+        33    jump +39                 (to 72)
+        34    load_var 4               (_4)
+        35    is_type 7                
+        36    pop_jump_if_false +2     (to 38)
+        37    jump +28                 (to 65)
+        38    load_var 4               (_4)
+        39    is_type 8                
+        40    pop_jump_if_false +2     (to 42)
+        41    jump +19                 (to 60)
+        42    load_var 4               (_4)
+        43    is_type 9                
+        44    pop_jump_if_false +2     (to 46)
+        45    jump +10                 (to 55)
+        46    load_var 4               (_4)
+        47    is_type 10               
+        48    pop_jump_if_false +213   (to 261)
+        49    load_type 0              
+        50    load_type 11             
+        51    load_var 4               (_4)
+        52    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    store_var 5              (_6)
+        54    jump +50                 (to 104)
+        55    load_var 4               (_4)
+        56    make_bound_method 576    
+        57    call_indirect            
+        58    store_var 5              (_6)
+        59    jump +45                 (to 104)
+        60    load_var 4               (_4)
+        61    make_bound_method 589    
+        62    call_indirect            
+        63    store_var 5              (_6)
+        64    jump +40                 (to 104)
+        65    load_type 0              
+        66    load_type 11             
+        67    load_type 11             
+        68    load_var 4               (_4)
+        69    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    store_var 5              (_6)
+        71    jump +33                 (to 104)
+        72    load_var 4               (_4)
+        73    make_bound_method 525    
+        74    call_indirect            
+        75    store_var 5              (_6)
+        76    jump +28                 (to 104)
+        77    load_type 0              
+        78    load_var 4               (_4)
+        79    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    store_var 5              (_6)
+        81    jump +23                 (to 104)
+        82    load_type 0              
+        83    load_type 11             
+        84    load_type 11             
+        85    load_var 4               (_4)
+        86    call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    store_var 5              (_6)
+        88    jump +16                 (to 104)
+        89    load_type 0              
         90    load_type 11             
-        91    load_var 3               (_3)
-        92    call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        93    store_var 4              (_4)
-        94    jump +23                 (to 117)
-        95    load_type 11             
-        96    load_type 12             
-        97    load_type 12             
-        98    load_var 3               (_3)
-        99    call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        100   store_var 4              (_4)
-        101   jump +16                 (to 117)
-        102   load_type 11             
-        103   load_type 12             
-        104   load_var 3               (_3)
-        105   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        106   store_var 4              (_4)
-        107   jump +10                 (to 117)
-        108   load_type 11             
-        109   load_var 3               (_3)
-        110   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        111   store_var 4              (_4)
-        112   jump +5                  (to 117)
-        113   load_var 3               (_3)
-        114   make_bound_method 588    
-        115   call_indirect            
-        116   store_var 4              (_4)
-        117   load_var 4               (_4)
-        118   is_type 0                
-        119   pop_jump_if_false +2     (to 121)
-        120   jump +87                 (to 207)
-        121   load_var 4               (_4)
-        122   is_type 1                
-        123   pop_jump_if_false +2     (to 125)
-        124   jump +78                 (to 202)
-        125   load_var 4               (_4)
-        126   is_type 2                
-        127   pop_jump_if_false +2     (to 129)
-        128   jump +68                 (to 196)
-        129   load_var 4               (_4)
-        130   is_type 3                
-        131   pop_jump_if_false +2     (to 133)
-        132   jump +57                 (to 189)
-        133   load_var 4               (_4)
-        134   is_type 4                
-        135   pop_jump_if_false +2     (to 137)
-        136   jump +48                 (to 184)
-        137   load_var 4               (_4)
-        138   is_type 5                
-        139   pop_jump_if_false +2     (to 141)
-        140   jump +39                 (to 179)
-        141   load_var 4               (_4)
-        142   is_type 6                
-        143   pop_jump_if_false +2     (to 145)
-        144   jump +28                 (to 172)
-        145   load_var 4               (_4)
-        146   is_type 7                
-        147   pop_jump_if_false +2     (to 149)
-        148   jump +19                 (to 167)
-        149   load_var 4               (_4)
-        150   is_type 8                
-        151   pop_jump_if_false +2     (to 153)
-        152   jump +10                 (to 162)
-        153   load_var 4               (_4)
-        154   is_type 9                
-        155   pop_jump_if_false +320   (to 475)
-        156   load_type 11             
-        157   load_type 12             
-        158   load_var 4               (_4)
-        159   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        160   store_var 5              (_35)
-        161   jump +50                 (to 211)
-        162   load_var 4               (_4)
-        163   make_bound_method 568    
-        164   call_indirect            
-        165   store_var 5              (_35)
-        166   jump +45                 (to 211)
-        167   load_var 4               (_4)
-        168   make_bound_method 581    
-        169   call_indirect            
-        170   store_var 5              (_35)
-        171   jump +40                 (to 211)
-        172   load_type 11             
-        173   load_type 12             
-        174   load_type 12             
-        175   load_var 4               (_4)
-        176   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        177   store_var 5              (_35)
-        178   jump +33                 (to 211)
-        179   load_var 4               (_4)
-        180   make_bound_method 517    
-        181   call_indirect            
-        182   store_var 5              (_35)
-        183   jump +28                 (to 211)
-        184   load_type 11             
-        185   load_var 4               (_4)
-        186   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        187   store_var 5              (_35)
-        188   jump +23                 (to 211)
-        189   load_type 11             
-        190   load_type 12             
-        191   load_type 12             
-        192   load_var 4               (_4)
-        193   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        194   store_var 5              (_35)
-        195   jump +16                 (to 211)
-        196   load_type 11             
-        197   load_type 12             
-        198   load_var 4               (_4)
-        199   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        200   store_var 5              (_35)
-        201   jump +10                 (to 211)
-        202   load_type 11             
-        203   load_var 4               (_4)
-        204   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        205   store_var 5              (_35)
-        206   jump +5                  (to 211)
-        207   load_var 4               (_4)
-        208   make_bound_method 552    
-        209   call_indirect            
-        210   store_var 5              (_35)
-        211   load_var 5               (_35)
-        212   is_type 13               
-        213   pop_jump_if_false +2     (to 215)
-        214   jump +9                  (to 223)
+        91    load_var 4               (_4)
+        92    call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    store_var 5              (_6)
+        94    jump +10                 (to 104)
+        95    load_type 0              
+        96    load_var 4               (_4)
+        97    call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    store_var 5              (_6)
+        99    jump +5                  (to 104)
+        100   load_var 4               (_4)
+        101   make_bound_method 560    
+        102   call_indirect            
+        103   store_var 5              (_6)
+        104   load_var 5               (_6)
+        105   is_type 12               
+        106   pop_jump_if_false +2     (to 108)
+        107   jump +9                  (to 116)
 
-  114   215   load_var 2               (items)
-        216   load_const 14            ("test")
+  114   108   load_var 2               (items)
+        109   load_const 13            ("test")
 
-  113   217   load_var 5               (_35)
-        218   load_field 0             (name)
-        219   init_instance 0          (testing.SerializedTest .type, .name)
-        220   call 17 ntypeargs=0      (baml.Array.push)
-        221   pop 1                    
-        222   jump -105                (to 117)
+  113   110   load_var 5               (_6)
+        111   load_field 0             (name)
+        112   init_instance 0          (testing.SerializedTest .type, .name)
+        113   call 17 ntypeargs=0      (baml.Array.push)
+        114   pop 1                    
+        115   jump -105                (to 10)
 
-  116   223   load_var 1               (self)
-        224   load_field 0             (collector)
-        225   load_field 2             (testsets)
-        226   store_var_load_var 6     (_68)
-        227   is_type 15               
-        228   pop_jump_if_false +2     (to 230)
-        229   jump +105                (to 334)
-        230   load_var 6               (_68)
-        231   is_type 16               
-        232   pop_jump_if_false +2     (to 234)
-        233   jump +96                 (to 329)
-        234   load_var 6               (_68)
-        235   is_type 17               
-        236   pop_jump_if_false +2     (to 238)
-        237   jump +86                 (to 323)
-        238   load_var 6               (_68)
-        239   is_type 18               
-        240   pop_jump_if_false +2     (to 242)
-        241   jump +75                 (to 316)
-        242   load_var 6               (_68)
-        243   is_type 19               
-        244   pop_jump_if_false +2     (to 246)
-        245   jump +66                 (to 311)
-        246   load_var 6               (_68)
-        247   is_type 20               
-        248   pop_jump_if_false +2     (to 250)
-        249   jump +57                 (to 306)
-        250   load_var 6               (_68)
-        251   is_type 21               
-        252   pop_jump_if_false +2     (to 254)
-        253   jump +46                 (to 299)
-        254   load_var 6               (_68)
-        255   is_type 22               
-        256   pop_jump_if_false +2     (to 258)
-        257   jump +37                 (to 294)
-        258   load_var 6               (_68)
-        259   is_type 23               
-        260   pop_jump_if_false +2     (to 262)
-        261   jump +28                 (to 289)
-        262   load_var 6               (_68)
-        263   is_type 24               
-        264   pop_jump_if_false +2     (to 266)
-        265   jump +18                 (to 283)
-        266   load_var 6               (_68)
-        267   is_type 10               
-        268   pop_jump_if_false +2     (to 270)
-        269   jump +9                  (to 278)
-        270   load_var 6               (_68)
-        271   is_type 10               
-        272   pop_jump_if_false +203   (to 475)
-        273   load_type 25             
-        274   load_var 6               (_68)
-        275   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        276   store_var 7              (_69)
-        277   jump +61                 (to 338)
-        278   load_type 25             
-        279   load_var 6               (_68)
-        280   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        281   store_var 7              (_69)
-        282   jump +56                 (to 338)
-        283   load_type 25             
-        284   load_type 12             
-        285   load_var 6               (_68)
-        286   call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        287   store_var 7              (_69)
-        288   jump +50                 (to 338)
-        289   load_var 6               (_68)
-        290   make_bound_method 514    
-        291   call_indirect            
-        292   store_var 7              (_69)
-        293   jump +45                 (to 338)
-        294   load_var 6               (_68)
-        295   make_bound_method 527    
-        296   call_indirect            
-        297   store_var 7              (_69)
-        298   jump +40                 (to 338)
-        299   load_type 25             
-        300   load_type 12             
-        301   load_type 12             
-        302   load_var 6               (_68)
-        303   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        304   store_var 7              (_69)
-        305   jump +33                 (to 338)
-        306   load_var 6               (_68)
-        307   make_bound_method 557    
-        308   call_indirect            
-        309   store_var 7              (_69)
-        310   jump +28                 (to 338)
-        311   load_type 25             
-        312   load_var 6               (_68)
-        313   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        314   store_var 7              (_69)
-        315   jump +23                 (to 338)
-        316   load_type 25             
-        317   load_type 12             
-        318   load_type 12             
-        319   load_var 6               (_68)
-        320   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        321   store_var 7              (_69)
-        322   jump +16                 (to 338)
-        323   load_type 25             
-        324   load_type 12             
-        325   load_var 6               (_68)
-        326   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        327   store_var 7              (_69)
-        328   jump +10                 (to 338)
-        329   load_type 25             
-        330   load_var 6               (_68)
-        331   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        332   store_var 7              (_69)
-        333   jump +5                  (to 338)
-        334   load_var 6               (_68)
-        335   make_bound_method 588    
-        336   call_indirect            
-        337   store_var 7              (_69)
-        338   load_var 7               (_69)
-        339   is_type 15               
-        340   pop_jump_if_false +2     (to 342)
-        341   jump +87                 (to 428)
-        342   load_var 7               (_69)
-        343   is_type 16               
-        344   pop_jump_if_false +2     (to 346)
-        345   jump +78                 (to 423)
-        346   load_var 7               (_69)
-        347   is_type 17               
-        348   pop_jump_if_false +2     (to 350)
-        349   jump +68                 (to 417)
-        350   load_var 7               (_69)
-        351   is_type 18               
-        352   pop_jump_if_false +2     (to 354)
-        353   jump +57                 (to 410)
-        354   load_var 7               (_69)
-        355   is_type 19               
-        356   pop_jump_if_false +2     (to 358)
-        357   jump +48                 (to 405)
-        358   load_var 7               (_69)
-        359   is_type 20               
-        360   pop_jump_if_false +2     (to 362)
-        361   jump +39                 (to 400)
-        362   load_var 7               (_69)
-        363   is_type 21               
-        364   pop_jump_if_false +2     (to 366)
-        365   jump +28                 (to 393)
-        366   load_var 7               (_69)
-        367   is_type 22               
-        368   pop_jump_if_false +2     (to 370)
-        369   jump +19                 (to 388)
-        370   load_var 7               (_69)
-        371   is_type 23               
-        372   pop_jump_if_false +2     (to 374)
-        373   jump +10                 (to 383)
-        374   load_var 7               (_69)
-        375   is_type 24               
-        376   pop_jump_if_false +99    (to 475)
-        377   load_type 25             
-        378   load_type 12             
-        379   load_var 7               (_69)
-        380   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        381   store_var 8              (_100)
-        382   jump +50                 (to 432)
-        383   load_var 7               (_69)
-        384   make_bound_method 568    
-        385   call_indirect            
-        386   store_var 8              (_100)
-        387   jump +45                 (to 432)
-        388   load_var 7               (_69)
-        389   make_bound_method 581    
-        390   call_indirect            
-        391   store_var 8              (_100)
-        392   jump +40                 (to 432)
-        393   load_type 25             
-        394   load_type 12             
-        395   load_type 12             
-        396   load_var 7               (_69)
-        397   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        398   store_var 8              (_100)
-        399   jump +33                 (to 432)
-        400   load_var 7               (_69)
-        401   make_bound_method 517    
-        402   call_indirect            
-        403   store_var 8              (_100)
-        404   jump +28                 (to 432)
-        405   load_type 25             
-        406   load_var 7               (_69)
-        407   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        408   store_var 8              (_100)
-        409   jump +23                 (to 432)
-        410   load_type 25             
-        411   load_type 12             
-        412   load_type 12             
-        413   load_var 7               (_69)
-        414   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        415   store_var 8              (_100)
-        416   jump +16                 (to 432)
-        417   load_type 25             
-        418   load_type 12             
-        419   load_var 7               (_69)
-        420   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        421   store_var 8              (_100)
-        422   jump +10                 (to 432)
-        423   load_type 25             
-        424   load_var 7               (_69)
-        425   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        426   store_var 8              (_100)
-        427   jump +5                  (to 432)
-        428   load_var 7               (_69)
-        429   make_bound_method 552    
-        430   call_indirect            
-        431   store_var 8              (_100)
-        432   load_var 8               (_100)
-        433   is_type 13               
-        434   pop_jump_if_false +2     (to 436)
-        435   jump +38                 (to 473)
-        436   load_var 8               (_100)
-        437   store_var 9              (ts)
+  116   116   load_var 1               (self)
+        117   load_field 0             (collector)
+        118   load_field 2             (testsets)
+        119   store_var 6              (_39)
+        120   load_type 14             
+        121   load_var 6               (_39)
+        122   call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        123   store_var 7              (_40)
+        124   load_var 7               (_40)
+        125   is_type 15               
+        126   pop_jump_if_false +2     (to 128)
+        127   jump +87                 (to 214)
+        128   load_var 7               (_40)
+        129   is_type 16               
+        130   pop_jump_if_false +2     (to 132)
+        131   jump +78                 (to 209)
+        132   load_var 7               (_40)
+        133   is_type 17               
+        134   pop_jump_if_false +2     (to 136)
+        135   jump +68                 (to 203)
+        136   load_var 7               (_40)
+        137   is_type 18               
+        138   pop_jump_if_false +2     (to 140)
+        139   jump +57                 (to 196)
+        140   load_var 7               (_40)
+        141   is_type 19               
+        142   pop_jump_if_false +2     (to 144)
+        143   jump +48                 (to 191)
+        144   load_var 7               (_40)
+        145   is_type 20               
+        146   pop_jump_if_false +2     (to 148)
+        147   jump +39                 (to 186)
+        148   load_var 7               (_40)
+        149   is_type 21               
+        150   pop_jump_if_false +2     (to 152)
+        151   jump +28                 (to 179)
+        152   load_var 7               (_40)
+        153   is_type 22               
+        154   pop_jump_if_false +2     (to 156)
+        155   jump +19                 (to 174)
+        156   load_var 7               (_40)
+        157   is_type 23               
+        158   pop_jump_if_false +2     (to 160)
+        159   jump +10                 (to 169)
+        160   load_var 7               (_40)
+        161   is_type 24               
+        162   pop_jump_if_false +99    (to 261)
+        163   load_type 14             
+        164   load_type 11             
+        165   load_var 7               (_40)
+        166   call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        167   store_var 8              (_42)
+        168   jump +50                 (to 218)
+        169   load_var 7               (_40)
+        170   make_bound_method 576    
+        171   call_indirect            
+        172   store_var 8              (_42)
+        173   jump +45                 (to 218)
+        174   load_var 7               (_40)
+        175   make_bound_method 589    
+        176   call_indirect            
+        177   store_var 8              (_42)
+        178   jump +40                 (to 218)
+        179   load_type 14             
+        180   load_type 11             
+        181   load_type 11             
+        182   load_var 7               (_40)
+        183   call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        184   store_var 8              (_42)
+        185   jump +33                 (to 218)
+        186   load_var 7               (_40)
+        187   make_bound_method 525    
+        188   call_indirect            
+        189   store_var 8              (_42)
+        190   jump +28                 (to 218)
+        191   load_type 14             
+        192   load_var 7               (_40)
+        193   call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        194   store_var 8              (_42)
+        195   jump +23                 (to 218)
+        196   load_type 14             
+        197   load_type 11             
+        198   load_type 11             
+        199   load_var 7               (_40)
+        200   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        201   store_var 8              (_42)
+        202   jump +16                 (to 218)
+        203   load_type 14             
+        204   load_type 11             
+        205   load_var 7               (_40)
+        206   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        207   store_var 8              (_42)
+        208   jump +10                 (to 218)
+        209   load_type 14             
+        210   load_var 7               (_40)
+        211   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        212   store_var 8              (_42)
+        213   jump +5                  (to 218)
+        214   load_var 7               (_40)
+        215   make_bound_method 560    
+        216   call_indirect            
+        217   store_var 8              (_42)
+        218   load_var 8               (_42)
+        219   is_type 12               
+        220   pop_jump_if_false +2     (to 222)
+        221   jump +38                 (to 259)
+        222   load_var 8               (_42)
+        223   store_var 9              (ts)
 
-  117   438   load_type 26             
-        439   load_type 27             
-        440   load_var 1               (self)
-        441   load_field 1             (expansions)
-        442   load_var 9               (ts)
-        443   load_field 0             (name)
-        444   call 53 ntypeargs=2      (baml.Map.get)
-        445   store_var 10             (expanded)
+  117   224   load_type 25             
+        225   load_type 26             
+        226   load_var 1               (self)
+        227   load_field 1             (expansions)
+        228   load_var 9               (ts)
+        229   load_field 0             (name)
+        230   call 52 ntypeargs=2      (baml.Map.get)
+        231   store_var 10             (expanded)
 
-  118   446   load_var 10              (expanded)
-        447   is_type 28               
-        448   pop_jump_if_false +2     (to 450)
-        449   jump +9                  (to 458)
+  118   232   load_var 10              (expanded)
+        233   is_type 27               
+        234   pop_jump_if_false +2     (to 236)
+        235   jump +9                  (to 244)
 
-  127   450   load_var 2               (items)
-        451   load_const 29            ("lazyTestSet")
-        452   load_var 9               (ts)
-        453   load_field 0             (name)
-        454   init_instance 1          (testing.SerializedTest .type, .name)
-        455   call 17 ntypeargs=0      (baml.Array.push)
-        456   pop 1                    
-        457   jump -119                (to 338)
+  127   236   load_var 2               (items)
+        237   load_const 28            ("lazyTestSet")
+        238   load_var 9               (ts)
+        239   load_field 0             (name)
+        240   init_instance 1          (testing.SerializedTest .type, .name)
+        241   call 17 ntypeargs=0      (baml.Array.push)
+        242   pop 1                    
+        243   jump -119                (to 124)
 
-  118   458   load_var 10              (expanded)
-        459   store_var 11             (sub)
+  118   244   load_var 10              (expanded)
+        245   store_var 11             (sub)
 
-  121   460   load_var 9               (ts)
-        461   load_field 0             (name)
-        462   store_var 12             (_139)
+  121   246   load_var 9               (ts)
+        247   load_field 0             (name)
+        248   store_var 12             (_81)
 
-  122   463   load_var 11              (sub)
-        464   call 746 ntypeargs=0     (testing.TestRegistry.serialize)
-        465   store_var 13             (_140)
+  122   249   load_var 11              (sub)
+        250   call 754 ntypeargs=0     (testing.TestRegistry.serialize)
+        251   store_var 13             (_82)
 
-  120   466   load_var2 2 12           
-        467   load_var2 13 11          
+  120   252   load_var2 2 12           
+        253   load_var2 13 11          
 
-  123   468   load_field 2             (loading_time_ms)
-        469   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        470   call 17 ntypeargs=0      (baml.Array.push)
-        471   pop 1                    
-        472   jump -134                (to 338)
+  123   254   load_field 2             (loading_time_ms)
+        255   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
+        256   call 17 ntypeargs=0      (baml.Array.push)
+        257   pop 1                    
+        258   jump -134                (to 124)
 
-  131   473   load_var 2               (items)
-        474   return                   
-        475   unreachable              
+  131   259   load_var 2               (items)
+        260   return                   
+        261   unreachable              
 }
 
 function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 758 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 766 ntypeargs=0   (testing.TestCollector.to_json)
        3    load_type 0            
        4    load_type 1            
        5    load_var 1             (self)
@@ -2598,7 +1633,7 @@ function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.j
        7    call 23 ntypeargs=2    (baml.Map.to_json)
        8    load_var 1             (self)
        9    load_field 2           (loading_time_ms)
-       10   call 63 ntypeargs=0    (baml.Int.to_json)
+       10   call 71 ntypeargs=0    (baml.Int.to_json)
        11   load_const 2           ("collector")
        12   load_const 3           ("expansions")
        13   load_const 4           ("loading_time_ms")
@@ -2609,18 +1644,18 @@ function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.j
 function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
   18   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("runs")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.TestReport .outcome, .runs)
        15   return                 
 }
@@ -2634,7 +1669,7 @@ function testing.TestReport.to_json(self: testing.TestReport) -> baml.json.json 
        5    load_type 1           
        6    load_var 1            (self)
        7    load_field 1          (runs)
-       8    call 38 ntypeargs=1   (baml.Array.to_json)
+       8    call 37 ntypeargs=1   (baml.Array.to_json)
        9    load_const 2          ("outcome")
        10   load_const 3          ("runs")
        11   alloc_map 2           
@@ -2644,25 +1679,25 @@ function testing.TestReport.to_json(self: testing.TestReport) -> baml.json.json 
 function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.TestSetRegistration {
   17   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("collector")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("runner")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestSetRegistration .name, .collector, .runner)
        22   return                 
 }
@@ -2670,47 +1705,47 @@ function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.Tes
 function testing.TestSetRegistration.to_json(self: testing.TestSetRegistration) -> baml.json.json {
   25   0   load_type 0            
        1   load_var 1             (self)
-       2   call 409 ntypeargs=1   (baml.json.to_string)
-       3   call 404 ntypeargs=0   (baml.json.parse)
+       2   call 417 ntypeargs=1   (baml.json.to_string)
+       3   call 412 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
 function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetReport {
   25   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("passed")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("failed")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 3            
        19   load_var 4             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   load_var 1             (j)
        22   load_const 5           ("total")
-       23   call 407 ntypeargs=0   (baml.json.field)
+       23   call 415 ntypeargs=0   (baml.json.field)
        24   store_var 5            (_12)
        25   load_type 3            
        26   load_var 5             (_12)
-       27   call 399 ntypeargs=1   (baml.json.from_json)
+       27   call 407 ntypeargs=1   (baml.json.from_json)
        28   load_var 1             (j)
        29   load_const 6           ("results")
-       30   call 407 ntypeargs=0   (baml.json.field)
+       30   call 415 ntypeargs=0   (baml.json.field)
        31   store_var 6            (_15)
        32   load_type 7            
        33   load_var 6             (_15)
-       34   call 399 ntypeargs=1   (baml.json.from_json)
+       34   call 407 ntypeargs=1   (baml.json.from_json)
        35   init_instance 0        (testing.TestSetReport .outcome, .passed, .failed, .total, .results)
        36   return                 
 }
@@ -2723,17 +1758,17 @@ function testing.TestSetReport.to_json(self: testing.TestSetReport) -> baml.json
        4    call_indirect         
        5    load_var 1            (self)
        6    load_field 1          (passed)
-       7    call 63 ntypeargs=0   (baml.Int.to_json)
+       7    call 71 ntypeargs=0   (baml.Int.to_json)
        8    load_var 1            (self)
        9    load_field 2          (failed)
-       10   call 63 ntypeargs=0   (baml.Int.to_json)
+       10   call 71 ntypeargs=0   (baml.Int.to_json)
        11   load_var 1            (self)
        12   load_field 3          (total)
-       13   call 63 ntypeargs=0   (baml.Int.to_json)
+       13   call 71 ntypeargs=0   (baml.Int.to_json)
        14   load_type 1           
        15   load_var 1            (self)
        16   load_field 4          (results)
-       17   call 38 ntypeargs=1   (baml.Array.to_json)
+       17   call 37 ntypeargs=1   (baml.Array.to_json)
        18   load_const 2          ("outcome")
        19   load_const 3          ("passed")
        20   load_const 4          ("failed")
@@ -2749,7 +1784,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 1405 1    
+        4    make_closure 1415 1    
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)
@@ -2790,18 +1825,18 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
   26   0    load_var 1             (j)
        1    load_const 0           ("code")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("message")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (user.ErrorInfo .code, .message)
        15   return                 
 }
@@ -2809,10 +1844,10 @@ function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
 function user.ErrorInfo.to_json(self: ErrorInfo) -> baml.json.json {
   26   0   load_var 1             (self)
        1   load_field 0           (code)
-       2   call 63 ntypeargs=0    (baml.Int.to_json)
+       2   call 71 ntypeargs=0    (baml.Int.to_json)
        3   load_var 1             (self)
        4   load_field 1           (message)
-       5   call 164 ntypeargs=0   (baml.String.to_json)
+       5   call 172 ntypeargs=0   (baml.String.to_json)
        6   load_const 0           ("code")
        7   load_const 1           ("message")
        8   alloc_map 2            
@@ -2822,25 +1857,25 @@ function user.ErrorInfo.to_json(self: ErrorInfo) -> baml.json.json {
 function user.Report.from_json(j: baml.json.json) -> Report {
   20   0    load_var 1             (j)
        1    load_const 0           ("score")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("label")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("breakdown")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (user.Report .score, .label, .breakdown)
        22   return                 
 }
@@ -2848,10 +1883,10 @@ function user.Report.from_json(j: baml.json.json) -> Report {
 function user.Report.to_json(self: Report) -> baml.json.json {
   20   0    load_var 1             (self)
        1    load_field 0           (score)
-       2    call 63 ntypeargs=0    (baml.Int.to_json)
+       2    call 71 ntypeargs=0    (baml.Int.to_json)
        3    load_var 1             (self)
        4    load_field 1           (label)
-       5    call 164 ntypeargs=0   (baml.String.to_json)
+       5    call 172 ntypeargs=0   (baml.String.to_json)
        6    load_type 0            
        7    load_type 1            
        8    load_var 1             (self)
@@ -2867,25 +1902,25 @@ function user.Report.to_json(self: Report) -> baml.json.json {
 function user.User.from_json(j: baml.json.json) -> User {
   3   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 407 ntypeargs=0   (baml.json.field)
+      2    call 415 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 399 ntypeargs=1   (baml.json.from_json)
+      6    call 407 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("age")
-      9    call 407 ntypeargs=0   (baml.json.field)
+      9    call 415 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 399 ntypeargs=1   (baml.json.from_json)
+      13   call 407 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("role")
-      16   call 407 ntypeargs=0   (baml.json.field)
+      16   call 415 ntypeargs=0   (baml.json.field)
       17   store_var 4            (_9)
       18   load_type 5            
       19   load_var 4             (_9)
-      20   call 399 ntypeargs=1   (baml.json.from_json)
+      20   call 407 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (user.User .name, .age, .role)
       22   return                 
 }
@@ -2919,10 +1954,10 @@ function user.User.promote(self: User, bonus: int) -> Report {
 function user.User.to_json(self: User) -> baml.json.json {
   3   0    load_var 1             (self)
       1    load_field 0           (name)
-      2    call 164 ntypeargs=0   (baml.String.to_json)
+      2    call 172 ntypeargs=0   (baml.String.to_json)
       3    load_var 1             (self)
       4    load_field 1           (age)
-      5    call 63 ntypeargs=0    (baml.Int.to_json)
+      5    call 71 ntypeargs=0    (baml.Int.to_json)
       6    load_var 1             (self)
       7    load_field 2           (role)
       8    load_const 0           ("to_json")

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -3,7 +3,7 @@ source: crates/baml_tests/tests/bytecode_format/main.rs
 ---
 function assert.contains(haystack: string, needle: string) -> null {
   32   0   load_var2 1 2          
-       1   call 179 ntypeargs=0   (baml.String.includes)
+       1   call 187 ntypeargs=0   (baml.String.includes)
        2   unary_op !             
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
@@ -13,7 +13,7 @@ function assert.contains(haystack: string, needle: string) -> null {
   32   6   jump +3                (to 9)
 
   33   7   load_const 1           ("assertion failed: string does not contain expected substring")
-       8   call 305 ntypeargs=0   (baml.sys.panic)
+       8   call 313 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -28,7 +28,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   23   5   jump +3                (to 8)
 
   24   6   load_const 1           ("assertion failed: expected equal values")
-       7   call 305 ntypeargs=0   (baml.sys.panic)
+       7   call 313 ntypeargs=0   (baml.sys.panic)
        8   return                 
 }
 
@@ -43,7 +43,7 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 305 ntypeargs=0   (baml.sys.panic)
+      7   call 313 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
@@ -59,7 +59,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 305 ntypeargs=0   (baml.sys.panic)
+       8   call 313 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -72,18 +72,18 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
   7   0    load_var 1             (j)
       1    load_const 0           ("outcome")
-      2    call 407 ntypeargs=0   (baml.json.field)
+      2    call 415 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 399 ntypeargs=1   (baml.json.from_json)
+      6    call 407 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("duration_ms")
-      9    call 407 ntypeargs=0   (baml.json.field)
+      9    call 415 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 399 ntypeargs=1   (baml.json.from_json)
+      13   call 407 ntypeargs=1   (baml.json.from_json)
       14   init_instance 0        (testing.RunReport .outcome, .duration_ms)
       15   store_var 2            (_0)
       16   load_var 2             (_0)
@@ -98,7 +98,7 @@ function testing.RunReport.to_json(self: testing.RunReport) -> baml.json.json {
       4    call_indirect         
       5    load_var 1            (self)
       6    load_field 1          (duration_ms)
-      7    call 63 ntypeargs=0   (baml.Int.to_json)
+      7    call 71 ntypeargs=0   (baml.Int.to_json)
       8    load_const 1          ("outcome")
       9    load_const 2          ("duration_ms")
       10   alloc_map 2           
@@ -110,18 +110,18 @@ function testing.RunReport.to_json(self: testing.RunReport) -> baml.json.json {
 function testing.SerializedTest.from_json(j: baml.json.json) -> testing.SerializedTest {
   78   0    load_var 1             (j)
        1    load_const 0           ("type")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("name")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 1            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.SerializedTest .type, .name)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -131,10 +131,10 @@ function testing.SerializedTest.from_json(j: baml.json.json) -> testing.Serializ
 function testing.SerializedTest.to_json(self: testing.SerializedTest) -> baml.json.json {
   78   0    load_var 1             (self)
        1    load_field 0           (type)
-       2    call 164 ntypeargs=0   (baml.String.to_json)
+       2    call 172 ntypeargs=0   (baml.String.to_json)
        3    load_var 1             (self)
        4    load_field 1           (name)
-       5    call 164 ntypeargs=0   (baml.String.to_json)
+       5    call 172 ntypeargs=0   (baml.String.to_json)
        6    load_const 0           ("type")
        7    load_const 1           ("name")
        8    alloc_map 2            
@@ -146,25 +146,25 @@ function testing.SerializedTest.to_json(self: testing.SerializedTest) -> baml.js
 function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.SerializedTestSet {
   83   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("items")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loadingTimeMs")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -174,14 +174,14 @@ function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.Seria
 function testing.SerializedTestSet.to_json(self: testing.SerializedTestSet) -> baml.json.json {
   83   0    load_var 1             (self)
        1    load_field 0           (name)
-       2    call 164 ntypeargs=0   (baml.String.to_json)
+       2    call 172 ntypeargs=0   (baml.String.to_json)
        3    load_type 0            
        4    load_var 1             (self)
        5    load_field 1           (items)
-       6    call 38 ntypeargs=1    (baml.Array.to_json)
+       6    call 37 ntypeargs=1    (baml.Array.to_json)
        7    load_var 1             (self)
        8    load_field 2           (loadingTimeMs)
-       9    call 63 ntypeargs=0    (baml.Int.to_json)
+       9    call 71 ntypeargs=0    (baml.Int.to_json)
        10   load_const 1           ("name")
        11   load_const 2           ("items")
        12   load_const 3           ("loadingTimeMs")
@@ -194,258 +194,151 @@ function testing.SerializedTestSet.to_json(self: testing.SerializedTestSet) -> b
 function testing.TestCollector.find_testset(self: testing.TestCollector, name: string) -> testing.TestSetRegistration {
   61   0     load_var 1               (self)
        1     load_field 2             (testsets)
-       2     store_var_load_var 4     (_3)
-       3     is_type 0                
-       4     pop_jump_if_false +2     (to 6)
-       5     jump +105                (to 110)
-       6     load_var 4               (_3)
-       7     is_type 1                
-       8     pop_jump_if_false +2     (to 10)
-       9     jump +96                 (to 105)
-       10    load_var 4               (_3)
-       11    is_type 2                
-       12    pop_jump_if_false +2     (to 14)
-       13    jump +86                 (to 99)
-       14    load_var 4               (_3)
-       15    is_type 3                
-       16    pop_jump_if_false +2     (to 18)
-       17    jump +75                 (to 92)
-       18    load_var 4               (_3)
-       19    is_type 4                
-       20    pop_jump_if_false +2     (to 22)
-       21    jump +66                 (to 87)
-       22    load_var 4               (_3)
-       23    is_type 5                
-       24    pop_jump_if_false +2     (to 26)
-       25    jump +57                 (to 82)
-       26    load_var 4               (_3)
-       27    is_type 6                
-       28    pop_jump_if_false +2     (to 30)
-       29    jump +46                 (to 75)
-       30    load_var 4               (_3)
-       31    is_type 7                
-       32    pop_jump_if_false +2     (to 34)
-       33    jump +37                 (to 70)
-       34    load_var 4               (_3)
-       35    is_type 8                
-       36    pop_jump_if_false +2     (to 38)
-       37    jump +28                 (to 65)
-       38    load_var 4               (_3)
-       39    is_type 9                
-       40    pop_jump_if_false +2     (to 42)
-       41    jump +18                 (to 59)
-       42    load_var 4               (_3)
-       43    is_type 10               
-       44    pop_jump_if_false +2     (to 46)
-       45    jump +9                  (to 54)
-       46    load_var 4               (_3)
-       47    is_type 10               
-       48    pop_jump_if_false +178   (to 226)
-       49    load_type 11             
-       50    load_var 4               (_3)
-       51    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       52    store_var 5              (_4)
-       53    jump +61                 (to 114)
-       54    load_type 11             
-       55    load_var 4               (_3)
-       56    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       57    store_var 5              (_4)
-       58    jump +56                 (to 114)
-       59    load_type 11             
-       60    load_type 12             
-       61    load_var 4               (_3)
-       62    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       63    store_var 5              (_4)
-       64    jump +50                 (to 114)
-       65    load_var 4               (_3)
-       66    make_bound_method 514    
-       67    call_indirect            
-       68    store_var 5              (_4)
-       69    jump +45                 (to 114)
-       70    load_var 4               (_3)
-       71    make_bound_method 527    
-       72    call_indirect            
-       73    store_var 5              (_4)
-       74    jump +40                 (to 114)
-       75    load_type 11             
-       76    load_type 12             
-       77    load_type 12             
-       78    load_var 4               (_3)
-       79    call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       80    store_var 5              (_4)
-       81    jump +33                 (to 114)
-       82    load_var 4               (_3)
-       83    make_bound_method 557    
-       84    call_indirect            
-       85    store_var 5              (_4)
-       86    jump +28                 (to 114)
+       2     store_var 4              (_3)
+       3     load_type 0              
+       4     load_var 4               (_3)
+       5     call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       6     store_var 5              (_4)
+       7     load_var 5               (_4)
+       8     is_type 1                
+       9     pop_jump_if_false +2     (to 11)
+       10    jump +87                 (to 97)
+       11    load_var 5               (_4)
+       12    is_type 2                
+       13    pop_jump_if_false +2     (to 15)
+       14    jump +78                 (to 92)
+       15    load_var 5               (_4)
+       16    is_type 3                
+       17    pop_jump_if_false +2     (to 19)
+       18    jump +68                 (to 86)
+       19    load_var 5               (_4)
+       20    is_type 4                
+       21    pop_jump_if_false +2     (to 23)
+       22    jump +57                 (to 79)
+       23    load_var 5               (_4)
+       24    is_type 5                
+       25    pop_jump_if_false +2     (to 27)
+       26    jump +48                 (to 74)
+       27    load_var 5               (_4)
+       28    is_type 6                
+       29    pop_jump_if_false +2     (to 31)
+       30    jump +39                 (to 69)
+       31    load_var 5               (_4)
+       32    is_type 7                
+       33    pop_jump_if_false +2     (to 35)
+       34    jump +28                 (to 62)
+       35    load_var 5               (_4)
+       36    is_type 8                
+       37    pop_jump_if_false +2     (to 39)
+       38    jump +19                 (to 57)
+       39    load_var 5               (_4)
+       40    is_type 9                
+       41    pop_jump_if_false +2     (to 43)
+       42    jump +10                 (to 52)
+       43    load_var 5               (_4)
+       44    is_type 10               
+       45    pop_jump_if_false +74    (to 119)
+       46    load_type 0              
+       47    load_type 11             
+       48    load_var 5               (_4)
+       49    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       50    store_var 6              (_6)
+       51    jump +50                 (to 101)
+       52    load_var 5               (_4)
+       53    make_bound_method 576    
+       54    call_indirect            
+       55    store_var 6              (_6)
+       56    jump +45                 (to 101)
+       57    load_var 5               (_4)
+       58    make_bound_method 589    
+       59    call_indirect            
+       60    store_var 6              (_6)
+       61    jump +40                 (to 101)
+       62    load_type 0              
+       63    load_type 11             
+       64    load_type 11             
+       65    load_var 5               (_4)
+       66    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       67    store_var 6              (_6)
+       68    jump +33                 (to 101)
+       69    load_var 5               (_4)
+       70    make_bound_method 525    
+       71    call_indirect            
+       72    store_var 6              (_6)
+       73    jump +28                 (to 101)
+       74    load_type 0              
+       75    load_var 5               (_4)
+       76    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       77    store_var 6              (_6)
+       78    jump +23                 (to 101)
+       79    load_type 0              
+       80    load_type 11             
+       81    load_type 11             
+       82    load_var 5               (_4)
+       83    call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       84    store_var 6              (_6)
+       85    jump +16                 (to 101)
+       86    load_type 0              
        87    load_type 11             
-       88    load_var 4               (_3)
-       89    call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       90    store_var 5              (_4)
-       91    jump +23                 (to 114)
-       92    load_type 11             
-       93    load_type 12             
-       94    load_type 12             
-       95    load_var 4               (_3)
-       96    call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       97    store_var 5              (_4)
-       98    jump +16                 (to 114)
-       99    load_type 11             
-       100   load_type 12             
-       101   load_var 4               (_3)
-       102   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       103   store_var 5              (_4)
-       104   jump +10                 (to 114)
-       105   load_type 11             
-       106   load_var 4               (_3)
-       107   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       108   store_var 5              (_4)
-       109   jump +5                  (to 114)
-       110   load_var 4               (_3)
-       111   make_bound_method 588    
-       112   call_indirect            
-       113   store_var 5              (_4)
-       114   load_var 5               (_4)
-       115   is_type 0                
-       116   pop_jump_if_false +2     (to 118)
-       117   jump +87                 (to 204)
-       118   load_var 5               (_4)
-       119   is_type 1                
-       120   pop_jump_if_false +2     (to 122)
-       121   jump +78                 (to 199)
-       122   load_var 5               (_4)
-       123   is_type 2                
-       124   pop_jump_if_false +2     (to 126)
-       125   jump +68                 (to 193)
-       126   load_var 5               (_4)
-       127   is_type 3                
-       128   pop_jump_if_false +2     (to 130)
-       129   jump +57                 (to 186)
-       130   load_var 5               (_4)
-       131   is_type 4                
-       132   pop_jump_if_false +2     (to 134)
-       133   jump +48                 (to 181)
-       134   load_var 5               (_4)
-       135   is_type 5                
-       136   pop_jump_if_false +2     (to 138)
-       137   jump +39                 (to 176)
-       138   load_var 5               (_4)
-       139   is_type 6                
-       140   pop_jump_if_false +2     (to 142)
-       141   jump +28                 (to 169)
-       142   load_var 5               (_4)
-       143   is_type 7                
-       144   pop_jump_if_false +2     (to 146)
-       145   jump +19                 (to 164)
-       146   load_var 5               (_4)
-       147   is_type 8                
-       148   pop_jump_if_false +2     (to 150)
-       149   jump +10                 (to 159)
-       150   load_var 5               (_4)
-       151   is_type 9                
-       152   pop_jump_if_false +74    (to 226)
-       153   load_type 11             
-       154   load_type 12             
-       155   load_var 5               (_4)
-       156   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       157   store_var 6              (_35)
-       158   jump +50                 (to 208)
-       159   load_var 5               (_4)
-       160   make_bound_method 568    
-       161   call_indirect            
-       162   store_var 6              (_35)
-       163   jump +45                 (to 208)
-       164   load_var 5               (_4)
-       165   make_bound_method 581    
-       166   call_indirect            
-       167   store_var 6              (_35)
-       168   jump +40                 (to 208)
-       169   load_type 11             
-       170   load_type 12             
-       171   load_type 12             
-       172   load_var 5               (_4)
-       173   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       174   store_var 6              (_35)
-       175   jump +33                 (to 208)
-       176   load_var 5               (_4)
-       177   make_bound_method 517    
-       178   call_indirect            
-       179   store_var 6              (_35)
-       180   jump +28                 (to 208)
-       181   load_type 11             
-       182   load_var 5               (_4)
-       183   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       184   store_var 6              (_35)
-       185   jump +23                 (to 208)
-       186   load_type 11             
-       187   load_type 12             
-       188   load_type 12             
-       189   load_var 5               (_4)
-       190   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       191   store_var 6              (_35)
-       192   jump +16                 (to 208)
-       193   load_type 11             
-       194   load_type 12             
-       195   load_var 5               (_4)
-       196   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       197   store_var 6              (_35)
-       198   jump +10                 (to 208)
-       199   load_type 11             
-       200   load_var 5               (_4)
-       201   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       202   store_var 6              (_35)
-       203   jump +5                  (to 208)
-       204   load_var 5               (_4)
-       205   make_bound_method 552    
-       206   call_indirect            
-       207   store_var 6              (_35)
-       208   load_var 6               (_35)
-       209   is_type 13               
-       210   pop_jump_if_false +2     (to 212)
-       211   jump +11                 (to 222)
-       212   load_var 6               (_35)
-       213   store_var_load_var 7     (ts)
+       88    load_var 5               (_4)
+       89    call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       90    store_var 6              (_6)
+       91    jump +10                 (to 101)
+       92    load_type 0              
+       93    load_var 5               (_4)
+       94    call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       95    store_var 6              (_6)
+       96    jump +5                  (to 101)
+       97    load_var 5               (_4)
+       98    make_bound_method 560    
+       99    call_indirect            
+       100   store_var 6              (_6)
+       101   load_var 6               (_6)
+       102   is_type 12               
+       103   pop_jump_if_false +2     (to 105)
+       104   jump +11                 (to 115)
+       105   load_var 6               (_6)
+       106   store_var_load_var 7     (ts)
 
-  62   214   load_field 0             (name)
-       215   load_var 2               (name)
-       216   cmp_op ==                
-       217   pop_jump_if_false -103   (to 114)
+  62   107   load_field 0             (name)
+       108   load_var 2               (name)
+       109   cmp_op ==                
+       110   pop_jump_if_false -103   (to 7)
 
-  63   218   load_var 7               (ts)
-       219   store_var 3              (_0)
-       220   load_var 3               (_0)
-       221   return                   
+  63   111   load_var 7               (ts)
+       112   store_var 3              (_0)
+       113   load_var 3               (_0)
+       114   return                   
 
-  66   222   load_const 14            ("TestSet not found: ")
-       223   load_var 2               (name)
-       224   bin_op +                 
-       225   throw                    
-       226   unreachable              
+  66   115   load_const 13            ("TestSet not found: ")
+       116   load_var 2               (name)
+       117   bin_op +                 
+       118   throw                    
+       119   unreachable              
 }
 
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
   29   0    load_var 1             (j)
        1    load_const 0           ("prefix")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("tests")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("testsets")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -490,272 +383,165 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
 
   42   22    load_var 1               (self)
        23    load_field 1             (tests)
-       24    store_var_load_var 9     (_13)
-       25    is_type 4                
-       26    pop_jump_if_false +2     (to 28)
-       27    jump +105                (to 132)
-       28    load_var 9               (_13)
-       29    is_type 5                
-       30    pop_jump_if_false +2     (to 32)
-       31    jump +96                 (to 127)
-       32    load_var 9               (_13)
-       33    is_type 6                
-       34    pop_jump_if_false +2     (to 36)
-       35    jump +86                 (to 121)
-       36    load_var 9               (_13)
-       37    is_type 7                
-       38    pop_jump_if_false +2     (to 40)
-       39    jump +75                 (to 114)
-       40    load_var 9               (_13)
-       41    is_type 8                
-       42    pop_jump_if_false +2     (to 44)
-       43    jump +66                 (to 109)
-       44    load_var 9               (_13)
-       45    is_type 9                
-       46    pop_jump_if_false +2     (to 48)
-       47    jump +57                 (to 104)
-       48    load_var 9               (_13)
-       49    is_type 10               
-       50    pop_jump_if_false +2     (to 52)
-       51    jump +46                 (to 97)
-       52    load_var 9               (_13)
-       53    is_type 11               
-       54    pop_jump_if_false +2     (to 56)
-       55    jump +37                 (to 92)
-       56    load_var 9               (_13)
-       57    is_type 12               
-       58    pop_jump_if_false +2     (to 60)
-       59    jump +28                 (to 87)
-       60    load_var 9               (_13)
-       61    is_type 13               
-       62    pop_jump_if_false +2     (to 64)
-       63    jump +18                 (to 81)
-       64    load_var 9               (_13)
-       65    is_type 14               
-       66    pop_jump_if_false +2     (to 68)
-       67    jump +9                  (to 76)
-       68    load_var 9               (_13)
-       69    is_type 14               
-       70    pop_jump_if_false +215   (to 285)
-       71    load_type 15             
-       72    load_var 9               (_13)
-       73    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       74    store_var 10             (_14)
-       75    jump +61                 (to 136)
-       76    load_type 15             
-       77    load_var 9               (_13)
-       78    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       79    store_var 10             (_14)
-       80    jump +56                 (to 136)
-       81    load_type 15             
-       82    load_type 16             
-       83    load_var 9               (_13)
-       84    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       85    store_var 10             (_14)
-       86    jump +50                 (to 136)
-       87    load_var 9               (_13)
-       88    make_bound_method 514    
-       89    call_indirect            
-       90    store_var 10             (_14)
-       91    jump +45                 (to 136)
-       92    load_var 9               (_13)
-       93    make_bound_method 527    
-       94    call_indirect            
-       95    store_var 10             (_14)
-       96    jump +40                 (to 136)
-       97    load_type 15             
-       98    load_type 16             
-       99    load_type 16             
-       100   load_var 9               (_13)
-       101   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       102   store_var 10             (_14)
-       103   jump +33                 (to 136)
-       104   load_var 9               (_13)
-       105   make_bound_method 557    
-       106   call_indirect            
-       107   store_var 10             (_14)
-       108   jump +28                 (to 136)
+       24    store_var 9              (_13)
+       25    load_type 4              
+       26    load_var 9               (_13)
+       27    call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       28    store_var 10             (_14)
+       29    load_var 10              (_14)
+       30    is_type 5                
+       31    pop_jump_if_false +2     (to 33)
+       32    jump +87                 (to 119)
+       33    load_var 10              (_14)
+       34    is_type 6                
+       35    pop_jump_if_false +2     (to 37)
+       36    jump +78                 (to 114)
+       37    load_var 10              (_14)
+       38    is_type 7                
+       39    pop_jump_if_false +2     (to 41)
+       40    jump +68                 (to 108)
+       41    load_var 10              (_14)
+       42    is_type 8                
+       43    pop_jump_if_false +2     (to 45)
+       44    jump +57                 (to 101)
+       45    load_var 10              (_14)
+       46    is_type 9                
+       47    pop_jump_if_false +2     (to 49)
+       48    jump +48                 (to 96)
+       49    load_var 10              (_14)
+       50    is_type 10               
+       51    pop_jump_if_false +2     (to 53)
+       52    jump +39                 (to 91)
+       53    load_var 10              (_14)
+       54    is_type 11               
+       55    pop_jump_if_false +2     (to 57)
+       56    jump +28                 (to 84)
+       57    load_var 10              (_14)
+       58    is_type 12               
+       59    pop_jump_if_false +2     (to 61)
+       60    jump +19                 (to 79)
+       61    load_var 10              (_14)
+       62    is_type 13               
+       63    pop_jump_if_false +2     (to 65)
+       64    jump +10                 (to 74)
+       65    load_var 10              (_14)
+       66    is_type 14               
+       67    pop_jump_if_false +111   (to 178)
+       68    load_type 4              
+       69    load_type 15             
+       70    load_var 10              (_14)
+       71    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       72    store_var 11             (_16)
+       73    jump +50                 (to 123)
+       74    load_var 10              (_14)
+       75    make_bound_method 576    
+       76    call_indirect            
+       77    store_var 11             (_16)
+       78    jump +45                 (to 123)
+       79    load_var 10              (_14)
+       80    make_bound_method 589    
+       81    call_indirect            
+       82    store_var 11             (_16)
+       83    jump +40                 (to 123)
+       84    load_type 4              
+       85    load_type 15             
+       86    load_type 15             
+       87    load_var 10              (_14)
+       88    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       89    store_var 11             (_16)
+       90    jump +33                 (to 123)
+       91    load_var 10              (_14)
+       92    make_bound_method 525    
+       93    call_indirect            
+       94    store_var 11             (_16)
+       95    jump +28                 (to 123)
+       96    load_type 4              
+       97    load_var 10              (_14)
+       98    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       99    store_var 11             (_16)
+       100   jump +23                 (to 123)
+       101   load_type 4              
+       102   load_type 15             
+       103   load_type 15             
+       104   load_var 10              (_14)
+       105   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       106   store_var 11             (_16)
+       107   jump +16                 (to 123)
+       108   load_type 4              
        109   load_type 15             
-       110   load_var 9               (_13)
-       111   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       112   store_var 10             (_14)
-       113   jump +23                 (to 136)
-       114   load_type 15             
-       115   load_type 16             
-       116   load_type 16             
-       117   load_var 9               (_13)
-       118   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       119   store_var 10             (_14)
-       120   jump +16                 (to 136)
-       121   load_type 15             
-       122   load_type 16             
-       123   load_var 9               (_13)
-       124   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       125   store_var 10             (_14)
-       126   jump +10                 (to 136)
-       127   load_type 15             
-       128   load_var 9               (_13)
-       129   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       130   store_var 10             (_14)
-       131   jump +5                  (to 136)
-       132   load_var 9               (_13)
-       133   make_bound_method 588    
-       134   call_indirect            
-       135   store_var 10             (_14)
-       136   load_var 10              (_14)
-       137   is_type 4                
-       138   pop_jump_if_false +2     (to 140)
-       139   jump +87                 (to 226)
-       140   load_var 10              (_14)
-       141   is_type 5                
-       142   pop_jump_if_false +2     (to 144)
-       143   jump +78                 (to 221)
-       144   load_var 10              (_14)
-       145   is_type 6                
-       146   pop_jump_if_false +2     (to 148)
-       147   jump +68                 (to 215)
-       148   load_var 10              (_14)
-       149   is_type 7                
-       150   pop_jump_if_false +2     (to 152)
-       151   jump +57                 (to 208)
-       152   load_var 10              (_14)
-       153   is_type 8                
-       154   pop_jump_if_false +2     (to 156)
-       155   jump +48                 (to 203)
-       156   load_var 10              (_14)
-       157   is_type 9                
-       158   pop_jump_if_false +2     (to 160)
-       159   jump +39                 (to 198)
-       160   load_var 10              (_14)
-       161   is_type 10               
-       162   pop_jump_if_false +2     (to 164)
-       163   jump +28                 (to 191)
-       164   load_var 10              (_14)
-       165   is_type 11               
-       166   pop_jump_if_false +2     (to 168)
-       167   jump +19                 (to 186)
-       168   load_var 10              (_14)
-       169   is_type 12               
-       170   pop_jump_if_false +2     (to 172)
-       171   jump +10                 (to 181)
-       172   load_var 10              (_14)
-       173   is_type 13               
-       174   pop_jump_if_false +111   (to 285)
-       175   load_type 15             
-       176   load_type 16             
-       177   load_var 10              (_14)
-       178   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       179   store_var 11             (_45)
-       180   jump +50                 (to 230)
-       181   load_var 10              (_14)
-       182   make_bound_method 568    
-       183   call_indirect            
-       184   store_var 11             (_45)
-       185   jump +45                 (to 230)
-       186   load_var 10              (_14)
-       187   make_bound_method 581    
-       188   call_indirect            
-       189   store_var 11             (_45)
-       190   jump +40                 (to 230)
-       191   load_type 15             
-       192   load_type 16             
-       193   load_type 16             
-       194   load_var 10              (_14)
-       195   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       196   store_var 11             (_45)
-       197   jump +33                 (to 230)
-       198   load_var 10              (_14)
-       199   make_bound_method 517    
-       200   call_indirect            
-       201   store_var 11             (_45)
-       202   jump +28                 (to 230)
-       203   load_type 15             
-       204   load_var 10              (_14)
-       205   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       206   store_var 11             (_45)
-       207   jump +23                 (to 230)
-       208   load_type 15             
-       209   load_type 16             
-       210   load_type 16             
-       211   load_var 10              (_14)
-       212   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       213   store_var 11             (_45)
-       214   jump +16                 (to 230)
-       215   load_type 15             
-       216   load_type 16             
-       217   load_var 10              (_14)
-       218   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       219   store_var 11             (_45)
-       220   jump +10                 (to 230)
-       221   load_type 15             
-       222   load_var 10              (_14)
-       223   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       224   store_var 11             (_45)
-       225   jump +5                  (to 230)
-       226   load_var 10              (_14)
-       227   make_bound_method 552    
-       228   call_indirect            
-       229   store_var 11             (_45)
-       230   load_var 11              (_45)
-       231   is_type 17               
-       232   pop_jump_if_false +2     (to 234)
-       233   jump +19                 (to 252)
-       234   load_var 11              (_45)
-       235   store_var_load_var 12    (t)
+       110   load_var 10              (_14)
+       111   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       112   store_var 11             (_16)
+       113   jump +10                 (to 123)
+       114   load_type 4              
+       115   load_var 10              (_14)
+       116   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       117   store_var 11             (_16)
+       118   jump +5                  (to 123)
+       119   load_var 10              (_14)
+       120   make_bound_method 560    
+       121   call_indirect            
+       122   store_var 11             (_16)
+       123   load_var 11              (_16)
+       124   is_type 16               
+       125   pop_jump_if_false +2     (to 127)
+       126   jump +19                 (to 145)
+       127   load_var 11              (_16)
+       128   store_var_load_var 12    (t)
 
-  43   236   load_field 0             (name)
-       237   load_var 6               (full_name)
-       238   cmp_op ==                
-       239   jump_if_false +2         (to 241)
-       240   jump +6                  (to 246)
-       241   pop 1                    
-       242   load_var 12              (t)
-       243   load_field 0             (name)
-       244   load_var 8               (hash_prefix)
-       245   call 152 ntypeargs=0     (baml.String.starts_with)
-       246   pop_jump_if_false -110   (to 136)
-       247   load_var 7               (count)
-       248   load_const 18            (1)
-       249   add_int                  
-       250   store_var 7              (count)
-       251   jump -115                (to 136)
+  43   129   load_field 0             (name)
+       130   load_var 6               (full_name)
+       131   cmp_op ==                
+       132   jump_if_false +2         (to 134)
+       133   jump +6                  (to 139)
+       134   pop 1                    
+       135   load_var 12              (t)
+       136   load_field 0             (name)
+       137   load_var 8               (hash_prefix)
+       138   call 160 ntypeargs=0     (baml.String.starts_with)
+       139   pop_jump_if_false -110   (to 29)
+       140   load_var 7               (count)
+       141   load_const 17            (1)
+       142   add_int                  
+       143   store_var 7              (count)
+       144   jump -115                (to 29)
 
-  45   252   load_var 7               (count)
-       253   load_const 2             (0)
-       254   cmp_int_op >             
-       255   pop_jump_if_false +2     (to 257)
-       256   jump +4                  (to 260)
-       257   load_var 6               (full_name)
-       258   store_var 13             (final_name)
-       259   jump +14                 (to 273)
-       260   load_var 6               (full_name)
-       261   load_const 19            ("#")
-       262   bin_op +                 
-       263   store_var 14             (_84)
-       264   load_type 20             
-       265   load_var 7               (count)
-       266   load_const 18            (1)
-       267   add_int                  
-       268   call 423 ntypeargs=1     (baml.unstable.string)
-       269   store_var 15             (_86)
-       270   load_var2 14 15          
-       271   bin_op +                 
-       272   store_var 13             (final_name)
+  45   145   load_var 7               (count)
+       146   load_const 2             (0)
+       147   cmp_int_op >             
+       148   pop_jump_if_false +2     (to 150)
+       149   jump +4                  (to 153)
+       150   load_var 6               (full_name)
+       151   store_var 13             (final_name)
+       152   jump +14                 (to 166)
+       153   load_var 6               (full_name)
+       154   load_const 18            ("#")
+       155   bin_op +                 
+       156   store_var 14             (_55)
+       157   load_type 19             
+       158   load_var 7               (count)
+       159   load_const 17            (1)
+       160   add_int                  
+       161   call 431 ntypeargs=1     (baml.unstable.string)
+       162   store_var 15             (_57)
+       163   load_var2 14 15          
+       164   bin_op +                 
+       165   store_var 13             (final_name)
 
-  46   273   load_type 15             
-       274   load_var 1               (self)
-       275   load_field 1             (tests)
-       276   load_var2 13 3           
-       277   load_var 4               (runner)
-       278   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
-       280   pop 1                    
+  46   166   load_type 4              
+       167   load_var 1               (self)
+       168   load_field 1             (tests)
+       169   load_var2 13 3           
+       170   load_var 4               (runner)
+       171   init_instance 0          (testing.TestRegistration .name, .body, .runner)
+       172   call 17 ntypeargs=1      (baml.Array.push)
+       173   pop 1                    
 
-  38   281   load_const 21            (null)
-       282   store_var 5              (_0)
-       283   load_var 5               (_0)
-       284   return                   
-       285   unreachable              
+  38   174   load_const 20            (null)
+       175   store_var 5              (_0)
+       176   load_var 5               (_0)
+       177   return                   
+       178   unreachable              
 }
 
 function testing.TestCollector.register_test_set(self: testing.TestCollector, name: string, collector: (testing.TestCollector) -> void throws unknown, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never) | null) -> void {
@@ -786,286 +572,179 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
 
   53   22    load_var 1               (self)
        23    load_field 2             (testsets)
-       24    store_var_load_var 9     (_13)
-       25    is_type 4                
-       26    pop_jump_if_false +2     (to 28)
-       27    jump +105                (to 132)
-       28    load_var 9               (_13)
-       29    is_type 5                
-       30    pop_jump_if_false +2     (to 32)
-       31    jump +96                 (to 127)
-       32    load_var 9               (_13)
-       33    is_type 6                
-       34    pop_jump_if_false +2     (to 36)
-       35    jump +86                 (to 121)
-       36    load_var 9               (_13)
-       37    is_type 7                
-       38    pop_jump_if_false +2     (to 40)
-       39    jump +75                 (to 114)
-       40    load_var 9               (_13)
-       41    is_type 8                
-       42    pop_jump_if_false +2     (to 44)
-       43    jump +66                 (to 109)
-       44    load_var 9               (_13)
-       45    is_type 9                
-       46    pop_jump_if_false +2     (to 48)
-       47    jump +57                 (to 104)
-       48    load_var 9               (_13)
-       49    is_type 10               
-       50    pop_jump_if_false +2     (to 52)
-       51    jump +46                 (to 97)
-       52    load_var 9               (_13)
-       53    is_type 11               
-       54    pop_jump_if_false +2     (to 56)
-       55    jump +37                 (to 92)
-       56    load_var 9               (_13)
-       57    is_type 12               
-       58    pop_jump_if_false +2     (to 60)
-       59    jump +28                 (to 87)
-       60    load_var 9               (_13)
-       61    is_type 13               
-       62    pop_jump_if_false +2     (to 64)
-       63    jump +18                 (to 81)
-       64    load_var 9               (_13)
-       65    is_type 14               
-       66    pop_jump_if_false +2     (to 68)
-       67    jump +9                  (to 76)
-       68    load_var 9               (_13)
-       69    is_type 14               
-       70    pop_jump_if_false +215   (to 285)
-       71    load_type 15             
-       72    load_var 9               (_13)
-       73    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       74    store_var 10             (_14)
-       75    jump +61                 (to 136)
-       76    load_type 15             
-       77    load_var 9               (_13)
-       78    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       79    store_var 10             (_14)
-       80    jump +56                 (to 136)
-       81    load_type 15             
-       82    load_type 16             
-       83    load_var 9               (_13)
-       84    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       85    store_var 10             (_14)
-       86    jump +50                 (to 136)
-       87    load_var 9               (_13)
-       88    make_bound_method 514    
-       89    call_indirect            
-       90    store_var 10             (_14)
-       91    jump +45                 (to 136)
-       92    load_var 9               (_13)
-       93    make_bound_method 527    
-       94    call_indirect            
-       95    store_var 10             (_14)
-       96    jump +40                 (to 136)
-       97    load_type 15             
-       98    load_type 16             
-       99    load_type 16             
-       100   load_var 9               (_13)
-       101   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       102   store_var 10             (_14)
-       103   jump +33                 (to 136)
-       104   load_var 9               (_13)
-       105   make_bound_method 557    
-       106   call_indirect            
-       107   store_var 10             (_14)
-       108   jump +28                 (to 136)
+       24    store_var 9              (_13)
+       25    load_type 4              
+       26    load_var 9               (_13)
+       27    call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       28    store_var 10             (_14)
+       29    load_var 10              (_14)
+       30    is_type 5                
+       31    pop_jump_if_false +2     (to 33)
+       32    jump +87                 (to 119)
+       33    load_var 10              (_14)
+       34    is_type 6                
+       35    pop_jump_if_false +2     (to 37)
+       36    jump +78                 (to 114)
+       37    load_var 10              (_14)
+       38    is_type 7                
+       39    pop_jump_if_false +2     (to 41)
+       40    jump +68                 (to 108)
+       41    load_var 10              (_14)
+       42    is_type 8                
+       43    pop_jump_if_false +2     (to 45)
+       44    jump +57                 (to 101)
+       45    load_var 10              (_14)
+       46    is_type 9                
+       47    pop_jump_if_false +2     (to 49)
+       48    jump +48                 (to 96)
+       49    load_var 10              (_14)
+       50    is_type 10               
+       51    pop_jump_if_false +2     (to 53)
+       52    jump +39                 (to 91)
+       53    load_var 10              (_14)
+       54    is_type 11               
+       55    pop_jump_if_false +2     (to 57)
+       56    jump +28                 (to 84)
+       57    load_var 10              (_14)
+       58    is_type 12               
+       59    pop_jump_if_false +2     (to 61)
+       60    jump +19                 (to 79)
+       61    load_var 10              (_14)
+       62    is_type 13               
+       63    pop_jump_if_false +2     (to 65)
+       64    jump +10                 (to 74)
+       65    load_var 10              (_14)
+       66    is_type 14               
+       67    pop_jump_if_false +111   (to 178)
+       68    load_type 4              
+       69    load_type 15             
+       70    load_var 10              (_14)
+       71    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       72    store_var 11             (_16)
+       73    jump +50                 (to 123)
+       74    load_var 10              (_14)
+       75    make_bound_method 576    
+       76    call_indirect            
+       77    store_var 11             (_16)
+       78    jump +45                 (to 123)
+       79    load_var 10              (_14)
+       80    make_bound_method 589    
+       81    call_indirect            
+       82    store_var 11             (_16)
+       83    jump +40                 (to 123)
+       84    load_type 4              
+       85    load_type 15             
+       86    load_type 15             
+       87    load_var 10              (_14)
+       88    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       89    store_var 11             (_16)
+       90    jump +33                 (to 123)
+       91    load_var 10              (_14)
+       92    make_bound_method 525    
+       93    call_indirect            
+       94    store_var 11             (_16)
+       95    jump +28                 (to 123)
+       96    load_type 4              
+       97    load_var 10              (_14)
+       98    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       99    store_var 11             (_16)
+       100   jump +23                 (to 123)
+       101   load_type 4              
+       102   load_type 15             
+       103   load_type 15             
+       104   load_var 10              (_14)
+       105   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       106   store_var 11             (_16)
+       107   jump +16                 (to 123)
+       108   load_type 4              
        109   load_type 15             
-       110   load_var 9               (_13)
-       111   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       112   store_var 10             (_14)
-       113   jump +23                 (to 136)
-       114   load_type 15             
-       115   load_type 16             
-       116   load_type 16             
-       117   load_var 9               (_13)
-       118   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       119   store_var 10             (_14)
-       120   jump +16                 (to 136)
-       121   load_type 15             
-       122   load_type 16             
-       123   load_var 9               (_13)
-       124   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       125   store_var 10             (_14)
-       126   jump +10                 (to 136)
-       127   load_type 15             
-       128   load_var 9               (_13)
-       129   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       130   store_var 10             (_14)
-       131   jump +5                  (to 136)
-       132   load_var 9               (_13)
-       133   make_bound_method 588    
-       134   call_indirect            
-       135   store_var 10             (_14)
-       136   load_var 10              (_14)
-       137   is_type 4                
-       138   pop_jump_if_false +2     (to 140)
-       139   jump +87                 (to 226)
-       140   load_var 10              (_14)
-       141   is_type 5                
-       142   pop_jump_if_false +2     (to 144)
-       143   jump +78                 (to 221)
-       144   load_var 10              (_14)
-       145   is_type 6                
-       146   pop_jump_if_false +2     (to 148)
-       147   jump +68                 (to 215)
-       148   load_var 10              (_14)
-       149   is_type 7                
-       150   pop_jump_if_false +2     (to 152)
-       151   jump +57                 (to 208)
-       152   load_var 10              (_14)
-       153   is_type 8                
-       154   pop_jump_if_false +2     (to 156)
-       155   jump +48                 (to 203)
-       156   load_var 10              (_14)
-       157   is_type 9                
-       158   pop_jump_if_false +2     (to 160)
-       159   jump +39                 (to 198)
-       160   load_var 10              (_14)
-       161   is_type 10               
-       162   pop_jump_if_false +2     (to 164)
-       163   jump +28                 (to 191)
-       164   load_var 10              (_14)
-       165   is_type 11               
-       166   pop_jump_if_false +2     (to 168)
-       167   jump +19                 (to 186)
-       168   load_var 10              (_14)
-       169   is_type 12               
-       170   pop_jump_if_false +2     (to 172)
-       171   jump +10                 (to 181)
-       172   load_var 10              (_14)
-       173   is_type 13               
-       174   pop_jump_if_false +111   (to 285)
-       175   load_type 15             
-       176   load_type 16             
-       177   load_var 10              (_14)
-       178   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       179   store_var 11             (_45)
-       180   jump +50                 (to 230)
-       181   load_var 10              (_14)
-       182   make_bound_method 568    
-       183   call_indirect            
-       184   store_var 11             (_45)
-       185   jump +45                 (to 230)
-       186   load_var 10              (_14)
-       187   make_bound_method 581    
-       188   call_indirect            
-       189   store_var 11             (_45)
-       190   jump +40                 (to 230)
-       191   load_type 15             
-       192   load_type 16             
-       193   load_type 16             
-       194   load_var 10              (_14)
-       195   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       196   store_var 11             (_45)
-       197   jump +33                 (to 230)
-       198   load_var 10              (_14)
-       199   make_bound_method 517    
-       200   call_indirect            
-       201   store_var 11             (_45)
-       202   jump +28                 (to 230)
-       203   load_type 15             
-       204   load_var 10              (_14)
-       205   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       206   store_var 11             (_45)
-       207   jump +23                 (to 230)
-       208   load_type 15             
-       209   load_type 16             
-       210   load_type 16             
-       211   load_var 10              (_14)
-       212   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       213   store_var 11             (_45)
-       214   jump +16                 (to 230)
-       215   load_type 15             
-       216   load_type 16             
-       217   load_var 10              (_14)
-       218   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       219   store_var 11             (_45)
-       220   jump +10                 (to 230)
-       221   load_type 15             
-       222   load_var 10              (_14)
-       223   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       224   store_var 11             (_45)
-       225   jump +5                  (to 230)
-       226   load_var 10              (_14)
-       227   make_bound_method 552    
-       228   call_indirect            
-       229   store_var 11             (_45)
-       230   load_var 11              (_45)
-       231   is_type 17               
-       232   pop_jump_if_false +2     (to 234)
-       233   jump +19                 (to 252)
-       234   load_var 11              (_45)
-       235   store_var_load_var 12    (ts)
+       110   load_var 10              (_14)
+       111   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       112   store_var 11             (_16)
+       113   jump +10                 (to 123)
+       114   load_type 4              
+       115   load_var 10              (_14)
+       116   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       117   store_var 11             (_16)
+       118   jump +5                  (to 123)
+       119   load_var 10              (_14)
+       120   make_bound_method 560    
+       121   call_indirect            
+       122   store_var 11             (_16)
+       123   load_var 11              (_16)
+       124   is_type 16               
+       125   pop_jump_if_false +2     (to 127)
+       126   jump +19                 (to 145)
+       127   load_var 11              (_16)
+       128   store_var_load_var 12    (ts)
 
-  54   236   load_field 0             (name)
-       237   load_var 6               (full_name)
-       238   cmp_op ==                
-       239   jump_if_false +2         (to 241)
-       240   jump +6                  (to 246)
-       241   pop 1                    
-       242   load_var 12              (ts)
-       243   load_field 0             (name)
-       244   load_var 8               (hash_prefix)
-       245   call 152 ntypeargs=0     (baml.String.starts_with)
-       246   pop_jump_if_false -110   (to 136)
-       247   load_var 7               (count)
-       248   load_const 18            (1)
-       249   add_int                  
-       250   store_var 7              (count)
-       251   jump -115                (to 136)
+  54   129   load_field 0             (name)
+       130   load_var 6               (full_name)
+       131   cmp_op ==                
+       132   jump_if_false +2         (to 134)
+       133   jump +6                  (to 139)
+       134   pop 1                    
+       135   load_var 12              (ts)
+       136   load_field 0             (name)
+       137   load_var 8               (hash_prefix)
+       138   call 160 ntypeargs=0     (baml.String.starts_with)
+       139   pop_jump_if_false -110   (to 29)
+       140   load_var 7               (count)
+       141   load_const 17            (1)
+       142   add_int                  
+       143   store_var 7              (count)
+       144   jump -115                (to 29)
 
-  56   252   load_var 7               (count)
-       253   load_const 2             (0)
-       254   cmp_int_op >             
-       255   pop_jump_if_false +2     (to 257)
-       256   jump +4                  (to 260)
-       257   load_var 6               (full_name)
-       258   store_var 13             (final_name)
-       259   jump +14                 (to 273)
-       260   load_var 6               (full_name)
-       261   load_const 19            ("#")
-       262   bin_op +                 
-       263   store_var 14             (_84)
-       264   load_type 20             
-       265   load_var 7               (count)
-       266   load_const 18            (1)
-       267   add_int                  
-       268   call 423 ntypeargs=1     (baml.unstable.string)
-       269   store_var 15             (_86)
-       270   load_var2 14 15          
-       271   bin_op +                 
-       272   store_var 13             (final_name)
+  56   145   load_var 7               (count)
+       146   load_const 2             (0)
+       147   cmp_int_op >             
+       148   pop_jump_if_false +2     (to 150)
+       149   jump +4                  (to 153)
+       150   load_var 6               (full_name)
+       151   store_var 13             (final_name)
+       152   jump +14                 (to 166)
+       153   load_var 6               (full_name)
+       154   load_const 18            ("#")
+       155   bin_op +                 
+       156   store_var 14             (_55)
+       157   load_type 19             
+       158   load_var 7               (count)
+       159   load_const 17            (1)
+       160   add_int                  
+       161   call 431 ntypeargs=1     (baml.unstable.string)
+       162   store_var 15             (_57)
+       163   load_var2 14 15          
+       164   bin_op +                 
+       165   store_var 13             (final_name)
 
-  57   273   load_type 15             
-       274   load_var 1               (self)
-       275   load_field 2             (testsets)
-       276   load_var2 13 3           
-       277   load_var 4               (runner)
-       278   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
-       280   pop 1                    
+  57   166   load_type 4              
+       167   load_var 1               (self)
+       168   load_field 2             (testsets)
+       169   load_var2 13 3           
+       170   load_var 4               (runner)
+       171   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
+       172   call 17 ntypeargs=1      (baml.Array.push)
+       173   pop 1                    
 
-  49   281   load_const 21            (null)
-       282   store_var 5              (_0)
-       283   load_var 5               (_0)
-       284   return                   
-       285   unreachable              
+  49   174   load_const 20            (null)
+       175   store_var 5              (_0)
+       176   load_var 5               (_0)
+       177   return                   
+       178   unreachable              
 }
 
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {
   29   0    load_var 1             (self)
        1    load_field 0           (prefix)
-       2    call 164 ntypeargs=0   (baml.String.to_json)
+       2    call 172 ntypeargs=0   (baml.String.to_json)
        3    load_type 0            
        4    load_var 1             (self)
        5    load_field 1           (tests)
-       6    call 38 ntypeargs=1    (baml.Array.to_json)
+       6    call 37 ntypeargs=1    (baml.Array.to_json)
        7    load_type 1            
        8    load_var 1             (self)
        9    load_field 2           (testsets)
-       10   call 38 ntypeargs=1    (baml.Array.to_json)
+       10   call 37 ntypeargs=1    (baml.Array.to_json)
        11   load_const 2           ("prefix")
        12   load_const 3           ("tests")
        13   load_const 4           ("testsets")
@@ -1078,25 +757,25 @@ function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json
 function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRegistration {
   5   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 407 ntypeargs=0   (baml.json.field)
+      2    call 415 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 399 ntypeargs=1   (baml.json.from_json)
+      6    call 407 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("body")
-      9    call 407 ntypeargs=0   (baml.json.field)
+      9    call 415 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 399 ntypeargs=1   (baml.json.from_json)
+      13   call 407 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("runner")
-      16   call 407 ntypeargs=0   (baml.json.field)
+      16   call 415 ntypeargs=0   (baml.json.field)
       17   store_var 5            (_9)
       18   load_type 5            
       19   load_var 5             (_9)
-      20   call 399 ntypeargs=1   (baml.json.from_json)
+      20   call 407 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (testing.TestRegistration .name, .body, .runner)
       22   store_var 2            (_0)
       23   load_var 2             (_0)
@@ -1106,8 +785,8 @@ function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRe
 function testing.TestRegistration.to_json(self: testing.TestRegistration) -> baml.json.json {
   13   0   load_type 0            
        1   load_var 1             (self)
-       2   call 409 ntypeargs=1   (baml.json.to_string)
-       3   call 404 ntypeargs=0   (baml.json.parse)
+       2   call 417 ntypeargs=1   (baml.json.to_string)
+       3   call 412 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
@@ -1115,529 +794,314 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   157   0     load_var 1               (self)
         1     load_field 0             (collector)
         2     load_field 2             (testsets)
-        3     store_var_load_var 3     (_3)
+        3     store_var 3              (_3)
 
-  156   4     is_type 0                
-        5     pop_jump_if_false +2     (to 7)
-        6     jump +105                (to 111)
-        7     load_var 3               (_3)
-        8     is_type 1                
-        9     pop_jump_if_false +2     (to 11)
-        10    jump +96                 (to 106)
-        11    load_var 3               (_3)
-        12    is_type 2                
-        13    pop_jump_if_false +2     (to 15)
-        14    jump +86                 (to 100)
-        15    load_var 3               (_3)
-        16    is_type 3                
-        17    pop_jump_if_false +2     (to 19)
-        18    jump +75                 (to 93)
-        19    load_var 3               (_3)
-        20    is_type 4                
-        21    pop_jump_if_false +2     (to 23)
-        22    jump +66                 (to 88)
-        23    load_var 3               (_3)
-        24    is_type 5                
-        25    pop_jump_if_false +2     (to 27)
-        26    jump +57                 (to 83)
-        27    load_var 3               (_3)
-        28    is_type 6                
-        29    pop_jump_if_false +2     (to 31)
-        30    jump +46                 (to 76)
-        31    load_var 3               (_3)
-        32    is_type 7                
-        33    pop_jump_if_false +2     (to 35)
-        34    jump +37                 (to 71)
-        35    load_var 3               (_3)
-        36    is_type 8                
-        37    pop_jump_if_false +2     (to 39)
-        38    jump +28                 (to 66)
-        39    load_var 3               (_3)
-        40    is_type 9                
-        41    pop_jump_if_false +2     (to 43)
-        42    jump +18                 (to 60)
-        43    load_var 3               (_3)
-        44    is_type 10               
-        45    pop_jump_if_false +2     (to 47)
-        46    jump +9                  (to 55)
-        47    load_var 3               (_3)
-        48    is_type 10               
-        49    pop_jump_if_false +435   (to 484)
-        50    load_type 11             
-        51    load_var 3               (_3)
-        52    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        53    store_var 4              (_4)
-        54    jump +61                 (to 115)
-        55    load_type 11             
-        56    load_var 3               (_3)
-        57    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        58    store_var 4              (_4)
-        59    jump +56                 (to 115)
-        60    load_type 11             
-        61    load_type 12             
-        62    load_var 3               (_3)
-        63    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        64    store_var 4              (_4)
-        65    jump +50                 (to 115)
-        66    load_var 3               (_3)
-        67    make_bound_method 514    
-        68    call_indirect            
-        69    store_var 4              (_4)
-        70    jump +45                 (to 115)
-        71    load_var 3               (_3)
-        72    make_bound_method 527    
-        73    call_indirect            
-        74    store_var 4              (_4)
-        75    jump +40                 (to 115)
-        76    load_type 11             
-        77    load_type 12             
-        78    load_type 12             
-        79    load_var 3               (_3)
-        80    call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        81    store_var 4              (_4)
-        82    jump +33                 (to 115)
-        83    load_var 3               (_3)
-        84    make_bound_method 557    
-        85    call_indirect            
-        86    store_var 4              (_4)
-        87    jump +28                 (to 115)
+  156   4     load_type 0              
+        5     load_var 3               (_3)
+        6     call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        7     store_var 4              (_4)
+        8     load_var 4               (_4)
+        9     is_type 1                
+        10    pop_jump_if_false +2     (to 12)
+        11    jump +87                 (to 98)
+        12    load_var 4               (_4)
+        13    is_type 2                
+        14    pop_jump_if_false +2     (to 16)
+        15    jump +78                 (to 93)
+        16    load_var 4               (_4)
+        17    is_type 3                
+        18    pop_jump_if_false +2     (to 20)
+        19    jump +68                 (to 87)
+        20    load_var 4               (_4)
+        21    is_type 4                
+        22    pop_jump_if_false +2     (to 24)
+        23    jump +57                 (to 80)
+        24    load_var 4               (_4)
+        25    is_type 5                
+        26    pop_jump_if_false +2     (to 28)
+        27    jump +48                 (to 75)
+        28    load_var 4               (_4)
+        29    is_type 6                
+        30    pop_jump_if_false +2     (to 32)
+        31    jump +39                 (to 70)
+        32    load_var 4               (_4)
+        33    is_type 7                
+        34    pop_jump_if_false +2     (to 36)
+        35    jump +28                 (to 63)
+        36    load_var 4               (_4)
+        37    is_type 8                
+        38    pop_jump_if_false +2     (to 40)
+        39    jump +19                 (to 58)
+        40    load_var 4               (_4)
+        41    is_type 9                
+        42    pop_jump_if_false +2     (to 44)
+        43    jump +10                 (to 53)
+        44    load_var 4               (_4)
+        45    is_type 10               
+        46    pop_jump_if_false +223   (to 269)
+        47    load_type 0              
+        48    load_type 11             
+        49    load_var 4               (_4)
+        50    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        51    store_var 5              (_6)
+        52    jump +50                 (to 102)
+        53    load_var 4               (_4)
+        54    make_bound_method 576    
+        55    call_indirect            
+        56    store_var 5              (_6)
+        57    jump +45                 (to 102)
+        58    load_var 4               (_4)
+        59    make_bound_method 589    
+        60    call_indirect            
+        61    store_var 5              (_6)
+        62    jump +40                 (to 102)
+        63    load_type 0              
+        64    load_type 11             
+        65    load_type 11             
+        66    load_var 4               (_4)
+        67    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        68    store_var 5              (_6)
+        69    jump +33                 (to 102)
+        70    load_var 4               (_4)
+        71    make_bound_method 525    
+        72    call_indirect            
+        73    store_var 5              (_6)
+        74    jump +28                 (to 102)
+        75    load_type 0              
+        76    load_var 4               (_4)
+        77    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        78    store_var 5              (_6)
+        79    jump +23                 (to 102)
+        80    load_type 0              
+        81    load_type 11             
+        82    load_type 11             
+        83    load_var 4               (_4)
+        84    call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        85    store_var 5              (_6)
+        86    jump +16                 (to 102)
+        87    load_type 0              
         88    load_type 11             
-        89    load_var 3               (_3)
-        90    call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        91    store_var 4              (_4)
-        92    jump +23                 (to 115)
-        93    load_type 11             
-        94    load_type 12             
-        95    load_type 12             
-        96    load_var 3               (_3)
-        97    call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        98    store_var 4              (_4)
-        99    jump +16                 (to 115)
-        100   load_type 11             
-        101   load_type 12             
-        102   load_var 3               (_3)
-        103   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        104   store_var 4              (_4)
-        105   jump +10                 (to 115)
-        106   load_type 11             
-        107   load_var 3               (_3)
-        108   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        109   store_var 4              (_4)
-        110   jump +5                  (to 115)
-        111   load_var 3               (_3)
-        112   make_bound_method 588    
-        113   call_indirect            
-        114   store_var 4              (_4)
-        115   load_var 4               (_4)
-        116   is_type 0                
-        117   pop_jump_if_false +2     (to 119)
-        118   jump +87                 (to 205)
-        119   load_var 4               (_4)
-        120   is_type 1                
-        121   pop_jump_if_false +2     (to 123)
-        122   jump +78                 (to 200)
-        123   load_var 4               (_4)
-        124   is_type 2                
-        125   pop_jump_if_false +2     (to 127)
-        126   jump +68                 (to 194)
-        127   load_var 4               (_4)
-        128   is_type 3                
-        129   pop_jump_if_false +2     (to 131)
-        130   jump +57                 (to 187)
-        131   load_var 4               (_4)
-        132   is_type 4                
-        133   pop_jump_if_false +2     (to 135)
-        134   jump +48                 (to 182)
-        135   load_var 4               (_4)
-        136   is_type 5                
-        137   pop_jump_if_false +2     (to 139)
-        138   jump +39                 (to 177)
-        139   load_var 4               (_4)
-        140   is_type 6                
-        141   pop_jump_if_false +2     (to 143)
-        142   jump +28                 (to 170)
-        143   load_var 4               (_4)
-        144   is_type 7                
-        145   pop_jump_if_false +2     (to 147)
-        146   jump +19                 (to 165)
-        147   load_var 4               (_4)
-        148   is_type 8                
-        149   pop_jump_if_false +2     (to 151)
-        150   jump +10                 (to 160)
-        151   load_var 4               (_4)
-        152   is_type 9                
-        153   pop_jump_if_false +331   (to 484)
-        154   load_type 11             
-        155   load_type 12             
-        156   load_var 4               (_4)
-        157   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        158   store_var 5              (_35)
-        159   jump +50                 (to 209)
-        160   load_var 4               (_4)
-        161   make_bound_method 568    
-        162   call_indirect            
-        163   store_var 5              (_35)
-        164   jump +45                 (to 209)
-        165   load_var 4               (_4)
-        166   make_bound_method 581    
-        167   call_indirect            
-        168   store_var 5              (_35)
-        169   jump +40                 (to 209)
-        170   load_type 11             
-        171   load_type 12             
-        172   load_type 12             
-        173   load_var 4               (_4)
-        174   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        175   store_var 5              (_35)
-        176   jump +33                 (to 209)
-        177   load_var 4               (_4)
-        178   make_bound_method 517    
-        179   call_indirect            
-        180   store_var 5              (_35)
-        181   jump +28                 (to 209)
-        182   load_type 11             
-        183   load_var 4               (_4)
-        184   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        185   store_var 5              (_35)
-        186   jump +23                 (to 209)
-        187   load_type 11             
-        188   load_type 12             
-        189   load_type 12             
-        190   load_var 4               (_4)
-        191   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        192   store_var 5              (_35)
-        193   jump +16                 (to 209)
-        194   load_type 11             
-        195   load_type 12             
-        196   load_var 4               (_4)
-        197   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        198   store_var 5              (_35)
-        199   jump +10                 (to 209)
-        200   load_type 11             
-        201   load_var 4               (_4)
-        202   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        203   store_var 5              (_35)
-        204   jump +5                  (to 209)
-        205   load_var 4               (_4)
-        206   make_bound_method 552    
-        207   call_indirect            
-        208   store_var 5              (_35)
-        209   load_var 5               (_35)
-        210   is_type 13               
-        211   pop_jump_if_false +2     (to 213)
-        212   jump +37                 (to 249)
-        213   load_var 5               (_35)
-        214   store_var_load_var 6     (ts)
+        89    load_var 4               (_4)
+        90    call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        91    store_var 5              (_6)
+        92    jump +10                 (to 102)
+        93    load_type 0              
+        94    load_var 4               (_4)
+        95    call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        96    store_var 5              (_6)
+        97    jump +5                  (to 102)
+        98    load_var 4               (_4)
+        99    make_bound_method 560    
+        100   call_indirect            
+        101   store_var 5              (_6)
+        102   load_var 5               (_6)
+        103   is_type 12               
+        104   pop_jump_if_false +2     (to 106)
+        105   jump +37                 (to 142)
+        106   load_var 5               (_6)
+        107   store_var_load_var 6     (ts)
 
-  158   215   load_field 0             (name)
-        216   load_var 2               (name)
-        217   cmp_op ==                
-        218   pop_jump_if_false -103   (to 115)
+  158   108   load_field 0             (name)
+        109   load_var 2               (name)
+        110   cmp_op ==                
+        111   pop_jump_if_false -103   (to 8)
 
-  159   219   call 301 ntypeargs=0     (baml.sys.now_ms)
-        220   store_var 7              (start)
+  159   112   call 309 ntypeargs=0     (baml.sys.now_ms)
+        113   store_var 7              (start)
 
-  160   221   load_var 2               (name)
-        222   alloc_array 0            
-        223   alloc_array 0            
-        224   init_instance 0          (testing.TestCollector .prefix, .tests, .testsets)
-        225   store_var_load_var 8     (sub_collector)
+  160   114   load_var 2               (name)
+        115   alloc_array 0            
+        116   alloc_array 0            
+        117   init_instance 0          (testing.TestCollector .prefix, .tests, .testsets)
+        118   store_var_load_var 8     (sub_collector)
 
-  161   226   load_var 6               (ts)
-        227   load_field 1             (collector)
-        228   call_indirect            
-        229   pop 1                    
+  161   119   load_var 6               (ts)
+        120   load_field 1             (collector)
+        121   call_indirect            
+        122   pop 1                    
 
-  162   230   call 301 ntypeargs=0     (baml.sys.now_ms)
-        231   load_var 7               (start)
-        232   sub_int                  
-        233   store_var 9              (elapsed)
+  162   123   call 309 ntypeargs=0     (baml.sys.now_ms)
+        124   load_var 7               (start)
+        125   sub_int                  
+        126   store_var 9              (elapsed)
 
-  164   234   load_var 8               (sub_collector)
+  164   127   load_var 8               (sub_collector)
 
-  165   235   alloc_map 0              
+  165   128   alloc_map 0              
 
-  166   236   load_var 9               (elapsed)
-        237   init_instance 1          (testing.TestRegistry .collector, .expansions, .loading_time_ms)
-        238   store_var 10             (sub_registry)
+  166   129   load_var 9               (elapsed)
+        130   init_instance 1          (testing.TestRegistry .collector, .expansions, .loading_time_ms)
+        131   store_var 10             (sub_registry)
 
-  168   239   load_type 14             
-        240   load_type 15             
-        241   load_var 1               (self)
-        242   load_field 1             (expansions)
-        243   load_var2 2 10           
-        244   call 22 ntypeargs=2      (baml.Map.set)
-        245   pop 1                    
+  168   132   load_type 13             
+        133   load_type 14             
+        134   load_var 1               (self)
+        135   load_field 1             (expansions)
+        136   load_var2 2 10           
+        137   call 22 ntypeargs=2      (baml.Map.set)
+        138   pop 1                    
 
-  169   246   load_var 1               (self)
-        247   call 746 ntypeargs=0     (testing.TestRegistry.serialize)
-        248   jump +231                (to 479)
+  169   139   load_var 1               (self)
+        140   call 754 ntypeargs=0     (testing.TestRegistry.serialize)
+        141   jump +123                (to 264)
 
-  173   249   load_type 14             
-        250   load_type 15             
-        251   load_var 1               (self)
-        252   load_field 1             (expansions)
-        253   call 20 ntypeargs=2      (baml.Map.keys)
-        254   store_var 11             (_86)
+  173   142   load_type 13             
+        143   load_type 14             
+        144   load_var 1               (self)
+        145   load_field 1             (expansions)
+        146   call 20 ntypeargs=2      (baml.Map.keys)
+        147   store_var 11             (_57)
 
-  172   255   load_var 11              (_86)
-        256   is_type 16               
-        257   pop_jump_if_false +2     (to 259)
-        258   jump +105                (to 363)
-        259   load_var 11              (_86)
-        260   is_type 17               
-        261   pop_jump_if_false +2     (to 263)
-        262   jump +96                 (to 358)
-        263   load_var 11              (_86)
-        264   is_type 18               
-        265   pop_jump_if_false +2     (to 267)
-        266   jump +86                 (to 352)
-        267   load_var 11              (_86)
-        268   is_type 19               
-        269   pop_jump_if_false +2     (to 271)
-        270   jump +75                 (to 345)
-        271   load_var 11              (_86)
-        272   is_type 20               
-        273   pop_jump_if_false +2     (to 275)
-        274   jump +66                 (to 340)
-        275   load_var 11              (_86)
-        276   is_type 21               
-        277   pop_jump_if_false +2     (to 279)
-        278   jump +57                 (to 335)
-        279   load_var 11              (_86)
-        280   is_type 22               
-        281   pop_jump_if_false +2     (to 283)
-        282   jump +46                 (to 328)
-        283   load_var 11              (_86)
-        284   is_type 23               
-        285   pop_jump_if_false +2     (to 287)
-        286   jump +37                 (to 323)
-        287   load_var 11              (_86)
-        288   is_type 24               
-        289   pop_jump_if_false +2     (to 291)
-        290   jump +28                 (to 318)
-        291   load_var 11              (_86)
-        292   is_type 25               
-        293   pop_jump_if_false +2     (to 295)
-        294   jump +18                 (to 312)
-        295   load_var 11              (_86)
-        296   is_type 10               
-        297   pop_jump_if_false +2     (to 299)
-        298   jump +9                  (to 307)
-        299   load_var 11              (_86)
-        300   is_type 10               
-        301   pop_jump_if_false +183   (to 484)
-        302   load_type 14             
-        303   load_var 11              (_86)
-        304   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        305   store_var 12             (_90)
-        306   jump +61                 (to 367)
-        307   load_type 14             
-        308   load_var 11              (_86)
-        309   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        310   store_var 12             (_90)
-        311   jump +56                 (to 367)
-        312   load_type 14             
-        313   load_type 12             
-        314   load_var 11              (_86)
-        315   call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        316   store_var 12             (_90)
-        317   jump +50                 (to 367)
-        318   load_var 11              (_86)
-        319   make_bound_method 514    
-        320   call_indirect            
-        321   store_var 12             (_90)
-        322   jump +45                 (to 367)
-        323   load_var 11              (_86)
-        324   make_bound_method 527    
-        325   call_indirect            
-        326   store_var 12             (_90)
-        327   jump +40                 (to 367)
-        328   load_type 14             
-        329   load_type 12             
-        330   load_type 12             
-        331   load_var 11              (_86)
-        332   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        333   store_var 12             (_90)
-        334   jump +33                 (to 367)
-        335   load_var 11              (_86)
-        336   make_bound_method 557    
-        337   call_indirect            
-        338   store_var 12             (_90)
-        339   jump +28                 (to 367)
-        340   load_type 14             
-        341   load_var 11              (_86)
-        342   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        343   store_var 12             (_90)
-        344   jump +23                 (to 367)
-        345   load_type 14             
-        346   load_type 12             
-        347   load_type 12             
-        348   load_var 11              (_86)
-        349   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        350   store_var 12             (_90)
-        351   jump +16                 (to 367)
-        352   load_type 14             
-        353   load_type 12             
-        354   load_var 11              (_86)
-        355   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        356   store_var 12             (_90)
-        357   jump +10                 (to 367)
-        358   load_type 14             
-        359   load_var 11              (_86)
-        360   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        361   store_var 12             (_90)
-        362   jump +5                  (to 367)
-        363   load_var 11              (_86)
-        364   make_bound_method 588    
-        365   call_indirect            
-        366   store_var 12             (_90)
-        367   load_var 12              (_90)
-        368   is_type 16               
-        369   pop_jump_if_false +2     (to 371)
-        370   jump +87                 (to 457)
-        371   load_var 12              (_90)
-        372   is_type 17               
-        373   pop_jump_if_false +2     (to 375)
-        374   jump +78                 (to 452)
-        375   load_var 12              (_90)
-        376   is_type 18               
-        377   pop_jump_if_false +2     (to 379)
-        378   jump +68                 (to 446)
-        379   load_var 12              (_90)
-        380   is_type 19               
-        381   pop_jump_if_false +2     (to 383)
-        382   jump +57                 (to 439)
-        383   load_var 12              (_90)
-        384   is_type 20               
-        385   pop_jump_if_false +2     (to 387)
-        386   jump +48                 (to 434)
-        387   load_var 12              (_90)
-        388   is_type 21               
-        389   pop_jump_if_false +2     (to 391)
-        390   jump +39                 (to 429)
-        391   load_var 12              (_90)
-        392   is_type 22               
-        393   pop_jump_if_false +2     (to 395)
-        394   jump +28                 (to 422)
-        395   load_var 12              (_90)
-        396   is_type 23               
-        397   pop_jump_if_false +2     (to 399)
-        398   jump +19                 (to 417)
-        399   load_var 12              (_90)
-        400   is_type 24               
-        401   pop_jump_if_false +2     (to 403)
-        402   jump +10                 (to 412)
-        403   load_var 12              (_90)
-        404   is_type 25               
-        405   pop_jump_if_false +79    (to 484)
-        406   load_type 14             
-        407   load_type 12             
-        408   load_var 12              (_90)
-        409   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        410   store_var 13             (_121)
-        411   jump +50                 (to 461)
-        412   load_var 12              (_90)
-        413   make_bound_method 568    
-        414   call_indirect            
-        415   store_var 13             (_121)
-        416   jump +45                 (to 461)
-        417   load_var 12              (_90)
-        418   make_bound_method 581    
-        419   call_indirect            
-        420   store_var 13             (_121)
-        421   jump +40                 (to 461)
-        422   load_type 14             
-        423   load_type 12             
-        424   load_type 12             
-        425   load_var 12              (_90)
-        426   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        427   store_var 13             (_121)
-        428   jump +33                 (to 461)
-        429   load_var 12              (_90)
-        430   make_bound_method 517    
-        431   call_indirect            
-        432   store_var 13             (_121)
-        433   jump +28                 (to 461)
-        434   load_type 14             
-        435   load_var 12              (_90)
-        436   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        437   store_var 13             (_121)
-        438   jump +23                 (to 461)
-        439   load_type 14             
-        440   load_type 12             
-        441   load_type 12             
-        442   load_var 12              (_90)
-        443   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        444   store_var 13             (_121)
-        445   jump +16                 (to 461)
-        446   load_type 14             
-        447   load_type 12             
-        448   load_var 12              (_90)
-        449   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        450   store_var 13             (_121)
-        451   jump +10                 (to 461)
-        452   load_type 14             
-        453   load_var 12              (_90)
-        454   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        455   store_var 13             (_121)
-        456   jump +5                  (to 461)
-        457   load_var 12              (_90)
-        458   make_bound_method 552    
-        459   call_indirect            
-        460   store_var 13             (_121)
-        461   load_var 13              (_121)
-        462   is_type 13               
-        463   pop_jump_if_false +2     (to 465)
-        464   jump +16                 (to 480)
-        465   load_var 13              (_121)
-        466   store_var 14             (k)
+  172   148   load_type 13             
+        149   load_var 11              (_57)
+        150   call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        151   store_var 12             (_61)
+        152   load_var 12              (_61)
+        153   is_type 15               
+        154   pop_jump_if_false +2     (to 156)
+        155   jump +87                 (to 242)
+        156   load_var 12              (_61)
+        157   is_type 16               
+        158   pop_jump_if_false +2     (to 160)
+        159   jump +78                 (to 237)
+        160   load_var 12              (_61)
+        161   is_type 17               
+        162   pop_jump_if_false +2     (to 164)
+        163   jump +68                 (to 231)
+        164   load_var 12              (_61)
+        165   is_type 18               
+        166   pop_jump_if_false +2     (to 168)
+        167   jump +57                 (to 224)
+        168   load_var 12              (_61)
+        169   is_type 19               
+        170   pop_jump_if_false +2     (to 172)
+        171   jump +48                 (to 219)
+        172   load_var 12              (_61)
+        173   is_type 20               
+        174   pop_jump_if_false +2     (to 176)
+        175   jump +39                 (to 214)
+        176   load_var 12              (_61)
+        177   is_type 21               
+        178   pop_jump_if_false +2     (to 180)
+        179   jump +28                 (to 207)
+        180   load_var 12              (_61)
+        181   is_type 22               
+        182   pop_jump_if_false +2     (to 184)
+        183   jump +19                 (to 202)
+        184   load_var 12              (_61)
+        185   is_type 23               
+        186   pop_jump_if_false +2     (to 188)
+        187   jump +10                 (to 197)
+        188   load_var 12              (_61)
+        189   is_type 24               
+        190   pop_jump_if_false +79    (to 269)
+        191   load_type 13             
+        192   load_type 11             
+        193   load_var 12              (_61)
+        194   call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        195   store_var 13             (_63)
+        196   jump +50                 (to 246)
+        197   load_var 12              (_61)
+        198   make_bound_method 576    
+        199   call_indirect            
+        200   store_var 13             (_63)
+        201   jump +45                 (to 246)
+        202   load_var 12              (_61)
+        203   make_bound_method 589    
+        204   call_indirect            
+        205   store_var 13             (_63)
+        206   jump +40                 (to 246)
+        207   load_type 13             
+        208   load_type 11             
+        209   load_type 11             
+        210   load_var 12              (_61)
+        211   call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        212   store_var 13             (_63)
+        213   jump +33                 (to 246)
+        214   load_var 12              (_61)
+        215   make_bound_method 525    
+        216   call_indirect            
+        217   store_var 13             (_63)
+        218   jump +28                 (to 246)
+        219   load_type 13             
+        220   load_var 12              (_61)
+        221   call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        222   store_var 13             (_63)
+        223   jump +23                 (to 246)
+        224   load_type 13             
+        225   load_type 11             
+        226   load_type 11             
+        227   load_var 12              (_61)
+        228   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        229   store_var 13             (_63)
+        230   jump +16                 (to 246)
+        231   load_type 13             
+        232   load_type 11             
+        233   load_var 12              (_61)
+        234   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        235   store_var 13             (_63)
+        236   jump +10                 (to 246)
+        237   load_type 13             
+        238   load_var 12              (_61)
+        239   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        240   store_var 13             (_63)
+        241   jump +5                  (to 246)
+        242   load_var 12              (_61)
+        243   make_bound_method 560    
+        244   call_indirect            
+        245   store_var 13             (_63)
+        246   load_var 13              (_63)
+        247   is_type 12               
+        248   pop_jump_if_false +2     (to 250)
+        249   jump +16                 (to 265)
+        250   load_var 13              (_63)
+        251   store_var 14             (k)
 
-  174   467   load_var 1               (self)
-        468   load_field 1             (expansions)
-        469   load_var 14              (k)
-        470   load_map_element         
-        471   store_var 15             (sub)
+  174   252   load_var 1               (self)
+        253   load_field 1             (expansions)
+        254   load_var 14              (k)
+        255   load_map_element         
+        256   store_var 15             (sub)
 
-  175   472   load_var2 2 14           
-        473   load_const 26            ("/")
-        474   bin_op +                 
-        475   call 152 ntypeargs=0     (baml.String.starts_with)
-        476   pop_jump_if_false -109   (to 367)
+  175   257   load_var2 2 14           
+        258   load_const 25            ("/")
+        259   bin_op +                 
+        260   call 160 ntypeargs=0     (baml.String.starts_with)
+        261   pop_jump_if_false -109   (to 152)
 
-  176   477   load_var2 15 2           
-        478   call 751 ntypeargs=0     (testing.TestRegistry.expand_set)
-        479   return                   
+  176   262   load_var2 15 2           
+        263   call 759 ntypeargs=0     (testing.TestRegistry.expand_set)
+        264   return                   
 
-  179   480   load_const 27            ("TestSet not found for expansion: ")
-        481   load_var 2               (name)
-        482   bin_op +                 
-        483   throw                    
-        484   unreachable              
+  179   265   load_const 26            ("TestSet not found for expansion: ")
+        266   load_var 2               (name)
+        267   bin_op +                 
+        268   throw                    
+        269   unreachable              
 }
 
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
   93   0    load_var 1             (j)
        1    load_const 0           ("collector")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("expansions")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loading_time_ms")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -1659,474 +1123,259 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
   137   0     load_var 1               (self)
         1     load_field 0             (collector)
         2     load_field 1             (tests)
-        3     store_var_load_var 3     (_3)
+        3     store_var 3              (_3)
 
-  136   4     is_type 0                
-        5     pop_jump_if_false +2     (to 7)
-        6     jump +105                (to 111)
-        7     load_var 3               (_3)
-        8     is_type 1                
-        9     pop_jump_if_false +2     (to 11)
-        10    jump +96                 (to 106)
-        11    load_var 3               (_3)
-        12    is_type 2                
-        13    pop_jump_if_false +2     (to 15)
-        14    jump +86                 (to 100)
-        15    load_var 3               (_3)
-        16    is_type 3                
-        17    pop_jump_if_false +2     (to 19)
-        18    jump +75                 (to 93)
-        19    load_var 3               (_3)
-        20    is_type 4                
-        21    pop_jump_if_false +2     (to 23)
-        22    jump +66                 (to 88)
-        23    load_var 3               (_3)
-        24    is_type 5                
-        25    pop_jump_if_false +2     (to 27)
-        26    jump +57                 (to 83)
-        27    load_var 3               (_3)
-        28    is_type 6                
-        29    pop_jump_if_false +2     (to 31)
-        30    jump +46                 (to 76)
-        31    load_var 3               (_3)
-        32    is_type 7                
-        33    pop_jump_if_false +2     (to 35)
-        34    jump +37                 (to 71)
-        35    load_var 3               (_3)
-        36    is_type 8                
-        37    pop_jump_if_false +2     (to 39)
-        38    jump +28                 (to 66)
-        39    load_var 3               (_3)
-        40    is_type 9                
-        41    pop_jump_if_false +2     (to 43)
-        42    jump +18                 (to 60)
-        43    load_var 3               (_3)
-        44    is_type 10               
-        45    pop_jump_if_false +2     (to 47)
-        46    jump +9                  (to 55)
-        47    load_var 3               (_3)
-        48    is_type 10               
-        49    pop_jump_if_false +411   (to 460)
-        50    load_type 11             
-        51    load_var 3               (_3)
-        52    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        53    store_var 4              (_4)
-        54    jump +61                 (to 115)
-        55    load_type 11             
-        56    load_var 3               (_3)
-        57    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        58    store_var 4              (_4)
-        59    jump +56                 (to 115)
-        60    load_type 11             
-        61    load_type 12             
-        62    load_var 3               (_3)
-        63    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        64    store_var 4              (_4)
-        65    jump +50                 (to 115)
-        66    load_var 3               (_3)
-        67    make_bound_method 514    
-        68    call_indirect            
-        69    store_var 4              (_4)
-        70    jump +45                 (to 115)
-        71    load_var 3               (_3)
-        72    make_bound_method 527    
-        73    call_indirect            
-        74    store_var 4              (_4)
-        75    jump +40                 (to 115)
-        76    load_type 11             
-        77    load_type 12             
-        78    load_type 12             
-        79    load_var 3               (_3)
-        80    call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        81    store_var 4              (_4)
-        82    jump +33                 (to 115)
-        83    load_var 3               (_3)
-        84    make_bound_method 557    
-        85    call_indirect            
-        86    store_var 4              (_4)
-        87    jump +28                 (to 115)
+  136   4     load_type 0              
+        5     load_var 3               (_3)
+        6     call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        7     store_var 4              (_4)
+        8     load_var 4               (_4)
+        9     is_type 1                
+        10    pop_jump_if_false +2     (to 12)
+        11    jump +87                 (to 98)
+        12    load_var 4               (_4)
+        13    is_type 2                
+        14    pop_jump_if_false +2     (to 16)
+        15    jump +78                 (to 93)
+        16    load_var 4               (_4)
+        17    is_type 3                
+        18    pop_jump_if_false +2     (to 20)
+        19    jump +68                 (to 87)
+        20    load_var 4               (_4)
+        21    is_type 4                
+        22    pop_jump_if_false +2     (to 24)
+        23    jump +57                 (to 80)
+        24    load_var 4               (_4)
+        25    is_type 5                
+        26    pop_jump_if_false +2     (to 28)
+        27    jump +48                 (to 75)
+        28    load_var 4               (_4)
+        29    is_type 6                
+        30    pop_jump_if_false +2     (to 32)
+        31    jump +39                 (to 70)
+        32    load_var 4               (_4)
+        33    is_type 7                
+        34    pop_jump_if_false +2     (to 36)
+        35    jump +28                 (to 63)
+        36    load_var 4               (_4)
+        37    is_type 8                
+        38    pop_jump_if_false +2     (to 40)
+        39    jump +19                 (to 58)
+        40    load_var 4               (_4)
+        41    is_type 9                
+        42    pop_jump_if_false +2     (to 44)
+        43    jump +10                 (to 53)
+        44    load_var 4               (_4)
+        45    is_type 10               
+        46    pop_jump_if_false +199   (to 245)
+        47    load_type 0              
+        48    load_type 11             
+        49    load_var 4               (_4)
+        50    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        51    store_var 5              (_6)
+        52    jump +50                 (to 102)
+        53    load_var 4               (_4)
+        54    make_bound_method 576    
+        55    call_indirect            
+        56    store_var 5              (_6)
+        57    jump +45                 (to 102)
+        58    load_var 4               (_4)
+        59    make_bound_method 589    
+        60    call_indirect            
+        61    store_var 5              (_6)
+        62    jump +40                 (to 102)
+        63    load_type 0              
+        64    load_type 11             
+        65    load_type 11             
+        66    load_var 4               (_4)
+        67    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        68    store_var 5              (_6)
+        69    jump +33                 (to 102)
+        70    load_var 4               (_4)
+        71    make_bound_method 525    
+        72    call_indirect            
+        73    store_var 5              (_6)
+        74    jump +28                 (to 102)
+        75    load_type 0              
+        76    load_var 4               (_4)
+        77    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        78    store_var 5              (_6)
+        79    jump +23                 (to 102)
+        80    load_type 0              
+        81    load_type 11             
+        82    load_type 11             
+        83    load_var 4               (_4)
+        84    call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        85    store_var 5              (_6)
+        86    jump +16                 (to 102)
+        87    load_type 0              
         88    load_type 11             
-        89    load_var 3               (_3)
-        90    call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        91    store_var 4              (_4)
-        92    jump +23                 (to 115)
-        93    load_type 11             
-        94    load_type 12             
-        95    load_type 12             
-        96    load_var 3               (_3)
-        97    call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        98    store_var 4              (_4)
-        99    jump +16                 (to 115)
-        100   load_type 11             
-        101   load_type 12             
-        102   load_var 3               (_3)
-        103   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        104   store_var 4              (_4)
-        105   jump +10                 (to 115)
-        106   load_type 11             
-        107   load_var 3               (_3)
-        108   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        109   store_var 4              (_4)
-        110   jump +5                  (to 115)
-        111   load_var 3               (_3)
-        112   make_bound_method 588    
-        113   call_indirect            
-        114   store_var 4              (_4)
-        115   load_var 4               (_4)
-        116   is_type 0                
-        117   pop_jump_if_false +2     (to 119)
-        118   jump +87                 (to 205)
-        119   load_var 4               (_4)
-        120   is_type 1                
-        121   pop_jump_if_false +2     (to 123)
-        122   jump +78                 (to 200)
-        123   load_var 4               (_4)
-        124   is_type 2                
-        125   pop_jump_if_false +2     (to 127)
-        126   jump +68                 (to 194)
-        127   load_var 4               (_4)
-        128   is_type 3                
-        129   pop_jump_if_false +2     (to 131)
-        130   jump +57                 (to 187)
-        131   load_var 4               (_4)
-        132   is_type 4                
-        133   pop_jump_if_false +2     (to 135)
-        134   jump +48                 (to 182)
-        135   load_var 4               (_4)
-        136   is_type 5                
-        137   pop_jump_if_false +2     (to 139)
-        138   jump +39                 (to 177)
-        139   load_var 4               (_4)
-        140   is_type 6                
-        141   pop_jump_if_false +2     (to 143)
-        142   jump +28                 (to 170)
-        143   load_var 4               (_4)
-        144   is_type 7                
-        145   pop_jump_if_false +2     (to 147)
-        146   jump +19                 (to 165)
-        147   load_var 4               (_4)
-        148   is_type 8                
-        149   pop_jump_if_false +2     (to 151)
-        150   jump +10                 (to 160)
-        151   load_var 4               (_4)
-        152   is_type 9                
-        153   pop_jump_if_false +307   (to 460)
-        154   load_type 11             
-        155   load_type 12             
-        156   load_var 4               (_4)
-        157   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        158   store_var 5              (_35)
-        159   jump +50                 (to 209)
-        160   load_var 4               (_4)
-        161   make_bound_method 568    
-        162   call_indirect            
-        163   store_var 5              (_35)
-        164   jump +45                 (to 209)
-        165   load_var 4               (_4)
-        166   make_bound_method 581    
-        167   call_indirect            
-        168   store_var 5              (_35)
-        169   jump +40                 (to 209)
-        170   load_type 11             
-        171   load_type 12             
-        172   load_type 12             
-        173   load_var 4               (_4)
-        174   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        175   store_var 5              (_35)
-        176   jump +33                 (to 209)
-        177   load_var 4               (_4)
-        178   make_bound_method 517    
-        179   call_indirect            
-        180   store_var 5              (_35)
-        181   jump +28                 (to 209)
-        182   load_type 11             
-        183   load_var 4               (_4)
-        184   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        185   store_var 5              (_35)
-        186   jump +23                 (to 209)
-        187   load_type 11             
-        188   load_type 12             
-        189   load_type 12             
-        190   load_var 4               (_4)
-        191   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        192   store_var 5              (_35)
-        193   jump +16                 (to 209)
-        194   load_type 11             
-        195   load_type 12             
-        196   load_var 4               (_4)
-        197   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        198   store_var 5              (_35)
-        199   jump +10                 (to 209)
-        200   load_type 11             
-        201   load_var 4               (_4)
-        202   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        203   store_var 5              (_35)
-        204   jump +5                  (to 209)
-        205   load_var 4               (_4)
-        206   make_bound_method 552    
-        207   call_indirect            
-        208   store_var 5              (_35)
-        209   load_var 5               (_35)
-        210   is_type 13               
-        211   pop_jump_if_false +2     (to 213)
-        212   jump +13                 (to 225)
-        213   load_var 5               (_35)
-        214   store_var_load_var 6     (t)
+        89    load_var 4               (_4)
+        90    call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        91    store_var 5              (_6)
+        92    jump +10                 (to 102)
+        93    load_type 0              
+        94    load_var 4               (_4)
+        95    call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        96    store_var 5              (_6)
+        97    jump +5                  (to 102)
+        98    load_var 4               (_4)
+        99    make_bound_method 560    
+        100   call_indirect            
+        101   store_var 5              (_6)
+        102   load_var 5               (_6)
+        103   is_type 12               
+        104   pop_jump_if_false +2     (to 106)
+        105   jump +13                 (to 118)
+        106   load_var 5               (_6)
+        107   store_var_load_var 6     (t)
 
-  138   215   load_field 0             (name)
-        216   load_var 2               (name)
-        217   cmp_op ==                
-        218   pop_jump_if_false -103   (to 115)
+  138   108   load_field 0             (name)
+        109   load_var 2               (name)
+        110   cmp_op ==                
+        111   pop_jump_if_false -103   (to 8)
 
-  139   219   load_var 6               (t)
-        220   load_field 1             (body)
-        221   load_var 6               (t)
-        222   load_field 2             (runner)
-        223   call 757 ntypeargs=0     (testing.run_test)
-        224   jump +231                (to 455)
+  139   112   load_var 6               (t)
+        113   load_field 1             (body)
+        114   load_var 6               (t)
+        115   load_field 2             (runner)
+        116   call 765 ntypeargs=0     (testing.run_test)
+        117   jump +123                (to 240)
 
-  143   225   load_type 14             
-        226   load_type 15             
-        227   load_var 1               (self)
-        228   load_field 1             (expansions)
-        229   call 20 ntypeargs=2      (baml.Map.keys)
-        230   store_var 7              (_69)
+  143   118   load_type 13             
+        119   load_type 14             
+        120   load_var 1               (self)
+        121   load_field 1             (expansions)
+        122   call 20 ntypeargs=2      (baml.Map.keys)
+        123   store_var 7              (_40)
 
-  142   231   load_var 7               (_69)
-        232   is_type 16               
-        233   pop_jump_if_false +2     (to 235)
-        234   jump +105                (to 339)
-        235   load_var 7               (_69)
-        236   is_type 17               
-        237   pop_jump_if_false +2     (to 239)
-        238   jump +96                 (to 334)
-        239   load_var 7               (_69)
-        240   is_type 18               
-        241   pop_jump_if_false +2     (to 243)
-        242   jump +86                 (to 328)
-        243   load_var 7               (_69)
-        244   is_type 19               
-        245   pop_jump_if_false +2     (to 247)
-        246   jump +75                 (to 321)
-        247   load_var 7               (_69)
-        248   is_type 20               
-        249   pop_jump_if_false +2     (to 251)
-        250   jump +66                 (to 316)
-        251   load_var 7               (_69)
-        252   is_type 21               
-        253   pop_jump_if_false +2     (to 255)
-        254   jump +57                 (to 311)
-        255   load_var 7               (_69)
-        256   is_type 22               
-        257   pop_jump_if_false +2     (to 259)
-        258   jump +46                 (to 304)
-        259   load_var 7               (_69)
-        260   is_type 23               
-        261   pop_jump_if_false +2     (to 263)
-        262   jump +37                 (to 299)
-        263   load_var 7               (_69)
-        264   is_type 24               
-        265   pop_jump_if_false +2     (to 267)
-        266   jump +28                 (to 294)
-        267   load_var 7               (_69)
-        268   is_type 25               
-        269   pop_jump_if_false +2     (to 271)
-        270   jump +18                 (to 288)
-        271   load_var 7               (_69)
-        272   is_type 10               
-        273   pop_jump_if_false +2     (to 275)
-        274   jump +9                  (to 283)
-        275   load_var 7               (_69)
-        276   is_type 10               
-        277   pop_jump_if_false +183   (to 460)
-        278   load_type 14             
-        279   load_var 7               (_69)
-        280   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        281   store_var 8              (_73)
-        282   jump +61                 (to 343)
-        283   load_type 14             
-        284   load_var 7               (_69)
-        285   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        286   store_var 8              (_73)
-        287   jump +56                 (to 343)
-        288   load_type 14             
-        289   load_type 12             
-        290   load_var 7               (_69)
-        291   call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        292   store_var 8              (_73)
-        293   jump +50                 (to 343)
-        294   load_var 7               (_69)
-        295   make_bound_method 514    
-        296   call_indirect            
-        297   store_var 8              (_73)
-        298   jump +45                 (to 343)
-        299   load_var 7               (_69)
-        300   make_bound_method 527    
-        301   call_indirect            
-        302   store_var 8              (_73)
-        303   jump +40                 (to 343)
-        304   load_type 14             
-        305   load_type 12             
-        306   load_type 12             
-        307   load_var 7               (_69)
-        308   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        309   store_var 8              (_73)
-        310   jump +33                 (to 343)
-        311   load_var 7               (_69)
-        312   make_bound_method 557    
-        313   call_indirect            
-        314   store_var 8              (_73)
-        315   jump +28                 (to 343)
-        316   load_type 14             
-        317   load_var 7               (_69)
-        318   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        319   store_var 8              (_73)
-        320   jump +23                 (to 343)
-        321   load_type 14             
-        322   load_type 12             
-        323   load_type 12             
-        324   load_var 7               (_69)
-        325   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        326   store_var 8              (_73)
-        327   jump +16                 (to 343)
-        328   load_type 14             
-        329   load_type 12             
-        330   load_var 7               (_69)
-        331   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        332   store_var 8              (_73)
-        333   jump +10                 (to 343)
-        334   load_type 14             
-        335   load_var 7               (_69)
-        336   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        337   store_var 8              (_73)
-        338   jump +5                  (to 343)
-        339   load_var 7               (_69)
-        340   make_bound_method 588    
-        341   call_indirect            
-        342   store_var 8              (_73)
-        343   load_var 8               (_73)
-        344   is_type 16               
-        345   pop_jump_if_false +2     (to 347)
-        346   jump +87                 (to 433)
-        347   load_var 8               (_73)
-        348   is_type 17               
-        349   pop_jump_if_false +2     (to 351)
-        350   jump +78                 (to 428)
-        351   load_var 8               (_73)
-        352   is_type 18               
-        353   pop_jump_if_false +2     (to 355)
-        354   jump +68                 (to 422)
-        355   load_var 8               (_73)
-        356   is_type 19               
-        357   pop_jump_if_false +2     (to 359)
-        358   jump +57                 (to 415)
-        359   load_var 8               (_73)
-        360   is_type 20               
-        361   pop_jump_if_false +2     (to 363)
-        362   jump +48                 (to 410)
-        363   load_var 8               (_73)
-        364   is_type 21               
-        365   pop_jump_if_false +2     (to 367)
-        366   jump +39                 (to 405)
-        367   load_var 8               (_73)
-        368   is_type 22               
-        369   pop_jump_if_false +2     (to 371)
-        370   jump +28                 (to 398)
-        371   load_var 8               (_73)
-        372   is_type 23               
-        373   pop_jump_if_false +2     (to 375)
-        374   jump +19                 (to 393)
-        375   load_var 8               (_73)
-        376   is_type 24               
-        377   pop_jump_if_false +2     (to 379)
-        378   jump +10                 (to 388)
-        379   load_var 8               (_73)
-        380   is_type 25               
-        381   pop_jump_if_false +79    (to 460)
-        382   load_type 14             
-        383   load_type 12             
-        384   load_var 8               (_73)
-        385   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        386   store_var 9              (_104)
-        387   jump +50                 (to 437)
-        388   load_var 8               (_73)
-        389   make_bound_method 568    
-        390   call_indirect            
-        391   store_var 9              (_104)
-        392   jump +45                 (to 437)
-        393   load_var 8               (_73)
-        394   make_bound_method 581    
-        395   call_indirect            
-        396   store_var 9              (_104)
-        397   jump +40                 (to 437)
-        398   load_type 14             
-        399   load_type 12             
-        400   load_type 12             
-        401   load_var 8               (_73)
-        402   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        403   store_var 9              (_104)
-        404   jump +33                 (to 437)
-        405   load_var 8               (_73)
-        406   make_bound_method 517    
-        407   call_indirect            
-        408   store_var 9              (_104)
-        409   jump +28                 (to 437)
-        410   load_type 14             
-        411   load_var 8               (_73)
-        412   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        413   store_var 9              (_104)
-        414   jump +23                 (to 437)
-        415   load_type 14             
-        416   load_type 12             
-        417   load_type 12             
-        418   load_var 8               (_73)
-        419   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        420   store_var 9              (_104)
-        421   jump +16                 (to 437)
-        422   load_type 14             
-        423   load_type 12             
-        424   load_var 8               (_73)
-        425   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        426   store_var 9              (_104)
-        427   jump +10                 (to 437)
-        428   load_type 14             
-        429   load_var 8               (_73)
-        430   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        431   store_var 9              (_104)
-        432   jump +5                  (to 437)
-        433   load_var 8               (_73)
-        434   make_bound_method 552    
-        435   call_indirect            
-        436   store_var 9              (_104)
-        437   load_var 9               (_104)
-        438   is_type 13               
-        439   pop_jump_if_false +2     (to 441)
-        440   jump +16                 (to 456)
-        441   load_var 9               (_104)
-        442   store_var 10             (k)
+  142   124   load_type 13             
+        125   load_var 7               (_40)
+        126   call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   store_var 8              (_44)
+        128   load_var 8               (_44)
+        129   is_type 15               
+        130   pop_jump_if_false +2     (to 132)
+        131   jump +87                 (to 218)
+        132   load_var 8               (_44)
+        133   is_type 16               
+        134   pop_jump_if_false +2     (to 136)
+        135   jump +78                 (to 213)
+        136   load_var 8               (_44)
+        137   is_type 17               
+        138   pop_jump_if_false +2     (to 140)
+        139   jump +68                 (to 207)
+        140   load_var 8               (_44)
+        141   is_type 18               
+        142   pop_jump_if_false +2     (to 144)
+        143   jump +57                 (to 200)
+        144   load_var 8               (_44)
+        145   is_type 19               
+        146   pop_jump_if_false +2     (to 148)
+        147   jump +48                 (to 195)
+        148   load_var 8               (_44)
+        149   is_type 20               
+        150   pop_jump_if_false +2     (to 152)
+        151   jump +39                 (to 190)
+        152   load_var 8               (_44)
+        153   is_type 21               
+        154   pop_jump_if_false +2     (to 156)
+        155   jump +28                 (to 183)
+        156   load_var 8               (_44)
+        157   is_type 22               
+        158   pop_jump_if_false +2     (to 160)
+        159   jump +19                 (to 178)
+        160   load_var 8               (_44)
+        161   is_type 23               
+        162   pop_jump_if_false +2     (to 164)
+        163   jump +10                 (to 173)
+        164   load_var 8               (_44)
+        165   is_type 24               
+        166   pop_jump_if_false +79    (to 245)
+        167   load_type 13             
+        168   load_type 11             
+        169   load_var 8               (_44)
+        170   call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   store_var 9              (_46)
+        172   jump +50                 (to 222)
+        173   load_var 8               (_44)
+        174   make_bound_method 576    
+        175   call_indirect            
+        176   store_var 9              (_46)
+        177   jump +45                 (to 222)
+        178   load_var 8               (_44)
+        179   make_bound_method 589    
+        180   call_indirect            
+        181   store_var 9              (_46)
+        182   jump +40                 (to 222)
+        183   load_type 13             
+        184   load_type 11             
+        185   load_type 11             
+        186   load_var 8               (_44)
+        187   call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   store_var 9              (_46)
+        189   jump +33                 (to 222)
+        190   load_var 8               (_44)
+        191   make_bound_method 525    
+        192   call_indirect            
+        193   store_var 9              (_46)
+        194   jump +28                 (to 222)
+        195   load_type 13             
+        196   load_var 8               (_44)
+        197   call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   store_var 9              (_46)
+        199   jump +23                 (to 222)
+        200   load_type 13             
+        201   load_type 11             
+        202   load_type 11             
+        203   load_var 8               (_44)
+        204   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   store_var 9              (_46)
+        206   jump +16                 (to 222)
+        207   load_type 13             
+        208   load_type 11             
+        209   load_var 8               (_44)
+        210   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   store_var 9              (_46)
+        212   jump +10                 (to 222)
+        213   load_type 13             
+        214   load_var 8               (_44)
+        215   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   store_var 9              (_46)
+        217   jump +5                  (to 222)
+        218   load_var 8               (_44)
+        219   make_bound_method 560    
+        220   call_indirect            
+        221   store_var 9              (_46)
+        222   load_var 9               (_46)
+        223   is_type 12               
+        224   pop_jump_if_false +2     (to 226)
+        225   jump +16                 (to 241)
+        226   load_var 9               (_46)
+        227   store_var 10             (k)
 
-  144   443   load_var 1               (self)
-        444   load_field 1             (expansions)
-        445   load_var 10              (k)
-        446   load_map_element         
-        447   store_var 11             (sub)
+  144   228   load_var 1               (self)
+        229   load_field 1             (expansions)
+        230   load_var 10              (k)
+        231   load_map_element         
+        232   store_var 11             (sub)
 
-  146   448   load_var2 2 10           
-        449   load_const 26            ("/")
-        450   bin_op +                 
-        451   call 152 ntypeargs=0     (baml.String.starts_with)
+  146   233   load_var2 2 10           
+        234   load_const 25            ("/")
+        235   bin_op +                 
+        236   call 160 ntypeargs=0     (baml.String.starts_with)
 
-  145   452   pop_jump_if_false -109   (to 343)
+  145   237   pop_jump_if_false -109   (to 128)
 
-  147   453   load_var2 11 2           
-        454   call 750 ntypeargs=0     (testing.TestRegistry.run_test)
-        455   return                   
+  147   238   load_var2 11 2           
+        239   call 758 ntypeargs=0     (testing.TestRegistry.run_test)
+        240   return                   
 
-  150   456   load_const 27            ("Test not found: ")
-        457   load_var 2               (name)
-        458   bin_op +                 
-        459   throw                    
-        460   unreachable              
+  150   241   load_const 26            ("Test not found: ")
+        242   load_var 2               (name)
+        243   bin_op +                 
+        244   throw                    
+        245   unreachable              
 }
 
 function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.SerializedTest | testing.SerializedTestSet)[] {
@@ -2136,498 +1385,284 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
   113   2     load_var 1               (self)
         3     load_field 0             (collector)
         4     load_field 1             (tests)
-        5     store_var_load_var 4     (_3)
-        6     is_type 0                
-        7     pop_jump_if_false +2     (to 9)
-        8     jump +105                (to 113)
-        9     load_var 4               (_3)
-        10    is_type 1                
-        11    pop_jump_if_false +2     (to 13)
-        12    jump +96                 (to 108)
-        13    load_var 4               (_3)
-        14    is_type 2                
-        15    pop_jump_if_false +2     (to 17)
-        16    jump +86                 (to 102)
-        17    load_var 4               (_3)
-        18    is_type 3                
-        19    pop_jump_if_false +2     (to 21)
-        20    jump +75                 (to 95)
-        21    load_var 4               (_3)
-        22    is_type 4                
-        23    pop_jump_if_false +2     (to 25)
-        24    jump +66                 (to 90)
-        25    load_var 4               (_3)
-        26    is_type 5                
-        27    pop_jump_if_false +2     (to 29)
-        28    jump +57                 (to 85)
-        29    load_var 4               (_3)
-        30    is_type 6                
-        31    pop_jump_if_false +2     (to 33)
-        32    jump +46                 (to 78)
-        33    load_var 4               (_3)
-        34    is_type 7                
-        35    pop_jump_if_false +2     (to 37)
-        36    jump +37                 (to 73)
-        37    load_var 4               (_3)
-        38    is_type 8                
-        39    pop_jump_if_false +2     (to 41)
-        40    jump +28                 (to 68)
-        41    load_var 4               (_3)
-        42    is_type 9                
-        43    pop_jump_if_false +2     (to 45)
-        44    jump +18                 (to 62)
-        45    load_var 4               (_3)
-        46    is_type 10               
-        47    pop_jump_if_false +2     (to 49)
-        48    jump +9                  (to 57)
-        49    load_var 4               (_3)
-        50    is_type 10               
-        51    pop_jump_if_false +428   (to 479)
-        52    load_type 11             
-        53    load_var 4               (_3)
-        54    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        55    store_var 5              (_4)
-        56    jump +61                 (to 117)
-        57    load_type 11             
-        58    load_var 4               (_3)
-        59    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        60    store_var 5              (_4)
-        61    jump +56                 (to 117)
-        62    load_type 11             
-        63    load_type 12             
-        64    load_var 4               (_3)
-        65    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        66    store_var 5              (_4)
-        67    jump +50                 (to 117)
-        68    load_var 4               (_3)
-        69    make_bound_method 514    
-        70    call_indirect            
-        71    store_var 5              (_4)
-        72    jump +45                 (to 117)
-        73    load_var 4               (_3)
-        74    make_bound_method 527    
-        75    call_indirect            
-        76    store_var 5              (_4)
-        77    jump +40                 (to 117)
-        78    load_type 11             
-        79    load_type 12             
-        80    load_type 12             
-        81    load_var 4               (_3)
-        82    call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        83    store_var 5              (_4)
-        84    jump +33                 (to 117)
-        85    load_var 4               (_3)
-        86    make_bound_method 557    
-        87    call_indirect            
-        88    store_var 5              (_4)
-        89    jump +28                 (to 117)
+        5     store_var 4              (_3)
+        6     load_type 0              
+        7     load_var 4               (_3)
+        8     call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     store_var 5              (_4)
+        10    load_var 5               (_4)
+        11    is_type 1                
+        12    pop_jump_if_false +2     (to 14)
+        13    jump +87                 (to 100)
+        14    load_var 5               (_4)
+        15    is_type 2                
+        16    pop_jump_if_false +2     (to 18)
+        17    jump +78                 (to 95)
+        18    load_var 5               (_4)
+        19    is_type 3                
+        20    pop_jump_if_false +2     (to 22)
+        21    jump +68                 (to 89)
+        22    load_var 5               (_4)
+        23    is_type 4                
+        24    pop_jump_if_false +2     (to 26)
+        25    jump +57                 (to 82)
+        26    load_var 5               (_4)
+        27    is_type 5                
+        28    pop_jump_if_false +2     (to 30)
+        29    jump +48                 (to 77)
+        30    load_var 5               (_4)
+        31    is_type 6                
+        32    pop_jump_if_false +2     (to 34)
+        33    jump +39                 (to 72)
+        34    load_var 5               (_4)
+        35    is_type 7                
+        36    pop_jump_if_false +2     (to 38)
+        37    jump +28                 (to 65)
+        38    load_var 5               (_4)
+        39    is_type 8                
+        40    pop_jump_if_false +2     (to 42)
+        41    jump +19                 (to 60)
+        42    load_var 5               (_4)
+        43    is_type 9                
+        44    pop_jump_if_false +2     (to 46)
+        45    jump +10                 (to 55)
+        46    load_var 5               (_4)
+        47    is_type 10               
+        48    pop_jump_if_false +217   (to 265)
+        49    load_type 0              
+        50    load_type 11             
+        51    load_var 5               (_4)
+        52    call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    store_var 6              (_6)
+        54    jump +50                 (to 104)
+        55    load_var 5               (_4)
+        56    make_bound_method 576    
+        57    call_indirect            
+        58    store_var 6              (_6)
+        59    jump +45                 (to 104)
+        60    load_var 5               (_4)
+        61    make_bound_method 589    
+        62    call_indirect            
+        63    store_var 6              (_6)
+        64    jump +40                 (to 104)
+        65    load_type 0              
+        66    load_type 11             
+        67    load_type 11             
+        68    load_var 5               (_4)
+        69    call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    store_var 6              (_6)
+        71    jump +33                 (to 104)
+        72    load_var 5               (_4)
+        73    make_bound_method 525    
+        74    call_indirect            
+        75    store_var 6              (_6)
+        76    jump +28                 (to 104)
+        77    load_type 0              
+        78    load_var 5               (_4)
+        79    call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    store_var 6              (_6)
+        81    jump +23                 (to 104)
+        82    load_type 0              
+        83    load_type 11             
+        84    load_type 11             
+        85    load_var 5               (_4)
+        86    call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    store_var 6              (_6)
+        88    jump +16                 (to 104)
+        89    load_type 0              
         90    load_type 11             
-        91    load_var 4               (_3)
-        92    call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        93    store_var 5              (_4)
-        94    jump +23                 (to 117)
-        95    load_type 11             
-        96    load_type 12             
-        97    load_type 12             
-        98    load_var 4               (_3)
-        99    call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        100   store_var 5              (_4)
-        101   jump +16                 (to 117)
-        102   load_type 11             
-        103   load_type 12             
-        104   load_var 4               (_3)
-        105   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        106   store_var 5              (_4)
-        107   jump +10                 (to 117)
-        108   load_type 11             
-        109   load_var 4               (_3)
-        110   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        111   store_var 5              (_4)
-        112   jump +5                  (to 117)
-        113   load_var 4               (_3)
-        114   make_bound_method 588    
-        115   call_indirect            
-        116   store_var 5              (_4)
-        117   load_var 5               (_4)
-        118   is_type 0                
-        119   pop_jump_if_false +2     (to 121)
-        120   jump +87                 (to 207)
-        121   load_var 5               (_4)
-        122   is_type 1                
-        123   pop_jump_if_false +2     (to 125)
-        124   jump +78                 (to 202)
-        125   load_var 5               (_4)
-        126   is_type 2                
-        127   pop_jump_if_false +2     (to 129)
-        128   jump +68                 (to 196)
-        129   load_var 5               (_4)
-        130   is_type 3                
-        131   pop_jump_if_false +2     (to 133)
-        132   jump +57                 (to 189)
-        133   load_var 5               (_4)
-        134   is_type 4                
-        135   pop_jump_if_false +2     (to 137)
-        136   jump +48                 (to 184)
-        137   load_var 5               (_4)
-        138   is_type 5                
-        139   pop_jump_if_false +2     (to 141)
-        140   jump +39                 (to 179)
-        141   load_var 5               (_4)
-        142   is_type 6                
-        143   pop_jump_if_false +2     (to 145)
-        144   jump +28                 (to 172)
-        145   load_var 5               (_4)
-        146   is_type 7                
-        147   pop_jump_if_false +2     (to 149)
-        148   jump +19                 (to 167)
-        149   load_var 5               (_4)
-        150   is_type 8                
-        151   pop_jump_if_false +2     (to 153)
-        152   jump +10                 (to 162)
-        153   load_var 5               (_4)
-        154   is_type 9                
-        155   pop_jump_if_false +324   (to 479)
-        156   load_type 11             
-        157   load_type 12             
-        158   load_var 5               (_4)
-        159   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        160   store_var 6              (_35)
-        161   jump +50                 (to 211)
-        162   load_var 5               (_4)
-        163   make_bound_method 568    
-        164   call_indirect            
-        165   store_var 6              (_35)
-        166   jump +45                 (to 211)
-        167   load_var 5               (_4)
-        168   make_bound_method 581    
-        169   call_indirect            
-        170   store_var 6              (_35)
-        171   jump +40                 (to 211)
-        172   load_type 11             
-        173   load_type 12             
-        174   load_type 12             
-        175   load_var 5               (_4)
-        176   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        177   store_var 6              (_35)
-        178   jump +33                 (to 211)
-        179   load_var 5               (_4)
-        180   make_bound_method 517    
-        181   call_indirect            
-        182   store_var 6              (_35)
-        183   jump +28                 (to 211)
-        184   load_type 11             
-        185   load_var 5               (_4)
-        186   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        187   store_var 6              (_35)
-        188   jump +23                 (to 211)
-        189   load_type 11             
-        190   load_type 12             
-        191   load_type 12             
-        192   load_var 5               (_4)
-        193   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        194   store_var 6              (_35)
-        195   jump +16                 (to 211)
-        196   load_type 11             
-        197   load_type 12             
-        198   load_var 5               (_4)
-        199   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        200   store_var 6              (_35)
-        201   jump +10                 (to 211)
-        202   load_type 11             
-        203   load_var 5               (_4)
-        204   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        205   store_var 6              (_35)
-        206   jump +5                  (to 211)
-        207   load_var 5               (_4)
-        208   make_bound_method 552    
-        209   call_indirect            
-        210   store_var 6              (_35)
-        211   load_var 6               (_35)
-        212   is_type 13               
-        213   pop_jump_if_false +2     (to 215)
-        214   jump +11                 (to 225)
-        215   load_var 6               (_35)
-        216   store_var 7              (t)
+        91    load_var 5               (_4)
+        92    call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    store_var 6              (_6)
+        94    jump +10                 (to 104)
+        95    load_type 0              
+        96    load_var 5               (_4)
+        97    call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    store_var 6              (_6)
+        99    jump +5                  (to 104)
+        100   load_var 5               (_4)
+        101   make_bound_method 560    
+        102   call_indirect            
+        103   store_var 6              (_6)
+        104   load_var 6               (_6)
+        105   is_type 12               
+        106   pop_jump_if_false +2     (to 108)
+        107   jump +11                 (to 118)
+        108   load_var 6               (_6)
+        109   store_var 7              (t)
 
-  114   217   load_var 3               (items)
-        218   load_const 14            ("test")
-        219   load_var 7               (t)
-        220   load_field 0             (name)
-        221   init_instance 0          (testing.SerializedTest .type, .name)
-        222   call 17 ntypeargs=0      (baml.Array.push)
-        223   pop 1                    
-        224   jump -107                (to 117)
+  114   110   load_var 3               (items)
+        111   load_const 13            ("test")
+        112   load_var 7               (t)
+        113   load_field 0             (name)
+        114   init_instance 0          (testing.SerializedTest .type, .name)
+        115   call 17 ntypeargs=0      (baml.Array.push)
+        116   pop 1                    
+        117   jump -107                (to 10)
 
-  116   225   load_var 1               (self)
-        226   load_field 0             (collector)
-        227   load_field 2             (testsets)
-        228   store_var_load_var 8     (_68)
-        229   is_type 15               
-        230   pop_jump_if_false +2     (to 232)
-        231   jump +105                (to 336)
-        232   load_var 8               (_68)
-        233   is_type 16               
-        234   pop_jump_if_false +2     (to 236)
-        235   jump +96                 (to 331)
-        236   load_var 8               (_68)
-        237   is_type 17               
-        238   pop_jump_if_false +2     (to 240)
-        239   jump +86                 (to 325)
-        240   load_var 8               (_68)
-        241   is_type 18               
-        242   pop_jump_if_false +2     (to 244)
-        243   jump +75                 (to 318)
-        244   load_var 8               (_68)
-        245   is_type 19               
-        246   pop_jump_if_false +2     (to 248)
-        247   jump +66                 (to 313)
-        248   load_var 8               (_68)
-        249   is_type 20               
-        250   pop_jump_if_false +2     (to 252)
-        251   jump +57                 (to 308)
-        252   load_var 8               (_68)
-        253   is_type 21               
-        254   pop_jump_if_false +2     (to 256)
-        255   jump +46                 (to 301)
-        256   load_var 8               (_68)
-        257   is_type 22               
-        258   pop_jump_if_false +2     (to 260)
-        259   jump +37                 (to 296)
-        260   load_var 8               (_68)
-        261   is_type 23               
-        262   pop_jump_if_false +2     (to 264)
-        263   jump +28                 (to 291)
-        264   load_var 8               (_68)
-        265   is_type 24               
-        266   pop_jump_if_false +2     (to 268)
-        267   jump +18                 (to 285)
-        268   load_var 8               (_68)
-        269   is_type 10               
-        270   pop_jump_if_false +2     (to 272)
-        271   jump +9                  (to 280)
-        272   load_var 8               (_68)
-        273   is_type 10               
-        274   pop_jump_if_false +205   (to 479)
-        275   load_type 25             
-        276   load_var 8               (_68)
-        277   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        278   store_var 9              (_69)
-        279   jump +61                 (to 340)
-        280   load_type 25             
-        281   load_var 8               (_68)
-        282   call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-        283   store_var 9              (_69)
-        284   jump +56                 (to 340)
-        285   load_type 25             
-        286   load_type 12             
-        287   load_var 8               (_68)
-        288   call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-        289   store_var 9              (_69)
-        290   jump +50                 (to 340)
-        291   load_var 8               (_68)
-        292   make_bound_method 514    
-        293   call_indirect            
-        294   store_var 9              (_69)
-        295   jump +45                 (to 340)
-        296   load_var 8               (_68)
-        297   make_bound_method 527    
-        298   call_indirect            
-        299   store_var 9              (_69)
-        300   jump +40                 (to 340)
-        301   load_type 25             
-        302   load_type 12             
-        303   load_type 12             
-        304   load_var 8               (_68)
-        305   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-        306   store_var 9              (_69)
-        307   jump +33                 (to 340)
-        308   load_var 8               (_68)
-        309   make_bound_method 557    
-        310   call_indirect            
-        311   store_var 9              (_69)
-        312   jump +28                 (to 340)
-        313   load_type 25             
-        314   load_var 8               (_68)
-        315   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-        316   store_var 9              (_69)
-        317   jump +23                 (to 340)
-        318   load_type 25             
-        319   load_type 12             
-        320   load_type 12             
-        321   load_var 8               (_68)
-        322   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-        323   store_var 9              (_69)
-        324   jump +16                 (to 340)
-        325   load_type 25             
-        326   load_type 12             
-        327   load_var 8               (_68)
-        328   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-        329   store_var 9              (_69)
-        330   jump +10                 (to 340)
-        331   load_type 25             
-        332   load_var 8               (_68)
-        333   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-        334   store_var 9              (_69)
-        335   jump +5                  (to 340)
-        336   load_var 8               (_68)
-        337   make_bound_method 588    
-        338   call_indirect            
-        339   store_var 9              (_69)
-        340   load_var 9               (_69)
-        341   is_type 15               
-        342   pop_jump_if_false +2     (to 344)
-        343   jump +87                 (to 430)
-        344   load_var 9               (_69)
-        345   is_type 16               
-        346   pop_jump_if_false +2     (to 348)
-        347   jump +78                 (to 425)
-        348   load_var 9               (_69)
-        349   is_type 17               
-        350   pop_jump_if_false +2     (to 352)
-        351   jump +68                 (to 419)
-        352   load_var 9               (_69)
-        353   is_type 18               
-        354   pop_jump_if_false +2     (to 356)
-        355   jump +57                 (to 412)
-        356   load_var 9               (_69)
-        357   is_type 19               
-        358   pop_jump_if_false +2     (to 360)
-        359   jump +48                 (to 407)
-        360   load_var 9               (_69)
-        361   is_type 20               
-        362   pop_jump_if_false +2     (to 364)
-        363   jump +39                 (to 402)
-        364   load_var 9               (_69)
-        365   is_type 21               
-        366   pop_jump_if_false +2     (to 368)
-        367   jump +28                 (to 395)
-        368   load_var 9               (_69)
-        369   is_type 22               
-        370   pop_jump_if_false +2     (to 372)
-        371   jump +19                 (to 390)
-        372   load_var 9               (_69)
-        373   is_type 23               
-        374   pop_jump_if_false +2     (to 376)
-        375   jump +10                 (to 385)
-        376   load_var 9               (_69)
-        377   is_type 24               
-        378   pop_jump_if_false +101   (to 479)
-        379   load_type 25             
-        380   load_type 12             
-        381   load_var 9               (_69)
-        382   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-        383   store_var 10             (_100)
-        384   jump +50                 (to 434)
-        385   load_var 9               (_69)
-        386   make_bound_method 568    
-        387   call_indirect            
-        388   store_var 10             (_100)
-        389   jump +45                 (to 434)
-        390   load_var 9               (_69)
-        391   make_bound_method 581    
-        392   call_indirect            
-        393   store_var 10             (_100)
-        394   jump +40                 (to 434)
-        395   load_type 25             
-        396   load_type 12             
-        397   load_type 12             
-        398   load_var 9               (_69)
-        399   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-        400   store_var 10             (_100)
-        401   jump +33                 (to 434)
-        402   load_var 9               (_69)
-        403   make_bound_method 517    
-        404   call_indirect            
-        405   store_var 10             (_100)
-        406   jump +28                 (to 434)
-        407   load_type 25             
-        408   load_var 9               (_69)
-        409   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-        410   store_var 10             (_100)
-        411   jump +23                 (to 434)
-        412   load_type 25             
-        413   load_type 12             
-        414   load_type 12             
-        415   load_var 9               (_69)
-        416   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-        417   store_var 10             (_100)
-        418   jump +16                 (to 434)
-        419   load_type 25             
-        420   load_type 12             
-        421   load_var 9               (_69)
-        422   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-        423   store_var 10             (_100)
-        424   jump +10                 (to 434)
-        425   load_type 25             
-        426   load_var 9               (_69)
-        427   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-        428   store_var 10             (_100)
-        429   jump +5                  (to 434)
-        430   load_var 9               (_69)
-        431   make_bound_method 552    
-        432   call_indirect            
-        433   store_var 10             (_100)
-        434   load_var 10              (_100)
-        435   is_type 13               
-        436   pop_jump_if_false +2     (to 438)
-        437   jump +38                 (to 475)
-        438   load_var 10              (_100)
-        439   store_var 11             (ts)
+  116   118   load_var 1               (self)
+        119   load_field 0             (collector)
+        120   load_field 2             (testsets)
+        121   store_var 8              (_39)
+        122   load_type 14             
+        123   load_var 8               (_39)
+        124   call 540 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        125   store_var 9              (_40)
+        126   load_var 9               (_40)
+        127   is_type 15               
+        128   pop_jump_if_false +2     (to 130)
+        129   jump +87                 (to 216)
+        130   load_var 9               (_40)
+        131   is_type 16               
+        132   pop_jump_if_false +2     (to 134)
+        133   jump +78                 (to 211)
+        134   load_var 9               (_40)
+        135   is_type 17               
+        136   pop_jump_if_false +2     (to 138)
+        137   jump +68                 (to 205)
+        138   load_var 9               (_40)
+        139   is_type 18               
+        140   pop_jump_if_false +2     (to 142)
+        141   jump +57                 (to 198)
+        142   load_var 9               (_40)
+        143   is_type 19               
+        144   pop_jump_if_false +2     (to 146)
+        145   jump +48                 (to 193)
+        146   load_var 9               (_40)
+        147   is_type 20               
+        148   pop_jump_if_false +2     (to 150)
+        149   jump +39                 (to 188)
+        150   load_var 9               (_40)
+        151   is_type 21               
+        152   pop_jump_if_false +2     (to 154)
+        153   jump +28                 (to 181)
+        154   load_var 9               (_40)
+        155   is_type 22               
+        156   pop_jump_if_false +2     (to 158)
+        157   jump +19                 (to 176)
+        158   load_var 9               (_40)
+        159   is_type 23               
+        160   pop_jump_if_false +2     (to 162)
+        161   jump +10                 (to 171)
+        162   load_var 9               (_40)
+        163   is_type 24               
+        164   pop_jump_if_false +101   (to 265)
+        165   load_type 14             
+        166   load_type 11             
+        167   load_var 9               (_40)
+        168   call 545 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        169   store_var 10             (_42)
+        170   jump +50                 (to 220)
+        171   load_var 9               (_40)
+        172   make_bound_method 576    
+        173   call_indirect            
+        174   store_var 10             (_42)
+        175   jump +45                 (to 220)
+        176   load_var 9               (_40)
+        177   make_bound_method 589    
+        178   call_indirect            
+        179   store_var 10             (_42)
+        180   jump +40                 (to 220)
+        181   load_type 14             
+        182   load_type 11             
+        183   load_type 11             
+        184   load_var 9               (_40)
+        185   call 512 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        186   store_var 10             (_42)
+        187   jump +33                 (to 220)
+        188   load_var 9               (_40)
+        189   make_bound_method 525    
+        190   call_indirect            
+        191   store_var 10             (_42)
+        192   jump +28                 (to 220)
+        193   load_type 14             
+        194   load_var 9               (_40)
+        195   call 539 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        196   store_var 10             (_42)
+        197   jump +23                 (to 220)
+        198   load_type 14             
+        199   load_type 11             
+        200   load_type 11             
+        201   load_var 9               (_40)
+        202   call 515 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        203   store_var 10             (_42)
+        204   jump +16                 (to 220)
+        205   load_type 14             
+        206   load_type 11             
+        207   load_var 9               (_40)
+        208   call 529 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        209   store_var 10             (_42)
+        210   jump +10                 (to 220)
+        211   load_type 14             
+        212   load_var 9               (_40)
+        213   call 571 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        214   store_var 10             (_42)
+        215   jump +5                  (to 220)
+        216   load_var 9               (_40)
+        217   make_bound_method 560    
+        218   call_indirect            
+        219   store_var 10             (_42)
+        220   load_var 10              (_42)
+        221   is_type 12               
+        222   pop_jump_if_false +2     (to 224)
+        223   jump +38                 (to 261)
+        224   load_var 10              (_42)
+        225   store_var 11             (ts)
 
-  117   440   load_type 26             
-        441   load_type 27             
-        442   load_var 1               (self)
-        443   load_field 1             (expansions)
-        444   load_var 11              (ts)
-        445   load_field 0             (name)
-        446   call 53 ntypeargs=2      (baml.Map.get)
-        447   store_var 12             (expanded)
+  117   226   load_type 25             
+        227   load_type 26             
+        228   load_var 1               (self)
+        229   load_field 1             (expansions)
+        230   load_var 11              (ts)
+        231   load_field 0             (name)
+        232   call 52 ntypeargs=2      (baml.Map.get)
+        233   store_var 12             (expanded)
 
-  118   448   load_var 12              (expanded)
-        449   is_type 28               
-        450   pop_jump_if_false +2     (to 452)
-        451   jump +9                  (to 460)
+  118   234   load_var 12              (expanded)
+        235   is_type 27               
+        236   pop_jump_if_false +2     (to 238)
+        237   jump +9                  (to 246)
 
-  127   452   load_var 3               (items)
-        453   load_const 29            ("lazyTestSet")
-        454   load_var 11              (ts)
-        455   load_field 0             (name)
-        456   init_instance 1          (testing.SerializedTest .type, .name)
-        457   call 17 ntypeargs=0      (baml.Array.push)
-        458   pop 1                    
-        459   jump -119                (to 340)
+  127   238   load_var 3               (items)
+        239   load_const 28            ("lazyTestSet")
+        240   load_var 11              (ts)
+        241   load_field 0             (name)
+        242   init_instance 1          (testing.SerializedTest .type, .name)
+        243   call 17 ntypeargs=0      (baml.Array.push)
+        244   pop 1                    
+        245   jump -119                (to 126)
 
-  118   460   load_var 12              (expanded)
-        461   store_var 13             (sub)
+  118   246   load_var 12              (expanded)
+        247   store_var 13             (sub)
 
-  121   462   load_var 11              (ts)
-        463   load_field 0             (name)
-        464   store_var 14             (_139)
+  121   248   load_var 11              (ts)
+        249   load_field 0             (name)
+        250   store_var 14             (_81)
 
-  122   465   load_var 13              (sub)
-        466   call 746 ntypeargs=0     (testing.TestRegistry.serialize)
-        467   store_var 15             (_140)
+  122   251   load_var 13              (sub)
+        252   call 754 ntypeargs=0     (testing.TestRegistry.serialize)
+        253   store_var 15             (_82)
 
-  120   468   load_var2 3 14           
-        469   load_var2 15 13          
+  120   254   load_var2 3 14           
+        255   load_var2 15 13          
 
-  123   470   load_field 2             (loading_time_ms)
-        471   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        472   call 17 ntypeargs=0      (baml.Array.push)
-        473   pop 1                    
-        474   jump -134                (to 340)
+  123   256   load_field 2             (loading_time_ms)
+        257   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
+        258   call 17 ntypeargs=0      (baml.Array.push)
+        259   pop 1                    
+        260   jump -134                (to 126)
 
-  131   475   load_var 3               (items)
-        476   store_var 2              (_0)
-        477   load_var 2               (_0)
-        478   return                   
-        479   unreachable              
+  131   261   load_var 3               (items)
+        262   store_var 2              (_0)
+        263   load_var 2               (_0)
+        264   return                   
+        265   unreachable              
 }
 
 function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.json {
   93   0    load_var 1             (self)
        1    load_field 0           (collector)
-       2    call 758 ntypeargs=0   (testing.TestCollector.to_json)
+       2    call 766 ntypeargs=0   (testing.TestCollector.to_json)
        3    load_type 0            
        4    load_type 1            
        5    load_var 1             (self)
@@ -2635,7 +1670,7 @@ function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.j
        7    call 23 ntypeargs=2    (baml.Map.to_json)
        8    load_var 1             (self)
        9    load_field 2           (loading_time_ms)
-       10   call 63 ntypeargs=0    (baml.Int.to_json)
+       10   call 71 ntypeargs=0    (baml.Int.to_json)
        11   load_const 2           ("collector")
        12   load_const 3           ("expansions")
        13   load_const 4           ("loading_time_ms")
@@ -2648,18 +1683,18 @@ function testing.TestRegistry.to_json(self: testing.TestRegistry) -> baml.json.j
 function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
   18   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("runs")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.TestReport .outcome, .runs)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -2675,7 +1710,7 @@ function testing.TestReport.to_json(self: testing.TestReport) -> baml.json.json 
        5    load_type 1           
        6    load_var 1            (self)
        7    load_field 1          (runs)
-       8    call 38 ntypeargs=1   (baml.Array.to_json)
+       8    call 37 ntypeargs=1   (baml.Array.to_json)
        9    load_const 2          ("outcome")
        10   load_const 3          ("runs")
        11   alloc_map 2           
@@ -2687,25 +1722,25 @@ function testing.TestReport.to_json(self: testing.TestReport) -> baml.json.json 
 function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.TestSetRegistration {
   17   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("collector")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("runner")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestSetRegistration .name, .collector, .runner)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -2715,47 +1750,47 @@ function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.Tes
 function testing.TestSetRegistration.to_json(self: testing.TestSetRegistration) -> baml.json.json {
   25   0   load_type 0            
        1   load_var 1             (self)
-       2   call 409 ntypeargs=1   (baml.json.to_string)
-       3   call 404 ntypeargs=0   (baml.json.parse)
+       2   call 417 ntypeargs=1   (baml.json.to_string)
+       3   call 412 ntypeargs=0   (baml.json.parse)
        4   return                 
 }
 
 function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetReport {
   25   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("passed")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("failed")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 3            
        19   load_var 5             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   load_var 1             (j)
        22   load_const 5           ("total")
-       23   call 407 ntypeargs=0   (baml.json.field)
+       23   call 415 ntypeargs=0   (baml.json.field)
        24   store_var 6            (_12)
        25   load_type 3            
        26   load_var 6             (_12)
-       27   call 399 ntypeargs=1   (baml.json.from_json)
+       27   call 407 ntypeargs=1   (baml.json.from_json)
        28   load_var 1             (j)
        29   load_const 6           ("results")
-       30   call 407 ntypeargs=0   (baml.json.field)
+       30   call 415 ntypeargs=0   (baml.json.field)
        31   store_var 7            (_15)
        32   load_type 7            
        33   load_var 7             (_15)
-       34   call 399 ntypeargs=1   (baml.json.from_json)
+       34   call 407 ntypeargs=1   (baml.json.from_json)
        35   init_instance 0        (testing.TestSetReport .outcome, .passed, .failed, .total, .results)
        36   store_var 2            (_0)
        37   load_var 2             (_0)
@@ -2770,17 +1805,17 @@ function testing.TestSetReport.to_json(self: testing.TestSetReport) -> baml.json
        4    call_indirect         
        5    load_var 1            (self)
        6    load_field 1          (passed)
-       7    call 63 ntypeargs=0   (baml.Int.to_json)
+       7    call 71 ntypeargs=0   (baml.Int.to_json)
        8    load_var 1            (self)
        9    load_field 2          (failed)
-       10   call 63 ntypeargs=0   (baml.Int.to_json)
+       10   call 71 ntypeargs=0   (baml.Int.to_json)
        11   load_var 1            (self)
        12   load_field 3          (total)
-       13   call 63 ntypeargs=0   (baml.Int.to_json)
+       13   call 71 ntypeargs=0   (baml.Int.to_json)
        14   load_type 1           
        15   load_var 1            (self)
        16   load_field 4          (results)
-       17   call 38 ntypeargs=1   (baml.Array.to_json)
+       17   call 37 ntypeargs=1   (baml.Array.to_json)
        18   load_const 2          ("outcome")
        19   load_const 3          ("passed")
        20   load_const 4          ("failed")
@@ -2798,7 +1833,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   185   3    load_var 1             (body)
-        4    make_closure 1405 1    
+        4    make_closure 1415 1    
         5    store_var 3            (base_run)
 
   200   6    load_var 2             (runner)
@@ -2843,18 +1878,18 @@ function testing.run_testset(run_children: () -> testing.TestSetReport throws ne
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
   26   0    load_var 1             (j)
        1    load_const 0           ("code")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("message")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (user.ErrorInfo .code, .message)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -2864,10 +1899,10 @@ function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
 function user.ErrorInfo.to_json(self: ErrorInfo) -> baml.json.json {
   26   0    load_var 1             (self)
        1    load_field 0           (code)
-       2    call 63 ntypeargs=0    (baml.Int.to_json)
+       2    call 71 ntypeargs=0    (baml.Int.to_json)
        3    load_var 1             (self)
        4    load_field 1           (message)
-       5    call 164 ntypeargs=0   (baml.String.to_json)
+       5    call 172 ntypeargs=0   (baml.String.to_json)
        6    load_const 0           ("code")
        7    load_const 1           ("message")
        8    alloc_map 2            
@@ -2879,25 +1914,25 @@ function user.ErrorInfo.to_json(self: ErrorInfo) -> baml.json.json {
 function user.Report.from_json(j: baml.json.json) -> Report {
   20   0    load_var 1             (j)
        1    load_const 0           ("score")
-       2    call 407 ntypeargs=0   (baml.json.field)
+       2    call 415 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 399 ntypeargs=1   (baml.json.from_json)
+       6    call 407 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("label")
-       9    call 407 ntypeargs=0   (baml.json.field)
+       9    call 415 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 399 ntypeargs=1   (baml.json.from_json)
+       13   call 407 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("breakdown")
-       16   call 407 ntypeargs=0   (baml.json.field)
+       16   call 415 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 399 ntypeargs=1   (baml.json.from_json)
+       20   call 407 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (user.Report .score, .label, .breakdown)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -2907,10 +1942,10 @@ function user.Report.from_json(j: baml.json.json) -> Report {
 function user.Report.to_json(self: Report) -> baml.json.json {
   20   0    load_var 1             (self)
        1    load_field 0           (score)
-       2    call 63 ntypeargs=0    (baml.Int.to_json)
+       2    call 71 ntypeargs=0    (baml.Int.to_json)
        3    load_var 1             (self)
        4    load_field 1           (label)
-       5    call 164 ntypeargs=0   (baml.String.to_json)
+       5    call 172 ntypeargs=0   (baml.String.to_json)
        6    load_type 0            
        7    load_type 1            
        8    load_var 1             (self)
@@ -2928,25 +1963,25 @@ function user.Report.to_json(self: Report) -> baml.json.json {
 function user.User.from_json(j: baml.json.json) -> User {
   3   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 407 ntypeargs=0   (baml.json.field)
+      2    call 415 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 399 ntypeargs=1   (baml.json.from_json)
+      6    call 407 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("age")
-      9    call 407 ntypeargs=0   (baml.json.field)
+      9    call 415 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 399 ntypeargs=1   (baml.json.from_json)
+      13   call 407 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("role")
-      16   call 407 ntypeargs=0   (baml.json.field)
+      16   call 415 ntypeargs=0   (baml.json.field)
       17   store_var 5            (_9)
       18   load_type 5            
       19   load_var 5             (_9)
-      20   call 399 ntypeargs=1   (baml.json.from_json)
+      20   call 407 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (user.User .name, .age, .role)
       22   store_var 2            (_0)
       23   load_var 2             (_0)
@@ -2985,10 +2020,10 @@ function user.User.promote(self: User, bonus: int) -> Report {
 function user.User.to_json(self: User) -> baml.json.json {
   3   0    load_var 1             (self)
       1    load_field 0           (name)
-      2    call 164 ntypeargs=0   (baml.String.to_json)
+      2    call 172 ntypeargs=0   (baml.String.to_json)
       3    load_var 1             (self)
       4    load_field 1           (age)
-      5    call 63 ntypeargs=0    (baml.Int.to_json)
+      5    call 71 ntypeargs=0    (baml.Int.to_json)
       6    load_var 1             (self)
       7    load_field 2           (role)
       8    load_const 0           ("to_json")

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -194,318 +194,167 @@ function testing.SerializedTestSet.to_json(self: testing.SerializedTestSet) -> b
 function testing.TestCollector.find_testset(self: testing.TestCollector, name: string) -> testing.TestSetRegistration {
     load_var self
     load_field .testsets
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _3
+    load_type testing.TestSetRegistration
+    load_var _3
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _3
-    is_type testing.TestSetRegistration[]
-    pop_jump_if_false L44
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L11:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L12:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
-
-  L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L15:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
-
-  L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L17:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
-
-  L18:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
-
-  L19:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
-
-  L20:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
-
-  L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L22:
     load_var _4
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _4
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _4
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _4
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _4
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _4
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _4
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _4
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _4
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _4
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L44
+    pop_jump_if_false L22
     load_type testing.TestSetRegistration
     load_type void
     load_var _4
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L32:
+  L10:
     load_var _4
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L33:
+  L11:
     load_var _4
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L34:
+  L12:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _4
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L35:
+  L13:
     load_var _4
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L36:
+  L14:
     load_type testing.TestSetRegistration
     load_var _4
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L37:
+  L15:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L38:
+  L16:
     load_type testing.TestSetRegistration
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L39:
+  L17:
     load_type testing.TestSetRegistration
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L40:
+  L18:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _6
 
-  L41:
-    load_var _35
+  L19:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _35
+  L20:
+    load_var _6
     store_var_load_var ts
     load_field .name
     load_var name
     cmp_op ==
-    pop_jump_if_false L22
+    pop_jump_if_false L0
     load_var ts
     return
 
-  L43:
+  L21:
     load_const "TestSet not found: "
     load_var name
     bin_op +
     throw
 
-  L44:
+  L22:
     unreachable
 }
 
@@ -574,353 +423,202 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     store_var hash_prefix
     load_var self
     load_field .tests
-    store_var_load_var _13
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L3
-    jump L24
+    store_var _13
+    load_type testing.TestRegistration
+    load_var _13
+    call baml.iter.Iterable$for$T[].iter
+    store_var _14
 
   L3:
-    load_var _13
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L4
-    jump L23
-
-  L4:
-    load_var _13
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L5
-    jump L22
-
-  L5:
-    load_var _13
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L6
-    jump L21
-
-  L6:
-    load_var _13
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L7
-    jump L20
-
-  L7:
-    load_var _13
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L8
-    jump L19
-
-  L8:
-    load_var _13
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L9
-    jump L18
-
-  L9:
-    load_var _13
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L10
-    jump L17
-
-  L10:
-    load_var _13
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L11
-    jump L16
-
-  L11:
-    load_var _13
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L12
-    jump L15
-
-  L12:
-    load_var _13
-    is_type unknown[]
-    pop_jump_if_false L13
-    jump L14
-
-  L13:
-    load_var _13
-    is_type testing.TestRegistration[]
-    pop_jump_if_false L52
-    load_type testing.TestRegistration
-    load_var _13
-    call baml.iter.Iterable$for$T[].iter
-    store_var _14
-    jump L25
-
-  L14:
-    load_type testing.TestRegistration
-    load_var _13
-    call baml.iter.Iterable$for$T[].iter
-    store_var _14
-    jump L25
-
-  L15:
-    load_type testing.TestRegistration
-    load_type void
-    load_var _13
-    call baml.iter.Peekable.Iterable.iter
-    store_var _14
-    jump L25
-
-  L16:
-    load_var _13
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L17:
-    load_var _13
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L18:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _13
-    call baml.iter.Filter.Iterable.iter
-    store_var _14
-    jump L25
-
-  L19:
-    load_var _13
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L20:
-    load_type testing.TestRegistration
-    load_var _13
-    call baml.iter.Repeat.Iterable.iter
-    store_var _14
-    jump L25
-
-  L21:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _13
-    call baml.iter.Chain.Iterable.iter
-    store_var _14
-    jump L25
-
-  L22:
-    load_type testing.TestRegistration
-    load_type void
-    load_var _13
-    call baml.iter.StepBy.Iterable.iter
-    store_var _14
-    jump L25
-
-  L23:
-    load_type testing.TestRegistration
-    load_var _13
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _14
-    jump L25
-
-  L24:
-    load_var _13
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _14
-
-  L25:
     load_var _14
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L4
+    jump L21
 
-  L26:
+  L4:
     load_var _14
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L5
+    jump L20
 
-  L27:
+  L5:
     load_var _14
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L6
+    jump L19
 
-  L28:
+  L6:
     load_var _14
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L7
+    jump L18
 
-  L29:
+  L7:
     load_var _14
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L8
+    jump L17
 
-  L30:
+  L8:
     load_var _14
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L9
+    jump L16
 
-  L31:
+  L9:
     load_var _14
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L10
+    jump L15
 
-  L32:
+  L10:
     load_var _14
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L11
+    jump L14
 
-  L33:
+  L11:
     load_var _14
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L12
+    jump L13
 
-  L34:
+  L12:
     load_var _14
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L52
+    pop_jump_if_false L30
     load_type testing.TestRegistration
     load_type void
     load_var _14
     call baml.iter.Peekable.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L35:
+  L13:
     load_var _14
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L36:
+  L14:
     load_var _14
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L37:
+  L15:
     load_type testing.TestRegistration
     load_type void
     load_type void
     load_var _14
     call baml.iter.Filter.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L38:
+  L16:
     load_var _14
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L39:
+  L17:
     load_type testing.TestRegistration
     load_var _14
     call baml.iter.Repeat.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L40:
+  L18:
     load_type testing.TestRegistration
     load_type void
     load_type void
     load_var _14
     call baml.iter.Chain.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L41:
+  L19:
     load_type testing.TestRegistration
     load_type void
     load_var _14
     call baml.iter.StepBy.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L42:
+  L20:
     load_type testing.TestRegistration
     load_var _14
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L43:
+  L21:
     load_var _14
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _45
+    store_var _16
 
-  L44:
-    load_var _45
+  L22:
+    load_var _16
     is_type baml.iter.Done
-    pop_jump_if_false L45
-    jump L48
+    pop_jump_if_false L23
+    jump L26
 
-  L45:
-    load_var _45
+  L23:
+    load_var _16
     store_var_load_var t
     load_field .name
     load_var full_name
     cmp_op ==
-    jump_if_false L46
-    jump L47
+    jump_if_false L24
+    jump L25
 
-  L46:
+  L24:
     pop 1
     load_var t
     load_field .name
     load_var hash_prefix
     call baml.String.starts_with
 
-  L47:
-    pop_jump_if_false L25
+  L25:
+    pop_jump_if_false L3
     load_var count
     load_const 1
     add_int
     store_var count
-    jump L25
+    jump L3
 
-  L48:
+  L26:
     load_var count
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L49
-    jump L50
+    pop_jump_if_false L27
+    jump L28
 
-  L49:
+  L27:
     load_var full_name
     store_var final_name
-    jump L51
+    jump L29
 
-  L50:
+  L28:
     load_var full_name
     load_const "#"
     bin_op +
-    store_var _84
+    store_var _55
     load_type int
     load_var count
     load_const 1
     add_int
     call baml.unstable.string
-    store_var _86
+    store_var _57
     load_var2 13 14
     bin_op +
     store_var final_name
 
-  L51:
+  L29:
     load_type testing.TestRegistration
     load_var self
     load_field .tests
@@ -932,7 +630,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     load_const null
     return
 
-  L52:
+  L30:
     unreachable
 }
 
@@ -967,353 +665,202 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     store_var hash_prefix
     load_var self
     load_field .testsets
-    store_var_load_var _13
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L3
-    jump L24
+    store_var _13
+    load_type testing.TestSetRegistration
+    load_var _13
+    call baml.iter.Iterable$for$T[].iter
+    store_var _14
 
   L3:
-    load_var _13
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L4
-    jump L23
-
-  L4:
-    load_var _13
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L5
-    jump L22
-
-  L5:
-    load_var _13
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L6
-    jump L21
-
-  L6:
-    load_var _13
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L7
-    jump L20
-
-  L7:
-    load_var _13
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L8
-    jump L19
-
-  L8:
-    load_var _13
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L9
-    jump L18
-
-  L9:
-    load_var _13
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L10
-    jump L17
-
-  L10:
-    load_var _13
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L11
-    jump L16
-
-  L11:
-    load_var _13
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L12
-    jump L15
-
-  L12:
-    load_var _13
-    is_type unknown[]
-    pop_jump_if_false L13
-    jump L14
-
-  L13:
-    load_var _13
-    is_type testing.TestSetRegistration[]
-    pop_jump_if_false L52
-    load_type testing.TestSetRegistration
-    load_var _13
-    call baml.iter.Iterable$for$T[].iter
-    store_var _14
-    jump L25
-
-  L14:
-    load_type testing.TestSetRegistration
-    load_var _13
-    call baml.iter.Iterable$for$T[].iter
-    store_var _14
-    jump L25
-
-  L15:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _13
-    call baml.iter.Peekable.Iterable.iter
-    store_var _14
-    jump L25
-
-  L16:
-    load_var _13
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L17:
-    load_var _13
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L18:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _13
-    call baml.iter.Filter.Iterable.iter
-    store_var _14
-    jump L25
-
-  L19:
-    load_var _13
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _14
-    jump L25
-
-  L20:
-    load_type testing.TestSetRegistration
-    load_var _13
-    call baml.iter.Repeat.Iterable.iter
-    store_var _14
-    jump L25
-
-  L21:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _13
-    call baml.iter.Chain.Iterable.iter
-    store_var _14
-    jump L25
-
-  L22:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _13
-    call baml.iter.StepBy.Iterable.iter
-    store_var _14
-    jump L25
-
-  L23:
-    load_type testing.TestSetRegistration
-    load_var _13
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _14
-    jump L25
-
-  L24:
-    load_var _13
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _14
-
-  L25:
     load_var _14
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L26
-    jump L43
+    pop_jump_if_false L4
+    jump L21
 
-  L26:
+  L4:
     load_var _14
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L27
-    jump L42
+    pop_jump_if_false L5
+    jump L20
 
-  L27:
+  L5:
     load_var _14
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L28
-    jump L41
+    pop_jump_if_false L6
+    jump L19
 
-  L28:
+  L6:
     load_var _14
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L29
-    jump L40
+    pop_jump_if_false L7
+    jump L18
 
-  L29:
+  L7:
     load_var _14
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L30
-    jump L39
+    pop_jump_if_false L8
+    jump L17
 
-  L30:
+  L8:
     load_var _14
     is_type baml.iter.Map<...>
-    pop_jump_if_false L31
-    jump L38
+    pop_jump_if_false L9
+    jump L16
 
-  L31:
+  L9:
     load_var _14
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L32
-    jump L37
+    pop_jump_if_false L10
+    jump L15
 
-  L32:
+  L10:
     load_var _14
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L33
-    jump L36
+    pop_jump_if_false L11
+    jump L14
 
-  L33:
+  L11:
     load_var _14
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L34
-    jump L35
+    pop_jump_if_false L12
+    jump L13
 
-  L34:
+  L12:
     load_var _14
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L52
+    pop_jump_if_false L30
     load_type testing.TestSetRegistration
     load_type void
     load_var _14
     call baml.iter.Peekable.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L35:
+  L13:
     load_var _14
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L36:
+  L14:
     load_var _14
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L37:
+  L15:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _14
     call baml.iter.Filter.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L38:
+  L16:
     load_var _14
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L39:
+  L17:
     load_type testing.TestSetRegistration
     load_var _14
     call baml.iter.Repeat.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L40:
+  L18:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _14
     call baml.iter.Chain.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L41:
+  L19:
     load_type testing.TestSetRegistration
     load_type void
     load_var _14
     call baml.iter.StepBy.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L42:
+  L20:
     load_type testing.TestSetRegistration
     load_var _14
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _45
-    jump L44
+    store_var _16
+    jump L22
 
-  L43:
+  L21:
     load_var _14
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _45
+    store_var _16
 
-  L44:
-    load_var _45
+  L22:
+    load_var _16
     is_type baml.iter.Done
-    pop_jump_if_false L45
-    jump L48
+    pop_jump_if_false L23
+    jump L26
 
-  L45:
-    load_var _45
+  L23:
+    load_var _16
     store_var_load_var ts
     load_field .name
     load_var full_name
     cmp_op ==
-    jump_if_false L46
-    jump L47
+    jump_if_false L24
+    jump L25
 
-  L46:
+  L24:
     pop 1
     load_var ts
     load_field .name
     load_var hash_prefix
     call baml.String.starts_with
 
-  L47:
-    pop_jump_if_false L25
+  L25:
+    pop_jump_if_false L3
     load_var count
     load_const 1
     add_int
     store_var count
-    jump L25
+    jump L3
 
-  L48:
+  L26:
     load_var count
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L49
-    jump L50
+    pop_jump_if_false L27
+    jump L28
 
-  L49:
+  L27:
     load_var full_name
     store_var final_name
-    jump L51
+    jump L29
 
-  L50:
+  L28:
     load_var full_name
     load_const "#"
     bin_op +
-    store_var _84
+    store_var _55
     load_type int
     load_var count
     load_const 1
     add_int
     call baml.unstable.string
-    store_var _86
+    store_var _57
     load_var2 13 14
     bin_op +
     store_var final_name
 
-  L51:
+  L29:
     load_type testing.TestSetRegistration
     load_var self
     load_field .testsets
@@ -1325,7 +872,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     load_const null
     return
 
-  L52:
+  L30:
     unreachable
 }
 
@@ -1386,308 +933,157 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_var self
     load_field .collector
     load_field .testsets
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _3
+    load_type testing.TestSetRegistration
+    load_var _3
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var _3
-    is_type testing.TestSetRegistration[]
-    pop_jump_if_false L89
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L11:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
-
-  L12:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
-
-  L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L15:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
-
-  L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L17:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
-
-  L18:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
-
-  L19:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
-
-  L20:
-    load_type testing.TestSetRegistration
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
-
-  L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L22:
     load_var _4
     is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
+    pop_jump_if_false L1
+    jump L18
 
-  L23:
+  L1:
     load_var _4
     is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
+    pop_jump_if_false L2
+    jump L17
 
-  L24:
+  L2:
     load_var _4
     is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
+    pop_jump_if_false L3
+    jump L16
 
-  L25:
+  L3:
     load_var _4
     is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
+    pop_jump_if_false L4
+    jump L15
 
-  L26:
+  L4:
     load_var _4
     is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
+    pop_jump_if_false L5
+    jump L14
 
-  L27:
+  L5:
     load_var _4
     is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
+    pop_jump_if_false L6
+    jump L13
 
-  L28:
+  L6:
     load_var _4
     is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
+    pop_jump_if_false L7
+    jump L12
 
-  L29:
+  L7:
     load_var _4
     is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
+    pop_jump_if_false L8
+    jump L11
 
-  L30:
+  L8:
     load_var _4
     is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
+    pop_jump_if_false L9
+    jump L10
 
-  L31:
+  L9:
     load_var _4
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L89
+    pop_jump_if_false L45
     load_type testing.TestSetRegistration
     load_type void
     load_var _4
     call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L32:
+  L10:
     load_var _4
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L33:
+  L11:
     load_var _4
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L34:
+  L12:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _4
     call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L35:
+  L13:
     load_var _4
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L36:
+  L14:
     load_type testing.TestSetRegistration
     load_var _4
     call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L37:
+  L15:
     load_type testing.TestSetRegistration
     load_type void
     load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L38:
+  L16:
     load_type testing.TestSetRegistration
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L39:
+  L17:
     load_type testing.TestSetRegistration
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L40:
+  L18:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _6
 
-  L41:
-    load_var _35
+  L19:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _35
+  L20:
+    load_var _6
     store_var_load_var ts
     load_field .name
     load_var name
     cmp_op ==
-    pop_jump_if_false L22
+    pop_jump_if_false L0
     call baml.sys.now_ms
     store_var start
     load_var name
@@ -1700,7 +1096,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     call_indirect
     pop 1
     call baml.sys.now_ms
-    store_var _75
+    store_var _46
     load_type string
     load_type testing.TestRegistry
     load_var self
@@ -1714,312 +1110,160 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     pop 1
     load_var self
     call testing.TestRegistry.serialize
-    jump L87
+    jump L43
 
-  L43:
+  L21:
     load_type string
     load_type testing.TestRegistry
     load_var self
     load_field .expansions
     call baml.Map.keys
-    store_var _86
-    load_var _86
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L44
-    jump L65
+    store_var _57
+    load_type string
+    load_var _57
+    call baml.iter.Iterable$for$T[].iter
+    store_var _61
 
-  L44:
-    load_var _86
+  L22:
+    load_var _61
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L23
+    jump L40
+
+  L23:
+    load_var _61
     is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L24
+    jump L39
+
+  L24:
+    load_var _61
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L25
+    jump L38
+
+  L25:
+    load_var _61
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L26
+    jump L37
+
+  L26:
+    load_var _61
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L27
+    jump L36
+
+  L27:
+    load_var _61
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L28
+    jump L35
+
+  L28:
+    load_var _61
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L29
+    jump L34
+
+  L29:
+    load_var _61
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L30
+    jump L33
+
+  L30:
+    load_var _61
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L31
+    jump L32
+
+  L31:
+    load_var _61
+    is_type baml.iter.Peekable<...>
     pop_jump_if_false L45
-    jump L64
-
-  L45:
-    load_var _86
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L46
-    jump L63
-
-  L46:
-    load_var _86
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L47
-    jump L62
-
-  L47:
-    load_var _86
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L48
-    jump L61
-
-  L48:
-    load_var _86
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L49
-    jump L60
-
-  L49:
-    load_var _86
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L50
-    jump L59
-
-  L50:
-    load_var _86
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L51
-    jump L58
-
-  L51:
-    load_var _86
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L52
-    jump L57
-
-  L52:
-    load_var _86
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L53
-    jump L56
-
-  L53:
-    load_var _86
-    is_type unknown[]
-    pop_jump_if_false L54
-    jump L55
-
-  L54:
-    load_var _86
-    is_type string[]
-    pop_jump_if_false L89
-    load_type string
-    load_var _86
-    call baml.iter.Iterable$for$T[].iter
-    store_var _90
-    jump L66
-
-  L55:
-    load_type string
-    load_var _86
-    call baml.iter.Iterable$for$T[].iter
-    store_var _90
-    jump L66
-
-  L56:
     load_type string
     load_type void
-    load_var _86
-    call baml.iter.Peekable.Iterable.iter
-    store_var _90
-    jump L66
-
-  L57:
-    load_var _86
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _90
-    jump L66
-
-  L58:
-    load_var _86
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _90
-    jump L66
-
-  L59:
-    load_type string
-    load_type void
-    load_type void
-    load_var _86
-    call baml.iter.Filter.Iterable.iter
-    store_var _90
-    jump L66
-
-  L60:
-    load_var _86
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _90
-    jump L66
-
-  L61:
-    load_type string
-    load_var _86
-    call baml.iter.Repeat.Iterable.iter
-    store_var _90
-    jump L66
-
-  L62:
-    load_type string
-    load_type void
-    load_type void
-    load_var _86
-    call baml.iter.Chain.Iterable.iter
-    store_var _90
-    jump L66
-
-  L63:
-    load_type string
-    load_type void
-    load_var _86
-    call baml.iter.StepBy.Iterable.iter
-    store_var _90
-    jump L66
-
-  L64:
-    load_type string
-    load_var _86
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _90
-    jump L66
-
-  L65:
-    load_var _86
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _90
-
-  L66:
-    load_var _90
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L67
-    jump L84
-
-  L67:
-    load_var _90
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L68
-    jump L83
-
-  L68:
-    load_var _90
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L69
-    jump L82
-
-  L69:
-    load_var _90
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L70
-    jump L81
-
-  L70:
-    load_var _90
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L71
-    jump L80
-
-  L71:
-    load_var _90
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L72
-    jump L79
-
-  L72:
-    load_var _90
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L73
-    jump L78
-
-  L73:
-    load_var _90
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L74
-    jump L77
-
-  L74:
-    load_var _90
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L75
-    jump L76
-
-  L75:
-    load_var _90
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L89
-    load_type string
-    load_type void
-    load_var _90
+    load_var _61
     call baml.iter.Peekable.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L76:
-    load_var _90
+  L32:
+    load_var _61
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L77:
-    load_var _90
+  L33:
+    load_var _61
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L78:
+  L34:
     load_type string
     load_type void
     load_type void
-    load_var _90
+    load_var _61
     call baml.iter.Filter.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L79:
-    load_var _90
+  L35:
+    load_var _61
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L80:
+  L36:
     load_type string
-    load_var _90
+    load_var _61
     call baml.iter.Repeat.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L81:
+  L37:
     load_type string
     load_type void
     load_type void
-    load_var _90
+    load_var _61
     call baml.iter.Chain.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L82:
+  L38:
     load_type string
     load_type void
-    load_var _90
+    load_var _61
     call baml.iter.StepBy.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L83:
+  L39:
     load_type string
-    load_var _90
+    load_var _61
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _121
-    jump L85
+    store_var _63
+    jump L41
 
-  L84:
-    load_var _90
+  L40:
+    load_var _61
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _121
+    store_var _63
 
-  L85:
-    load_var _121
+  L41:
+    load_var _63
     is_type baml.iter.Done
-    pop_jump_if_false L86
-    jump L88
+    pop_jump_if_false L42
+    jump L44
 
-  L86:
-    load_var _121
+  L42:
+    load_var _63
     store_var k
     load_var self
     load_field .expansions
@@ -2030,20 +1274,20 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_const "/"
     bin_op +
     call baml.String.starts_with
-    pop_jump_if_false L66
+    pop_jump_if_false L22
     load_var2 14 2
     call testing.TestRegistry.expand_set
 
-  L87:
+  L43:
     return
 
-  L88:
+  L44:
     load_const "TestSet not found for expansion: "
     load_var name
     bin_op +
     throw
 
-  L89:
+  L45:
     unreachable
 }
 
@@ -2085,619 +1329,316 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var self
     load_field .collector
     load_field .tests
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _3
+    load_type testing.TestRegistration
+    load_var _3
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
+    load_var _4
+    is_type baml.iter.Flatten<...>
     pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
     jump L18
 
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
+  L1:
+    load_var _4
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L2
     jump L17
 
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
+  L2:
+    load_var _4
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L3
     jump L16
 
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
+  L3:
+    load_var _4
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L4
     jump L15
 
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
+  L4:
+    load_var _4
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L5
     jump L14
 
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
+  L5:
+    load_var _4
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L6
     jump L13
 
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
+  L6:
+    load_var _4
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L7
     jump L12
 
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
+  L7:
+    load_var _4
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L8
     jump L11
 
-  L10:
-    load_var _3
-    is_type testing.TestRegistration[]
-    pop_jump_if_false L89
+  L8:
+    load_var _4
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L9
+    jump L10
+
+  L9:
+    load_var _4
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L45
     load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
+    load_type void
+    load_var _4
+    call baml.iter.Peekable.Iterator.next
+    store_var _6
+    jump L19
+
+  L10:
+    load_var _4
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L19
 
   L11:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
+    load_var _4
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L19
 
   L12:
     load_type testing.TestRegistration
     load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
+    load_type void
+    load_var _4
+    call baml.iter.Filter.Iterator.next
+    store_var _6
+    jump L19
 
   L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
+    load_var _4
+    make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _4
-    jump L22
+    store_var _6
+    jump L19
 
   L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
+    load_type testing.TestRegistration
+    load_var _4
+    call baml.iter.Repeat.Iterator.next
+    store_var _6
+    jump L19
 
   L15:
     load_type testing.TestRegistration
     load_type void
     load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
-
-  L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
-
-  L17:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
-
-  L18:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
-
-  L19:
-    load_type testing.TestRegistration
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
-
-  L20:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
-
-  L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
-
-  L22:
-    load_var _4
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L23
-    jump L40
-
-  L23:
-    load_var _4
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L24
-    jump L39
-
-  L24:
-    load_var _4
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L25
-    jump L38
-
-  L25:
-    load_var _4
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L26
-    jump L37
-
-  L26:
-    load_var _4
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L27
-    jump L36
-
-  L27:
-    load_var _4
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L28
-    jump L35
-
-  L28:
-    load_var _4
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L29
-    jump L34
-
-  L29:
-    load_var _4
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L30
-    jump L33
-
-  L30:
-    load_var _4
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L31
-    jump L32
-
-  L31:
-    load_var _4
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L89
-    load_type testing.TestRegistration
-    load_type void
-    load_var _4
-    call baml.iter.Peekable.Iterator.next
-    store_var _35
-    jump L41
-
-  L32:
-    load_var _4
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _35
-    jump L41
-
-  L33:
-    load_var _4
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _35
-    jump L41
-
-  L34:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _4
-    call baml.iter.Filter.Iterator.next
-    store_var _35
-    jump L41
-
-  L35:
-    load_var _4
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _35
-    jump L41
-
-  L36:
-    load_type testing.TestRegistration
-    load_var _4
-    call baml.iter.Repeat.Iterator.next
-    store_var _35
-    jump L41
-
-  L37:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
     load_var _4
     call baml.iter.Chain.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L38:
+  L16:
     load_type testing.TestRegistration
     load_type void
     load_var _4
     call baml.iter.StepBy.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L39:
+  L17:
     load_type testing.TestRegistration
     load_var _4
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
-    jump L41
+    store_var _6
+    jump L19
 
-  L40:
+  L18:
     load_var _4
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _6
 
-  L41:
-    load_var _35
+  L19:
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L42
-    jump L43
+    pop_jump_if_false L20
+    jump L21
 
-  L42:
-    load_var _35
+  L20:
+    load_var _6
     store_var_load_var t
     load_field .name
     load_var name
     cmp_op ==
-    pop_jump_if_false L22
+    pop_jump_if_false L0
     load_var t
     load_field .body
     load_var t
     load_field .runner
     call testing.run_test
-    jump L87
+    jump L43
 
-  L43:
+  L21:
     load_type string
     load_type testing.TestRegistry
     load_var self
     load_field .expansions
     call baml.Map.keys
-    store_var _69
-    load_var _69
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L44
-    jump L65
+    store_var _40
+    load_type string
+    load_var _40
+    call baml.iter.Iterable$for$T[].iter
+    store_var _44
 
-  L44:
-    load_var _69
+  L22:
+    load_var _44
+    is_type baml.iter.Flatten<...>
+    pop_jump_if_false L23
+    jump L40
+
+  L23:
+    load_var _44
     is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L24
+    jump L39
+
+  L24:
+    load_var _44
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L25
+    jump L38
+
+  L25:
+    load_var _44
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L26
+    jump L37
+
+  L26:
+    load_var _44
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L27
+    jump L36
+
+  L27:
+    load_var _44
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L28
+    jump L35
+
+  L28:
+    load_var _44
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L29
+    jump L34
+
+  L29:
+    load_var _44
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L30
+    jump L33
+
+  L30:
+    load_var _44
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L31
+    jump L32
+
+  L31:
+    load_var _44
+    is_type baml.iter.Peekable<...>
     pop_jump_if_false L45
-    jump L64
-
-  L45:
-    load_var _69
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L46
-    jump L63
-
-  L46:
-    load_var _69
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L47
-    jump L62
-
-  L47:
-    load_var _69
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L48
-    jump L61
-
-  L48:
-    load_var _69
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L49
-    jump L60
-
-  L49:
-    load_var _69
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L50
-    jump L59
-
-  L50:
-    load_var _69
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L51
-    jump L58
-
-  L51:
-    load_var _69
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L52
-    jump L57
-
-  L52:
-    load_var _69
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L53
-    jump L56
-
-  L53:
-    load_var _69
-    is_type unknown[]
-    pop_jump_if_false L54
-    jump L55
-
-  L54:
-    load_var _69
-    is_type string[]
-    pop_jump_if_false L89
-    load_type string
-    load_var _69
-    call baml.iter.Iterable$for$T[].iter
-    store_var _73
-    jump L66
-
-  L55:
-    load_type string
-    load_var _69
-    call baml.iter.Iterable$for$T[].iter
-    store_var _73
-    jump L66
-
-  L56:
     load_type string
     load_type void
-    load_var _69
-    call baml.iter.Peekable.Iterable.iter
-    store_var _73
-    jump L66
-
-  L57:
-    load_var _69
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _73
-    jump L66
-
-  L58:
-    load_var _69
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _73
-    jump L66
-
-  L59:
-    load_type string
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Filter.Iterable.iter
-    store_var _73
-    jump L66
-
-  L60:
-    load_var _69
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _73
-    jump L66
-
-  L61:
-    load_type string
-    load_var _69
-    call baml.iter.Repeat.Iterable.iter
-    store_var _73
-    jump L66
-
-  L62:
-    load_type string
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Chain.Iterable.iter
-    store_var _73
-    jump L66
-
-  L63:
-    load_type string
-    load_type void
-    load_var _69
-    call baml.iter.StepBy.Iterable.iter
-    store_var _73
-    jump L66
-
-  L64:
-    load_type string
-    load_var _69
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _73
-    jump L66
-
-  L65:
-    load_var _69
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _73
-
-  L66:
-    load_var _73
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L67
-    jump L84
-
-  L67:
-    load_var _73
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L68
-    jump L83
-
-  L68:
-    load_var _73
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L69
-    jump L82
-
-  L69:
-    load_var _73
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L70
-    jump L81
-
-  L70:
-    load_var _73
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L71
-    jump L80
-
-  L71:
-    load_var _73
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L72
-    jump L79
-
-  L72:
-    load_var _73
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L73
-    jump L78
-
-  L73:
-    load_var _73
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L74
-    jump L77
-
-  L74:
-    load_var _73
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L75
-    jump L76
-
-  L75:
-    load_var _73
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L89
-    load_type string
-    load_type void
-    load_var _73
+    load_var _44
     call baml.iter.Peekable.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L76:
-    load_var _73
+  L32:
+    load_var _44
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L77:
-    load_var _73
+  L33:
+    load_var _44
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L78:
+  L34:
     load_type string
     load_type void
     load_type void
-    load_var _73
+    load_var _44
     call baml.iter.Filter.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L79:
-    load_var _73
+  L35:
+    load_var _44
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L80:
+  L36:
     load_type string
-    load_var _73
+    load_var _44
     call baml.iter.Repeat.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L81:
+  L37:
     load_type string
     load_type void
     load_type void
-    load_var _73
+    load_var _44
     call baml.iter.Chain.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L82:
+  L38:
     load_type string
     load_type void
-    load_var _73
+    load_var _44
     call baml.iter.StepBy.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L83:
+  L39:
     load_type string
-    load_var _73
+    load_var _44
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _104
-    jump L85
+    store_var _46
+    jump L41
 
-  L84:
-    load_var _73
+  L40:
+    load_var _44
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _104
+    store_var _46
 
-  L85:
-    load_var _104
+  L41:
+    load_var _46
     is_type baml.iter.Done
-    pop_jump_if_false L86
-    jump L88
+    pop_jump_if_false L42
+    jump L44
 
-  L86:
-    load_var _104
+  L42:
+    load_var _46
     store_var k
     load_var self
     load_field .expansions
@@ -2708,20 +1649,20 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_const "/"
     bin_op +
     call baml.String.starts_with
-    pop_jump_if_false L66
+    pop_jump_if_false L22
     load_var2 11 2
     call testing.TestRegistry.run_test
 
-  L87:
+  L43:
     return
 
-  L88:
+  L44:
     load_const "Test not found: "
     load_var name
     bin_op +
     throw
 
-  L89:
+  L45:
     unreachable
 }
 
@@ -2731,612 +1672,310 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     load_var self
     load_field .collector
     load_field .tests
-    store_var_load_var _3
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L0
-    jump L21
+    store_var _3
+    load_type testing.TestRegistration
+    load_var _3
+    call baml.iter.Iterable$for$T[].iter
+    store_var _4
 
   L0:
-    load_var _3
-    is_type baml.iter.ArrayIterator<...>
+    load_var _4
+    is_type baml.iter.Flatten<...>
     pop_jump_if_false L1
-    jump L20
-
-  L1:
-    load_var _3
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
-    load_var _3
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L3
     jump L18
 
-  L3:
-    load_var _3
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L4
+  L1:
+    load_var _4
+    is_type baml.iter.ArrayIterator<...>
+    pop_jump_if_false L2
     jump L17
 
-  L4:
-    load_var _3
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L5
+  L2:
+    load_var _4
+    is_type baml.iter.StepBy<...>
+    pop_jump_if_false L3
     jump L16
 
-  L5:
-    load_var _3
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L6
+  L3:
+    load_var _4
+    is_type baml.iter.Chain<...>
+    pop_jump_if_false L4
     jump L15
 
-  L6:
-    load_var _3
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L7
+  L4:
+    load_var _4
+    is_type baml.iter.Repeat<...>
+    pop_jump_if_false L5
     jump L14
 
-  L7:
-    load_var _3
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L8
+  L5:
+    load_var _4
+    is_type baml.iter.Map<...>
+    pop_jump_if_false L6
     jump L13
 
-  L8:
-    load_var _3
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L9
+  L6:
+    load_var _4
+    is_type baml.iter.Filter<...>
+    pop_jump_if_false L7
     jump L12
 
-  L9:
-    load_var _3
-    is_type unknown[]
-    pop_jump_if_false L10
+  L7:
+    load_var _4
+    is_type baml.iter.FilterMap<...>
+    pop_jump_if_false L8
     jump L11
 
-  L10:
-    load_var _3
-    is_type testing.TestRegistration[]
-    pop_jump_if_false L90
+  L8:
+    load_var _4
+    is_type baml.iter.FlatMap<...>
+    pop_jump_if_false L9
+    jump L10
+
+  L9:
+    load_var _4
+    is_type baml.iter.Peekable<...>
+    pop_jump_if_false L46
     load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
+    load_type void
+    load_var _4
+    call baml.iter.Peekable.Iterator.next
+    store_var _6
+    jump L19
+
+  L10:
+    load_var _4
+    make_bound_method baml.iter.FlatMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L19
 
   L11:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Iterable$for$T[].iter
-    store_var _4
-    jump L22
+    load_var _4
+    make_bound_method baml.iter.FilterMap.Iterator.next
+    call_indirect
+    store_var _6
+    jump L19
 
   L12:
     load_type testing.TestRegistration
     load_type void
-    load_var _3
-    call baml.iter.Peekable.Iterable.iter
-    store_var _4
-    jump L22
+    load_type void
+    load_var _4
+    call baml.iter.Filter.Iterator.next
+    store_var _6
+    jump L19
 
   L13:
-    load_var _3
-    make_bound_method baml.iter.FlatMap.Iterable.iter
+    load_var _4
+    make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _4
-    jump L22
+    store_var _6
+    jump L19
 
   L14:
-    load_var _3
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
+    load_type testing.TestRegistration
+    load_var _4
+    call baml.iter.Repeat.Iterator.next
+    store_var _6
+    jump L19
 
   L15:
     load_type testing.TestRegistration
     load_type void
     load_type void
-    load_var _3
-    call baml.iter.Filter.Iterable.iter
-    store_var _4
-    jump L22
+    load_var _4
+    call baml.iter.Chain.Iterator.next
+    store_var _6
+    jump L19
 
   L16:
-    load_var _3
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _4
-    jump L22
+    load_type testing.TestRegistration
+    load_type void
+    load_var _4
+    call baml.iter.StepBy.Iterator.next
+    store_var _6
+    jump L19
 
   L17:
     load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.Repeat.Iterable.iter
-    store_var _4
-    jump L22
+    load_var _4
+    call baml.iter.ArrayIterator.Iterator.next
+    store_var _6
+    jump L19
 
   L18:
-    load_type testing.TestRegistration
-    load_type void
-    load_type void
-    load_var _3
-    call baml.iter.Chain.Iterable.iter
-    store_var _4
-    jump L22
+    load_var _4
+    make_bound_method baml.iter.Flatten.Iterator.next
+    call_indirect
+    store_var _6
 
   L19:
-    load_type testing.TestRegistration
-    load_type void
-    load_var _3
-    call baml.iter.StepBy.Iterable.iter
-    store_var _4
-    jump L22
+    load_var _6
+    is_type baml.iter.Done
+    pop_jump_if_false L20
+    jump L21
 
   L20:
-    load_type testing.TestRegistration
-    load_var _3
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _4
-    jump L22
+    load_var items
+    load_const "test"
+    load_var _6
+    load_field .name
+    init_instance testing.SerializedTest .type, .name
+    call baml.Array.push
+    pop 1
+    jump L0
 
   L21:
-    load_var _3
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _4
+    load_var self
+    load_field .collector
+    load_field .testsets
+    store_var _39
+    load_type testing.TestSetRegistration
+    load_var _39
+    call baml.iter.Iterable$for$T[].iter
+    store_var _40
 
   L22:
-    load_var _4
+    load_var _40
     is_type baml.iter.Flatten<...>
     pop_jump_if_false L23
     jump L40
 
   L23:
-    load_var _4
+    load_var _40
     is_type baml.iter.ArrayIterator<...>
     pop_jump_if_false L24
     jump L39
 
   L24:
-    load_var _4
+    load_var _40
     is_type baml.iter.StepBy<...>
     pop_jump_if_false L25
     jump L38
 
   L25:
-    load_var _4
+    load_var _40
     is_type baml.iter.Chain<...>
     pop_jump_if_false L26
     jump L37
 
   L26:
-    load_var _4
+    load_var _40
     is_type baml.iter.Repeat<...>
     pop_jump_if_false L27
     jump L36
 
   L27:
-    load_var _4
+    load_var _40
     is_type baml.iter.Map<...>
     pop_jump_if_false L28
     jump L35
 
   L28:
-    load_var _4
+    load_var _40
     is_type baml.iter.Filter<...>
     pop_jump_if_false L29
     jump L34
 
   L29:
-    load_var _4
+    load_var _40
     is_type baml.iter.FilterMap<...>
     pop_jump_if_false L30
     jump L33
 
   L30:
-    load_var _4
+    load_var _40
     is_type baml.iter.FlatMap<...>
     pop_jump_if_false L31
     jump L32
 
   L31:
-    load_var _4
+    load_var _40
     is_type baml.iter.Peekable<...>
-    pop_jump_if_false L90
-    load_type testing.TestRegistration
+    pop_jump_if_false L46
+    load_type testing.TestSetRegistration
     load_type void
-    load_var _4
+    load_var _40
     call baml.iter.Peekable.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L32:
-    load_var _4
+    load_var _40
     make_bound_method baml.iter.FlatMap.Iterator.next
     call_indirect
-    store_var _35
+    store_var _42
     jump L41
 
   L33:
-    load_var _4
+    load_var _40
     make_bound_method baml.iter.FilterMap.Iterator.next
     call_indirect
-    store_var _35
+    store_var _42
     jump L41
 
   L34:
-    load_type testing.TestRegistration
+    load_type testing.TestSetRegistration
     load_type void
     load_type void
-    load_var _4
+    load_var _40
     call baml.iter.Filter.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L35:
-    load_var _4
+    load_var _40
     make_bound_method baml.iter.Map.Iterator.next
     call_indirect
-    store_var _35
+    store_var _42
     jump L41
 
   L36:
-    load_type testing.TestRegistration
-    load_var _4
+    load_type testing.TestSetRegistration
+    load_var _40
     call baml.iter.Repeat.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L37:
-    load_type testing.TestRegistration
+    load_type testing.TestSetRegistration
     load_type void
     load_type void
-    load_var _4
+    load_var _40
     call baml.iter.Chain.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L38:
-    load_type testing.TestRegistration
+    load_type testing.TestSetRegistration
     load_type void
-    load_var _4
+    load_var _40
     call baml.iter.StepBy.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L39:
-    load_type testing.TestRegistration
-    load_var _4
+    load_type testing.TestSetRegistration
+    load_var _40
     call baml.iter.ArrayIterator.Iterator.next
-    store_var _35
+    store_var _42
     jump L41
 
   L40:
-    load_var _4
+    load_var _40
     make_bound_method baml.iter.Flatten.Iterator.next
     call_indirect
-    store_var _35
+    store_var _42
 
   L41:
-    load_var _35
+    load_var _42
     is_type baml.iter.Done
     pop_jump_if_false L42
-    jump L43
+    jump L45
 
   L42:
-    load_var items
-    load_const "test"
-    load_var _35
-    load_field .name
-    init_instance testing.SerializedTest .type, .name
-    call baml.Array.push
-    pop 1
-    jump L22
-
-  L43:
-    load_var self
-    load_field .collector
-    load_field .testsets
-    store_var_load_var _68
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L44
-    jump L65
-
-  L44:
-    load_var _68
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L45
-    jump L64
-
-  L45:
-    load_var _68
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L46
-    jump L63
-
-  L46:
-    load_var _68
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L47
-    jump L62
-
-  L47:
-    load_var _68
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L48
-    jump L61
-
-  L48:
-    load_var _68
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L49
-    jump L60
-
-  L49:
-    load_var _68
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L50
-    jump L59
-
-  L50:
-    load_var _68
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L51
-    jump L58
-
-  L51:
-    load_var _68
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L52
-    jump L57
-
-  L52:
-    load_var _68
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L53
-    jump L56
-
-  L53:
-    load_var _68
-    is_type unknown[]
-    pop_jump_if_false L54
-    jump L55
-
-  L54:
-    load_var _68
-    is_type testing.TestSetRegistration[]
-    pop_jump_if_false L90
-    load_type testing.TestSetRegistration
-    load_var _68
-    call baml.iter.Iterable$for$T[].iter
-    store_var _69
-    jump L66
-
-  L55:
-    load_type testing.TestSetRegistration
-    load_var _68
-    call baml.iter.Iterable$for$T[].iter
-    store_var _69
-    jump L66
-
-  L56:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _68
-    call baml.iter.Peekable.Iterable.iter
-    store_var _69
-    jump L66
-
-  L57:
-    load_var _68
-    make_bound_method baml.iter.FlatMap.Iterable.iter
-    call_indirect
-    store_var _69
-    jump L66
-
-  L58:
-    load_var _68
-    make_bound_method baml.iter.FilterMap.Iterable.iter
-    call_indirect
-    store_var _69
-    jump L66
-
-  L59:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _68
-    call baml.iter.Filter.Iterable.iter
-    store_var _69
-    jump L66
-
-  L60:
-    load_var _68
-    make_bound_method baml.iter.Map.Iterable.iter
-    call_indirect
-    store_var _69
-    jump L66
-
-  L61:
-    load_type testing.TestSetRegistration
-    load_var _68
-    call baml.iter.Repeat.Iterable.iter
-    store_var _69
-    jump L66
-
-  L62:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _68
-    call baml.iter.Chain.Iterable.iter
-    store_var _69
-    jump L66
-
-  L63:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _68
-    call baml.iter.StepBy.Iterable.iter
-    store_var _69
-    jump L66
-
-  L64:
-    load_type testing.TestSetRegistration
-    load_var _68
-    call baml.iter.ArrayIterator.Iterable.iter
-    store_var _69
-    jump L66
-
-  L65:
-    load_var _68
-    make_bound_method baml.iter.Flatten.Iterable.iter
-    call_indirect
-    store_var _69
-
-  L66:
-    load_var _69
-    is_type baml.iter.Flatten<...>
-    pop_jump_if_false L67
-    jump L84
-
-  L67:
-    load_var _69
-    is_type baml.iter.ArrayIterator<...>
-    pop_jump_if_false L68
-    jump L83
-
-  L68:
-    load_var _69
-    is_type baml.iter.StepBy<...>
-    pop_jump_if_false L69
-    jump L82
-
-  L69:
-    load_var _69
-    is_type baml.iter.Chain<...>
-    pop_jump_if_false L70
-    jump L81
-
-  L70:
-    load_var _69
-    is_type baml.iter.Repeat<...>
-    pop_jump_if_false L71
-    jump L80
-
-  L71:
-    load_var _69
-    is_type baml.iter.Map<...>
-    pop_jump_if_false L72
-    jump L79
-
-  L72:
-    load_var _69
-    is_type baml.iter.Filter<...>
-    pop_jump_if_false L73
-    jump L78
-
-  L73:
-    load_var _69
-    is_type baml.iter.FilterMap<...>
-    pop_jump_if_false L74
-    jump L77
-
-  L74:
-    load_var _69
-    is_type baml.iter.FlatMap<...>
-    pop_jump_if_false L75
-    jump L76
-
-  L75:
-    load_var _69
-    is_type baml.iter.Peekable<...>
-    pop_jump_if_false L90
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _69
-    call baml.iter.Peekable.Iterator.next
-    store_var _100
-    jump L85
-
-  L76:
-    load_var _69
-    make_bound_method baml.iter.FlatMap.Iterator.next
-    call_indirect
-    store_var _100
-    jump L85
-
-  L77:
-    load_var _69
-    make_bound_method baml.iter.FilterMap.Iterator.next
-    call_indirect
-    store_var _100
-    jump L85
-
-  L78:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Filter.Iterator.next
-    store_var _100
-    jump L85
-
-  L79:
-    load_var _69
-    make_bound_method baml.iter.Map.Iterator.next
-    call_indirect
-    store_var _100
-    jump L85
-
-  L80:
-    load_type testing.TestSetRegistration
-    load_var _69
-    call baml.iter.Repeat.Iterator.next
-    store_var _100
-    jump L85
-
-  L81:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_type void
-    load_var _69
-    call baml.iter.Chain.Iterator.next
-    store_var _100
-    jump L85
-
-  L82:
-    load_type testing.TestSetRegistration
-    load_type void
-    load_var _69
-    call baml.iter.StepBy.Iterator.next
-    store_var _100
-    jump L85
-
-  L83:
-    load_type testing.TestSetRegistration
-    load_var _69
-    call baml.iter.ArrayIterator.Iterator.next
-    store_var _100
-    jump L85
-
-  L84:
-    load_var _69
-    make_bound_method baml.iter.Flatten.Iterator.next
-    call_indirect
-    store_var _100
-
-  L85:
-    load_var _100
-    is_type baml.iter.Done
-    pop_jump_if_false L86
-    jump L89
-
-  L86:
-    load_var _100
+    load_var _42
     store_var ts
     load_type string
     load_type testing.TestRegistry
@@ -3348,10 +1987,10 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var expanded
     load_var expanded
     is_type testing.TestRegistry
-    pop_jump_if_false L87
-    jump L88
+    pop_jump_if_false L43
+    jump L44
 
-  L87:
+  L43:
     load_var items
     load_const "lazyTestSet"
     load_var ts
@@ -3359,30 +1998,30 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     init_instance testing.SerializedTest .type, .name
     call baml.Array.push
     pop 1
-    jump L66
+    jump L22
 
-  L88:
+  L44:
     load_var expanded
     store_var sub
     load_var ts
     load_field .name
-    store_var _139
+    store_var _81
     load_var sub
     call testing.TestRegistry.serialize
-    store_var _140
+    store_var _82
     load_var2 2 12
     load_var2 13 11
     load_field .loading_time_ms
     init_instance testing.SerializedTestSet .name, .items, .loadingTimeMs
     call baml.Array.push
     pop 1
-    jump L66
+    jump L22
 
-  L89:
+  L45:
     load_var items
     return
 
-  L90:
+  L46:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/tests/comparable_sort.rs
+++ b/baml_language/crates/baml_tests/tests/comparable_sort.rs
@@ -1,0 +1,1374 @@
+//! Spike tests for the `Comparable` / `Sortable` array-sort design
+//! (thoughts/sam-projects/array-sort/01b-option-5-tdd-plan.md, Phase 1).
+//!
+//! These tests pin the three pieces of type-system machinery the design
+//! depends on, using throwaway interfaces so failures point at the compiler
+//! rather than at the stdlib:
+//!
+//!   1a. An associated-type *binding whose value is a projection off the
+//!       impl's type variable* (`type WE = (T as HasErr).E`) inside a blanket
+//!       impl for `T[]`, with the projection used in `throws` position and
+//!       normalized at concrete call sites (`never` ⇒ no handling required).
+//!   1b. Method resolution of blanket-impl interface methods on *array
+//!       receivers* via direct call syntax (`xs.method()`), the call-site
+//!       error for non-qualifying element types, and the BEP-044 rule that a
+//!       class method shadows a same-named interface method.
+//!   1c. A two-`Self` method (`compare(self, other: Self)`) called through a
+//!       bounded type variable.
+//!
+//! Later phases (the real `Comparable`/`Sortable` stdlib work) build on these;
+//! see `baml_src/ns_arrays/arrays.baml` for the runtime characterization net.
+
+use std::collections::HashSet;
+
+use baml_compiler_diagnostics::Severity;
+use baml_project::{collect_diagnostics, testing::setup_test_db};
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+fn collect_compile_errors(source: &str) -> Vec<String> {
+    let db = setup_test_db(source);
+    let project = db.get_project().expect("project must be set");
+    let all_files = db.get_source_files();
+    let user_file_ids: HashSet<_> = all_files.iter().map(|f| f.file_id(&db)).collect();
+
+    collect_diagnostics(&db, project, &all_files)
+        .into_iter()
+        .filter(|d| matches!(d.severity, Severity::Error))
+        .filter(|d| {
+            d.primary_span()
+                .map(|span| user_file_ids.contains(&span.file_id))
+                .unwrap_or(false)
+        })
+        .map(|d| format!("[{}] {}", d.code(), d.message))
+        .collect()
+}
+
+#[track_caller]
+fn assert_zero_compile_errors(source: &str) {
+    let errors = collect_compile_errors(source);
+    assert!(
+        errors.is_empty(),
+        "expected zero compile errors, got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+#[track_caller]
+fn assert_compile_error_contains(source: &str, needle: &str) {
+    let errors = collect_compile_errors(source);
+    assert!(
+        errors.iter().any(|e| e.contains(needle)),
+        "expected a compile error containing {needle:?}; got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+// ── 1a: projection-valued associated-type binding in a blanket impl ─────────
+//
+// The throwaway scaffolding mirrors the eventual `Comparable`/`Sortable`
+// shape: `HasErr` plays `Comparable` (associated error `E`), `Wrap` plays
+// `Sortable` (associated error `WE` bound per-impl to the *projection*
+// `(T as HasErr).E`).
+
+const SPIKE_1A_SCAFFOLD: &str = r#"
+    interface HasErr {
+        type E
+        function f(self) -> int throws E
+    }
+
+    interface Wrap {
+        type WE
+        function g(self) -> int throws WE
+    }
+
+    implements<T extends HasErr> Wrap for T[] {
+        type WE = T.E
+
+        // NB: spelling matters throughout this impl. In throws position
+        // neither `WE` nor `Self.WE` resolves (E0002), and the checker does
+        // not unify the qualified projection `(T as HasErr).E` with the
+        // body's inferred shorthand `T.E` (E0096/E0120) — so the binding,
+        // the signature, and the body must all agree on the `T.E` spelling.
+        function g(self) -> int throws T.E {
+            if (self.length() == 0) { return 0 }
+            return self[0].f()
+        }
+    }
+"#;
+
+#[test]
+fn spike_1a_projection_valued_assoc_binding_in_blanket_impl_compiles() {
+    assert_zero_compile_errors(SPIKE_1A_SCAFFOLD);
+}
+
+#[tokio::test]
+async fn spike_1a_projection_normalizes_to_never_at_concrete_callsite() {
+    // `Safe.E = never`, so `(Safe as HasErr).E = never` and `xs.g()` requires
+    // no error handling: `main` declares no `throws` and uses no `catch`.
+    let output = baml_test!(&format!(
+        r#"
+        {SPIKE_1A_SCAFFOLD}
+
+        class Safe {{
+            value: int
+            implements HasErr {{
+                type E = never
+                function f(self) -> int throws never {{ return self.value }}
+            }}
+        }}
+
+        function main() -> int throws never {{
+            let xs: Safe[] = [Safe {{ value: 7 }}]
+            return xs.g()
+        }}
+        "#
+    ));
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(7));
+}
+
+#[test]
+fn spike_1a_projection_with_concrete_error_requires_handling() {
+    // `Risky.E = Kaboom`, so `xs.g()` throws `Kaboom` at the call site; a
+    // caller that neither catches nor declares it must not compile.
+    assert_compile_error_contains(
+        &format!(
+            r#"
+            {SPIKE_1A_SCAFFOLD}
+
+            class Kaboom {{
+                message: string
+            }}
+
+            class Risky {{
+                implements HasErr {{
+                    type E = Kaboom
+                    function f(self) -> int throws Kaboom {{
+                        throw Kaboom {{ message: "kaboom" }}
+                    }}
+                }}
+            }}
+
+            // An undeclared `throws` is *inferred*, so the unhandled-error
+            // check only fires against an explicit declaration.
+            function main() -> int throws never {{
+                let xs: Risky[] = [Risky {{}}]
+                return xs.g()
+            }}
+            "#
+        ),
+        "Kaboom",
+    );
+}
+
+#[tokio::test]
+async fn spike_1a_concrete_error_is_catchable_at_callsite() {
+    let output = baml_test!(&format!(
+        r#"
+        {SPIKE_1A_SCAFFOLD}
+
+        class Kaboom {{
+            message: string
+        }}
+
+        class Risky {{
+            implements HasErr {{
+                type E = Kaboom
+                function f(self) -> int throws Kaboom {{
+                    throw Kaboom {{ message: "kaboom" }}
+                }}
+            }}
+        }}
+
+        function main() -> string {{
+            let xs: Risky[] = [Risky {{}}]
+            return {{
+                let v = xs.g();
+                "no throw"
+            }} catch (e) {{
+                Kaboom => "caught:" + e.message
+            }}
+        }}
+        "#
+    ));
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("caught:kaboom".into())
+    );
+}
+
+#[tokio::test]
+async fn spike_1a_symbolic_projection_propagates_through_generic_code() {
+    // Inside generic code over `U extends HasErr`, `us.g()` stays symbolic:
+    // the wrapper declares `throws (U as HasErr).E` and re-throws. At the
+    // concrete call site the projection resolves to `Kaboom` and is caught.
+    let output = baml_test!(&format!(
+        r#"
+        {SPIKE_1A_SCAFFOLD}
+
+        class Kaboom {{
+            message: string
+        }}
+
+        class Risky {{
+            implements HasErr {{
+                type E = Kaboom
+                function f(self) -> int throws Kaboom {{
+                    throw Kaboom {{ message: "kaboom" }}
+                }}
+            }}
+        }}
+
+        function call_g<U extends HasErr>(us: U[]) -> int throws U.E {{
+            return us.g()
+        }}
+
+        function main() -> string {{
+            let xs: Risky[] = [Risky {{}}]
+            return {{
+                let v = call_g(xs);
+                "no throw"
+            }} catch (e) {{
+                Kaboom => "caught:" + e.message
+            }}
+        }}
+        "#
+    ));
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("caught:kaboom".into())
+    );
+}
+
+#[test]
+fn spike_1a_symbolic_projection_in_generic_signature_compiles() {
+    assert_zero_compile_errors(&format!(
+        r#"
+        {SPIKE_1A_SCAFFOLD}
+
+        function call_g<U extends HasErr>(us: U[]) -> int throws U.E {{
+            return us.g()
+        }}
+        "#
+    ));
+}
+
+#[test]
+fn spike_1a_diagnostics_path_survives_non_qualifying_projection() {
+    // BEP-057 flags TIR projection-on-type-variable normalization as the
+    // historically crash-prone layer. Feed the diagnostics pipeline a call
+    // site whose element type does NOT satisfy the bound: we must get
+    // ordinary diagnostics back (any number), never a panic.
+    let errors = collect_compile_errors(&format!(
+        r#"
+        {SPIKE_1A_SCAFFOLD}
+
+        class NoImpl {{
+            value: int
+        }}
+
+        function main() -> int {{
+            let xs: NoImpl[] = [NoImpl {{ value: 1 }}]
+            return xs.g()
+        }}
+        "#
+    ));
+    assert!(
+        !errors.is_empty(),
+        "expected a call-site error for a non-qualifying element type"
+    );
+}
+
+// ── 1b: blanket-impl method resolution on array receivers ───────────────────
+
+const SPIKE_1B_SCAFFOLD: &str = r#"
+    interface Named {
+        name: string
+    }
+
+    interface FirstNamed {
+        function first_name(self) -> string
+    }
+
+    implements<T extends Named> FirstNamed for T[] {
+        function first_name(self) -> string {
+            if (self.length() == 0) { return "" }
+            return self[0].name
+        }
+    }
+
+    class Person {
+        name: string
+        implements Named {}
+    }
+"#;
+
+#[tokio::test]
+async fn spike_1b_blanket_method_resolves_on_array_receiver() {
+    // Direct call syntax on the array receiver — not via an interface-typed
+    // variable. Runtime result proves dispatch found the blanket impl.
+    let output = baml_test!(&format!(
+        r#"
+        {SPIKE_1B_SCAFFOLD}
+
+        function main() -> string {{
+            let xs: Person[] = [Person {{ name: "Ada" }}, Person {{ name: "Bob" }}]
+            return xs.first_name()
+        }}
+        "#
+    ));
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("Ada".into())
+    );
+}
+
+#[test]
+fn spike_1b_non_qualifying_element_is_compile_error_at_callsite() {
+    // `Rock` does not implement `Named`, so `rocks.first_name()` must fail at
+    // the call site. This is the exact error a user will see for
+    // `Resume[].sort()` — Phase 6 polishes its wording; here we only pin that
+    // it exists and names the offending type.
+    assert_compile_error_contains(
+        &format!(
+            r#"
+            {SPIKE_1B_SCAFFOLD}
+
+            class Rock {{
+                label: string
+            }}
+
+            function main() -> string {{
+                let rocks: Rock[] = [Rock {{ label: "igneous" }}]
+                return rocks.first_name()
+            }}
+            "#
+        ),
+        "Rock",
+    );
+}
+
+#[tokio::test]
+async fn spike_1b_blanket_interface_method_wins_over_array_class_method() {
+    // FINDING (deviates from the plan's expectation): BEP-044 documents
+    // class-method precedence on direct calls, but for structural array
+    // receivers the blanket impl's `count` (returning -1) currently wins over
+    // `Array.count()` (= length, 3). Pinned as-is. Phase 4 still deletes
+    // `sort` from `class Array<T>` — under this ordering the class method
+    // would be unreachable dead code, and under the BEP-044 ordering it would
+    // shadow the interface; removal is correct either way.
+    let output = baml_test!(
+        r#"
+        interface Countable {
+            function count(self) -> int
+        }
+
+        implements<T> Countable for T[] {
+            function count(self) -> int { return -1 }
+        }
+
+        function main() -> int {
+            let xs: int[] = [1, 2, 3]
+            return xs.count()
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(-1));
+}
+
+// ── 1c: two-`Self` method called through a bounded type variable ────────────
+
+#[tokio::test]
+async fn spike_1c_two_self_method_through_bounded_typevar_runs() {
+    // Both arguments are the same type variable `T`, so the `Self`s provably
+    // match — exactly the shape of `a.compare(b)` inside the blanket `sort`.
+    let output = baml_test!(
+        r#"
+        interface Cmp {
+            function compare(self, other: Self) -> int
+        }
+
+        class Num {
+            value: int
+            implements Cmp {
+                function compare(self, other: Self) -> int {
+                    return self.value - other.value
+                }
+            }
+        }
+
+        function lt<T extends Cmp>(a: T, b: T) -> bool {
+            return a.compare(b) < 0
+        }
+
+        function main() -> bool {
+            return lt(Num { value: 1 }, Num { value: 2 })
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Bool(true));
+}
+
+#[test]
+fn spike_1c_interface_typed_values_cannot_call_two_self_method() {
+    // Guard against accidental loosening of the existing `Self` rule: two
+    // *interface-typed* values have unprovable `Self`s and must not compile.
+    assert_compile_error_contains(
+        r#"
+        interface Cmp {
+            function compare(self, other: Self) -> int
+        }
+
+        function bad(a: Cmp, b: Cmp) -> bool {
+            return a.compare(b) < 0
+        }
+        "#,
+        "Self",
+    );
+}
+
+// ── Phase 2 repro: user-class Comparable dispatch (fast harness) ────────────
+
+#[test]
+fn phase2_user_class_missing_cmperror_binding_is_error() {
+    // `Comparable.CmpError` is undefaulted, so omitting `type CmpError` is a
+    // compile error — the binding is mandatory (E0001), distinct from the
+    // method's `throws` (E0120).
+    assert_compile_error_contains(
+        r#"
+        class Score {
+            points: int
+            implements baml.Comparable {
+                function compare(self, other: Self) -> int throws never {
+                    if (self.points < other.points) { -1 }
+                    else if (self.points > other.points) { 1 }
+                    else { 0 }
+                }
+            }
+        }
+        "#,
+        "CmpError",
+    );
+}
+
+#[tokio::test]
+async fn phase2_user_class_compare_direct_call_in_main() {
+    let output = baml_test!(
+        r#"
+        class Score {
+            points: int
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    if (self.points < other.points) { -1 }
+                    else if (self.points > other.points) { 1 }
+                    else { 0 }
+                }
+            }
+        }
+
+        function main() -> int throws never {
+            let high = Score { points: 9 }
+            let low = Score { points: 1 }
+            return high.compare(low)
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
+}
+
+#[tokio::test]
+async fn phase2_user_class_compare_with_explicit_binding_in_main() {
+    let output = baml_test!(
+        r#"
+        class Score {
+            points: int
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    if (self.points < other.points) { -1 }
+                    else if (self.points > other.points) { 1 }
+                    else { 0 }
+                }
+            }
+        }
+
+        function main() -> int throws never {
+            let high = Score { points: 9 }
+            let low = Score { points: 1 }
+            return high.compare(low)
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
+}
+
+#[tokio::test]
+async fn phase2_user_class_compare_direct_call_mir_optimized() {
+    let output = baml_tests::baml_test_optimized!(
+        r#"
+        class Score {
+            points: int
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    if (self.points < other.points) { -1 }
+                    else if (self.points > other.points) { 1 }
+                    else { 0 }
+                }
+            }
+        }
+
+        function main() -> int throws never {
+            let high = Score { points: 9 }
+            let low = Score { points: 1 }
+            return high.compare(low)
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
+}
+
+// ── Phase 3: `Sortable` blanket impl + projection normalization ─────────────
+//
+// Canonical scaffold mirrors the real stdlib: `Comparable`-style interface
+// with an UNDEFAULTED associated error (`type CE`, no `= never`), a
+// `Sortable`-style blanket impl binding `SE = T.CE`, and user classes that
+// bind `CE` explicitly (to `never` or a concrete error).
+//
+// FINDING — a *defaulted* associated error breaks the fallible case: see
+// `phase3_defaulted_assoc_error_over_constrains_bound` below. That is why the
+// stdlib `Comparable.CmpError` is intentionally undefaulted.
+
+const PHASE3_SCAFFOLD: &str = r#"
+    interface Cmp2 {
+        type CE
+        function comp(self, other: Self) -> int throws CE
+    }
+
+    interface Srt2 {
+        type SE
+        function srt(self) -> Self throws SE
+    }
+
+    implements<T extends Cmp2> Srt2 for T[] {
+        type SE = T.CE
+
+        function srt(self) -> Self throws T.CE {
+            self.sort_by((a: T, b: T) -> int throws T.CE { a.comp(b) })
+        }
+    }
+
+    class Boom2 { message: string }
+
+    class WithNever {
+        v: int
+        implements Cmp2 {
+            type CE = never
+            function comp(self, other: Self) -> int throws never { return 0 }
+        }
+    }
+
+    class WithErr {
+        v: int
+        implements Cmp2 {
+            type CE = Boom2
+            function comp(self, other: Self) -> int throws Boom2 { return 0 }
+        }
+    }
+"#;
+
+#[test]
+fn phase3_never_binding_callsite_normalizes_to_never() {
+    // `WithNever.CE = never`, so `(WithNever[] as Srt2).SE` normalizes to
+    // `never`: `srt()` requires no error handling.
+    assert_zero_compile_errors(&format!(
+        r#"
+        {PHASE3_SCAFFOLD}
+        function f(xs: WithNever[]) -> WithNever[] throws never {{
+            xs.srt()
+        }}
+        "#
+    ));
+}
+
+#[test]
+fn phase3_error_binding_callsite_throws_it() {
+    // `WithErr.CE = Boom2`, so `srt()` throws `Boom2` and the caller must
+    // declare it (here) or catch it.
+    assert_zero_compile_errors(&format!(
+        r#"
+        {PHASE3_SCAFFOLD}
+        function f(xs: WithErr[]) -> WithErr[] throws Boom2 {{
+            xs.srt()
+        }}
+        "#
+    ));
+}
+
+#[test]
+fn phase3_error_binding_unhandled_is_compile_error() {
+    // The dual of the previous test: failing to handle `Boom2` is an error.
+    assert_compile_error_contains(
+        &format!(
+            r#"
+            {PHASE3_SCAFFOLD}
+            function f(xs: WithErr[]) -> WithErr[] throws never {{
+                xs.srt()
+            }}
+            "#
+        ),
+        "Boom2",
+    );
+}
+
+// Issue-A regression: a projection off a *primitive* base type
+// (`int.CE` via `implements Cmp2 for int`) must normalize. Before the
+// `resolve_primitive_projection` fix this stayed symbolic and `int[].srt()`
+// spuriously "threw `int.CE`".
+#[test]
+fn phase3_out_of_body_impl_on_builtin_normalizes_to_never() {
+    assert_zero_compile_errors(&format!(
+        r#"
+        {PHASE3_SCAFFOLD}
+
+        implements Cmp2 for int {{
+            type CE = never
+            function comp(self, other: Self) -> int throws never {{ return 0 }}
+        }}
+
+        function f(xs: int[]) -> int[] throws never {{
+            xs.srt()
+        }}
+        "#
+    ));
+}
+
+#[test]
+fn phase3_out_of_body_impl_on_builtin_with_error_throws_it() {
+    assert_zero_compile_errors(&format!(
+        r#"
+        {PHASE3_SCAFFOLD}
+
+        implements Cmp2 for int {{
+            type CE = Boom2
+            function comp(self, other: Self) -> int throws Boom2 {{ return 0 }}
+        }}
+
+        function f(xs: int[]) -> int[] throws Boom2 {{
+            xs.srt()
+        }}
+        "#
+    ));
+}
+
+// FINDING (documents *why* the stdlib `Comparable.CmpError` is undefaulted):
+// when the interface associated type has a default, a bare `T extends Cmp`
+// bound is silently constrained to that default, so an implementor that
+// overrides it (a fallible comparator) is rejected by the blanket impl —
+// `srt` does not resolve on its array. Pinned as a known limitation.
+#[test]
+fn phase3_defaulted_assoc_error_over_constrains_bound() {
+    let errors = collect_compile_errors(
+        r#"
+        interface CmpD {
+            type CE = never
+            function comp(self, other: Self) -> int throws CE
+        }
+
+        interface SrtD {
+            type SE
+            function srt(self) -> Self throws SE
+        }
+
+        implements<T extends CmpD> SrtD for T[] {
+            type SE = T.CE
+            function srt(self) -> Self throws T.CE {
+                self.sort_by((a: T, b: T) -> int throws T.CE { a.comp(b) })
+            }
+        }
+
+        class BoomD { message: string }
+
+        class WithErrD {
+            v: int
+            implements CmpD {
+                type CE = BoomD
+                function comp(self, other: Self) -> int throws BoomD { return 0 }
+            }
+        }
+
+        function f(xs: WithErrD[]) -> WithErrD[] throws BoomD {
+            xs.srt()
+        }
+        "#,
+    );
+    assert!(
+        errors.iter().any(|e| e.contains("srt")),
+        "expected the defaulted-assoc-type bug to block `srt` resolution; got:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+// ── Phase 3 runtime: actually execute the blanket `sort` ───────────────────
+
+#[tokio::test]
+async fn phase3_runtime_sort_ints() {
+    // join() stringifies only strings, so assert via indexing on the result.
+    let output = baml_test!(
+        r#"
+        function main() -> int throws never {
+            let xs = [3, 1, 2]
+            let s = xs.sort()
+            return s[0] * 100 + s[1] * 10 + s[2]
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(123));
+}
+
+// ── Phase 3 runtime gap-mapping: generic dispatch to primitive vs class ─────
+
+#[tokio::test]
+async fn phase3_runtime_generic_compare_on_primitive() {
+    let output = baml_test!(
+        r#"
+        function cmp<T extends baml.Comparable>(a: T, b: T) -> int throws T.CmpError {
+            return a.compare(b)
+        }
+        function main() -> int throws never {
+            let a: int = 3
+            let b: int = 1
+            return cmp(a, b)
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
+}
+
+#[tokio::test]
+async fn phase3_runtime_generic_compare_on_user_class() {
+    let output = baml_test!(
+        r#"
+        class Score {
+            points: int
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    return self.points.compare(other.points)
+                }
+            }
+        }
+        function cmp<T extends baml.Comparable>(a: T, b: T) -> int throws T.CmpError {
+            return a.compare(b)
+        }
+        function main() -> int throws never {
+            return cmp(Score { points: 9 }, Score { points: 1 })
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
+}
+
+#[tokio::test]
+async fn phase3_runtime_sort_user_class() {
+    let output = baml_test!(
+        r#"
+        class Score {
+            points: int
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    return self.points.compare(other.points)
+                }
+            }
+        }
+        function main() -> int throws never {
+            let xs = [Score { points: 3 }, Score { points: 1 }, Score { points: 2 }]
+            let sorted = xs.sort()
+            return sorted[0].points
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
+}
+
+// Same body as the blanket `sort`, but as a plain generic function — isolates
+// whether the failure is the blanket-impl context or generic lambda dispatch.
+#[tokio::test]
+async fn phase3_runtime_generic_fn_sort_by_compare_ints() {
+    let output = baml_test!(
+        r#"
+        function gsort<T extends baml.Comparable>(xs: T[]) -> T[] throws T.CmpError {
+            return xs.sort_by((a: T, b: T) -> int throws T.CmpError { a.compare(b) })
+        }
+        function main() -> int throws never {
+            let xs = [3, 1, 2]
+            let s = gsort(xs)
+            return s[0] * 100 + s[1] * 10 + s[2]
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(123));
+}
+
+// User-code generic `sort_by`-with-compare-lambda over a *user class*. Unlike
+// the stdlib `Sortable.sort` (which routes through `_compare_shim` because it
+// cannot see downstream impls), a user generic body sees its own `Comparable`
+// impl and dispatches `compare` statically.
+#[tokio::test]
+async fn phase3_runtime_user_generic_sort_by_compare_user_class() {
+    let output = baml_test!(
+        r#"
+        class Score {
+            points: int
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    return self.points.compare(other.points)
+                }
+            }
+        }
+        function gsort<T extends baml.Comparable>(xs: T[]) -> T[] throws T.CmpError {
+            return xs.sort_by((a: T, b: T) -> int throws T.CmpError { a.compare(b) })
+        }
+        function main() -> int throws never {
+            let xs = [Score { points: 3 }, Score { points: 1 }, Score { points: 2 }]
+            let s = gsort(xs)
+            return s[0].points * 100 + s[1].points * 10 + s[2].points
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(123));
+}
+
+#[tokio::test]
+async fn phase3_runtime_sort_param_receiver_in_function() {
+    // Param-receiver dispatch in a real function (not a test block). The
+    // baml_src test-block versions fail only because passing a test-block
+    // `let` local to a function is a known VM quirk, unrelated to sort.
+    let output = baml_test!(
+        r#"
+        function do_sort(xs: int[]) -> int[] throws never {
+            return xs.sort()
+        }
+        function main() -> int throws never {
+            let xs = [3, 1, 2]
+            let s = do_sort(xs)
+            return s[0] * 100 + s[1] * 10 + s[2]
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(123));
+}
+
+// ── Phase 5: deliberate breaking changes (now compile errors) ───────────────
+//
+// After the cutover, `sort()` is the `Sortable` blanket method requiring
+// `T implements Comparable`. Element types that cannot implement `Comparable`
+// — unions (including optionals) and user classes without an impl — no longer
+// compile, where the old native `Array.sort` accepted them and threw at
+// runtime.
+
+#[test]
+fn phase5_union_int_float_sort_is_compile_error() {
+    // A union element can't implement `Comparable`, so `T.CmpError` stays
+    // un-normalizable and surfaces as an unhandled-throws error naming the
+    // union (`int | float.CmpError`).
+    assert_compile_error_contains(
+        r#"
+        function f() -> null throws never {
+            let xs: (int | float)[] = [1, 2.5]
+            xs.sort()
+            return null
+        }
+        "#,
+        "int | float",
+    );
+}
+
+#[test]
+fn phase5_optional_element_sort_is_compile_error() {
+    // Optional = union with null; `sort` doesn't resolve on the array at all
+    // (E0007 names the offending array type and the missing member).
+    let source = r#"
+        function f() -> null throws never {
+            let xs: int?[] = [1, null, 2]
+            xs.sort()
+            return null
+        }
+        "#;
+    assert_compile_error_contains(source, "(int | null)[]");
+    assert_compile_error_contains(source, "no member `sort`");
+}
+
+#[test]
+fn phase5_sort_by_key_nullable_key_is_compile_error() {
+    // `sort_by_key` now requires `U extends Comparable` (it orders by the key's
+    // natural order). A nullable key (`int?` = a union) cannot implement
+    // `Comparable`, so `U.CmpError` stays un-normalizable (named after the
+    // union key type) — replacing the old runtime `InvalidArgument` rejection.
+    assert_compile_error_contains(
+        r#"
+        function f() -> null throws never {
+            let xs = [3, 1, 2]
+            xs.sort_by_key((x: int) -> int? { if (x == 1) { null } else { x } })
+            return null
+        }
+        "#,
+        "int | null",
+    );
+}
+
+#[test]
+fn phase5_union_int_string_sort_is_compile_error() {
+    assert_compile_error_contains(
+        r#"
+        function f() -> null throws never {
+            let xs: (int | string)[] = [2, "x", 1]
+            xs.sort()
+            return null
+        }
+        "#,
+        "int | string",
+    );
+}
+
+#[test]
+fn phase5_class_without_comparable_sort_is_compile_error() {
+    // E0007: the array type has no `sort` member (no `Comparable` impl, so
+    // the `Sortable` blanket impl doesn't apply). phase6 pins the full
+    // message shape; here we pin the offending type and member.
+    let source = r#"
+        class Resume {
+            name: string
+        }
+        function f() -> null throws never {
+            let xs = [Resume { name: "b" }, Resume { name: "a" }]
+            xs.sort()
+            return null
+        }
+        "#;
+    assert_compile_error_contains(source, "Resume[]");
+    assert_compile_error_contains(source, "sort");
+}
+
+#[tokio::test]
+async fn phase5_class_with_comparable_sort_compiles_and_runs() {
+    // The dual: a class that DOES implement Comparable sorts fine.
+    let output = baml_test!(
+        r#"
+        class Resume {
+            rank: int
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    return self.rank.compare(other.rank)
+                }
+            }
+        }
+        function main() -> int throws never {
+            let xs = [Resume { rank: 3 }, Resume { rank: 1 }, Resume { rank: 2 }]
+            let sorted = xs.sort()
+            return sorted[0].rank
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
+}
+
+// ── 02 Phase 1: dispatch shape for the primitive fast path ──────────────────
+//
+// Spikes for thoughts/sam-projects/array-sort/02-native-sort-fast-path-plan.md.
+//
+// FINDING (kills the plan's primary shape): the intended
+// `match (self) { int[] => …, bigint[] => …, …, _ => … }` dispatch cannot
+// work. Array type patterns do not discriminate element types — the runtime
+// `IsType` test for an array type is just the LIST type *tag* (`value_type_tag`
+// in `bex_vm/src/vm.rs` carries no element type), and the exhaustiveness
+// matrix mirrors that: the first array arm covers all of `T[]`, so every later
+// arm is `[E0063] unreachable arm` (pinned below). Per-arm refinement of `T`
+// never gets a chance to matter.
+//
+// SECOND FINDING: the pre-approved fallback "boolean `is`-test" cannot be a
+// *BAML-level* `is` either. `x is int` on a `T`-typed value compiles, but TIR
+// records the pattern type as the intersection of `T` and `int` — `Never` —
+// and MIR lowers a `Never` pattern type to a constant-false test
+// (`lower_pattern_test` → `convert_tir2_ty`), so the test never fires at
+// runtime (pinned below).
+//
+// The dispatch therefore uses a single native boolean,
+// `root._is_primitive_array(self)`, which reads the first element's runtime
+// type *tag* (per-element tags DO discriminate int/bigint/string/float),
+// routing to a single `root._rust_sort(self)`. `T` stays fully symbolic — no
+// refinement needed, `_rust_sort` is itself generic over `T extends
+// Comparable` — and the homogeneity of `T[]` plus `T extends Comparable`
+// guarantees a primitive first element implies a primitive `T`. Like
+// `_compare_shim`, the native test dispatches on runtime *values*, not on
+// frame type arguments, so it is immune to type-arg plumbing gaps. `is_fast`
+// stands in for the native boolean; `fast_g` for `_rust_sort`; `slow_g` for
+// the `sort_by` path.
+
+#[test]
+fn match_dispatch_array_type_arms_do_not_discriminate() {
+    // Documents WHY the dispatch is an element `is`-test rather than the
+    // plan's `match (self)` shape: the second and later array-type arms are
+    // unreachable (one LIST tag, no element type at runtime).
+    assert_compile_error_contains(
+        r#"
+        function fast_g<T extends baml.Comparable>(xs: T[]) -> T[] throws T.CmpError {
+            return xs
+        }
+
+        function dispatch_f<T extends baml.Comparable>(xs: T[]) -> T[] throws T.CmpError {
+            match (xs) {
+                int[] => fast_g(xs),
+                bigint[] => fast_g(xs),
+                string[] => fast_g(xs),
+                float[] => fast_g(xs),
+                _ => xs,
+            }
+        }
+        "#,
+        "unreachable arm",
+    );
+}
+
+#[tokio::test]
+async fn is_primitive_on_generic_value_folds_to_false() {
+    // Documents WHY the boolean test is native: a BAML-level `is int` on a
+    // `T`-typed value lowers to a constant-false test (pattern type `T ∩ int`
+    // = `Never`), so even an actual int reports false. If this ever starts
+    // returning 11, the `Sortable.sort` dispatch can move back to pure BAML.
+    let output = baml_test!(
+        r#"
+        function probe<T>(x: T) -> int {
+            if (x is int) { 1 } else { 0 }
+        }
+        function main() -> int {
+            let a: int = 42
+            return probe(a) * 10 + probe("s")
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(0));
+}
+
+const ELEMENT_DISPATCH_SCAFFOLD: &str = r#"
+    function is_fast<T extends baml.Comparable>(xs: T[]) -> bool throws never {
+        return xs.length() == 0
+    }
+
+    function fast_g<T extends baml.Comparable>(xs: T[]) -> T[] throws T.CmpError {
+        return xs
+    }
+
+    function slow_g<T extends baml.Comparable>(xs: T[]) -> T[] throws T.CmpError {
+        return xs
+    }
+
+    function dispatch_f<T extends baml.Comparable>(xs: T[]) -> T[] throws T.CmpError {
+        if (is_fast(xs)) {
+            fast_g(xs)
+        } else {
+            slow_g(xs)
+        }
+    }
+"#;
+
+#[test]
+fn element_is_dispatch_compiles() {
+    // The fallback shape: a boolean guard routing between two generic callees
+    // instantiated at the *symbolic* `T` (return `T[]`, throws `T.CmpError`)
+    // with no refinement anywhere.
+    assert_zero_compile_errors(ELEMENT_DISPATCH_SCAFFOLD);
+}
+
+#[test]
+fn element_is_dispatch_int_callsite_normalizes_to_never() {
+    assert_zero_compile_errors(&format!(
+        r#"
+        {ELEMENT_DISPATCH_SCAFFOLD}
+        function use_int(xs: int[]) -> int[] throws never {{
+            dispatch_f(xs)
+        }}
+        "#
+    ));
+}
+
+#[test]
+fn element_is_dispatch_float_callsite_normalizes_to_never() {
+    // Relies on the 02-plan float decision: `float.CmpError = never`
+    // (total_cmp ordering), so a `float[]` call site needs no handling.
+    assert_zero_compile_errors(&format!(
+        r#"
+        {ELEMENT_DISPATCH_SCAFFOLD}
+        function use_float(xs: float[]) -> float[] throws never {{
+            dispatch_f(xs)
+        }}
+        "#
+    ));
+}
+
+#[test]
+fn element_is_dispatch_user_error_callsite_requires_handling() {
+    assert_compile_error_contains(
+        &format!(
+            r#"
+            {ELEMENT_DISPATCH_SCAFFOLD}
+
+            class DispatchBoom {{ message: string }}
+
+            class DispatchErr {{
+                v: int
+                implements baml.Comparable {{
+                    type CmpError = DispatchBoom
+                    function compare(self, other: Self) -> int throws DispatchBoom {{ return 0 }}
+                }}
+            }}
+
+            function use_err(xs: DispatchErr[]) -> DispatchErr[] throws never {{
+                dispatch_f(xs)
+            }}
+            "#
+        ),
+        "DispatchBoom",
+    );
+}
+
+#[tokio::test]
+async fn element_is_dispatch_runtime_both_branches() {
+    // The dispatch shape executes correctly at runtime for a primitive and a
+    // user-class element type, through both branches (empty → `is_fast` true
+    // in the stand-in, non-empty → the slow branch). Real routing through the
+    // native `_is_primitive_array` is pinned by the Phase 4/5 sort tests.
+    let output = baml_test!(&format!(
+        r#"
+        {ELEMENT_DISPATCH_SCAFFOLD}
+
+        class RouteItem {{
+            rank int
+            implements baml.Comparable {{
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {{
+                    self.rank.compare(other.rank)
+                }}
+            }}
+        }}
+
+        function main() -> int throws never {{
+            let empty: int[] = []
+            let ints = [3, 1]
+            let items = [RouteItem {{ rank: 7 }}]
+            if (dispatch_f(empty).length() != 0) {{ return -1 }}
+            if (dispatch_f(ints).length() != 2) {{ return -2 }}
+            return dispatch_f(items)[0].rank
+        }}
+        "#
+    ));
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(7));
+}
+
+// ── 02 Phase 5: performance / parity for the native fast path ───────────────
+
+#[tokio::test]
+async fn perf_large_int_array_uses_native_fast_path() {
+    // 10k pseudo-random ints. On the native fast path this is instant; the
+    // comparator path (CPS insertion sort) would make O(n²) ≈ 10⁷–10⁸ yields
+    // into BAML and blow the coarse bound below by orders of magnitude — the
+    // bound is the assertion that primitives no longer route through
+    // `sort_by` + `_compare_shim`.
+    let start = std::time::Instant::now();
+    let output = baml_test!(
+        r#"
+        function main() -> int throws never {
+            let xs: int[] = []
+            let seed = 42
+            let i = 0
+            while (i < 10000) {
+                seed = (seed * 1103515245 + 12345) % 2147483648
+                xs.push(seed)
+                i += 1
+            }
+            let result = xs.sort()
+            if (result != xs) { return -3 }
+            let j = 1
+            while (j < 10000) {
+                match (xs.at(j - 1)) {
+                    null => { return -1 }
+                    let a: int => {
+                        match (xs.at(j)) {
+                            null => { return -1 }
+                            let b: int => { if (a > b) { return -2 } }
+                        }
+                    }
+                }
+                j += 1
+            }
+            return xs.length()
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(10000));
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(60),
+        "10k-int sort took {elapsed:?}; the native fast path should be far \
+         under this bound — did primitives fall back to the comparator path?"
+    );
+}
+
+#[tokio::test]
+async fn parity_fast_path_matches_comparator_path() {
+    // The native natural sort and the `sort_by` + `compare` path must produce
+    // identical orderings for every primitive domain — including float with
+    // NaN/±inf/±0, where both paths must agree on `total_cmp`. The user-class
+    // domain rides along as a sanity check (both sides take the comparator
+    // path there).
+    let output = baml_test!(
+        r#"
+        class ParityItem {
+            rank int
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    self.rank.compare(other.rank)
+                }
+            }
+        }
+
+        function check<T extends baml.Comparable>(xs: T[], ys: T[]) -> bool throws T.CmpError {
+            xs.sort();
+            ys.sort_by((a: T, b: T) -> int throws T.CmpError { a.compare(b) });
+            return baml.deep_equals(xs, ys)
+        }
+
+        function main() -> int throws never {
+            if (!check([3, 1, 2, 1, 3], [3, 1, 2, 1, 3])) { return 1 }
+            let f = [2.5, float.nan(), 0.0 - float.inf(), 0.5, float.inf(), 0.0, float.nan(), 1.5]
+            let g = [2.5, float.nan(), 0.0 - float.inf(), 0.5, float.inf(), 0.0, float.nan(), 1.5]
+            if (!check(f, g)) { return 2 }
+            if (!check(["b", "a", "aa", "b"], ["b", "a", "aa", "b"])) { return 3 }
+            if (!check([3n, 1n, 2n, 1n], [3n, 1n, 2n, 1n])) { return 4 }
+            if (!check(
+                [ParityItem { rank: 3 }, ParityItem { rank: 1 }, ParityItem { rank: 2 }],
+                [ParityItem { rank: 3 }, ParityItem { rank: 1 }, ParityItem { rank: 2 }]
+            )) { return 5 }
+            return 0
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(0));
+}
+
+#[tokio::test]
+async fn float_nan_sorts_via_total_order_no_throw() {
+    // Replacement for the 01b NaN-throws test, through the native fast path:
+    // `float[].sort()` is infallible and places NaN after +inf.
+    let output = baml_test!(
+        r#"
+        function main() -> bool throws never {
+            let xs = [1.0, float.nan(), 0.5, float.inf()]
+            xs.sort()
+            if (xs.at(0) != 0.5 || xs.at(1) != 1.0 || xs.at(2) != float.inf()) { return false }
+            match (xs.at(3)) {
+                null => false
+                let f: float => f.is_nan()
+            }
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Bool(true));
+}
+
+#[tokio::test]
+async fn sort_user_class_with_out_of_body_comparable_impl() {
+    // PR #3732 review (codex P2): an *out-of-body* `implements
+    // baml.Comparable for Score { … }` registers `compare` under the
+    // synthetic `Comparable$for$Score` class (as spelled at the impl site),
+    // not under `Score`. `make_compare_callee` must find it there — the
+    // in-body-only lookup made `Score[].sort()` type-check but fail at
+    // runtime with "compare dispatch: function … not found".
+    let output = baml_test!(
+        r#"
+        class Score {
+            points: int
+        }
+
+        implements baml.Comparable for Score {
+            type CmpError = never
+            function compare(self, other: Self) -> int throws never {
+                self.points.compare(other.points)
+            }
+        }
+
+        function main() -> int throws never {
+            let xs = [Score { points: 3 }, Score { points: 1 }, Score { points: 2 }]
+            let s = xs.sort()
+            return s[0].points * 100 + s[1].points * 10 + s[2].points
+        }
+        "#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(123));
+}
+
+#[tokio::test]
+async fn user_class_still_sorts_through_comparator_path() {
+    // Phase 2/4 interaction regression: a user `Comparable` class routes
+    // through native `sort_by` + the `_compare_shim` lambda (the dispatch's
+    // fallback branch) and still sorts stably, in place, returning self.
+    let output = baml_test!(
+        r#"
+        class Ranked {
+            rank int
+            tag string
+            implements baml.Comparable {
+                type CmpError = never
+                function compare(self, other: Self) -> int throws never {
+                    self.rank.compare(other.rank)
+                }
+            }
+        }
+        function main() -> string throws never {
+            let xs = [
+                Ranked { rank: 2, tag: "a" },
+                Ranked { rank: 1, tag: "b" },
+                Ranked { rank: 2, tag: "c" },
+                Ranked { rank: 1, tag: "d" }
+            ]
+            let result = xs.sort()
+            if (result != xs) { return "not self" }
+            return xs.map((x: Ranked) -> string { x.tag }).join("")
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("bdac".into())
+    );
+}
+
+#[test]
+fn phase6_sort_error_message_names_the_array_type() {
+    // The `Resume[].sort()` failure (no `Comparable` impl) names the array type
+    // and the missing `sort` member, with a stable `E0007` code. (A richer
+    // "implement Comparable or use sort_by" hint would live in the diagnostic
+    // rendering layer rather than the `TirTypeError` Display — deferred.)
+    let errors = collect_compile_errors(
+        r#"
+        class Resume { name: string }
+        function f() -> null throws never {
+            let xs = [Resume { name: "b" }, Resume { name: "a" }]
+            xs.sort()
+            return null
+        }
+        "#,
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.starts_with("[E0007]") && e.contains("Resume[]") && e.contains("sort")),
+        "expected a typed `no member sort` error on `Resume[]`; got:\n  {}",
+        errors.join("\n  ")
+    );
+}

--- a/baml_language/crates/bex_vm/src/package_baml/array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/array.rs
@@ -112,8 +112,20 @@ fn expect_int(vm: &BexVm, value: Value) -> Result<i64, NativeCallResult> {
     }
 }
 
+// ── Natural-order sort machinery (`baml._rust_sort` fast path) ───────────────
+//
+// `Sortable.sort` routes homogeneous primitive arrays (int/bigint/string/
+// float) here via the `_is_primitive_array` guard; everything else goes
+// through `sort_by` + `_compare_shim`. The float domain orders by
+// `f64::total_cmp` — a total order over all doubles including NaN — kept
+// bit-exact with `_float_total_cmp` (which backs `Comparable for float`), so
+// the fast path and the comparator path can never disagree on an ordering.
+// The mixed-domain / null / non-primitive rejections below are defensive:
+// `_rust_sort` is only reached for arrays the type system already proved
+// homogeneous primitive.
+
 #[derive(Clone, Copy)]
-enum NaturalDomain {
+pub(super) enum NaturalDomain {
     Int,
     Float,
     Bigint,
@@ -174,16 +186,9 @@ fn natural_kind(vm: &BexVm, context: &str, value: Value) -> Result<NaturalKind, 
         ));
     };
     match vm.get_object(ptr) {
-        Object::Float(f) => {
-            if f.is_nan() {
-                Err(invalid_sort(
-                    context,
-                    "natural ordering does not support NaN",
-                ))
-            } else {
-                Ok(NaturalKind::Float)
-            }
-        }
+        // NaN is *not* rejected: the float domain orders by `total_cmp`,
+        // which gives NaN a defined position.
+        Object::Float(_) => Ok(NaturalKind::Float),
         Object::Bigint(_) => Ok(NaturalKind::Bigint),
         Object::String(_) => Ok(NaturalKind::String),
         _ => Err(invalid_sort(
@@ -196,7 +201,7 @@ fn natural_kind(vm: &BexVm, context: &str, value: Value) -> Result<NaturalKind, 
     }
 }
 
-fn validate_natural_order_with_vm(
+pub(super) fn validate_natural_order_with_vm(
     vm: &BexVm,
     context: &str,
     values: &[Value],
@@ -276,7 +281,7 @@ fn value_as_string_for_sort(vm: &BexVm, value: Value) -> &bex_str::BexStr {
     }
 }
 
-fn compare_natural_values(
+pub(super) fn compare_natural_values(
     vm: &BexVm,
     domain: NaturalDomain,
     left: Value,
@@ -291,14 +296,35 @@ fn compare_natural_values(
                     .as_int()
                     .expect("validated int sort value should be int"),
             ),
-        NaturalDomain::Float => value_as_float_for_sort(vm, left)
-            .partial_cmp(&value_as_float_for_sort(vm, right))
-            .expect("validated float sort values should not be NaN"),
+        NaturalDomain::Float => {
+            value_as_float_for_sort(vm, left).total_cmp(&value_as_float_for_sort(vm, right))
+        }
         NaturalDomain::Bigint => {
             value_as_bigint_cow_for_sort(vm, left).cmp(&value_as_bigint_cow_for_sort(vm, right))
         }
         NaturalDomain::String => {
             value_as_string_for_sort(vm, left).cmp(value_as_string_for_sort(vm, right))
+        }
+    }
+}
+
+/// Whether the first element's runtime type tag puts `values` in one of the
+/// natural-sort primitive domains. Decides `Sortable.sort`'s dispatch (see
+/// `baml._is_primitive_array` in `comparable.baml`). Empty → `true`.
+pub(super) fn is_primitive_array_values(vm: &BexVm, values: &[Value]) -> bool {
+    match values.first() {
+        None => true,
+        Some(v) => {
+            if v.as_int().is_some() {
+                true
+            } else if let Some(ptr) = v.as_object_ptr() {
+                matches!(
+                    vm.get_object(ptr),
+                    Object::Float(_) | Object::Bigint(_) | Object::String(_)
+                )
+            } else {
+                false
+            }
         }
     }
 }
@@ -324,19 +350,6 @@ fn write_back_array_result(
         Ok(value) => NativeCallResult::Done(value),
         Err(e) => NativeCallResult::Error(e),
     }
-}
-
-fn sort_values_natural(
-    vm: &BexVm,
-    context: &str,
-    values: &mut [Value],
-) -> Result<(), VmRustFnError> {
-    if values.is_empty() {
-        return Ok(());
-    }
-    let domain = validate_natural_order_with_vm(vm, context, values)?;
-    values.sort_by(|left, right| compare_natural_values(vm, domain, *left, *right));
-    Ok(())
 }
 
 // Boilerplate macro for the standard `Continuation` GC impls. Captures named
@@ -607,46 +620,12 @@ impl Continuation for FlatMapContinuation {
     gc_impl_array!(f_ptr: f_ptr, values: [array, results]);
 }
 
-// ─── Array.to_json continuation ──────────────────────────────────────────────
-
-/// Continuation for `Array.to_json`. Dispatches `v.to_json()` for each element
-/// in order, accumulating json results and finalizing into a `json[]` value.
-struct ToJsonContinuation {
-    /// The original array elements.
-    array: Vec<Value>,
-    /// Index of the element whose `to_json()` callback result we are about to receive.
-    /// Starts at 0 (we yield for index 0 before constructing the continuation).
-    idx: usize,
-    /// Accumulated json results so far (does not include in-flight result).
-    results: Vec<Value>,
-}
-
-impl Continuation for ToJsonContinuation {
-    fn call(mut self: Box<Self>, vm: &mut BexVm, value: Value) -> NativeCallResult {
-        self.results.push(value);
-        self.idx += 1;
-
-        if self.idx >= self.array.len() {
-            return NativeCallResult::Done(Value::object(vm.alloc_array(self.results)));
-        }
-
-        let next_val = self.array[self.idx];
-        match make_to_json_callee(vm, next_val) {
-            Ok(callee) => NativeCallResult::YieldToCall {
-                callee,
-                args: vec![],
-                type_args: vec![],
-                continuation: self,
-            },
-            Err(e) => NativeCallResult::Error(e),
-        }
-    }
-
-    gc_impl_array!(values: [array, results]);
-}
-
 // ─── Array.sort_by continuation ─────────────────────────────────────────────
 
+/// CPS insertion sort: builds `sorted` one element at a time, yielding to the
+/// BAML comparator for each `(current, sorted[insert_idx])` pair. The receiver
+/// is only written back once the whole sort completes, so a throwing
+/// comparator leaves the array in its pre-sort state.
 struct SortByContinuation {
     receiver: Value,
     f_ptr: HeapPtr,
@@ -713,64 +692,42 @@ impl Continuation for SortByContinuation {
     }
 }
 
-// ─── Array.sort_by_key continuation ─────────────────────────────────────────
+// ─── Array.to_json continuation ──────────────────────────────────────────────
 
-struct SortByKeyContinuation {
-    receiver: Value,
-    f_ptr: HeapPtr,
-    items: Vec<Value>,
+/// Continuation for `Array.to_json`. Dispatches `v.to_json()` for each element
+/// in order, accumulating json results and finalizing into a `json[]` value.
+struct ToJsonContinuation {
+    /// The original array elements.
+    array: Vec<Value>,
+    /// Index of the element whose `to_json()` callback result we are about to receive.
+    /// Starts at 0 (we yield for index 0 before constructing the continuation).
     idx: usize,
-    keys: Vec<Value>,
+    /// Accumulated json results so far (does not include in-flight result).
+    results: Vec<Value>,
 }
 
-impl SortByKeyContinuation {
-    fn finish(self, vm: &mut BexVm) -> NativeCallResult {
-        let domain = match validate_natural_order_with_vm(vm, "array.sort_by_key", &self.keys) {
-            Ok(domain) => domain,
-            Err(e) => return NativeCallResult::Error(e),
-        };
-        let mut indices: Vec<usize> = (0..self.items.len()).collect();
-        indices.sort_by(|left, right| {
-            compare_natural_values(vm, domain, self.keys[*left], self.keys[*right])
-                .then_with(|| left.cmp(right))
-        });
-        let sorted = indices
-            .into_iter()
-            .map(|idx| self.items[idx])
-            .collect::<Vec<_>>();
-        write_back_array_result(vm, self.receiver, sorted)
-    }
-}
-
-impl Continuation for SortByKeyContinuation {
+impl Continuation for ToJsonContinuation {
     fn call(mut self: Box<Self>, vm: &mut BexVm, value: Value) -> NativeCallResult {
-        self.keys.push(value);
+        self.results.push(value);
         self.idx += 1;
-        if self.idx >= self.items.len() {
-            return self.finish(vm);
+
+        if self.idx >= self.array.len() {
+            return NativeCallResult::Done(Value::object(vm.alloc_array(self.results)));
         }
-        NativeCallResult::YieldToCall {
-            callee: self.f_ptr,
-            args: vec![self.items[self.idx]],
-            type_args: vec![],
-            continuation: self,
+
+        let next_val = self.array[self.idx];
+        match make_to_json_callee(vm, next_val) {
+            Ok(callee) => NativeCallResult::YieldToCall {
+                callee,
+                args: vec![],
+                type_args: vec![],
+                continuation: self,
+            },
+            Err(e) => NativeCallResult::Error(e),
         }
     }
 
-    fn gc_roots(&self) -> Vec<HeapPtr> {
-        let mut roots = vec![self.f_ptr];
-        collect_value_roots(&[self.receiver], &mut roots);
-        collect_value_roots(&self.items, &mut roots);
-        collect_value_roots(&self.keys, &mut roots);
-        roots
-    }
-
-    fn apply_forwarding(&mut self, forwarding: &HashMap<HeapPtr, HeapPtr>) {
-        forward_ptr(&mut self.f_ptr, forwarding);
-        forward_values(std::slice::from_mut(&mut self.receiver), forwarding);
-        forward_values(&mut self.items, forwarding);
-        forward_values(&mut self.keys, forwarding);
-    }
+    gc_impl_array!(values: [array, results]);
 }
 
 impl BamlClassArray for PackageBamlImpl {
@@ -802,73 +759,6 @@ impl BamlClassArray for PackageBamlImpl {
         let mut result = array.to_vec();
         result.reverse();
         result
-    }
-
-    fn sort(vm: &mut BexVm, array: &Value) -> NativeCallResult {
-        let mut values = match vm.as_array(array) {
-            Ok(array) => array.to_vec(),
-            Err(e) => return NativeCallResult::Error(e.into()),
-        };
-        if let Err(e) = sort_values_natural(vm, "array.sort", &mut values) {
-            return NativeCallResult::Error(e);
-        }
-        write_back_array_result(vm, *array, values)
-    }
-
-    fn sort_by(vm: &mut BexVm, array: &Value, compare: &Value) -> NativeCallResult {
-        let f_ptr = match extract_callable(vm, *compare) {
-            Ok(p) => p,
-            Err(e) => return e,
-        };
-        let items = match vm.as_array(array) {
-            Ok(array) => array.to_vec(),
-            Err(e) => return NativeCallResult::Error(e.into()),
-        };
-        if items.len() <= 1 {
-            return write_back_array_result(vm, *array, items);
-        }
-        let first_sorted = items[0];
-        let first_current = items[1];
-        NativeCallResult::YieldToCall {
-            callee: f_ptr,
-            args: vec![first_current, first_sorted],
-            type_args: vec![],
-            continuation: Box::new(SortByContinuation {
-                receiver: *array,
-                f_ptr,
-                items,
-                next_idx: 2,
-                sorted: vec![first_sorted],
-                insert_idx: 0,
-                current: first_current,
-            }),
-        }
-    }
-
-    fn sort_by_key(vm: &mut BexVm, array: &Value, key: &Value) -> NativeCallResult {
-        let f_ptr = match extract_callable(vm, *key) {
-            Ok(p) => p,
-            Err(e) => return e,
-        };
-        let items = match vm.as_array(array) {
-            Ok(array) => array.to_vec(),
-            Err(e) => return NativeCallResult::Error(e.into()),
-        };
-        if items.is_empty() {
-            return write_back_array_result(vm, *array, items);
-        }
-        NativeCallResult::YieldToCall {
-            callee: f_ptr,
-            args: vec![items[0]],
-            type_args: vec![],
-            continuation: Box::new(SortByKeyContinuation {
-                receiver: *array,
-                f_ptr,
-                items,
-                idx: 0,
-                keys: Vec::new(),
-            }),
-        }
     }
 
     #[allow(
@@ -977,6 +867,36 @@ impl BamlClassArray for PackageBamlImpl {
         let end = start_usize.saturating_add(count_usize).min(len);
         array.splice(start_usize..end, replace.iter().copied());
         Ok(())
+    }
+
+    fn sort_by(vm: &mut BexVm, array: &Value, compare: &Value) -> NativeCallResult {
+        let f_ptr = match extract_callable(vm, *compare) {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let items = match vm.as_array(array) {
+            Ok(array) => array.to_vec(),
+            Err(e) => return NativeCallResult::Error(e.into()),
+        };
+        if items.len() <= 1 {
+            return write_back_array_result(vm, *array, items);
+        }
+        let first_sorted = items[0];
+        let first_current = items[1];
+        NativeCallResult::YieldToCall {
+            callee: f_ptr,
+            args: vec![first_current, first_sorted],
+            type_args: vec![],
+            continuation: Box::new(SortByContinuation {
+                receiver: *array,
+                f_ptr,
+                items,
+                next_idx: 2,
+                sorted: vec![first_sorted],
+                insert_idx: 0,
+                current: first_current,
+            }),
+        }
     }
 
     fn map(vm: &mut BexVm, array: &[Value], f: &Value) -> NativeCallResult {

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -10,7 +10,9 @@
 //! - `math` — `BamlNamespaceMath` (trunc)
 //! - `media` — `BamlClassMedia{Pdf,Audio,Video,Image}` + `BamlNamespaceMedia`
 //! - `unstable` — `BamlNamespaceUnstable` (string)
-//! - `root` — `BamlPackageBaml` (`deep_copy`, `deep_equals`)
+//! - `root` — `BamlPackageBaml` (`deep_copy`, `deep_equals`, and the
+//!   `Sortable.sort` shims `_compare_shim` / `_is_primitive_array` /
+//!   `_rust_sort` / `_float_total_cmp`)
 //!
 //! # Adding a new builtin
 //!
@@ -202,6 +204,68 @@ pub(super) fn make_to_json_callee(vm: &mut BexVm, v: Value) -> Result<HeapPtr, V
     })?;
 
     // Allocate a BoundMethod with the value as receiver.
+    Ok(vm.alloc_bound_method(bex_vm_types::BoundMethod {
+        function: fn_ptr,
+        receiver: v,
+    }))
+}
+
+/// For a value `v` whose type implements `baml.Comparable`, look up the
+/// matching `compare` function and return a `BoundMethod { compare, receiver: v }`.
+///
+/// Builtin impls are out-of-body (`baml.Comparable$for$int.compare`, …); user
+/// classes carry the in-body impl method `{class_fqn}.baml.Comparable.compare`.
+/// The bound method has `receiver = v` baked in, so the VM inserts it as `self`
+/// and the comparison call only passes the `other` argument
+/// (`YieldToCall { args: [other] }`).
+///
+/// Used by the native `baml._compare_shim` (`root.rs`) that the BAML
+/// `Sortable.sort` passes to `sort_by` on its non-primitive path: `compare`'s
+/// two `Self` params make it undispatchable through an interface-typed value,
+/// so the per-pair comparison is resolved here on the receiver's runtime class
+/// (the homogeneous `T[]` guarantees the other element shares that class).
+pub(super) fn make_compare_callee(vm: &mut BexVm, v: Value) -> Result<HeapPtr, VmRustFnError> {
+    use bex_vm_types::ValueKind;
+    let fn_name: String = match v.kind() {
+        ValueKind::Int(_) => "baml.Comparable$for$int.compare".to_string(),
+        ValueKind::Object(ptr) => match vm.get_object(ptr) {
+            Object::Float(_) => "baml.Comparable$for$float.compare".to_string(),
+            Object::String(_) => "baml.Comparable$for$string.compare".to_string(),
+            Object::Bigint(_) => "baml.Comparable$for$bigint.compare".to_string(),
+            Object::Instance(inst) => {
+                let class_ptr = inst.class;
+                let fqn = match vm.get_object(class_ptr) {
+                    Object::Class(c) => c.name.render_dotted(false),
+                    _ => {
+                        return Err(VmRustFnError::InternalError(
+                            VmInternalError::MissingNativeFunction {
+                                name: "compare dispatch: instance.class is not a Class".to_string(),
+                            },
+                        ));
+                    }
+                };
+                format!("{fqn}.baml.Comparable.compare")
+            }
+            _ => {
+                return Err(VmRustFnError::BamlError(VmBamlError::InvalidArgument {
+                    message: "_compare_shim: element type does not implement Comparable"
+                        .to_string(),
+                }));
+            }
+        },
+        _ => {
+            return Err(VmRustFnError::BamlError(VmBamlError::InvalidArgument {
+                message: "_compare_shim: element type does not implement Comparable".to_string(),
+            }));
+        }
+    };
+
+    let fn_ptr = vm.find_function_by_name(&fn_name).ok_or_else(|| {
+        VmRustFnError::InternalError(VmInternalError::MissingNativeFunction {
+            name: format!("compare dispatch: function '{fn_name}' not found in globals"),
+        })
+    })?;
+
     Ok(vm.alloc_bound_method(bex_vm_types::BoundMethod {
         function: fn_ptr,
         receiver: v,

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -6,7 +6,14 @@ use bex_vm_types::{
 };
 use indexmap::IndexMap;
 
-use super::{BamlPackageBaml, PackageBamlImpl};
+use super::{
+    BamlPackageBaml, Continuation, NativeCallResult, PackageBamlImpl,
+    array::{
+        NaturalDomain, compare_natural_values, is_primitive_array_values,
+        validate_natural_order_with_vm,
+    },
+    make_compare_callee,
+};
 use crate::BexVm;
 
 impl BamlPackageBaml for PackageBamlImpl {
@@ -19,6 +26,113 @@ impl BamlPackageBaml for PackageBamlImpl {
         let mut visited = HashMap::new();
         deep_equals_recursive(vm, *a, *b, &mut visited)
     }
+
+    /// `baml._float_total_cmp(a, b)` — bit-exact `f64::total_cmp` three-way
+    /// comparison backing `Comparable for float`. Kept in lockstep with the
+    /// float domain of `compare_natural_values` (the `_rust_sort` fast path)
+    /// so the two sort paths can never disagree on a float ordering.
+    fn _float_total_cmp(a: f64, b: f64) -> i64 {
+        match a.total_cmp(&b) {
+            std::cmp::Ordering::Less => -1,
+            std::cmp::Ordering::Equal => 0,
+            std::cmp::Ordering::Greater => 1,
+        }
+    }
+
+    /// `baml._is_primitive_array(arr)` — `Sortable.sort`'s dispatch guard:
+    /// whether the first element's runtime tag is a natural-sort primitive
+    /// (int/bigint/string/float). Empty arrays report `true`.
+    fn _is_primitive_array(vm: &BexVm, arr: &[Value]) -> bool {
+        is_primitive_array_values(vm, arr)
+    }
+
+    /// `baml._rust_sort(arr)` — the primitive fast path of `Sortable.sort`.
+    /// Stable natural-order sort of a homogeneous primitive array, in place
+    /// (the receiver's backing `Vec` is sorted or replaced; the returned value
+    /// IS the receiver). The comparator is pure Rust — no per-pair yield to
+    /// BAML — and the float domain uses `f64::total_cmp`, so no domain throws.
+    /// The validation rejections are defensive only: the `_is_primitive_array`
+    /// guard plus `T[]` homogeneity make them unreachable from `Sortable.sort`.
+    fn _rust_sort(vm: &mut BexVm, arr: &Value) -> NativeCallResult {
+        let domain = {
+            let values = match vm.as_array(arr) {
+                Ok(guard) => guard,
+                Err(e) => return NativeCallResult::Error(e.into()),
+            };
+            if values.len() <= 1 {
+                return NativeCallResult::Done(*arr);
+            }
+            match validate_natural_order_with_vm(vm, "sort", &values) {
+                Ok(domain) => domain,
+                Err(e) => return NativeCallResult::Error(e),
+            }
+        };
+        if matches!(domain, NaturalDomain::Int) {
+            // Int values are tag-only (no heap reads), so the comparator
+            // needs no `&BexVm` and the backing Vec sorts truly in place.
+            let mut values = match vm.as_array_mut(arr) {
+                Ok(guard) => guard,
+                Err(e) => return NativeCallResult::Error(e.into()),
+            };
+            values.sort_by(|left, right| {
+                left.as_int()
+                    .expect("validated int sort value should be int")
+                    .cmp(
+                        &right
+                            .as_int()
+                            .expect("validated int sort value should be int"),
+                    )
+            });
+            return NativeCallResult::Done(*arr);
+        }
+        // Heap-read domains (float/bigint/string): the comparator needs
+        // `&BexVm`, which conflicts with holding the array's mutable guard —
+        // sort a snapshot of the backing Vec, then swap it back in. One Vec
+        // (re)allocation; still no per-element BAML round trips or re-push.
+        let mut values = match vm.as_array(arr) {
+            Ok(guard) => guard.to_vec(),
+            Err(e) => return NativeCallResult::Error(e.into()),
+        };
+        values.sort_by(|left, right| compare_natural_values(vm, domain, *left, *right));
+        match vm.as_array_mut(arr) {
+            Ok(mut guard) => *guard = values,
+            Err(e) => return NativeCallResult::Error(e.into()),
+        }
+        NativeCallResult::Done(*arr)
+    }
+
+    /// `baml._compare_shim(a, b)` — the dispatch shim for the `Sortable`
+    /// blanket `sort`'s comparator path. Resolves `Comparable.compare` on
+    /// `a`'s runtime class and yields to it with `b`; the comparison's `int`
+    /// result (or thrown error) is returned straight through. See
+    /// `make_compare_callee` for why the sort cannot dispatch `compare`
+    /// itself.
+    fn _compare_shim(vm: &mut BexVm, a: &Value, b: &Value) -> NativeCallResult {
+        let callee = match make_compare_callee(vm, *a) {
+            Ok(ptr) => ptr,
+            Err(e) => return NativeCallResult::Error(e),
+        };
+        NativeCallResult::YieldToCall {
+            callee,
+            args: vec![*b],
+            type_args: vec![],
+            continuation: Box::new(PassThroughContinuation),
+        }
+    }
+}
+
+/// Returns the callee's result unchanged. Used by `_compare_shim`, whose only
+/// job is to dispatch one `compare` call and surface its value.
+struct PassThroughContinuation;
+
+impl Continuation for PassThroughContinuation {
+    fn call(self: Box<Self>, _vm: &mut BexVm, value: Value) -> NativeCallResult {
+        NativeCallResult::Done(value)
+    }
+    fn gc_roots(&self) -> Vec<HeapPtr> {
+        Vec::new()
+    }
+    fn apply_forwarding(&mut self, _forwarding: &HashMap<HeapPtr, HeapPtr>) {}
 }
 
 fn deep_copy_value_recursive(

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -4888,6 +4888,7 @@ impl BexVm {
                         .checked_sub(arg_count)
                         .ok_or(VmInternalError::NotEnoughItemsOnStack(arg_count))?;
                     let locals_offset = StackIndex::from_raw(args_offset);
+
                     // Save pc as return address before pushing new frame.
                     let Frame::Bytecode(bf) = &mut self.frames[*frame_idx] else {
                         verifier_unreachable!()


### PR DESCRIPTION
Replace the builtin-only `Array.sort()` with a `Sortable` interface blanket-implemented for `T[]` where `T implements Comparable`. Adds a `Comparable` interface (`compare` + associated `CmpError`) with builtin impls for int/float/bigint/string, and a native VM implementation (`array::sort_comparable_native`) that dispatches `compare` by runtime type — a primitive natural-order fast path plus a stable per-pair `compare` continuation for user `Comparable` types.

- int[]/string[]/bigint[] sort is now infallible (`throws never`).
- float[] sort still rejects NaN at runtime (float binds `CmpError = InvalidArgument`).
- User classes sort by implementing `Comparable`; fallible comparators propagate their error and roll the array back on a mid-sort throw.

Also: resolve associated-type projections off primitive base types (`int.CmpError`); single-candidate interface dispatch skips its (sometimes unrepresentable) IsType guard and a concrete container receiver resolves to its single definitive blanket-impl candidate (also simplifies array `.iter()`-style dispatch).

BREAKING CHANGE: `sort()` now requires the element type to implement `Comparable`. `(int | float)[]`, `(float | bigint)[]`, `int?[]`, `(int | string)[]`, and classes without a `Comparable` impl — which previously sorted by domain coercion or threw `InvalidArgument` at runtime — are now compile errors. Use `sort_by` with an explicit comparator for those cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Comparable and Sortable interfaces; arrays whose element type implements Comparable gain stable, in-place sort. Primitives (int, bigint, string, float) have defined compare behavior (float uses deterministic total ordering).

* **Changes**
  * Array.sort moved to the Sortable design; sort_by is stable. sort_by_key now computes keys once and surfaces element-compare errors; some former runtime rejections are now compile-time errors.

* **Tests**
  * New and expanded tests for compare semantics, in-place sorting, stability, error propagation/rollback, and NaN ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->