### PR TITLE
Report unsupported python/pydantic language naming convention

### DIFF
--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -239,17 +239,11 @@ fn discover_generators(
                 file_id,
                 &mut diags,
             );
-            let naming_convention_expected = match output_type {
-                Some(OutputType::PythonPydantic | OutputType::PythonPydanticV1) => {
-                    r#""preserve-case""#
-                }
-                Some(OutputType::TypescriptNode) | None => r#""preserve-case" or "language""#,
-            };
             let naming_convention = parse_required_property::<NamingConvention>(
                 *id,
                 generator_item,
                 "naming_convention",
-                naming_convention_expected,
+                r#""preserve-case""#,
                 &source_map,
                 file_id,
                 &mut diags,
@@ -303,16 +297,16 @@ fn validate_target_naming_convention(
     file_id: baml_db::FileId,
     diags: &mut Vec<Diagnostic>,
 ) -> bool {
-    match (output_type, naming_convention) {
-        (OutputType::PythonPydantic | OutputType::PythonPydanticV1, NamingConvention::Language) => {
+    match naming_convention {
+        NamingConvention::Language => {
             let item_range =
                 generator_config_item_span(id, generator, "naming_convention", source_map);
             diags.push(
                 Diagnostic::error(
                     DiagnosticId::InvalidGeneratorPropertyValue,
                     format!(
-                        "invalid value `language` for `naming_convention` on generator `{}` \
-                         with output_type `{output_type}` (expected \"preserve-case\")",
+                        "generator `{}` with output_type `{output_type}` requires \
+                         `naming_convention \"preserve-case\"` (got `language`)",
                         generator.name
                     ),
                 )
@@ -327,7 +321,7 @@ fn validate_target_naming_convention(
             );
             false
         }
-        _ => true,
+        NamingConvention::PreserveCase => true,
     }
 }
 

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -152,6 +152,7 @@ impl GenerateArgs {
                         &baml_bytecode,
                         generator.naming_convention,
                     )
+                    .map_err(|e| anyhow!(e))?
                 }
                 OutputType::TypescriptNode => sdkgen_typescript_node::to_source_code_with_bytecode(
                     &pool,
@@ -238,11 +239,17 @@ fn discover_generators(
                 file_id,
                 &mut diags,
             );
+            let naming_convention_expected = match output_type {
+                Some(OutputType::PythonPydantic | OutputType::PythonPydanticV1) => {
+                    r#""preserve-case""#
+                }
+                Some(OutputType::TypescriptNode) | None => r#""preserve-case" or "language""#,
+            };
             let naming_convention = parse_required_property::<NamingConvention>(
                 *id,
                 generator_item,
                 "naming_convention",
-                r#""preserve-case" or "language""#,
+                naming_convention_expected,
                 &source_map,
                 file_id,
                 &mut diags,
@@ -263,6 +270,18 @@ fn discover_generators(
                 continue;
             };
 
+            if !validate_target_naming_convention(
+                *id,
+                generator_item,
+                output_type,
+                naming_convention,
+                &source_map,
+                file_id,
+                &mut diags,
+            ) {
+                continue;
+            }
+
             generators.push(GeneratorDef {
                 name: generator_item.name.to_string(),
                 output_type,
@@ -273,6 +292,43 @@ fn discover_generators(
     }
 
     (generators, diags)
+}
+
+fn validate_target_naming_convention(
+    id: LocalItemId<GeneratorMarker>,
+    generator: &Generator,
+    output_type: OutputType,
+    naming_convention: NamingConvention,
+    source_map: &ItemTreeSourceMap,
+    file_id: baml_db::FileId,
+    diags: &mut Vec<Diagnostic>,
+) -> bool {
+    match (output_type, naming_convention) {
+        (OutputType::PythonPydantic | OutputType::PythonPydanticV1, NamingConvention::Language) => {
+            let item_range =
+                generator_config_item_span(id, generator, "naming_convention", source_map);
+            diags.push(
+                Diagnostic::error(
+                    DiagnosticId::InvalidGeneratorPropertyValue,
+                    format!(
+                        "invalid value `language` for `naming_convention` on generator `{}` \
+                         with output_type `{output_type}` (expected \"preserve-case\")",
+                        generator.name
+                    ),
+                )
+                .with_primary(
+                    Span {
+                        file_id,
+                        range: item_range,
+                    },
+                    "`language` is not supported by this generator",
+                )
+                .with_phase(DiagnosticPhase::Validation),
+            );
+            false
+        }
+        _ => true,
+    }
 }
 
 /// Look up `property` on a generator block and parse it as `T` via strum.
@@ -325,11 +381,7 @@ fn parse_required_property<T: std::str::FromStr>(
     match value.parse::<T>() {
         Ok(parsed) => Some(parsed),
         Err(_) => {
-            let item_range = source_map
-                .generator_config_item_spans
-                .get(&id)
-                .and_then(|spans| spans.get(item_idx).copied())
-                .unwrap_or(block_range);
+            let item_range = generator_config_item_span(id, generator, property, source_map);
             diags.push(
                 Diagnostic::error(
                     DiagnosticId::InvalidGeneratorPropertyValue,
@@ -351,6 +403,31 @@ fn parse_required_property<T: std::str::FromStr>(
             None
         }
     }
+}
+
+fn generator_config_item_span(
+    id: LocalItemId<GeneratorMarker>,
+    generator: &Generator,
+    property: &str,
+    source_map: &ItemTreeSourceMap,
+) -> text_size::TextRange {
+    let block_range = source_map
+        .generator_block_spans
+        .get(&id)
+        .copied()
+        .unwrap_or_default();
+    let Some(item_idx) = generator
+        .config_items
+        .iter()
+        .position(|c| c.key.as_str() == property)
+    else {
+        return block_range;
+    };
+    source_map
+        .generator_config_item_spans
+        .get(&id)
+        .and_then(|spans| spans.get(item_idx).copied())
+        .unwrap_or(block_range)
 }
 
 /// Look up a config key in a generator's config items.

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -239,7 +239,6 @@ fn generate_python_pydantic_language_naming_convention_returns_diagnostic() {
         r#"generator target {
   output_type "python/pydantic"
   output_dir "../"
-  default_client_mode "sync"
   naming_convention "language"
 }
 
@@ -262,12 +261,61 @@ function main() -> string {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("invalid value `language` for `naming_convention`"),
+        stderr.contains(
+            "output_type `python/pydantic` requires `naming_convention \"preserve-case\"`"
+        ),
         "Expected structured invalid-value diagnostic, got: {stderr}",
     );
     assert!(
-        stderr.contains("expected \"preserve-case\""),
-        "Expected diagnostic to list only the supported value, got: {stderr}",
+        stderr.contains("(got `language`)"),
+        "Expected diagnostic to mention the unsupported value, got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "Diagnostic path should not panic, got: {stderr}",
+    );
+}
+
+#[test]
+fn generate_typescript_node_language_naming_convention_returns_diagnostic() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        r#"generator target {
+  output_type "typescript/node"
+  output_dir "../"
+  naming_convention "language"
+}
+
+function main() -> string {
+  "hello"
+}
+"#,
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for unsupported typescript/node naming_convention, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(output.status.code(), Some(4));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "output_type `typescript/node` requires `naming_convention \"preserve-case\"`"
+        ),
+        "Expected structured invalid-value diagnostic, got: {stderr}",
+    );
+    assert!(
+        stderr.contains("(got `language`)"),
+        "Expected diagnostic to mention the unsupported value, got: {stderr}",
     );
     assert!(
         !stderr.contains("panicked at"),
@@ -313,6 +361,47 @@ function main() -> string {
     assert!(
         !stderr.contains("\"language\""),
         "python/pydantic guidance should not advertise unsupported `language`, got: {stderr}",
+    );
+}
+
+#[test]
+fn generate_typescript_node_missing_naming_convention_lists_supported_value() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        r#"generator target {
+  output_type "typescript/node"
+  output_dir "../"
+}
+
+function main() -> string {
+  "hello"
+}
+"#,
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for missing naming_convention, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(output.status.code(), Some(4));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr
+            .contains("missing required property `naming_convention` (expected \"preserve-case\")"),
+        "Expected typescript/node naming_convention guidance, got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("\"language\""),
+        "typescript/node guidance should not advertise unsupported `language`, got: {stderr}",
     );
 }
 

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -229,6 +229,93 @@ fn generate_valid_project_returns_zero_exit_code() {
     );
 }
 
+#[test]
+fn generate_python_pydantic_language_naming_convention_returns_diagnostic() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        r#"generator target {
+  output_type "python/pydantic"
+  output_dir "../"
+  default_client_mode "sync"
+  naming_convention "language"
+}
+
+function main() -> string {
+  "hello"
+}
+"#,
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for unsupported python/pydantic naming_convention, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(output.status.code(), Some(4));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid value `language` for `naming_convention`"),
+        "Expected structured invalid-value diagnostic, got: {stderr}",
+    );
+    assert!(
+        stderr.contains("expected \"preserve-case\""),
+        "Expected diagnostic to list only the supported value, got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "Diagnostic path should not panic, got: {stderr}",
+    );
+}
+
+#[test]
+fn generate_python_pydantic_missing_naming_convention_lists_supported_value() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        r#"generator target {
+  output_type "python/pydantic"
+  output_dir "../"
+}
+
+function main() -> string {
+  "hello"
+}
+"#,
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit code for missing naming_convention, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(output.status.code(), Some(4));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr
+            .contains("missing required property `naming_convention` (expected \"preserve-case\")"),
+        "Expected pydantic-specific naming_convention guidance, got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("\"language\""),
+        "python/pydantic guidance should not advertise unsupported `language`, got: {stderr}",
+    );
+}
+
 // ============================================================================
 // Tests for `baml run` exit codes
 // ============================================================================

--- a/baml_language/sdk_tests/harness_setup/src/python_pydantic2.rs
+++ b/baml_language/sdk_tests/harness_setup/src/python_pydantic2.rs
@@ -124,7 +124,7 @@ fn codegen_fixture(
         )
     }));
     match codegen_result {
-        Ok(output) => {
+        Ok(Ok(output)) => {
             for (rel, content) in output {
                 let path = baml_sdk.join(&rel);
                 if let Some(parent) = path.parent() {
@@ -145,6 +145,9 @@ fn codegen_fixture(
                     );
                 }
             }
+        }
+        Ok(Err(e)) => {
+            diagnostics.record("codegen", fixture, e.to_string());
         }
         Err(_) => {
             diagnostics.record(

--- a/baml_language/sdk_tests/harness_setup/src/python_pydantic2.rs
+++ b/baml_language/sdk_tests/harness_setup/src/python_pydantic2.rs
@@ -122,9 +122,11 @@ fn codegen_fixture(
             &baml_bytecode,
             NamingConvention::PreserveCase,
         )
-    }));
+    }))
+    .map_err(|_| "sdkgen_python_pydantic2::to_source_code panicked".to_string())
+    .and_then(|result| result.map_err(|e| e.to_string()));
     match codegen_result {
-        Ok(Ok(output)) => {
+        Ok(output) => {
             for (rel, content) in output {
                 let path = baml_sdk.join(&rel);
                 if let Some(parent) = path.parent() {
@@ -146,15 +148,8 @@ fn codegen_fixture(
                 }
             }
         }
-        Ok(Err(e)) => {
-            diagnostics.record("codegen", fixture, e.to_string());
-        }
-        Err(_) => {
-            diagnostics.record(
-                "codegen",
-                fixture,
-                "sdkgen_python_pydantic2::to_source_code panicked",
-            );
+        Err(e) => {
+            diagnostics.record("codegen", fixture, e);
         }
     }
 

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -29,6 +29,23 @@ use crate::{
     routing::{LeafPath, route},
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnsupportedNamingConvention {
+    pub naming_convention: NamingConvention,
+}
+
+impl std::fmt::Display for UnsupportedNamingConvention {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "sdkgen_python_pydantic2 only supports naming_convention = PreserveCase (got {})",
+            self.naming_convention
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedNamingConvention {}
+
 /// Banner prepended to every generated `.py` / `.pyi` file. Mirrors
 /// the legacy `engine/generators/languages/python` `CONTENT_PREFIX`,
 /// plus a block of file-level lint/format ignore directives matching
@@ -109,7 +126,7 @@ pub fn to_source_code(
     pool: &SymbolPool,
     user_baml_files: &[UserBamlFile],
     naming_convention: NamingConvention,
-) -> HashMap<PathBuf, String> {
+) -> Result<HashMap<PathBuf, String>, UnsupportedNamingConvention> {
     to_source_code_internal(
         pool,
         RuntimePayload::SourceFiles(user_baml_files),
@@ -123,7 +140,7 @@ pub fn to_source_code_with_bytecode(
     pool: &SymbolPool,
     baml_bytecode: &[u8],
     naming_convention: NamingConvention,
-) -> HashMap<PathBuf, String> {
+) -> Result<HashMap<PathBuf, String>, UnsupportedNamingConvention> {
     to_source_code_internal(
         pool,
         RuntimePayload::Bytecode(baml_bytecode),
@@ -135,14 +152,11 @@ fn to_source_code_internal(
     pool: &SymbolPool,
     runtime_payload: RuntimePayload<'_>,
     naming_convention: NamingConvention,
-) -> HashMap<PathBuf, String> {
-    // Only `PreserveCase` is wired up so far; `Language`-mode rewriting
-    // is the next piece of work and panics loudly until then.
-    assert!(
-        matches!(naming_convention, NamingConvention::PreserveCase),
-        "sdkgen_python_pydantic2 only supports naming_convention = PreserveCase \
-         (got {naming_convention})",
-    );
+) -> Result<HashMap<PathBuf, String>, UnsupportedNamingConvention> {
+    if !matches!(naming_convention, NamingConvention::PreserveCase) {
+        return Err(UnsupportedNamingConvention { naming_convention });
+    }
+
     let mut out: HashMap<PathBuf, String> = HashMap::new();
 
     // Every symbol in the pool routes to exactly one leaf. Dedup via
@@ -266,7 +280,7 @@ fn to_source_code_internal(
         }
     }
 
-    out
+    Ok(out)
 }
 
 fn init_py_path(dir: &[String]) -> PathBuf {
@@ -635,9 +649,22 @@ mod tests {
     }
 
     #[test]
+    fn language_naming_convention_returns_error() {
+        let pool: SymbolPool = HashMap::new();
+
+        let err = to_source_code(&pool, &[], NamingConvention::Language).unwrap_err();
+
+        assert_eq!(err.naming_convention, NamingConvention::Language);
+        assert_eq!(
+            err.to_string(),
+            "sdkgen_python_pydantic2 only supports naming_convention = PreserveCase (got language)"
+        );
+    }
+
+    #[test]
     fn empty_pool_emits_structural_files() {
         let pool: SymbolPool = HashMap::new();
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
 
         assert!(out.contains_key(&PathBuf::from("__init__.py")));
         assert!(out.contains_key(&PathBuf::from("baml/__init__.py")));
@@ -689,7 +716,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Resume");
         pool.insert(n.clone(), class(n));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
 
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(leaf.starts_with(HEADER));
@@ -710,7 +737,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Sentiment");
         pool.insert(n.clone(), enum_(n, "x.baml", 0));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(leaf.contains("import enum\n"));
         assert!(leaf.contains("class Sentiment(str, enum.Enum):\n    A = \"A\"\n"));
@@ -722,7 +749,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Foo");
         pool.insert(n.clone(), alias(n, "x.baml", 0));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(leaf.contains("import typing\n"));
         assert!(leaf.contains("Foo: typing.TypeAlias = int\n"));
@@ -763,7 +790,7 @@ mod tests {
             ),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains(
@@ -790,7 +817,7 @@ mod tests {
             ),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         // Field /// goes into the class body docstring as an
         // Attributes: section — there is no inline `# ` comment.
@@ -830,7 +857,7 @@ mod tests {
             ),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains(
@@ -857,7 +884,7 @@ mod tests {
             ),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains("    \"\"\"\n    first line\n    second line\n    \"\"\""),
@@ -890,7 +917,7 @@ mod tests {
             }),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         // Once at least one variant carries a `///`, the Members: block
         // appears and lists *every* variant — undocumented ones render
@@ -931,7 +958,7 @@ mod tests {
             }),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains(
@@ -971,7 +998,7 @@ mod tests {
             ),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         assert!(
             !leaf.contains("Attributes:"),
@@ -1006,7 +1033,7 @@ mod tests {
             ),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains(
@@ -1022,7 +1049,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Resume");
         pool.insert(n.clone(), class(n));
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.py")];
         assert!(!leaf.contains("\"\"\""));
         assert!(
@@ -1041,7 +1068,7 @@ mod tests {
             Symbol::Function(f),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.pyi")];
         assert!(
             leaf.contains(
@@ -1060,7 +1087,7 @@ mod tests {
             Symbol::Function(f),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.pyi")];
         assert!(leaf.contains("def ExtractResume(x: int) -> int: ..."));
     }
@@ -1094,7 +1121,7 @@ mod tests {
             }),
         );
 
-        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase)
+        let leaf = &to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap()
             [&PathBuf::from("lorem/__init__.pyi")];
         assert!(
             leaf.contains(":\n        \"\"\"Summarize the resume.\"\"\"\n"),
@@ -1108,7 +1135,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "extract_resume");
         pool.insert(n, func_sym("extract_resume", "x.baml", 0));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         let sync_line = "extract_resume       = _define_function(\"user.lorem.extract_resume\", \"sync\",  [\"x\"])\n";
         let async_line = "extract_resume_async = _define_function(\"user.lorem.extract_resume\", \"async\", [\"x\"])\n";
@@ -1137,7 +1164,7 @@ mod tests {
             vec![("stream", companion)],
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains(
@@ -1167,7 +1194,7 @@ mod tests {
             vec![("build_request", companion)],
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains(
@@ -1189,7 +1216,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Resume$stream");
         pool.insert(n.clone(), class(n));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("stream_types/lorem/__init__.py")];
         assert!(leaf.contains("class Resume(pydantic.BaseModel):\n"));
         // The Python identifier strips `$stream`; the engine FQN keeps
@@ -1213,7 +1240,7 @@ mod tests {
         pool.insert(late.clone(), class_at(late, "x.baml", 200));
         pool.insert(early.clone(), class_at(early, "x.baml", 100));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         let idx_foo = leaf.find("class Foo(pydantic.BaseModel):").unwrap();
         let idx_bar = leaf.find("class Bar(pydantic.BaseModel):").unwrap();
@@ -1230,7 +1257,7 @@ mod tests {
         pool.insert(a.clone(), class_at(a, "b.baml", 0));
         pool.insert(b.clone(), class_at(b, "a.baml", 0));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         // B (a.baml) sorts before A (b.baml).
         let idx_a = leaf.find("class A(pydantic.BaseModel):").unwrap();
@@ -1246,7 +1273,7 @@ mod tests {
         pool.insert(c.clone(), class_at(c, "x.baml", 0));
         pool.insert(e.clone(), enum_(e, "x.baml", 50));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(leaf.contains("__all__ = [\n    \"Resume\",\n    \"Sentiment\",\n]"));
     }
@@ -1257,7 +1284,7 @@ mod tests {
         let n = cg_name("aws", &["s3"], "Bucket");
         pool.insert(n.clone(), class(n));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
 
         assert!(out.contains_key(&PathBuf::from("vendor/__init__.py")));
         assert!(out.contains_key(&PathBuf::from("vendor/aws/__init__.py")));
@@ -1294,7 +1321,7 @@ mod tests {
         let n = cg_name("user", &[], "Foo");
         pool.insert(n.clone(), class(n));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let root = &out[&PathBuf::from("__init__.py")];
         assert!(root.contains("BamlRuntime.initialize_runtime("));
         // Body appended after the runtime init + re-exports.
@@ -1321,7 +1348,7 @@ mod tests {
         let c2 = cg_name("user", &["ipsum"], "Tag");
         pool.insert(c2.clone(), class(c2));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
 
         let lorem = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
@@ -1361,7 +1388,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Resume$stream");
         pool.insert(n.clone(), class(n));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
 
         assert!(out.contains_key(&PathBuf::from("stream_types/__init__.py")));
         assert!(out.contains_key(&PathBuf::from("stream_types/lorem/__init__.py")));
@@ -1385,7 +1412,7 @@ mod tests {
                 "function foo() -> int { 1 }\n".to_string(),
             ),
         ];
-        let out = to_source_code(&pool, &files, NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &files, NamingConvention::PreserveCase).unwrap();
 
         let inl = &out[&PathBuf::from("_inlinedbaml.py")];
         assert!(inl.starts_with(HEADER));
@@ -1406,7 +1433,8 @@ mod tests {
     fn bytecode_payload_initializes_runtime_from_bytecode() {
         let pool: SymbolPool = HashMap::new();
         let bytecode = b"\x00BAML\"\n\xff";
-        let out = to_source_code_with_bytecode(&pool, bytecode, NamingConvention::PreserveCase);
+        let out =
+            to_source_code_with_bytecode(&pool, bytecode, NamingConvention::PreserveCase).unwrap();
 
         let root = &out[&PathBuf::from("__init__.py")];
         assert!(
@@ -1475,7 +1503,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         let expected = "class Resume(pydantic.BaseModel):\n\
                         \x20   model_config = pydantic.ConfigDict(extra=\"forbid\")\n\
@@ -1490,7 +1518,7 @@ mod tests {
         let mut pool: SymbolPool = HashMap::new();
         let n = cg_name("user", &["lorem"], "Empty");
         pool.insert(n.clone(), class_with_props(n, vec![], "x.baml", 0));
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         let expected = "class Empty(pydantic.BaseModel):\n\
                         \x20   model_config = pydantic.ConfigDict(extra=\"forbid\")\n";
@@ -1526,7 +1554,7 @@ mod tests {
                 origin: origin("x.baml", 0),
             }),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("ipsum/__init__.py")];
         let expected = "class Sentiment(str, enum.Enum):\n\
                         \x20   POSITIVE = \"POSITIVE\"\n\
@@ -1548,7 +1576,7 @@ mod tests {
                 origin: origin("x.baml", 0),
             }),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(leaf.contains("class Nothing(str, enum.Enum):\n    pass\n"));
     }
@@ -1569,7 +1597,7 @@ mod tests {
             Ty::List(Box::new(Ty::TypeAlias(n.clone()))),
         ]);
         pool.insert(n.clone(), alias_full(n, rhs, true, "tree.baml", 0));
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("tree/__init__.py")];
         assert!(leaf.contains("import typing_extensions\n"));
         assert!(leaf.contains(
@@ -1605,7 +1633,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains(
@@ -1641,7 +1669,7 @@ mod tests {
                 100,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("tree/__init__.py")];
         assert!(leaf.contains("Bar: typing.TypeAlias = typing.List[JsonValue]\n"));
     }
@@ -1669,7 +1697,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
 
         // Non-stream leaf has the sibling.
         let non_stream_leaf = &out[&PathBuf::from("lorem/__init__.py")];
@@ -1728,7 +1756,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let lorem_leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(lorem_leaf.contains("    sentiment: ipsum.Sentiment\n"));
         // 25b2 Phase 4: cross-leaf Pydantic field-edge import is now
@@ -1805,7 +1833,7 @@ mod tests {
     fn function_zero_args_renders_empty_param_list() {
         let mut pool: SymbolPool = HashMap::new();
         insert_parent_only(&mut pool, "user", &["lorem"], "ping", &[], "x.baml", 0);
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains("ping       = _define_function(\"user.lorem.ping\", \"sync\",  [])\n")
@@ -1827,7 +1855,7 @@ mod tests {
             "x.baml",
             0,
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(leaf.contains(
             "make       = _define_function(\"user.lorem.make\", \"sync\",  [\"a\", \"b\", \"c\"])\n"
@@ -1899,7 +1927,7 @@ mod tests {
             }),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(py.contains(
             "search       = _define_function(\"user.lorem.search\", \"sync\",  [\"query\"], [\"max_results\", \"filter\", \"tags\", \"metadata\", \"fallback\"])\n"
@@ -1968,7 +1996,7 @@ mod tests {
             }),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(py.contains(
             "extract_resume       = _define_function(\"user.lorem.extract_resume\", \"sync\",  [\"resume\"], [\"client\"])\n"
@@ -2026,7 +2054,7 @@ mod tests {
             }),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
 
         assert!(pyi.contains(
@@ -2051,7 +2079,7 @@ mod tests {
             "x.baml",
             0,
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         // Parent uses parent params.
         assert!(leaf.contains(
@@ -2083,7 +2111,7 @@ mod tests {
             "x.baml",
             0,
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         // Each companion pair appears.
         for needle in [
@@ -2134,7 +2162,7 @@ mod tests {
     fn vendor_function_fqn_uses_vendor_pkg() {
         let mut pool: SymbolPool = HashMap::new();
         insert_parent_only(&mut pool, "aws", &["s3"], "create_bucket", &[], "x.baml", 0);
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("vendor/aws/s3/__init__.py")];
         assert!(leaf.contains(
             "create_bucket       = _define_function(\"aws.s3.create_bucket\", \"sync\",  [])\n"
@@ -2145,7 +2173,7 @@ mod tests {
     fn baml_pkg_function_fqn_keeps_baml_prefix() {
         let mut pool: SymbolPool = HashMap::new();
         insert_parent_only(&mut pool, "baml", &["http"], "fetch", &["url"], "x.baml", 0);
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("baml/http/__init__.py")];
         assert!(leaf.contains(
             "fetch       = _define_function(\"baml.http.fetch\", \"sync\",  [\"url\"])\n"
@@ -2156,7 +2184,7 @@ mod tests {
     fn root_no_namespace_function_fqn_drops_segment() {
         let mut pool: SymbolPool = HashMap::new();
         insert_parent_only(&mut pool, "user", &[], "ping", &[], "x.baml", 0);
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let root = &out[&PathBuf::from("__init__.py")];
         assert!(
             root.contains("ping       = _define_function(\"user.ping\", \"sync\",  [])\n"),
@@ -2177,8 +2205,8 @@ mod tests {
             b.clone(),
             class_with_props(b, vec![("y", Ty::String)], "b.baml", 0),
         );
-        let out1 = to_source_code(&pool, &[], NamingConvention::PreserveCase);
-        let out2 = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out1 = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
+        let out2 = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         // Same keys + same contents on every path.
         let mut k1: Vec<_> = out1.keys().collect();
         let mut k2: Vec<_> = out2.keys().collect();
@@ -2244,7 +2272,7 @@ mod tests {
             ),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains("define_function as _define_function"),
@@ -2283,7 +2311,7 @@ mod tests {
             ),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains("define_function as _define_function"),
@@ -2324,7 +2352,7 @@ mod tests {
             ),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         // Both static and instance methods route through the same
         // `define_function` factory, so the import collapses to one
@@ -2343,7 +2371,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Resume");
         pool.insert(n.clone(), class(n));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
             !leaf.contains("_define_function"),
@@ -2358,7 +2386,7 @@ mod tests {
     #[test]
     fn no_legacy_output_paths() {
         let pool: SymbolPool = HashMap::new();
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         for path in out.keys() {
             let s = path.to_string_lossy();
             assert!(!s.starts_with("baml_types/"));
@@ -2390,7 +2418,7 @@ mod tests {
         let bucket = cg_name("aws", &["s3"], "Bucket");
         pool.insert(bucket.clone(), class(bucket));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
 
         for path in out.keys() {
             let s = path.to_string_lossy();
@@ -2423,7 +2451,7 @@ mod tests {
             ),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
 
         // Field declarations are mirrored into the stub so type
@@ -2466,7 +2494,7 @@ mod tests {
             }),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("ipsum/__init__.pyi")];
 
         let expected = "class Sentiment(str, enum.Enum):\n\
@@ -2503,7 +2531,7 @@ mod tests {
             }),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
 
         assert!(
@@ -2570,7 +2598,7 @@ mod tests {
             }),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
 
         // Parent uses parent params/return.
@@ -2592,7 +2620,7 @@ mod tests {
         let n = cg_name("user", &["util"], "Foo");
         pool.insert(n.clone(), alias(n, "x.baml", 0));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("util/__init__.pyi")];
         // 12d §3.3: type-alias body is identical between `.py` and `.pyi`.
         assert!(leaf.contains("Foo: typing.TypeAlias = int\n"));
@@ -2611,7 +2639,7 @@ mod tests {
         ]);
         pool.insert(n.clone(), alias_full(n, rhs, true, "tree.baml", 0));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("tree/__init__.pyi")];
         assert!(leaf.contains("import typing_extensions\n"));
         assert!(leaf.contains(
@@ -2634,7 +2662,7 @@ mod tests {
             ),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
 
         // 12b method-bearing class: body is the method block, not `...`.
@@ -2666,7 +2694,7 @@ mod tests {
             ),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
 
         // Instance methods: `self` (no annotation) + typed remaining params.
@@ -2688,7 +2716,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Resume");
         pool.insert(n.clone(), class(n));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
 
         // Field declaration is mirrored, but no method block exists.
@@ -2704,7 +2732,7 @@ mod tests {
         pool.insert(c.clone(), class_at(c, "x.baml", 0));
         pool.insert(e.clone(), enum_(e, "x.baml", 50));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
         assert!(py.contains("__all__ = [\n    \"Resume\",\n    \"Sentiment\",\n]"));
@@ -2721,14 +2749,14 @@ mod tests {
         let n = cg_name("user", &["lorem"], "Resume");
         pool.insert(n.clone(), class(n));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
         assert!(leaf.contains("import typing"), "typing expected:\n{leaf}");
 
         // Adding a function still results in typing being imported.
         let f = cg_name("user", &["lorem"], "ping");
         pool.insert(f, func_sym("ping", "x.baml", 100));
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
         assert!(leaf.contains("import typing"));
     }
@@ -2739,7 +2767,7 @@ mod tests {
         let n = cg_name("user", &["lorem"], "extract_resume");
         pool.insert(n, func_sym("extract_resume", "x.baml", 100));
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         for (path, content) in &out {
             if !path.to_string_lossy().ends_with(".pyi") {
                 continue;
@@ -2789,7 +2817,7 @@ mod tests {
             ),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         // 25b2 Phase 4: cross-leaf Pydantic field-edge import is now
         // unconditional in `.py` (the typemap installs sentinel-resolved
@@ -2834,7 +2862,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         // 25b2 Phase 4: lifted out of TYPE_CHECKING in `.py`.
         assert!(
@@ -2870,7 +2898,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("__init__.py")];
         assert!(
             !py.contains("from . import Foo") && !py.contains("from .. import Foo"),
@@ -2897,7 +2925,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         // Import the top-level segment (`baml`) from the SDK root; the
         // annotation uses the fully-qualified `baml.http.Response`.
@@ -2930,7 +2958,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         // Import the top-level segment `vendor` from the SDK root;
         // annotation uses `vendor.aws.s3.Bucket`.
@@ -2965,7 +2993,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("stream_types/lorem/__init__.py")];
         // 25b2 Phase 4: lifted out of TYPE_CHECKING in `.py`. Different
         // first segments (stream_types vs lorem) so import stays root-
@@ -2999,7 +3027,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("stream_types/vendor/aws/s3/__init__.py")];
         assert!(
             py.contains("\nfrom ..... import baml\n"),
@@ -3050,7 +3078,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         // Every cross-leaf field-edge import lifts to a runtime
         // `from <root_dots> import <top_seg>` line — no TYPE_CHECKING
@@ -3100,7 +3128,7 @@ mod tests {
                 0,
             ),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         assert_eq!(
             py.matches("from .. import vendor").count(),
@@ -3123,7 +3151,7 @@ mod tests {
             other.clone(),
             class_with_props(other, vec![("r", Ty::Class(resume, vec![]))], "x.baml", 100),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let py = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(!py.contains("if typing.TYPE_CHECKING:"));
         assert!(!py.contains("from .."));
@@ -3170,7 +3198,7 @@ mod tests {
                 origin: origin("x.baml", 100),
             }),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
         assert!(
             pyi.contains("if typing.TYPE_CHECKING:\n    from .. import ipsum\n"),
@@ -3199,7 +3227,7 @@ mod tests {
             0,
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.pyi")];
         // Sync→async→companion sync→companion async should appear
         // contiguously without blank-line separators.
@@ -3271,7 +3299,7 @@ mod tests {
             }),
         );
 
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let leaf = &out[&PathBuf::from("lorem/__init__.py")];
         assert!(
             leaf.contains("T = typing.TypeVar(\"T\")"),
@@ -3344,7 +3372,7 @@ mod tests {
                 origin: origin("echo.baml", 0),
             }),
         );
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
         assert!(
             pyi.contains("T = typing.TypeVar(\"T\")"),
@@ -3367,7 +3395,7 @@ mod tests {
         // sdk_root is deleted in Phase 5; codegen drops the kwarg now (no
         // runtime consumer, no diagnostic value worth a separate argument).
         let pool: SymbolPool = HashMap::new();
-        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase).unwrap();
         let root = &out[&PathBuf::from("__init__.py")];
         assert!(
             root.contains(

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -38,7 +38,8 @@ impl std::fmt::Display for UnsupportedNamingConvention {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "sdkgen_python_pydantic2 only supports naming_convention = PreserveCase (got {})",
+            "generator python/pydantic requires setting naming_convention \"preserve-case\" \
+             (got \"{}\")",
             self.naming_convention
         )
     }
@@ -657,7 +658,8 @@ mod tests {
         assert_eq!(err.naming_convention, NamingConvention::Language);
         assert_eq!(
             err.to_string(),
-            "sdkgen_python_pydantic2 only supports naming_convention = PreserveCase (got language)"
+            "generator python/pydantic requires setting naming_convention \"preserve-case\" \
+             (got \"language\")"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
- [ ] This PR fixes/closes #[issue number]

## The error

The following BAML crashed before this change when generated with the compiler2 CLI:

```baml
generator target {
  output_type "python/pydantic"
  output_dir "../"
  default_client_mode "sync"
  naming_convention "language"
}

function main() -> string {
  "hello"
}
```

Pre-fix reproduction with `cargo run -p baml_cli --bin baml-cli -- generate --from /tmp/tmp.WSMWmSKIpB` exited through Rust panic while running under Cargo:

```text
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
     Loading /tmp/tmp.WSMWmSKIpB/baml_src/main.baml
    Checking 1 file(s)
   Resolving generator blocks
   Compiling 1 file(s)
  Generating target

thread 'main' (32002) panicked at sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs:141:5:
sdkgen_python_pydantic2 only supports naming_convention = PreserveCase (got language)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Root cause

`baml_language/crates/baml_cli/src/generate.rs::discover_generators` parsed `naming_convention` with a target-agnostic expected-value list that accepted and advertised both `"preserve-case"` and `"language"` for every generator. The python/pydantic backend in `baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs::to_source_code_internal` only supports `PreserveCase` and asserted when it received `Language`, so CLI validation let an unsupported value reach a panic path.

The SDK test harness in `baml_language/sdk_tests/harness_setup/src/python_pydantic2.rs::codegen_fixture` also called that backend directly and needed to handle the new fallible result instead of only catching panics.

## The fix

- Make generator validation target-aware for `python/pydantic` and `python/pydantic/v1`, so missing `naming_convention` guidance lists only `"preserve-case"` for those targets.
- Reject parsed `naming_convention "language"` for python/pydantic targets with `DiagnosticId::InvalidGeneratorPropertyValue` and a primary span on the offending generator config item.
- Make the python sdkgen entrypoints return a typed `UnsupportedNamingConvention` error instead of asserting internally.
- Update the python SDK test harness to record fallible codegen errors.
- Add CLI e2e tests for the unsupported value and corrected missing-property guidance, plus a sdkgen unit test for the typed error.

## Verification

Pre-fix reproduction was run first and produced the panic shown above.

Post-fix manual reproduction:

```text
$ ./target/debug/baml-cli generate --from /tmp/tmp.prkLQQ52G5
EXIT=4
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
     Loading /tmp/tmp.prkLQQ52G5/baml_src/main.baml
    Checking 1 file(s)
   Resolving generator blocks
error: invalid value `language` for `naming_convention` on generator `target` with output_type `python/pydantic` (expected "preserve-case")
   ╭─[ main.baml:4:29 ]
   │
 4 │ ╭─▶   default_client_mode "sync"
 5 │ ├─▶   naming_convention "language"
   │ │                                    
   │ ╰──────────────────────────────────── `language` is not supported by this generator
   │     
   │     Note: Error code: E0019
───╯
```

Commands run from `baml_language/`:

```text
cargo test -p sdkgen_python_pydantic2 language_naming_convention_returns_error
# 1 passed

cargo test -p baml_cli --test exit_code_e2e generate_python_pydantic
# 2 passed

cargo test --lib
# Failed only because explicit --lib forces bridge_nodejs into a standalone lib-test link mode;
# sdks/nodejs/bridge_nodejs/Cargo.toml documents that this cannot link N-API symbols.

cargo test --lib --workspace --exclude bridge_nodejs --exclude bridge_python
# Passed. bridge_python is the analogous cdylib bridge and failed standalone lib-test linking with missing libpython3.12.

mise trust /workspace/baml_language/mise.toml
./sdk_tests/crates/typescript_node/setup.sh
cargo test
# Passed full workspace suite after SDK fixture setup.

cargo fmt --all --check
# Passed

cargo clippy --all-targets -- -D warnings
# Passed
```

Snapshot tests were covered by the full `cargo test`; there were no snapshot updates to accept.

CodeRabbit:

```text
curl -fsSL https://cli.coderabbit.ai/install.sh | sh
# Installed coderabbit 0.6.0 successfully.
CODERABBIT_API_KEY is not set
```

Because `CODERABBIT_API_KEY` is missing from this environment, I could not authenticate or run `coderabbit review --plain --base canary`.

Environment note: the repository setup script installed the main mise-managed toolchain but exited while installing `cargo-shear@latest` with cargo exit code 101 in this environment. I continued after trusting `baml_language/mise.toml` and running the SDK setup needed by plain `cargo test`.

## Changes

See **The fix** above.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in linux 6.1.147 Cursor Cloud environment

## Screenshots

N/A

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not needed; validator/tests only)
- [x] My changes generate no new warnings

## Additional Notes

All code changes are inside `baml_language/`. The legacy `engine/` directory was not modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7376783b-4c5c-427f-8e86-2181bb0701b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7376783b-4c5c-427f-8e86-2181bb0701b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generators now fail with clear, non-panic errors when an unsupported naming convention is used; commands return the appropriate exit code.
* **Improvements**
  * Validation and diagnostics for generator `naming_convention` were tightened to only allow the supported option and to surface precise error locations.
* **Tests**
  * End-to-end tests added to cover naming-convention validation for multiple generator targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->