### PR TITLE
[codex] Optimize int local arithmetic in bytecode

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -815,6 +815,69 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         }
     }
 
+    fn operand_is_local(operand: &Operand, local: Local) -> bool {
+        matches!(
+            operand,
+            Operand::Copy(Place::Local(candidate)) | Operand::Move(Place::Local(candidate))
+                if *candidate == local
+        )
+    }
+
+    fn small_int_constant(operand: &Operand) -> Option<i8> {
+        let Operand::Constant(Constant::Int(value)) = operand else {
+            return None;
+        };
+        i8::try_from(*value).ok()
+    }
+
+    fn try_emit_int_local_add_store(&mut self, local: Local, value: &Rvalue) -> bool {
+        let Rvalue::BinaryOp {
+            op: BinOp::Add,
+            left,
+            right,
+        } = value
+        else {
+            return false;
+        };
+
+        if self.captured_locals.contains(&local)
+            || !self.binary_operands_can_use_specialized_op(left, right)
+        {
+            return false;
+        }
+
+        let Some(left_ty) = self.resolve_operand_type(left) else {
+            return false;
+        };
+        let Some(right_ty) = self.resolve_operand_type(right) else {
+            return false;
+        };
+        if Self::classify_arith_ty(&left_ty) != Some(ArithTyClass::Int)
+            || Self::classify_arith_ty(&right_ty) != Some(ArithTyClass::Int)
+        {
+            return false;
+        }
+
+        let rhs = if Self::operand_is_local(left, local) {
+            right
+        } else if Self::operand_is_local(right, local) {
+            left
+        } else {
+            return false;
+        };
+
+        let slot = self.local_slot_or_panic(local, "int local add-store");
+        if let Some(imm) = Self::small_int_constant(rhs) {
+            let inst = self.emit(Instruction::AddIntSmallStoreVar { slot, imm });
+            self.set_var_operand(inst, slot);
+        } else {
+            self.emit_operand_pull(rhs);
+            let inst = self.emit(Instruction::AddIntStoreVar(slot));
+            self.set_var_operand(inst, slot);
+        }
+        true
+    }
+
     fn local_slot_or_panic(&self, local: Local, context: &str) -> usize {
         *self.local_slots.get(&local).unwrap_or_else(|| {
             panic!("local {local} has no allocated slot while emitting {context}")
@@ -1367,6 +1430,10 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
 
                 match destination {
                     Place::Local(local) => {
+                        if self.try_emit_int_local_add_store(*local, value) {
+                            return;
+                        }
+
                         // Local assignment: emit rvalue then store
                         self.emit_rvalue_pull(value);
                         self.emit_store_place(destination);

--- a/baml_language/crates/baml_tests/snapshots/baml_src/control_flow.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/control_flow.snap
@@ -229,10 +229,7 @@ function control_flow.concat_oks(items: (control_flow.Ok | control_flow.Err)[]) 
     load_var2 1 3
     load_array_element
     store_var item
-    load_var i
-    load_const 1
-    add_int
-    store_var i
+    add_int_small_store_var i 1
     load_var item
     store_var_load_var _9
     is_type control_flow.Ok
@@ -267,17 +264,11 @@ function control_flow.continue_loop(x: int) -> int {
     jump L4
 
   L3:
-    load_var i
-    load_const 10
-    add_int
-    store_var i
+    add_int_small_store_var i 10
     jump L0
 
   L4:
-    load_var i
-    load_const 1
-    add_int
-    store_var i
+    add_int_small_store_var i 1
     jump L0
 }
 
@@ -517,10 +508,7 @@ function control_flow.pick_first_ok(items: (control_flow.Ok | control_flow.Err)[
     load_var _9
     load_field .value
     store_var result
-    load_var i
-    load_const 1
-    add_int
-    store_var i
+    add_int_small_store_var i 1
     jump L0
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
@@ -84,13 +84,9 @@ function for_loops.for_loops_c_for_sum_to_ten() -> int {
     return
 
   L2:
-    load_var2 1 2
-    add_int
-    store_var s
     load_var i
-    load_const 1
-    add_int
-    store_var i
+    add_int_store_var s
+    add_int_small_store_var i 1
     jump L0
 }
 
@@ -767,9 +763,8 @@ function for_loops.for_loops_for_with_break(xs: int[]) -> int {
     jump L48
 
   L47:
-    load_var2 2 5
-    add_int
-    store_var result
+    load_var x
+    add_int_store_var result
     jump L24
 
   L48:
@@ -1111,9 +1106,8 @@ function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
     jump L24
 
   L47:
-    load_var2 2 5
-    add_int
-    store_var result
+    load_var x
+    add_int_store_var result
     jump L24
 
   L48:
@@ -2380,11 +2374,9 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
     jump L24
 
   L93:
-    load_var2 3 6
-    load_var _99
+    load_var2 6 8
     mul_int
-    add_int
-    store_var result
+    add_int_store_var result
     jump L71
 
   L94:
@@ -3045,9 +3037,8 @@ function for_loops.for_loops_sum(xs: int[]) -> int {
     jump L47
 
   L46:
-    load_var2 2 4
-    add_int
-    store_var result
+    load_var _35
+    add_int_store_var result
     jump L24
 
   L47:
@@ -3385,9 +3376,8 @@ function for_loops.for_loops_sum_let_var() -> int {
     jump L47
 
   L46:
-    load_var2 1 4
-    add_int
-    store_var sum
+    load_var _36
+    add_int_store_var sum
     jump L24
 
   L47:
@@ -3725,9 +3715,8 @@ function for_loops.for_loops_sum_let_var_no_parens() -> int {
     jump L47
 
   L46:
-    load_var2 1 4
-    add_int
-    store_var sum
+    load_var _36
+    add_int_store_var sum
     jump L24
 
   L47:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/iter.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/iter.snap
@@ -6900,10 +6900,9 @@ function iter.iter_for_in_array_of_classes() -> int {
     jump L43
 
   L42:
-    load_var2 1 4
+    load_var _36
     load_field .value
-    add_int
-    store_var total
+    add_int_store_var total
     jump L22
 
   L43:
@@ -7228,16 +7227,12 @@ function iter.iter_for_in_array_of_unions() -> int {
     load_const "two"
     cmp_op ==
     pop_jump_if_false L22
-    load_var total
-    load_const 20
-    add_int
-    store_var total
+    add_int_small_store_var total 20
     jump L22
 
   L44:
-    load_var2 1 5
-    add_int
-    store_var total
+    load_var x
+    add_int_store_var total
     jump L22
 
   L45:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/iter_impl_generics_only.core.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/iter_impl_generics_only.core.snap
@@ -4467,10 +4467,7 @@ function iter_impl_generics_only.core.Iterator.count(self: iter_impl_generics_on
     jump L23
 
   L22:
-    load_var n
-    load_const 1
-    add_int
-    store_var n
+    add_int_small_store_var n 1
     jump L0
 
   L23:
@@ -6545,10 +6542,7 @@ function iter_impl_generics_only.core.StepBy$stream.Iterator<T, E>.next(self: it
     jump L46
 
   L45:
-    load_var i
-    load_const 1
-    add_int
-    store_var i
+    add_int_small_store_var i 1
     jump L1
 
   L46:
@@ -6992,10 +6986,7 @@ function iter_impl_generics_only.core.StepBy.Iterator<T, E>.next(self: iter_impl
     jump L46
 
   L45:
-    load_var i
-    load_const 1
-    add_int
-    store_var i
+    add_int_small_store_var i 1
     jump L1
 
   L46:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -1096,10 +1096,9 @@ function patterns_new_runtime.from_array_boxes(boxes: patterns_new_runtime.BoxT<
     jump L43
 
   L42:
-    load_var2 2 4
+    load_var _34
     load_field .value
-    add_int
-    store_var total
+    add_int_store_var total
     jump L22
 
   L43:
@@ -4246,12 +4245,11 @@ function patterns_new_runtime.test_for_deep_class_sums() -> int {
     jump L43
 
   L42:
-    load_var2 1 4
+    load_var _44
     load_field .address
     load_field .coordinate
     load_field .zip
-    add_int
-    store_var total
+    add_int_store_var total
     jump L22
 
   L43:
@@ -4575,9 +4573,8 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     load_field .scores
     container_len
     store_var _72
-    load_var2 1 5
-    add_int
-    store_var total
+    load_var _72
+    add_int_store_var total
     jump L22
 
   L43:
@@ -5292,12 +5289,10 @@ function patterns_new_runtime.test_for_let_chain_of_bindings() -> int {
 
   L46:
     load_var _35
-    store_var _64
-    load_var2 1 5
+    store_var_load_var _64
     load_var _64
     add_int
-    add_int
-    store_var total
+    add_int_store_var total
     jump L24
 
   L47:
@@ -5620,7 +5615,7 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     load_var row
     container_len
     store_var _69
-    load_var2 1 6
+    load_var _69
     load_const 100
     mul_int
     load_var row
@@ -5632,8 +5627,7 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     load_var row
     container_len
     add_int
-    add_int
-    store_var total
+    add_int_store_var total
     jump L22
 
   L43:
@@ -5974,9 +5968,8 @@ function patterns_new_runtime.test_for_let_or_same_binding() -> int {
   L46:
     load_var _35
     store_var _64
-    load_var2 1 5
-    add_int
-    store_var total
+    load_var _64
+    add_int_store_var total
     jump L24
 
   L47:
@@ -6316,9 +6309,8 @@ function patterns_new_runtime.test_for_let_or_six_bindings() -> int {
   L46:
     load_var _35
     store_var _64
-    load_var2 1 5
-    add_int
-    store_var total
+    load_var _64
+    add_int_store_var total
     jump L24
 
   L47:
@@ -6624,10 +6616,7 @@ function patterns_new_runtime.test_for_nested_rest_irrefutable() -> int {
     jump L43
 
   L42:
-    load_var total
-    load_const 1
-    add_int
-    store_var total
+    add_int_small_store_var total 1
     jump L22
 
   L43:
@@ -7302,9 +7291,8 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     load_var _38
     container_len
     store_var _68
-    load_var2 1 5
-    add_int
-    store_var total
+    load_var _68
+    add_int_store_var total
     jump L22
 
   L43:
@@ -7610,10 +7598,7 @@ function patterns_new_runtime.test_for_rest_wildcard_irrefutable() -> int {
     jump L43
 
   L42:
-    load_var count
-    load_const 1
-    add_int
-    store_var count
+    add_int_small_store_var count 1
     jump L22
 
   L43:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
@@ -465,9 +465,8 @@ function typed_inputs.sum(arr: int[]) -> int {
     jump L47
 
   L46:
-    load_var2 2 4
-    add_int
-    store_var total
+    load_var _35
+    add_int_store_var total
     jump L24
 
   L47:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/while_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/while_loops.snap
@@ -69,10 +69,8 @@ function while_loops.while_loops_break_at_two() -> int {
     load_const 5
     cmp_int_op <
     pop_jump_if_false L1
+    add_int_small_store_var a 1
     load_var a
-    load_const 1
-    add_int
-    store_var_load_var a
     load_const 2
     cmp_int_op ==
     pop_jump_if_false L0

--- a/baml_language/crates/baml_tests/tests/arithmetic_perf.rs
+++ b/baml_language/crates/baml_tests/tests/arithmetic_perf.rs
@@ -1,0 +1,39 @@
+use baml_tests::engine::{OptLevel, run_test};
+use bex_external_types::BexExternalValue;
+use indexmap::IndexMap;
+
+#[tokio::test]
+async fn arithmetic_loop_uses_int_local_update_superinstructions() {
+    let output = run_test(
+        r#"
+        function work(lo: int, hi: int) -> int {
+          let acc = 0;
+          for (let i = lo; i < hi; i += 1) {
+            let m = i % 65536;
+            acc += (m * m) % 1000003;
+          }
+          acc
+        }
+
+        function main() -> int {
+          work(0, 4)
+        }
+        "#,
+        "main",
+        IndexMap::new(),
+        OptLevel::One,
+    )
+    .await;
+
+    assert_eq!(output.result, Ok(BexExternalValue::Int(14)));
+    assert!(
+        output.bytecode.contains("add_int_store_var"),
+        "expected acc += rhs to use add_int_store_var:\n{}",
+        output.bytecode
+    );
+    assert!(
+        output.bytecode.contains("add_int_small_store_var"),
+        "expected i += 1 to use add_int_small_store_var:\n{}",
+        output.bytecode
+    );
+}

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -445,591 +445,585 @@ function testing.TestCollector.new(prefix: string) -> testing.TestCollector {
 }
 
 function testing.TestCollector.register_test(self: testing.TestCollector, name: string, body: () -> void throws unknown, runner: ((() -> testing.TestReport throws never) -> (() -> testing.TestReport throws never) throws never) | null) -> void {
-  39   0     load_var 1               (self)
-       1     load_field 0             (prefix)
-       2     load_const 0             ("")
-       3     cmp_op ==                
-       4     pop_jump_if_false +2     (to 6)
-       5     jump +9                  (to 14)
-       6     load_var 1               (self)
-       7     load_field 0             (prefix)
-       8     load_const 1             ("/")
-       9     bin_op +                 
-       10    load_var 2               (name)
-       11    bin_op +                 
-       12    store_var 5              (full_name)
-       13    jump +3                  (to 16)
-       14    load_var 2               (name)
-       15    store_var 5              (full_name)
+  39   0     load_var 1                    (self)
+       1     load_field 0                  (prefix)
+       2     load_const 0                  ("")
+       3     cmp_op ==                     
+       4     pop_jump_if_false +2          (to 6)
+       5     jump +9                       (to 14)
+       6     load_var 1                    (self)
+       7     load_field 0                  (prefix)
+       8     load_const 1                  ("/")
+       9     bin_op +                      
+       10    load_var 2                    (name)
+       11    bin_op +                      
+       12    store_var 5                   (full_name)
+       13    jump +3                       (to 16)
+       14    load_var 2                    (name)
+       15    store_var 5                   (full_name)
 
-  40   16    load_const 2             (0)
-       17    store_var 6              (count)
+  40   16    load_const 2                  (0)
+       17    store_var 6                   (count)
 
-  41   18    load_var 5               (full_name)
-       19    load_const 3             ("#")
-       20    bin_op +                 
-       21    store_var 7              (hash_prefix)
+  41   18    load_var 5                    (full_name)
+       19    load_const 3                  ("#")
+       20    bin_op +                      
+       21    store_var 7                   (hash_prefix)
 
-  42   22    load_var 1               (self)
-       23    load_field 1             (tests)
-       24    store_var_load_var 8     (_13)
-       25    is_type 4                
-       26    pop_jump_if_false +2     (to 28)
-       27    jump +105                (to 132)
-       28    load_var 8               (_13)
-       29    is_type 5                
-       30    pop_jump_if_false +2     (to 32)
-       31    jump +96                 (to 127)
-       32    load_var 8               (_13)
-       33    is_type 6                
-       34    pop_jump_if_false +2     (to 36)
-       35    jump +86                 (to 121)
-       36    load_var 8               (_13)
-       37    is_type 7                
-       38    pop_jump_if_false +2     (to 40)
-       39    jump +75                 (to 114)
-       40    load_var 8               (_13)
-       41    is_type 8                
-       42    pop_jump_if_false +2     (to 44)
-       43    jump +66                 (to 109)
-       44    load_var 8               (_13)
-       45    is_type 9                
-       46    pop_jump_if_false +2     (to 48)
-       47    jump +57                 (to 104)
-       48    load_var 8               (_13)
-       49    is_type 10               
-       50    pop_jump_if_false +2     (to 52)
-       51    jump +46                 (to 97)
-       52    load_var 8               (_13)
-       53    is_type 11               
-       54    pop_jump_if_false +2     (to 56)
-       55    jump +37                 (to 92)
-       56    load_var 8               (_13)
-       57    is_type 12               
-       58    pop_jump_if_false +2     (to 60)
-       59    jump +28                 (to 87)
-       60    load_var 8               (_13)
-       61    is_type 13               
-       62    pop_jump_if_false +2     (to 64)
-       63    jump +18                 (to 81)
-       64    load_var 8               (_13)
-       65    is_type 14               
-       66    pop_jump_if_false +2     (to 68)
-       67    jump +9                  (to 76)
-       68    load_var 8               (_13)
-       69    is_type 14               
-       70    pop_jump_if_false +213   (to 283)
-       71    load_type 15             
-       72    load_var 8               (_13)
-       73    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       74    store_var 9              (_14)
-       75    jump +61                 (to 136)
-       76    load_type 15             
-       77    load_var 8               (_13)
-       78    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       79    store_var 9              (_14)
-       80    jump +56                 (to 136)
-       81    load_type 15             
-       82    load_type 16             
-       83    load_var 8               (_13)
-       84    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       85    store_var 9              (_14)
-       86    jump +50                 (to 136)
-       87    load_var 8               (_13)
-       88    make_bound_method 514    
-       89    call_indirect            
-       90    store_var 9              (_14)
-       91    jump +45                 (to 136)
-       92    load_var 8               (_13)
-       93    make_bound_method 527    
-       94    call_indirect            
-       95    store_var 9              (_14)
-       96    jump +40                 (to 136)
-       97    load_type 15             
-       98    load_type 16             
-       99    load_type 16             
-       100   load_var 8               (_13)
-       101   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       102   store_var 9              (_14)
-       103   jump +33                 (to 136)
-       104   load_var 8               (_13)
-       105   make_bound_method 557    
-       106   call_indirect            
-       107   store_var 9              (_14)
-       108   jump +28                 (to 136)
-       109   load_type 15             
-       110   load_var 8               (_13)
-       111   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       112   store_var 9              (_14)
-       113   jump +23                 (to 136)
-       114   load_type 15             
-       115   load_type 16             
-       116   load_type 16             
-       117   load_var 8               (_13)
-       118   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       119   store_var 9              (_14)
-       120   jump +16                 (to 136)
-       121   load_type 15             
-       122   load_type 16             
-       123   load_var 8               (_13)
-       124   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       125   store_var 9              (_14)
-       126   jump +10                 (to 136)
-       127   load_type 15             
-       128   load_var 8               (_13)
-       129   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       130   store_var 9              (_14)
-       131   jump +5                  (to 136)
-       132   load_var 8               (_13)
-       133   make_bound_method 588    
-       134   call_indirect            
-       135   store_var 9              (_14)
-       136   load_var 9               (_14)
-       137   is_type 4                
-       138   pop_jump_if_false +2     (to 140)
-       139   jump +87                 (to 226)
-       140   load_var 9               (_14)
-       141   is_type 5                
-       142   pop_jump_if_false +2     (to 144)
-       143   jump +78                 (to 221)
-       144   load_var 9               (_14)
-       145   is_type 6                
-       146   pop_jump_if_false +2     (to 148)
-       147   jump +68                 (to 215)
-       148   load_var 9               (_14)
-       149   is_type 7                
-       150   pop_jump_if_false +2     (to 152)
-       151   jump +57                 (to 208)
-       152   load_var 9               (_14)
-       153   is_type 8                
-       154   pop_jump_if_false +2     (to 156)
-       155   jump +48                 (to 203)
-       156   load_var 9               (_14)
-       157   is_type 9                
-       158   pop_jump_if_false +2     (to 160)
-       159   jump +39                 (to 198)
-       160   load_var 9               (_14)
-       161   is_type 10               
-       162   pop_jump_if_false +2     (to 164)
-       163   jump +28                 (to 191)
-       164   load_var 9               (_14)
-       165   is_type 11               
-       166   pop_jump_if_false +2     (to 168)
-       167   jump +19                 (to 186)
-       168   load_var 9               (_14)
-       169   is_type 12               
-       170   pop_jump_if_false +2     (to 172)
-       171   jump +10                 (to 181)
-       172   load_var 9               (_14)
-       173   is_type 13               
-       174   pop_jump_if_false +109   (to 283)
-       175   load_type 15             
-       176   load_type 16             
-       177   load_var 9               (_14)
-       178   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       179   store_var 10             (_45)
-       180   jump +50                 (to 230)
-       181   load_var 9               (_14)
-       182   make_bound_method 568    
-       183   call_indirect            
-       184   store_var 10             (_45)
-       185   jump +45                 (to 230)
-       186   load_var 9               (_14)
-       187   make_bound_method 581    
-       188   call_indirect            
-       189   store_var 10             (_45)
-       190   jump +40                 (to 230)
-       191   load_type 15             
-       192   load_type 16             
-       193   load_type 16             
-       194   load_var 9               (_14)
-       195   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       196   store_var 10             (_45)
-       197   jump +33                 (to 230)
-       198   load_var 9               (_14)
-       199   make_bound_method 517    
-       200   call_indirect            
-       201   store_var 10             (_45)
-       202   jump +28                 (to 230)
-       203   load_type 15             
-       204   load_var 9               (_14)
-       205   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       206   store_var 10             (_45)
-       207   jump +23                 (to 230)
-       208   load_type 15             
-       209   load_type 16             
-       210   load_type 16             
-       211   load_var 9               (_14)
-       212   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       213   store_var 10             (_45)
-       214   jump +16                 (to 230)
-       215   load_type 15             
-       216   load_type 16             
-       217   load_var 9               (_14)
-       218   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       219   store_var 10             (_45)
-       220   jump +10                 (to 230)
-       221   load_type 15             
-       222   load_var 9               (_14)
-       223   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       224   store_var 10             (_45)
-       225   jump +5                  (to 230)
-       226   load_var 9               (_14)
-       227   make_bound_method 552    
-       228   call_indirect            
-       229   store_var 10             (_45)
-       230   load_var 10              (_45)
-       231   is_type 17               
-       232   pop_jump_if_false +2     (to 234)
-       233   jump +19                 (to 252)
-       234   load_var 10              (_45)
-       235   store_var_load_var 11    (t)
+  42   22    load_var 1                    (self)
+       23    load_field 1                  (tests)
+       24    store_var_load_var 8          (_13)
+       25    is_type 4                     
+       26    pop_jump_if_false +2          (to 28)
+       27    jump +105                     (to 132)
+       28    load_var 8                    (_13)
+       29    is_type 5                     
+       30    pop_jump_if_false +2          (to 32)
+       31    jump +96                      (to 127)
+       32    load_var 8                    (_13)
+       33    is_type 6                     
+       34    pop_jump_if_false +2          (to 36)
+       35    jump +86                      (to 121)
+       36    load_var 8                    (_13)
+       37    is_type 7                     
+       38    pop_jump_if_false +2          (to 40)
+       39    jump +75                      (to 114)
+       40    load_var 8                    (_13)
+       41    is_type 8                     
+       42    pop_jump_if_false +2          (to 44)
+       43    jump +66                      (to 109)
+       44    load_var 8                    (_13)
+       45    is_type 9                     
+       46    pop_jump_if_false +2          (to 48)
+       47    jump +57                      (to 104)
+       48    load_var 8                    (_13)
+       49    is_type 10                    
+       50    pop_jump_if_false +2          (to 52)
+       51    jump +46                      (to 97)
+       52    load_var 8                    (_13)
+       53    is_type 11                    
+       54    pop_jump_if_false +2          (to 56)
+       55    jump +37                      (to 92)
+       56    load_var 8                    (_13)
+       57    is_type 12                    
+       58    pop_jump_if_false +2          (to 60)
+       59    jump +28                      (to 87)
+       60    load_var 8                    (_13)
+       61    is_type 13                    
+       62    pop_jump_if_false +2          (to 64)
+       63    jump +18                      (to 81)
+       64    load_var 8                    (_13)
+       65    is_type 14                    
+       66    pop_jump_if_false +2          (to 68)
+       67    jump +9                       (to 76)
+       68    load_var 8                    (_13)
+       69    is_type 14                    
+       70    pop_jump_if_false +210        (to 280)
+       71    load_type 15                  
+       72    load_var 8                    (_13)
+       73    call 532 ntypeargs=1          (baml.iter.Iterable$for$T[].iter)
+       74    store_var 9                   (_14)
+       75    jump +61                      (to 136)
+       76    load_type 15                  
+       77    load_var 8                    (_13)
+       78    call 532 ntypeargs=1          (baml.iter.Iterable$for$T[].iter)
+       79    store_var 9                   (_14)
+       80    jump +56                      (to 136)
+       81    load_type 15                  
+       82    load_type 16                  
+       83    load_var 8                    (_13)
+       84    call 579 ntypeargs=2          (baml.iter.Peekable.Iterable.iter)
+       85    store_var 9                   (_14)
+       86    jump +50                      (to 136)
+       87    load_var 8                    (_13)
+       88    make_bound_method 514         
+       89    call_indirect                 
+       90    store_var 9                   (_14)
+       91    jump +45                      (to 136)
+       92    load_var 8                    (_13)
+       93    make_bound_method 527         
+       94    call_indirect                 
+       95    store_var 9                   (_14)
+       96    jump +40                      (to 136)
+       97    load_type 15                  
+       98    load_type 16                  
+       99    load_type 16                  
+       100   load_var 8                    (_13)
+       101   call 541 ntypeargs=3          (baml.iter.Filter.Iterable.iter)
+       102   store_var 9                   (_14)
+       103   jump +33                      (to 136)
+       104   load_var 8                    (_13)
+       105   make_bound_method 557         
+       106   call_indirect                 
+       107   store_var 9                   (_14)
+       108   jump +28                      (to 136)
+       109   load_type 15                  
+       110   load_var 8                    (_13)
+       111   call 575 ntypeargs=1          (baml.iter.Repeat.Iterable.iter)
+       112   store_var 9                   (_14)
+       113   jump +23                      (to 136)
+       114   load_type 15                  
+       115   load_type 16                  
+       116   load_type 16                  
+       117   load_var 8                    (_13)
+       118   call 550 ntypeargs=3          (baml.iter.Chain.Iterable.iter)
+       119   store_var 9                   (_14)
+       120   jump +16                      (to 136)
+       121   load_type 15                  
+       122   load_type 16                  
+       123   load_var 8                    (_13)
+       124   call 565 ntypeargs=2          (baml.iter.StepBy.Iterable.iter)
+       125   store_var 9                   (_14)
+       126   jump +10                      (to 136)
+       127   load_type 15                  
+       128   load_var 8                    (_13)
+       129   call 510 ntypeargs=1          (baml.iter.ArrayIterator.Iterable.iter)
+       130   store_var 9                   (_14)
+       131   jump +5                       (to 136)
+       132   load_var 8                    (_13)
+       133   make_bound_method 588         
+       134   call_indirect                 
+       135   store_var 9                   (_14)
+       136   load_var 9                    (_14)
+       137   is_type 4                     
+       138   pop_jump_if_false +2          (to 140)
+       139   jump +87                      (to 226)
+       140   load_var 9                    (_14)
+       141   is_type 5                     
+       142   pop_jump_if_false +2          (to 144)
+       143   jump +78                      (to 221)
+       144   load_var 9                    (_14)
+       145   is_type 6                     
+       146   pop_jump_if_false +2          (to 148)
+       147   jump +68                      (to 215)
+       148   load_var 9                    (_14)
+       149   is_type 7                     
+       150   pop_jump_if_false +2          (to 152)
+       151   jump +57                      (to 208)
+       152   load_var 9                    (_14)
+       153   is_type 8                     
+       154   pop_jump_if_false +2          (to 156)
+       155   jump +48                      (to 203)
+       156   load_var 9                    (_14)
+       157   is_type 9                     
+       158   pop_jump_if_false +2          (to 160)
+       159   jump +39                      (to 198)
+       160   load_var 9                    (_14)
+       161   is_type 10                    
+       162   pop_jump_if_false +2          (to 164)
+       163   jump +28                      (to 191)
+       164   load_var 9                    (_14)
+       165   is_type 11                    
+       166   pop_jump_if_false +2          (to 168)
+       167   jump +19                      (to 186)
+       168   load_var 9                    (_14)
+       169   is_type 12                    
+       170   pop_jump_if_false +2          (to 172)
+       171   jump +10                      (to 181)
+       172   load_var 9                    (_14)
+       173   is_type 13                    
+       174   pop_jump_if_false +106        (to 280)
+       175   load_type 15                  
+       176   load_type 16                  
+       177   load_var 9                    (_14)
+       178   call 537 ntypeargs=2          (baml.iter.Peekable.Iterator.next)
+       179   store_var 10                  (_45)
+       180   jump +50                      (to 230)
+       181   load_var 9                    (_14)
+       182   make_bound_method 568         
+       183   call_indirect                 
+       184   store_var 10                  (_45)
+       185   jump +45                      (to 230)
+       186   load_var 9                    (_14)
+       187   make_bound_method 581         
+       188   call_indirect                 
+       189   store_var 10                  (_45)
+       190   jump +40                      (to 230)
+       191   load_type 15                  
+       192   load_type 16                  
+       193   load_type 16                  
+       194   load_var 9                    (_14)
+       195   call 504 ntypeargs=3          (baml.iter.Filter.Iterator.next)
+       196   store_var 10                  (_45)
+       197   jump +33                      (to 230)
+       198   load_var 9                    (_14)
+       199   make_bound_method 517         
+       200   call_indirect                 
+       201   store_var 10                  (_45)
+       202   jump +28                      (to 230)
+       203   load_type 15                  
+       204   load_var 9                    (_14)
+       205   call 531 ntypeargs=1          (baml.iter.Repeat.Iterator.next)
+       206   store_var 10                  (_45)
+       207   jump +23                      (to 230)
+       208   load_type 15                  
+       209   load_type 16                  
+       210   load_type 16                  
+       211   load_var 9                    (_14)
+       212   call 507 ntypeargs=3          (baml.iter.Chain.Iterator.next)
+       213   store_var 10                  (_45)
+       214   jump +16                      (to 230)
+       215   load_type 15                  
+       216   load_type 16                  
+       217   load_var 9                    (_14)
+       218   call 521 ntypeargs=2          (baml.iter.StepBy.Iterator.next)
+       219   store_var 10                  (_45)
+       220   jump +10                      (to 230)
+       221   load_type 15                  
+       222   load_var 9                    (_14)
+       223   call 563 ntypeargs=1          (baml.iter.ArrayIterator.Iterator.next)
+       224   store_var 10                  (_45)
+       225   jump +5                       (to 230)
+       226   load_var 9                    (_14)
+       227   make_bound_method 552         
+       228   call_indirect                 
+       229   store_var 10                  (_45)
+       230   load_var 10                   (_45)
+       231   is_type 17                    
+       232   pop_jump_if_false +2          (to 234)
+       233   jump +16                      (to 249)
+       234   load_var 10                   (_45)
+       235   store_var_load_var 11         (t)
 
-  43   236   load_field 0             (name)
-       237   load_var 5               (full_name)
-       238   cmp_op ==                
-       239   jump_if_false +2         (to 241)
-       240   jump +6                  (to 246)
-       241   pop 1                    
-       242   load_var 11              (t)
-       243   load_field 0             (name)
-       244   load_var 7               (hash_prefix)
-       245   call 152 ntypeargs=0     (baml.String.starts_with)
-       246   pop_jump_if_false -110   (to 136)
-       247   load_var 6               (count)
-       248   load_const 18            (1)
-       249   add_int                  
-       250   store_var 6              (count)
-       251   jump -115                (to 136)
+  43   236   load_field 0                  (name)
+       237   load_var 5                    (full_name)
+       238   cmp_op ==                     
+       239   jump_if_false +2              (to 241)
+       240   jump +6                       (to 246)
+       241   pop 1                         
+       242   load_var 11                   (t)
+       243   load_field 0                  (name)
+       244   load_var 7                    (hash_prefix)
+       245   call 152 ntypeargs=0          (baml.String.starts_with)
+       246   pop_jump_if_false -110        (to 136)
+       247   add_int_small_store_var 6 1   (count)
+       248   jump -112                     (to 136)
 
-  45   252   load_var 6               (count)
-       253   load_const 2             (0)
-       254   cmp_int_op >             
-       255   pop_jump_if_false +2     (to 257)
-       256   jump +4                  (to 260)
-       257   load_var 5               (full_name)
-       258   store_var 12             (final_name)
-       259   jump +14                 (to 273)
-       260   load_var 5               (full_name)
-       261   load_const 19            ("#")
-       262   bin_op +                 
-       263   store_var 13             (_84)
-       264   load_type 20             
-       265   load_var 6               (count)
-       266   load_const 18            (1)
-       267   add_int                  
-       268   call 423 ntypeargs=1     (baml.unstable.string)
-       269   store_var 14             (_86)
-       270   load_var2 13 14          
-       271   bin_op +                 
-       272   store_var 12             (final_name)
+  45   249   load_var 6                    (count)
+       250   load_const 2                  (0)
+       251   cmp_int_op >                  
+       252   pop_jump_if_false +2          (to 254)
+       253   jump +4                       (to 257)
+       254   load_var 5                    (full_name)
+       255   store_var 12                  (final_name)
+       256   jump +14                      (to 270)
+       257   load_var 5                    (full_name)
+       258   load_const 18                 ("#")
+       259   bin_op +                      
+       260   store_var 13                  (_84)
+       261   load_type 19                  
+       262   load_var 6                    (count)
+       263   load_const 20                 (1)
+       264   add_int                       
+       265   call 423 ntypeargs=1          (baml.unstable.string)
+       266   store_var 14                  (_86)
+       267   load_var2 13 14               
+       268   bin_op +                      
+       269   store_var 12                  (final_name)
 
-  46   273   load_type 15             
-       274   load_var 1               (self)
-       275   load_field 1             (tests)
-       276   load_var2 12 3           
-       277   load_var 4               (runner)
-       278   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
-       280   pop 1                    
+  46   270   load_type 15                  
+       271   load_var 1                    (self)
+       272   load_field 1                  (tests)
+       273   load_var2 12 3                
+       274   load_var 4                    (runner)
+       275   init_instance 0               (testing.TestRegistration .name, .body, .runner)
+       276   call 17 ntypeargs=1           (baml.Array.push)
+       277   pop 1                         
 
-  38   281   load_const 21            (null)
-       282   return                   
-       283   unreachable              
+  38   278   load_const 21                 (null)
+       279   return                        
+       280   unreachable                   
 }
 
 function testing.TestCollector.register_test_set(self: testing.TestCollector, name: string, collector: (testing.TestCollector) -> void throws unknown, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never) | null) -> void {
-  50   0     load_var 1               (self)
-       1     load_field 0             (prefix)
-       2     load_const 0             ("")
-       3     cmp_op ==                
-       4     pop_jump_if_false +2     (to 6)
-       5     jump +9                  (to 14)
-       6     load_var 1               (self)
-       7     load_field 0             (prefix)
-       8     load_const 1             ("/")
-       9     bin_op +                 
-       10    load_var 2               (name)
-       11    bin_op +                 
-       12    store_var 5              (full_name)
-       13    jump +3                  (to 16)
-       14    load_var 2               (name)
-       15    store_var 5              (full_name)
+  50   0     load_var 1                    (self)
+       1     load_field 0                  (prefix)
+       2     load_const 0                  ("")
+       3     cmp_op ==                     
+       4     pop_jump_if_false +2          (to 6)
+       5     jump +9                       (to 14)
+       6     load_var 1                    (self)
+       7     load_field 0                  (prefix)
+       8     load_const 1                  ("/")
+       9     bin_op +                      
+       10    load_var 2                    (name)
+       11    bin_op +                      
+       12    store_var 5                   (full_name)
+       13    jump +3                       (to 16)
+       14    load_var 2                    (name)
+       15    store_var 5                   (full_name)
 
-  51   16    load_const 2             (0)
-       17    store_var 6              (count)
+  51   16    load_const 2                  (0)
+       17    store_var 6                   (count)
 
-  52   18    load_var 5               (full_name)
-       19    load_const 3             ("#")
-       20    bin_op +                 
-       21    store_var 7              (hash_prefix)
+  52   18    load_var 5                    (full_name)
+       19    load_const 3                  ("#")
+       20    bin_op +                      
+       21    store_var 7                   (hash_prefix)
 
-  53   22    load_var 1               (self)
-       23    load_field 2             (testsets)
-       24    store_var_load_var 8     (_13)
-       25    is_type 4                
-       26    pop_jump_if_false +2     (to 28)
-       27    jump +105                (to 132)
-       28    load_var 8               (_13)
-       29    is_type 5                
-       30    pop_jump_if_false +2     (to 32)
-       31    jump +96                 (to 127)
-       32    load_var 8               (_13)
-       33    is_type 6                
-       34    pop_jump_if_false +2     (to 36)
-       35    jump +86                 (to 121)
-       36    load_var 8               (_13)
-       37    is_type 7                
-       38    pop_jump_if_false +2     (to 40)
-       39    jump +75                 (to 114)
-       40    load_var 8               (_13)
-       41    is_type 8                
-       42    pop_jump_if_false +2     (to 44)
-       43    jump +66                 (to 109)
-       44    load_var 8               (_13)
-       45    is_type 9                
-       46    pop_jump_if_false +2     (to 48)
-       47    jump +57                 (to 104)
-       48    load_var 8               (_13)
-       49    is_type 10               
-       50    pop_jump_if_false +2     (to 52)
-       51    jump +46                 (to 97)
-       52    load_var 8               (_13)
-       53    is_type 11               
-       54    pop_jump_if_false +2     (to 56)
-       55    jump +37                 (to 92)
-       56    load_var 8               (_13)
-       57    is_type 12               
-       58    pop_jump_if_false +2     (to 60)
-       59    jump +28                 (to 87)
-       60    load_var 8               (_13)
-       61    is_type 13               
-       62    pop_jump_if_false +2     (to 64)
-       63    jump +18                 (to 81)
-       64    load_var 8               (_13)
-       65    is_type 14               
-       66    pop_jump_if_false +2     (to 68)
-       67    jump +9                  (to 76)
-       68    load_var 8               (_13)
-       69    is_type 14               
-       70    pop_jump_if_false +213   (to 283)
-       71    load_type 15             
-       72    load_var 8               (_13)
-       73    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       74    store_var 9              (_14)
-       75    jump +61                 (to 136)
-       76    load_type 15             
-       77    load_var 8               (_13)
-       78    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       79    store_var 9              (_14)
-       80    jump +56                 (to 136)
-       81    load_type 15             
-       82    load_type 16             
-       83    load_var 8               (_13)
-       84    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       85    store_var 9              (_14)
-       86    jump +50                 (to 136)
-       87    load_var 8               (_13)
-       88    make_bound_method 514    
-       89    call_indirect            
-       90    store_var 9              (_14)
-       91    jump +45                 (to 136)
-       92    load_var 8               (_13)
-       93    make_bound_method 527    
-       94    call_indirect            
-       95    store_var 9              (_14)
-       96    jump +40                 (to 136)
-       97    load_type 15             
-       98    load_type 16             
-       99    load_type 16             
-       100   load_var 8               (_13)
-       101   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       102   store_var 9              (_14)
-       103   jump +33                 (to 136)
-       104   load_var 8               (_13)
-       105   make_bound_method 557    
-       106   call_indirect            
-       107   store_var 9              (_14)
-       108   jump +28                 (to 136)
-       109   load_type 15             
-       110   load_var 8               (_13)
-       111   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       112   store_var 9              (_14)
-       113   jump +23                 (to 136)
-       114   load_type 15             
-       115   load_type 16             
-       116   load_type 16             
-       117   load_var 8               (_13)
-       118   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       119   store_var 9              (_14)
-       120   jump +16                 (to 136)
-       121   load_type 15             
-       122   load_type 16             
-       123   load_var 8               (_13)
-       124   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       125   store_var 9              (_14)
-       126   jump +10                 (to 136)
-       127   load_type 15             
-       128   load_var 8               (_13)
-       129   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       130   store_var 9              (_14)
-       131   jump +5                  (to 136)
-       132   load_var 8               (_13)
-       133   make_bound_method 588    
-       134   call_indirect            
-       135   store_var 9              (_14)
-       136   load_var 9               (_14)
-       137   is_type 4                
-       138   pop_jump_if_false +2     (to 140)
-       139   jump +87                 (to 226)
-       140   load_var 9               (_14)
-       141   is_type 5                
-       142   pop_jump_if_false +2     (to 144)
-       143   jump +78                 (to 221)
-       144   load_var 9               (_14)
-       145   is_type 6                
-       146   pop_jump_if_false +2     (to 148)
-       147   jump +68                 (to 215)
-       148   load_var 9               (_14)
-       149   is_type 7                
-       150   pop_jump_if_false +2     (to 152)
-       151   jump +57                 (to 208)
-       152   load_var 9               (_14)
-       153   is_type 8                
-       154   pop_jump_if_false +2     (to 156)
-       155   jump +48                 (to 203)
-       156   load_var 9               (_14)
-       157   is_type 9                
-       158   pop_jump_if_false +2     (to 160)
-       159   jump +39                 (to 198)
-       160   load_var 9               (_14)
-       161   is_type 10               
-       162   pop_jump_if_false +2     (to 164)
-       163   jump +28                 (to 191)
-       164   load_var 9               (_14)
-       165   is_type 11               
-       166   pop_jump_if_false +2     (to 168)
-       167   jump +19                 (to 186)
-       168   load_var 9               (_14)
-       169   is_type 12               
-       170   pop_jump_if_false +2     (to 172)
-       171   jump +10                 (to 181)
-       172   load_var 9               (_14)
-       173   is_type 13               
-       174   pop_jump_if_false +109   (to 283)
-       175   load_type 15             
-       176   load_type 16             
-       177   load_var 9               (_14)
-       178   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       179   store_var 10             (_45)
-       180   jump +50                 (to 230)
-       181   load_var 9               (_14)
-       182   make_bound_method 568    
-       183   call_indirect            
-       184   store_var 10             (_45)
-       185   jump +45                 (to 230)
-       186   load_var 9               (_14)
-       187   make_bound_method 581    
-       188   call_indirect            
-       189   store_var 10             (_45)
-       190   jump +40                 (to 230)
-       191   load_type 15             
-       192   load_type 16             
-       193   load_type 16             
-       194   load_var 9               (_14)
-       195   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       196   store_var 10             (_45)
-       197   jump +33                 (to 230)
-       198   load_var 9               (_14)
-       199   make_bound_method 517    
-       200   call_indirect            
-       201   store_var 10             (_45)
-       202   jump +28                 (to 230)
-       203   load_type 15             
-       204   load_var 9               (_14)
-       205   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       206   store_var 10             (_45)
-       207   jump +23                 (to 230)
-       208   load_type 15             
-       209   load_type 16             
-       210   load_type 16             
-       211   load_var 9               (_14)
-       212   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       213   store_var 10             (_45)
-       214   jump +16                 (to 230)
-       215   load_type 15             
-       216   load_type 16             
-       217   load_var 9               (_14)
-       218   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       219   store_var 10             (_45)
-       220   jump +10                 (to 230)
-       221   load_type 15             
-       222   load_var 9               (_14)
-       223   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       224   store_var 10             (_45)
-       225   jump +5                  (to 230)
-       226   load_var 9               (_14)
-       227   make_bound_method 552    
-       228   call_indirect            
-       229   store_var 10             (_45)
-       230   load_var 10              (_45)
-       231   is_type 17               
-       232   pop_jump_if_false +2     (to 234)
-       233   jump +19                 (to 252)
-       234   load_var 10              (_45)
-       235   store_var_load_var 11    (ts)
+  53   22    load_var 1                    (self)
+       23    load_field 2                  (testsets)
+       24    store_var_load_var 8          (_13)
+       25    is_type 4                     
+       26    pop_jump_if_false +2          (to 28)
+       27    jump +105                     (to 132)
+       28    load_var 8                    (_13)
+       29    is_type 5                     
+       30    pop_jump_if_false +2          (to 32)
+       31    jump +96                      (to 127)
+       32    load_var 8                    (_13)
+       33    is_type 6                     
+       34    pop_jump_if_false +2          (to 36)
+       35    jump +86                      (to 121)
+       36    load_var 8                    (_13)
+       37    is_type 7                     
+       38    pop_jump_if_false +2          (to 40)
+       39    jump +75                      (to 114)
+       40    load_var 8                    (_13)
+       41    is_type 8                     
+       42    pop_jump_if_false +2          (to 44)
+       43    jump +66                      (to 109)
+       44    load_var 8                    (_13)
+       45    is_type 9                     
+       46    pop_jump_if_false +2          (to 48)
+       47    jump +57                      (to 104)
+       48    load_var 8                    (_13)
+       49    is_type 10                    
+       50    pop_jump_if_false +2          (to 52)
+       51    jump +46                      (to 97)
+       52    load_var 8                    (_13)
+       53    is_type 11                    
+       54    pop_jump_if_false +2          (to 56)
+       55    jump +37                      (to 92)
+       56    load_var 8                    (_13)
+       57    is_type 12                    
+       58    pop_jump_if_false +2          (to 60)
+       59    jump +28                      (to 87)
+       60    load_var 8                    (_13)
+       61    is_type 13                    
+       62    pop_jump_if_false +2          (to 64)
+       63    jump +18                      (to 81)
+       64    load_var 8                    (_13)
+       65    is_type 14                    
+       66    pop_jump_if_false +2          (to 68)
+       67    jump +9                       (to 76)
+       68    load_var 8                    (_13)
+       69    is_type 14                    
+       70    pop_jump_if_false +210        (to 280)
+       71    load_type 15                  
+       72    load_var 8                    (_13)
+       73    call 532 ntypeargs=1          (baml.iter.Iterable$for$T[].iter)
+       74    store_var 9                   (_14)
+       75    jump +61                      (to 136)
+       76    load_type 15                  
+       77    load_var 8                    (_13)
+       78    call 532 ntypeargs=1          (baml.iter.Iterable$for$T[].iter)
+       79    store_var 9                   (_14)
+       80    jump +56                      (to 136)
+       81    load_type 15                  
+       82    load_type 16                  
+       83    load_var 8                    (_13)
+       84    call 579 ntypeargs=2          (baml.iter.Peekable.Iterable.iter)
+       85    store_var 9                   (_14)
+       86    jump +50                      (to 136)
+       87    load_var 8                    (_13)
+       88    make_bound_method 514         
+       89    call_indirect                 
+       90    store_var 9                   (_14)
+       91    jump +45                      (to 136)
+       92    load_var 8                    (_13)
+       93    make_bound_method 527         
+       94    call_indirect                 
+       95    store_var 9                   (_14)
+       96    jump +40                      (to 136)
+       97    load_type 15                  
+       98    load_type 16                  
+       99    load_type 16                  
+       100   load_var 8                    (_13)
+       101   call 541 ntypeargs=3          (baml.iter.Filter.Iterable.iter)
+       102   store_var 9                   (_14)
+       103   jump +33                      (to 136)
+       104   load_var 8                    (_13)
+       105   make_bound_method 557         
+       106   call_indirect                 
+       107   store_var 9                   (_14)
+       108   jump +28                      (to 136)
+       109   load_type 15                  
+       110   load_var 8                    (_13)
+       111   call 575 ntypeargs=1          (baml.iter.Repeat.Iterable.iter)
+       112   store_var 9                   (_14)
+       113   jump +23                      (to 136)
+       114   load_type 15                  
+       115   load_type 16                  
+       116   load_type 16                  
+       117   load_var 8                    (_13)
+       118   call 550 ntypeargs=3          (baml.iter.Chain.Iterable.iter)
+       119   store_var 9                   (_14)
+       120   jump +16                      (to 136)
+       121   load_type 15                  
+       122   load_type 16                  
+       123   load_var 8                    (_13)
+       124   call 565 ntypeargs=2          (baml.iter.StepBy.Iterable.iter)
+       125   store_var 9                   (_14)
+       126   jump +10                      (to 136)
+       127   load_type 15                  
+       128   load_var 8                    (_13)
+       129   call 510 ntypeargs=1          (baml.iter.ArrayIterator.Iterable.iter)
+       130   store_var 9                   (_14)
+       131   jump +5                       (to 136)
+       132   load_var 8                    (_13)
+       133   make_bound_method 588         
+       134   call_indirect                 
+       135   store_var 9                   (_14)
+       136   load_var 9                    (_14)
+       137   is_type 4                     
+       138   pop_jump_if_false +2          (to 140)
+       139   jump +87                      (to 226)
+       140   load_var 9                    (_14)
+       141   is_type 5                     
+       142   pop_jump_if_false +2          (to 144)
+       143   jump +78                      (to 221)
+       144   load_var 9                    (_14)
+       145   is_type 6                     
+       146   pop_jump_if_false +2          (to 148)
+       147   jump +68                      (to 215)
+       148   load_var 9                    (_14)
+       149   is_type 7                     
+       150   pop_jump_if_false +2          (to 152)
+       151   jump +57                      (to 208)
+       152   load_var 9                    (_14)
+       153   is_type 8                     
+       154   pop_jump_if_false +2          (to 156)
+       155   jump +48                      (to 203)
+       156   load_var 9                    (_14)
+       157   is_type 9                     
+       158   pop_jump_if_false +2          (to 160)
+       159   jump +39                      (to 198)
+       160   load_var 9                    (_14)
+       161   is_type 10                    
+       162   pop_jump_if_false +2          (to 164)
+       163   jump +28                      (to 191)
+       164   load_var 9                    (_14)
+       165   is_type 11                    
+       166   pop_jump_if_false +2          (to 168)
+       167   jump +19                      (to 186)
+       168   load_var 9                    (_14)
+       169   is_type 12                    
+       170   pop_jump_if_false +2          (to 172)
+       171   jump +10                      (to 181)
+       172   load_var 9                    (_14)
+       173   is_type 13                    
+       174   pop_jump_if_false +106        (to 280)
+       175   load_type 15                  
+       176   load_type 16                  
+       177   load_var 9                    (_14)
+       178   call 537 ntypeargs=2          (baml.iter.Peekable.Iterator.next)
+       179   store_var 10                  (_45)
+       180   jump +50                      (to 230)
+       181   load_var 9                    (_14)
+       182   make_bound_method 568         
+       183   call_indirect                 
+       184   store_var 10                  (_45)
+       185   jump +45                      (to 230)
+       186   load_var 9                    (_14)
+       187   make_bound_method 581         
+       188   call_indirect                 
+       189   store_var 10                  (_45)
+       190   jump +40                      (to 230)
+       191   load_type 15                  
+       192   load_type 16                  
+       193   load_type 16                  
+       194   load_var 9                    (_14)
+       195   call 504 ntypeargs=3          (baml.iter.Filter.Iterator.next)
+       196   store_var 10                  (_45)
+       197   jump +33                      (to 230)
+       198   load_var 9                    (_14)
+       199   make_bound_method 517         
+       200   call_indirect                 
+       201   store_var 10                  (_45)
+       202   jump +28                      (to 230)
+       203   load_type 15                  
+       204   load_var 9                    (_14)
+       205   call 531 ntypeargs=1          (baml.iter.Repeat.Iterator.next)
+       206   store_var 10                  (_45)
+       207   jump +23                      (to 230)
+       208   load_type 15                  
+       209   load_type 16                  
+       210   load_type 16                  
+       211   load_var 9                    (_14)
+       212   call 507 ntypeargs=3          (baml.iter.Chain.Iterator.next)
+       213   store_var 10                  (_45)
+       214   jump +16                      (to 230)
+       215   load_type 15                  
+       216   load_type 16                  
+       217   load_var 9                    (_14)
+       218   call 521 ntypeargs=2          (baml.iter.StepBy.Iterator.next)
+       219   store_var 10                  (_45)
+       220   jump +10                      (to 230)
+       221   load_type 15                  
+       222   load_var 9                    (_14)
+       223   call 563 ntypeargs=1          (baml.iter.ArrayIterator.Iterator.next)
+       224   store_var 10                  (_45)
+       225   jump +5                       (to 230)
+       226   load_var 9                    (_14)
+       227   make_bound_method 552         
+       228   call_indirect                 
+       229   store_var 10                  (_45)
+       230   load_var 10                   (_45)
+       231   is_type 17                    
+       232   pop_jump_if_false +2          (to 234)
+       233   jump +16                      (to 249)
+       234   load_var 10                   (_45)
+       235   store_var_load_var 11         (ts)
 
-  54   236   load_field 0             (name)
-       237   load_var 5               (full_name)
-       238   cmp_op ==                
-       239   jump_if_false +2         (to 241)
-       240   jump +6                  (to 246)
-       241   pop 1                    
-       242   load_var 11              (ts)
-       243   load_field 0             (name)
-       244   load_var 7               (hash_prefix)
-       245   call 152 ntypeargs=0     (baml.String.starts_with)
-       246   pop_jump_if_false -110   (to 136)
-       247   load_var 6               (count)
-       248   load_const 18            (1)
-       249   add_int                  
-       250   store_var 6              (count)
-       251   jump -115                (to 136)
+  54   236   load_field 0                  (name)
+       237   load_var 5                    (full_name)
+       238   cmp_op ==                     
+       239   jump_if_false +2              (to 241)
+       240   jump +6                       (to 246)
+       241   pop 1                         
+       242   load_var 11                   (ts)
+       243   load_field 0                  (name)
+       244   load_var 7                    (hash_prefix)
+       245   call 152 ntypeargs=0          (baml.String.starts_with)
+       246   pop_jump_if_false -110        (to 136)
+       247   add_int_small_store_var 6 1   (count)
+       248   jump -112                     (to 136)
 
-  56   252   load_var 6               (count)
-       253   load_const 2             (0)
-       254   cmp_int_op >             
-       255   pop_jump_if_false +2     (to 257)
-       256   jump +4                  (to 260)
-       257   load_var 5               (full_name)
-       258   store_var 12             (final_name)
-       259   jump +14                 (to 273)
-       260   load_var 5               (full_name)
-       261   load_const 19            ("#")
-       262   bin_op +                 
-       263   store_var 13             (_84)
-       264   load_type 20             
-       265   load_var 6               (count)
-       266   load_const 18            (1)
-       267   add_int                  
-       268   call 423 ntypeargs=1     (baml.unstable.string)
-       269   store_var 14             (_86)
-       270   load_var2 13 14          
-       271   bin_op +                 
-       272   store_var 12             (final_name)
+  56   249   load_var 6                    (count)
+       250   load_const 2                  (0)
+       251   cmp_int_op >                  
+       252   pop_jump_if_false +2          (to 254)
+       253   jump +4                       (to 257)
+       254   load_var 5                    (full_name)
+       255   store_var 12                  (final_name)
+       256   jump +14                      (to 270)
+       257   load_var 5                    (full_name)
+       258   load_const 18                 ("#")
+       259   bin_op +                      
+       260   store_var 13                  (_84)
+       261   load_type 19                  
+       262   load_var 6                    (count)
+       263   load_const 20                 (1)
+       264   add_int                       
+       265   call 423 ntypeargs=1          (baml.unstable.string)
+       266   store_var 14                  (_86)
+       267   load_var2 13 14               
+       268   bin_op +                      
+       269   store_var 12                  (final_name)
 
-  57   273   load_type 15             
-       274   load_var 1               (self)
-       275   load_field 2             (testsets)
-       276   load_var2 12 3           
-       277   load_var 4               (runner)
-       278   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
-       280   pop 1                    
+  57   270   load_type 15                  
+       271   load_var 1                    (self)
+       272   load_field 2                  (testsets)
+       273   load_var2 12 3                
+       274   load_var 4                    (runner)
+       275   init_instance 0               (testing.TestSetRegistration .name, .collector, .runner)
+       276   call 17 ntypeargs=1           (baml.Array.push)
+       277   pop 1                         
 
-  49   281   load_const 21            (null)
-       282   return                   
-       283   unreachable              
+  49   278   load_const 21                 (null)
+       279   return                        
+       280   unreachable                   
 }
 
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -463,595 +463,589 @@ function testing.TestCollector.new(prefix: string) -> testing.TestCollector {
 }
 
 function testing.TestCollector.register_test(self: testing.TestCollector, name: string, body: () -> void throws unknown, runner: ((() -> testing.TestReport throws never) -> (() -> testing.TestReport throws never) throws never) | null) -> void {
-  39   0     load_var 1               (self)
-       1     load_field 0             (prefix)
-       2     load_const 0             ("")
-       3     cmp_op ==                
-       4     pop_jump_if_false +2     (to 6)
-       5     jump +9                  (to 14)
-       6     load_var 1               (self)
-       7     load_field 0             (prefix)
-       8     load_const 1             ("/")
-       9     bin_op +                 
-       10    load_var 2               (name)
-       11    bin_op +                 
-       12    store_var 6              (full_name)
-       13    jump +3                  (to 16)
-       14    load_var 2               (name)
-       15    store_var 6              (full_name)
+  39   0     load_var 1                    (self)
+       1     load_field 0                  (prefix)
+       2     load_const 0                  ("")
+       3     cmp_op ==                     
+       4     pop_jump_if_false +2          (to 6)
+       5     jump +9                       (to 14)
+       6     load_var 1                    (self)
+       7     load_field 0                  (prefix)
+       8     load_const 1                  ("/")
+       9     bin_op +                      
+       10    load_var 2                    (name)
+       11    bin_op +                      
+       12    store_var 6                   (full_name)
+       13    jump +3                       (to 16)
+       14    load_var 2                    (name)
+       15    store_var 6                   (full_name)
 
-  40   16    load_const 2             (0)
-       17    store_var 7              (count)
+  40   16    load_const 2                  (0)
+       17    store_var 7                   (count)
 
-  41   18    load_var 6               (full_name)
-       19    load_const 3             ("#")
-       20    bin_op +                 
-       21    store_var 8              (hash_prefix)
+  41   18    load_var 6                    (full_name)
+       19    load_const 3                  ("#")
+       20    bin_op +                      
+       21    store_var 8                   (hash_prefix)
 
-  42   22    load_var 1               (self)
-       23    load_field 1             (tests)
-       24    store_var_load_var 9     (_13)
-       25    is_type 4                
-       26    pop_jump_if_false +2     (to 28)
-       27    jump +105                (to 132)
-       28    load_var 9               (_13)
-       29    is_type 5                
-       30    pop_jump_if_false +2     (to 32)
-       31    jump +96                 (to 127)
-       32    load_var 9               (_13)
-       33    is_type 6                
-       34    pop_jump_if_false +2     (to 36)
-       35    jump +86                 (to 121)
-       36    load_var 9               (_13)
-       37    is_type 7                
-       38    pop_jump_if_false +2     (to 40)
-       39    jump +75                 (to 114)
-       40    load_var 9               (_13)
-       41    is_type 8                
-       42    pop_jump_if_false +2     (to 44)
-       43    jump +66                 (to 109)
-       44    load_var 9               (_13)
-       45    is_type 9                
-       46    pop_jump_if_false +2     (to 48)
-       47    jump +57                 (to 104)
-       48    load_var 9               (_13)
-       49    is_type 10               
-       50    pop_jump_if_false +2     (to 52)
-       51    jump +46                 (to 97)
-       52    load_var 9               (_13)
-       53    is_type 11               
-       54    pop_jump_if_false +2     (to 56)
-       55    jump +37                 (to 92)
-       56    load_var 9               (_13)
-       57    is_type 12               
-       58    pop_jump_if_false +2     (to 60)
-       59    jump +28                 (to 87)
-       60    load_var 9               (_13)
-       61    is_type 13               
-       62    pop_jump_if_false +2     (to 64)
-       63    jump +18                 (to 81)
-       64    load_var 9               (_13)
-       65    is_type 14               
-       66    pop_jump_if_false +2     (to 68)
-       67    jump +9                  (to 76)
-       68    load_var 9               (_13)
-       69    is_type 14               
-       70    pop_jump_if_false +215   (to 285)
-       71    load_type 15             
-       72    load_var 9               (_13)
-       73    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       74    store_var 10             (_14)
-       75    jump +61                 (to 136)
-       76    load_type 15             
-       77    load_var 9               (_13)
-       78    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       79    store_var 10             (_14)
-       80    jump +56                 (to 136)
-       81    load_type 15             
-       82    load_type 16             
-       83    load_var 9               (_13)
-       84    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       85    store_var 10             (_14)
-       86    jump +50                 (to 136)
-       87    load_var 9               (_13)
-       88    make_bound_method 514    
-       89    call_indirect            
-       90    store_var 10             (_14)
-       91    jump +45                 (to 136)
-       92    load_var 9               (_13)
-       93    make_bound_method 527    
-       94    call_indirect            
-       95    store_var 10             (_14)
-       96    jump +40                 (to 136)
-       97    load_type 15             
-       98    load_type 16             
-       99    load_type 16             
-       100   load_var 9               (_13)
-       101   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       102   store_var 10             (_14)
-       103   jump +33                 (to 136)
-       104   load_var 9               (_13)
-       105   make_bound_method 557    
-       106   call_indirect            
-       107   store_var 10             (_14)
-       108   jump +28                 (to 136)
-       109   load_type 15             
-       110   load_var 9               (_13)
-       111   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       112   store_var 10             (_14)
-       113   jump +23                 (to 136)
-       114   load_type 15             
-       115   load_type 16             
-       116   load_type 16             
-       117   load_var 9               (_13)
-       118   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       119   store_var 10             (_14)
-       120   jump +16                 (to 136)
-       121   load_type 15             
-       122   load_type 16             
-       123   load_var 9               (_13)
-       124   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       125   store_var 10             (_14)
-       126   jump +10                 (to 136)
-       127   load_type 15             
-       128   load_var 9               (_13)
-       129   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       130   store_var 10             (_14)
-       131   jump +5                  (to 136)
-       132   load_var 9               (_13)
-       133   make_bound_method 588    
-       134   call_indirect            
-       135   store_var 10             (_14)
-       136   load_var 10              (_14)
-       137   is_type 4                
-       138   pop_jump_if_false +2     (to 140)
-       139   jump +87                 (to 226)
-       140   load_var 10              (_14)
-       141   is_type 5                
-       142   pop_jump_if_false +2     (to 144)
-       143   jump +78                 (to 221)
-       144   load_var 10              (_14)
-       145   is_type 6                
-       146   pop_jump_if_false +2     (to 148)
-       147   jump +68                 (to 215)
-       148   load_var 10              (_14)
-       149   is_type 7                
-       150   pop_jump_if_false +2     (to 152)
-       151   jump +57                 (to 208)
-       152   load_var 10              (_14)
-       153   is_type 8                
-       154   pop_jump_if_false +2     (to 156)
-       155   jump +48                 (to 203)
-       156   load_var 10              (_14)
-       157   is_type 9                
-       158   pop_jump_if_false +2     (to 160)
-       159   jump +39                 (to 198)
-       160   load_var 10              (_14)
-       161   is_type 10               
-       162   pop_jump_if_false +2     (to 164)
-       163   jump +28                 (to 191)
-       164   load_var 10              (_14)
-       165   is_type 11               
-       166   pop_jump_if_false +2     (to 168)
-       167   jump +19                 (to 186)
-       168   load_var 10              (_14)
-       169   is_type 12               
-       170   pop_jump_if_false +2     (to 172)
-       171   jump +10                 (to 181)
-       172   load_var 10              (_14)
-       173   is_type 13               
-       174   pop_jump_if_false +111   (to 285)
-       175   load_type 15             
-       176   load_type 16             
-       177   load_var 10              (_14)
-       178   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       179   store_var 11             (_45)
-       180   jump +50                 (to 230)
-       181   load_var 10              (_14)
-       182   make_bound_method 568    
-       183   call_indirect            
-       184   store_var 11             (_45)
-       185   jump +45                 (to 230)
-       186   load_var 10              (_14)
-       187   make_bound_method 581    
-       188   call_indirect            
-       189   store_var 11             (_45)
-       190   jump +40                 (to 230)
-       191   load_type 15             
-       192   load_type 16             
-       193   load_type 16             
-       194   load_var 10              (_14)
-       195   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       196   store_var 11             (_45)
-       197   jump +33                 (to 230)
-       198   load_var 10              (_14)
-       199   make_bound_method 517    
-       200   call_indirect            
-       201   store_var 11             (_45)
-       202   jump +28                 (to 230)
-       203   load_type 15             
-       204   load_var 10              (_14)
-       205   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       206   store_var 11             (_45)
-       207   jump +23                 (to 230)
-       208   load_type 15             
-       209   load_type 16             
-       210   load_type 16             
-       211   load_var 10              (_14)
-       212   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       213   store_var 11             (_45)
-       214   jump +16                 (to 230)
-       215   load_type 15             
-       216   load_type 16             
-       217   load_var 10              (_14)
-       218   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       219   store_var 11             (_45)
-       220   jump +10                 (to 230)
-       221   load_type 15             
-       222   load_var 10              (_14)
-       223   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       224   store_var 11             (_45)
-       225   jump +5                  (to 230)
-       226   load_var 10              (_14)
-       227   make_bound_method 552    
-       228   call_indirect            
-       229   store_var 11             (_45)
-       230   load_var 11              (_45)
-       231   is_type 17               
-       232   pop_jump_if_false +2     (to 234)
-       233   jump +19                 (to 252)
-       234   load_var 11              (_45)
-       235   store_var_load_var 12    (t)
+  42   22    load_var 1                    (self)
+       23    load_field 1                  (tests)
+       24    store_var_load_var 9          (_13)
+       25    is_type 4                     
+       26    pop_jump_if_false +2          (to 28)
+       27    jump +105                     (to 132)
+       28    load_var 9                    (_13)
+       29    is_type 5                     
+       30    pop_jump_if_false +2          (to 32)
+       31    jump +96                      (to 127)
+       32    load_var 9                    (_13)
+       33    is_type 6                     
+       34    pop_jump_if_false +2          (to 36)
+       35    jump +86                      (to 121)
+       36    load_var 9                    (_13)
+       37    is_type 7                     
+       38    pop_jump_if_false +2          (to 40)
+       39    jump +75                      (to 114)
+       40    load_var 9                    (_13)
+       41    is_type 8                     
+       42    pop_jump_if_false +2          (to 44)
+       43    jump +66                      (to 109)
+       44    load_var 9                    (_13)
+       45    is_type 9                     
+       46    pop_jump_if_false +2          (to 48)
+       47    jump +57                      (to 104)
+       48    load_var 9                    (_13)
+       49    is_type 10                    
+       50    pop_jump_if_false +2          (to 52)
+       51    jump +46                      (to 97)
+       52    load_var 9                    (_13)
+       53    is_type 11                    
+       54    pop_jump_if_false +2          (to 56)
+       55    jump +37                      (to 92)
+       56    load_var 9                    (_13)
+       57    is_type 12                    
+       58    pop_jump_if_false +2          (to 60)
+       59    jump +28                      (to 87)
+       60    load_var 9                    (_13)
+       61    is_type 13                    
+       62    pop_jump_if_false +2          (to 64)
+       63    jump +18                      (to 81)
+       64    load_var 9                    (_13)
+       65    is_type 14                    
+       66    pop_jump_if_false +2          (to 68)
+       67    jump +9                       (to 76)
+       68    load_var 9                    (_13)
+       69    is_type 14                    
+       70    pop_jump_if_false +212        (to 282)
+       71    load_type 15                  
+       72    load_var 9                    (_13)
+       73    call 532 ntypeargs=1          (baml.iter.Iterable$for$T[].iter)
+       74    store_var 10                  (_14)
+       75    jump +61                      (to 136)
+       76    load_type 15                  
+       77    load_var 9                    (_13)
+       78    call 532 ntypeargs=1          (baml.iter.Iterable$for$T[].iter)
+       79    store_var 10                  (_14)
+       80    jump +56                      (to 136)
+       81    load_type 15                  
+       82    load_type 16                  
+       83    load_var 9                    (_13)
+       84    call 579 ntypeargs=2          (baml.iter.Peekable.Iterable.iter)
+       85    store_var 10                  (_14)
+       86    jump +50                      (to 136)
+       87    load_var 9                    (_13)
+       88    make_bound_method 514         
+       89    call_indirect                 
+       90    store_var 10                  (_14)
+       91    jump +45                      (to 136)
+       92    load_var 9                    (_13)
+       93    make_bound_method 527         
+       94    call_indirect                 
+       95    store_var 10                  (_14)
+       96    jump +40                      (to 136)
+       97    load_type 15                  
+       98    load_type 16                  
+       99    load_type 16                  
+       100   load_var 9                    (_13)
+       101   call 541 ntypeargs=3          (baml.iter.Filter.Iterable.iter)
+       102   store_var 10                  (_14)
+       103   jump +33                      (to 136)
+       104   load_var 9                    (_13)
+       105   make_bound_method 557         
+       106   call_indirect                 
+       107   store_var 10                  (_14)
+       108   jump +28                      (to 136)
+       109   load_type 15                  
+       110   load_var 9                    (_13)
+       111   call 575 ntypeargs=1          (baml.iter.Repeat.Iterable.iter)
+       112   store_var 10                  (_14)
+       113   jump +23                      (to 136)
+       114   load_type 15                  
+       115   load_type 16                  
+       116   load_type 16                  
+       117   load_var 9                    (_13)
+       118   call 550 ntypeargs=3          (baml.iter.Chain.Iterable.iter)
+       119   store_var 10                  (_14)
+       120   jump +16                      (to 136)
+       121   load_type 15                  
+       122   load_type 16                  
+       123   load_var 9                    (_13)
+       124   call 565 ntypeargs=2          (baml.iter.StepBy.Iterable.iter)
+       125   store_var 10                  (_14)
+       126   jump +10                      (to 136)
+       127   load_type 15                  
+       128   load_var 9                    (_13)
+       129   call 510 ntypeargs=1          (baml.iter.ArrayIterator.Iterable.iter)
+       130   store_var 10                  (_14)
+       131   jump +5                       (to 136)
+       132   load_var 9                    (_13)
+       133   make_bound_method 588         
+       134   call_indirect                 
+       135   store_var 10                  (_14)
+       136   load_var 10                   (_14)
+       137   is_type 4                     
+       138   pop_jump_if_false +2          (to 140)
+       139   jump +87                      (to 226)
+       140   load_var 10                   (_14)
+       141   is_type 5                     
+       142   pop_jump_if_false +2          (to 144)
+       143   jump +78                      (to 221)
+       144   load_var 10                   (_14)
+       145   is_type 6                     
+       146   pop_jump_if_false +2          (to 148)
+       147   jump +68                      (to 215)
+       148   load_var 10                   (_14)
+       149   is_type 7                     
+       150   pop_jump_if_false +2          (to 152)
+       151   jump +57                      (to 208)
+       152   load_var 10                   (_14)
+       153   is_type 8                     
+       154   pop_jump_if_false +2          (to 156)
+       155   jump +48                      (to 203)
+       156   load_var 10                   (_14)
+       157   is_type 9                     
+       158   pop_jump_if_false +2          (to 160)
+       159   jump +39                      (to 198)
+       160   load_var 10                   (_14)
+       161   is_type 10                    
+       162   pop_jump_if_false +2          (to 164)
+       163   jump +28                      (to 191)
+       164   load_var 10                   (_14)
+       165   is_type 11                    
+       166   pop_jump_if_false +2          (to 168)
+       167   jump +19                      (to 186)
+       168   load_var 10                   (_14)
+       169   is_type 12                    
+       170   pop_jump_if_false +2          (to 172)
+       171   jump +10                      (to 181)
+       172   load_var 10                   (_14)
+       173   is_type 13                    
+       174   pop_jump_if_false +108        (to 282)
+       175   load_type 15                  
+       176   load_type 16                  
+       177   load_var 10                   (_14)
+       178   call 537 ntypeargs=2          (baml.iter.Peekable.Iterator.next)
+       179   store_var 11                  (_45)
+       180   jump +50                      (to 230)
+       181   load_var 10                   (_14)
+       182   make_bound_method 568         
+       183   call_indirect                 
+       184   store_var 11                  (_45)
+       185   jump +45                      (to 230)
+       186   load_var 10                   (_14)
+       187   make_bound_method 581         
+       188   call_indirect                 
+       189   store_var 11                  (_45)
+       190   jump +40                      (to 230)
+       191   load_type 15                  
+       192   load_type 16                  
+       193   load_type 16                  
+       194   load_var 10                   (_14)
+       195   call 504 ntypeargs=3          (baml.iter.Filter.Iterator.next)
+       196   store_var 11                  (_45)
+       197   jump +33                      (to 230)
+       198   load_var 10                   (_14)
+       199   make_bound_method 517         
+       200   call_indirect                 
+       201   store_var 11                  (_45)
+       202   jump +28                      (to 230)
+       203   load_type 15                  
+       204   load_var 10                   (_14)
+       205   call 531 ntypeargs=1          (baml.iter.Repeat.Iterator.next)
+       206   store_var 11                  (_45)
+       207   jump +23                      (to 230)
+       208   load_type 15                  
+       209   load_type 16                  
+       210   load_type 16                  
+       211   load_var 10                   (_14)
+       212   call 507 ntypeargs=3          (baml.iter.Chain.Iterator.next)
+       213   store_var 11                  (_45)
+       214   jump +16                      (to 230)
+       215   load_type 15                  
+       216   load_type 16                  
+       217   load_var 10                   (_14)
+       218   call 521 ntypeargs=2          (baml.iter.StepBy.Iterator.next)
+       219   store_var 11                  (_45)
+       220   jump +10                      (to 230)
+       221   load_type 15                  
+       222   load_var 10                   (_14)
+       223   call 563 ntypeargs=1          (baml.iter.ArrayIterator.Iterator.next)
+       224   store_var 11                  (_45)
+       225   jump +5                       (to 230)
+       226   load_var 10                   (_14)
+       227   make_bound_method 552         
+       228   call_indirect                 
+       229   store_var 11                  (_45)
+       230   load_var 11                   (_45)
+       231   is_type 17                    
+       232   pop_jump_if_false +2          (to 234)
+       233   jump +16                      (to 249)
+       234   load_var 11                   (_45)
+       235   store_var_load_var 12         (t)
 
-  43   236   load_field 0             (name)
-       237   load_var 6               (full_name)
-       238   cmp_op ==                
-       239   jump_if_false +2         (to 241)
-       240   jump +6                  (to 246)
-       241   pop 1                    
-       242   load_var 12              (t)
-       243   load_field 0             (name)
-       244   load_var 8               (hash_prefix)
-       245   call 152 ntypeargs=0     (baml.String.starts_with)
-       246   pop_jump_if_false -110   (to 136)
-       247   load_var 7               (count)
-       248   load_const 18            (1)
-       249   add_int                  
-       250   store_var 7              (count)
-       251   jump -115                (to 136)
+  43   236   load_field 0                  (name)
+       237   load_var 6                    (full_name)
+       238   cmp_op ==                     
+       239   jump_if_false +2              (to 241)
+       240   jump +6                       (to 246)
+       241   pop 1                         
+       242   load_var 12                   (t)
+       243   load_field 0                  (name)
+       244   load_var 8                    (hash_prefix)
+       245   call 152 ntypeargs=0          (baml.String.starts_with)
+       246   pop_jump_if_false -110        (to 136)
+       247   add_int_small_store_var 7 1   (count)
+       248   jump -112                     (to 136)
 
-  45   252   load_var 7               (count)
-       253   load_const 2             (0)
-       254   cmp_int_op >             
-       255   pop_jump_if_false +2     (to 257)
-       256   jump +4                  (to 260)
-       257   load_var 6               (full_name)
-       258   store_var 13             (final_name)
-       259   jump +14                 (to 273)
-       260   load_var 6               (full_name)
-       261   load_const 19            ("#")
-       262   bin_op +                 
-       263   store_var 14             (_84)
-       264   load_type 20             
-       265   load_var 7               (count)
-       266   load_const 18            (1)
-       267   add_int                  
-       268   call 423 ntypeargs=1     (baml.unstable.string)
-       269   store_var 15             (_86)
-       270   load_var2 14 15          
-       271   bin_op +                 
-       272   store_var 13             (final_name)
+  45   249   load_var 7                    (count)
+       250   load_const 2                  (0)
+       251   cmp_int_op >                  
+       252   pop_jump_if_false +2          (to 254)
+       253   jump +4                       (to 257)
+       254   load_var 6                    (full_name)
+       255   store_var 13                  (final_name)
+       256   jump +14                      (to 270)
+       257   load_var 6                    (full_name)
+       258   load_const 18                 ("#")
+       259   bin_op +                      
+       260   store_var 14                  (_84)
+       261   load_type 19                  
+       262   load_var 7                    (count)
+       263   load_const 20                 (1)
+       264   add_int                       
+       265   call 423 ntypeargs=1          (baml.unstable.string)
+       266   store_var 15                  (_86)
+       267   load_var2 14 15               
+       268   bin_op +                      
+       269   store_var 13                  (final_name)
 
-  46   273   load_type 15             
-       274   load_var 1               (self)
-       275   load_field 1             (tests)
-       276   load_var2 13 3           
-       277   load_var 4               (runner)
-       278   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
-       280   pop 1                    
+  46   270   load_type 15                  
+       271   load_var 1                    (self)
+       272   load_field 1                  (tests)
+       273   load_var2 13 3                
+       274   load_var 4                    (runner)
+       275   init_instance 0               (testing.TestRegistration .name, .body, .runner)
+       276   call 17 ntypeargs=1           (baml.Array.push)
+       277   pop 1                         
 
-  38   281   load_const 21            (null)
-       282   store_var 5              (_0)
-       283   load_var 5               (_0)
-       284   return                   
-       285   unreachable              
+  38   278   load_const 21                 (null)
+       279   store_var 5                   (_0)
+       280   load_var 5                    (_0)
+       281   return                        
+       282   unreachable                   
 }
 
 function testing.TestCollector.register_test_set(self: testing.TestCollector, name: string, collector: (testing.TestCollector) -> void throws unknown, runner: ((() -> testing.TestSetReport throws never) -> (() -> testing.TestSetReport throws never) throws never) | null) -> void {
-  50   0     load_var 1               (self)
-       1     load_field 0             (prefix)
-       2     load_const 0             ("")
-       3     cmp_op ==                
-       4     pop_jump_if_false +2     (to 6)
-       5     jump +9                  (to 14)
-       6     load_var 1               (self)
-       7     load_field 0             (prefix)
-       8     load_const 1             ("/")
-       9     bin_op +                 
-       10    load_var 2               (name)
-       11    bin_op +                 
-       12    store_var 6              (full_name)
-       13    jump +3                  (to 16)
-       14    load_var 2               (name)
-       15    store_var 6              (full_name)
+  50   0     load_var 1                    (self)
+       1     load_field 0                  (prefix)
+       2     load_const 0                  ("")
+       3     cmp_op ==                     
+       4     pop_jump_if_false +2          (to 6)
+       5     jump +9                       (to 14)
+       6     load_var 1                    (self)
+       7     load_field 0                  (prefix)
+       8     load_const 1                  ("/")
+       9     bin_op +                      
+       10    load_var 2                    (name)
+       11    bin_op +                      
+       12    store_var 6                   (full_name)
+       13    jump +3                       (to 16)
+       14    load_var 2                    (name)
+       15    store_var 6                   (full_name)
 
-  51   16    load_const 2             (0)
-       17    store_var 7              (count)
+  51   16    load_const 2                  (0)
+       17    store_var 7                   (count)
 
-  52   18    load_var 6               (full_name)
-       19    load_const 3             ("#")
-       20    bin_op +                 
-       21    store_var 8              (hash_prefix)
+  52   18    load_var 6                    (full_name)
+       19    load_const 3                  ("#")
+       20    bin_op +                      
+       21    store_var 8                   (hash_prefix)
 
-  53   22    load_var 1               (self)
-       23    load_field 2             (testsets)
-       24    store_var_load_var 9     (_13)
-       25    is_type 4                
-       26    pop_jump_if_false +2     (to 28)
-       27    jump +105                (to 132)
-       28    load_var 9               (_13)
-       29    is_type 5                
-       30    pop_jump_if_false +2     (to 32)
-       31    jump +96                 (to 127)
-       32    load_var 9               (_13)
-       33    is_type 6                
-       34    pop_jump_if_false +2     (to 36)
-       35    jump +86                 (to 121)
-       36    load_var 9               (_13)
-       37    is_type 7                
-       38    pop_jump_if_false +2     (to 40)
-       39    jump +75                 (to 114)
-       40    load_var 9               (_13)
-       41    is_type 8                
-       42    pop_jump_if_false +2     (to 44)
-       43    jump +66                 (to 109)
-       44    load_var 9               (_13)
-       45    is_type 9                
-       46    pop_jump_if_false +2     (to 48)
-       47    jump +57                 (to 104)
-       48    load_var 9               (_13)
-       49    is_type 10               
-       50    pop_jump_if_false +2     (to 52)
-       51    jump +46                 (to 97)
-       52    load_var 9               (_13)
-       53    is_type 11               
-       54    pop_jump_if_false +2     (to 56)
-       55    jump +37                 (to 92)
-       56    load_var 9               (_13)
-       57    is_type 12               
-       58    pop_jump_if_false +2     (to 60)
-       59    jump +28                 (to 87)
-       60    load_var 9               (_13)
-       61    is_type 13               
-       62    pop_jump_if_false +2     (to 64)
-       63    jump +18                 (to 81)
-       64    load_var 9               (_13)
-       65    is_type 14               
-       66    pop_jump_if_false +2     (to 68)
-       67    jump +9                  (to 76)
-       68    load_var 9               (_13)
-       69    is_type 14               
-       70    pop_jump_if_false +215   (to 285)
-       71    load_type 15             
-       72    load_var 9               (_13)
-       73    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       74    store_var 10             (_14)
-       75    jump +61                 (to 136)
-       76    load_type 15             
-       77    load_var 9               (_13)
-       78    call 532 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
-       79    store_var 10             (_14)
-       80    jump +56                 (to 136)
-       81    load_type 15             
-       82    load_type 16             
-       83    load_var 9               (_13)
-       84    call 579 ntypeargs=2     (baml.iter.Peekable.Iterable.iter)
-       85    store_var 10             (_14)
-       86    jump +50                 (to 136)
-       87    load_var 9               (_13)
-       88    make_bound_method 514    
-       89    call_indirect            
-       90    store_var 10             (_14)
-       91    jump +45                 (to 136)
-       92    load_var 9               (_13)
-       93    make_bound_method 527    
-       94    call_indirect            
-       95    store_var 10             (_14)
-       96    jump +40                 (to 136)
-       97    load_type 15             
-       98    load_type 16             
-       99    load_type 16             
-       100   load_var 9               (_13)
-       101   call 541 ntypeargs=3     (baml.iter.Filter.Iterable.iter)
-       102   store_var 10             (_14)
-       103   jump +33                 (to 136)
-       104   load_var 9               (_13)
-       105   make_bound_method 557    
-       106   call_indirect            
-       107   store_var 10             (_14)
-       108   jump +28                 (to 136)
-       109   load_type 15             
-       110   load_var 9               (_13)
-       111   call 575 ntypeargs=1     (baml.iter.Repeat.Iterable.iter)
-       112   store_var 10             (_14)
-       113   jump +23                 (to 136)
-       114   load_type 15             
-       115   load_type 16             
-       116   load_type 16             
-       117   load_var 9               (_13)
-       118   call 550 ntypeargs=3     (baml.iter.Chain.Iterable.iter)
-       119   store_var 10             (_14)
-       120   jump +16                 (to 136)
-       121   load_type 15             
-       122   load_type 16             
-       123   load_var 9               (_13)
-       124   call 565 ntypeargs=2     (baml.iter.StepBy.Iterable.iter)
-       125   store_var 10             (_14)
-       126   jump +10                 (to 136)
-       127   load_type 15             
-       128   load_var 9               (_13)
-       129   call 510 ntypeargs=1     (baml.iter.ArrayIterator.Iterable.iter)
-       130   store_var 10             (_14)
-       131   jump +5                  (to 136)
-       132   load_var 9               (_13)
-       133   make_bound_method 588    
-       134   call_indirect            
-       135   store_var 10             (_14)
-       136   load_var 10              (_14)
-       137   is_type 4                
-       138   pop_jump_if_false +2     (to 140)
-       139   jump +87                 (to 226)
-       140   load_var 10              (_14)
-       141   is_type 5                
-       142   pop_jump_if_false +2     (to 144)
-       143   jump +78                 (to 221)
-       144   load_var 10              (_14)
-       145   is_type 6                
-       146   pop_jump_if_false +2     (to 148)
-       147   jump +68                 (to 215)
-       148   load_var 10              (_14)
-       149   is_type 7                
-       150   pop_jump_if_false +2     (to 152)
-       151   jump +57                 (to 208)
-       152   load_var 10              (_14)
-       153   is_type 8                
-       154   pop_jump_if_false +2     (to 156)
-       155   jump +48                 (to 203)
-       156   load_var 10              (_14)
-       157   is_type 9                
-       158   pop_jump_if_false +2     (to 160)
-       159   jump +39                 (to 198)
-       160   load_var 10              (_14)
-       161   is_type 10               
-       162   pop_jump_if_false +2     (to 164)
-       163   jump +28                 (to 191)
-       164   load_var 10              (_14)
-       165   is_type 11               
-       166   pop_jump_if_false +2     (to 168)
-       167   jump +19                 (to 186)
-       168   load_var 10              (_14)
-       169   is_type 12               
-       170   pop_jump_if_false +2     (to 172)
-       171   jump +10                 (to 181)
-       172   load_var 10              (_14)
-       173   is_type 13               
-       174   pop_jump_if_false +111   (to 285)
-       175   load_type 15             
-       176   load_type 16             
-       177   load_var 10              (_14)
-       178   call 537 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
-       179   store_var 11             (_45)
-       180   jump +50                 (to 230)
-       181   load_var 10              (_14)
-       182   make_bound_method 568    
-       183   call_indirect            
-       184   store_var 11             (_45)
-       185   jump +45                 (to 230)
-       186   load_var 10              (_14)
-       187   make_bound_method 581    
-       188   call_indirect            
-       189   store_var 11             (_45)
-       190   jump +40                 (to 230)
-       191   load_type 15             
-       192   load_type 16             
-       193   load_type 16             
-       194   load_var 10              (_14)
-       195   call 504 ntypeargs=3     (baml.iter.Filter.Iterator.next)
-       196   store_var 11             (_45)
-       197   jump +33                 (to 230)
-       198   load_var 10              (_14)
-       199   make_bound_method 517    
-       200   call_indirect            
-       201   store_var 11             (_45)
-       202   jump +28                 (to 230)
-       203   load_type 15             
-       204   load_var 10              (_14)
-       205   call 531 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
-       206   store_var 11             (_45)
-       207   jump +23                 (to 230)
-       208   load_type 15             
-       209   load_type 16             
-       210   load_type 16             
-       211   load_var 10              (_14)
-       212   call 507 ntypeargs=3     (baml.iter.Chain.Iterator.next)
-       213   store_var 11             (_45)
-       214   jump +16                 (to 230)
-       215   load_type 15             
-       216   load_type 16             
-       217   load_var 10              (_14)
-       218   call 521 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
-       219   store_var 11             (_45)
-       220   jump +10                 (to 230)
-       221   load_type 15             
-       222   load_var 10              (_14)
-       223   call 563 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
-       224   store_var 11             (_45)
-       225   jump +5                  (to 230)
-       226   load_var 10              (_14)
-       227   make_bound_method 552    
-       228   call_indirect            
-       229   store_var 11             (_45)
-       230   load_var 11              (_45)
-       231   is_type 17               
-       232   pop_jump_if_false +2     (to 234)
-       233   jump +19                 (to 252)
-       234   load_var 11              (_45)
-       235   store_var_load_var 12    (ts)
+  53   22    load_var 1                    (self)
+       23    load_field 2                  (testsets)
+       24    store_var_load_var 9          (_13)
+       25    is_type 4                     
+       26    pop_jump_if_false +2          (to 28)
+       27    jump +105                     (to 132)
+       28    load_var 9                    (_13)
+       29    is_type 5                     
+       30    pop_jump_if_false +2          (to 32)
+       31    jump +96                      (to 127)
+       32    load_var 9                    (_13)
+       33    is_type 6                     
+       34    pop_jump_if_false +2          (to 36)
+       35    jump +86                      (to 121)
+       36    load_var 9                    (_13)
+       37    is_type 7                     
+       38    pop_jump_if_false +2          (to 40)
+       39    jump +75                      (to 114)
+       40    load_var 9                    (_13)
+       41    is_type 8                     
+       42    pop_jump_if_false +2          (to 44)
+       43    jump +66                      (to 109)
+       44    load_var 9                    (_13)
+       45    is_type 9                     
+       46    pop_jump_if_false +2          (to 48)
+       47    jump +57                      (to 104)
+       48    load_var 9                    (_13)
+       49    is_type 10                    
+       50    pop_jump_if_false +2          (to 52)
+       51    jump +46                      (to 97)
+       52    load_var 9                    (_13)
+       53    is_type 11                    
+       54    pop_jump_if_false +2          (to 56)
+       55    jump +37                      (to 92)
+       56    load_var 9                    (_13)
+       57    is_type 12                    
+       58    pop_jump_if_false +2          (to 60)
+       59    jump +28                      (to 87)
+       60    load_var 9                    (_13)
+       61    is_type 13                    
+       62    pop_jump_if_false +2          (to 64)
+       63    jump +18                      (to 81)
+       64    load_var 9                    (_13)
+       65    is_type 14                    
+       66    pop_jump_if_false +2          (to 68)
+       67    jump +9                       (to 76)
+       68    load_var 9                    (_13)
+       69    is_type 14                    
+       70    pop_jump_if_false +212        (to 282)
+       71    load_type 15                  
+       72    load_var 9                    (_13)
+       73    call 532 ntypeargs=1          (baml.iter.Iterable$for$T[].iter)
+       74    store_var 10                  (_14)
+       75    jump +61                      (to 136)
+       76    load_type 15                  
+       77    load_var 9                    (_13)
+       78    call 532 ntypeargs=1          (baml.iter.Iterable$for$T[].iter)
+       79    store_var 10                  (_14)
+       80    jump +56                      (to 136)
+       81    load_type 15                  
+       82    load_type 16                  
+       83    load_var 9                    (_13)
+       84    call 579 ntypeargs=2          (baml.iter.Peekable.Iterable.iter)
+       85    store_var 10                  (_14)
+       86    jump +50                      (to 136)
+       87    load_var 9                    (_13)
+       88    make_bound_method 514         
+       89    call_indirect                 
+       90    store_var 10                  (_14)
+       91    jump +45                      (to 136)
+       92    load_var 9                    (_13)
+       93    make_bound_method 527         
+       94    call_indirect                 
+       95    store_var 10                  (_14)
+       96    jump +40                      (to 136)
+       97    load_type 15                  
+       98    load_type 16                  
+       99    load_type 16                  
+       100   load_var 9                    (_13)
+       101   call 541 ntypeargs=3          (baml.iter.Filter.Iterable.iter)
+       102   store_var 10                  (_14)
+       103   jump +33                      (to 136)
+       104   load_var 9                    (_13)
+       105   make_bound_method 557         
+       106   call_indirect                 
+       107   store_var 10                  (_14)
+       108   jump +28                      (to 136)
+       109   load_type 15                  
+       110   load_var 9                    (_13)
+       111   call 575 ntypeargs=1          (baml.iter.Repeat.Iterable.iter)
+       112   store_var 10                  (_14)
+       113   jump +23                      (to 136)
+       114   load_type 15                  
+       115   load_type 16                  
+       116   load_type 16                  
+       117   load_var 9                    (_13)
+       118   call 550 ntypeargs=3          (baml.iter.Chain.Iterable.iter)
+       119   store_var 10                  (_14)
+       120   jump +16                      (to 136)
+       121   load_type 15                  
+       122   load_type 16                  
+       123   load_var 9                    (_13)
+       124   call 565 ntypeargs=2          (baml.iter.StepBy.Iterable.iter)
+       125   store_var 10                  (_14)
+       126   jump +10                      (to 136)
+       127   load_type 15                  
+       128   load_var 9                    (_13)
+       129   call 510 ntypeargs=1          (baml.iter.ArrayIterator.Iterable.iter)
+       130   store_var 10                  (_14)
+       131   jump +5                       (to 136)
+       132   load_var 9                    (_13)
+       133   make_bound_method 588         
+       134   call_indirect                 
+       135   store_var 10                  (_14)
+       136   load_var 10                   (_14)
+       137   is_type 4                     
+       138   pop_jump_if_false +2          (to 140)
+       139   jump +87                      (to 226)
+       140   load_var 10                   (_14)
+       141   is_type 5                     
+       142   pop_jump_if_false +2          (to 144)
+       143   jump +78                      (to 221)
+       144   load_var 10                   (_14)
+       145   is_type 6                     
+       146   pop_jump_if_false +2          (to 148)
+       147   jump +68                      (to 215)
+       148   load_var 10                   (_14)
+       149   is_type 7                     
+       150   pop_jump_if_false +2          (to 152)
+       151   jump +57                      (to 208)
+       152   load_var 10                   (_14)
+       153   is_type 8                     
+       154   pop_jump_if_false +2          (to 156)
+       155   jump +48                      (to 203)
+       156   load_var 10                   (_14)
+       157   is_type 9                     
+       158   pop_jump_if_false +2          (to 160)
+       159   jump +39                      (to 198)
+       160   load_var 10                   (_14)
+       161   is_type 10                    
+       162   pop_jump_if_false +2          (to 164)
+       163   jump +28                      (to 191)
+       164   load_var 10                   (_14)
+       165   is_type 11                    
+       166   pop_jump_if_false +2          (to 168)
+       167   jump +19                      (to 186)
+       168   load_var 10                   (_14)
+       169   is_type 12                    
+       170   pop_jump_if_false +2          (to 172)
+       171   jump +10                      (to 181)
+       172   load_var 10                   (_14)
+       173   is_type 13                    
+       174   pop_jump_if_false +108        (to 282)
+       175   load_type 15                  
+       176   load_type 16                  
+       177   load_var 10                   (_14)
+       178   call 537 ntypeargs=2          (baml.iter.Peekable.Iterator.next)
+       179   store_var 11                  (_45)
+       180   jump +50                      (to 230)
+       181   load_var 10                   (_14)
+       182   make_bound_method 568         
+       183   call_indirect                 
+       184   store_var 11                  (_45)
+       185   jump +45                      (to 230)
+       186   load_var 10                   (_14)
+       187   make_bound_method 581         
+       188   call_indirect                 
+       189   store_var 11                  (_45)
+       190   jump +40                      (to 230)
+       191   load_type 15                  
+       192   load_type 16                  
+       193   load_type 16                  
+       194   load_var 10                   (_14)
+       195   call 504 ntypeargs=3          (baml.iter.Filter.Iterator.next)
+       196   store_var 11                  (_45)
+       197   jump +33                      (to 230)
+       198   load_var 10                   (_14)
+       199   make_bound_method 517         
+       200   call_indirect                 
+       201   store_var 11                  (_45)
+       202   jump +28                      (to 230)
+       203   load_type 15                  
+       204   load_var 10                   (_14)
+       205   call 531 ntypeargs=1          (baml.iter.Repeat.Iterator.next)
+       206   store_var 11                  (_45)
+       207   jump +23                      (to 230)
+       208   load_type 15                  
+       209   load_type 16                  
+       210   load_type 16                  
+       211   load_var 10                   (_14)
+       212   call 507 ntypeargs=3          (baml.iter.Chain.Iterator.next)
+       213   store_var 11                  (_45)
+       214   jump +16                      (to 230)
+       215   load_type 15                  
+       216   load_type 16                  
+       217   load_var 10                   (_14)
+       218   call 521 ntypeargs=2          (baml.iter.StepBy.Iterator.next)
+       219   store_var 11                  (_45)
+       220   jump +10                      (to 230)
+       221   load_type 15                  
+       222   load_var 10                   (_14)
+       223   call 563 ntypeargs=1          (baml.iter.ArrayIterator.Iterator.next)
+       224   store_var 11                  (_45)
+       225   jump +5                       (to 230)
+       226   load_var 10                   (_14)
+       227   make_bound_method 552         
+       228   call_indirect                 
+       229   store_var 11                  (_45)
+       230   load_var 11                   (_45)
+       231   is_type 17                    
+       232   pop_jump_if_false +2          (to 234)
+       233   jump +16                      (to 249)
+       234   load_var 11                   (_45)
+       235   store_var_load_var 12         (ts)
 
-  54   236   load_field 0             (name)
-       237   load_var 6               (full_name)
-       238   cmp_op ==                
-       239   jump_if_false +2         (to 241)
-       240   jump +6                  (to 246)
-       241   pop 1                    
-       242   load_var 12              (ts)
-       243   load_field 0             (name)
-       244   load_var 8               (hash_prefix)
-       245   call 152 ntypeargs=0     (baml.String.starts_with)
-       246   pop_jump_if_false -110   (to 136)
-       247   load_var 7               (count)
-       248   load_const 18            (1)
-       249   add_int                  
-       250   store_var 7              (count)
-       251   jump -115                (to 136)
+  54   236   load_field 0                  (name)
+       237   load_var 6                    (full_name)
+       238   cmp_op ==                     
+       239   jump_if_false +2              (to 241)
+       240   jump +6                       (to 246)
+       241   pop 1                         
+       242   load_var 12                   (ts)
+       243   load_field 0                  (name)
+       244   load_var 8                    (hash_prefix)
+       245   call 152 ntypeargs=0          (baml.String.starts_with)
+       246   pop_jump_if_false -110        (to 136)
+       247   add_int_small_store_var 7 1   (count)
+       248   jump -112                     (to 136)
 
-  56   252   load_var 7               (count)
-       253   load_const 2             (0)
-       254   cmp_int_op >             
-       255   pop_jump_if_false +2     (to 257)
-       256   jump +4                  (to 260)
-       257   load_var 6               (full_name)
-       258   store_var 13             (final_name)
-       259   jump +14                 (to 273)
-       260   load_var 6               (full_name)
-       261   load_const 19            ("#")
-       262   bin_op +                 
-       263   store_var 14             (_84)
-       264   load_type 20             
-       265   load_var 7               (count)
-       266   load_const 18            (1)
-       267   add_int                  
-       268   call 423 ntypeargs=1     (baml.unstable.string)
-       269   store_var 15             (_86)
-       270   load_var2 14 15          
-       271   bin_op +                 
-       272   store_var 13             (final_name)
+  56   249   load_var 7                    (count)
+       250   load_const 2                  (0)
+       251   cmp_int_op >                  
+       252   pop_jump_if_false +2          (to 254)
+       253   jump +4                       (to 257)
+       254   load_var 6                    (full_name)
+       255   store_var 13                  (final_name)
+       256   jump +14                      (to 270)
+       257   load_var 6                    (full_name)
+       258   load_const 18                 ("#")
+       259   bin_op +                      
+       260   store_var 14                  (_84)
+       261   load_type 19                  
+       262   load_var 7                    (count)
+       263   load_const 20                 (1)
+       264   add_int                       
+       265   call 423 ntypeargs=1          (baml.unstable.string)
+       266   store_var 15                  (_86)
+       267   load_var2 14 15               
+       268   bin_op +                      
+       269   store_var 13                  (final_name)
 
-  57   273   load_type 15             
-       274   load_var 1               (self)
-       275   load_field 2             (testsets)
-       276   load_var2 13 3           
-       277   load_var 4               (runner)
-       278   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       279   call 17 ntypeargs=1      (baml.Array.push)
-       280   pop 1                    
+  57   270   load_type 15                  
+       271   load_var 1                    (self)
+       272   load_field 2                  (testsets)
+       273   load_var2 13 3                
+       274   load_var 4                    (runner)
+       275   init_instance 0               (testing.TestSetRegistration .name, .collector, .runner)
+       276   call 17 ntypeargs=1           (baml.Array.push)
+       277   pop 1                         
 
-  49   281   load_const 21            (null)
-       282   store_var 5              (_0)
-       283   load_var 5               (_0)
-       284   return                   
-       285   unreachable              
+  49   278   load_const 21                 (null)
+       279   store_var 5                   (_0)
+       280   load_var 5                    (_0)
+       281   return                        
+       282   unreachable                   
 }
 
 function testing.TestCollector.to_json(self: testing.TestCollector) -> baml.json.json {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -887,10 +887,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
 
   L47:
     pop_jump_if_false L25
-    load_var count
-    load_const 1
-    add_int
-    store_var count
+    add_int_small_store_var count 1
     jump L25
 
   L48:
@@ -1280,10 +1277,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
 
   L47:
     pop_jump_if_false L25
-    load_var count
-    load_const 1
-    add_int
-    store_var count
+    add_int_small_store_var count 1
     jump L25
 
   L48:

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -155,6 +155,8 @@ pub(crate) fn display_instruction(
         Instruction::LoadVar(index)
         | Instruction::StoreVar(index)
         | Instruction::StoreVarLoadVar(index)
+        | Instruction::AddIntStoreVar(index)
+        | Instruction::AddIntSmallStoreVar { slot: index, .. }
         | Instruction::Watch(index)
         | Instruction::Unwatch(index)
         | Instruction::Notify(index) => match function.local_names.get(*index) {
@@ -370,6 +372,8 @@ fn instruction_style(instruction: &Instruction) -> Style {
         | Instruction::LoadMapElement => Style::new().blue(),
         Instruction::StoreVar(_)
         | Instruction::StoreVarLoadVar(_)
+        | Instruction::AddIntStoreVar(_)
+        | Instruction::AddIntSmallStoreVar { .. }
         | Instruction::StoreVar2(..)
         | Instruction::StoreGlobal(_)
         | Instruction::StoreField(_)
@@ -730,6 +734,10 @@ fn display_instruction_textual(
         Instruction::LoadVar(idx) => format!("load_var {}", meta_str(idx)),
         Instruction::StoreVar(idx) => format!("store_var {}", meta_str(idx)),
         Instruction::StoreVarLoadVar(idx) => format!("store_var_load_var {}", meta_str(idx)),
+        Instruction::AddIntStoreVar(idx) => format!("add_int_store_var {}", meta_str(idx)),
+        Instruction::AddIntSmallStoreVar { slot, imm } => {
+            format!("add_int_small_store_var {} {imm}", meta_str(slot))
+        }
         Instruction::LoadVar2(a, b) => format!("load_var2 {a} {b}"),
         Instruction::StoreVar2(a, b) => format!("store_var2 {a} {b}"),
 
@@ -1133,6 +1141,8 @@ fn display_expanded_metadata(ip: usize, instruction: &Instruction, function: &Fu
         | Instruction::LoadVar(_)
         | Instruction::StoreVar(_)
         | Instruction::StoreVarLoadVar(_)
+        | Instruction::AddIntStoreVar(_)
+        | Instruction::AddIntSmallStoreVar { .. }
         | Instruction::LoadGlobal(_)
         | Instruction::StoreGlobal(_)
         | Instruction::LoadField(_)
@@ -1332,6 +1342,7 @@ pub fn display_compact_bytecode(
             OpCode::LoadVar
             | OpCode::StoreVar
             | OpCode::StoreVarLoadVar
+            | OpCode::AddIntStoreVar
             | OpCode::LoadGlobal
             | OpCode::StoreGlobal
             | OpCode::LoadField
@@ -1362,6 +1373,13 @@ pub fn display_compact_bytecode(
             | OpCode::CaptureRef => {
                 let val = read_u32(code, &mut pc);
                 writeln!(f, "{val}")?;
+            }
+
+            OpCode::AddIntSmallStoreVar => {
+                let slot = read_u32(code, &mut pc);
+                let imm = code[pc] as i8;
+                pc += 1;
+                writeln!(f, "{slot} {imm}")?;
             }
 
             // Jump i32 operand: show relative offset and resolved absolute target

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -4350,6 +4350,35 @@ impl BexVm {
                     }
                 }
 
+                OpCode::AddIntStoreVar => {
+                    let slot = { read_u32_unchecked(code, pc) as usize };
+                    let Frame::Bytecode(bf) = &self.frames[*frame_idx] else {
+                        unreachable!()
+                    };
+                    let local_var_index = Self::local_slot_stack_index(bf.locals_offset, slot);
+                    let rhs = self.stack.ensure_pop();
+                    let lhs = self.stack.get_at(local_var_index);
+                    let value = Value::tagged_int_add(lhs, rhs);
+                    if let Some(state) = self.store_local_value(local_var_index, value)? {
+                        return Ok(Some(state));
+                    }
+                }
+
+                OpCode::AddIntSmallStoreVar => {
+                    let slot = { read_u32_unchecked(code, pc) as usize };
+                    let imm = { read_i8_unchecked(code, pc) };
+                    let Frame::Bytecode(bf) = &self.frames[*frame_idx] else {
+                        unreachable!()
+                    };
+                    let local_var_index = Self::local_slot_stack_index(bf.locals_offset, slot);
+                    let lhs = self.stack.get_at(local_var_index);
+                    let rhs = Value::int(i64::from(imm));
+                    let value = Value::tagged_int_add(lhs, rhs);
+                    if let Some(state) = self.store_local_value(local_var_index, value)? {
+                        return Ok(Some(state));
+                    }
+                }
+
                 // ── LoadGlobal / StoreGlobal ──────────────────────────────────
                 OpCode::LoadGlobal => {
                     let raw = { read_u32_unchecked(code, pc) };
@@ -6061,7 +6090,12 @@ impl BexVm {
                             },
                         )));
                     }
-                    self.stack.push(Value::int(l % r));
+                    let result = if l >= 0 && r > 0 && (r & (r - 1)) == 0 {
+                        l & (r - 1)
+                    } else {
+                        l % r
+                    };
+                    self.stack.push(Value::int(result));
                 }
 
                 // ── Specialized float arithmetic (skip type dispatch) ─────────

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -210,6 +210,17 @@ pub enum Instruction {
     /// in `Vm::stack` array.
     StoreVarLoadVar(usize),
 
+    /// Adds the stack top to a local integer slot and stores the result.
+    ///
+    /// Equivalent to `LOAD_VAR i; ADD_INT; STORE_VAR i` when the left operand
+    /// is local `i`, but avoids the local reload and result stack round-trip.
+    AddIntStoreVar(usize),
+
+    /// Adds a small immediate integer to a local integer slot and stores the result.
+    ///
+    /// Equivalent to `LOAD_VAR i; LOAD_INT_SMALL n; ADD_INT; STORE_VAR i`.
+    AddIntSmallStoreVar { slot: usize, imm: i8 },
+
     /// Load a global variable from the `Vm::globals` array.
     ///
     /// Format: `LOAD_GLOBAL i` where `i` is the index of the global variable
@@ -944,6 +955,10 @@ pub enum OpCode {
     // ── Unit op appended out of group order to preserve discriminants ──
     // BEP-034 `baml.future.__await_any`: no operands (1 byte), like `Await`.
     AwaitAny,
+
+    // ── Local integer update superinstructions, appended to preserve discriminants ──
+    AddIntStoreVar,      // u32 slot
+    AddIntSmallStoreVar, // u32 slot + i8 imm
 }
 
 impl OpCode {
@@ -1030,11 +1045,15 @@ impl OpCode {
             // 2-byte: opcode + i8
             Self::LoadIntSmall => 2,
 
+            // 6-byte: opcode + u32 + i8
+            Self::AddIntSmallStoreVar => 6,
+
             // 5-byte: opcode + u32/i32
             Self::LoadConst
             | Self::LoadVar
             | Self::StoreVar
             | Self::StoreVarLoadVar
+            | Self::AddIntStoreVar
             | Self::LoadGlobal
             | Self::StoreGlobal
             | Self::LoadField
@@ -1093,6 +1112,8 @@ impl TryFrom<u8> for OpCode {
             x if x == Self::Return as u8 => Ok(Self::Return),
             x if x == Self::Await as u8 => Ok(Self::Await),
             x if x == Self::AwaitAny as u8 => Ok(Self::AwaitAny),
+            x if x == Self::AddIntStoreVar as u8 => Ok(Self::AddIntStoreVar),
+            x if x == Self::AddIntSmallStoreVar as u8 => Ok(Self::AddIntSmallStoreVar),
             x if x == Self::Throw as u8 => Ok(Self::Throw),
             x if x == Self::LoadArrayElement as u8 => Ok(Self::LoadArrayElement),
             x if x == Self::LoadMapElement as u8 => Ok(Self::LoadMapElement),
@@ -1222,6 +1243,8 @@ impl std::fmt::Display for OpCode {
             Self::Return => "RETURN",
             Self::Await => "AWAIT",
             Self::AwaitAny => "AWAIT_ANY",
+            Self::AddIntStoreVar => "ADD_INT_STORE_VAR",
+            Self::AddIntSmallStoreVar => "ADD_INT_SMALL_STORE_VAR",
             Self::Throw => "THROW",
             Self::LoadArrayElement => "LOAD_ARRAY_ELEMENT",
             Self::LoadMapElement => "LOAD_MAP_ELEMENT",
@@ -1532,6 +1555,10 @@ impl std::fmt::Display for Instruction {
             Instruction::LoadVar(i) => write!(f, "LOAD_VAR {i}"),
             Instruction::StoreVar(i) => write!(f, "STORE_VAR {i}"),
             Instruction::StoreVarLoadVar(i) => write!(f, "STORE_VAR_LOAD_VAR {i}"),
+            Instruction::AddIntStoreVar(i) => write!(f, "ADD_INT_STORE_VAR {i}"),
+            Instruction::AddIntSmallStoreVar { slot, imm } => {
+                write!(f, "ADD_INT_SMALL_STORE_VAR {slot} {imm}")
+            }
             Instruction::LoadGlobal(i) => write!(f, "LOAD_GLOBAL {i}"),
             Instruction::StoreGlobal(i) => write!(f, "STORE_GLOBAL {i}"),
             Instruction::LoadField(i) => write!(f, "LOAD_FIELD {i}"),
@@ -2072,6 +2099,7 @@ impl Bytecode {
                 Instruction::LoadVar(v)
                 | Instruction::StoreVar(v)
                 | Instruction::StoreVarLoadVar(v)
+                | Instruction::AddIntStoreVar(v)
                 | Instruction::LoadField(v)
                 | Instruction::StoreField(v)
                 | Instruction::InitField(v)
@@ -2098,6 +2126,16 @@ impl Bytecode {
                     code.extend_from_slice(
                         &u32::try_from(*v).expect("operand fits u32").to_le_bytes(),
                     );
+                }
+
+                // ── Local update with small immediate ───────────────
+                Instruction::AddIntSmallStoreVar { slot, imm } => {
+                    code.extend_from_slice(
+                        &u32::try_from(*slot)
+                            .expect("operand fits u32")
+                            .to_le_bytes(),
+                    );
+                    code.push(*imm as u8);
                 }
 
                 // ── GlobalIndex operand → u32 ───────────────────────
@@ -2378,6 +2416,8 @@ impl Bytecode {
             Instruction::LoadVar(_) => OpCode::LoadVar,
             Instruction::StoreVar(_) => OpCode::StoreVar,
             Instruction::StoreVarLoadVar(_) => OpCode::StoreVarLoadVar,
+            Instruction::AddIntStoreVar(_) => OpCode::AddIntStoreVar,
+            Instruction::AddIntSmallStoreVar { .. } => OpCode::AddIntSmallStoreVar,
             Instruction::LoadGlobal(_) => OpCode::LoadGlobal,
             Instruction::StoreGlobal(_) => OpCode::StoreGlobal,
             Instruction::LoadField(_) => OpCode::LoadField,
@@ -2564,6 +2604,41 @@ mod compact_tests {
         let compact = bc.lower_to_compact();
         assert_eq!(compact.code.len(), 1);
         assert_eq!(compact.code[0], OpCode::Add as u8);
+    }
+
+    #[test]
+    fn encode_int_local_update_superinstructions() {
+        let bc = make_bytecode(
+            vec![
+                Instruction::AddIntStoreVar(7),
+                Instruction::AddIntSmallStoreVar { slot: 9, imm: -3 },
+            ],
+            vec![],
+        );
+        let compact = bc.lower_to_compact();
+
+        assert_eq!(compact.code.len(), 11);
+        assert_eq!(compact.code[0], OpCode::AddIntStoreVar as u8);
+        assert_eq!(
+            u32::from_le_bytes([
+                compact.code[1],
+                compact.code[2],
+                compact.code[3],
+                compact.code[4],
+            ]),
+            7
+        );
+        assert_eq!(compact.code[5], OpCode::AddIntSmallStoreVar as u8);
+        assert_eq!(
+            u32::from_le_bytes([
+                compact.code[6],
+                compact.code[7],
+                compact.code[8],
+                compact.code[9],
+            ]),
+            9
+        );
+        assert_eq!(compact.code[10] as i8, -3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add compact bytecode superinstructions for typed int local updates: `add_int_store_var` and `add_int_small_store_var`.
- Teach the emitter to recognize safe `local = local + rhs` / `+=`-style int local updates when the local is not captured.
- Dispatch the new VM ops directly and add a fast path for positive power-of-two int modulo.
- Add regression coverage that the arithmetic loop emits the new superinstructions, plus refreshed bytecode snapshots.

## Performance

Measured with release-built packed BAML binaries for the arithmetic loop discussed in the thread:

| Iterations | Before | After | Speedup | Time saved |
|---:|---:|---:|---:|---:|
| 5,000,000 | 246.13 ms | 138.17 ms | 1.78x | 43.9% |
| 50,000,000 | 2447.49 ms | 1287.48 ms | 1.90x | 47.4% |

I also ran the existing speedtest harness against arithmetic-adjacent workloads with the improved build. There is not currently a dedicated speedtest workload for the exact optimized loop, but `compute::nested loops 500x500` is now roughly tied with Bun in that run.

## Validation

- `cargo nextest run -p baml_tests --test arithmetic_perf --test bytecode_format --test optimization --test baml_src --no-fail-fast`
- `cargo nextest run -p bex_vm -p bex_vm_types --no-fail-fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VM opcode dispatch and local mutation semantics; incorrect peephole matching could change arithmetic behavior for edge cases (captured locals, non-int types).
> 
> **Overview**
> Adds **int local update superinstructions** so common loop patterns (`i += 1`, `acc += x`) compile to fewer VM steps instead of load/add/store sequences.
> 
> The compiler emitter now recognizes assignments of the form `local = local + rhs` when both sides are typed `int`, the destination local is not captured, and operands pass the same guards as other specialized binops. It emits **`add_int_store_var`** when the addend is on the stack, or **`add_int_small_store_var`** when the addend is a small `i8` constant (e.g. `i += 1`). New opcodes are wired through bytecode encoding, VM execution (`tagged_int_add` in-place on the local slot), and debug/disassembly output.
> 
> Separately, **positive int modulo** with a power-of-two divisor uses a bitmask fast path in the VM.
> 
> Regression test `arithmetic_perf` asserts the optimized loop bytecode contains both superinstructions; many bytecode snapshots are refreshed to show the shorter instruction sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e93ba035ba27ddf7e98528fd1992b388636b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->