### PR TITLE
[codex] Keep non-website branch improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,7 @@ rpi/
 
 # Riptide artifacts (cloud-synced)
 .humanlayer/tasks/
+.codeboarding/
 
 # Track generated Node bridge package JS/TS dist outputs, but not native addons.
 !baml_language/sdks/nodejs/bridge_nodejs/dist/

--- a/.vercelignore
+++ b/.vercelignore
@@ -24,11 +24,10 @@
 **/*.node
 **/*.abi3.so
 
-# Entire trees the website build never reads (old codebases, other products).
-# baml_language stays: vercel-build.sh compiles bridge_wasm from it on cache
-# miss and generates pkg-proto from its bridge_ctypes/types.
-/engine
-/typescript
+# Entire trees the website build never reads (other products).
+# Keep /engine and /typescript: this root ignore file is shared by legacy
+# Vercel projects, and the old promptfiddle build compiles engine WASM from
+# typescript/apps/fiddle-web-app/vercel-build.sh.
 /jetbrains
 /languages
 /integ-tests

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,54 @@
+# Vercel direct deploy uploads from the monorepo root so the project's
+# configured Root Directory (`typescript2/app-website`) is applied once.
+# Keep the upload to source files only; dependencies and generated artifacts
+# are rebuilt or restored from Vercel's build cache.
+
+.git
+.github
+.vercel
+
+**/node_modules
+**/.next
+**/.next-dev
+**/.turbo
+**/.cache
+**/dist
+**/build
+**/coverage
+**/.DS_Store
+**/.venv
+
+# Rust build output can be very large locally.
+**/target
+# Prebuilt native SDK binaries (100MB+ each); not used by any web build.
+**/*.node
+**/*.abi3.so
+
+# Entire trees the website build never reads (old codebases, other products).
+# baml_language stays: vercel-build.sh compiles bridge_wasm from it on cache
+# miss and generates pkg-proto from its bridge_ctypes/types.
+/engine
+/typescript
+/jetbrains
+/languages
+/integ-tests
+/fern
+/docs
+/examples
+# NOTE: typescript2/pkg-playground/wasm is intentionally NOT ignored here. It is
+# gitignored (so it never reaches GitHub), but we DO want the locally-prebuilt
+# bridge_wasm uploaded with `vercel deploy` so the build skips the ~15 min
+# rustup/cargo recompile (vercel-build.sh detects it and skips). This only
+# affects CLI deploys; GitHub-triggered builds don't use .vercelignore and still
+# compile the wasm from source.
+
+# Local/editor state and secrets.
+**/.env
+**/.env.*
+!.env.example
+**/*.log
+**/tsconfig.tsbuildinfo
+
+# Tooling caches.
+**/.claude
+**/.codeboarding

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,7 +60,6 @@
       "editor.tabSize": 2
   },
   "baml.enablePlaygroundProxy": true,
-  "editor.accessibilitySupport": "off",
   "explorer.sortOrder": "mixed",
   "nixEnvSelector.suggestion": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,4 +60,7 @@
       "editor.tabSize": 2
   },
   "baml.enablePlaygroundProxy": true,
+  "editor.accessibilitySupport": "off",
+  "explorer.sortOrder": "mixed",
+  "nixEnvSelector.suggestion": false,
 }

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -855,10 +855,12 @@ fn definition_line_range_comment_only_span_does_not_reverse() {
 
 // ── Truncation / budget tests ────────────────────────────────────────────────
 
-/// Methods remain discoverable under tight budgets, but their entries consume
-/// the remaining section budget and overflow is summarized explicitly.
+/// The soft budget bounds the whole rendering, not just the body: method
+/// sections are truncated to fit, with an explicit elision marker, while
+/// their headers stay visible so the symbol's surface remains discoverable.
+/// A generous budget still renders every method in full.
 #[test]
-fn render_describe_methods_share_remaining_budget() {
+fn render_describe_methods_respect_budget() {
     let db = simple_project();
     let files = baml_compiler2_hir::compiler2_all_files(&db);
     let descs = baml_lsp2_actions::describe(&db, &files, "String");
@@ -878,6 +880,31 @@ fn render_describe_methods_share_remaining_budget() {
         );
     }
 
+    // Tight output is meaningfully bounded: the budget is soft, but elided
+    // method lists must not blow past it by more than the fixed per-section
+    // overhead (headers + markers).
+    let tight_lines = tight.lines().count();
+    let full_lines = full.lines().count();
+    assert!(
+        tight_lines < full_lines / 2 && tight_lines <= 5 + 20,
+        "budget 5 should bound output well below the full {full_lines} lines, got {tight_lines}:\n{tight}"
+    );
+
+    // A generous budget renders every method, with no elision marker.
+    for needle in [
+        "function to_json(self) -> json",
+        "static_methods:",
+        "function from_code_points(unicode: int[]) -> string",
+    ] {
+        assert!(
+            full.contains(needle),
+            "`{needle}` missing from describe output under budget 1000:\n{full}"
+        );
+    }
+    assert!(
+        !full.contains("re-run with a higher --budget"),
+        "no elision marker expected at budget 1000:\n{full}"
+    );
     assert!(
         !tight.contains("function to_json(self) -> json"),
         "late methods should be elided under budget 5:\n{tight}"
@@ -903,6 +930,14 @@ fn render_describe_fields_only_body_fits_tight_budget() {
     assert!(
         !tight.contains("[INFO] Showing"),
         "fields-only body must not truncate at budget 5:\n{tight}"
+    );
+    // The header + body block is identical at both budgets; only the trailing
+    // list sections (methods here) give way under the tight budget.
+    let body_part = |s: &str| s[..s.find("\nmethods:").expect("methods section")].to_string();
+    assert_eq!(body_part(&tight), body_part(&full));
+    assert!(
+        tight.contains("more lines (re-run with a higher --budget)"),
+        "methods exceeding the tight budget must be elided with a marker:\n{tight}"
     );
     for needle in ["class User {", "    name: string,", "    age: int,", "}"] {
         assert!(

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/flatten.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/flatten.rs
@@ -249,20 +249,32 @@ fn compute_required_nodes(graph: &ControlFlowGraph) -> HashSet<NodeId> {
         }
     }
 
-    // Early returns render whenever their enclosing scope renders. This runs
-    // after the arm pass so returns directly inside a kept arm survive.
+    // Early returns render whenever their enclosing rendered scope renders.
+    // Keep any wrapper nodes needed to connect the return back to that scope.
     for node in graph.nodes.values() {
         if !matches!(node.node_type, NodeType::Return) {
             continue;
         }
-        match node.parent_node_id {
-            Some(parent_id) if keep.contains(&parent_id) => {
-                keep.insert(node.id);
+
+        let Some(parent_id) = node.parent_node_id else {
+            keep.insert(node.id);
+            continue;
+        };
+
+        let mut current = Some(parent_id);
+        let mut path = Vec::new();
+        let mut seen = HashSet::new();
+        while let Some(ancestor_id) = current {
+            if !seen.insert(ancestor_id) {
+                break;
             }
-            None => {
+            path.push(ancestor_id);
+            if keep.contains(&ancestor_id) {
                 keep.insert(node.id);
+                keep.extend(path);
+                break;
             }
-            _ => {}
+            current = graph.nodes.get(&ancestor_id).and_then(|n| n.parent_node_id);
         }
     }
 
@@ -1388,5 +1400,28 @@ mod tests {
             cont_dsts.contains(&7),
             "non-returning arm should flow to the successor, got: {cont_dsts:?}"
         );
+    }
+
+    #[test]
+    fn pass1_keeps_wrapper_path_for_nested_return_under_header() {
+        let mut graph = ControlFlowGraph::default();
+        let root = Node::root(NodeId::new(0), "f|root:0", "func");
+        let header = make_node(1, Some(0), "Process", NodeType::HeaderContextEnter);
+        let wrapper = make_node(2, Some(1), "let x = if ...", NodeType::OtherScope);
+        let bg = make_node(3, Some(2), "if (x)", NodeType::BranchGroup);
+        let arm = make_node(4, Some(3), "if (x)", NodeType::BranchArm);
+        let ret = make_node(5, Some(4), "return 1", NodeType::Return);
+        for n in [root, header, wrapper, bg, arm, ret] {
+            graph.nodes.insert(n.id, n);
+        }
+
+        let filtered = remove_implicit_nodes(&graph);
+
+        for id in [1, 2, 3, 4, 5] {
+            assert!(
+                filtered.nodes.contains_key(&NodeId::new(id)),
+                "expected node {id} to survive so the nested return stays visible"
+            );
+        }
     }
 }

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/flatten.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/flatten.rs
@@ -24,16 +24,13 @@ pub fn flatten_control_flow_graph(graph: &ControlFlowGraph) -> ControlFlowGraph 
 }
 
 /// Produces a visualization-ready graph by:
-/// 1. Hoisting branch arms with labeled fan-out edges (adapted Pass 2)
-/// 2. Renaming `_` branch arm labels to `"default"`
-/// 3. Inlining branch-arm containers so arms are represented as edge labels
-/// 4. Computing `is_container` for each node
-///
-/// Does NOT run Pass 1 (`remove_implicit_nodes`) or Pass 3
-/// (`inline_branch_arms_and_scopes`) — the playground needs all nodes
-/// visible. Branch arms are the exception: `ReactFlow` already renders branch
-/// structure as labeled fan-out edges, so keeping them as group containers
-/// creates redundant nested boxes.
+/// 1. Pruning to required nodes — only headers (`//#`), LLM functions/calls,
+///    structure that contains them (an annotated if-branch or loop body pulls
+///    in the whole if / loop), and early returns inside rendered scopes
+/// 2. Hoisting branch arms with labeled fan-out edges (adapted Pass 2)
+/// 3. Renaming `_` branch arm labels to `"default"`
+/// 4. Inlining branch-arm containers so arms are represented as edge labels
+/// 5. Computing `is_container` for each node
 pub fn prepare_control_flow_graph_for_visualization(graph: &ControlFlowGraph) -> ControlFlowGraph {
     struct BranchGroupInfo {
         node_id: NodeId,
@@ -43,7 +40,9 @@ pub fn prepare_control_flow_graph_for_visualization(graph: &ControlFlowGraph) ->
         successors: Vec<NodeId>,
     }
 
-    let mut graph = graph.clone();
+    // ── Step 0: Prune to header/LLM-anchored nodes ─────────────────────
+    let keep = compute_required_nodes(graph);
+    let mut graph = filter_graph(graph, &keep);
 
     // ── Step 1: Hoist branch arms with labeled fan-out edges ──────────
     // Adapted from hoist_branch_arms — same deepest-first BranchGroup
@@ -194,23 +193,85 @@ fn inline_branch_arms_for_visualization(graph: &mut ControlFlowGraph) {
 // ===========================================================================
 
 fn remove_implicit_nodes(graph: &ControlFlowGraph) -> ControlFlowGraph {
+    let keep = compute_required_nodes(graph);
+    filter_graph(graph, &keep)
+}
+
+/// A node that renders no matter where it appears: header comment nodes
+/// (`//#`) and LLM functions / calls to LLM functions.
+fn is_always_rendered(node: &Node) -> bool {
+    matches!(
+        node.node_type,
+        NodeType::HeaderContextEnter | NodeType::LlmFunction
+    ) || node.llm_client.is_some()
+}
+
+/// Compute the set of nodes that must be rendered:
+/// - the function root,
+/// - header comment nodes and LLM functions / LLM calls (always),
+/// - any structural node (loop, branch group, scope) whose subtree contains
+///   one of the above — a `//#` inside an if-branch or loop body forces the
+///   whole if / loop to render,
+/// - every arm of a rendered branch group (one annotated branch extracts all
+///   branches),
+/// - return nodes whose enclosing rendered scope survives, so early returns
+///   stay visible.
+fn compute_required_nodes(graph: &ControlFlowGraph) -> HashSet<NodeId> {
     let children = build_children_map(&graph.nodes);
     let mut memo: HashMap<NodeId, bool> = HashMap::new();
     for node in graph.nodes.values() {
-        compute_has_header(node.id, &graph.nodes, &children, &mut memo);
+        compute_has_anchor(node.id, &graph.nodes, &children, &mut memo);
     }
 
     let mut keep: HashSet<NodeId> = HashSet::new();
     for node in graph.nodes.values() {
-        if should_keep(node, &graph.nodes, &memo) {
+        let required = matches!(node.node_type, NodeType::FunctionRoot)
+            || *memo.get(&node.id).unwrap_or(&false);
+        if required {
             keep.insert(node.id);
         }
     }
 
-    filter_graph(graph, &keep)
+    // All arms of a kept branch group render, even header-less ones.
+    for node in graph.nodes.values() {
+        if !matches!(node.node_type, NodeType::BranchArm) {
+            continue;
+        }
+        if let Some(parent_id) = node.parent_node_id {
+            let parent_is_kept_group = keep.contains(&parent_id)
+                && matches!(
+                    graph.nodes.get(&parent_id).map(|p| &p.node_type),
+                    Some(NodeType::BranchGroup)
+                );
+            if parent_is_kept_group {
+                keep.insert(node.id);
+            }
+        }
+    }
+
+    // Early returns render whenever their enclosing scope renders. This runs
+    // after the arm pass so returns directly inside a kept arm survive.
+    for node in graph.nodes.values() {
+        if !matches!(node.node_type, NodeType::Return) {
+            continue;
+        }
+        match node.parent_node_id {
+            Some(parent_id) if keep.contains(&parent_id) => {
+                keep.insert(node.id);
+            }
+            None => {
+                keep.insert(node.id);
+            }
+            _ => {}
+        }
+    }
+
+    keep
 }
 
-fn compute_has_header(
+/// Whether `node_id` or any of its descendants is an always-rendered node
+/// (header / LLM).
+fn compute_has_anchor(
     node_id: NodeId,
     nodes: &IndexMap<NodeId, Node>,
     children: &HashMap<NodeId, Vec<NodeId>>,
@@ -225,10 +286,10 @@ fn compute_has_header(
         return false;
     };
 
-    let mut result = matches!(node.node_type, NodeType::HeaderContextEnter);
+    let mut result = is_always_rendered(node);
     if let Some(child_ids) = children.get(&node_id) {
         for child in child_ids {
-            if compute_has_header(*child, nodes, children, memo) {
+            if compute_has_anchor(*child, nodes, children, memo) {
                 result = true;
                 break;
             }
@@ -239,29 +300,9 @@ fn compute_has_header(
     result
 }
 
-fn should_keep(
-    node: &Node,
-    nodes: &IndexMap<NodeId, Node>,
-    has_header: &HashMap<NodeId, bool>,
-) -> bool {
-    match node.node_type {
-        NodeType::FunctionRoot | NodeType::LlmFunction | NodeType::HeaderContextEnter => true,
-        NodeType::BranchArm => {
-            if *has_header.get(&node.id).unwrap_or(&false) {
-                true
-            } else if let Some(parent_id) = node.parent_node_id {
-                matches!(
-                    nodes.get(&parent_id).map(|parent| &parent.node_type),
-                    Some(NodeType::BranchGroup)
-                ) && *has_header.get(&parent_id).unwrap_or(&false)
-            } else {
-                false
-            }
-        }
-        _ => *has_header.get(&node.id).unwrap_or(&false),
-    }
-}
-
+/// Drop all nodes outside `keep`, splicing sequential edges through removed
+/// nodes so surviving siblings stay connected (kept → dropped → kept becomes
+/// kept → kept).
 fn filter_graph(graph: &ControlFlowGraph, keep: &HashSet<NodeId>) -> ControlFlowGraph {
     let mut nodes = IndexMap::new();
     for (id, node) in &graph.nodes {
@@ -275,11 +316,26 @@ fn filter_graph(graph: &ControlFlowGraph, keep: &HashSet<NodeId>) -> ControlFlow
         if !keep.contains(src) {
             continue;
         }
-        let filtered: Vec<Edge> = edges
-            .iter()
-            .filter(|edge| keep.contains(&edge.dst))
-            .cloned()
-            .collect();
+        let mut filtered: Vec<Edge> = Vec::new();
+        let mut seen: HashSet<NodeId> = HashSet::new();
+        for edge in edges {
+            if keep.contains(&edge.dst) {
+                if seen.insert(edge.dst) {
+                    filtered.push(edge.clone());
+                }
+            } else {
+                // Walk through the dropped node(s) to the next kept nodes.
+                for dst in kept_successors_through(edge.dst, graph, keep) {
+                    if seen.insert(dst) {
+                        filtered.push(Edge {
+                            src: *src,
+                            dst,
+                            label: None,
+                        });
+                    }
+                }
+            }
+        }
         if !filtered.is_empty() {
             edges_by_src.insert(*src, filtered);
         }
@@ -289,6 +345,33 @@ fn filter_graph(graph: &ControlFlowGraph, keep: &HashSet<NodeId>) -> ControlFlow
         nodes,
         edges_by_src,
     }
+}
+
+/// Starting from a dropped node, follow outgoing edges through other dropped
+/// nodes and return the kept nodes reachable that way.
+fn kept_successors_through(
+    start: NodeId,
+    graph: &ControlFlowGraph,
+    keep: &HashSet<NodeId>,
+) -> Vec<NodeId> {
+    let mut result = Vec::new();
+    let mut visited: HashSet<NodeId> = HashSet::new();
+    let mut stack = vec![start];
+    while let Some(id) = stack.pop() {
+        if !visited.insert(id) {
+            continue;
+        }
+        if keep.contains(&id) {
+            result.push(id);
+            continue;
+        }
+        if let Some(edges) = graph.edges_by_src.get(&id) {
+            for edge in edges {
+                stack.push(edge.dst);
+            }
+        }
+    }
+    result
 }
 
 // ===========================================================================
@@ -499,8 +582,31 @@ fn collect_exit_nodes_recursive(
         .map(|edges| !edges.is_empty())
         .unwrap_or(false);
 
-    if !has_outgoing {
+    if !has_outgoing && !is_terminal_subtree(node_id, children_map, graph) {
         exits.push(node_id);
+    }
+}
+
+/// Whether control flow always leaves the function inside this subtree: the
+/// node is a `return`, or a container all of whose children are terminal.
+/// Terminal subtrees must never fan out to whatever comes after an inlined
+/// container — e.g. a header whose only content is an early return.
+fn is_terminal_subtree(
+    node_id: NodeId,
+    children_map: &HashMap<NodeId, Vec<NodeId>>,
+    graph: &ControlFlowGraph,
+) -> bool {
+    let Some(node) = graph.nodes.get(&node_id) else {
+        return false;
+    };
+    if matches!(node.node_type, NodeType::Return) {
+        return true;
+    }
+    match children_map.get(&node_id) {
+        Some(children) if !children.is_empty() => children
+            .iter()
+            .all(|child| is_terminal_subtree(*child, children_map, graph)),
+        _ => false,
     }
 }
 
@@ -616,6 +722,7 @@ mod tests {
             node_type,
             llm_client: None,
             callee_name: None,
+            callee_names: Vec::new(),
             source_span: None,
             is_container: false,
         }
@@ -893,28 +1000,25 @@ mod tests {
             "BranchGroup should NOT be a container (diamond dispatch)"
         );
 
-        // Header "True branch" (id=4): has child leaf → true
+        // Plain leaves "yes" (5) and "no" (8) are not header/LLM anchored →
+        // pruned from the visualization graph.
         assert!(
-            result.nodes.get(&NodeId::new(4)).unwrap().is_container,
-            "Header 'True branch' should be a container (has child leaf)"
+            result.nodes.get(&NodeId::new(5)).is_none(),
+            "Plain leaf 'yes' should be pruned"
+        );
+        assert!(
+            result.nodes.get(&NodeId::new(8)).is_none(),
+            "Plain leaf 'no' should be pruned"
         );
 
-        // Leaf "yes" (id=5): no children → false
+        // With their leaves pruned, the branch headers become leaf nodes.
         assert!(
-            !result.nodes.get(&NodeId::new(5)).unwrap().is_container,
-            "Leaf 'yes' should NOT be a container"
+            !result.nodes.get(&NodeId::new(4)).unwrap().is_container,
+            "Header 'True branch' should be a leaf after pruning"
         );
-
-        // Header "False branch" (id=7): has child leaf → true
         assert!(
-            result.nodes.get(&NodeId::new(7)).unwrap().is_container,
-            "Header 'False branch' should be a container (has child leaf)"
-        );
-
-        // Leaf "no" (id=8): no children → false
-        assert!(
-            !result.nodes.get(&NodeId::new(8)).unwrap().is_container,
-            "Leaf 'no' should NOT be a container"
+            !result.nodes.get(&NodeId::new(7)).unwrap().is_container,
+            "Header 'False branch' should be a leaf after pruning"
         );
     }
 
@@ -945,12 +1049,13 @@ mod tests {
     /// ```text
     /// FunctionRoot (0)
     ///   └─ Header "Setup" (1)
-    ///   │    └─ OtherScope "x = 1" (2)
+    ///   │    └─ OtherScope "x = 1" (2)      ← pruned (no header/LLM anchor)
     ///   └─ Header "Process" (3)
-    ///        └─ BranchGroup "if (x)" (4)
+    ///        └─ BranchGroup "if (x)" (4)    ← kept: header inside true arm
     ///             ├─ BranchArm "true" (5)
-    ///             └─ BranchArm "false" (6)
-    ///        └─ OtherScope "done" (7)  ← successor after the if/else
+    ///             │    └─ Header "Work" (8)
+    ///             └─ BranchArm "false" (6)  ← kept: sibling arm of annotated arm
+    ///        └─ Header "Done" (7)           ← successor after the if/else
     /// ```
     /// Edges: 1→3 (sequential headers), 4→7 (`BranchGroup` to successor)
     /// Within Header "Process": 4 and 7 are sequential children.
@@ -965,30 +1070,37 @@ mod tests {
         let bg = make_node(4, Some(3), "if (x)", NodeType::BranchGroup);
         let arm_true = make_node(5, Some(4), "true", NodeType::BranchArm);
         let arm_false = make_node(6, Some(4), "false", NodeType::BranchArm);
-        let leaf_done = make_node(7, Some(3), "done", NodeType::OtherScope);
+        let h_done = make_node(7, Some(3), "Done", NodeType::HeaderContextEnter);
+        let h_work = make_node(8, Some(5), "Work", NodeType::HeaderContextEnter);
 
         for n in [
-            root, h_setup, leaf_x, h_process, bg, arm_true, arm_false, leaf_done,
+            root, h_setup, leaf_x, h_process, bg, arm_true, arm_false, h_done, h_work,
         ] {
             graph.nodes.insert(n.id, n);
         }
 
         // Sequential edges:
         add_edge(&mut graph, 1, 3); // Setup → Process (at FunctionRoot level)
-        add_edge(&mut graph, 4, 7); // BranchGroup → done (at Header "Process" level)
+        add_edge(&mut graph, 4, 7); // BranchGroup → Done (at Header "Process" level)
 
         let result = prepare_control_flow_graph_for_visualization(&graph);
 
-        // Empty arms remain visible so implicit/synthetic branches are not
-        // hidden. The BranchGroup fans out to those arm leaf nodes.
+        // The plain leaf under "Setup" is pruned.
+        assert!(
+            result.nodes.get(&NodeId::new(2)).is_none(),
+            "plain OtherScope leaf should be pruned"
+        );
+
+        // The annotated arm is inlined (it has content); the empty false arm
+        // stays visible. Fan-out goes to the arm content / the empty arm.
         let bg_edges = result.edges_by_src.get(&NodeId::new(4));
         let bg_edges: Vec<_> = bg_edges.map(|es| es.iter().collect()).unwrap_or_default();
         let bg_edge_dsts: Vec<u32> = bg_edges.iter().map(|e| e.dst.raw()).collect();
         let bg_edge_labels: Vec<_> = bg_edges.iter().filter_map(|e| e.label.as_deref()).collect();
         assert_eq!(
             bg_edge_dsts,
-            vec![5, 6],
-            "BranchGroup should fan out to empty arm nodes, got: {bg_edge_dsts:?}"
+            vec![8, 6],
+            "BranchGroup should fan out to arm content and empty arm, got: {bg_edge_dsts:?}"
         );
         assert_eq!(
             bg_edge_labels,
@@ -997,15 +1109,15 @@ mod tests {
         );
 
         assert!(
-            result.nodes.get(&NodeId::new(5)).is_some(),
-            "empty true arm should stay visible"
+            result.nodes.get(&NodeId::new(5)).is_none(),
+            "non-empty true arm should be inlined"
         );
         assert!(
             result.nodes.get(&NodeId::new(6)).is_some(),
             "empty false arm should stay visible"
         );
         assert_eq!(
-            result.nodes.get(&NodeId::new(5)).unwrap().parent_node_id,
+            result.nodes.get(&NodeId::new(8)).unwrap().parent_node_id,
             Some(NodeId::new(3))
         );
         assert_eq!(
@@ -1013,14 +1125,14 @@ mod tests {
             Some(NodeId::new(3))
         );
 
-        let arm_true_dsts: Vec<u32> = result
+        let work_dsts: Vec<u32> = result
             .edges_by_src
-            .get(&NodeId::new(5))
+            .get(&NodeId::new(8))
             .map(|es| es.iter().map(|e| e.dst.raw()).collect())
             .unwrap_or_default();
         assert!(
-            arm_true_dsts.contains(&7),
-            "true arm should flow to successor 7, got: {arm_true_dsts:?}"
+            work_dsts.contains(&7),
+            "true arm content should flow to successor 7, got: {work_dsts:?}"
         );
         let arm_false_dsts: Vec<u32> = result
             .edges_by_src
@@ -1044,10 +1156,10 @@ mod tests {
         let h_process = make_node(1, Some(0), "Process", NodeType::HeaderContextEnter);
         let bg = make_node(2, Some(1), "if (x)", NodeType::BranchGroup);
         let arm_true = make_node(3, Some(2), "true", NodeType::BranchArm);
-        let leaf_true = make_node(4, Some(3), "work", NodeType::OtherScope);
+        let leaf_true = make_node(4, Some(3), "work", NodeType::HeaderContextEnter);
         let arm_false = make_node(5, Some(2), "false", NodeType::BranchArm);
-        let leaf_false = make_node(6, Some(5), "fallback", NodeType::OtherScope);
-        let leaf_done = make_node(7, Some(1), "done", NodeType::OtherScope);
+        let leaf_false = make_node(6, Some(5), "fallback", NodeType::HeaderContextEnter);
+        let leaf_done = make_node(7, Some(1), "done", NodeType::HeaderContextEnter);
 
         for n in [
             root, h_process, bg, arm_true, leaf_true, arm_false, leaf_false, leaf_done,
@@ -1104,10 +1216,11 @@ mod tests {
         let root = Node::root(NodeId::new(0), "f|root:0", "func");
         let bg = make_node(1, Some(0), "match", NodeType::BranchGroup);
         let arm1 = make_node(2, Some(1), "1", NodeType::BranchArm);
+        let h_one = make_node(5, Some(2), "Handle one", NodeType::HeaderContextEnter);
         let arm_wildcard = make_node(3, Some(1), "_", NodeType::BranchArm);
-        let done = make_node(4, Some(0), "done", NodeType::OtherScope);
+        let done = make_node(4, Some(0), "Done", NodeType::HeaderContextEnter);
 
-        for n in [root, bg, arm1, arm_wildcard, done] {
+        for n in [root, bg, arm1, h_one, arm_wildcard, done] {
             graph.nodes.insert(n.id, n);
         }
         add_edge(&mut graph, 1, 4);
@@ -1122,6 +1235,158 @@ mod tests {
                 .iter()
                 .any(|e| e.dst == NodeId::new(3) && e.label.as_deref() == Some("default")),
             "Wildcard branch should become a default-labeled edge to the branch node"
+        );
+    }
+
+    // -- Pruning tests (header / LLM anchoring) --
+
+    #[test]
+    fn viz_prep_prunes_unannotated_structure() {
+        // if/loop/call nodes with no header or LLM call anywhere inside are
+        // dropped; only the root survives.
+        let mut graph = ControlFlowGraph::default();
+        let root = Node::root(NodeId::new(0), "f|root:0", "func");
+        let bg = make_node(1, Some(0), "if (x)", NodeType::BranchGroup);
+        let arm1 = make_node(2, Some(1), "if (x)", NodeType::BranchArm);
+        let arm2 = make_node(3, Some(1), "else", NodeType::BranchArm);
+        let lp = make_node(4, Some(0), "while (y)", NodeType::Loop);
+        let call = make_node(5, Some(0), "Helper(x)", NodeType::OtherScope);
+        for n in [root, bg, arm1, arm2, lp, call] {
+            graph.nodes.insert(n.id, n);
+        }
+        add_edge(&mut graph, 1, 4);
+        add_edge(&mut graph, 4, 5);
+
+        let result = prepare_control_flow_graph_for_visualization(&graph);
+        let ids: Vec<u32> = result.nodes.keys().map(NodeId::raw).collect();
+        assert_eq!(ids, vec![0], "only the function root should survive");
+    }
+
+    #[test]
+    fn viz_prep_keeps_llm_calls_without_headers() {
+        let mut graph = ControlFlowGraph::default();
+        let root = Node::root(NodeId::new(0), "f|root:0", "func");
+        let llm_call = make_node(1, Some(0), "Summarize(text)", NodeType::OtherScope)
+            .with_llm_client("openai/gpt-4o");
+        let plain_call = make_node(2, Some(0), "Helper(x)", NodeType::OtherScope);
+        for n in [root, llm_call, plain_call] {
+            graph.nodes.insert(n.id, n);
+        }
+        add_edge(&mut graph, 1, 2);
+
+        let result = prepare_control_flow_graph_for_visualization(&graph);
+        assert!(
+            result.nodes.contains_key(&NodeId::new(1)),
+            "LLM call must always render"
+        );
+        assert!(
+            !result.nodes.contains_key(&NodeId::new(2)),
+            "plain call should be pruned"
+        );
+    }
+
+    #[test]
+    fn viz_prep_header_inside_loop_keeps_loop() {
+        let mut graph = ControlFlowGraph::default();
+        let root = Node::root(NodeId::new(0), "f|root:0", "func");
+        let lp = make_node(1, Some(0), "for (item in items)", NodeType::Loop);
+        let bg = make_node(2, Some(1), "if (x)", NodeType::BranchGroup);
+        let arm1 = make_node(3, Some(2), "if (x)", NodeType::BranchArm);
+        let header = make_node(4, Some(3), "Annotated", NodeType::HeaderContextEnter);
+        let arm2 = make_node(5, Some(2), "else", NodeType::BranchArm);
+        for n in [root, lp, bg, arm1, header, arm2] {
+            graph.nodes.insert(n.id, n);
+        }
+
+        let result = prepare_control_flow_graph_for_visualization(&graph);
+        assert!(
+            result.nodes.contains_key(&NodeId::new(1)),
+            "loop containing a header (transitively) must render"
+        );
+        assert!(
+            result.nodes.contains_key(&NodeId::new(2)),
+            "if containing a header must render"
+        );
+        assert!(
+            result.nodes.contains_key(&NodeId::new(5)),
+            "the unannotated sibling branch must render too"
+        );
+        assert!(result.nodes.contains_key(&NodeId::new(4)));
+    }
+
+    #[test]
+    fn viz_prep_splices_edges_through_pruned_nodes() {
+        // Header → plain call → Header: dropping the call must not disconnect
+        // the headers.
+        let mut graph = ControlFlowGraph::default();
+        let root = Node::root(NodeId::new(0), "f|root:0", "func");
+        let h1 = make_node(1, Some(0), "Step 1", NodeType::HeaderContextEnter);
+        let call = make_node(2, Some(0), "Helper(x)", NodeType::OtherScope);
+        let h2 = make_node(3, Some(0), "Step 2", NodeType::HeaderContextEnter);
+        for n in [root, h1, call, h2] {
+            graph.nodes.insert(n.id, n);
+        }
+        add_edge(&mut graph, 1, 2);
+        add_edge(&mut graph, 2, 3);
+
+        let result = prepare_control_flow_graph_for_visualization(&graph);
+        assert!(!result.nodes.contains_key(&NodeId::new(2)));
+        let h1_dsts: Vec<u32> = result
+            .edges_by_src
+            .get(&NodeId::new(1))
+            .map(|es| es.iter().map(|e| e.dst.raw()).collect())
+            .unwrap_or_default();
+        assert_eq!(
+            h1_dsts,
+            vec![3],
+            "edge must be spliced through the pruned call node"
+        );
+    }
+
+    #[test]
+    fn viz_prep_return_in_branch_does_not_reach_successor() {
+        // Header
+        //   └─ BranchGroup "if (x)" ── successor Header "Done"
+        //        ├─ arm "if (x)" └─ Return "return 1"
+        //        └─ arm "else"   └─ Header "Continue"
+        // The returning arm must NOT flow to "Done".
+        let mut graph = ControlFlowGraph::default();
+        let root = Node::root(NodeId::new(0), "f|root:0", "func");
+        let h = make_node(1, Some(0), "Process", NodeType::HeaderContextEnter);
+        let bg = make_node(2, Some(1), "if (x)", NodeType::BranchGroup);
+        let arm_ret = make_node(3, Some(2), "if (x)", NodeType::BranchArm);
+        let ret = make_node(4, Some(3), "return 1", NodeType::Return);
+        let arm_else = make_node(5, Some(2), "else", NodeType::BranchArm);
+        let h_cont = make_node(6, Some(5), "Continue", NodeType::HeaderContextEnter);
+        let h_done = make_node(7, Some(1), "Done", NodeType::HeaderContextEnter);
+        for n in [root, h, bg, arm_ret, ret, arm_else, h_cont, h_done] {
+            graph.nodes.insert(n.id, n);
+        }
+        add_edge(&mut graph, 2, 7); // BranchGroup → Done successor
+
+        let result = prepare_control_flow_graph_for_visualization(&graph);
+
+        assert!(
+            result.nodes.contains_key(&NodeId::new(4)),
+            "return inside a rendered arm must stay visible"
+        );
+        let ret_dsts: Vec<u32> = result
+            .edges_by_src
+            .get(&NodeId::new(4))
+            .map(|es| es.iter().map(|e| e.dst.raw()).collect())
+            .unwrap_or_default();
+        assert!(
+            ret_dsts.is_empty(),
+            "return node must not flow to the successor, got: {ret_dsts:?}"
+        );
+        let cont_dsts: Vec<u32> = result
+            .edges_by_src
+            .get(&NodeId::new(6))
+            .map(|es| es.iter().map(|e| e.dst.raw()).collect())
+            .unwrap_or_default();
+        assert!(
+            cont_dsts.contains(&7),
+            "non-returning arm should flow to the successor, got: {cont_dsts:?}"
         );
     }
 }

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
@@ -2050,29 +2050,29 @@ mod tests {
         assert_eq!(rendered, "Resp { ... }");
     }
 
-    /// Calls embedded inside another node's expression must surface via
-    /// `callee_names` even though they don't get CFG nodes of their own.
-    ///
-    /// Fixture mirrors:
-    /// ```baml
-    /// function ValidateInvoice(inv: Invoice) -> ValidationIssue[] {
-    ///     if (Abs(LineTotal(inv.line_items) - inv.total) > 0.02) {
-    ///         // ...
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// Resulting nodes (documented here as the contract):
-    /// - `[0]` FunctionRoot "ValidateInvoice"            — calleeNames: []
-    /// - `[1]` BranchGroup  "if (Abs(LineTotal(inv.line_items) - inv.total) > 0.02)"
-    ///                                                    — calleeNames: ["Abs", "LineTotal"]
-    /// - `[2]` BranchArm    "if (...)" (then branch)      — calleeNames: []
-    /// - `[3]` Header       "Flag mismatch"               — calleeNames: []
-    /// - `[4]` BranchArm    "else" (synthetic)            — calleeNames: []
-    ///
-    /// Names come out exactly as written in source — bare `"Abs"` /
-    /// `"LineTotal"`, NOT qualified (`main.Abs`), in first-encounter order
-    /// (outermost call first).
+    // Calls embedded inside another node's expression must surface via
+    // `callee_names` even though they don't get CFG nodes of their own.
+    //
+    // Fixture mirrors:
+    // ```baml
+    // function ValidateInvoice(inv: Invoice) -> ValidationIssue[] {
+    //     if (Abs(LineTotal(inv.line_items) - inv.total) > 0.02) {
+    //         // ...
+    //     }
+    // }
+    // ```
+    //
+    // Resulting nodes (documented here as the contract):
+    // - `[0]` FunctionRoot "ValidateInvoice"            - calleeNames: []
+    // - `[1]` BranchGroup  "if (Abs(LineTotal(inv.line_items) - inv.total) > 0.02)"
+    //                                                    - calleeNames: ["Abs", "LineTotal"]
+    // - `[2]` BranchArm    "if (...)" (then branch)      - calleeNames: []
+    // - `[3]` Header       "Flag mismatch"               - calleeNames: []
+    // - `[4]` BranchArm    "else" (synthetic)            - calleeNames: []
+    //
+    // Names come out exactly as written in source: bare `"Abs"` /
+    // `"LineTotal"`, not qualified (`main.Abs`), in first-encounter order
+    // (outermost call first).
     #[test]
     fn embedded_calls_in_if_condition_surface_in_callee_names() {
         let body = make_ast_body(|exprs, stmts, _, _| {
@@ -2155,9 +2155,9 @@ mod tests {
         );
     }
 
-    /// Nested calls in call arguments surface on the call's own node too:
-    /// `Process(Helper(x))` yields calleeNames ["Process", "Helper"] while
-    /// callee_name (singular) remains just "Process".
+    // Nested calls in call arguments surface on the call's own node too:
+    // `Process(Helper(x))` yields calleeNames ["Process", "Helper"] while
+    // `callee_name` (singular) remains just "Process".
     #[test]
     fn nested_call_arguments_surface_in_callee_names() {
         let body = make_ast_body(|exprs, _, _, _| {

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
@@ -246,28 +246,37 @@ impl<'a> AstGraphBuilder<'a> {
                 self.visit_expr(*value);
             }
 
+            ast::Stmt::For {
+                binding,
+                collection,
+                body,
+            } => {
+                let label = format!(
+                    "for ({} in {})",
+                    self.format_pattern(*binding),
+                    render_expr_compact_ast(self.body, *collection)
+                );
+                self.visit_loop_with_label(label, *collection, *body);
+            }
+
             ast::Stmt::Return(Some(expr_id)) => {
-                let return_expr = self.body.exprs[*expr_id].clone();
-                match &return_expr {
-                    // Calls already produce their own graph node via visit_expr.
-                    ast::Expr::Call { .. } | ast::Expr::OptionalCall { .. } => {
-                        self.visit_expr(*expr_id);
-                    }
-                    // For other return values, emit a leaf node showing the
-                    // return path so branching returns are visible in the graph.
-                    _ => {
-                        let label =
-                            format!("return {}", render_expr_compact_ast(self.body, *expr_id));
-                        self.emit_return_leaf(*expr_id, &label);
-                    }
-                }
+                let label = format!("return {}", render_expr_compact_ast(self.body, *expr_id));
+                self.emit_return_leaf(Some(*expr_id), None, &label);
+                // Control flow leaves the function here: statements after an
+                // early return must not receive an edge from the return node.
+                self.mark_flow_terminal();
+            }
+
+            ast::Stmt::Return(None) => {
+                self.emit_return_leaf(None, Some(id), "return");
+                self.mark_flow_terminal();
             }
 
             ast::Stmt::Assign { value, .. } | ast::Stmt::AssignOp { value, .. } => {
                 self.visit_expr(*value);
             }
 
-            // Break, Continue, bare Return, Assert, Missing — no graph nodes.
+            // Break, Continue, Assert, Missing — no graph nodes.
             _ => {}
         }
     }
@@ -309,7 +318,8 @@ impl<'a> AstGraphBuilder<'a> {
             label,
             Some(if_expr.into_raw().into_u32()),
             NodeType::BranchGroup,
-        );
+        )
+        .with_callee_names(collect_callee_names(self.body, if_expr));
         self.graph.add_node(node);
         let parent_index = self.current_parent_index();
         self.register_child_with_parent(parent_index, node_id);
@@ -321,6 +331,7 @@ impl<'a> AstGraphBuilder<'a> {
         self.visit_branch_arm(arm_label, then_branch);
 
         // Flatten else-if chains
+        let mut has_final_else = false;
         let mut current_else = else_branch;
         while let Some(else_id) = current_else {
             let else_expr = self.body.exprs[else_id].clone();
@@ -339,13 +350,15 @@ impl<'a> AstGraphBuilder<'a> {
                 }
                 _ => {
                     self.visit_branch_arm("else".to_string(), else_id);
+                    has_final_else = true;
                     current_else = None;
                 }
             }
         }
 
-        // Synthetic "else" arm if no else branch
-        if else_branch.is_none() {
+        // Synthetic "else" arm when the if — or the last else-if in a chain —
+        // has no explicit else branch, so the fall-through path stays visible.
+        if !has_final_else {
             self.emit_synthetic_branch_arm("else".to_string());
         }
 
@@ -378,7 +391,8 @@ impl<'a> AstGraphBuilder<'a> {
             label,
             Some(body_expr.into_raw().into_u32()),
             NodeType::BranchArm,
-        );
+        )
+        .with_callee_names(collect_callee_names(self.body, body_expr));
         self.graph.add_node(node);
         let parent_index = self.current_parent_index();
         self.register_child_with_parent(parent_index, node_id);
@@ -455,7 +469,8 @@ impl<'a> AstGraphBuilder<'a> {
             label,
             Some(match_expr.into_raw().into_u32()),
             NodeType::BranchGroup,
-        );
+        )
+        .with_callee_names(collect_callee_names(self.body, match_expr));
         self.graph.add_node(node);
         let parent_index = self.current_parent_index();
         self.register_child_with_parent(parent_index, node_id);
@@ -474,14 +489,6 @@ impl<'a> AstGraphBuilder<'a> {
     // -- While / for loops --
 
     fn visit_loop(&mut self, condition: ast::ExprId, body: ast::ExprId, origin: ast::LoopOrigin) {
-        let parent_depth = self.frames.len();
-        let ordinal = {
-            let frame = self
-                .frames
-                .last_mut()
-                .expect("frame stack should not be empty");
-            frame.next_ordinal(&CounterKind::Loop)
-        };
         let keyword = match origin {
             ast::LoopOrigin::While => "while",
             ast::LoopOrigin::For => "for",
@@ -490,6 +497,21 @@ impl<'a> AstGraphBuilder<'a> {
             "{keyword} ({})",
             render_expr_compact_ast(self.body, condition)
         );
+        self.visit_loop_with_label(label, condition, body);
+    }
+
+    /// Emit a loop node with a pre-rendered label. `condition` is the
+    /// expression shown in the loop header (while-condition or for-in
+    /// collection); it provides the node's source span and embedded calls.
+    fn visit_loop_with_label(&mut self, label: String, condition: ast::ExprId, body: ast::ExprId) {
+        let parent_depth = self.frames.len();
+        let ordinal = {
+            let frame = self
+                .frames
+                .last_mut()
+                .expect("frame stack should not be empty");
+            frame.next_ordinal(&CounterKind::Loop)
+        };
         let slug_base = slugify(&label);
         let slug = if slug_base.is_empty() {
             format!("loop-{ordinal}")
@@ -507,7 +529,8 @@ impl<'a> AstGraphBuilder<'a> {
             label,
             Some(condition.into_raw().into_u32()),
             NodeType::Loop,
-        );
+        )
+        .with_callee_names(collect_callee_names(self.body, condition));
         self.graph.add_node(node);
         let parent_index = self.current_parent_index();
         self.register_child_with_parent(parent_index, node_id);
@@ -590,16 +613,22 @@ impl<'a> AstGraphBuilder<'a> {
             Some(call_expr.into_raw().into_u32()),
             NodeType::OtherScope,
         )
-        .with_callee_name(callee_name);
+        .with_callee_name(callee_name)
+        .with_callee_names(collect_callee_names(self.body, call_expr));
         self.graph.add_node(node);
         let parent_index = self.current_parent_index();
         self.register_child_with_parent(parent_index, node_id);
         // Note: no frame push / recursion — call nodes are leaves.
     }
 
-    // -- Return leaf (leaf node for return statements with non-call values) --
+    // -- Return leaf (terminal node for return statements) --
 
-    fn emit_return_leaf(&mut self, return_expr: ast::ExprId, label: &str) {
+    fn emit_return_leaf(
+        &mut self,
+        return_expr: Option<ast::ExprId>,
+        return_stmt: Option<ast::StmtId>,
+        label: &str,
+    ) {
         let ordinal = {
             let frame = self
                 .frames
@@ -617,17 +646,40 @@ impl<'a> AstGraphBuilder<'a> {
         let log_filter_key = self.build_log_filter_key(&segment);
         let node_id = self.graph.allocate_id();
         let parent_id = self.current_parent_id();
-        let node = Node::new(
+        let source_expr = return_expr
+            .map(|e| e.into_raw().into_u32())
+            .or_else(|| return_stmt.map(stmt_id_to_source_expr));
+        let mut node = Node::new(
             node_id,
             parent_id,
             log_filter_key,
             label.to_string(),
-            Some(return_expr.into_raw().into_u32()),
-            NodeType::OtherScope,
+            source_expr,
+            NodeType::Return,
         );
+        if let Some(expr) = return_expr {
+            // `return Foo(...)` — keep the callee visible so the call can be
+            // expanded / recognized as an LLM call like any other call node.
+            if matches!(
+                self.body.exprs[expr],
+                ast::Expr::Call { .. } | ast::Expr::OptionalCall { .. }
+            ) {
+                node = node.with_callee_name(call_callee_name(self.body, expr));
+            }
+            node = node.with_callee_names(collect_callee_names(self.body, expr));
+        }
         self.graph.add_node(node);
         let parent_index = self.current_parent_index();
         self.register_child_with_parent(parent_index, node_id);
+    }
+
+    /// Stop linear-flow edge chaining in the current frame: the next sibling
+    /// node will not receive an incoming edge from the node just emitted.
+    /// Used after `return`, which exits the function.
+    fn mark_flow_terminal(&mut self) {
+        if let Some(frame) = self.frames.last_mut() {
+            frame.last_linear_child = None;
+        }
     }
 
     // -- OtherScope --
@@ -660,7 +712,8 @@ impl<'a> AstGraphBuilder<'a> {
             node_label,
             Some(inner_expr.into_raw().into_u32()),
             NodeType::OtherScope,
-        );
+        )
+        .with_callee_names(collect_callee_names(self.body, inner_expr));
         self.graph.add_node(node);
         let parent_index = self.current_parent_index();
         self.register_child_with_parent(parent_index, node_id);
@@ -760,6 +813,231 @@ fn call_callee_name(body: &ast::ExprBody, id: ast::ExprId) -> String {
             render_expr_compact_ast(body, *callee)
         }
         _ => render_expr_compact_ast(body, id),
+    }
+}
+
+/// Render the display name of a call's callee expression.
+///
+/// Generic instantiations (`foo<int>(x)`) unwrap to the base path so the
+/// name stays a plain identifier instead of the renderer's `...` fallback.
+fn callee_display_name(body: &ast::ExprBody, callee: ast::ExprId) -> String {
+    match &body.exprs[callee] {
+        ast::Expr::GenericApply { base, .. } => render_expr_compact_ast(body, *base),
+        _ => render_expr_compact_ast(body, callee),
+    }
+}
+
+/// Collect the names of ALL functions called anywhere within the expression
+/// subtree rooted at `id` — nested calls, call arguments, binary operands,
+/// block statements, match arms, catch arms, etc.
+///
+/// This generalizes [`call_callee_name`] (which only inspects the top-level
+/// expression) so that calls embedded inside another node's expression — for
+/// example `if (Abs(LineTotal(items) - total) > 0.02)` — become visible on
+/// the CFG node for that expression.
+///
+/// Names are rendered exactly as written in source (`LineTotal` stays bare;
+/// `utils.Abs` stays qualified), deduplicated, in first-encounter order.
+fn collect_callee_names(body: &ast::ExprBody, id: ast::ExprId) -> Vec<String> {
+    let mut names = Vec::new();
+    collect_callee_names_expr(body, id, &mut names);
+    names
+}
+
+fn push_callee_name(names: &mut Vec<String>, name: String) {
+    if !names.contains(&name) {
+        names.push(name);
+    }
+}
+
+fn collect_callee_names_expr(body: &ast::ExprBody, id: ast::ExprId, names: &mut Vec<String>) {
+    match &body.exprs[id] {
+        ast::Expr::Call { callee, args, .. } => {
+            push_callee_name(names, callee_display_name(body, *callee));
+            collect_callee_names_expr(body, *callee, names);
+            for arg in args {
+                collect_callee_names_expr(body, arg.expr, names);
+            }
+        }
+        ast::Expr::OptionalCall { callee, args } => {
+            push_callee_name(names, callee_display_name(body, *callee));
+            collect_callee_names_expr(body, *callee, names);
+            for arg in args {
+                collect_callee_names_expr(body, arg.expr, names);
+            }
+        }
+
+        ast::Expr::GenericApply { base, .. } => collect_callee_names_expr(body, *base, names),
+        ast::Expr::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            collect_callee_names_expr(body, *condition, names);
+            collect_callee_names_expr(body, *then_branch, names);
+            if let Some(else_branch) = else_branch {
+                collect_callee_names_expr(body, *else_branch, names);
+            }
+        }
+        ast::Expr::IfLet {
+            scrutinee,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            collect_callee_names_expr(body, *scrutinee, names);
+            collect_callee_names_expr(body, *then_branch, names);
+            if let Some(else_branch) = else_branch {
+                collect_callee_names_expr(body, *else_branch, names);
+            }
+        }
+        ast::Expr::Match {
+            scrutinee, arms, ..
+        } => {
+            collect_callee_names_expr(body, *scrutinee, names);
+            for arm_id in arms {
+                let arm = &body.match_arms[*arm_id];
+                if let Some(guard) = arm.guard {
+                    collect_callee_names_expr(body, guard, names);
+                }
+                collect_callee_names_expr(body, arm.body, names);
+            }
+        }
+        ast::Expr::Is { scrutinee, .. } => collect_callee_names_expr(body, *scrutinee, names),
+        ast::Expr::Catch { base, clauses } => {
+            collect_callee_names_expr(body, *base, names);
+            for clause in clauses {
+                for arm_id in &clause.arms {
+                    collect_callee_names_expr(body, body.catch_arms[*arm_id].body, names);
+                }
+            }
+        }
+        ast::Expr::Throw { value } => collect_callee_names_expr(body, *value, names),
+        ast::Expr::Spawn {
+            name,
+            with_exprs,
+            body: spawn_body,
+        } => {
+            if let Some(name) = name {
+                collect_callee_names_expr(body, *name, names);
+            }
+            for with_expr in with_exprs {
+                collect_callee_names_expr(body, *with_expr, names);
+            }
+            collect_callee_names_expr(body, *spawn_body, names);
+        }
+        ast::Expr::Await { future } => collect_callee_names_expr(body, *future, names),
+        ast::Expr::Binary { lhs, rhs, .. } => {
+            collect_callee_names_expr(body, *lhs, names);
+            collect_callee_names_expr(body, *rhs, names);
+        }
+        ast::Expr::Unary { expr, .. } => collect_callee_names_expr(body, *expr, names),
+        ast::Expr::Object {
+            fields, spreads, ..
+        } => {
+            for (_, field_expr) in fields {
+                collect_callee_names_expr(body, *field_expr, names);
+            }
+            for spread in spreads {
+                collect_callee_names_expr(body, spread.expr, names);
+            }
+        }
+        ast::Expr::Array { elements } => {
+            for element in elements {
+                collect_callee_names_expr(body, *element, names);
+            }
+        }
+        ast::Expr::Map { entries } => {
+            for (key, value) in entries {
+                collect_callee_names_expr(body, *key, names);
+                collect_callee_names_expr(body, *value, names);
+            }
+        }
+        ast::Expr::Block { stmts, tail_expr } => {
+            for stmt_id in stmts {
+                collect_callee_names_stmt(body, *stmt_id, names);
+            }
+            if let Some(tail) = tail_expr {
+                collect_callee_names_expr(body, *tail, names);
+            }
+        }
+        ast::Expr::MemberAccess { base, .. }
+        | ast::Expr::OptionalMemberAccess { base, .. }
+        | ast::Expr::Upcast { base, .. } => collect_callee_names_expr(body, *base, names),
+        ast::Expr::Index { base, index } | ast::Expr::OptionalIndex { base, index } => {
+            collect_callee_names_expr(body, *base, names);
+            collect_callee_names_expr(body, *index, names);
+        }
+        ast::Expr::OptionalChain { expr } => collect_callee_names_expr(body, *expr, names),
+
+        // Leaves (no nested expressions in this body's arena). Lambda bodies
+        // live in their own ExprBody, so they cannot be walked from here.
+        ast::Expr::Literal(_)
+        | ast::Expr::ByteStringLiteral(_)
+        | ast::Expr::Null
+        | ast::Expr::Path(_)
+        | ast::Expr::Lambda(_)
+        | ast::Expr::Missing => {}
+    }
+}
+
+fn collect_callee_names_stmt(body: &ast::ExprBody, id: ast::StmtId, names: &mut Vec<String>) {
+    match &body.stmts[id] {
+        ast::Stmt::Expr(expr) => collect_callee_names_expr(body, *expr, names),
+        ast::Stmt::Let {
+            initializer,
+            else_branch,
+            ..
+        } => {
+            if let Some(init) = initializer {
+                collect_callee_names_expr(body, *init, names);
+            }
+            if let Some(else_branch) = else_branch {
+                collect_callee_names_expr(body, *else_branch, names);
+            }
+        }
+        ast::Stmt::While {
+            condition,
+            body: loop_body,
+            after,
+            ..
+        } => {
+            collect_callee_names_expr(body, *condition, names);
+            collect_callee_names_expr(body, *loop_body, names);
+            if let Some(after) = after {
+                collect_callee_names_stmt(body, *after, names);
+            }
+        }
+        ast::Stmt::WhileLet {
+            scrutinee,
+            body: loop_body,
+            ..
+        } => {
+            collect_callee_names_expr(body, *scrutinee, names);
+            collect_callee_names_expr(body, *loop_body, names);
+        }
+        ast::Stmt::For {
+            collection,
+            body: loop_body,
+            ..
+        } => {
+            collect_callee_names_expr(body, *collection, names);
+            collect_callee_names_expr(body, *loop_body, names);
+        }
+        ast::Stmt::Return(expr) => {
+            if let Some(expr) = expr {
+                collect_callee_names_expr(body, *expr, names);
+            }
+        }
+        ast::Stmt::Throw { value } => collect_callee_names_expr(body, *value, names),
+        ast::Stmt::Assign { target, value } | ast::Stmt::AssignOp { target, value, .. } => {
+            collect_callee_names_expr(body, *target, names);
+            collect_callee_names_expr(body, *value, names);
+        }
+        ast::Stmt::Break
+        | ast::Stmt::Continue
+        | ast::Stmt::Missing
+        | ast::Stmt::HeaderComment { .. } => {}
     }
 }
 
@@ -1107,6 +1385,39 @@ mod tests {
             .filter(|n| matches!(n.node_type, NodeType::BranchGroup))
             .collect();
         assert_eq!(groups.len(), 1);
+    }
+
+    #[test]
+    fn else_if_chain_without_final_else_gets_synthetic_else() {
+        // if (a) {} else if (b) {}  — no trailing else
+        let body = make_ast_body(|exprs, _, _, _| {
+            let cond1 = exprs.alloc(ast::Expr::Literal(ast::Literal::Bool(true)));
+            let then1 = exprs.alloc(ast::Expr::Null);
+            let cond2 = exprs.alloc(ast::Expr::Literal(ast::Literal::Bool(false)));
+            let then2 = exprs.alloc(ast::Expr::Null);
+
+            let inner_if = exprs.alloc(ast::Expr::If {
+                condition: cond2,
+                then_branch: then2,
+                else_branch: None,
+            });
+
+            Some(exprs.alloc(ast::Expr::If {
+                condition: cond1,
+                then_branch: then1,
+                else_branch: Some(inner_if),
+            }))
+        });
+        let graph = build_control_flow_graph_from_ast("Func", &body);
+        // Root + BranchGroup + 3 arms (if, else if, synthetic else)
+        assert_eq!(graph.nodes.len(), 5);
+        let else_arm = graph
+            .nodes
+            .values()
+            .find(|n| n.label == "else")
+            .expect("chain without final else should get a synthetic else arm");
+        assert!(matches!(else_arm.node_type, NodeType::BranchArm));
+        assert!(else_arm.source_expr.is_none());
     }
 
     #[test]
@@ -1519,7 +1830,7 @@ mod tests {
             .values()
             .find(|n| n.label.starts_with("return"))
             .expect("should have return node");
-        assert!(matches!(ret_node.node_type, NodeType::OtherScope));
+        assert!(matches!(ret_node.node_type, NodeType::Return));
         assert!(
             ret_node.label.contains("MyResponse"),
             "Return label should include the type name, got: {}",
@@ -1548,14 +1859,117 @@ mod tests {
             }))
         });
         let graph = build_control_flow_graph_from_ast("Func", &body);
-        // Root + call scope (no extra return node — calls are handled by visit_expr)
+        // Root + a single Return node that doubles as the call site.
         assert_eq!(graph.nodes.len(), 2);
         let call_node = graph
             .nodes
             .values()
             .find(|n| n.label.contains("Process"))
-            .expect("should have call node");
-        assert!(matches!(call_node.node_type, NodeType::OtherScope));
+            .expect("should have return-call node");
+        assert!(matches!(call_node.node_type, NodeType::Return));
+        assert_eq!(
+            call_node.callee_name.as_deref(),
+            Some("Process"),
+            "return-of-call keeps the callee visible for expansion/LLM marking"
+        );
+        assert!(
+            call_node.source_expr.is_some(),
+            "return-of-call points at the call expression for expansion"
+        );
+    }
+
+    #[test]
+    fn bare_return_creates_terminal_node() {
+        let body = make_ast_body(|exprs, stmts, _, _| {
+            let ret = stmts.alloc(ast::Stmt::Return(None));
+            Some(exprs.alloc(ast::Expr::Block {
+                stmts: vec![ret],
+                tail_expr: None,
+            }))
+        });
+        let graph = build_control_flow_graph_from_ast("Func", &body);
+        assert_eq!(graph.nodes.len(), 2);
+        let ret_node = graph
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::Return))
+            .expect("bare return should create a node");
+        assert_eq!(ret_node.label, "return");
+        let se = ret_node.source_expr.expect("bare return has a stmt span");
+        assert!(se & STMT_SOURCE_EXPR_TAG != 0);
+    }
+
+    #[test]
+    fn early_return_has_no_outgoing_edges() {
+        // { return 1; Cleanup() } — the statement after the return must not
+        // receive an edge from the return node.
+        let body = make_ast_body(|exprs, stmts, _, _| {
+            let one = exprs.alloc(ast::Expr::Literal(ast::Literal::Int(1)));
+            let ret = stmts.alloc(ast::Stmt::Return(Some(one)));
+            let callee = exprs.alloc(ast::Expr::Path(vec!["Cleanup".into()]));
+            let call = exprs.alloc(ast::Expr::Call {
+                callee,
+                type_args: vec![],
+                args: vec![],
+            });
+            let call_stmt = stmts.alloc(ast::Stmt::Expr(call));
+            Some(exprs.alloc(ast::Expr::Block {
+                stmts: vec![ret, call_stmt],
+                tail_expr: None,
+            }))
+        });
+        let graph = build_control_flow_graph_from_ast("Func", &body);
+        let ret_node = graph
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::Return))
+            .expect("should have return node");
+        assert!(
+            graph.edges_by_src.get(&ret_node.id).is_none(),
+            "return node must be terminal (no outgoing edges)"
+        );
+    }
+
+    #[test]
+    fn for_in_loop_creates_loop_node_and_visits_body() {
+        // for (let item in items) { //# Inside }
+        let body = make_ast_body(|exprs, stmts, patterns, _| {
+            let collection = exprs.alloc(ast::Expr::Path(vec!["items".into()]));
+            let binding = patterns.alloc(ast::Pattern::Bind {
+                name: "item".into(),
+                subpat: None,
+            });
+            let header = stmts.alloc(ast::Stmt::HeaderComment {
+                name: "Inside".into(),
+                level: 1,
+            });
+            let loop_body = exprs.alloc(ast::Expr::Block {
+                stmts: vec![header],
+                tail_expr: None,
+            });
+            let for_stmt = stmts.alloc(ast::Stmt::For {
+                binding,
+                collection,
+                body: loop_body,
+            });
+            Some(exprs.alloc(ast::Expr::Block {
+                stmts: vec![for_stmt],
+                tail_expr: None,
+            }))
+        });
+        let graph = build_control_flow_graph_from_ast("Func", &body);
+        let loop_node = graph
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::Loop))
+            .expect("for-in loop should create a Loop node");
+        assert!(loop_node.label.starts_with("for ("), "{}", loop_node.label);
+        let header = graph
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::HeaderContextEnter))
+            .expect("header inside for body should be visited");
+        assert_eq!(header.parent_node_id, Some(loop_node.id));
     }
 
     #[test]
@@ -1634,5 +2048,143 @@ mod tests {
 
         let rendered = render_expr_compact_ast(&body, obj);
         assert_eq!(rendered, "Resp { ... }");
+    }
+
+    /// Calls embedded inside another node's expression must surface via
+    /// `callee_names` even though they don't get CFG nodes of their own.
+    ///
+    /// Fixture mirrors:
+    /// ```baml
+    /// function ValidateInvoice(inv: Invoice) -> ValidationIssue[] {
+    ///     if (Abs(LineTotal(inv.line_items) - inv.total) > 0.02) {
+    ///         // ...
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Resulting nodes (documented here as the contract):
+    /// - `[0]` FunctionRoot "ValidateInvoice"            — calleeNames: []
+    /// - `[1]` BranchGroup  "if (Abs(LineTotal(inv.line_items) - inv.total) > 0.02)"
+    ///                                                    — calleeNames: ["Abs", "LineTotal"]
+    /// - `[2]` BranchArm    "if (...)" (then branch)      — calleeNames: []
+    /// - `[3]` Header       "Flag mismatch"               — calleeNames: []
+    /// - `[4]` BranchArm    "else" (synthetic)            — calleeNames: []
+    ///
+    /// Names come out exactly as written in source — bare `"Abs"` /
+    /// `"LineTotal"`, NOT qualified (`main.Abs`), in first-encounter order
+    /// (outermost call first).
+    #[test]
+    fn embedded_calls_in_if_condition_surface_in_callee_names() {
+        let body = make_ast_body(|exprs, stmts, _, _| {
+            // LineTotal(inv.line_items)
+            let line_total_callee = exprs.alloc(ast::Expr::Path(vec!["LineTotal".into()]));
+            let line_items = exprs.alloc(ast::Expr::Path(vec!["inv".into(), "line_items".into()]));
+            let line_total_call = exprs.alloc(ast::Expr::Call {
+                callee: line_total_callee,
+                type_args: vec![],
+                args: vec![ast::CallArg::positional(line_items)],
+            });
+            // LineTotal(inv.line_items) - inv.total
+            let inv_total = exprs.alloc(ast::Expr::Path(vec!["inv".into(), "total".into()]));
+            let diff = exprs.alloc(ast::Expr::Binary {
+                op: ast::BinaryOp::Sub,
+                lhs: line_total_call,
+                rhs: inv_total,
+            });
+            // Abs(...)
+            let abs_callee = exprs.alloc(ast::Expr::Path(vec!["Abs".into()]));
+            let abs_call = exprs.alloc(ast::Expr::Call {
+                callee: abs_callee,
+                type_args: vec![],
+                args: vec![ast::CallArg::positional(diff)],
+            });
+            // Abs(...) > 0.02
+            let threshold = exprs.alloc(ast::Expr::Literal(ast::Literal::Float("0.02".into())));
+            let cond = exprs.alloc(ast::Expr::Binary {
+                op: ast::BinaryOp::Gt,
+                lhs: abs_call,
+                rhs: threshold,
+            });
+            // A header inside the then-branch keeps the if rendered through
+            // the visualization prep pruning.
+            let header = stmts.alloc(ast::Stmt::HeaderComment {
+                name: "Flag mismatch".into(),
+                level: 1,
+            });
+            let then_b = exprs.alloc(ast::Expr::Block {
+                stmts: vec![header],
+                tail_expr: None,
+            });
+            Some(exprs.alloc(ast::Expr::If {
+                condition: cond,
+                then_branch: then_b,
+                else_branch: None,
+            }))
+        });
+        let graph = build_control_flow_graph_from_ast("ValidateInvoice", &body);
+
+        // Root + BranchGroup + then arm + header + synthetic else arm.
+        assert_eq!(graph.nodes.len(), 5);
+        let if_node = graph
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::BranchGroup))
+            .expect("should have BranchGroup for the if");
+        assert_eq!(
+            if_node.label,
+            "if (Abs(LineTotal(inv.line_items) - inv.total) > 0.02)"
+        );
+        assert_eq!(
+            if_node.callee_names,
+            vec!["Abs".to_string(), "LineTotal".to_string()],
+            "if-condition node must expose embedded calls, bare and outermost-first"
+        );
+        // `callee_name` (singular) stays reserved for nodes that ARE a call.
+        assert!(if_node.callee_name.is_none());
+
+        // The field must survive the visualization prep pipeline.
+        let prepared = super::super::prepare_control_flow_graph_for_visualization(&graph);
+        let prepared_if = prepared
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::BranchGroup))
+            .expect("BranchGroup survives visualization prep");
+        assert_eq!(
+            prepared_if.callee_names,
+            vec!["Abs".to_string(), "LineTotal".to_string()]
+        );
+    }
+
+    /// Nested calls in call arguments surface on the call's own node too:
+    /// `Process(Helper(x))` yields calleeNames ["Process", "Helper"] while
+    /// callee_name (singular) remains just "Process".
+    #[test]
+    fn nested_call_arguments_surface_in_callee_names() {
+        let body = make_ast_body(|exprs, _, _, _| {
+            let helper_callee = exprs.alloc(ast::Expr::Path(vec!["Helper".into()]));
+            let x = exprs.alloc(ast::Expr::Path(vec!["x".into()]));
+            let helper_call = exprs.alloc(ast::Expr::Call {
+                callee: helper_callee,
+                type_args: vec![],
+                args: vec![ast::CallArg::positional(x)],
+            });
+            let process_callee = exprs.alloc(ast::Expr::Path(vec!["Process".into()]));
+            Some(exprs.alloc(ast::Expr::Call {
+                callee: process_callee,
+                type_args: vec![],
+                args: vec![ast::CallArg::positional(helper_call)],
+            }))
+        });
+        let graph = build_control_flow_graph_from_ast("Func", &body);
+        let call_node = graph
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::OtherScope))
+            .expect("should have call node");
+        assert_eq!(call_node.callee_name.as_deref(), Some("Process"));
+        assert_eq!(
+            call_node.callee_names,
+            vec!["Process".to_string(), "Helper".to_string()]
+        );
     }
 }

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/mod.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/mod.rs
@@ -59,6 +59,9 @@ pub enum NodeType {
     BranchArm,
     Loop,
     OtherScope,
+    /// A `return` statement. Terminal: it never has outgoing edges, since
+    /// control flow leaves the function here.
+    Return,
 }
 
 /// Source range for a graph node.
@@ -98,6 +101,15 @@ pub struct Node {
     pub llm_client: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub callee_name: Option<String>,
+    /// Names of ALL functions called anywhere within this node's source
+    /// expression subtree (nested calls, call arguments, binary operands,
+    /// block statements, …). Unlike `callee_name` — which is set only when
+    /// the node itself IS a call — this surfaces calls embedded inside
+    /// conditions, return values, and other compound expressions.
+    /// Serialized as `calleeNames`; omitted when empty (clients treat
+    /// missing as `[]`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub callee_names: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_span: Option<SourceSpan>,
     #[serde(default)]
@@ -122,6 +134,7 @@ impl Node {
             node_type,
             llm_client: None,
             callee_name: None,
+            callee_names: Vec::new(),
             source_span: None,
             is_container: false,
         }
@@ -147,6 +160,12 @@ impl Node {
     #[must_use]
     pub fn with_callee_name(mut self, callee_name: impl Into<String>) -> Self {
         self.callee_name = Some(callee_name.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_callee_names(mut self, callee_names: Vec<String>) -> Self {
+        self.callee_names = callee_names;
         self
     }
 }
@@ -377,6 +396,7 @@ pub fn describe_node_type(node_type: &NodeType) -> &'static str {
         NodeType::BranchArm => "branch-arm",
         NodeType::Loop => "loop",
         NodeType::OtherScope => "other-scope",
+        NodeType::Return => "return",
     }
 }
 

--- a/baml_language/crates/baml_lsp2_actions/src/actions.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/actions.rs
@@ -19,10 +19,10 @@
 //!   the Playground.
 
 use baml_base::SourceFile;
-use baml_compiler2_ast::ast::FunctionOrigin;
-use baml_compiler2_hir::{contributions::Definition, file_item_tree, file_symbol_contributions};
 use baml_compiler_parser::syntax_tree;
 use baml_compiler_syntax::{SyntaxElement, SyntaxKind, SyntaxNode, ast::StringLiteral};
+use baml_compiler2_ast::ast::FunctionOrigin;
+use baml_compiler2_hir::{contributions::Definition, file_item_tree, file_symbol_contributions};
 use rowan::ast::AstNode;
 use text_size::TextRange;
 

--- a/baml_language/crates/baml_lsp2_actions/src/actions.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/actions.rs
@@ -21,6 +21,9 @@
 use baml_base::SourceFile;
 use baml_compiler2_ast::ast::FunctionOrigin;
 use baml_compiler2_hir::{contributions::Definition, file_item_tree, file_symbol_contributions};
+use baml_compiler_parser::syntax_tree;
+use baml_compiler_syntax::{SyntaxElement, SyntaxKind, SyntaxNode, ast::StringLiteral};
+use rowan::ast::AstNode;
 use text_size::TextRange;
 
 use crate::Db;
@@ -37,6 +40,8 @@ pub enum FileActionKind {
     RunInPlayground,
     /// Run this test case in the BAML Playground.
     RunTest,
+    /// Run all tests in this testset.
+    RunTestSet,
 }
 
 // ── FileAction ────────────────────────────────────────────────────────────────
@@ -98,7 +103,66 @@ pub fn file_actions(db: &dyn Db, file: SourceFile) -> Vec<FileAction> {
         }
     }
 
+    // New expr-body `test "..."` and `testset "..."` blocks are desugared into a
+    // synthesized `$init_test` function during CST->AST lowering, so they never
+    // appear as contributions. Enumerate them directly from the syntax tree.
+    let tree = syntax_tree(db, file);
+    for node in tree.children() {
+        let (keyword, kind) = match node.kind() {
+            SyntaxKind::TEST_EXPR_DEF => (SyntaxKind::KW_TEST, FileActionKind::RunTest),
+            SyntaxKind::TESTSET_DEF => (SyntaxKind::KW_TESTSET, FileActionKind::RunTestSet),
+            _ => continue,
+        };
+        let Some(name_el) = test_name_element(&node, keyword) else {
+            continue;
+        };
+        let name = match name_el.as_node() {
+            Some(n) => StringLiteral::cast(n.clone())
+                .map(|s| s.value())
+                .unwrap_or_else(|| n.text().to_string()),
+            None => name_el
+                .as_token()
+                .map(|t| t.text().to_string())
+                .unwrap_or_default(),
+        };
+        actions.push(FileAction {
+            name,
+            name_span: name_el.text_range(),
+            kind,
+        });
+    }
+
     actions
+}
+
+/// Find the name element of a `test`/`testset` CST node: the first non-trivia
+/// element after the keyword, stopping at a `with` clause or the body block.
+fn test_name_element(node: &SyntaxNode, keyword: SyntaxKind) -> Option<SyntaxElement> {
+    let mut past_keyword = false;
+    for child in node.children_with_tokens() {
+        let k = child.kind();
+        if matches!(
+            k,
+            SyntaxKind::WHITESPACE
+                | SyntaxKind::NEWLINE
+                | SyntaxKind::LINE_COMMENT
+                | SyntaxKind::BLOCK_COMMENT
+                | SyntaxKind::HEADER_COMMENT
+        ) {
+            continue;
+        }
+        if k == keyword {
+            past_keyword = true;
+            continue;
+        }
+        if k == SyntaxKind::KW_WITH || k == SyntaxKind::BLOCK_EXPR {
+            break;
+        }
+        if past_keyword {
+            return Some(child);
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/baml_language/crates/baml_lsp2_actions/src/actions.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/actions.rs
@@ -107,15 +107,21 @@ pub fn file_actions(db: &dyn Db, file: SourceFile) -> Vec<FileAction> {
     // synthesized `$init_test` function during CST->AST lowering, so they never
     // appear as contributions. Enumerate them directly from the syntax tree.
     let tree = syntax_tree(db, file);
-    for node in tree.children() {
-        let (keyword, kind) = match node.kind() {
-            SyntaxKind::TEST_EXPR_DEF => (SyntaxKind::KW_TEST, FileActionKind::RunTest),
-            SyntaxKind::TESTSET_DEF => (SyntaxKind::KW_TESTSET, FileActionKind::RunTestSet),
-            _ => continue,
-        };
-        let Some(name_el) = test_name_element(&node, keyword) else {
-            continue;
-        };
+    collect_expr_body_test_actions(&tree, &mut actions);
+
+    actions
+}
+
+fn collect_expr_body_test_actions(node: &SyntaxNode, actions: &mut Vec<FileAction>) {
+    let action = match node.kind() {
+        SyntaxKind::TEST_EXPR_DEF => Some((SyntaxKind::KW_TEST, FileActionKind::RunTest)),
+        SyntaxKind::TESTSET_DEF => Some((SyntaxKind::KW_TESTSET, FileActionKind::RunTestSet)),
+        _ => None,
+    };
+
+    if let Some((keyword, kind)) = action
+        && let Some(name_el) = test_name_element(node, keyword)
+    {
         let name = match name_el.as_node() {
             Some(n) => StringLiteral::cast(n.clone())
                 .map(|s| s.value())
@@ -132,7 +138,9 @@ pub fn file_actions(db: &dyn Db, file: SourceFile) -> Vec<FileAction> {
         });
     }
 
-    actions
+    for child in node.children() {
+        collect_expr_body_test_actions(&child, actions);
+    }
 }
 
 /// Find the name element of a `test`/`testset` CST node: the first non-trivia
@@ -192,5 +200,42 @@ function Summarize(input: string) -> string {
 
         assert_eq!(playground_actions.len(), 1);
         assert_eq!(playground_actions[0].name, "Summarize");
+    }
+
+    #[test]
+    fn file_actions_include_tests_nested_in_testsets() {
+        let mut builder = ProjectTest::builder();
+        builder.source(
+            "main.baml",
+            r##"
+testset "math" {
+    test "adds" {
+        assert.equal(1 + 1, 2)
+    }
+
+    testset "nested" {
+        test "subtracts" {
+            assert.equal(2 - 1, 1)
+        }
+    }
+}
+"##,
+        );
+        let project = builder.build();
+
+        let actions = file_actions(&project.db, project.files[0]);
+        let tests: Vec<_> = actions
+            .iter()
+            .filter(|action| action.kind == FileActionKind::RunTest)
+            .map(|action| action.name.as_str())
+            .collect();
+        let testsets: Vec<_> = actions
+            .iter()
+            .filter(|action| action.kind == FileActionKind::RunTestSet)
+            .map(|action| action.name.as_str())
+            .collect();
+
+        assert_eq!(tests, vec!["adds", "subtracts"]);
+        assert_eq!(testsets, vec!["math", "nested"]);
     }
 }

--- a/baml_language/crates/baml_lsp2_actions/src/annotations.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/annotations.rs
@@ -34,8 +34,9 @@
 //!
 //! ## Scopes
 //!
-//! Types are resolved across the file's scopes (any-scope lookup) so a
-//! binding/expression living in a nested block or lambda still resolves.
+//! Types are resolved through the source span's ancestor scopes so a
+//! binding/expression living in a nested block or lambda resolves without
+//! accidentally matching an arena-local id from a different body.
 //!
 //! ## Suppression
 //!
@@ -56,7 +57,11 @@ use baml_compiler2_ast::{
     Expr, ExprId, Stmt,
     ast::{AstSourceMap, DeclarativeMeta, ExprBody, FunctionBodyDef, FunctionOrigin},
 };
-use baml_compiler2_hir::{body::FunctionBody, loc::FunctionLoc};
+use baml_compiler2_hir::{
+    body::FunctionBody,
+    loc::FunctionLoc,
+    scope::{FileScopeId, ScopeKind},
+};
 use baml_compiler2_tir::{inference::infer_scope_types, ty::Ty};
 use text_size::TextSize;
 
@@ -132,7 +137,19 @@ pub fn annotations(db: &dyn Db, file: SourceFile) -> Vec<InlineAnnotation> {
             continue;
         };
 
-        process_body(db, file, &index, expr_body, &source_map, &mut out);
+        let owner_scope = function_scope_for(&index, func_data.span, &func_data.name)
+            .unwrap_or_else(|| {
+                index.scope_at_offset(func_data.span.start(), Some(&func_data.name))
+            });
+        process_body(
+            db,
+            file,
+            &index,
+            owner_scope,
+            expr_body,
+            &source_map,
+            &mut out,
+        );
     }
 
     // Sort by offset to ensure document order (required by LSP).
@@ -148,6 +165,7 @@ fn process_body(
     db: &dyn Db,
     file: SourceFile,
     index: &SemanticIndex<'_>,
+    owner_scope: FileScopeId,
     body: &ExprBody,
     source_map: &AstSourceMap,
     out: &mut Vec<InlineAnnotation>,
@@ -163,8 +181,10 @@ fn process_body(
         let pat = &body.patterns[*pattern];
         if matches!(
             pat,
-            baml_compiler2_ast::Pattern::Bind { subpat: Some(_), .. }
-                | baml_compiler2_ast::Pattern::Type(_)
+            baml_compiler2_ast::Pattern::Bind {
+                subpat: Some(_),
+                ..
+            } | baml_compiler2_ast::Pattern::Type(_)
         ) {
             continue;
         }
@@ -179,11 +199,14 @@ fn process_body(
             continue;
         }
 
-        // Resolve the binding's type across all scopes (the binding may live in
-        // a nested block / lambda scope, not the body's own scope).
+        // Resolve through the binding's real source scope chain. PatIds are
+        // arena-local, so scanning every file scope can hit a foreign body that
+        // happens to reuse the same numeric id.
         let mut ty_str: Option<String> = None;
-        for scope_id in &index.scope_ids {
-            let inference = infer_scope_types(db, *scope_id);
+        let use_scope = scope_at_offset_within_body(index, pat_span.start(), owner_scope);
+        for file_scope_id in ancestor_scopes_within_body(index, use_scope, owner_scope) {
+            let scope_id = index.scope_ids[file_scope_id.index() as usize];
+            let inference = infer_scope_types(db, scope_id);
             if let Some(ty) = inference.binding_type(*pattern) {
                 if !should_suppress_type(ty) {
                     ty_str = Some(utils::display_ty_for_file(db, file, ty));
@@ -205,7 +228,7 @@ fn process_body(
     }
 
     // ── Parameter-name hints on calls + recurse into lambdas ──────────────────
-    for (_expr_id, expr) in body.exprs.iter() {
+    for (expr_id, expr) in body.exprs.iter() {
         match expr {
             Expr::Call { callee, args, .. } => {
                 // Skip synthesized test/testset registration calls — their
@@ -215,12 +238,20 @@ fn process_body(
                 if is_synthetic_registration(body, *callee) {
                     continue;
                 }
+                let callee_span = source_map.expr_span(*callee);
+                if callee_span.is_empty() {
+                    continue;
+                }
+
                 // Find a scope where the callee resolves to a function type.
-                // ExprIds are arena-local (per body), so a foreign scope may
-                // hold the same numeric id; on an arity mismatch keep searching
-                // rather than giving up, so the correct same-arena scope wins.
-                for scope_id in &index.scope_ids {
-                    let inference = infer_scope_types(db, *scope_id);
+                // ExprIds are arena-local (per body), so restrict lookup to the
+                // callee's source scope chain instead of scanning every scope in
+                // the file for the first matching numeric id.
+                let use_scope =
+                    scope_at_offset_within_body(index, callee_span.start(), owner_scope);
+                for file_scope_id in ancestor_scopes_within_body(index, use_scope, owner_scope) {
+                    let scope_id = index.scope_ids[file_scope_id.index() as usize];
+                    let inference = infer_scope_types(db, scope_id);
                     let Some(Ty::Function { params, .. }) = inference.expression_type(*callee)
                     else {
                         continue;
@@ -259,7 +290,10 @@ fn process_body(
             // own body + source map — recurse so their lets and calls get hints.
             Expr::Lambda(func_def) => {
                 if let Some(FunctionBodyDef::Expr(lbody, lsmap)) = &func_def.body {
-                    process_body(db, file, index, lbody, lsmap, out);
+                    let lambda_scope = index
+                        .lambda_scope_for(source_map.expr_span(expr_id))
+                        .unwrap_or(owner_scope);
+                    process_body(db, file, index, lambda_scope, lbody, lsmap, out);
                 }
             }
             _ => {}
@@ -296,6 +330,64 @@ fn is_synthetic_registration(body: &ExprBody, callee: ExprId) -> bool {
         _ => return false,
     };
     matches!(name, "register_test" | "register_test_set")
+}
+
+fn function_scope_for(
+    index: &SemanticIndex<'_>,
+    span: text_size::TextRange,
+    name: &baml_base::Name,
+) -> Option<FileScopeId> {
+    index
+        .scopes
+        .iter()
+        .enumerate()
+        .find(|(_, scope)| {
+            matches!(scope.kind, ScopeKind::Function)
+                && scope.range == span
+                && scope.name.as_ref() == Some(name)
+        })
+        .map(|(idx, _)| FileScopeId::new(u32::try_from(idx).expect("scope index fits in u32")))
+}
+
+fn scope_at_offset_within_body(
+    index: &SemanticIndex<'_>,
+    offset: TextSize,
+    owner_scope: FileScopeId,
+) -> FileScopeId {
+    let scope_id = index.scope_at_offset(offset, None);
+    if scope_is_descendant_or_self(index, scope_id, owner_scope) {
+        scope_id
+    } else {
+        owner_scope
+    }
+}
+
+fn ancestor_scopes_within_body(
+    index: &SemanticIndex<'_>,
+    start_scope: FileScopeId,
+    owner_scope: FileScopeId,
+) -> Vec<FileScopeId> {
+    let mut scopes = Vec::new();
+    let mut current = Some(start_scope);
+    while let Some(scope_id) = current {
+        scopes.push(scope_id);
+        if scope_id == owner_scope {
+            return scopes;
+        }
+        current = index.scopes[scope_id.index() as usize].parent;
+    }
+    vec![owner_scope]
+}
+
+fn scope_is_descendant_or_self(
+    index: &SemanticIndex<'_>,
+    scope_id: FileScopeId,
+    owner_scope: FileScopeId,
+) -> bool {
+    scope_id == owner_scope
+        || index.scopes[owner_scope.index() as usize]
+            .descendants
+            .contains(&scope_id)
 }
 
 #[cfg(test)]
@@ -432,6 +524,46 @@ testset "math" {
                 .iter()
                 .all(|label| !matches!(*label, "name: " | "body: " | "collector: " | "runner: ")),
             "synthesized test/testset registration hints should be suppressed, got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn call_parameter_hints_use_the_calls_own_scope() {
+        let mut builder = ProjectTest::builder();
+        let source = r##"
+function Left(alpha: string) -> string {
+    alpha
+}
+
+function Right(beta: string) -> string {
+    beta
+}
+
+function Earlier() -> string {
+    Left("x")
+}
+
+function Later() -> string {
+    Right("y")
+}
+"##;
+        builder.source("main.baml", source);
+        let project = builder.build();
+
+        let hints = annotations(&project.db, project.files[0]);
+        let y_offset = TextSize::from(
+            u32::try_from(source.find("\"y\"").expect("test arg")).expect("offset fits"),
+        );
+        let labels_at_y: Vec<_> = hints
+            .iter()
+            .filter(|hint| hint.offset == y_offset)
+            .map(|hint| hint.label.as_str())
+            .collect();
+
+        assert_eq!(
+            labels_at_y,
+            vec!["beta: "],
+            "expected Later's call to use Right's parameter, got {labels_at_y:?}"
         );
     }
 }

--- a/baml_language/crates/baml_lsp2_actions/src/annotations.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/annotations.rs
@@ -1,8 +1,11 @@
 //! Inline type / parameter-name annotations for BAML files (inlay hints).
 //!
 //! Provides `annotations(db, file) -> Vec<InlineAnnotation>` — a regular
-//! function (not a Salsa query) that walks all expression-body functions in a
-//! file and produces two kinds of hints:
+//! function (not a Salsa query) that walks expression-body functions in a file
+//! (top-level functions, class/interface methods, and the synthesized
+//! `$init_test` registration functions), recursing into lambda bodies (e.g.
+//! the bodies of `test` / `testset` blocks, which lower to lambdas passed to
+//! `register_test`). It produces two kinds of hints:
 //!
 //! ## Type hints on `let` bindings
 //!
@@ -29,6 +32,11 @@
 //!
 //! Each hint is positioned at the start of the argument's span.
 //!
+//! ## Scopes
+//!
+//! Types are resolved across the file's scopes (any-scope lookup) so a
+//! binding/expression living in a nested block or lambda still resolves.
+//!
 //! ## Suppression
 //!
 //! We suppress type hints for:
@@ -39,17 +47,22 @@
 //! - The callee type is not `Ty::Function` (no param info)
 //! - The param name is `None` (positional-only parameter)
 //! - The argument count != param count (variadic / error cases)
+//!
+//! LLM declarative functions are skipped entirely (and never recursed into), so
+//! their synthetic `client` / `function_name` / `args` calls produce no hints.
 
 use baml_base::SourceFile;
 use baml_compiler2_ast::{
-    Expr, Stmt,
-    ast::{DeclarativeMeta, FunctionOrigin},
+    Expr, ExprId, Stmt,
+    ast::{AstSourceMap, DeclarativeMeta, ExprBody, FunctionBodyDef, FunctionOrigin},
 };
-use baml_compiler2_hir::{body::FunctionBody, loc::FunctionLoc, scope::ScopeKind};
-use baml_compiler2_tir::ty::Ty;
+use baml_compiler2_hir::{body::FunctionBody, loc::FunctionLoc};
+use baml_compiler2_tir::{inference::infer_scope_types, ty::Ty};
 use text_size::TextSize;
 
 use crate::{Db, utils};
+
+type SemanticIndex<'a> = baml_compiler2_hir::semantic_index::FileSemanticIndex<'a>;
 
 // ── Public types ──────────────────────────────────────────────────────────────
 
@@ -94,7 +107,15 @@ pub fn annotations(db: &dyn Db, file: SourceFile) -> Vec<InlineAnnotation> {
     let mut out: Vec<InlineAnnotation> = Vec::new();
 
     for (func_local_id, func_data) in &item_tree.functions {
-        if func_data.origin != FunctionOrigin::UserDefined
+        // Process user-written functions and methods, plus the synthesized
+        // `$init_test*` registration functions (so test/testset bodies — which
+        // lower to lambdas — get hints). Skip LLM declarative functions: we must
+        // never surface their synthetic `client` / `function_name` / `args`
+        // calls, and since we don't recurse into skipped functions, their
+        // internals stay hidden.
+        let is_user = func_data.origin == FunctionOrigin::UserDefined;
+        let is_test_init = func_data.name.as_str().starts_with("$init_test");
+        if (!is_user && !is_test_init)
             || matches!(func_data.declarative_meta, Some(DeclarativeMeta::Llm(_)))
         {
             continue;
@@ -102,179 +123,148 @@ pub fn annotations(db: &dyn Db, file: SourceFile) -> Vec<InlineAnnotation> {
 
         let func_loc = FunctionLoc::new(db, file, *func_local_id);
 
-        // Only expression-body functions have type information we can display.
         let body = baml_compiler2_hir::body::function_body(db, func_loc);
         let FunctionBody::Expr(expr_body) = body.as_ref() else {
             continue;
         };
-
-        // Source map gives ExprId/StmtId/PatId → TextRange.
         let Some(source_map) = baml_compiler2_hir::body::function_body_source_map(db, func_loc)
         else {
             continue;
         };
 
-        // Find the function's scope in the semantic index.
-        let func_scope_file_id = index
-            .scopes
-            .iter()
-            .enumerate()
-            .find(|(_, s)| s.kind == ScopeKind::Function && s.range == func_data.span)
-            .map(|(i, _)| {
-                #[allow(clippy::cast_possible_truncation)]
-                baml_compiler2_hir::scope::FileScopeId::new(i as u32)
-            });
-
-        let Some(func_scope_file_id) = func_scope_file_id else {
-            continue;
-        };
-
-        let func_scope_id = index.scope_ids[func_scope_file_id.index() as usize];
-        let inference = baml_compiler2_tir::inference::infer_scope_types(db, func_scope_id);
-
-        // ── Type hints for let bindings without annotations ───────────────────
-
-        for (stmt_id, stmt) in expr_body.stmts.iter() {
-            let Stmt::Let { pattern, .. } = stmt else {
-                continue;
-            };
-
-            // Skip if the pattern itself encodes an annotation (a `Chain`
-            // with at least one `Type` link). Plain `Pattern::Bind` means
-            // the user wrote no annotation — that's where we want hints.
-            //
-            // STUB(patterns/phase2): a more accurate check would walk the
-            // chain looking for Type links. For now we just check if the
-            // outermost pattern is a Chain — any chain is treated as
-            // "has annotation."
-            let pat = &expr_body.patterns[*pattern];
-            // A `let x: <pattern>` binding (Bind with sub-pattern) or a
-            // bare type pattern already carries an explicit annotation
-            // — skip.
-            if matches!(
-                pat,
-                baml_compiler2_ast::Pattern::Bind {
-                    subpat: Some(_),
-                    ..
-                } | baml_compiler2_ast::Pattern::Type(_)
-            ) {
-                continue;
-            }
-
-            // Get the binding name to suppress hints for `_`.
-            let Some(binding_name) = pat.binding_name(&expr_body.patterns) else {
-                continue; // Not a simple binding (or `_` wildcard) — skip
-            };
-            let _binding_name = binding_name.as_str();
-
-            // Look up the inferred type.
-            let Some(ty) = inference.binding_type(*pattern) else {
-                // Try other scopes for nested blocks.
-                let ty_str = find_binding_ty_any_scope(db, file, index, *pattern);
-                if let Some(ty_str) = ty_str {
-                    // Emit hint: position at end of pattern span.
-                    let pat_span = source_map.pattern_span(*pattern);
-                    if !pat_span.is_empty() {
-                        out.push(InlineAnnotation {
-                            offset: pat_span.end(),
-                            label: format!(": {ty_str}"),
-                            kind: AnnotationKind::Type,
-                            padding_left: false,
-                            padding_right: true,
-                        });
-                    }
-                }
-                continue;
-            };
-
-            // Suppress noisy / unhelpful types.
-            if should_suppress_type(ty) {
-                continue;
-            }
-
-            let ty_str = utils::display_ty_for_file(db, file, ty);
-
-            // Position the hint at the end of the pattern span (after the var name).
-            let pat_span = source_map.pattern_span(*pattern);
-            if pat_span.is_empty() {
-                // Fall back to using the statement span start if the pattern span is unknown.
-                let stmt_span = source_map.stmt_span(stmt_id);
-                if stmt_span.is_empty() {
-                    continue;
-                }
-                // Emit after the identifier — we don't know the exact position, skip.
-                let _ = stmt_span;
-                continue;
-            }
-
-            out.push(InlineAnnotation {
-                offset: pat_span.end(),
-                label: format!(": {ty_str}"),
-                kind: AnnotationKind::Type,
-                padding_left: false,
-                padding_right: true,
-            });
-        }
-
-        // ── Parameter-name hints on call expressions ──────────────────────────
-
-        for (_expr_id, expr) in expr_body.exprs.iter() {
-            let Expr::Call { callee, args, .. } = expr else {
-                continue;
-            };
-
-            // Get the callee's type.
-            let Some(callee_ty) = inference.expression_type(*callee) else {
-                continue;
-            };
-
-            // Only process `Ty::Function` where params have names.
-            let Ty::Function { params, .. } = callee_ty else {
-                continue;
-            };
-
-            // Skip if arg count doesn't match param count (variadic / error cases).
-            if args.len() != params.len() {
-                continue;
-            }
-
-            for (arg, param) in args.iter().zip(params.iter()) {
-                if arg.label.is_some() {
-                    continue;
-                }
-
-                // Only emit hints for named parameters.
-                let Some(name) = &param.name else {
-                    continue;
-                };
-
-                let name_str = name.as_str();
-
-                // Skip `self` parameter hints — they're implicit.
-                if name_str == "self" {
-                    continue;
-                }
-
-                // Position hint at the start of the argument's span.
-                let arg_span = source_map.expr_span(arg.expr);
-                if arg_span.is_empty() {
-                    continue;
-                }
-
-                out.push(InlineAnnotation {
-                    offset: arg_span.start(),
-                    label: format!("{name_str}: "),
-                    kind: AnnotationKind::Parameter,
-                    padding_left: false,
-                    padding_right: false,
-                });
-            }
-        }
+        process_body(db, file, &index, expr_body, &source_map, &mut out);
     }
 
     // Sort by offset to ensure document order (required by LSP).
     out.sort_by_key(|h| h.offset);
     out
+}
+
+/// Emit hints for a single expression body — `let`-binding type hints and call
+/// parameter-name hints — then recurse into any lambda bodies it contains
+/// (each lambda has its own `ExprBody` arena and source map, e.g. the body of a
+/// `test` block lowered to a lambda passed to `register_test`).
+fn process_body(
+    db: &dyn Db,
+    file: SourceFile,
+    index: &SemanticIndex<'_>,
+    body: &ExprBody,
+    source_map: &AstSourceMap,
+    out: &mut Vec<InlineAnnotation>,
+) {
+    // ── Type hints for let bindings without annotations ───────────────────────
+    for (_stmt_id, stmt) in body.stmts.iter() {
+        let Stmt::Let { pattern, .. } = stmt else {
+            continue;
+        };
+
+        // `let x: T` (Bind with sub-pattern) or a bare type pattern already
+        // carries an explicit annotation — skip.
+        let pat = &body.patterns[*pattern];
+        if matches!(
+            pat,
+            baml_compiler2_ast::Pattern::Bind { subpat: Some(_), .. }
+                | baml_compiler2_ast::Pattern::Type(_)
+        ) {
+            continue;
+        }
+
+        // Skip `_` / non-simple bindings.
+        if pat.binding_name(&body.patterns).is_none() {
+            continue;
+        }
+
+        let pat_span = source_map.pattern_span(*pattern);
+        if pat_span.is_empty() {
+            continue;
+        }
+
+        // Resolve the binding's type across all scopes (the binding may live in
+        // a nested block / lambda scope, not the body's own scope).
+        let mut ty_str: Option<String> = None;
+        for scope_id in &index.scope_ids {
+            let inference = infer_scope_types(db, *scope_id);
+            if let Some(ty) = inference.binding_type(*pattern) {
+                if !should_suppress_type(ty) {
+                    ty_str = Some(utils::display_ty_for_file(db, file, ty));
+                }
+                break;
+            }
+        }
+        let Some(ty_str) = ty_str else {
+            continue;
+        };
+
+        out.push(InlineAnnotation {
+            offset: pat_span.end(),
+            label: format!(": {ty_str}"),
+            kind: AnnotationKind::Type,
+            padding_left: false,
+            padding_right: true,
+        });
+    }
+
+    // ── Parameter-name hints on calls + recurse into lambdas ──────────────────
+    for (_expr_id, expr) in body.exprs.iter() {
+        match expr {
+            Expr::Call { callee, args, .. } => {
+                // Skip synthesized test/testset registration calls — their
+                // `name` / `body` / `collector` / `runner` arguments are codegen,
+                // not user-facing. We still recurse into their lambda arguments
+                // (the actual test bodies) via the `Expr::Lambda` arm below.
+                if is_synthetic_registration(body, *callee) {
+                    continue;
+                }
+                // Find a scope where the callee resolves to a function type.
+                // ExprIds are arena-local (per body), so a foreign scope may
+                // hold the same numeric id; on an arity mismatch keep searching
+                // rather than giving up, so the correct same-arena scope wins.
+                for scope_id in &index.scope_ids {
+                    let inference = infer_scope_types(db, *scope_id);
+                    let Some(Ty::Function { params, .. }) = inference.expression_type(*callee)
+                    else {
+                        continue;
+                    };
+                    if args.len() != params.len() {
+                        continue;
+                    }
+                    for (arg, param) in args.iter().zip(params.iter()) {
+                        if arg.label.is_some() {
+                            continue;
+                        }
+                        let Some(name) = &param.name else {
+                            continue;
+                        };
+                        let name_str = name.as_str();
+                        // `self` is implicit.
+                        if name_str == "self" {
+                            continue;
+                        }
+                        let arg_span = source_map.expr_span(arg.expr);
+                        if arg_span.is_empty() {
+                            continue;
+                        }
+                        out.push(InlineAnnotation {
+                            offset: arg_span.start(),
+                            label: format!("{name_str}: "),
+                            kind: AnnotationKind::Parameter,
+                            padding_left: false,
+                            padding_right: false,
+                        });
+                    }
+                    break;
+                }
+            }
+            // Lambdas (including desugared `test` / `testset` bodies) carry their
+            // own body + source map — recurse so their lets and calls get hints.
+            Expr::Lambda(func_def) => {
+                if let Some(FunctionBodyDef::Expr(lbody, lsmap)) = &func_def.body {
+                    process_body(db, file, index, lbody, lsmap, out);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -292,27 +282,20 @@ fn should_suppress_type(ty: &Ty) -> bool {
     )
 }
 
-/// Search all scopes in the file for the binding type of `pat_id`.
-///
-/// Used as a fallback when the let binding is in a nested block scope
-/// (not directly in the enclosing function scope). Returns the display
-/// string directly to avoid allocating a `Ty`.
-fn find_binding_ty_any_scope(
-    db: &dyn Db,
-    file: SourceFile,
-    index: &baml_compiler2_hir::semantic_index::FileSemanticIndex<'_>,
-    pat_id: baml_compiler2_ast::PatId,
-) -> Option<String> {
-    for scope_id in &index.scope_ids {
-        let inference = baml_compiler2_tir::inference::infer_scope_types(db, *scope_id);
-        if let Some(ty) = inference.binding_type(pat_id) {
-            if should_suppress_type(ty) {
-                return None;
-            }
-            return Some(utils::display_ty_for_file(db, file, ty));
-        }
-    }
-    None
+/// True if `callee` names a synthesized test/testset registration method
+/// (`register_test` / `register_test_set`). These calls are emitted by
+/// `$init_test` desugaring; their `name` / `body` / `collector` / `runner`
+/// arguments are codegen and shouldn't get parameter-name hints.
+fn is_synthetic_registration(body: &ExprBody, callee: ExprId) -> bool {
+    let name = match &body.exprs[callee] {
+        Expr::MemberAccess { member, .. } => member.as_str(),
+        Expr::Path(segments) => match segments.last() {
+            Some(n) => n.as_str(),
+            None => return false,
+        },
+        _ => return false,
+    };
+    matches!(name, "register_test" | "register_test_set")
 }
 
 #[cfg(test)]
@@ -354,6 +337,101 @@ function UseEcho() -> string {
                 .iter()
                 .all(|label| !matches!(*label, "client: " | "function_name: " | "args: ")),
             "LLM synthetic call hints should be suppressed, got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn annotations_inside_test_bodies() {
+        let mut builder = ProjectTest::builder();
+        builder.source(
+            "main.baml",
+            r##"
+function greet(name: string) -> string {
+    name
+}
+
+test "greets" {
+    let g = greet("x")
+    assert.equal(g, "x")
+}
+"##,
+        );
+        let project = builder.build();
+
+        let hints = annotations(&project.db, project.files[0]);
+        let labels: Vec<_> = hints.iter().map(|hint| hint.label.as_str()).collect();
+
+        assert!(
+            labels.contains(&"name: "),
+            "expected a parameter hint inside the test body, got {labels:?}"
+        );
+        assert!(
+            labels.iter().any(|label| label.starts_with(": ")),
+            "expected a let type hint inside the test body, got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn annotations_inside_methods() {
+        let mut builder = ProjectTest::builder();
+        builder.source(
+            "main.baml",
+            r##"
+function greet(name: string) -> string {
+    name
+}
+
+class Greeter {
+    prefix: string,
+
+    function run(self, name: string) -> string {
+        let g = greet(name)
+        g
+    }
+}
+"##,
+        );
+        let project = builder.build();
+
+        let hints = annotations(&project.db, project.files[0]);
+        let labels: Vec<_> = hints.iter().map(|hint| hint.label.as_str()).collect();
+
+        assert!(
+            labels.contains(&"name: "),
+            "expected a parameter hint inside the method body, got {labels:?}"
+        );
+        assert!(
+            labels.iter().any(|label| label.starts_with(": ")),
+            "expected a let type hint inside the method body, got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn annotations_suppress_test_registration_hints() {
+        let mut builder = ProjectTest::builder();
+        builder.source(
+            "main.baml",
+            r##"
+testset "math" {
+    test "adds" {
+        assert.equal(1 + 1, 2)
+    }
+    test "subtracts" {
+        assert.equal(2 - 1, 1)
+    }
+}
+"##,
+        );
+        let project = builder.build();
+
+        let hints = annotations(&project.db, project.files[0]);
+        let labels: Vec<_> = hints.iter().map(|hint| hint.label.as_str()).collect();
+
+        assert!(
+            labels
+                .iter()
+                .all(|label| !matches!(*label, "name: " | "body: " | "collector: " | "runner: ")),
+            "synthesized test/testset registration hints should be suppressed, got {labels:?}"
         );
     }
 }

--- a/baml_language/crates/baml_lsp2_actions/src/annotations.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/annotations.rs
@@ -137,14 +137,14 @@ pub fn annotations(db: &dyn Db, file: SourceFile) -> Vec<InlineAnnotation> {
             continue;
         };
 
-        let owner_scope = function_scope_for(&index, func_data.span, &func_data.name)
+        let owner_scope = function_scope_for(index, func_data.span, &func_data.name)
             .unwrap_or_else(|| {
                 index.scope_at_offset(func_data.span.start(), Some(&func_data.name))
             });
         process_body(
             db,
             file,
-            &index,
+            index,
             owner_scope,
             expr_body,
             &source_map,

--- a/baml_language/crates/baml_lsp_server/src/playground_sender.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_sender.rs
@@ -41,6 +41,8 @@ impl bex_project::PlaygroundSender for NativePlaygroundSender {
         if let bex_project::PlaygroundNotification::OpenPlayground {
             ref project,
             ref function_name,
+            ref test_name,
+            ref testset_name,
         } = notification
         {
             if self.playground_via_browser {
@@ -53,6 +55,8 @@ impl bex_project::PlaygroundSender for NativePlaygroundSender {
                     "port": self.playground_port,
                     "projectPath": project,
                     "functionName": function_name,
+                    "testName": test_name,
+                    "testsetName": testset_name,
                 });
                 let notif =
                     lsp_server::Notification::new("baml/openPlayground".to_string(), params);

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -547,8 +547,11 @@ impl ProjectDatabase {
 
     /// Find the `//#` header comment immediately above a function declaration,
     /// if any. Blank lines and regular `//` comments between the header and
-    /// the declaration are skipped; any other code stops the search.
+    /// the declaration are skipped; any other code stops the search. If multiple
+    /// same-named declarations have different headers, do not guess which one a
+    /// name-only call resolved to.
     fn function_header_title(&self, function_name: &str) -> Option<String> {
+        let mut unique_title = None;
         for source_file in self.file_map.values().copied() {
             let index = baml_compiler2_ppir::file_semantic_index(self, source_file);
             for func_data in index.item_tree.functions.values() {
@@ -558,11 +561,15 @@ impl ProjectDatabase {
                 let text = source_file.text(self);
                 let start = usize::from(func_data.span.start()).min(text.len());
                 if let Some(title) = header_title_above(&text[..start]) {
-                    return Some(title);
+                    match &unique_title {
+                        Some(existing) if existing != &title => return None,
+                        Some(_) => {}
+                        None => unique_title = Some(title),
+                    }
                 }
             }
         }
-        None
+        unique_title
     }
 
     fn call_sites_by_source_expr(body: &baml_compiler2_ast::ExprBody) -> Vec<(u32, String)> {
@@ -1592,6 +1599,24 @@ function helper(x: int) -> int { x + 1 }
             db.function_header_title("helper"),
             Some("titled helper".to_string())
         );
+    }
+
+    #[test]
+    fn test_function_header_title_ignores_ambiguous_same_name_headers() {
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/dupe.baml"),
+            r#"
+//# first helper
+function helper(x: int) -> int { x }
+
+//# second helper
+function helper(x: int) -> int { x + 1 }
+"#,
+        );
+
+        assert_eq!(db.function_header_title("helper"), None);
     }
 
     #[test]

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -557,7 +557,9 @@ impl ProjectDatabase {
                 }
                 let text = source_file.text(self);
                 let start = usize::from(func_data.span.start()).min(text.len());
-                return header_title_above(&text[..start]);
+                if let Some(title) = header_title_above(&text[..start]) {
+                    return Some(title);
+                }
             }
         }
         None
@@ -1569,6 +1571,26 @@ function Caller(x: int) -> int {
         assert!(
             prepared.nodes.contains_key(&plain_node.id),
             "function-level header alone is enough to render the call node"
+        );
+    }
+
+    #[test]
+    fn test_function_header_title_keeps_searching_after_missing_header() {
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/dupe.baml"),
+            r#"
+function helper(x: int) -> int { x }
+
+//# titled helper
+function helper(x: int) -> int { x + 1 }
+"#,
+        );
+
+        assert_eq!(
+            db.function_header_title("helper"),
+            Some("titled helper".to_string())
         );
     }
 

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -494,6 +494,8 @@ impl ProjectDatabase {
         body: &baml_compiler2_ast::ExprBody,
         expanding: &mut HashSet<String>,
     ) {
+        use baml_compiler2_visualization::control_flow::NodeType;
+
         for (call_expr, callee_name) in Self::call_sites_by_source_expr(body) {
             let Some(call_node_id) = graph
                 .nodes
@@ -508,12 +510,57 @@ impl ProjectDatabase {
             else {
                 continue;
             };
+
             if Self::is_single_llm_graph(&callee_graph) {
+                // Calls to LLM functions always render. Mark the call node so
+                // the visualization prep keeps it (and styles it as an LLM
+                // call) instead of pruning it like a plain function call.
+                let client_name = callee_graph
+                    .nodes
+                    .values()
+                    .next()
+                    .and_then(|node| node.llm_client.clone());
+                if let Some(node) = graph.nodes.get_mut(&call_node_id) {
+                    node.llm_client = Some(client_name.unwrap_or_else(|| "unknown".to_string()));
+                    if matches!(node.node_type, NodeType::OtherScope) {
+                        node.node_type = NodeType::LlmFunction;
+                    }
+                }
                 continue;
+            }
+
+            // A `//#` header directly above the callee's declaration names the
+            // call node: `//# process stuff` above `function somefunc()` makes
+            // every `somefunc()` call render as a "process stuff" node.
+            if let Some(title) = self.function_header_title(&callee_name) {
+                if let Some(node) = graph.nodes.get_mut(&call_node_id) {
+                    node.label = title;
+                    if matches!(node.node_type, NodeType::OtherScope) {
+                        node.node_type = NodeType::HeaderContextEnter;
+                    }
+                }
             }
 
             Self::merge_callee_graph_under_call_node(graph, call_node_id, &callee_graph);
         }
+    }
+
+    /// Find the `//#` header comment immediately above a function declaration,
+    /// if any. Blank lines and regular `//` comments between the header and
+    /// the declaration are skipped; any other code stops the search.
+    fn function_header_title(&self, function_name: &str) -> Option<String> {
+        for source_file in self.file_map.values().copied() {
+            let index = baml_compiler2_ppir::file_semantic_index(self, source_file);
+            for func_data in index.item_tree.functions.values() {
+                if func_data.name.as_str() != function_name {
+                    continue;
+                }
+                let text = source_file.text(self);
+                let start = usize::from(func_data.span.start()).min(text.len());
+                return header_title_above(&text[..start]);
+            }
+        }
+        None
     }
 
     fn call_sites_by_source_expr(body: &baml_compiler2_ast::ExprBody) -> Vec<(u32, String)> {
@@ -1142,6 +1189,32 @@ impl ProjectDatabase {
     }
 }
 
+/// Scan backwards through the source text that precedes a declaration and
+/// return the title of the nearest `//#` header comment, if it is separated
+/// from the declaration only by blank lines and regular `//` comments.
+fn header_title_above(before: &str) -> Option<String> {
+    for line in before.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some(rest) = trimmed.strip_prefix("//") else {
+            // Reached code — no header directly above the declaration.
+            return None;
+        };
+        if let Some(title) = rest.strip_prefix('#') {
+            let title = title.trim_start_matches('#').trim();
+            if title.is_empty() {
+                return None;
+            }
+            return Some(title.to_string());
+        }
+        // Regular `//` or `///` comment between the header and the
+        // declaration — keep scanning upwards.
+    }
+    None
+}
+
 impl Default for ProjectDatabase {
     fn default() -> Self {
         Self::new()
@@ -1381,6 +1454,195 @@ function GuessingGame() -> string {
             edge_labels.contains(&r#""hit""#) && edge_labels.contains(&"default"),
             "prepared match fan-out edges should preserve match arm labels, got {edge_labels:?}"
         );
+    }
+
+    #[test]
+    fn test_llm_call_node_is_marked_and_always_rendered() {
+        use baml_compiler2_visualization::control_flow::{
+            NodeType, prepare_control_flow_graph_for_visualization,
+        };
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/wf.baml"),
+            r##"
+function Summarize(input: string) -> string {
+    client GPT4
+    prompt #"Summarize {{ input }}"#
+}
+
+function Workflow(input: string) -> string {
+    let x = Summarize(input);
+    x
+}
+"##,
+        );
+
+        let graph = db
+            .ast_control_flow_graph("Workflow")
+            .expect("expected graph for Workflow");
+        let call_node = graph
+            .nodes
+            .values()
+            .find(|n| n.label == "Summarize(input)")
+            .expect("caller graph should contain the Summarize call node");
+        assert!(
+            matches!(call_node.node_type, NodeType::LlmFunction),
+            "LLM call node should be marked as LlmFunction, got {:?}",
+            call_node.node_type
+        );
+        assert_eq!(call_node.llm_client.as_deref(), Some("GPT4"));
+
+        // Even with no //# headers anywhere, the LLM call must survive
+        // visualization prep.
+        let prepared = prepare_control_flow_graph_for_visualization(&graph);
+        assert!(
+            prepared.nodes.contains_key(&call_node.id),
+            "LLM call must always render"
+        );
+    }
+
+    #[test]
+    fn test_function_level_header_labels_call_nodes() {
+        use baml_compiler2_visualization::control_flow::{
+            NodeType, prepare_control_flow_graph_for_visualization,
+        };
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/wf.baml"),
+            r#"
+//# process stuff
+function somefunc(x: int) -> int {
+    //# inner step
+    x + 1
+}
+
+//# do the thing
+
+// a regular note between the header and the function is fine
+function plain(x: int) -> int { x + 1 }
+
+function Caller(x: int) -> int {
+    let a = somefunc(x);
+    let b = plain(a);
+    b
+}
+"#,
+        );
+
+        let graph = db
+            .ast_control_flow_graph("Caller")
+            .expect("expected graph for Caller");
+
+        let somefunc_node = graph
+            .nodes
+            .values()
+            .find(|n| n.label == "process stuff")
+            .expect("somefunc call should be relabeled from its function-level header");
+        assert!(matches!(
+            somefunc_node.node_type,
+            NodeType::HeaderContextEnter
+        ));
+        // The callee's body headers nest under the relabeled call node.
+        assert!(
+            graph
+                .nodes
+                .values()
+                .any(|n| n.label == "inner step" && n.log_filter_key.starts_with("somefunc|")),
+            "callee body headers should be expanded under the call node"
+        );
+
+        let plain_node = graph
+            .nodes
+            .values()
+            .find(|n| n.label == "do the thing")
+            .expect("plain call should be relabeled from its function-level header");
+
+        let prepared = prepare_control_flow_graph_for_visualization(&graph);
+        assert!(
+            prepared.nodes.contains_key(&somefunc_node.id),
+            "annotated function call must render"
+        );
+        assert!(
+            prepared.nodes.contains_key(&plain_node.id),
+            "function-level header alone is enough to render the call node"
+        );
+    }
+
+    #[test]
+    fn test_early_return_renders_as_terminal_node() {
+        use baml_compiler2_visualization::control_flow::{
+            NodeType, prepare_control_flow_graph_for_visualization,
+        };
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/early.baml"),
+            r#"
+function Early(x: int) -> string {
+    //# Validate
+    if (x < 0) {
+        //# bail out
+        return "neg";
+    }
+    //# Continue
+    "ok"
+}
+"#,
+        );
+
+        let graph = db
+            .ast_control_flow_graph("Early")
+            .expect("expected graph for Early");
+        let ret_node = graph
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::Return))
+            .expect("early return should create a Return node");
+        assert!(ret_node.label.starts_with("return"));
+
+        let prepared = prepare_control_flow_graph_for_visualization(&graph);
+        let prepared_ret = prepared
+            .nodes
+            .get(&ret_node.id)
+            .expect("return inside annotated branch should render");
+        let outgoing = prepared
+            .edges_by_src
+            .get(&prepared_ret.id)
+            .map(Vec::len)
+            .unwrap_or(0);
+        assert_eq!(
+            outgoing, 0,
+            "return node must not be connected to later nodes"
+        );
+    }
+
+    #[test]
+    fn test_header_title_above() {
+        assert_eq!(
+            header_title_above("//# process stuff\n"),
+            Some("process stuff".to_string())
+        );
+        assert_eq!(
+            header_title_above("//# process stuff\n\n// note\n/// docs\n"),
+            Some("process stuff".to_string()),
+            "blank lines and comments between header and declaration are skipped"
+        );
+        assert_eq!(
+            header_title_above("//## nested level\n"),
+            Some("nested level".to_string())
+        );
+        assert_eq!(
+            header_title_above("//# old header\n}\n"),
+            None,
+            "code between the header and the declaration stops the search"
+        );
+        assert_eq!(header_title_above("// just a comment\n"), None);
+        assert_eq!(header_title_above(""), None);
     }
 
     #[test]

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -497,14 +497,17 @@ impl ProjectDatabase {
         use baml_compiler2_visualization::control_flow::NodeType;
 
         for (call_expr, callee_name) in Self::call_sites_by_source_expr(body) {
-            let Some(call_node_id) = graph
+            let Some((call_node_id, is_return_node)) = graph
                 .nodes
                 .values()
                 .find(|node| node.source_expr == Some(call_expr))
-                .map(|node| node.id)
+                .map(|node| (node.id, matches!(node.node_type, NodeType::Return)))
             else {
                 continue;
             };
+            if is_return_node {
+                continue;
+            }
 
             let Some(callee_graph) = self.ast_control_flow_graph_impl(&callee_name, expanding)
             else {
@@ -1665,6 +1668,53 @@ function Early(x: int) -> string {
         assert_eq!(
             outgoing, 0,
             "return node must not be connected to later nodes"
+        );
+    }
+
+    #[test]
+    fn test_return_call_is_not_expanded_under_return_node() {
+        use baml_compiler2_visualization::control_flow::NodeType;
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/return-call.baml"),
+            r#"
+function Helper() -> string {
+    //# helper body
+    "ok"
+}
+
+function Early(x: int) -> string {
+    if (x < 0) {
+        return Helper();
+    }
+
+    "later"
+}
+"#,
+        );
+
+        let graph = db
+            .ast_control_flow_graph("Early")
+            .expect("expected graph for Early");
+        let ret_node = graph
+            .nodes
+            .values()
+            .find(|n| matches!(n.node_type, NodeType::Return))
+            .expect("return call should create a Return node");
+
+        assert_eq!(ret_node.label, "return Helper()");
+        assert!(
+            graph
+                .edges_by_src
+                .get(&ret_node.id)
+                .is_none_or(Vec::is_empty),
+            "return-call node must stay terminal instead of owning callee edges"
+        );
+        assert!(
+            graph.nodes.values().all(|n| n.label != "helper body"),
+            "callee body headers should not be expanded below a terminal return"
         );
     }
 

--- a/baml_language/crates/bex_project/src/bex_lsp/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/mod.rs
@@ -138,7 +138,12 @@ pub enum PlaygroundNotification {
     #[serde(rename_all = "camelCase")]
     OpenPlayground {
         project: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         function_name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        test_name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        testset_name: Option<String>,
     },
     #[serde(rename_all = "camelCase")]
     ControlFlowGraphResult {

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/commands.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/commands.rs
@@ -36,12 +36,17 @@ pub(super) struct OpenBamlPanel {
     pub project_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function_name: Option<String>,
+    /// Lens title override (display-only; not serialized into command args).
+    #[serde(skip)]
+    pub title: Option<String>,
 }
 
 impl BexLspCommand for OpenBamlPanel {
     const COMMAND_ID: &'static str = "baml.openBamlPanel";
 
     fn command_text(&self) -> String {
-        "▶ Open 🐑 Playground".to_string()
+        self.title
+            .clone()
+            .unwrap_or_else(|| "▶ Open 🐑 Playground".to_string())
     }
 }

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/commands.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/commands.rs
@@ -36,6 +36,10 @@ pub(super) struct OpenBamlPanel {
     pub project_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub testset_name: Option<String>,
     /// Lens title override (display-only; not serialized into command args).
     #[serde(skip)]
     pub title: Option<String>,

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -194,6 +194,8 @@ impl BexLspRequest for BexMulitProject {
                             super::commands::OpenBamlPanel {
                                 project_path: Some(root_path.as_str().to_string()),
                                 function_name: Some(action.name),
+                                test_name: None,
+                                testset_name: None,
                                 title: None,
                             }
                             .to_lsp_command()
@@ -201,7 +203,9 @@ impl BexLspRequest for BexMulitProject {
                         baml_lsp2_actions::FileActionKind::RunTest => {
                             super::commands::OpenBamlPanel {
                                 project_path: Some(root_path.as_str().to_string()),
-                                function_name: Some(action.name),
+                                function_name: None,
+                                test_name: Some(action.name),
+                                testset_name: None,
                                 title: Some("▶ Run test".to_string()),
                             }
                             .to_lsp_command()
@@ -209,7 +213,9 @@ impl BexLspRequest for BexMulitProject {
                         baml_lsp2_actions::FileActionKind::RunTestSet => {
                             super::commands::OpenBamlPanel {
                                 project_path: Some(root_path.as_str().to_string()),
-                                function_name: Some(action.name),
+                                function_name: None,
+                                test_name: None,
+                                testset_name: Some(action.name),
                                 title: Some("▶ Run testset".to_string()),
                             }
                             .to_lsp_command()
@@ -397,6 +403,8 @@ impl BexLspRequest for BexMulitProject {
                             super::commands::OpenBamlPanel {
                                 project_path: Some(root_path.as_str().to_string()),
                                 function_name,
+                                test_name: None,
+                                testset_name: None,
                                 title: None,
                             }
                             .to_lsp_code_action()
@@ -431,6 +439,8 @@ impl BexLspRequest for BexMulitProject {
                 let commands::OpenBamlPanel {
                     project_path,
                     function_name,
+                    test_name,
+                    testset_name,
                     ..
                 } = serde_json::from_value(args).map_err(|e| {
                     LspError::InvalidCommandArguments {
@@ -463,6 +473,8 @@ impl BexLspRequest for BexMulitProject {
                     crate::bex_lsp::PlaygroundNotification::OpenPlayground {
                         project: project_path.as_str().to_string(),
                         function_name,
+                        test_name,
+                        testset_name,
                     },
                 );
 

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -194,6 +194,7 @@ impl BexLspRequest for BexMulitProject {
                             super::commands::OpenBamlPanel {
                                 project_path: Some(root_path.as_str().to_string()),
                                 function_name: Some(action.name),
+                                title: None,
                             }
                             .to_lsp_command()
                         }
@@ -201,6 +202,15 @@ impl BexLspRequest for BexMulitProject {
                             super::commands::OpenBamlPanel {
                                 project_path: Some(root_path.as_str().to_string()),
                                 function_name: Some(action.name),
+                                title: Some("▶ Run test".to_string()),
+                            }
+                            .to_lsp_command()
+                        }
+                        baml_lsp2_actions::FileActionKind::RunTestSet => {
+                            super::commands::OpenBamlPanel {
+                                project_path: Some(root_path.as_str().to_string()),
+                                function_name: Some(action.name),
+                                title: Some("▶ Run testset".to_string()),
                             }
                             .to_lsp_command()
                         }
@@ -387,6 +397,7 @@ impl BexLspRequest for BexMulitProject {
                             super::commands::OpenBamlPanel {
                                 project_path: Some(root_path.as_str().to_string()),
                                 function_name,
+                                title: None,
                             }
                             .to_lsp_code_action()
                         }
@@ -420,6 +431,7 @@ impl BexLspRequest for BexMulitProject {
                 let commands::OpenBamlPanel {
                     project_path,
                     function_name,
+                    ..
                 } = serde_json::from_value(args).map_err(|e| {
                     LspError::InvalidCommandArguments {
                         command: params.command.clone(),

--- a/baml_language/crates/bridge_wasm/src/wasm_lsp.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_lsp.rs
@@ -6,6 +6,18 @@ use wasm_bindgen::JsValue;
 
 use crate::send_wrapper::SendWrapper;
 
+/// Serialize a value to a `JsValue` via `serde_json` (NOT serde-wasm-bindgen),
+/// so `arbitrary_precision` numbers come out as plain JSON numbers instead of
+/// the `{ "$serde_json::private::Number": "8" }` struct. Used for outbound LSP
+/// payloads, whose `serde_json::Value` params would otherwise leak that tag and
+/// make every position read as 0 on the JS side.
+pub(crate) fn to_json_jsvalue<T: Serialize>(value: &T) -> JsValue {
+    serde_json::to_string(value)
+        .ok()
+        .and_then(|s| js_sys::JSON::parse(&s).ok())
+        .unwrap_or(JsValue::NULL)
+}
+
 #[derive(Tsify, Serialize, Deserialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct LspNotification {
@@ -153,19 +165,19 @@ impl WasmLsp {
     fn send_notification(&self, notification: lsp_server::Notification) {
         let send_notification_fn = self.send_notification_fn.inner();
         let notif: LspNotification = notification.into();
-        let _ = send_notification_fn.call1(&JsValue::NULL, &notif.into());
+        let _ = send_notification_fn.call1(&JsValue::NULL, &to_json_jsvalue(&notif));
     }
 
     fn send_response(&self, response: lsp_server::Response) {
         let send_response_fn = self.send_response_fn.inner();
         let response: LspResponse = response.into();
-        let _ = send_response_fn.call1(&JsValue::NULL, &response.into());
+        let _ = send_response_fn.call1(&JsValue::NULL, &to_json_jsvalue(&response));
     }
 
     fn make_request(&self, request: lsp_server::Request) {
         let make_request_fn = self.make_request_fn.inner();
         let request: LspRequest = request.into();
-        let _ = make_request_fn.call1(&JsValue::NULL, &request.into());
+        let _ = make_request_fn.call1(&JsValue::NULL, &to_json_jsvalue(&request));
     }
 }
 

--- a/baml_language/crates/bridge_wasm/src/wasm_lsp.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_lsp.rs
@@ -11,11 +11,18 @@ use crate::send_wrapper::SendWrapper;
 /// the `{ "$serde_json::private::Number": "8" }` struct. Used for outbound LSP
 /// payloads, whose `serde_json::Value` params would otherwise leak that tag and
 /// make every position read as 0 on the JS side.
-pub(crate) fn to_json_jsvalue<T: Serialize>(value: &T) -> JsValue {
-    serde_json::to_string(value)
-        .ok()
-        .and_then(|s| js_sys::JSON::parse(&s).ok())
-        .unwrap_or(JsValue::NULL)
+pub(crate) fn to_json_jsvalue<T: Serialize>(
+    value: &T,
+    payload_name: &str,
+) -> Result<JsValue, LspError> {
+    let json = serde_json::to_string(value).map_err(|e| {
+        LspError::UnknownErrorCode(format!("failed to serialize {payload_name} payload: {e}"))
+    })?;
+    js_sys::JSON::parse(&json).map_err(|e| {
+        LspError::UnknownErrorCode(format!(
+            "failed to parse serialized {payload_name} payload as JSON: {e:?}"
+        ))
+    })
 }
 
 #[derive(Tsify, Serialize, Deserialize)]
@@ -162,38 +169,53 @@ impl WasmLsp {
         }
     }
 
-    fn send_notification(&self, notification: lsp_server::Notification) {
+    fn send_notification(&self, notification: lsp_server::Notification) -> Result<(), LspError> {
         let send_notification_fn = self.send_notification_fn.inner();
         let notif: LspNotification = notification.into();
-        let _ = send_notification_fn.call1(&JsValue::NULL, &to_json_jsvalue(&notif));
+        let payload = to_json_jsvalue(&notif, "LSP notification")?;
+        send_notification_fn
+            .call1(&JsValue::NULL, &payload)
+            .map(|_| ())
+            .map_err(|e| {
+                LspError::UnknownErrorCode(format!("failed to send LSP notification to JS: {e:?}"))
+            })
     }
 
-    fn send_response(&self, response: lsp_server::Response) {
+    fn send_response(&self, response: lsp_server::Response) -> Result<(), LspError> {
         let send_response_fn = self.send_response_fn.inner();
         let response: LspResponse = response.into();
-        let _ = send_response_fn.call1(&JsValue::NULL, &to_json_jsvalue(&response));
+        let payload = to_json_jsvalue(&response, "LSP response")?;
+        send_response_fn
+            .call1(&JsValue::NULL, &payload)
+            .map(|_| ())
+            .map_err(|e| {
+                LspError::UnknownErrorCode(format!("failed to send LSP response to JS: {e:?}"))
+            })
     }
 
-    fn make_request(&self, request: lsp_server::Request) {
+    fn make_request(&self, request: lsp_server::Request) -> Result<(), LspError> {
         let make_request_fn = self.make_request_fn.inner();
         let request: LspRequest = request.into();
-        let _ = make_request_fn.call1(&JsValue::NULL, &to_json_jsvalue(&request));
+        let payload = to_json_jsvalue(&request, "LSP request")?;
+        make_request_fn
+            .call1(&JsValue::NULL, &payload)
+            .map(|_| ())
+            .map_err(|e| {
+                LspError::UnknownErrorCode(format!("failed to send LSP request to JS: {e:?}"))
+            })
     }
 }
 
 impl bex_project::LspClientSenderTrait for WasmLsp {
     fn send_notification(&self, notif: lsp_server::Notification) -> Result<(), LspError> {
-        self.send_notification(notif);
-        Ok(())
+        self.send_notification(notif)
     }
 
     fn send_response_impl(&self, response: lsp_server::Response) -> Result<(), LspError> {
-        self.send_response(response);
-        Ok(())
+        self.send_response(response)
     }
 
     fn make_request(&self, req: lsp_server::Request) -> Result<(), LspError> {
-        self.make_request(req);
-        Ok(())
+        self.make_request(req)
     }
 }

--- a/baml_language/crates/bridge_wasm/src/wasm_playground.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_playground.rs
@@ -207,6 +207,18 @@ impl bex_project::PlaygroundSender for WasmPlaygroundSender {
     fn send_playground_notification(&self, notification: bex_project::PlaygroundNotification) {
         let wasm_notif: PlaygroundNotification = notification.into();
         let callback = self.callback.inner();
-        let _ = callback.call1(&JsValue::NULL, &wasm_notif.into());
+        // Variants carrying `serde_json::Value` payloads must cross the
+        // boundary as JSON text: with serde_json's `arbitrary_precision`
+        // feature, serde-wasm-bindgen/Tsify renders every Value number as
+        // `{ "$serde_json::private::Number": "…" }`, which broke graph
+        // node ids / parent ids / edges on the JS side.
+        let js_notif: JsValue = match &wasm_notif {
+            PlaygroundNotification::ControlFlowGraphResult { .. }
+            | PlaygroundNotification::CursorContext { .. } => {
+                crate::wasm_lsp::to_json_jsvalue(&wasm_notif)
+            }
+            _ => wasm_notif.into(),
+        };
+        let _ = callback.call1(&JsValue::NULL, &js_notif);
     }
 }

--- a/baml_language/crates/bridge_wasm/src/wasm_playground.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_playground.rs
@@ -75,7 +75,12 @@ pub enum PlaygroundNotification {
     #[serde(rename_all = "camelCase")]
     OpenPlayground {
         project: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         function_name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        test_name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        testset_name: Option<String>,
     },
     #[serde(rename_all = "camelCase")]
     ControlFlowGraphResult {
@@ -157,9 +162,13 @@ impl From<bex_project::PlaygroundNotification> for PlaygroundNotification {
             bex_project::PlaygroundNotification::OpenPlayground {
                 project,
                 function_name,
+                test_name,
+                testset_name,
             } => PlaygroundNotification::OpenPlayground {
                 project,
                 function_name,
+                test_name,
+                testset_name,
             },
             bex_project::PlaygroundNotification::ControlFlowGraphResult {
                 function_name,
@@ -215,7 +224,13 @@ impl bex_project::PlaygroundSender for WasmPlaygroundSender {
         let js_notif: JsValue = match &wasm_notif {
             PlaygroundNotification::ControlFlowGraphResult { .. }
             | PlaygroundNotification::CursorContext { .. } => {
-                crate::wasm_lsp::to_json_jsvalue(&wasm_notif)
+                match crate::wasm_lsp::to_json_jsvalue(&wasm_notif, "playground notification") {
+                    Ok(value) => value,
+                    Err(e) => {
+                        log::error!("failed to serialize playground notification for JS: {e}");
+                        return;
+                    }
+                }
             }
             _ => wasm_notif.into(),
         };

--- a/engine/language_client_python/pyproject.toml
+++ b/engine/language_client_python/pyproject.toml
@@ -3,6 +3,7 @@ name = "baml-py"
 version = "0.222.0"
 description = "BAML python bindings (pyproject.toml)"
 readme = "README.md"
+requires-python = ">=3.10"
 authors = [{ "name" = "Boundary", "email" = "contact@boundaryml.com" }]
 # This is what controls the Python license file, see
 # https://github.com/PyO3/maturin/issues/2718 and

--- a/engine/language_client_python/uv.lock
+++ b/engine/language_client_python/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 [[package]]
 name = "baml-py"

--- a/engine/language_client_python/uv.lock
+++ b/engine/language_client_python/uv.lock
@@ -1,7 +1,8 @@
 version = 1
-requires-python = ">=3.10"
+revision = 3
+requires-python = ">=3.11"
 
 [[package]]
 name = "baml-py"
-version = "0.211.2"
+version = "0.222.0"
 source = { editable = "." }

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1006,9 +1006,10 @@ colors:
     light: "#ffffff"
     dark: "#0b0d0e"
 logo:
-  light: assets/favicon.ico
-  dark: assets/favicon.ico
-  height: 40
+  light: assets/boundary-black-big.svg
+  dark: assets/boundary-white.svg
+  height: 28
+  href: https://boundaryml.com
 favicon: assets/favicon.ico
 css: assets/styles.css
 layout:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1006,10 +1006,9 @@ colors:
     light: "#ffffff"
     dark: "#0b0d0e"
 logo:
-  light: assets/boundary-black-big.svg
-  dark: assets/boundary-white.svg
-  height: 28
-  href: https://boundaryml.com
+  light: assets/favicon.ico
+  dark: assets/favicon.ico
+  height: 40
 favicon: assets/favicon.ico
 css: assets/styles.css
 layout:

--- a/typescript2/.gitignore
+++ b/typescript2/.gitignore
@@ -26,3 +26,6 @@ pkg-playground/wasm/
 
 # Riptide artifacts (cloud-synced)
 .humanlayer/tasks/
+
+# Staged copy of pkg-playground/wasm for npm publishing (prep-wasm-publish.mjs)
+wasm-publish/

--- a/typescript2/app-vscode-ext/src/extension.ts
+++ b/typescript2/app-vscode-ext/src/extension.ts
@@ -227,9 +227,9 @@ function wireClient(projectRoot: string, client: LanguageClient) {
     }) => {
       await WebviewPanel.render(context.extensionUri, params.port, {
         project: params.projectPath,
-        ...(params.functionName ? { functionName: params.functionName } : {}),
-        ...(params.testName ? { testName: params.testName } : {}),
-        ...(params.testsetName ? { testsetName: params.testsetName } : {}),
+        ...(params.functionName !== undefined ? { functionName: params.functionName } : {}),
+        ...(params.testName !== undefined ? { testName: params.testName } : {}),
+        ...(params.testsetName !== undefined ? { testsetName: params.testsetName } : {}),
       });
     },
   );

--- a/typescript2/app-vscode-ext/src/extension.ts
+++ b/typescript2/app-vscode-ext/src/extension.ts
@@ -218,10 +218,18 @@ function wireClient(projectRoot: string, client: LanguageClient) {
 
   client.onNotification(
     'baml/openPlayground',
-    async (params: { port: number; projectPath: string; functionName?: string }) => {
+    async (params: {
+      port: number;
+      projectPath: string;
+      functionName?: string;
+      testName?: string;
+      testsetName?: string;
+    }) => {
       await WebviewPanel.render(context.extensionUri, params.port, {
         project: params.projectPath,
         ...(params.functionName ? { functionName: params.functionName } : {}),
+        ...(params.testName ? { testName: params.testName } : {}),
+        ...(params.testsetName ? { testsetName: params.testsetName } : {}),
       });
     },
   );

--- a/typescript2/app-vscode-ext/src/panels/WebviewPanel.ts
+++ b/typescript2/app-vscode-ext/src/panels/WebviewPanel.ts
@@ -33,6 +33,8 @@ interface CursorPosition {
 interface OpenPlaygroundTarget {
   project: string;
   functionName?: string;
+  testName?: string;
+  testsetName?: string;
 }
 
 function isBamlEditor(editor: TextEditor): boolean {

--- a/typescript2/app-vscode-webview/src/App.browser.test.tsx
+++ b/typescript2/app-vscode-webview/src/App.browser.test.tsx
@@ -10,10 +10,11 @@ describe('App (Browser)', () => {
       await screen.findByText(/Select a function to run|Connecting to playground server/);
     });
 
-    it('shows functions area (empty or list)', async () => {
+    it('shows the sidebar sections and empty editor state', async () => {
       render(<App />);
 
-      expect(await screen.findByText('No functions yet')).toBeInTheDocument();
+      expect(await screen.findByText('Functions')).toBeInTheDocument();
+      expect(screen.getByText('Tests')).toBeInTheDocument();
       expect(screen.getByText('Select a function to run')).toBeInTheDocument();
     });
 

--- a/typescript2/app-vscode-webview/src/App.test.tsx
+++ b/typescript2/app-vscode-webview/src/App.test.tsx
@@ -12,10 +12,11 @@ describe('App', () => {
       await screen.findByText(/Select a function to run|Connecting to playground server/);
     });
 
-    it('shows functions area (empty or list)', async () => {
+    it('shows the sidebar sections and empty editor state', async () => {
       render(<App />);
 
-      expect(await screen.findByText('No functions yet')).toBeInTheDocument();
+      expect(await screen.findByText('Functions')).toBeInTheDocument();
+      expect(screen.getByText('Tests')).toBeInTheDocument();
       expect(screen.getByText('Select a function to run')).toBeInTheDocument();
     });
 

--- a/typescript2/app-vscode-webview/src/App.tsx
+++ b/typescript2/app-vscode-webview/src/App.tsx
@@ -60,9 +60,9 @@ const App: React.FC = () => {
         notification: {
           type: 'openPlayground',
           project: target.project,
-          ...(target.functionName ? { functionName: target.functionName } : {}),
-          ...(target.testName ? { testName: target.testName } : {}),
-          ...(target.testsetName ? { testsetName: target.testsetName } : {}),
+          ...(target.functionName !== undefined ? { functionName: target.functionName } : {}),
+          ...(target.testName !== undefined ? { testName: target.testName } : {}),
+          ...(target.testsetName !== undefined ? { testsetName: target.testsetName } : {}),
         },
       });
     }
@@ -116,9 +116,9 @@ const App: React.FC = () => {
         notification: {
           type: 'openPlayground',
           project: target.project,
-          ...(target.functionName ? { functionName: target.functionName } : {}),
-          ...(target.testName ? { testName: target.testName } : {}),
-          ...(target.testsetName ? { testsetName: target.testsetName } : {}),
+          ...(target.functionName !== undefined ? { functionName: target.functionName } : {}),
+          ...(target.testName !== undefined ? { testName: target.testName } : {}),
+          ...(target.testsetName !== undefined ? { testsetName: target.testsetName } : {}),
         },
       });
     };

--- a/typescript2/app-vscode-webview/src/App.tsx
+++ b/typescript2/app-vscode-webview/src/App.tsx
@@ -29,6 +29,8 @@ interface OpenPlaygroundMessage {
   target: {
     project: string;
     functionName?: string;
+    testName?: string;
+    testsetName?: string;
   };
 }
 
@@ -59,6 +61,8 @@ const App: React.FC = () => {
           type: 'openPlayground',
           project: target.project,
           ...(target.functionName ? { functionName: target.functionName } : {}),
+          ...(target.testName ? { testName: target.testName } : {}),
+          ...(target.testsetName ? { testsetName: target.testsetName } : {}),
         },
       });
     }
@@ -113,6 +117,8 @@ const App: React.FC = () => {
           type: 'openPlayground',
           project: target.project,
           ...(target.functionName ? { functionName: target.functionName } : {}),
+          ...(target.testName ? { testName: target.testName } : {}),
+          ...(target.testsetName ? { testsetName: target.testsetName } : {}),
         },
       });
     };

--- a/typescript2/package.json
+++ b/typescript2/package.json
@@ -10,6 +10,7 @@
     "dev:cargo": "cargo watch -C ../baml_language  --ignore '**/target/**' --skip-local-deps --watch-when-idle -w crates -x 'build -p baml_cli'",
     "dev:vscode": "turbo run build --filter=app-vscode-webview && turbo run dev --filter=baml-language --filter=app-vscode-webview --filter=@b/pkg-playground '//#dev:cargo'",
     "dev:promptfiddle": "turbo run dev --filter app-promptfiddle --filter @b/pkg-playground '//#dev:wasm'",
+    "dev:website": "turbo run dev --filter app-website",
     "build": "turbo run build",
     "vscode:package": "pnpm run vscode:package:clean && pnpm run vscode:package:build && pnpm run vscode:package:stage && pnpm run vscode:package:vsix",
     "vscode:package:clean": "rm -rf app-vscode-webview/dist app-vscode-ext/dist app-vscode-ext/*.vsix",

--- a/typescript2/pkg-playground/package.json
+++ b/typescript2/pkg-playground/package.json
@@ -2,13 +2,20 @@
   "name": "@b/pkg-playground",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
     "build:wasm": "wasm-pack build ../../baml_language/crates/bridge_wasm --target web --out-dir ../../../typescript2/pkg-playground/wasm --release",
+    "prep:wasm-publish": "node scripts/prep-wasm-publish.mjs",
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
     "typecheck": "tsc --noEmit",

--- a/typescript2/pkg-playground/package.json
+++ b/typescript2/pkg-playground/package.json
@@ -11,7 +11,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build:wasm": "wasm-pack build ../../baml_language/crates/bridge_wasm --target web --out-dir ../../../typescript2/pkg-playground/wasm --release",

--- a/typescript2/pkg-playground/scripts/prep-wasm-publish.mjs
+++ b/typescript2/pkg-playground/scripts/prep-wasm-publish.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Stage the locally built `wasm/` artifacts into `wasm-publish/` as the
+ * publishable npm package `@boundaryml/bridge-wasm`.
+ *
+ * Why a staging dir: wasm-pack regenerates `wasm/package.json` on every
+ * `pnpm build:wasm` (as `@b/bridge_wasm`, a workspace-private name), so the
+ * publish metadata can't live there. Local consumers keep their
+ * `"@b/bridge_wasm": "link:../pkg-playground/wasm"` deps — pnpm places link:
+ * deps by dependency key, so the published twin having a different inner name
+ * is fine.
+ *
+ * Usage:
+ *   pnpm build:wasm                       # make sure the artifact is fresh
+ *   node scripts/prep-wasm-publish.mjs [version]
+ *   cd wasm-publish && npm publish
+ *
+ * Without [version], a unique canary version is derived from the git HEAD:
+ * 0.1.0-canary.<shortsha>. The chosen version is also written to
+ * `wasm.version` (committed), which scripts/vercel-build.sh uses to restore
+ * the artifact from npm instead of compiling Rust on Vercel.
+ */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const wasmDir = path.join(pkgRoot, 'wasm');
+const outDir = path.join(pkgRoot, 'wasm-publish');
+const pinFile = path.join(pkgRoot, 'wasm.version');
+
+const ARTIFACTS = [
+  'bridge_wasm.js',
+  'bridge_wasm.d.ts',
+  'bridge_wasm_bg.wasm',
+  'bridge_wasm_bg.wasm.d.ts',
+];
+
+const srcPkgPath = path.join(wasmDir, 'package.json');
+if (!fs.existsSync(srcPkgPath)) {
+  console.error('wasm/package.json not found — run `pnpm build:wasm` first.');
+  process.exit(1);
+}
+for (const f of ARTIFACTS) {
+  if (!fs.existsSync(path.join(wasmDir, f))) {
+    console.error(`wasm/${f} missing — run \`pnpm build:wasm\` first.`);
+    process.exit(1);
+  }
+}
+
+const ageHours =
+  (Date.now() - fs.statSync(path.join(wasmDir, 'bridge_wasm_bg.wasm')).mtimeMs) / 3.6e6;
+if (ageHours > 24) {
+  console.warn(
+    `warning: bridge_wasm_bg.wasm was built ${Math.round(ageHours)}h ago — ` +
+      'consider `pnpm build:wasm` for a fresh artifact.',
+  );
+}
+
+const shortSha = execSync('git rev-parse --short HEAD', { cwd: pkgRoot })
+  .toString()
+  .trim();
+const version = process.argv[2] ?? `0.1.0-canary.${shortSha}`;
+
+const srcPkg = JSON.parse(fs.readFileSync(srcPkgPath, 'utf8'));
+const outPkg = {
+  ...srcPkg,
+  name: '@boundaryml/bridge-wasm',
+  version,
+  description:
+    'Prebuilt BAML bridge_wasm (wasm-pack --target web) — the playground runtime for web apps.',
+  license: 'Apache-2.0',
+  repository: {
+    type: 'git',
+    url: 'https://github.com/boundaryml/baml',
+    directory: 'baml_language/crates/bridge_wasm',
+  },
+  files: ARTIFACTS,
+  publishConfig: { access: 'public' },
+};
+// wasm-pack sometimes emits collaborators/scripts that don't belong on npm.
+delete outPkg.collaborators;
+delete outPkg.scripts;
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+for (const f of ARTIFACTS) {
+  fs.copyFileSync(path.join(wasmDir, f), path.join(outDir, f));
+}
+fs.writeFileSync(
+  path.join(outDir, 'package.json'),
+  `${JSON.stringify(outPkg, null, 2)}\n`,
+);
+fs.writeFileSync(
+  path.join(outDir, 'README.md'),
+  [
+    '# @boundaryml/bridge-wasm',
+    '',
+    'Prebuilt `bridge_wasm` artifact (wasm-pack `--target web`) from',
+    'https://github.com/boundaryml/baml — published so web deploys can skip the',
+    'Rust toolchain. Built from `baml_language/crates/bridge_wasm`.',
+    '',
+    `Built at commit \`${shortSha}\`.`,
+    '',
+  ].join('\n'),
+);
+
+fs.writeFileSync(pinFile, `${version}\n`);
+
+console.log(`staged ${outDir.replace(`${process.cwd()}/`, '')} as @boundaryml/bridge-wasm@${version}`);
+console.log(`pinned version in pkg-playground/wasm.version (commit this file)`);
+console.log('');
+console.log('to publish:');
+console.log('  cd typescript2/pkg-playground/wasm-publish && npm publish');

--- a/typescript2/pkg-playground/src/EventValueDisplay.tsx
+++ b/typescript2/pkg-playground/src/EventValueDisplay.tsx
@@ -12,5 +12,9 @@ export const EventValueDisplay: FC<{
   value: BamlJsValue;
   customRenderers?: Record<string, FC<ResultRendererProps>>;
 }> = ({ value, customRenderers }) => (
-  <ValueRenderer value={value} displayMode="inline" customRenderers={customRenderers} />
+  <ValueRenderer
+    value={value}
+    displayMode="inline"
+    customRenderers={customRenderers}
+  />
 );

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -132,18 +132,26 @@ function collectAllTestNames(item: SerializedTestDef): string[] {
 function collectTestNamesInSet(
   items: SerializedTestDef[],
   target: string,
-): string[] | null {
+): string[] | 'pending' | null {
   for (const item of items) {
     if ('type' in item && item.type === 'lazyTestSet') {
-      if (testTargetMatches(item.name, target)) return null;
+      if (testTargetMatches(item.name, target)) return 'pending';
       continue;
     }
     if (!isExpandedTestSet(item)) continue;
     if (testTargetMatches(item.name, target)) return collectAllTestNames(item);
     const nested = collectTestNamesInSet(item.items, target);
-    if (nested) return nested;
+    if (nested !== null) return nested;
   }
   return null;
+}
+
+function hasLazyTestSets(items: SerializedTestDef[]): boolean {
+  for (const item of items) {
+    if ('type' in item && item.type === 'lazyTestSet') return true;
+    if (isExpandedTestSet(item) && hasLazyTestSets(item.items)) return true;
+  }
+  return false;
 }
 
 function findLatestGraphRun(
@@ -1720,20 +1728,34 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       return;
     }
     if (pendingTestTarget.project !== selectedProject) {
+      setPendingTestTarget(null);
+      setViewingTestRun(false);
       return;
     }
 
     const treeItems = testTree as SerializedTestDef[];
+    const hasPendingLazyTestSets = hasLazyTestSets(treeItems);
     if (pendingTestTarget.kind === 'test') {
       const testName = findTestNameInTree(treeItems, pendingTestTarget.name);
-      if (!testName) return;
+      if (!testName) {
+        if (hasPendingLazyTestSets) return;
+        setPendingTestTarget(null);
+        setViewingTestRun(false);
+        return;
+      }
       setPendingTestTarget(null);
       void handleRunTest(testName);
       return;
     }
 
     const testNames = collectTestNamesInSet(treeItems, pendingTestTarget.name);
-    if (!testNames) return;
+    if (testNames === 'pending') return;
+    if (testNames === null) {
+      if (hasPendingLazyTestSets) return;
+      setPendingTestTarget(null);
+      setViewingTestRun(false);
+      return;
+    }
     setPendingTestTarget(null);
     setViewingTestRun(true);
     void (async () => {

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -10,14 +10,19 @@
  */
 
 import type { ChangeEvent, FC, ReactNode, RefObject } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { encodeCallArgs } from '@b/pkg-proto';
 import type { BamlJsMedia, BamlJsValue } from '@b/pkg-proto';
-import { KeyRound, PanelLeft, Square } from 'lucide-react';
+import { KeyRound, PanelLeft, Settings, Square } from 'lucide-react';
 import { Button } from './components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
 import { Input } from './components/ui/input';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './components/ui/tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './components/ui/tooltip';
 import { CodeBlock } from './components/ui/code-block';
 import { ToggleGroup } from './components/ui/toggle-group';
 import { cn } from './lib/utils';
@@ -42,7 +47,10 @@ import type {
 import type { ResultRendererProps } from './result-renderers';
 import { ResultDisplay } from './ResultDisplay';
 import { registerBuiltinResultRenderers } from './renderers/registerBuiltins';
-import { HttpRequestCurlRenderer, isHttpRequest } from './renderers/HttpRequestCurl';
+import {
+  HttpRequestCurlRenderer,
+  isHttpRequest,
+} from './renderers/HttpRequestCurl';
 import { GraphView } from './graph/GraphView';
 import { FunctionSidebar } from './FunctionSidebar';
 import { EventValueDisplay } from './EventValueDisplay';
@@ -69,21 +77,34 @@ function tryFormatJson(str: string): string {
 }
 
 function stringifyResult(value: BamlJsValue): string {
-  return JSON.stringify(value, (_, v) => (typeof v === 'bigint' ? v.toString() : v), 2);
+  return JSON.stringify(
+    value,
+    (_, v) => (typeof v === 'bigint' ? v.toString() : v),
+    2,
+  );
 }
 
-function findLatestGraphRun(runs: RunEntry[], selectedFn: string | null): RunEntry | undefined {
+function findLatestGraphRun(
+  runs: RunEntry[],
+  selectedFn: string | null,
+): RunEntry | undefined {
   if (!selectedFn) return undefined;
 
   for (let i = runs.length - 1; i >= 0; i -= 1) {
     const run = runs[i];
     if (!run) continue;
     if (run.functionName === selectedFn) return run;
-    if (run.runtimeEvents.some((evt) => {
-      const kind = evt.event;
-      return (kind?.$case === 'functionStart' && kind.functionStart.name === selectedFn)
-        || (kind?.$case === 'functionEnd' && kind.functionEnd.name === selectedFn);
-    })) {
+    if (
+      run.runtimeEvents.some((evt) => {
+        const kind = evt.event;
+        return (
+          (kind?.$case === 'functionStart' &&
+            kind.functionStart.name === selectedFn) ||
+          (kind?.$case === 'functionEnd' &&
+            kind.functionEnd.name === selectedFn)
+        );
+      })
+    ) {
       return run;
     }
   }
@@ -130,14 +151,21 @@ const InlineImageOutputs: FC<{ images: BamlJsMedia[] }> = ({ images }) => {
 };
 
 const FunctionEndPayload: FC<{
-  event: { name: string; durationMs: number; result: BamlJsValue | null; error?: string | null };
+  event: {
+    name: string;
+    durationMs: number;
+    result: BamlJsValue | null;
+    error?: string | null;
+  };
   customRenderers?: Record<string, FC<ResultRendererProps>>;
 }> = ({ event, customRenderers }) => {
   const images = event.result == null ? [] : findImageMedia(event.result);
 
   return (
     <span className="inline-flex min-w-0 flex-wrap items-center gap-1 align-middle">
-      <span>{event.name} ({event.durationMs}ms)</span>
+      <span>
+        {event.name} ({event.durationMs}ms)
+      </span>
       {event.error && (
         <>
           <span className="text-vsc-text-faint">=&gt;</span>
@@ -148,16 +176,27 @@ const FunctionEndPayload: FC<{
         <>
           <span className="text-vsc-text-faint">=&gt;</span>
           {images.length > 0 && <InlineImageOutputs images={images} />}
-          <EventValueDisplay value={event.result} customRenderers={customRenderers} />
+          <EventValueDisplay
+            value={event.result}
+            customRenderers={customRenderers}
+          />
         </>
       )}
     </span>
   );
 };
 
-function formatBuildTime(epochSecs: number): { absolute: string; relative: string } {
+function formatBuildTime(epochSecs: number): {
+  absolute: string;
+  relative: string;
+} {
   const d = new Date(epochSecs * 1000);
-  const absolute = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
+  const absolute = d.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
   const delta = Math.floor(Date.now() / 1000) - epochSecs;
   let relative: string;
   if (delta < 60) relative = `${delta}s ago`;
@@ -186,6 +225,18 @@ export interface ExecutionPanelProps {
   onReload?: () => void;
   /** Called when user clicks an event with source location to jump to that line. */
   onNavigateToSource?: (source: SourceNavigationTarget) => void;
+  /** Tab shown on mount (default 'run'). Embedded views often want 'graph'. */
+  initialTab?: 'run' | 'graph' | 'prompt' | 'curl';
+  /** Auto-select this function once the project reports it (applied once). */
+  initialFunctionName?: string;
+  /** Seed for the args JSON editor (default '{}'). */
+  initialArgsJson?: string;
+  /** Per-function seeds for the args editor, keyed by bare or fully-qualified
+      function name. Applied when a function is selected; args the user typed
+      for a function this session take precedence over its seed. */
+  argsByFunction?: Record<string, string>;
+  /** Whether the function/tests sidebar starts open (default true). */
+  initialSidebarOpen?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -199,23 +250,43 @@ interface CollectionRunViewProps {
   resultRenderers?: Record<string, FC<ResultRendererProps>>;
 }
 
-const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, setExpandedLogId, resultRenderers }) => {
+const CollectionRunView: FC<CollectionRunViewProps> = ({
+  run,
+  expandedLogId,
+  setExpandedLogId,
+  resultRenderers,
+}) => {
   const hasError = run.status === 'error';
   const errorMessage = run.error || 'Unknown expansion error';
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {/* Header */}
       <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-vsc-surface border-b border-vsc-border shrink-0">
-        <span className={cn('w-1.5 h-1.5 rounded-full shrink-0', hasError ? 'bg-vsc-red' : 'bg-vsc-green')} />
-        <span className="text-vsc-accent font-semibold text-[11px]">$collect_tests</span>
-        <span className="text-vsc-text-faint text-[10px] flex-1">{hasError ? 'expansion error' : 'collection fetch logs'}</span>
-        <span className="text-vsc-text-faint text-[10px]">{run.fetchLogs.length} request{run.fetchLogs.length !== 1 ? 's' : ''}</span>
+        <span
+          className={cn(
+            'w-1.5 h-1.5 rounded-full shrink-0',
+            hasError ? 'bg-vsc-red' : 'bg-vsc-green',
+          )}
+        />
+        <span className="text-vsc-accent font-semibold text-[11px]">
+          $collect_tests
+        </span>
+        <span className="text-vsc-text-faint text-[10px] flex-1">
+          {hasError ? 'expansion error' : 'collection fetch logs'}
+        </span>
+        <span className="text-vsc-text-faint text-[10px]">
+          {run.fetchLogs.length} request{run.fetchLogs.length !== 1 ? 's' : ''}
+        </span>
       </div>
       {/* Error message */}
       {hasError && (
         <div className="px-2.5 py-2 bg-vsc-surface border-b border-vsc-border">
-          <div className="text-[10px] font-semibold text-red-500 mb-1 uppercase tracking-wide">Expansion Error</div>
-          <pre className="text-[11px] text-vsc-text whitespace-pre-wrap font-vsc-mono bg-vsc-bg p-2 rounded border border-vsc-border overflow-auto max-h-[300px]">{errorMessage}</pre>
+          <div className="text-[10px] font-semibold text-red-500 mb-1 uppercase tracking-wide">
+            Expansion Error
+          </div>
+          <pre className="text-[11px] text-vsc-text whitespace-pre-wrap font-vsc-mono bg-vsc-bg p-2 rounded border border-vsc-border overflow-auto max-h-[300px]">
+            {errorMessage}
+          </pre>
         </div>
       )}
       {/* Fetch logs */}
@@ -227,37 +298,64 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
         )}
         {run.fetchLogs.map((log) => {
           const isExp = expandedLogId === log.id;
-          const statusColorCls = log.status === null ? 'text-vsc-text-muted'
-            : log.status >= 200 && log.status < 300 ? 'text-vsc-green'
-            : log.status === 0 ? 'text-vsc-red' : 'text-vsc-yellow';
+          const statusColorCls =
+            log.status === null
+              ? 'text-vsc-text-muted'
+              : log.status >= 200 && log.status < 300
+                ? 'text-vsc-green'
+                : log.status === 0
+                  ? 'text-vsc-red'
+                  : 'text-vsc-yellow';
           return (
             <div key={`cl-${log.id}`}>
               <div
                 onClick={() => setExpandedLogId(isExp ? null : log.id)}
                 className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
               >
-                <span className={`${statusColorCls} font-semibold text-[11px]`}>{log.status ?? '...'}</span>
-                <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
-                <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
-                {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
-                <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
+                <span className={`${statusColorCls} font-semibold text-[11px]`}>
+                  {log.status ?? '...'}
+                </span>
+                <span className="text-vsc-text-faint text-[10px]">
+                  {log.method}
+                </span>
+                <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">
+                  {log.url}
+                </span>
+                {log.durationMs != null && (
+                  <span className="text-vsc-text-faint text-[10px]">
+                    {log.durationMs}ms
+                  </span>
+                )}
+                <span className="text-vsc-text-faint text-[9px]">
+                  {isExp ? '\u25B4' : '\u25BE'}
+                </span>
               </div>
               {isExp && (
                 <div className="py-2 pr-2.5 pl-[22px] flex flex-col gap-2 border-b border-vsc-border">
-                  {log.error && <CodeBlock variant="error">{log.error}</CodeBlock>}
+                  {log.error && (
+                    <CodeBlock variant="error">{log.error}</CodeBlock>
+                  )}
                   <div>
-                    <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Request Headers</div>
-                    <CodeBlock>{JSON.stringify(log.requestHeaders, null, 2)}</CodeBlock>
+                    <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                      Request Headers
+                    </div>
+                    <CodeBlock>
+                      {JSON.stringify(log.requestHeaders, null, 2)}
+                    </CodeBlock>
                   </div>
                   {log.requestBody && (
                     <div>
-                      <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Request Body</div>
+                      <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                        Request Body
+                      </div>
                       <CodeBlock>{tryFormatJson(log.requestBody)}</CodeBlock>
                     </div>
                   )}
                   {log.responseBody != null && (
                     <div>
-                      <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Response Body</div>
+                      <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                        Response Body
+                      </div>
                       <CodeBlock>{tryFormatJson(log.responseBody)}</CodeBlock>
                     </div>
                   )}
@@ -289,27 +387,53 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
                     break;
                   case 'functionEnd':
                     label = 'END';
-                    payload = <FunctionEndPayload event={kind.functionEnd} customRenderers={resultRenderers} />;
-                    colorCls = kind.functionEnd.error ? 'text-vsc-red' : 'text-vsc-text-muted';
+                    payload = (
+                      <FunctionEndPayload
+                        event={kind.functionEnd}
+                        customRenderers={resultRenderers}
+                      />
+                    );
+                    colorCls = kind.functionEnd.error
+                      ? 'text-vsc-red'
+                      : 'text-vsc-text-muted';
                     break;
                   case 'log': {
                     const lvl = kind.log.level;
                     label = lvl;
-                    payload = <EventValueDisplay value={kind.log.data} customRenderers={resultRenderers} />;
-                    colorCls = lvl === 'error' ? 'text-vsc-red'
-                      : lvl === 'warn' ? 'text-vsc-yellow'
-                      : lvl === 'debug' ? 'text-vsc-text-muted'
-                      : 'text-vsc-blue';
+                    payload = (
+                      <EventValueDisplay
+                        value={kind.log.data}
+                        customRenderers={resultRenderers}
+                      />
+                    );
+                    colorCls =
+                      lvl === 'error'
+                        ? 'text-vsc-red'
+                        : lvl === 'warn'
+                          ? 'text-vsc-yellow'
+                          : lvl === 'debug'
+                            ? 'text-vsc-text-muted'
+                            : 'text-vsc-blue';
                     break;
                   }
                   case 'custom':
                     label = 'EVENT';
-                    payload = <><span>{kind.custom.name}: </span><EventValueDisplay value={kind.custom.data} customRenderers={resultRenderers} /></>;
+                    payload = (
+                      <>
+                        <span>{kind.custom.name}: </span>
+                        <EventValueDisplay
+                          value={kind.custom.data}
+                          customRenderers={resultRenderers}
+                        />
+                      </>
+                    );
                     colorCls = 'text-vsc-purple';
                     break;
                   case 'setTags':
                     label = 'TAGS';
-                    payload = kind.setTags.tags.map(t => `${t.key}=${t.value}`).join(', ');
+                    payload = kind.setTags.tags
+                      .map((t) => `${t.key}=${t.value}`)
+                      .join(', ');
                     colorCls = 'text-vsc-text-muted';
                     break;
                   default:
@@ -317,8 +441,15 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
                 }
 
                 return (
-                  <div key={evtIdx} className="flex items-start gap-1.5 text-[11px]">
-                    <span className={`${colorCls} font-semibold uppercase shrink-0`}>{label}</span>
+                  <div
+                    key={evtIdx}
+                    className="flex items-start gap-1.5 text-[11px]"
+                  >
+                    <span
+                      className={`${colorCls} font-semibold uppercase shrink-0`}
+                    >
+                      {label}
+                    </span>
                     <span className="text-vsc-text break-all">{payload}</span>
                   </div>
                 );
@@ -335,13 +466,28 @@ const CollectionRunView: FC<CollectionRunViewProps> = ({ run, expandedLogId, set
 // Component
 // ---------------------------------------------------------------------------
 
-export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersion, resultRenderers, onReload, onNavigateToSource }) => {
+export const ExecutionPanel: FC<ExecutionPanelProps> = ({
+  port,
+  connectionVersion,
+  resultRenderers,
+  onReload,
+  onNavigateToSource,
+  initialTab,
+  initialFunctionName,
+  initialArgsJson,
+  argsByFunction,
+  initialSidebarOpen = true,
+}) => {
   const [projectRoots, setProjectRoots] = useState<string[]>([]);
-  const [projectUpdates, setProjectUpdates] = useState<Record<string, ProjectUpdate>>({});
+  const [projectUpdates, setProjectUpdates] = useState<
+    Record<string, ProjectUpdate>
+  >({});
   const [testTree, setTestTree] = useState<any>(null);
   const [collectionCallId, setCollectionCallId] = useState<number | null>(null);
   const [generation, setGeneration] = useState<number>(0);
-  const [testRunResults, setTestRunResults] = useState<Map<string, unknown>>(new Map());
+  const [testRunResults, setTestRunResults] = useState<Map<string, unknown>>(
+    new Map(),
+  );
   const [failedExpands, setFailedExpands] = useState<Set<string>>(new Set());
   // Synthetic RunEntry that accumulates fetch logs from test collection/expansion operations
   const [collectionRun, setCollectionRun] = useState<RunEntry | null>(null);
@@ -353,7 +499,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
   const [selectedFn, setSelectedFn] = useState<string | null>(null);
   const [showInternalFunctions, setShowInternalFunctions] = useState(false);
-  const [argsJson, setArgsJson] = useState('{}');
+  const [argsJson, setArgsJson] = useState(initialArgsJson ?? '{}');
+  // Args the user typed for each function this session — restored (over the
+  // `argsByFunction` seed) when they switch back to that function.
+  const typedArgsByFnRef = useRef<Record<string, string>>({});
 
   // Run history — each entry is a complete invocation with its logs + result
   const [runs, setRuns] = useState<RunEntry[]>([]);
@@ -361,9 +510,18 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   const outputRef = useRef<HTMLDivElement>(null);
   const promptContentRef = useRef<HTMLDivElement>(null);
 
-  const [controlFlowGraph, setControlFlowGraph] = useState<ControlFlowGraph | null>(null);
-  const [activeTab, setActiveTab] = useState<'run' | 'graph' | 'prompt' | 'curl'>('run');
-  const [highlightedNodeId, setHighlightedNodeId] = useState<number | null>(null);
+  const [controlFlowGraph, setControlFlowGraph] =
+    useState<ControlFlowGraph | null>(null);
+  // CFGs for EVERY function in the project (prefetched) — powers the
+  // workflow-root heuristic when a function is picked from the list.
+  const workflowCfgCacheRef = useRef<Map<string, ControlFlowGraph>>(new Map());
+  const [workflowCacheVersion, setWorkflowCacheVersion] = useState(0);
+  const [activeTab, setActiveTab] = useState<
+    'run' | 'graph' | 'prompt' | 'curl'
+  >(initialTab ?? 'run');
+  const [highlightedNodeId, setHighlightedNodeId] = useState<number | null>(
+    null,
+  );
   const [cursorOffset, setCursorOffset] = useState<number | null>(null);
 
   // Workflow context: when a function belongs to multiple workflows,
@@ -372,39 +530,82 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     functionName: string;
     workflows: string[];
   } | null>(null);
-  const [promptPreviewResult, setPromptPreviewResult] = useState<BamlJsValue | null>(null);
-  const [curlPreviewResult, setCurlPreviewResult] = useState<BamlJsValue | null>(null);
-  const [promptPreviewError, setPromptPreviewError] = useState<string | null>(null);
+  const [promptPreviewResult, setPromptPreviewResult] =
+    useState<BamlJsValue | null>(null);
+  const [curlPreviewResult, setCurlPreviewResult] =
+    useState<BamlJsValue | null>(null);
+  const [promptPreviewError, setPromptPreviewError] = useState<string | null>(
+    null,
+  );
   const [curlPreviewError, setCurlPreviewError] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [sidebarWidth, setSidebarWidth] = useState(220);
-  const [logsPanelHeight, setLogsPanelHeight] = useState(LOGS_PANEL_DEFAULT_HEIGHT);
+  const [sidebarOpen, setSidebarOpen] = useState(initialSidebarOpen);
+  const [sidebarWidth, setSidebarWidth] = useState(168);
+  const [showSettingsMenu, setShowSettingsMenu] = useState(false);
+  const [logsPanelHeight, setLogsPanelHeight] = useState(
+    LOGS_PANEL_DEFAULT_HEIGHT,
+  );
   const resizingRef = useRef(false);
-  const [resultModes, setResultModes] = useState<Record<number, 'parsed' | 'raw'>>({});
+  const [resultModes, setResultModes] = useState<
+    Record<number, 'parsed' | 'raw'>
+  >({});
 
   const [showApiKeysDialog, setShowApiKeysDialog] = useState(false);
   const showApiKeysDialogRef = useRef(false);
 
   // Pending io.input() requests keyed by callId, each entry is a queue of { id, prompt }
-  const [pendingInputs, setPendingInputs] = useState<Map<number, Array<{ id: number; prompt: string | undefined }>>>(new Map());
+  const [pendingInputs, setPendingInputs] = useState<
+    Map<number, Array<{ id: number; prompt: string | undefined }>>
+  >(new Map());
 
   const [diagsExpanded, setDiagsExpanded] = useState(false);
   const [buildTime, setBuildTime] = useState<number | null>(null);
-  const [wasmPanic, setWasmPanic] = useState<{ message: string; stack?: string } | null>(null);
-  const { envVars, knownRequiredKeys, shellEnvVars, shellOverriddenKeys, shellDeletedKeys, addEnvVar, removeEnvVar, importEnvVars, addRequiredKey, addShellEnvVar, importShellEnvVars, revertToShell } = useEnvVars(port);
+  const [wasmPanic, setWasmPanic] = useState<{
+    message: string;
+    stack?: string;
+  } | null>(null);
+  const {
+    envVars,
+    knownRequiredKeys,
+    shellEnvVars,
+    shellOverriddenKeys,
+    shellDeletedKeys,
+    addEnvVar,
+    removeEnvVar,
+    importEnvVars,
+    addRequiredKey,
+    addShellEnvVar,
+    importShellEnvVars,
+    revertToShell,
+  } = useEnvVars(port);
   // In-flight worker requests waiting for a value: id → variable name. Ref because it doesn't drive renders.
   const pendingEnvRequestsRef = useRef<Map<number, string>>(new Map());
 
   // Ref mirror of envVars so the message handler closure always sees current values.
   const envVarsRef = useRef(envVars);
-  useEffect(() => { envVarsRef.current = envVars; }, [envVars]);
+  useEffect(() => {
+    envVarsRef.current = envVars;
+  }, [envVars]);
 
   // Ref mirrors for cursor context handler (avoids stale closures in port.onMessage).
+  // workflowRouteFor is defined further down (it needs the function list);
+  // the cursor handler only runs on messages, after the mirror is set.
+  const workflowRouteForRef = useRef<
+    (fn: string) => { roots: string[]; firstHop: Map<string, string> }
+  >(() => ({ roots: [], firstHop: new Map() }));
+  // Highlight to apply once the promoted workflow's graph arrives (the
+  // selection-change effect clears highlights, so apply after, not before).
+  const pendingHighlightRef = useRef<{ fn: string; nodeId: number } | null>(
+    null,
+  );
   const selectedFnRef = useRef(selectedFn);
-  useEffect(() => { selectedFnRef.current = selectedFn; }, [selectedFn]);
+  useEffect(() => {
+    selectedFnRef.current = selectedFn;
+  }, [selectedFn]);
   const controlFlowGraphRef = useRef(controlFlowGraph);
-  useEffect(() => { controlFlowGraphRef.current = controlFlowGraph; }, [controlFlowGraph]);
+  useEffect(() => {
+    controlFlowGraphRef.current = controlFlowGraph;
+  }, [controlFlowGraph]);
   const graphNavigationRef = useRef<{
     nodeId: number;
     startOffset: number;
@@ -412,7 +613,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     expiresAt: number;
   } | null>(null);
 
-  const pendingCallsRef = useRef<Map<number, { resolve: (v: BamlJsValue) => void; reject: (e: Error) => void }>>(new Map());
+  const pendingCallsRef = useRef<
+    Map<
+      number,
+      { resolve: (v: BamlJsValue) => void; reject: (e: Error) => void }
+    >
+  >(new Map());
   // Buffer fetch logs by callId so logs that arrive before testCollectionResult are not lost.
   const pendingLogsRef = useRef<Map<number, FetchLogEntry[]>>(new Map());
 
@@ -421,7 +627,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   /** Build a lookup from sourceExpr → nodeId for the cached CFG.
    *  When multiple nodes share a sourceExpr, prefer semantic types
    *  (call/loop/branch/header) over structural ones (branchArm). */
-  function graphNodeOwnerFunction(node: ControlFlowGraph['nodes'][string]): string | null {
+  function graphNodeOwnerFunction(
+    node: ControlFlowGraph['nodes'][string],
+  ): string | null {
     return node.logFilterKey.split('|', 1)[0] || null;
   }
 
@@ -444,12 +652,29 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     const owner = new Map<number, number>();
     const any = new Map<number, number>();
     if (!graph) return { owner, any };
-    const preferred = new Set(['otherScope', 'loop', 'branchGroup', 'headerContextEnter']);
+    const preferred = new Set([
+      'otherScope',
+      'loop',
+      'branchGroup',
+      'headerContextEnter',
+    ]);
     for (const [, node] of Object.entries(graph.nodes)) {
       if (node.sourceExpr == null) continue;
-      setSourceExprIndexEntry(any, node.sourceExpr, node.id, node.nodeType, preferred);
+      setSourceExprIndexEntry(
+        any,
+        node.sourceExpr,
+        node.id,
+        node.nodeType,
+        preferred,
+      );
       if (functionName && graphNodeOwnerFunction(node) === functionName) {
-        setSourceExprIndexEntry(owner, node.sourceExpr, node.id, node.nodeType, preferred);
+        setSourceExprIndexEntry(
+          owner,
+          node.sourceExpr,
+          node.id,
+          node.nodeType,
+          preferred,
+        );
       }
     }
     return { owner, any };
@@ -480,13 +705,16 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
   function functionNameAliases(functionName: string): string[] {
     const shortName = functionName.split('.').pop();
-    return shortName && shortName !== functionName ? [functionName, shortName] : [functionName];
+    return shortName && shortName !== functionName
+      ? [functionName, shortName]
+      : [functionName];
   }
 
   function labelCalleeName(label: string): string {
     const trimmed = label.trim();
     const optionalCallStart = trimmed.indexOf('?.(');
-    if (optionalCallStart >= 0) return trimmed.slice(0, optionalCallStart).trim();
+    if (optionalCallStart >= 0)
+      return trimmed.slice(0, optionalCallStart).trim();
 
     const callStart = trimmed.indexOf('(');
     if (callStart >= 0) return trimmed.slice(0, callStart).trim();
@@ -494,9 +722,14 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     return trimmed;
   }
 
-  function nodeLabelMatchesFunctionName(label: string, functionName: string): boolean {
+  function nodeLabelMatchesFunctionName(
+    label: string,
+    functionName: string,
+  ): boolean {
     const calleeName = labelCalleeName(label);
-    return functionNameAliases(functionName).some((name) => calleeName === name);
+    return functionNameAliases(functionName).some(
+      (name) => calleeName === name,
+    );
   }
 
   function nodeMatchesFunctionName(
@@ -526,9 +759,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   function handleGraphNodeClick(nodeId: number) {
     setHighlightedNodeId(nodeId);
 
-    const source = (controlFlowGraph ?? controlFlowGraphRef.current)
-      ?.nodes[String(nodeId)]
-      ?.sourceSpan;
+    const source = (controlFlowGraph ?? controlFlowGraphRef.current)?.nodes[
+      String(nodeId)
+    ]?.sourceSpan;
     if (source && onNavigateToSource) {
       if (source.startOffset != null && source.endOffset != null) {
         graphNavigationRef.current = {
@@ -548,11 +781,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
     const graphNavigation = graphNavigationRef.current;
     if (
-      graphNavigation
-      && performance.now() <= graphNavigation.expiresAt
-      && ctx.cursorOffset != null
-      && ctx.cursorOffset >= graphNavigation.startOffset
-      && ctx.cursorOffset <= graphNavigation.endOffset
+      graphNavigation &&
+      performance.now() <= graphNavigation.expiresAt &&
+      ctx.cursorOffset != null &&
+      ctx.cursorOffset >= graphNavigation.startOffset &&
+      ctx.cursorOffset <= graphNavigation.endOffset
     ) {
       setHighlightedNodeId(graphNavigation.nodeId);
       graphNavigationRef.current = null;
@@ -568,9 +801,17 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     const cachedGraph = controlFlowGraphRef.current;
 
     const candidates = ctx.sourceExprCandidates ?? [];
-    const sourceExprFunctionName = ctx.sourceExprFunctionName ?? ctx.functionName;
-    const nodeId = resolveCandidatesToNodeId(cachedGraph, candidates, sourceExprFunctionName)
-      ?? (ctx.sourceExprId != null ? resolveNodeByFunctionName(cachedGraph, ctx.functionName) : null);
+    const sourceExprFunctionName =
+      ctx.sourceExprFunctionName ?? ctx.functionName;
+    const nodeId =
+      resolveCandidatesToNodeId(
+        cachedGraph,
+        candidates,
+        sourceExprFunctionName,
+      ) ??
+      (ctx.sourceExprId != null
+        ? resolveNodeByFunctionName(cachedGraph, ctx.functionName)
+        : null);
     const isCallSite = sourceExprFunctionName !== ctx.functionName;
 
     // Rule 1: cursor is on a node in the currently-displayed workflow
@@ -598,24 +839,50 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       return;
     }
 
-    // Rule 4: navigate to the function definition/reference the cursor is on.
+    // Rule 4: navigate to the function the cursor is on — always promoted to
+    // a workflow that contains it. LineTotal inside Main→Review→ValidateInvoice
+    // shows Main's graph, not LineTotal's, with the call-site node on the path
+    // highlighted. When the helper belongs to several workflows, stay on the
+    // current one if it's among them (else pick the first) and offer a
+    // switcher above the graph. Whole-call-graph roots are preferred; the
+    // worker's direct-caller membership info is the fallback.
+    const route = workflowRouteForRef.current(ctx.functionName);
+    const workflows =
+      route.roots.length > 0 ? route.roots : ctx.workflowMemberships;
+    const root =
+      currentFn && workflows.includes(currentFn) ? currentFn : workflows[0];
+    if (root) {
+      // Prefer the node that calls the function under the cursor (its call
+      // site survives in the expanded graph, e.g. relabeled by a //# header
+      // above the function); fall back to the first hop from the root.
+      const hop = route.firstHop.get(root) ?? ctx.functionName;
+      const target =
+        findCallSiteNode(root, ctx.functionName) ?? findCallSiteNode(root, hop);
+      if (root !== currentFn) {
+        pendingHighlightRef.current =
+          target != null ? { fn: root, nodeId: target } : null;
+        setSelectedFn(root);
+        setViewingCollection(false);
+        setViewingTestRun(false);
+        setHighlightedNodeId(null);
+      } else if (target != null) {
+        setHighlightedNodeId(target);
+      }
+      setWorkflowContext(
+        workflows.length > 1
+          ? { functionName: ctx.functionName, workflows }
+          : null,
+      );
+      return;
+    }
+    // Not part of any workflow — show the function's own graph.
     if (ctx.functionName !== currentFn) {
       setSelectedFn(ctx.functionName);
       setViewingCollection(false);
       setViewingTestRun(false);
       setHighlightedNodeId(null);
     }
-    // Update "called from" context (shown as a picker above the graph).
-    // Set on every navigation, including when already on the function,
-    // so it reflects the current membership info.
-    if (ctx.workflowMemberships.length > 0) {
-      setWorkflowContext({
-        functionName: ctx.functionName,
-        workflows: ctx.workflowMemberships,
-      });
-    } else {
-      setWorkflowContext(null);
-    }
+    setWorkflowContext(null);
   }
 
   // ── Port message handler ─────────────────────────────────────────────
@@ -639,7 +906,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
               break;
             case 'testCollectionResult': {
               try {
-                const jsonStr = new TextDecoder().decode(new Uint8Array(n.data));
+                const jsonStr = new TextDecoder().decode(
+                  new Uint8Array(n.data),
+                );
                 const tree = JSON.parse(jsonStr);
 
                 // Track failed expansions from the server-provided error field
@@ -689,7 +958,20 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
               }
               break;
             case 'controlFlowGraphResult':
-              if (n.graph) setControlFlowGraph(n.graph);
+              if (n.graph) {
+                workflowCfgCacheRef.current.set(n.functionName, n.graph);
+                setWorkflowCacheVersion((v) => v + 1);
+                // Only the selected function's graph drives the display —
+                // prefetched graphs for other functions just fill the cache.
+                if (n.functionName === selectedFnRef.current) {
+                  setControlFlowGraph(n.graph);
+                  const pending = pendingHighlightRef.current;
+                  if (pending && pending.fn === n.functionName) {
+                    pendingHighlightRef.current = null;
+                    setHighlightedNodeId(pending.nodeId);
+                  }
+                }
+              }
               break;
           }
           break;
@@ -741,7 +1023,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
             const targetIdx = prev.findIndex((r) => r.id === logEntry.callId);
             if (targetIdx === -1) return prev;
             const target = prev[targetIdx];
-            return [...prev.slice(0, targetIdx), { ...target, fetchLogs: [...target.fetchLogs, logEntry] }, ...prev.slice(targetIdx + 1)];
+            return [
+              ...prev.slice(0, targetIdx),
+              { ...target, fetchLogs: [...target.fetchLogs, logEntry] },
+              ...prev.slice(targetIdx + 1),
+            ];
           });
           break;
         }
@@ -750,14 +1036,18 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
           // Also update collection run logs
           setCollectionRun((prev) => {
             if (!prev) return prev;
-            const updated = prev.fetchLogs.map((e) => (e.id === data.logId ? { ...e, ...data.patch } : e));
+            const updated = prev.fetchLogs.map((e) =>
+              e.id === data.logId ? { ...e, ...data.patch } : e,
+            );
             if (updated === prev.fetchLogs) return prev;
             return { ...prev, fetchLogs: updated };
           });
           setRuns((prev) =>
             prev.map((r) => ({
               ...r,
-              fetchLogs: r.fetchLogs.map((e) => (e.id === data.logId ? { ...e, ...data.patch } : e)),
+              fetchLogs: r.fetchLogs.map((e) =>
+                e.id === data.logId ? { ...e, ...data.patch } : e,
+              ),
             })),
           );
           break;
@@ -769,13 +1059,16 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
               prev.map((r) =>
                 r.id === data.callId
                   ? { ...r, runtimeEvents: [...r.runtimeEvents, eventEntry] }
-                  : r
-              )
+                  : r,
+              ),
             );
             // Also route to collection run if this event belongs to it
             setCollectionRun((prev) => {
               if (!prev || prev.id !== data.callId) return prev;
-              return { ...prev, runtimeEvents: [...prev.runtimeEvents, eventEntry] };
+              return {
+                ...prev,
+                runtimeEvents: [...prev.runtimeEvents, eventEntry],
+              };
             });
           }
           break;
@@ -804,7 +1097,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
           addRequiredKey(data.variable);
           const cached = envVarsRef.current[data.variable];
           if (cached !== undefined) {
-            port.postMessage({ type: 'envVarResponse', id: data.id, value: cached, variable: data.variable });
+            port.postMessage({
+              type: 'envVarResponse',
+              id: data.id,
+              value: cached,
+              variable: data.variable,
+            });
           } else {
             // Park the request — it will be resolved when the dialog closes
             pendingEnvRequestsRef.current.set(data.id, data.variable);
@@ -839,36 +1137,47 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
           break;
         }
 
-        case "ready":
+        case 'ready':
           break;
 
         case 'buildTime':
           setBuildTime(Number(data.value) || null);
           break;
 
-        case "vfsFileChanged":
-        case "vfsFileDeleted":
-        case "diagnostics":
+        case 'vfsFileChanged':
+        case 'vfsFileDeleted':
+        case 'diagnostics':
           break;
 
-        case "controlFlowGraphResult":
-          if (data.graph) setControlFlowGraph(data.graph);
+        case 'controlFlowGraphResult':
+          if (data.graph) {
+            workflowCfgCacheRef.current.set(data.functionName, data.graph);
+            setWorkflowCacheVersion((v) => v + 1);
+            if (data.functionName === selectedFnRef.current) {
+              setControlFlowGraph(data.graph);
+              const pending = pendingHighlightRef.current;
+              if (pending && pending.fn === data.functionName) {
+                pendingHighlightRef.current = null;
+                setHighlightedNodeId(pending.nodeId);
+              }
+            }
+          }
           break;
 
-        case "cursorContext":
+        case 'cursorContext':
           handleCursorContext(data.context);
           break;
 
-        case "wasmPanic":
+        case 'wasmPanic':
           setWasmPanic({ message: data.message, stack: data.stack });
           break;
 
-        case "logDecorations":
-        case "clearLogDecorations":
+        case 'logDecorations':
+        case 'clearLogDecorations':
           // These are handled by MonacoEditor, ignore here
           break;
 
-        case "runtimeEventError":
+        case 'runtimeEventError':
           console.warn('[ExecutionPanel] runtimeEventError:', data.error);
           break;
 
@@ -890,7 +1199,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   // On code edit (projectUpdateVersion): keep old graph visible, swap when new one arrives.
   const prevGraphFnRef = useRef(selectedFn);
   const prevGraphProjectRef = useRef(selectedProject);
-  const projectUpdateVersion = selectedProject ? projectUpdates[selectedProject] : undefined;
+  const projectUpdateVersion = selectedProject
+    ? projectUpdates[selectedProject]
+    : undefined;
 
   useEffect(() => {
     const fnChanged = prevGraphFnRef.current !== selectedFn;
@@ -903,7 +1214,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       setHighlightedNodeId(null);
     }
     if (!selectedFn || !selectedProject) return;
-    port.postMessage({ type: 'requestControlFlowGraph', project: selectedProject, functionName: selectedFn });
+    port.postMessage({
+      type: 'requestControlFlowGraph',
+      project: selectedProject,
+      functionName: selectedFn,
+    });
   }, [port, selectedFn, selectedProject, projectUpdateVersion]);
 
   // Clear preview results when selected function changes
@@ -915,14 +1230,32 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     setPreviewLoading(false);
   }, [selectedFn]);
 
+  // Swap the args editor when the selected function changes: args the user
+  // typed for that function win, then its `argsByFunction` seed (exact or
+  // bare-name key, since selection may be namespaced), then the panel seed.
+  const prevArgsFnRef = useRef(selectedFn);
+  useEffect(() => {
+    if (prevArgsFnRef.current === selectedFn) return;
+    prevArgsFnRef.current = selectedFn;
+    if (!selectedFn) return;
+    const seed =
+      argsByFunction?.[selectedFn] ??
+      argsByFunction?.[selectedFn.split('.').pop() ?? ''];
+    setArgsJson(
+      typedArgsByFnRef.current[selectedFn] ?? seed ?? initialArgsJson ?? '{}',
+    );
+  }, [selectedFn, argsByFunction, initialArgsJson]);
+
   // Auto-refresh prompt/curl preview when args change while tab is active
   useEffect(() => {
     if (activeTab !== 'prompt' && activeTab !== 'curl') return;
     if (!selectedFn || !selectedProject) return;
 
     const subFn = activeTab === 'prompt' ? 'render_prompt' : 'build_request';
-    const setResult = activeTab === 'prompt' ? setPromptPreviewResult : setCurlPreviewResult;
-    const setError = activeTab === 'prompt' ? setPromptPreviewError : setCurlPreviewError;
+    const setResult =
+      activeTab === 'prompt' ? setPromptPreviewResult : setCurlPreviewResult;
+    const setError =
+      activeTab === 'prompt' ? setPromptPreviewError : setCurlPreviewError;
 
     // Clear previous error while loading (keep last result visible)
     setError(null);
@@ -942,7 +1275,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       return;
     }
 
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
       setPreviewLoading(false);
       setError('Args must be a JSON object');
       return;
@@ -953,17 +1290,22 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     const timer = setTimeout(async () => {
       try {
         const callId = await port.nextFunctionCall();
-        const argsProto = encodeCallArgs(parsed as Record<string, unknown>, callId);
-        const resultValue = await new Promise<BamlJsValue>((resolve, reject) => {
-          pendingCallsRef.current.set(callId, { resolve, reject });
-          port.postMessage({
-            type: 'callFunction',
-            id: callId,
-            name: companionFunctionName(selectedFn, subFn),
-            argsProto: new Uint8Array(argsProto),
-            project: selectedProject,
-          });
-        });
+        const argsProto = encodeCallArgs(
+          parsed as Record<string, unknown>,
+          callId,
+        );
+        const resultValue = await new Promise<BamlJsValue>(
+          (resolve, reject) => {
+            pendingCallsRef.current.set(callId, { resolve, reject });
+            port.postMessage({
+              type: 'callFunction',
+              id: callId,
+              name: companionFunctionName(selectedFn, subFn),
+              argsProto: new Uint8Array(argsProto),
+              project: selectedProject,
+            });
+          },
+        );
         setResult(resultValue);
         setError(null);
         setPreviewLoading(false);
@@ -975,9 +1317,19 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
       }
     }, 500);
 
-    return () => { clearTimeout(timer); setPreviewLoading(false); };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTab, selectedFn, selectedProject, argsJson, port, projectUpdateVersion]);
+    return () => {
+      clearTimeout(timer);
+      setPreviewLoading(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    activeTab,
+    selectedFn,
+    selectedProject,
+    argsJson,
+    port,
+    projectUpdateVersion,
+  ]);
 
   // Sync existing envVars to the port whenever port changes
   useEffect(() => {
@@ -987,29 +1339,44 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only sync when port changes
   }, [port]);
 
-  const onArgsJsonChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    setArgsJson(e.target.value);
-  }, []);
+  const onArgsJsonChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setArgsJson(e.target.value);
+      if (selectedFn) typedArgsByFnRef.current[selectedFn] = e.target.value;
+    },
+    [selectedFn],
+  );
 
   // ── Run function ───────────────────────────────────────────────────────
 
-  const isRunning = runs.length > 0 && runs[runs.length - 1].status === 'running';
+  const isRunning =
+    runs.length > 0 && runs[runs.length - 1].status === 'running';
 
-  const onCancelRun = useCallback((runId: number) => {
-    if (!selectedProject) return;
-    port.postMessage({ type: 'cancelCall', id: runId, project: selectedProject });
-  }, [port, selectedProject]);
+  const onCancelRun = useCallback(
+    (runId: number) => {
+      if (!selectedProject) return;
+      port.postMessage({
+        type: 'cancelCall',
+        id: runId,
+        project: selectedProject,
+      });
+    },
+    [port, selectedProject],
+  );
 
-  const submitInput = useCallback((id: number, value: string, callId: number) => {
-    port.postMessage({ type: 'inputResponse', id, value, callId });
-    setPendingInputs((prev) => {
-      const next = new Map(prev);
-      const arr = (next.get(callId) ?? []).filter((r) => r.id !== id);
-      if (arr.length === 0) next.delete(callId);
-      else next.set(callId, arr);
-      return next;
-    });
-  }, [port]);
+  const submitInput = useCallback(
+    (id: number, value: string, callId: number) => {
+      port.postMessage({ type: 'inputResponse', id, value, callId });
+      setPendingInputs((prev) => {
+        const next = new Map(prev);
+        const arr = (next.get(callId) ?? []).filter((r) => r.id !== id);
+        if (arr.length === 0) next.delete(callId);
+        else next.set(callId, arr);
+        return next;
+      });
+    },
+    [port],
+  );
 
   const toggleResultMode = useCallback((runId: number) => {
     setResultModes((prev) => ({
@@ -1018,42 +1385,56 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     }));
   }, []);
 
-  const onResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    resizingRef.current = true;
-    const startX = e.clientX;
-    const startWidth = sidebarWidth;
+  const onResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      resizingRef.current = true;
+      const startX = e.clientX;
+      const startWidth = sidebarWidth;
 
-    const onMouseMove = (moveE: MouseEvent) => {
-      const delta = moveE.clientX - startX;
-      setSidebarWidth(Math.max(160, Math.min(400, startWidth + delta)));
-    };
-    const onMouseUp = () => {
-      resizingRef.current = false;
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-    };
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }, [sidebarWidth]);
+      const onMouseMove = (moveE: MouseEvent) => {
+        const delta = moveE.clientX - startX;
+        setSidebarWidth(Math.max(160, Math.min(400, startWidth + delta)));
+      };
+      const onMouseUp = () => {
+        resizingRef.current = false;
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+      };
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    },
+    [sidebarWidth],
+  );
 
-  const onLogsResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    const startY = e.clientY;
-    const startHeight = logsPanelHeight;
+  const onLogsResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startY = e.clientY;
+      const startHeight = logsPanelHeight;
 
-    const onMouseMove = (moveE: MouseEvent) => {
-      const delta = startY - moveE.clientY;
-      const maxHeight = Math.max(LOGS_PANEL_MIN_HEIGHT, Math.min(LOGS_PANEL_MAX_HEIGHT, window.innerHeight - 220));
-      setLogsPanelHeight(Math.max(LOGS_PANEL_MIN_HEIGHT, Math.min(maxHeight, startHeight + delta)));
-    };
-    const onMouseUp = () => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-    };
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }, [logsPanelHeight]);
+      const onMouseMove = (moveE: MouseEvent) => {
+        const delta = startY - moveE.clientY;
+        const maxHeight = Math.max(
+          LOGS_PANEL_MIN_HEIGHT,
+          Math.min(LOGS_PANEL_MAX_HEIGHT, window.innerHeight - 220),
+        );
+        setLogsPanelHeight(
+          Math.max(
+            LOGS_PANEL_MIN_HEIGHT,
+            Math.min(maxHeight, startHeight + delta),
+          ),
+        );
+      };
+      const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+      };
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    },
+    [logsPanelHeight],
+  );
 
   const onRunFunction = useCallback(async () => {
     if (!selectedFn || !selectedProject || isRunning) return;
@@ -1083,30 +1464,52 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
 
     try {
       const parsed = JSON.parse(argsJson);
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        throw new Error('Arguments must be a JSON object, e.g. {"arr": [3,1,2]}');
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new Error(
+          'Arguments must be a JSON object, e.g. {"arr": [3,1,2]}',
+        );
       }
       const argsProto = encodeCallArgs(parsed as Record<string, unknown>, runId);
 
       const resultValue = await new Promise<BamlJsValue>((resolve, reject) => {
         pendingCallsRef.current.set(runId, { resolve, reject });
-        port.postMessage(
-          { type: 'callFunction', id: runId, name: selectedFn, argsProto: new Uint8Array(argsProto), project: selectedProject },
-        );
+        port.postMessage({
+          type: 'callFunction',
+          id: runId,
+          name: selectedFn,
+          argsProto: new Uint8Array(argsProto),
+          project: selectedProject,
+        });
       });
 
       const dur = Math.round(performance.now() - startTime);
-      setRuns((prev) => prev.map((r) => r.id === runId ? { ...r, result: resultValue, status: 'success', durationMs: dur } : r));
+      setRuns((prev) =>
+        prev.map((r) =>
+          r.id === runId
+            ? { ...r, result: resultValue, status: 'success', durationMs: dur }
+            : r,
+        ),
+      );
     } catch (e) {
       const isCancelled = e instanceof Error && (e as any).cancelled === true;
       const errMsg = e instanceof Error ? e.message : String(e);
       const dur = Math.round(performance.now() - startTime);
-      setRuns((prev) => prev.map((r) => r.id === runId ? {
-        ...r,
-        error: isCancelled ? null : errMsg,
-        status: isCancelled ? 'cancelled' : 'error',
-        durationMs: dur,
-      } : r));
+      setRuns((prev) =>
+        prev.map((r) =>
+          r.id === runId
+            ? {
+                ...r,
+                error: isCancelled ? null : errMsg,
+                status: isCancelled ? 'cancelled' : 'error',
+                durationMs: dur,
+              }
+            : r,
+        ),
+      );
     }
   }, [selectedFn, selectedProject, argsJson, isRunning, port]);
 
@@ -1115,68 +1518,94 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     port.postMessage({ type: 'requestCollectTests', project: selectedProject });
   }, [selectedProject, port]);
 
-  const handleRunTest = useCallback(async (name: string) => {
-    if (!selectedProject) return;
-    // Switch to the test run view so the runs panel is visible even when no function is selected.
-    setViewingTestRun(true);
-    setViewingCollection(false);
-    const runId = await port.nextFunctionCall();
-    const newRun: RunEntry = {
-      id: runId,
-      functionName: 'testing.run_test',
-      testName: name,
-      argsJson: `(test: ${name})`,
-      fetchLogs: [],
-      runtimeEvents: [],
-      result: null,
-      error: null,
-      status: 'running',
-      startTime: performance.now(),
-      durationMs: null,
-    };
-    setRuns((prev) => [...prev, newRun]);
+  const handleRunTest = useCallback(
+    async (name: string) => {
+      if (!selectedProject) return;
+      // Switch to the test run view so the runs panel is visible even when no function is selected.
+      setViewingTestRun(true);
+      setViewingCollection(false);
+      const runId = await port.nextFunctionCall();
+      const newRun: RunEntry = {
+        id: runId,
+        functionName: 'testing.run_test',
+        testName: name,
+        argsJson: `(test: ${name})`,
+        fetchLogs: [],
+        runtimeEvents: [],
+        result: null,
+        error: null,
+        status: 'running',
+        startTime: performance.now(),
+        durationMs: null,
+      };
+      setRuns((prev) => [...prev, newRun]);
 
-    try {
-      const resultValue = await new Promise<BamlJsValue>((resolve, reject) => {
-        pendingCallsRef.current.set(runId, { resolve, reject });
-        port.postMessage({
-          type: 'callTestFunction',
-          id: runId,
-          project: selectedProject,
-          generation,
-          testName: name,
-        });
-      });
+      try {
+        const resultValue = await new Promise<BamlJsValue>(
+          (resolve, reject) => {
+            pendingCallsRef.current.set(runId, { resolve, reject });
+            port.postMessage({
+              type: 'callTestFunction',
+              id: runId,
+              project: selectedProject,
+              generation,
+              testName: name,
+            });
+          },
+        );
 
-      const dur = Math.round(performance.now() - newRun.startTime);
-      setRuns((prev) =>
-        prev.map((r) =>
-          r.id === runId
-            ? { ...r, result: resultValue, status: 'success', durationMs: dur }
-            : r,
-        ),
-      );
+        const dur = Math.round(performance.now() - newRun.startTime);
+        setRuns((prev) =>
+          prev.map((r) =>
+            r.id === runId
+              ? {
+                  ...r,
+                  result: resultValue,
+                  status: 'success',
+                  durationMs: dur,
+                }
+              : r,
+          ),
+        );
 
-      setTestRunResults((prev) => new Map(prev).set(name, resultValue));
-    } catch (e: any) {
-      const dur = Math.round(performance.now() - newRun.startTime);
-      const cancelled = e instanceof Error && (e as any).cancelled === true;
-      setRuns((prev) =>
-        prev.map((r) =>
-          r.id === runId
-            ? { ...r, error: cancelled ? null : (e instanceof Error ? e.message : String(e)), status: cancelled ? 'cancelled' : 'error', durationMs: dur }
-            : r,
-        ),
-      );
+        setTestRunResults((prev) => new Map(prev).set(name, resultValue));
+      } catch (e: any) {
+        const dur = Math.round(performance.now() - newRun.startTime);
+        const cancelled = e instanceof Error && (e as any).cancelled === true;
+        setRuns((prev) =>
+          prev.map((r) =>
+            r.id === runId
+              ? {
+                  ...r,
+                  error: cancelled
+                    ? null
+                    : e instanceof Error
+                      ? e.message
+                      : String(e),
+                  status: cancelled ? 'cancelled' : 'error',
+                  durationMs: dur,
+                }
+              : r,
+          ),
+        );
 
-      setTestRunResults((prev) =>
-        new Map(prev).set(name, { outcome: 'error', error: e instanceof Error ? e.message : String(e) }),
-      );
-    }
-  }, [selectedProject, generation, port]);
+        setTestRunResults((prev) =>
+          new Map(prev).set(name, {
+            outcome: 'error',
+            error: e instanceof Error ? e.message : String(e),
+          }),
+        );
+      }
+    },
+    [selectedProject, generation, port],
+  );
 
   // Track which testsets we've already requested expansion for (per generation)
-  const pendingExpandsRef = useRef<{ project: string | null; generation: number; names: Set<string> }>({ project: null, generation: -1, names: new Set() });
+  const pendingExpandsRef = useRef<{
+    project: string | null;
+    generation: number;
+    names: Set<string>;
+  }>({ project: null, generation: -1, names: new Set() });
 
   // Auto-expand lazy testsets after receiving a new testTree
   useEffect(() => {
@@ -1184,15 +1613,21 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
     // Reset pending set and failed state when generation or project changes.
     // Generation is per-project on the server, so different projects can share
     // the same generation number — we must track both to avoid leaking state.
-    if (pendingExpandsRef.current.generation !== generation || pendingExpandsRef.current.project !== selectedProject) {
-      pendingExpandsRef.current = { project: selectedProject, generation, names: new Set() };
+    if (
+      pendingExpandsRef.current.generation !== generation ||
+      pendingExpandsRef.current.project !== selectedProject
+    ) {
+      pendingExpandsRef.current = {
+        project: selectedProject,
+        generation,
+        names: new Set(),
+      };
       setFailedExpands(new Set());
     }
     const pending = pendingExpandsRef.current.names;
     const expandLazy = (items: any[]) => {
       for (const item of items) {
         if (item && item.type === 'lazyTestSet' && !pending.has(item.name)) {
-
           pending.add(item.name);
           port.postMessage({
             type: 'expandTestSet',
@@ -1212,32 +1647,39 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   }, [testTree, selectedProject, generation, port]);
 
   // Retry expansion for a failed (or already expanded) testset
-  const handleRetryExpand = useCallback((testsetName: string) => {
-    if (!selectedProject) return;
-    // Remove from failed set so it shows spinner again
-    setFailedExpands((prev) => {
-      const next = new Set(prev);
-      next.delete(testsetName);
-      return next;
-    });
-    // Remove from pending so auto-expand doesn't skip it
-    pendingExpandsRef.current.names.delete(testsetName);
-    // Re-send expansion request
-    pendingExpandsRef.current.names.add(testsetName);
-    port.postMessage({
-      type: 'expandTestSet',
-      project: selectedProject,
-      generation,
-      testsetName,
-    });
-  }, [selectedProject, generation, port]);
+  const handleRetryExpand = useCallback(
+    (testsetName: string) => {
+      if (!selectedProject) return;
+      // Remove from failed set so it shows spinner again
+      setFailedExpands((prev) => {
+        const next = new Set(prev);
+        next.delete(testsetName);
+        return next;
+      });
+      // Remove from pending so auto-expand doesn't skip it
+      pendingExpandsRef.current.names.delete(testsetName);
+      // Re-send expansion request
+      pendingExpandsRef.current.names.add(testsetName);
+      port.postMessage({
+        type: 'expandTestSet',
+        project: selectedProject,
+        generation,
+        testsetName,
+      });
+    },
+    [selectedProject, generation, port],
+  );
 
   // ── Derived state ──────────────────────────────────────────────────────
 
-  const currentUpdate = selectedProject ? projectUpdates[selectedProject] : undefined;
+  const currentUpdate = selectedProject
+    ? projectUpdates[selectedProject]
+    : undefined;
   const functions: FunctionInfo[] = currentUpdate?.functions ?? [];
   const internalFunctionCount = functions.filter(isInternalFunction).length;
-  const visibleFunctions = showInternalFunctions ? functions : functions.filter((fn) => !isInternalFunction(fn));
+  const visibleFunctions = showInternalFunctions
+    ? functions
+    : functions.filter((fn) => !isInternalFunction(fn));
   const functionNames = visibleFunctions.map((f) => f.name);
   const engineStale = currentUpdate ? !currentUpdate.isBexCurrent : false;
   const diags = currentUpdate?.diagnostics ?? [];
@@ -1246,10 +1688,161 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   const canPreviewPrompt = selectedFnInfo?.capabilities?.renderPrompt ?? false;
   const canPreviewCurl = selectedFnInfo?.capabilities?.buildRequest ?? false;
   const latestGraphRun = findLatestGraphRun(runs, selectedFn);
+  // The run-history/logs strip is lifted out of the sidebar+content row so it
+  // spans the panel's full width; the row gets bottom padding to make room.
+  const runLogsVisible =
+    activeTab === 'run' &&
+    !!selectedFn &&
+    !viewingCollection &&
+    !viewingTestRun;
 
   useEffect(() => {
-    setSelectedFn((prev) => prev && !functionNames.includes(prev) ? null : prev);
+    setSelectedFn((prev) =>
+      prev && !functionNames.includes(prev) ? null : prev,
+    );
   }, [functionNames]);
+
+  // Prefetch every visible function's CFG once per project build so the
+  // workflow-root heuristic can see the whole call graph. The responses
+  // land in workflowCfgCacheRef (display is guarded by selectedFn).
+  const prefetchedCfgRef = useRef<{ version: unknown; names: Set<string> }>({
+    version: undefined,
+    names: new Set(),
+  });
+  useEffect(() => {
+    if (!selectedProject) return;
+    const slot = prefetchedCfgRef.current;
+    if (slot.version !== projectUpdateVersion) {
+      slot.version = projectUpdateVersion;
+      slot.names = new Set();
+      workflowCfgCacheRef.current = new Map();
+    }
+    for (const name of functionNames) {
+      if (slot.names.has(name)) continue;
+      slot.names.add(name);
+      port.postMessage({
+        type: 'requestControlFlowGraph',
+        project: selectedProject,
+        functionName: name,
+      });
+    }
+  }, [functionNames, selectedProject, projectUpdateVersion, port]);
+
+  // Reverse call map over the cached CFGs: callee -> the functions that
+  // call it. calleeName may be bare while function names are qualified
+  // (`main.illustrate`), so resolve by exact match or trailing segment.
+  const workflowCallers = useMemo(() => {
+    void workflowCacheVersion;
+    const resolve = (callee: string): string | null =>
+      functionNames.find(
+        (n) =>
+          n === callee || n.endsWith(`.${callee}`) || callee.endsWith(`.${n}`),
+      ) ?? null;
+    const callers = new Map<string, Set<string>>();
+    for (const [fn, g] of workflowCfgCacheRef.current) {
+      for (const node of Object.values(g.nodes)) {
+        // calleeNames covers calls nested inside conditions/arguments;
+        // calleeName alone only covers nodes that ARE a call.
+        const names =
+          node.calleeNames && node.calleeNames.length > 0
+            ? node.calleeNames
+            : node.calleeName
+              ? [node.calleeName]
+              : [];
+        for (const raw of names) {
+          const callee = resolve(raw);
+          if (!callee || callee === fn) continue;
+          let set = callers.get(callee);
+          if (!set) {
+            set = new Set();
+            callers.set(callee, set);
+          }
+          set.add(fn);
+        }
+      }
+    }
+    return callers;
+  }, [workflowCacheVersion, functionNames]);
+
+  // The topmost workflows containing fn: walk the caller chain upward to
+  // functions nobody else calls. Tests never appear — they are not in the
+  // function list, so their call sites are not in the cache. The input may
+  // be a bare name (cursor context) while the map keys are the qualified
+  // list names, so canonicalize first. Alongside the roots, report each
+  // root's "first hop" — the function the root calls on the path down to
+  // fn — so the call-site node can be highlighted after promotion.
+  const workflowRouteFor = useCallback(
+    (rawFn: string): { roots: string[]; firstHop: Map<string, string> } => {
+      const fn =
+        functionNames.find(
+          (n) =>
+            n === rawFn || n.endsWith(`.${rawFn}`) || rawFn.endsWith(`.${n}`),
+        ) ?? rawFn;
+      const roots = new Set<string>();
+      const firstHop = new Map<string, string>();
+      const seen = new Set<string>([fn]);
+      const stack: Array<{ node: string; via: string }> = [
+        ...(workflowCallers.get(fn) ?? []),
+      ].map((c) => ({ node: c, via: fn }));
+      while (stack.length > 0) {
+        const entry = stack.pop();
+        if (!entry || seen.has(entry.node)) continue;
+        seen.add(entry.node);
+        const ups = workflowCallers.get(entry.node);
+        if (!ups || ups.size === 0) {
+          roots.add(entry.node);
+          if (!firstHop.has(entry.node)) firstHop.set(entry.node, entry.via);
+        } else {
+          stack.push(...[...ups].map((u) => ({ node: u, via: entry.node })));
+        }
+      }
+      return { roots: [...roots], firstHop };
+    },
+    [workflowCallers, functionNames],
+  );
+  useEffect(() => {
+    workflowRouteForRef.current = workflowRouteFor;
+  }, [workflowRouteFor]);
+
+  // The node in rootFn's CFG whose expression calls hopFn — what to
+  // highlight after promoting to the workflow root.
+  const findCallSiteNode = useCallback(
+    (rootFn: string, hopFn: string): number | null => {
+      const g = workflowCfgCacheRef.current.get(rootFn);
+      if (!g) return null;
+      const matches = (raw: string) =>
+        raw === hopFn || hopFn.endsWith(`.${raw}`) || raw.endsWith(`.${hopFn}`);
+      let fallback: number | null = null;
+      for (const node of Object.values(g.nodes)) {
+        const names =
+          node.calleeNames && node.calleeNames.length > 0
+            ? node.calleeNames
+            : node.calleeName
+              ? [node.calleeName]
+              : [];
+        if (!names.some(matches)) continue;
+        if (!node.isContainer) return node.id;
+        fallback = fallback ?? node.id;
+      }
+      return fallback;
+    },
+    [],
+  );
+
+  // Apply the caller's initial function selection once, as soon as the
+  // project reports a matching function. Function names may arrive
+  // namespace-qualified (e.g. `main.illustrate`), so match by exact name
+  // or trailing segment. Never overrides a user choice.
+  const appliedInitialFnRef = useRef(false);
+  useEffect(() => {
+    if (appliedInitialFnRef.current || !initialFunctionName) return;
+    const match = functionNames.find(
+      (n) => n === initialFunctionName || n.endsWith(`.${initialFunctionName}`),
+    );
+    if (!match) return;
+    appliedInitialFnRef.current = true;
+    setSelectedFn((prev) => prev ?? match);
+  }, [functionNames, initialFunctionName]);
 
   // Reset active tab if current tab is no longer available for the selected function
   useEffect(() => {
@@ -1264,18 +1857,51 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
   // Whether any known-required keys are missing — proactive, not just reactive to pending requests
   const hasMissingKeys = [...knownRequiredKeys].some((k) => !envVars[k]);
 
+  // Workflow switcher bar — shown above the graph when the function under
+  // the cursor belongs to more than one workflow. The graph always shows a
+  // containing workflow; this bar switches between them.
+  const workflowSwitcherBar = workflowContext && (
+    <div className="flex items-center gap-1.5 px-2.5 py-1 text-[10px] bg-vsc-bg-secondary border-b border-vsc-border shrink-0">
+      <span className="text-vsc-text-faint">Workflow:</span>
+      {workflowContext.workflows.map((wf) => (
+        <Button
+          key={wf}
+          variant={wf === selectedFn ? 'secondary' : 'outline'}
+          size="sm"
+          className="h-auto px-1.5 py-0.5 text-[10px]"
+          onClick={() => {
+            if (wf === selectedFn) return;
+            const route = workflowRouteFor(workflowContext.functionName);
+            const hop = route.firstHop.get(wf) ?? workflowContext.functionName;
+            const target =
+              findCallSiteNode(wf, workflowContext.functionName) ??
+              findCallSiteNode(wf, hop);
+            pendingHighlightRef.current =
+              target != null ? { fn: wf, nodeId: target } : null;
+            setSelectedFn(wf);
+            setHighlightedNodeId(null);
+          }}
+        >
+          {wf}
+        </Button>
+      ))}
+    </div>
+  );
+
   // ── Render ─────────────────────────────────────────────────────────────
 
   return (
     <>
       {buildTime != null && (
-        <span data-testid="hot-reload-test" style={{ display: 'none' }}>{buildTime}</span>
+        <span data-testid="hot-reload-test" style={{ display: 'none' }}>
+          {buildTime}
+        </span>
       )}
 
       <Tabs
         value={activeTab}
         onValueChange={(v) => setActiveTab(v as typeof activeTab)}
-        className="flex-1 flex flex-col min-h-0 gap-0"
+        className="relative flex-1 flex flex-col min-h-0 gap-0"
       >
         {/* ──── Combined top bar ──── */}
         <div className="flex items-center gap-1.5 px-2 py-1 shrink-0 border-b border-vsc-border bg-vsc-surface">
@@ -1291,16 +1917,24 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                   <PanelLeft className="h-3.5 w-3.5 text-vsc-text-muted" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>{sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}</TooltipContent>
+              <TooltipContent>
+                {sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+              </TooltipContent>
             </Tooltip>
           </TooltipProvider>
 
           {selectedFn && !viewingCollection && !viewingTestRun && (
             <>
-              <span className="text-[11px] font-vsc-mono text-vsc-accent font-semibold whitespace-nowrap">{selectedFn}()</span>
+              <span className="text-[11px] font-vsc-mono text-vsc-accent font-semibold whitespace-nowrap">
+                {selectedFn}()
+              </span>
               <TabsList className="bg-transparent border-b-0 ml-1 h-7">
-                <TabsTrigger value="run" className="py-1 h-7">Run</TabsTrigger>
-                <TabsTrigger value="graph" className="py-1 h-7">Graph</TabsTrigger>
+                <TabsTrigger value="run" className="py-1 h-7">
+                  Run
+                </TabsTrigger>
+                <TabsTrigger value="graph" className="py-1 h-7">
+                  Graph
+                </TabsTrigger>
                 {canPreviewPrompt && (
                   <TabsTrigger value="prompt" className="py-1 h-7">
                     Prompt
@@ -1311,7 +1945,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                     )}
                   </TabsTrigger>
                 )}
-                {canPreviewCurl && <TabsTrigger value="curl" className="py-1 h-7">cURL</TabsTrigger>}
+                {canPreviewCurl && (
+                  <TabsTrigger value="curl" className="py-1 h-7">
+                    cURL
+                  </TabsTrigger>
+                )}
               </TabsList>
             </>
           )}
@@ -1327,9 +1965,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                 label: (
                   <>
                     {root}
-                    {projectUpdates[root] && !projectUpdates[root].isBexCurrent && (
-                      <span className="ml-0.5 text-vsc-yellow">*</span>
-                    )}
+                    {projectUpdates[root] &&
+                      !projectUpdates[root].isBexCurrent && (
+                        <span className="ml-0.5 text-vsc-yellow">*</span>
+                      )}
                   </>
                 ),
               }))}
@@ -1337,20 +1976,25 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
             />
           )}
 
-          {selectedFn && !viewingCollection && !viewingTestRun && activeTab === 'run' && runs.length > 0 && !isRunning && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-[10px] text-vsc-text-muted hover:text-vsc-text"
-              onClick={() => {
-                const runIds = runs.map((r) => r.id);
-                port.postMessage({ type: 'clearHandles', runIds });
-                setRuns([]);
-              }}
-            >
-              Clear
-            </Button>
-          )}
+          {selectedFn &&
+            !viewingCollection &&
+            !viewingTestRun &&
+            activeTab === 'run' &&
+            runs.length > 0 &&
+            !isRunning && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-[10px] text-vsc-text-muted hover:text-vsc-text"
+                onClick={() => {
+                  const runIds = runs.map((r) => r.id);
+                  port.postMessage({ type: 'clearHandles', runIds });
+                  setRuns([]);
+                }}
+              >
+                Clear
+              </Button>
+            )}
 
           {selectedFn && !viewingCollection && !viewingTestRun && (
             <Button
@@ -1367,7 +2011,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" className="relative h-7 w-7 shrink-0" onClick={() => setShowApiKeysDialog(true)}>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="relative h-7 w-7 shrink-0"
+                  onClick={() => setShowApiKeysDialog(true)}
+                >
                   <KeyRound size={14} />
                   {hasMissingKeys && (
                     <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-yellow-400" />
@@ -1378,455 +2027,585 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                 <div className="flex flex-col gap-0.5">
                   <span>API Keys</span>
                   {connectionVersion != null && (
-                    <span className="text-[9px] text-vsc-text-faint font-vsc-mono">v{connectionVersion}</span>
+                    <span className="text-[9px] text-vsc-text-faint font-vsc-mono">
+                      v{connectionVersion}
+                    </span>
                   )}
-                  {buildTime != null && (() => {
-                    const { absolute, relative } = formatBuildTime(buildTime);
-                    return (
-                      <span className="text-[9px] text-vsc-text-faint font-vsc-mono">{absolute} ({relative})</span>
-                    );
-                  })()}
+                  {buildTime != null &&
+                    (() => {
+                      const { absolute, relative } = formatBuildTime(buildTime);
+                      return (
+                        <span className="text-[9px] text-vsc-text-faint font-vsc-mono">
+                          {absolute} ({relative})
+                        </span>
+                      );
+                    })()}
                   {projectRoots.length === 1 && (
-                    <span className="text-[9px] text-vsc-text-faint font-vsc-mono">{projectRoots[0]}</span>
+                    <span className="text-[9px] text-vsc-text-faint font-vsc-mono">
+                      {projectRoots[0]}
+                    </span>
                   )}
                 </div>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
+
+          {/* Settings (gear) menu */}
+          <div className="relative shrink-0">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0"
+                    onClick={() => setShowSettingsMenu((v) => !v)}
+                  >
+                    <Settings size={14} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Playground settings</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            {showSettingsMenu && (
+              <>
+                <button
+                  type="button"
+                  aria-label="Close settings"
+                  className="fixed inset-0 z-40 cursor-default bg-transparent border-none"
+                  onClick={() => setShowSettingsMenu(false)}
+                />
+                <div className="absolute right-0 top-full mt-1 z-50 w-60 rounded border border-vsc-border bg-vsc-surface shadow-lg p-2.5">
+                  <label className="flex items-center gap-1.5 text-[11px] text-vsc-text-muted cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={showInternalFunctions}
+                      onChange={(e) =>
+                        setShowInternalFunctions(e.currentTarget.checked)
+                      }
+                      className="h-3 w-3 accent-vsc-accent"
+                    />
+                    <span>Show internal functions</span>
+                    <span className="ml-auto font-vsc-mono text-vsc-text-faint">
+                      {internalFunctionCount}
+                    </span>
+                  </label>
+                </div>
+              </>
+            )}
+          </div>
         </div>
 
         {/* WASM Panic banner */}
-      {wasmPanic && (
-        <button
-          type="button"
-          onClick={() => {
-            setWasmPanic(null);
-            if (onReload) {
-              onReload();
-            } else {
-              window.location.reload();
-            }
-          }}
-          className="w-full flex items-center gap-2 px-2.5 py-2 border-none border-b border-vsc-border shrink-0 bg-[#5c1a1a] hover:bg-[#6e1f1f] transition-colors cursor-pointer text-left"
-        >
-          <span className="text-[12px]">⚠️</span>
-          <div className="flex-1 min-w-0">
-            <span className="font-vsc-mono text-[11px] text-[#ff6b6b] font-medium">
-              WASM Panic — Click to reload worker
-            </span>
-            <div className="font-vsc-mono text-[10px] text-[#ff6b6b]/70 truncate">
-              {wasmPanic.message}
+        {wasmPanic && (
+          <button
+            type="button"
+            onClick={() => {
+              setWasmPanic(null);
+              if (onReload) {
+                onReload();
+              } else {
+                window.location.reload();
+              }
+            }}
+            className="w-full flex items-center gap-2 px-2.5 py-2 border-none border-b border-vsc-border shrink-0 bg-[#5c1a1a] hover:bg-[#6e1f1f] transition-colors cursor-pointer text-left"
+          >
+            <span className="text-[12px]">⚠️</span>
+            <div className="flex-1 min-w-0">
+              <span className="font-vsc-mono text-[11px] text-[#ff6b6b] font-medium">
+                WASM Panic — Click to reload worker
+              </span>
+              <div className="font-vsc-mono text-[10px] text-[#ff6b6b]/70 truncate">
+                {wasmPanic.message}
+              </div>
             </div>
-          </div>
-        </button>
-      )}
-
-      {/* Diagnostics banner */}
-      {(hasErrors || engineStale) && (
-        <div className="border-b border-vsc-border shrink-0 bg-[#3e1a1a]">
-          {diags.length > 0 ? (
-            <>
-              <button
-                type="button"
-                onClick={() => setDiagsExpanded((v) => !v)}
-                className="w-full flex items-center gap-1 px-2.5 py-1 bg-transparent border-none cursor-pointer text-left"
-              >
-                <span
-                  className="text-[10px] text-[#f48771] select-none transition-transform duration-150"
-                  style={{ display: 'inline-block', transform: diagsExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
-                >
-                  ▶
-                </span>
-                <span className="font-vsc-mono text-[10px] text-[#f48771]">
-                  {errors.length > 0 ? `${errors.length} error${errors.length !== 1 ? 's' : ''}` : ''}
-                  {errors.length > 0 && warnings.length > 0 ? ', ' : ''}
-                  {warnings.length > 0 ? `${warnings.length} warning${warnings.length !== 1 ? 's' : ''}` : ''}
-                  {' — using last successful build'}
-                </span>
-              </button>
-              {diagsExpanded && (
-                <div className="px-2.5 pb-1.5 flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
-                  {errors.map((e, i) => (
-                    <div key={`e${i}`} className="font-vsc-mono text-[10px] text-[#f48771]/80 pl-3.5 break-words whitespace-pre-wrap">
-                      {e.message}
-                    </div>
-                  ))}
-                  {warnings.map((w, i) => (
-                    <div key={`w${i}`} className="font-vsc-mono text-[10px] text-[#cca700]/80 pl-3.5 break-words whitespace-pre-wrap">
-                      {w.message}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="px-2.5 py-1 font-vsc-mono text-[10px] text-[#f48771]">
-              Build is stale — using last successful build
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Main layout: sidebar + content */}
-      <div className="flex flex-1 min-h-0">
-        {/* Sidebar */}
-        {sidebarOpen && (
-          <>
-            <div className="shrink-0 overflow-hidden" style={{ width: sidebarWidth }}>
-              <FunctionSidebar
-                functions={visibleFunctions}
-                showInternalFunctions={showInternalFunctions}
-                onShowInternalFunctionsChange={setShowInternalFunctions}
-                internalFunctionCount={internalFunctionCount}
-                testTree={testTree}
-                selectedFn={selectedFn}
-                onSelectFn={(fn) => { setWorkflowContext(null); setSelectedFn(fn); setViewingCollection(false); setViewingTestRun(false); }}
-                onRefreshTests={handleRefreshTests}
-                onRunTest={handleRunTest}
-                testRunResults={testRunResults}
-                failedExpands={failedExpands}
-                onRetryExpand={handleRetryExpand}
-                collectionRun={collectionRun}
-                viewingCollection={viewingCollection}
-                onSelectCollectionView={() => { setViewingCollection(true); setViewingTestRun(false); setSelectedFn(null); }}
-              />
-            </div>
-            <div
-              onMouseDown={onResizeStart}
-              className="w-1 shrink-0 cursor-col-resize hover:bg-vsc-accent/30 transition-colors border-r border-vsc-border"
-            />
-          </>
+          </button>
         )}
 
-        {/* Content area */}
-        <div className="flex-1 flex flex-col min-h-0 min-w-0">
-          {viewingCollection && collectionRun ? (
-            <CollectionRunView
-              run={collectionRun}
-              expandedLogId={expandedLogId}
-              setExpandedLogId={setExpandedLogId}
-              resultRenderers={resultRenderers}
-            />
-          ) : viewingTestRun ? (
-            <div ref={outputRef} className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg">
-              {runs.length === 0 && (
-                <div className="p-5 text-center text-vsc-text-faint text-[11px]">
-                  No test runs yet
-                </div>
-              )}
-              {[...runs].reverse().map((run, runIdx) => {
-                const isLatest = runIdx === 0;
-                const statusCls = run.status === 'error' ? 'bg-vsc-red' : run.status === 'success' ? 'bg-vsc-green' : run.status === 'cancelled' ? 'bg-vsc-yellow' : 'bg-vsc-text-muted';
-                return (
-                  <div key={run.id} className={!isLatest ? 'border-b-2 border-vsc-border' : ''}>
-                    <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-vsc-surface border-b border-vsc-border-subtle">
-                      <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusCls}`} />
-                      <span className="text-vsc-accent font-semibold text-[11px]">
-                        {run.testName ?? run.functionName}
-                      </span>
-                      {run.status === 'running' && (
-                        <>
-                          <span className="text-vsc-text-muted text-[10px]">running...</span>
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-5 w-5 text-vsc-text-muted hover:text-vsc-error"
-                                  onClick={() => onCancelRun(run.id)}
-                                >
-                                  <Square size={12} />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent>Cancel execution</TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        </>
-                      )}
-                      {run.durationMs != null && (
-                        <span className="text-vsc-text-faint text-[10px] shrink-0">{run.durationMs}ms</span>
-                      )}
-                    </div>
-                    {run.fetchLogs.map((log) => {
-                      const isExp = expandedLogId === log.id;
-                      const statusColorCls = log.status === null ? 'text-vsc-text-muted'
-                        : log.status >= 200 && log.status < 300 ? 'text-vsc-green'
-                        : log.status === 0 ? 'text-vsc-red' : 'text-vsc-yellow';
-                      return (
-                        <div key={`t-${log.id}`}>
-                          <div
-                            onClick={() => setExpandedLogId(isExp ? null : log.id)}
-                            className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
-                          >
-                            <span className={`${statusColorCls} font-semibold text-[11px]`}>{log.status ?? '...'}</span>
-                            <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
-                            <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
-                            {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
-                            <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
-                          </div>
-                          {isExp && (
-                            <div className="py-2 pr-2.5 pl-[22px] flex flex-col gap-2 border-b border-vsc-border">
-                              {log.error && <CodeBlock variant="error">{log.error}</CodeBlock>}
-                              <div>
-                                <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Request Headers</div>
-                                <CodeBlock>{JSON.stringify(log.requestHeaders, null, 2)}</CodeBlock>
-                              </div>
-                              {log.requestBody && (
-                                <div>
-                                  <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Request Body</div>
-                                  <CodeBlock>{tryFormatJson(log.requestBody)}</CodeBlock>
-                                </div>
-                              )}
-                              {log.responseBody != null && (
-                                <div>
-                                  <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Response Body</div>
-                                  <CodeBlock>{tryFormatJson(log.responseBody)}</CodeBlock>
-                                </div>
-                              )}
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                    {/* Runtime events (log.info, baml.events.send, etc.) */}
-                    {run.runtimeEvents.length > 0 && (
-                      <div className="py-1.5 pr-2.5 pl-[22px] border-b border-vsc-border-subtle">
-                        <div className="text-[10px] font-semibold text-vsc-text-muted mb-1 uppercase tracking-wide">
-                          Events ({run.runtimeEvents.length})
-                        </div>
-                        <div className="flex flex-col gap-0.5">
-                          {run.runtimeEvents.map((evt, evtIdx) => {
-                            const kind = evt.event;
-                            if (!kind) return null;
-
-                            let label: string;
-                            let payload: ReactNode;
-                            let colorCls: string;
-
-                            switch (kind.$case) {
-                              case 'functionStart':
-                                label = 'START';
-                                payload = kind.functionStart.name;
-                                colorCls = 'text-vsc-green';
-                                break;
-                              case 'functionEnd':
-                                label = 'END';
-                                payload = <FunctionEndPayload event={kind.functionEnd} customRenderers={resultRenderers} />;
-                                colorCls = kind.functionEnd.error ? 'text-vsc-red' : 'text-vsc-text-muted';
-                                break;
-                              case 'log': {
-                                const lvl = kind.log.level;
-                                label = lvl;
-                                payload = <EventValueDisplay value={kind.log.data} customRenderers={resultRenderers} />;
-                                colorCls = lvl === 'error' ? 'text-vsc-red'
-                                  : lvl === 'warn' ? 'text-vsc-yellow'
-                                  : lvl === 'debug' ? 'text-vsc-text-muted'
-                                  : 'text-vsc-blue';
-                                break;
-                              }
-                              case 'custom':
-                                label = 'EVENT';
-                                payload = <><span>{kind.custom.name}: </span><EventValueDisplay value={kind.custom.data} customRenderers={resultRenderers} /></>;
-                                colorCls = 'text-vsc-purple';
-                                break;
-                              case 'setTags':
-                                label = 'TAGS';
-                                payload = kind.setTags.tags.map(t => `${t.key}=${t.value}`).join(', ');
-                                colorCls = 'text-vsc-text-muted';
-                                break;
-                              default:
-                                return null;
-                            }
-
-                            // Check if cursor is within this event's source span
-                            const source = kind.$case === 'log' ? kind.log.source : undefined;
-                            const isCursorMatch = cursorOffset != null && source != null &&
-                              cursorOffset > source.startOffset && cursorOffset <= source.endOffset;
-
-                            return (
-                              <div
-                                key={`${evt.spanId}-${evtIdx}`}
-                                className={cn(
-                                  "flex items-start gap-1.5 text-[11px]",
-                                  isCursorMatch && "bg-vsc-yellow/20 rounded px-1 -mx-1",
-                                  source && onNavigateToSource && "cursor-pointer hover:bg-vsc-bg-secondary"
-                                )}
-                                onClick={source && onNavigateToSource ? () => onNavigateToSource({ fileId: source.fileId, line: source.line, column: source.column }) : undefined}
-                              >
-                                <span className={`${colorCls} font-semibold shrink-0 w-10 uppercase`}>{label}</span>
-                                <div className="text-vsc-text flex-1 min-w-0 break-all">{payload}</div>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    )}
-                    {/* Inline io.input() prompts for this run */}
-                    {(pendingInputs.get(run.id) ?? []).map((req) => (
-                      <div key={req.id} className="flex items-center gap-2 px-[22px] py-1.5 border-b border-vsc-border bg-vsc-surface">
-                        <span className="text-vsc-text-faint text-xs shrink-0">{req.prompt ?? 'Input:'}</span>
-                        <input
-                          className="flex-1 bg-vsc-bg border border-vsc-border rounded px-2 py-1 text-xs text-vsc-text font-vsc-mono focus:outline-none focus:border-vsc-accent"
-                          autoFocus
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') {
-                              submitInput(req.id, e.currentTarget.value, run.id);
-                            }
-                          }}
-                        />
-                      </div>
-                    ))}
-                    {run.status === 'cancelled' && (
-                      <div className="py-1.5 pr-2.5 pl-[22px]">
-                        <div className="text-[11px] text-vsc-text-faint italic">Cancelled</div>
-                      </div>
-                    )}
-                    {run.error && (
-                      <div className="py-1.5 pr-2.5 pl-[22px]">
-                        <div className="text-[10px] font-semibold text-vsc-red mb-0.5 uppercase tracking-wide">Error</div>
-                        <ErrorDisplay error={run.error} />
-                      </div>
-                    )}
-                    {run.result != null && (
-                      <div className="py-1.5 pr-2.5 pl-[22px]">
-                        <div className="text-[10px] font-semibold text-vsc-green mb-0.5 uppercase tracking-wide">Result</div>
-                        <ResultDisplay result={run.result} customRenderers={resultRenderers} />
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          ) : selectedFn ? (
-            <>
-              {/* Graph view */}
-              <TabsContent value="graph" className="flex-1 min-h-0 mt-0 flex flex-col" style={{ minHeight: 300 }}>
-                {/* "Called from" bar — shown when the current function is called from workflows */}
-                {workflowContext && (
-                  <div className="flex items-center gap-1.5 px-2.5 py-1 text-[10px] bg-vsc-bg-secondary border-b border-vsc-border shrink-0">
-                    <span className="text-vsc-text-faint">Called from:</span>
-                    {workflowContext.workflows.map((wf) => (
-                      <Button
-                        key={wf}
-                        variant="outline"
-                        size="sm"
-                        className="h-auto px-1.5 py-0.5 text-[10px]"
-                        onClick={() => {
-                          setWorkflowContext(null);
-                          setSelectedFn(wf);
-                          setHighlightedNodeId(null);
-                        }}
-                      >
-                        {wf}
-                      </Button>
-                    ))}
-                  </div>
-                )}
-                {controlFlowGraph ? (
-                  <GraphView
-                    graph={controlFlowGraph}
-                    runtimeEvents={latestGraphRun?.runtimeEvents}
-                    runStatus={latestGraphRun?.status}
-                    runError={latestGraphRun?.error}
-                    runFunctionName={latestGraphRun?.functionName}
-                    customRenderers={resultRenderers}
-                    selectedNodeId={highlightedNodeId}
-                    onNodeClick={handleGraphNodeClick}
-                  />
-                ) : (
-                  <div className="flex-1 flex items-center justify-center text-vsc-text-faint text-xs bg-vsc-bg h-full">
-                    Loading graph...
-                  </div>
-                )}
-              </TabsContent>
-
-              {/* Prompt preview */}
-              {canPreviewPrompt && (
-                <TabsContent value="prompt" className="flex-1 flex flex-col overflow-hidden mt-0">
-                  {promptPreviewError && (
-                    <div className="px-2.5 py-1.5 text-[10px] text-vsc-error bg-vsc-error/10 border-b border-vsc-error/20 shrink-0">
-                      Preview error: {promptPreviewError}
-                    </div>
-                  )}
-                  <div className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg p-2.5 group relative">
-                    {promptPreviewResult != null && (
-                      <div className="absolute top-1 right-1 z-10">
-                        <CopyButton textRef={promptContentRef} />
-                      </div>
-                    )}
-                    <div ref={promptContentRef}>
-                      {promptPreviewResult != null ? (
-                        <ResultDisplay result={promptPreviewResult} customRenderers={resultRenderers} />
-                      ) : (
-                        <div className="flex items-center justify-center text-vsc-text-faint text-xs h-full">
-                          {previewLoading ? 'Loading prompt preview...' : 'Enter args to preview prompt'}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                  {promptPreviewResult != null && <PromptStats text={stringifyResult(promptPreviewResult)} />}
-                </TabsContent>
-              )}
-
-              {/* cURL preview */}
-              {canPreviewCurl && (
-                <TabsContent value="curl" className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg p-2.5 mt-0">
-                  {curlPreviewResult != null ? (
-                    <ResultDisplay result={curlPreviewResult} customRenderers={resultRenderers} />
-                  ) : curlPreviewError ? (
-                    <div className="flex items-center justify-center text-vsc-error text-xs h-full">
-                      {curlPreviewError}
-                    </div>
-                  ) : (
-                    <div className="flex items-center justify-center text-vsc-text-faint text-xs h-full">
-                      {previewLoading ? 'Loading cURL preview...' : 'Enter args to preview cURL'}
-                    </div>
-                  )}
-                </TabsContent>
-              )}
-
-              {/* Execution area */}
-              <TabsContent value="run" className="flex-1 flex flex-col min-h-0 mt-0">
-                {/* Args */}
-                <div className="flex items-center border-b border-vsc-border shrink-0">
-                  <span className="px-2 py-1 text-[10px] text-vsc-text-faint font-vsc-mono bg-vsc-surface border-r border-vsc-border self-stretch flex items-center">
-                    args
+        {/* Diagnostics banner */}
+        {(hasErrors || engineStale) && (
+          <div className="border-b border-vsc-border shrink-0 bg-[#3e1a1a]">
+            {diags.length > 0 ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setDiagsExpanded((v) => !v)}
+                  className="w-full flex items-center gap-1 px-2.5 py-1 bg-transparent border-none cursor-pointer text-left"
+                >
+                  <span
+                    className="text-[10px] text-[#f48771] select-none transition-transform duration-150"
+                    style={{
+                      display: 'inline-block',
+                      transform: diagsExpanded
+                        ? 'rotate(90deg)'
+                        : 'rotate(0deg)',
+                    }}
+                  >
+                    ▶
                   </span>
-                  <Input
-                    spellCheck={false}
-                    value={argsJson}
-                    onChange={onArgsJsonChange}
-                    className="flex-1 h-7 rounded-none border-none font-vsc-mono text-xs"
-                    placeholder='{"key": "value"}'
-                  />
-                </div>
+                  <span className="font-vsc-mono text-[10px] text-[#f48771]">
+                    {errors.length > 0
+                      ? `${errors.length} error${errors.length !== 1 ? 's' : ''}`
+                      : ''}
+                    {errors.length > 0 && warnings.length > 0 ? ', ' : ''}
+                    {warnings.length > 0
+                      ? `${warnings.length} warning${warnings.length !== 1 ? 's' : ''}`
+                      : ''}
+                    {' — using last successful build'}
+                  </span>
+                </button>
+                {diagsExpanded && (
+                  <div className="px-2.5 pb-1.5 flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
+                    {errors.map((e, i) => (
+                      <div
+                        key={`e${i}`}
+                        className="font-vsc-mono text-[10px] text-[#f48771]/80 pl-3.5 break-words whitespace-pre-wrap"
+                      >
+                        {e.message}
+                      </div>
+                    ))}
+                    {warnings.map((w, i) => (
+                      <div
+                        key={`w${i}`}
+                        className="font-vsc-mono text-[10px] text-[#cca700]/80 pl-3.5 break-words whitespace-pre-wrap"
+                      >
+                        {w.message}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="px-2.5 py-1 font-vsc-mono text-[10px] text-[#f48771]">
+                Build is stale — using last successful build
+              </div>
+            )}
+          </div>
+        )}
 
-                {/* Live graph */}
-                <div className="flex-1 min-h-0 flex flex-col bg-vsc-bg border-b border-vsc-border" style={{ minHeight: 180 }}>
-                  {workflowContext && (
-                    <div className="flex items-center gap-1.5 px-2.5 py-1 text-[10px] bg-vsc-bg-secondary border-b border-vsc-border shrink-0">
-                      <span className="text-vsc-text-faint">Called from:</span>
-                      {workflowContext.workflows.map((wf) => (
-                        <Button
-                          key={wf}
-                          variant="outline"
-                          size="sm"
-                          className="h-auto px-1.5 py-0.5 text-[10px]"
-                          onClick={() => {
-                            setWorkflowContext(null);
-                            setSelectedFn(wf);
-                            setHighlightedNodeId(null);
-                          }}
+        {/* Main layout: sidebar + content. When the run-history strip is
+            visible it is absolutely positioned across the panel's full
+            width, so the row ends above it. */}
+        <div
+          className="flex flex-1 min-h-0"
+          style={{
+            paddingBottom: runLogsVisible ? logsPanelHeight + 6 : 0,
+          }}
+        >
+          {/* Sidebar */}
+          {sidebarOpen && (
+            <>
+              <div
+                className="shrink-0 overflow-hidden"
+                style={{ width: sidebarWidth }}
+              >
+                <FunctionSidebar
+                  functions={visibleFunctions}
+                  showInternalFunctions={showInternalFunctions}
+                  internalFunctionCount={internalFunctionCount}
+                  testTree={testTree}
+                  selectedFn={selectedFn}
+                  onSelectFn={(fn) => {
+                    setViewingCollection(false);
+                    setViewingTestRun(false);
+                    setHighlightedNodeId(null);
+                    if (!fn) {
+                      setWorkflowContext(null);
+                      setSelectedFn(fn);
+                      return;
+                    }
+                    // Workflow heuristic: a helper that lives inside exactly
+                    // one workflow shows that whole workflow (with its call
+                    // site highlighted); an ambiguous one keeps itself
+                    // selected and asks via the picker bar.
+                    const route = workflowRouteFor(fn);
+                    const roots = route.roots;
+                    if (roots.length === 1 && roots[0]) {
+                      const root = roots[0];
+                      const hop = route.firstHop.get(root);
+                      const target = hop ? findCallSiteNode(root, hop) : null;
+                      setWorkflowContext(null);
+                      if (root !== selectedFn) {
+                        pendingHighlightRef.current =
+                          target != null ? { fn: root, nodeId: target } : null;
+                        setSelectedFn(root);
+                      } else if (target != null) {
+                        setHighlightedNodeId(target);
+                      }
+                    } else if (roots.length > 1) {
+                      setSelectedFn(fn);
+                      setWorkflowContext({ functionName: fn, workflows: roots });
+                    } else {
+                      setWorkflowContext(null);
+                      setSelectedFn(fn);
+                    }
+                  }}
+                  onRefreshTests={handleRefreshTests}
+                  onRunTest={handleRunTest}
+                  testRunResults={testRunResults}
+                  failedExpands={failedExpands}
+                  onRetryExpand={handleRetryExpand}
+                  collectionRun={collectionRun}
+                  viewingCollection={viewingCollection}
+                  onSelectCollectionView={() => {
+                    setViewingCollection(true);
+                    setViewingTestRun(false);
+                    setSelectedFn(null);
+                  }}
+                />
+              </div>
+              <div
+                onMouseDown={onResizeStart}
+                className="w-1 shrink-0 cursor-col-resize hover:bg-vsc-accent/30 transition-colors border-r border-vsc-border"
+              />
+            </>
+          )}
+
+          {/* Content area */}
+          <div className="flex-1 flex flex-col min-h-0 min-w-0">
+            {viewingCollection && collectionRun ? (
+              <CollectionRunView
+                run={collectionRun}
+                expandedLogId={expandedLogId}
+                setExpandedLogId={setExpandedLogId}
+                resultRenderers={resultRenderers}
+              />
+            ) : viewingTestRun ? (
+              <div
+                ref={outputRef}
+                className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg"
+              >
+                {runs.length === 0 && (
+                  <div className="p-5 text-center text-vsc-text-faint text-[11px]">
+                    No test runs yet
+                  </div>
+                )}
+                {[...runs].reverse().map((run, runIdx) => {
+                  const isLatest = runIdx === 0;
+                  const statusCls =
+                    run.status === 'error'
+                      ? 'bg-vsc-red'
+                      : run.status === 'success'
+                        ? 'bg-vsc-green'
+                        : run.status === 'cancelled'
+                          ? 'bg-vsc-yellow'
+                          : 'bg-vsc-text-muted';
+                  return (
+                    <div
+                      key={run.id}
+                      className={
+                        !isLatest ? 'border-b-2 border-vsc-border' : ''
+                      }
+                    >
+                      <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-vsc-surface border-b border-vsc-border-subtle">
+                        <span
+                          className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusCls}`}
+                        />
+                        <span className="text-vsc-accent font-semibold text-[11px]">
+                          {run.testName ?? run.functionName}
+                        </span>
+                        {run.status === 'running' && (
+                          <>
+                            <span className="text-vsc-text-muted text-[10px]">
+                              running...
+                            </span>
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-5 w-5 text-vsc-text-muted hover:text-vsc-error"
+                                    onClick={() => onCancelRun(run.id)}
+                                  >
+                                    <Square size={12} />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  Cancel execution
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          </>
+                        )}
+                        {run.durationMs != null && (
+                          <span className="text-vsc-text-faint text-[10px] shrink-0">
+                            {run.durationMs}ms
+                          </span>
+                        )}
+                      </div>
+                      {run.fetchLogs.map((log) => {
+                        const isExp = expandedLogId === log.id;
+                        const statusColorCls =
+                          log.status === null
+                            ? 'text-vsc-text-muted'
+                            : log.status >= 200 && log.status < 300
+                              ? 'text-vsc-green'
+                              : log.status === 0
+                                ? 'text-vsc-red'
+                                : 'text-vsc-yellow';
+                        return (
+                          <div key={`t-${log.id}`}>
+                            <div
+                              onClick={() =>
+                                setExpandedLogId(isExp ? null : log.id)
+                              }
+                              className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
+                            >
+                              <span
+                                className={`${statusColorCls} font-semibold text-[11px]`}
+                              >
+                                {log.status ?? '...'}
+                              </span>
+                              <span className="text-vsc-text-faint text-[10px]">
+                                {log.method}
+                              </span>
+                              <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">
+                                {log.url}
+                              </span>
+                              {log.durationMs != null && (
+                                <span className="text-vsc-text-faint text-[10px]">
+                                  {log.durationMs}ms
+                                </span>
+                              )}
+                              <span className="text-vsc-text-faint text-[9px]">
+                                {isExp ? '\u25B4' : '\u25BE'}
+                              </span>
+                            </div>
+                            {isExp && (
+                              <div className="py-2 pr-2.5 pl-[22px] flex flex-col gap-2 border-b border-vsc-border">
+                                {log.error && (
+                                  <CodeBlock variant="error">
+                                    {log.error}
+                                  </CodeBlock>
+                                )}
+                                <div>
+                                  <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                                    Request Headers
+                                  </div>
+                                  <CodeBlock>
+                                    {JSON.stringify(
+                                      log.requestHeaders,
+                                      null,
+                                      2,
+                                    )}
+                                  </CodeBlock>
+                                </div>
+                                {log.requestBody && (
+                                  <div>
+                                    <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                                      Request Body
+                                    </div>
+                                    <CodeBlock>
+                                      {tryFormatJson(log.requestBody)}
+                                    </CodeBlock>
+                                  </div>
+                                )}
+                                {log.responseBody != null && (
+                                  <div>
+                                    <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                                      Response Body
+                                    </div>
+                                    <CodeBlock>
+                                      {tryFormatJson(log.responseBody)}
+                                    </CodeBlock>
+                                  </div>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                      {/* Runtime events (log.info, baml.events.send, etc.) */}
+                      {run.runtimeEvents.length > 0 && (
+                        <div className="py-1.5 pr-2.5 pl-[22px] border-b border-vsc-border-subtle">
+                          <div className="text-[10px] font-semibold text-vsc-text-muted mb-1 uppercase tracking-wide">
+                            Events ({run.runtimeEvents.length})
+                          </div>
+                          <div className="flex flex-col gap-0.5">
+                            {run.runtimeEvents.map((evt, evtIdx) => {
+                              const kind = evt.event;
+                              if (!kind) return null;
+
+                              let label: string;
+                              let payload: ReactNode;
+                              let colorCls: string;
+
+                              switch (kind.$case) {
+                                case 'functionStart':
+                                  label = 'START';
+                                  payload = kind.functionStart.name;
+                                  colorCls = 'text-vsc-green';
+                                  break;
+                                case 'functionEnd':
+                                  label = 'END';
+                                  payload = (
+                                    <FunctionEndPayload
+                                      event={kind.functionEnd}
+                                      customRenderers={resultRenderers}
+                                    />
+                                  );
+                                  colorCls = kind.functionEnd.error
+                                    ? 'text-vsc-red'
+                                    : 'text-vsc-text-muted';
+                                  break;
+                                case 'log': {
+                                  const lvl = kind.log.level;
+                                  label = lvl;
+                                  payload = (
+                                    <EventValueDisplay
+                                      value={kind.log.data}
+                                      customRenderers={resultRenderers}
+                                    />
+                                  );
+                                  colorCls =
+                                    lvl === 'error'
+                                      ? 'text-vsc-red'
+                                      : lvl === 'warn'
+                                        ? 'text-vsc-yellow'
+                                        : lvl === 'debug'
+                                          ? 'text-vsc-text-muted'
+                                          : 'text-vsc-blue';
+                                  break;
+                                }
+                                case 'custom':
+                                  label = 'EVENT';
+                                  payload = (
+                                    <>
+                                      <span>{kind.custom.name}: </span>
+                                      <EventValueDisplay
+                                        value={kind.custom.data}
+                                        customRenderers={resultRenderers}
+                                      />
+                                    </>
+                                  );
+                                  colorCls = 'text-vsc-purple';
+                                  break;
+                                case 'setTags':
+                                  label = 'TAGS';
+                                  payload = kind.setTags.tags
+                                    .map((t) => `${t.key}=${t.value}`)
+                                    .join(', ');
+                                  colorCls = 'text-vsc-text-muted';
+                                  break;
+                                default:
+                                  return null;
+                              }
+
+                              // Check if cursor is within this event's source span
+                              const source =
+                                kind.$case === 'log'
+                                  ? kind.log.source
+                                  : undefined;
+                              const isCursorMatch =
+                                cursorOffset != null &&
+                                source != null &&
+                                cursorOffset > source.startOffset &&
+                                cursorOffset <= source.endOffset;
+
+                              return (
+                                <div
+                                  key={`${evt.spanId}-${evtIdx}`}
+                                  className={cn(
+                                    'flex items-start gap-1.5 text-[11px]',
+                                    isCursorMatch &&
+                                      'bg-vsc-yellow/20 rounded px-1 -mx-1',
+                                    source &&
+                                      onNavigateToSource &&
+                                      'cursor-pointer hover:bg-vsc-bg-secondary',
+                                  )}
+                                  onClick={
+                                    source && onNavigateToSource
+                                      ? () =>
+                                          onNavigateToSource({
+                                            fileId: source.fileId,
+                                            line: source.line,
+                                            column: source.column,
+                                          })
+                                      : undefined
+                                  }
+                                >
+                                  <span
+                                    className={`${colorCls} font-semibold shrink-0 w-10 uppercase`}
+                                  >
+                                    {label}
+                                  </span>
+                                  <div className="text-vsc-text flex-1 min-w-0 break-all">
+                                    {payload}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+                      {/* Inline io.input() prompts for this run */}
+                      {(pendingInputs.get(run.id) ?? []).map((req) => (
+                        <div
+                          key={req.id}
+                          className="flex items-center gap-2 px-[22px] py-1.5 border-b border-vsc-border bg-vsc-surface"
                         >
-                          {wf}
-                        </Button>
+                          <span className="text-vsc-text-faint text-xs shrink-0">
+                            {req.prompt ?? 'Input:'}
+                          </span>
+                          <input
+                            className="flex-1 bg-vsc-bg border border-vsc-border rounded px-2 py-1 text-xs text-vsc-text font-vsc-mono focus:outline-none focus:border-vsc-accent"
+                            autoFocus
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                submitInput(
+                                  req.id,
+                                  e.currentTarget.value,
+                                  run.id,
+                                );
+                              }
+                            }}
+                          />
+                        </div>
                       ))}
+                      {run.status === 'cancelled' && (
+                        <div className="py-1.5 pr-2.5 pl-[22px]">
+                          <div className="text-[11px] text-vsc-text-faint italic">
+                            Cancelled
+                          </div>
+                        </div>
+                      )}
+                      {run.error && (
+                        <div className="py-1.5 pr-2.5 pl-[22px]">
+                          <div className="text-[10px] font-semibold text-vsc-red mb-0.5 uppercase tracking-wide">
+                            Error
+                          </div>
+                          <ErrorDisplay error={run.error} />
+                        </div>
+                      )}
+                      {run.result != null && (
+                        <div className="py-1.5 pr-2.5 pl-[22px]">
+                          <div className="text-[10px] font-semibold text-vsc-green mb-0.5 uppercase tracking-wide">
+                            Result
+                          </div>
+                          <ResultDisplay
+                            result={run.result}
+                            customRenderers={resultRenderers}
+                          />
+                        </div>
+                      )}
                     </div>
-                  )}
+                  );
+                })}
+              </div>
+            ) : selectedFn ? (
+              <>
+                {/* Graph view */}
+                <TabsContent
+                  value="graph"
+                  className="flex-1 min-h-0 mt-0 flex flex-col"
+                  style={{ minHeight: 300 }}
+                >
+                  {workflowSwitcherBar}
                   {controlFlowGraph ? (
                     <GraphView
                       graph={controlFlowGraph}
+                      functionName={selectedFn}
                       runtimeEvents={latestGraphRun?.runtimeEvents}
                       runStatus={latestGraphRun?.status}
                       runError={latestGraphRun?.error}
@@ -1840,254 +2619,516 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({ port, connectionVersio
                       Loading graph...
                     </div>
                   )}
-                </div>
+                </TabsContent>
 
-                <div
-                  onMouseDown={onLogsResizeStart}
-                  className="h-1.5 shrink-0 cursor-row-resize bg-vsc-surface hover:bg-vsc-accent/30 transition-colors border-y border-vsc-border"
-                  title="Resize logs"
-                />
-
-                {/* Run history (scrollable) */}
-                <div
-                  ref={outputRef}
-                  className="shrink-0 overflow-auto font-vsc-mono text-xs bg-vsc-bg"
-                  style={{ height: logsPanelHeight }}
-                >
-                  {runs.length === 0 && (
-                    <div className="p-5 text-center text-vsc-text-faint text-[11px]">
-                      Press Run to execute {selectedFn}()
-                    </div>
-                  )}
-
-                  {[...runs].reverse().map((run, runIdx) => {
-                    const isLatest = runIdx === 0;
-                    const statusCls = run.status === 'error' ? 'bg-vsc-red' : run.status === 'success' ? 'bg-vsc-green' : run.status === 'cancelled' ? 'bg-vsc-yellow' : 'bg-vsc-text-muted';
-
-                    return (
-                      <div key={run.id} className={!isLatest ? 'border-b-2 border-vsc-border' : ''}>
-                        {/* Run header */}
-                        <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-vsc-surface border-b border-vsc-border-subtle">
-                          <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusCls}`} />
-                          <span className="text-vsc-accent font-semibold text-[11px]">
-                            {run.functionName}()
-                          </span>
-                          <span className="text-vsc-text-faint text-[10px] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                            {run.argsJson}
-                          </span>
-                          {run.status === 'running' && (
-                            <>
-                              <span className="text-vsc-text-muted text-[10px]">running...</span>
-                              <TooltipProvider>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-5 w-5 text-vsc-text-muted hover:text-vsc-error"
-                                      onClick={() => onCancelRun(run.id)}
-                                    >
-                                      <Square size={12} />
-                                    </Button>
-                                  </TooltipTrigger>
-                                  <TooltipContent>Cancel execution</TooltipContent>
-                                </Tooltip>
-                              </TooltipProvider>
-                            </>
-                          )}
-                          {run.durationMs != null && (
-                            <span className="text-vsc-text-faint text-[10px] shrink-0">{run.durationMs}ms</span>
-                          )}
+                {/* Prompt preview */}
+                {canPreviewPrompt && (
+                  <TabsContent
+                    value="prompt"
+                    className="flex-1 flex flex-col overflow-hidden mt-0"
+                  >
+                    {promptPreviewError && (
+                      <div className="px-2.5 py-1.5 text-[10px] text-vsc-error bg-vsc-error/10 border-b border-vsc-error/20 shrink-0">
+                        Preview error: {promptPreviewError}
+                      </div>
+                    )}
+                    <div className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg p-2.5 group relative">
+                      {promptPreviewResult != null && (
+                        <div className="absolute top-1 right-1 z-10">
+                          <CopyButton textRef={promptContentRef} />
                         </div>
-
-                        {/* Fetch logs for this run */}
-                        {run.fetchLogs.map((log) => {
-                          const isExp = expandedLogId === log.id;
-                          const statusColorCls = log.status === null ? 'text-vsc-text-muted'
-                            : log.status >= 200 && log.status < 300 ? 'text-vsc-green'
-                            : log.status === 0 ? 'text-vsc-red' : 'text-vsc-yellow';
-                          return (
-                            <div key={`n-${log.id}`}>
-                              <div
-                                onClick={() => setExpandedLogId(isExp ? null : log.id)}
-                                className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
-                              >
-                                <span className={`${statusColorCls} font-semibold text-[11px]`}>{log.status ?? '...'}</span>
-                                <span className="text-vsc-text-faint text-[10px]">{log.method}</span>
-                                <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">{log.url}</span>
-                                {log.durationMs != null && <span className="text-vsc-text-faint text-[10px]">{log.durationMs}ms</span>}
-                                <span className="text-vsc-text-faint text-[9px]">{isExp ? '\u25B4' : '\u25BE'}</span>
-                              </div>
-                              {isExp && (
-                                <div className="py-2 pr-2.5 pl-[22px] flex flex-col gap-2 border-b border-vsc-border">
-                                  {log.error && <CodeBlock variant="error">{log.error}</CodeBlock>}
-                                  <div>
-                                    <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Request Headers</div>
-                                    <CodeBlock>{JSON.stringify(log.requestHeaders, null, 2)}</CodeBlock>
-                                  </div>
-                                  {log.requestBody && (
-                                    <div>
-                                      <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Request Body</div>
-                                      <CodeBlock>{tryFormatJson(log.requestBody)}</CodeBlock>
-                                    </div>
-                                  )}
-                                  {log.responseBody != null && (
-                                    <div>
-                                      <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">Response Body</div>
-                                      <CodeBlock>{tryFormatJson(log.responseBody)}</CodeBlock>
-                                    </div>
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                          );
-                        })}
-
-                        {/* Runtime events (log.info, baml.events.send, etc.) */}
-                        {run.runtimeEvents.length > 0 && (
-                          <div className="py-1.5 pr-2.5 pl-[22px] border-b border-vsc-border-subtle">
-                            <div className="text-[10px] font-semibold text-vsc-text-muted mb-1 uppercase tracking-wide">
-                              Events ({run.runtimeEvents.length})
-                            </div>
-                            <div className="flex flex-col gap-0.5">
-                              {run.runtimeEvents.map((evt, evtIdx) => {
-                                const kind = evt.event;
-                                if (!kind) return null;
-
-                                let label: string;
-                                let payload: ReactNode;
-                                let colorCls: string;
-
-                                switch (kind.$case) {
-                                  case 'functionStart':
-                                    label = 'START';
-                                    payload = kind.functionStart.name;
-                                    colorCls = 'text-vsc-green';
-                                    break;
-                                  case 'functionEnd':
-                                    label = 'END';
-                                    payload = <FunctionEndPayload event={kind.functionEnd} customRenderers={resultRenderers} />;
-                                    colorCls = kind.functionEnd.error ? 'text-vsc-red' : 'text-vsc-text-muted';
-                                    break;
-                                  case 'log': {
-                                    const lvl = kind.log.level;
-                                    label = lvl;
-                                    payload = <EventValueDisplay value={kind.log.data} customRenderers={resultRenderers} />;
-                                    colorCls = lvl === 'error' ? 'text-vsc-red'
-                                      : lvl === 'warn' ? 'text-vsc-yellow'
-                                      : lvl === 'debug' ? 'text-vsc-text-muted'
-                                      : 'text-vsc-blue';
-                                    break;
-                                  }
-                                  case 'custom':
-                                    label = 'EVENT';
-                                    payload = <><span>{kind.custom.name}: </span><EventValueDisplay value={kind.custom.data} customRenderers={resultRenderers} /></>;
-                                    colorCls = 'text-vsc-purple';
-                                    break;
-                                  case 'setTags':
-                                    label = 'TAGS';
-                                    payload = kind.setTags.tags.map(t => `${t.key}=${t.value}`).join(', ');
-                                    colorCls = 'text-vsc-text-muted';
-                                    break;
-                                  default:
-                                    return null;
-                                }
-
-                                // Check if cursor is within this event's source span
-                                const source = kind.$case === 'log' ? kind.log.source : undefined;
-                                const isCursorMatch = cursorOffset != null && source != null &&
-                                  cursorOffset > source.startOffset && cursorOffset <= source.endOffset;
-
-                                return (
-                                  <div
-                                    key={`${evt.spanId}-${evtIdx}`}
-                                    className={cn(
-                                      "flex items-start gap-1.5 text-[11px]",
-                                      isCursorMatch && "bg-vsc-yellow/20 rounded px-1 -mx-1",
-                                      source && onNavigateToSource && "cursor-pointer hover:bg-vsc-bg-secondary"
-                                    )}
-                                    onClick={source && onNavigateToSource ? () => onNavigateToSource({ fileId: source.fileId, line: source.line, column: source.column }) : undefined}
-                                  >
-                                    <span className={`${colorCls} font-semibold shrink-0 w-10 uppercase`}>{label}</span>
-                                    <div className="text-vsc-text flex-1 min-w-0 break-all">{payload}</div>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        )}
-                        {/* Inline io.input() prompts for this run */}
-                        {(pendingInputs.get(run.id) ?? []).map((req) => (
-                          <div key={req.id} className="flex items-center gap-2 px-[22px] py-1.5 border-b border-vsc-border bg-vsc-surface">
-                            <span className="text-vsc-text-faint text-xs shrink-0">{req.prompt ?? 'Input:'}</span>
-                            <input
-                              className="flex-1 bg-vsc-bg border border-vsc-border rounded px-2 py-1 text-xs text-vsc-text font-vsc-mono focus:outline-none focus:border-vsc-accent"
-                              autoFocus
-                              onKeyDown={(e) => {
-                                if (e.key === 'Enter') {
-                                  submitInput(req.id, e.currentTarget.value, run.id);
-                                }
-                              }}
-                            />
-                          </div>
-                        ))}
-
-                        {/* Result / Error / Cancelled for this run */}
-                        {run.status === 'cancelled' && (
-                          <div className="py-1.5 pr-2.5 pl-[22px]">
-                            <div className="text-[11px] text-vsc-text-faint italic">Cancelled</div>
-                          </div>
-                        )}
-                        {run.error && (
-                          <div className="py-1.5 pr-2.5 pl-[22px]">
-                            <div className="text-[10px] font-semibold text-vsc-red mb-0.5 uppercase tracking-wide">Error</div>
-                            <ErrorDisplay error={run.error} onRetry={onRunFunction} />
-                          </div>
-                        )}
-                        {run.result != null && (
-                          <div className="py-1.5 pr-2.5 pl-[22px]">
-                            {run.status === 'success' && run.fetchLogs.length > 0 && (
-                              <div className="mb-1">
-                                <MetadataBadges fetchLogs={run.fetchLogs} durationMs={run.durationMs} />
-                              </div>
-                            )}
-                            <div className="space-y-1">
-                              <div className="flex items-center gap-1">
-                                <div className="text-[10px] font-semibold text-vsc-green uppercase tracking-wide">Result</div>
-                                <ToggleGroup
-                                  value={resultModes[run.id] ?? 'parsed'}
-                                  onValueChange={(v) => setResultModes((prev) => ({ ...prev, [run.id]: v as 'parsed' | 'raw' }))}
-                                  options={[
-                                    { value: 'parsed', label: 'Parsed' },
-                                    { value: 'raw', label: 'Raw' },
-                                  ]}
-                                  size="sm"
-                                />
-                                <CopyButton text={stringifyResult(run.result)} iconSize={11} />
-                              </div>
-                              {(resultModes[run.id] ?? 'parsed') === 'parsed' ? (
-                                <ResultDisplay result={run.result} customRenderers={resultRenderers} />
-                              ) : (
-                                <pre className="whitespace-pre-wrap break-all font-vsc-mono text-[11px] text-vsc-text bg-vsc-bg-secondary p-2 rounded border border-vsc-border max-h-[400px] overflow-auto">
-                                  {stringifyResult(run.result)}
-                                </pre>
-                              )}
-                            </div>
+                      )}
+                      <div ref={promptContentRef}>
+                        {promptPreviewResult != null ? (
+                          <ResultDisplay
+                            result={promptPreviewResult}
+                            customRenderers={resultRenderers}
+                          />
+                        ) : (
+                          <div className="flex items-center justify-center text-vsc-text-faint text-xs h-full">
+                            {previewLoading
+                              ? 'Loading prompt preview...'
+                              : 'Enter args to preview prompt'}
                           </div>
                         )}
                       </div>
-                    );
-                  })}
-                </div>
-              </TabsContent>
-            </>
-          ) : (
-            <div className="flex-1 flex items-center justify-center text-vsc-text-faint text-xs bg-vsc-bg">
-              {viewingCollection ? 'Collection not yet available — click Refresh' : 'Select a function to run'}
-            </div>
-          )}
+                    </div>
+                    {promptPreviewResult != null && (
+                      <PromptStats
+                        text={stringifyResult(promptPreviewResult)}
+                      />
+                    )}
+                  </TabsContent>
+                )}
+
+                {/* cURL preview */}
+                {canPreviewCurl && (
+                  <TabsContent
+                    value="curl"
+                    className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg p-2.5 mt-0"
+                  >
+                    {curlPreviewResult != null ? (
+                      <ResultDisplay
+                        result={curlPreviewResult}
+                        customRenderers={resultRenderers}
+                      />
+                    ) : curlPreviewError ? (
+                      <div className="flex items-center justify-center text-vsc-error text-xs h-full">
+                        {curlPreviewError}
+                      </div>
+                    ) : (
+                      <div className="flex items-center justify-center text-vsc-text-faint text-xs h-full">
+                        {previewLoading
+                          ? 'Loading cURL preview...'
+                          : 'Enter args to preview cURL'}
+                      </div>
+                    )}
+                  </TabsContent>
+                )}
+
+                {/* Execution area */}
+                <TabsContent
+                  value="run"
+                  className="flex-1 flex flex-col min-h-0 mt-0"
+                >
+                  {/* Args */}
+                  {/* `nokey`: keep React Flow's global key capture (Space,
+                      Backspace, ...) out of the args input */}
+                  <div className="nokey flex items-center border-b border-vsc-border shrink-0">
+                    <span className="px-2 py-1 text-[10px] text-vsc-text-faint font-vsc-mono bg-vsc-surface border-r border-vsc-border self-stretch flex items-center">
+                      args
+                    </span>
+                    <Input
+                      spellCheck={false}
+                      value={argsJson}
+                      onChange={onArgsJsonChange}
+                      className="flex-1 h-7 rounded-none border-none font-vsc-mono text-xs"
+                      placeholder='{"key": "value"}'
+                    />
+                  </div>
+
+                  {/* Live graph */}
+                  <div
+                    className="flex-1 min-h-0 flex flex-col bg-vsc-bg border-b border-vsc-border"
+                    style={{ minHeight: 180 }}
+                  >
+                    {workflowSwitcherBar}
+                    {controlFlowGraph ? (
+                      <GraphView
+                        graph={controlFlowGraph}
+                        functionName={selectedFn}
+                        runtimeEvents={latestGraphRun?.runtimeEvents}
+                        runStatus={latestGraphRun?.status}
+                        runError={latestGraphRun?.error}
+                        runFunctionName={latestGraphRun?.functionName}
+                        customRenderers={resultRenderers}
+                        selectedNodeId={highlightedNodeId}
+                        onNodeClick={handleGraphNodeClick}
+                      />
+                    ) : (
+                      <div className="flex-1 flex items-center justify-center text-vsc-text-faint text-xs bg-vsc-bg h-full">
+                        Loading graph...
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Logs resize handle — spans the full panel width, pinned
+                      just above the run-history strip. */}
+                  <div
+                    onMouseDown={onLogsResizeStart}
+                    className="absolute left-0 right-0 z-10 h-1.5 cursor-row-resize bg-vsc-surface hover:bg-vsc-accent/30 transition-colors border-y border-vsc-border"
+                    style={{ bottom: logsPanelHeight }}
+                    title="Resize logs"
+                  />
+
+                  {/* Run history (scrollable) — full panel width, below the
+                      sidebar+content row. */}
+                  <div
+                    ref={outputRef}
+                    className="absolute left-0 right-0 bottom-0 z-10 overflow-auto font-vsc-mono text-xs bg-vsc-bg"
+                    style={{ height: logsPanelHeight }}
+                  >
+                    {runs.length === 0 && (
+                      <div className="p-5 text-center text-vsc-text-faint text-[11px]">
+                        Press Run to execute {selectedFn}()
+                      </div>
+                    )}
+
+                    {[...runs].reverse().map((run, runIdx) => {
+                      const isLatest = runIdx === 0;
+                      const statusCls =
+                        run.status === 'error'
+                          ? 'bg-vsc-red'
+                          : run.status === 'success'
+                            ? 'bg-vsc-green'
+                            : run.status === 'cancelled'
+                              ? 'bg-vsc-yellow'
+                              : 'bg-vsc-text-muted';
+
+                      return (
+                        <div
+                          key={run.id}
+                          className={
+                            !isLatest ? 'border-b-2 border-vsc-border' : ''
+                          }
+                        >
+                          {/* Run header */}
+                          <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-vsc-surface border-b border-vsc-border-subtle">
+                            <span
+                              className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusCls}`}
+                            />
+                            <span className="text-vsc-accent font-semibold text-[11px]">
+                              {run.functionName}()
+                            </span>
+                            <span className="text-vsc-text-faint text-[10px] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                              {run.argsJson}
+                            </span>
+                            {run.status === 'running' && (
+                              <>
+                                <span className="text-vsc-text-muted text-[10px]">
+                                  running...
+                                </span>
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-5 w-5 text-vsc-text-muted hover:text-vsc-error"
+                                        onClick={() => onCancelRun(run.id)}
+                                      >
+                                        <Square size={12} />
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      Cancel execution
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              </>
+                            )}
+                            {run.durationMs != null && (
+                              <span className="text-vsc-text-faint text-[10px] shrink-0">
+                                {run.durationMs}ms
+                              </span>
+                            )}
+                          </div>
+
+                          {/* Fetch logs for this run */}
+                          {run.fetchLogs.map((log) => {
+                            const isExp = expandedLogId === log.id;
+                            const statusColorCls =
+                              log.status === null
+                                ? 'text-vsc-text-muted'
+                                : log.status >= 200 && log.status < 300
+                                  ? 'text-vsc-green'
+                                  : log.status === 0
+                                    ? 'text-vsc-red'
+                                    : 'text-vsc-yellow';
+                            return (
+                              <div key={`n-${log.id}`}>
+                                <div
+                                  onClick={() =>
+                                    setExpandedLogId(isExp ? null : log.id)
+                                  }
+                                  className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
+                                >
+                                  <span
+                                    className={`${statusColorCls} font-semibold text-[11px]`}
+                                  >
+                                    {log.status ?? '...'}
+                                  </span>
+                                  <span className="text-vsc-text-faint text-[10px]">
+                                    {log.method}
+                                  </span>
+                                  <span className="text-vsc-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px]">
+                                    {log.url}
+                                  </span>
+                                  {log.durationMs != null && (
+                                    <span className="text-vsc-text-faint text-[10px]">
+                                      {log.durationMs}ms
+                                    </span>
+                                  )}
+                                  <span className="text-vsc-text-faint text-[9px]">
+                                    {isExp ? '\u25B4' : '\u25BE'}
+                                  </span>
+                                </div>
+                                {isExp && (
+                                  <div className="py-2 pr-2.5 pl-[22px] flex flex-col gap-2 border-b border-vsc-border">
+                                    {log.error && (
+                                      <CodeBlock variant="error">
+                                        {log.error}
+                                      </CodeBlock>
+                                    )}
+                                    <div>
+                                      <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                                        Request Headers
+                                      </div>
+                                      <CodeBlock>
+                                        {JSON.stringify(
+                                          log.requestHeaders,
+                                          null,
+                                          2,
+                                        )}
+                                      </CodeBlock>
+                                    </div>
+                                    {log.requestBody && (
+                                      <div>
+                                        <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                                          Request Body
+                                        </div>
+                                        <CodeBlock>
+                                          {tryFormatJson(log.requestBody)}
+                                        </CodeBlock>
+                                      </div>
+                                    )}
+                                    {log.responseBody != null && (
+                                      <div>
+                                        <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                                          Response Body
+                                        </div>
+                                        <CodeBlock>
+                                          {tryFormatJson(log.responseBody)}
+                                        </CodeBlock>
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })}
+
+                          {/* Runtime events (log.info, baml.events.send, etc.) */}
+                          {run.runtimeEvents.length > 0 && (
+                            <div className="py-1.5 pr-2.5 pl-[22px] border-b border-vsc-border-subtle">
+                              <div className="text-[10px] font-semibold text-vsc-text-muted mb-1 uppercase tracking-wide">
+                                Events ({run.runtimeEvents.length})
+                              </div>
+                              <div className="flex flex-col gap-0.5">
+                                {run.runtimeEvents.map((evt, evtIdx) => {
+                                  const kind = evt.event;
+                                  if (!kind) return null;
+
+                                  let label: string;
+                                  let payload: ReactNode;
+                                  let colorCls: string;
+
+                                  switch (kind.$case) {
+                                    case 'functionStart':
+                                      label = 'START';
+                                      payload = kind.functionStart.name;
+                                      colorCls = 'text-vsc-green';
+                                      break;
+                                    case 'functionEnd':
+                                      label = 'END';
+                                      payload = (
+                                        <FunctionEndPayload
+                                          event={kind.functionEnd}
+                                          customRenderers={resultRenderers}
+                                        />
+                                      );
+                                      colorCls = kind.functionEnd.error
+                                        ? 'text-vsc-red'
+                                        : 'text-vsc-text-muted';
+                                      break;
+                                    case 'log': {
+                                      const lvl = kind.log.level;
+                                      label = lvl;
+                                      payload = (
+                                        <EventValueDisplay
+                                          value={kind.log.data}
+                                          customRenderers={resultRenderers}
+                                        />
+                                      );
+                                      colorCls =
+                                        lvl === 'error'
+                                          ? 'text-vsc-red'
+                                          : lvl === 'warn'
+                                            ? 'text-vsc-yellow'
+                                            : lvl === 'debug'
+                                              ? 'text-vsc-text-muted'
+                                              : 'text-vsc-blue';
+                                      break;
+                                    }
+                                    case 'custom':
+                                      label = 'EVENT';
+                                      payload = (
+                                        <>
+                                          <span>{kind.custom.name}: </span>
+                                          <EventValueDisplay
+                                            value={kind.custom.data}
+                                            customRenderers={resultRenderers}
+                                          />
+                                        </>
+                                      );
+                                      colorCls = 'text-vsc-purple';
+                                      break;
+                                    case 'setTags':
+                                      label = 'TAGS';
+                                      payload = kind.setTags.tags
+                                        .map((t) => `${t.key}=${t.value}`)
+                                        .join(', ');
+                                      colorCls = 'text-vsc-text-muted';
+                                      break;
+                                    default:
+                                      return null;
+                                  }
+
+                                  // Check if cursor is within this event's source span
+                                  const source =
+                                    kind.$case === 'log'
+                                      ? kind.log.source
+                                      : undefined;
+                                  const isCursorMatch =
+                                    cursorOffset != null &&
+                                    source != null &&
+                                    cursorOffset > source.startOffset &&
+                                    cursorOffset <= source.endOffset;
+
+                                  return (
+                                    <div
+                                      key={`${evt.spanId}-${evtIdx}`}
+                                      className={cn(
+                                        'flex items-start gap-1.5 text-[11px]',
+                                        isCursorMatch &&
+                                          'bg-vsc-yellow/20 rounded px-1 -mx-1',
+                                        source &&
+                                          onNavigateToSource &&
+                                          'cursor-pointer hover:bg-vsc-bg-secondary',
+                                      )}
+                                      onClick={
+                                        source && onNavigateToSource
+                                          ? () =>
+                                              onNavigateToSource({
+                                                fileId: source.fileId,
+                                                line: source.line,
+                                                column: source.column,
+                                              })
+                                          : undefined
+                                      }
+                                    >
+                                      <span
+                                        className={`${colorCls} font-semibold shrink-0 w-10 uppercase`}
+                                      >
+                                        {label}
+                                      </span>
+                                      <div className="text-vsc-text flex-1 min-w-0 break-all">
+                                        {payload}
+                                      </div>
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          )}
+                          {/* Inline io.input() prompts for this run */}
+                          {(pendingInputs.get(run.id) ?? []).map((req) => (
+                            <div
+                              key={req.id}
+                              className="flex items-center gap-2 px-[22px] py-1.5 border-b border-vsc-border bg-vsc-surface"
+                            >
+                              <span className="text-vsc-text-faint text-xs shrink-0">
+                                {req.prompt ?? 'Input:'}
+                              </span>
+                              <input
+                                className="flex-1 bg-vsc-bg border border-vsc-border rounded px-2 py-1 text-xs text-vsc-text font-vsc-mono focus:outline-none focus:border-vsc-accent"
+                                autoFocus
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter') {
+                                    submitInput(
+                                      req.id,
+                                      e.currentTarget.value,
+                                      run.id,
+                                    );
+                                  }
+                                }}
+                              />
+                            </div>
+                          ))}
+
+                          {/* Result / Error / Cancelled for this run */}
+                          {run.status === 'cancelled' && (
+                            <div className="py-1.5 pr-2.5 pl-[22px]">
+                              <div className="text-[11px] text-vsc-text-faint italic">
+                                Cancelled
+                              </div>
+                            </div>
+                          )}
+                          {run.error && (
+                            <div className="py-1.5 pr-2.5 pl-[22px]">
+                              <div className="text-[10px] font-semibold text-vsc-red mb-0.5 uppercase tracking-wide">
+                                Error
+                              </div>
+                              <ErrorDisplay
+                                error={run.error}
+                                onRetry={onRunFunction}
+                              />
+                            </div>
+                          )}
+                          {run.result != null && (
+                            <div className="py-1.5 pr-2.5 pl-[22px]">
+                              {run.status === 'success' &&
+                                run.fetchLogs.length > 0 && (
+                                  <div className="mb-1">
+                                    <MetadataBadges
+                                      fetchLogs={run.fetchLogs}
+                                      durationMs={run.durationMs}
+                                    />
+                                  </div>
+                                )}
+                              <div className="space-y-1">
+                                <div className="flex items-center gap-1">
+                                  <div className="text-[10px] font-semibold text-vsc-green uppercase tracking-wide">
+                                    Result
+                                  </div>
+                                  <ToggleGroup
+                                    value={resultModes[run.id] ?? 'parsed'}
+                                    onValueChange={(v) =>
+                                      setResultModes((prev) => ({
+                                        ...prev,
+                                        [run.id]: v as 'parsed' | 'raw',
+                                      }))
+                                    }
+                                    options={[
+                                      { value: 'parsed', label: 'Parsed' },
+                                      { value: 'raw', label: 'Raw' },
+                                    ]}
+                                    size="sm"
+                                  />
+                                  <CopyButton
+                                    text={stringifyResult(run.result)}
+                                    iconSize={11}
+                                  />
+                                </div>
+                                {(resultModes[run.id] ?? 'parsed') ===
+                                'parsed' ? (
+                                  <ResultDisplay
+                                    result={run.result}
+                                    customRenderers={resultRenderers}
+                                  />
+                                ) : (
+                                  <pre className="whitespace-pre-wrap break-all font-vsc-mono text-[11px] text-vsc-text bg-vsc-bg-secondary p-2 rounded border border-vsc-border max-h-[400px] overflow-auto">
+                                    {stringifyResult(run.result)}
+                                  </pre>
+                                )}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </TabsContent>
+              </>
+            ) : (
+              <div className="flex-1 flex items-center justify-center text-vsc-text-faint text-xs bg-vsc-bg">
+                {viewingCollection
+                  ? 'Collection not yet available — click Refresh'
+                  : 'Select a function to run'}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
       </Tabs>
 
       <ApiKeysDialog

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -52,7 +52,11 @@ import {
   isHttpRequest,
 } from './renderers/HttpRequestCurl';
 import { GraphView } from './graph/GraphView';
-import { FunctionSidebar } from './FunctionSidebar';
+import {
+  FunctionSidebar,
+  type SerializedTestDef,
+  type SerializedTestSet,
+} from './FunctionSidebar';
 import { EventValueDisplay } from './EventValueDisplay';
 import { findImageMedia, mediaToSrc } from './shared/media-values';
 import { companionFunctionName } from './shared/companion-functions';
@@ -82,6 +86,64 @@ function stringifyResult(value: BamlJsValue): string {
     (_, v) => (typeof v === 'bigint' ? v.toString() : v),
     2,
   );
+}
+
+type PendingTestTarget = {
+  project: string;
+  kind: 'test' | 'testset';
+  name: string;
+};
+
+function testTargetMatches(candidate: string, target: string): boolean {
+  return (
+    candidate === target ||
+    candidate.endsWith(`/${target}`) ||
+    candidate.split('/').pop() === target
+  );
+}
+
+function isExpandedTestSet(def: SerializedTestDef): def is SerializedTestSet {
+  return Array.isArray((def as { items?: unknown }).items);
+}
+
+function findTestNameInTree(
+  items: SerializedTestDef[],
+  target: string,
+): string | null {
+  for (const item of items) {
+    if ('type' in item && item.type === 'test') {
+      if (testTargetMatches(item.name, target)) return item.name;
+      continue;
+    }
+    if (isExpandedTestSet(item)) {
+      const found = findTestNameInTree(item.items, target);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function collectAllTestNames(item: SerializedTestDef): string[] {
+  if ('type' in item && item.type === 'test') return [item.name];
+  if (!isExpandedTestSet(item)) return [];
+  return item.items.flatMap(collectAllTestNames);
+}
+
+function collectTestNamesInSet(
+  items: SerializedTestDef[],
+  target: string,
+): string[] | null {
+  for (const item of items) {
+    if ('type' in item && item.type === 'lazyTestSet') {
+      if (testTargetMatches(item.name, target)) return null;
+      continue;
+    }
+    if (!isExpandedTestSet(item)) continue;
+    if (testTargetMatches(item.name, target)) return collectAllTestNames(item);
+    const nested = collectTestNamesInSet(item.items, target);
+    if (nested) return nested;
+  }
+  return null;
 }
 
 function findLatestGraphRun(
@@ -229,6 +291,10 @@ export interface ExecutionPanelProps {
   initialTab?: 'run' | 'graph' | 'prompt' | 'curl';
   /** Auto-select this function once the project reports it (applied once). */
   initialFunctionName?: string;
+  /** Auto-run this test once the test tree reports it (applied once). */
+  initialTestName?: string;
+  /** Auto-run tests under this testset once the test tree reports it (applied once). */
+  initialTestsetName?: string;
   /** Seed for the args JSON editor (default '{}'). */
   initialArgsJson?: string;
   /** Per-function seeds for the args editor, keyed by bare or fully-qualified
@@ -474,6 +540,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   onNavigateToSource,
   initialTab,
   initialFunctionName,
+  initialTestName,
+  initialTestsetName,
   initialArgsJson,
   argsByFunction,
   initialSidebarOpen = true,
@@ -496,6 +564,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   // When true, the main content area shows the test run history panel
   const [viewingTestRun, setViewingTestRun] = useState(false);
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
+  const [pendingTestTarget, setPendingTestTarget] =
+    useState<PendingTestTarget | null>(null);
 
   const [selectedFn, setSelectedFn] = useState<string | null>(null);
   const [showInternalFunctions, setShowInternalFunctions] = useState(false);
@@ -955,6 +1025,24 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 setSelectedFn(n.functionName);
                 setViewingCollection(false);
                 setViewingTestRun(false);
+              } else if (n.testName || n.testsetName) {
+                setWorkflowContext(null);
+                setSelectedFn(null);
+                setViewingCollection(false);
+                setViewingTestRun(true);
+                setTestTree(null);
+                setCollectionCallId(null);
+                setCollectionRun(null);
+                setTestRunResults(new Map());
+                setPendingTestTarget({
+                  project: n.project,
+                  kind: n.testName ? 'test' : 'testset',
+                  name: n.testName ?? n.testsetName!,
+                });
+                port.postMessage({
+                  type: 'requestCollectTests',
+                  project: n.project,
+                });
               }
               break;
             case 'controlFlowGraphResult':
@@ -1518,6 +1606,33 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     port.postMessage({ type: 'requestCollectTests', project: selectedProject });
   }, [selectedProject, port]);
 
+  const appliedInitialTestTargetRef = useRef(false);
+  useEffect(() => {
+    if (
+      appliedInitialTestTargetRef.current ||
+      !selectedProject ||
+      (!initialTestName && !initialTestsetName)
+    ) {
+      return;
+    }
+
+    appliedInitialTestTargetRef.current = true;
+    setWorkflowContext(null);
+    setSelectedFn(null);
+    setViewingCollection(false);
+    setViewingTestRun(true);
+    setTestTree(null);
+    setCollectionCallId(null);
+    setCollectionRun(null);
+    setTestRunResults(new Map());
+    setPendingTestTarget({
+      project: selectedProject,
+      kind: initialTestName ? 'test' : 'testset',
+      name: initialTestName ?? initialTestsetName!,
+    });
+    port.postMessage({ type: 'requestCollectTests', project: selectedProject });
+  }, [initialTestName, initialTestsetName, selectedProject, port]);
+
   const handleRunTest = useCallback(
     async (name: string) => {
       if (!selectedProject) return;
@@ -1599,6 +1714,34 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     },
     [selectedProject, generation, port],
   );
+
+  useEffect(() => {
+    if (!pendingTestTarget || !selectedProject || !Array.isArray(testTree)) {
+      return;
+    }
+    if (pendingTestTarget.project !== selectedProject) {
+      return;
+    }
+
+    const treeItems = testTree as SerializedTestDef[];
+    if (pendingTestTarget.kind === 'test') {
+      const testName = findTestNameInTree(treeItems, pendingTestTarget.name);
+      if (!testName) return;
+      setPendingTestTarget(null);
+      void handleRunTest(testName);
+      return;
+    }
+
+    const testNames = collectTestNamesInSet(treeItems, pendingTestTarget.name);
+    if (!testNames) return;
+    setPendingTestTarget(null);
+    setViewingTestRun(true);
+    void (async () => {
+      for (const testName of testNames) {
+        await handleRunTest(testName);
+      }
+    })();
+  }, [pendingTestTarget, selectedProject, testTree, handleRunTest]);
 
   // Track which testsets we've already requested expansion for (per generation)
   const pendingExpandsRef = useRef<{

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -1,10 +1,23 @@
 import type { FC } from 'react';
 import { useState } from 'react';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './components/ui/collapsible';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from './components/ui/collapsible';
 import { Button } from './components/ui/button';
 import { Input } from './components/ui/input';
 import { cn } from './lib/utils';
-import { Bot, FunctionSquare, ChevronRight, RefreshCw, Search, Loader2, FlaskConical, Wrench } from 'lucide-react';
+import {
+  Bot,
+  FunctionSquare,
+  ChevronRight,
+  RefreshCw,
+  Search,
+  Loader2,
+  FlaskConical,
+  Wrench,
+} from 'lucide-react';
 import type { FunctionInfo, RunEntry } from './worker-protocol';
 
 // ---------------------------------------------------------------------------
@@ -18,9 +31,16 @@ export type SerializedTest = { type: 'test'; name: string };
 export type SerializedLazyTestSet = { type: 'lazyTestSet'; name: string };
 
 /** An expanded testset: { name: string, items: SerializedTestDef[], loadingTimeMs: number } */
-export type SerializedTestSet = { name: string; items: SerializedTestDef[]; loadingTimeMs: number };
+export type SerializedTestSet = {
+  name: string;
+  items: SerializedTestDef[];
+  loadingTimeMs: number;
+};
 
-export type SerializedTestDef = SerializedTest | SerializedLazyTestSet | SerializedTestSet;
+export type SerializedTestDef =
+  | SerializedTest
+  | SerializedLazyTestSet
+  | SerializedTestSet;
 
 // ---------------------------------------------------------------------------
 // TestTreeNode — recursive tree renderer for SerializedTestDef items
@@ -35,7 +55,14 @@ interface TestTreeNodeProps {
   onRetryExpand?: (name: string) => void;
 }
 
-function TestTreeNode({ def, depth = 0, onRunTest, testRunResults, failedExpands, onRetryExpand }: TestTreeNodeProps) {
+function TestTreeNode({
+  def,
+  depth = 0,
+  onRunTest,
+  testRunResults,
+  failedExpands,
+  onRetryExpand,
+}: TestTreeNodeProps) {
   const [expanded, setExpanded] = useState(true);
   const indent = 8 + depth * 12;
 
@@ -49,18 +76,29 @@ function TestTreeNode({ def, depth = 0, onRunTest, testRunResults, failedExpands
         {isFailed ? (
           <FlaskConical size={12} className="text-red-500 shrink-0" />
         ) : (
-          <Loader2 size={12} className="animate-spin text-vsc-text-faint shrink-0" />
+          <Loader2
+            size={12}
+            className="animate-spin text-vsc-text-faint shrink-0"
+          />
         )}
         <span className="truncate text-[11px] font-medium italic text-vsc-text-faint">
           {def.name.split('/').pop()}
         </span>
-        <span className={cn('text-[9px] ml-1', isFailed ? 'text-red-500' : 'text-vsc-text-faint')}>
+        <span
+          className={cn(
+            'text-[9px] ml-1',
+            isFailed ? 'text-red-500' : 'text-vsc-text-faint',
+          )}
+        >
           {isFailed ? 'failed' : 'loading\u2026'}
         </span>
         {isFailed && onRetryExpand && (
           <button
             className="ml-auto text-[9px] text-vsc-text-faint hover:text-vsc-text px-1 shrink-0"
-            onClick={(e) => { e.stopPropagation(); onRetryExpand(def.name); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRetryExpand(def.name);
+            }}
             title={`Retry expansion: ${def.name}`}
           >
             retry
@@ -72,29 +110,40 @@ function TestTreeNode({ def, depth = 0, onRunTest, testRunResults, failedExpands
 
   if ('type' in def && def.type === 'test') {
     const report = testRunResults?.get(def.name);
-    const reportObj = report != null && typeof report === 'object' ? (report as Record<string, unknown>) : null;
-    const outcome = typeof reportObj?.outcome === 'string' ? reportObj.outcome : undefined;
+    const reportObj =
+      report != null && typeof report === 'object'
+        ? (report as Record<string, unknown>)
+        : null;
+    const outcome =
+      typeof reportObj?.outcome === 'string' ? reportObj.outcome : undefined;
     return (
       <div
         className="flex items-center gap-1.5 pr-2 py-0.5 text-[10px] font-vsc-mono text-vsc-text-muted"
         style={{ paddingLeft: indent }}
       >
         <FlaskConical size={12} className="text-vsc-text-faint shrink-0" />
-        <span className="truncate text-[11px]">{def.name.split('/').pop()}</span>
+        <span className="truncate text-[11px]">
+          {def.name.split('/').pop()}
+        </span>
         {onRunTest && (
           <button
             className="ml-auto text-[9px] text-vsc-text-faint hover:text-vsc-text px-1 shrink-0"
-            onClick={(e) => { e.stopPropagation(); onRunTest(def.name); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRunTest(def.name);
+            }}
             title={`Run test: ${def.name}`}
           >
             run
           </button>
         )}
         {outcome && (
-          <span className={cn(
-            'text-[9px] shrink-0',
-            outcome === 'pass' ? 'text-green-500' : 'text-red-500'
-          )}>
+          <span
+            className={cn(
+              'text-[9px] shrink-0',
+              outcome === 'pass' ? 'text-green-500' : 'text-red-500',
+            )}
+          >
             {outcome}
           </span>
         )}
@@ -110,8 +159,15 @@ function TestTreeNode({ def, depth = 0, onRunTest, testRunResults, failedExpands
         className="flex items-center gap-1 w-full pr-2 py-0.5 cursor-pointer text-[10px] font-vsc-mono text-vsc-text-muted hover:bg-vsc-hover"
         style={{ paddingLeft: indent }}
       >
-        <ChevronRight className={cn('h-3 w-3 text-vsc-text-faint transition-transform', expanded && 'rotate-90')} />
-        <span className="truncate text-[11px] font-medium">{set.name.split('/').pop()}</span>
+        <ChevronRight
+          className={cn(
+            'h-3 w-3 text-vsc-text-faint transition-transform',
+            expanded && 'rotate-90',
+          )}
+        />
+        <span className="truncate text-[11px] font-medium">
+          {set.name.split('/').pop()}
+        </span>
         <span className="text-vsc-text-faint ml-1">({set.items.length})</span>
         {set.loadingTimeMs > 0 && (
           <span className="text-[9px] text-vsc-text-faint ml-auto shrink-0">
@@ -124,7 +180,7 @@ function TestTreeNode({ def, depth = 0, onRunTest, testRunResults, failedExpands
       <CollapsibleContent>
         {set.items.map((child, i) => (
           <TestTreeNode
-            key={`${('name' in child ? child.name : i)}-${i}`}
+            key={`${'name' in child ? child.name : i}-${i}`}
             def={child}
             depth={depth + 1}
             onRunTest={onRunTest}
@@ -144,8 +200,9 @@ function TestTreeNode({ def, depth = 0, onRunTest, testRunResults, failedExpands
 
 export interface FunctionSidebarProps {
   functions: FunctionInfo[];
+  /** Whether internal functions are currently shown (toggled from the
+   * panel's settings gear menu) — used only for the empty-state message. */
   showInternalFunctions: boolean;
-  onShowInternalFunctionsChange: (show: boolean) => void;
   internalFunctionCount: number;
   testTree?: any; // SerializedTestDef[] from BAML TestRegistry.serialize()
   selectedFn: string | null;
@@ -172,7 +229,6 @@ export interface FunctionSidebarProps {
 export const FunctionSidebar: FC<FunctionSidebarProps> = ({
   functions,
   showInternalFunctions,
-  onShowInternalFunctionsChange,
   internalFunctionCount,
   testTree,
   selectedFn,
@@ -187,6 +243,9 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
   onSelectCollectionView,
 }) => {
   const [search, setSearch] = useState('');
+  // Accordion state: tests are the primary view; functions start collapsed.
+  const [functionsOpen, setFunctionsOpen] = useState(false);
+  const [testsOpen, setTestsOpen] = useState(true);
 
   const lowerSearch = search.toLowerCase();
 
@@ -196,12 +255,15 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
     return fn.name.toLowerCase().includes(lowerSearch);
   });
 
-  const treeItems: SerializedTestDef[] = Array.isArray(testTree) ? testTree : [];
+  const treeItems: SerializedTestDef[] = Array.isArray(testTree)
+    ? testTree
+    : [];
   let emptyFunctionMessage = 'No matches';
   if (functions.length === 0) {
-    emptyFunctionMessage = internalFunctionCount > 0 && !showInternalFunctions
-      ? 'No user functions'
-      : 'No functions yet';
+    emptyFunctionMessage =
+      internalFunctionCount > 0 && !showInternalFunctions
+        ? 'No user functions'
+        : 'No functions yet';
   }
 
   return (
@@ -217,108 +279,129 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
             className="flex-1 h-6 border-none bg-transparent text-xs"
           />
         </div>
-        {internalFunctionCount > 0 && (
-          <label className="mt-1.5 flex items-center gap-1.5 text-[10px] text-vsc-text-faint cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={showInternalFunctions}
-              onChange={(e) => onShowInternalFunctionsChange(e.currentTarget.checked)}
-              className="h-3 w-3 accent-vsc-accent"
-            />
-            <span>Show internal functions</span>
-            <span className="ml-auto font-vsc-mono">{internalFunctionCount}</span>
-          </label>
-        )}
       </div>
 
-      {/* Function list */}
+      {/* Accordion: Functions (collapsed by default) + Tests (open) */}
       <div className="flex-1 overflow-y-auto py-0.5">
-        {filteredFns.length === 0 && (
-          <div className="px-2 py-3 text-center text-vsc-text-faint text-[11px]">
-            {emptyFunctionMessage}
-          </div>
-        )}
-
-        {filteredFns.map((fn) => {
-          const isSelected = selectedFn === fn.name;
-          const isInternal = fn.origin !== 'userDefined';
-          const Icon = fn.kind === 'llm' ? Bot : FunctionSquare;
-
-          return (
-            <button
-              type="button"
-              key={fn.name}
-              className={`flex items-center gap-1 w-full px-2 py-1 cursor-pointer text-[11px] font-vsc-mono text-left ${
-                isSelected
-                  ? 'bg-vsc-accent/15 text-vsc-text font-semibold'
-                  : 'text-vsc-text-muted hover:bg-vsc-hover'
-              }`}
-              onClick={() => onSelectFn(isSelected ? null : fn.name)}
-            >
-              <span className="w-4 shrink-0" />
-              <Icon className="h-3.5 w-3.5 shrink-0 text-vsc-text-faint" />
-              <span className="truncate">{fn.name}</span>
-              {isInternal && (
-                <span className="ml-auto shrink-0 rounded border border-vsc-border px-1 py-0 text-[9px] text-vsc-text-faint">
-                  {fn.origin}
-                </span>
+        {/* Functions section — typing in the filter forces it open */}
+        <Collapsible
+          open={functionsOpen || search !== ''}
+          onOpenChange={setFunctionsOpen}
+        >
+          <CollapsibleTrigger className="flex items-center gap-1 w-full px-2 py-1 cursor-pointer text-[11px] font-semibold text-vsc-text-muted hover:bg-vsc-hover">
+            <ChevronRight
+              className={cn(
+                'h-3 w-3 text-vsc-text-faint transition-transform',
+                (functionsOpen || search !== '') && 'rotate-90',
               )}
-            </button>
-          );
-        })}
+            />
+            <FunctionSquare size={12} />
+            <span>Functions</span>
+            <span className="text-vsc-text-faint ml-1">
+              ({filteredFns.length})
+            </span>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            {filteredFns.length === 0 && (
+              <div className="px-2 py-3 text-center text-vsc-text-faint text-[11px]">
+                {emptyFunctionMessage}
+              </div>
+            )}
 
-        {/* Tests section */}
+            {filteredFns.map((fn) => {
+              const isSelected = selectedFn === fn.name;
+              const isInternal = fn.origin !== 'userDefined';
+              const Icon = fn.kind === 'llm' ? Bot : FunctionSquare;
+
+              return (
+                <button
+                  type="button"
+                  key={fn.name}
+                  className={`flex items-center gap-1 w-full px-2 py-1 cursor-pointer text-[11px] font-vsc-mono text-left ${
+                    isSelected
+                      ? 'bg-vsc-accent/15 text-vsc-text font-semibold'
+                      : 'text-vsc-text-muted hover:bg-vsc-hover'
+                  }`}
+                  onClick={() => onSelectFn(isSelected ? null : fn.name)}
+                >
+                  <span className="w-4 shrink-0" />
+                  <Icon className="h-3.5 w-3.5 shrink-0 text-vsc-text-faint" />
+                  <span className="truncate">{fn.name}</span>
+                  {isInternal && (
+                    <span className="ml-auto shrink-0 rounded border border-vsc-border px-1 py-0 text-[9px] text-vsc-text-faint">
+                      {fn.origin}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </CollapsibleContent>
+        </Collapsible>
+
+        {/* Tests section — open by default */}
         <div className="border-t border-vsc-border mt-1">
-          <div className="flex items-center gap-1 px-2 py-1 text-[11px] font-semibold text-vsc-text-muted">
-            <FlaskConical size={12} />
-            <span>Tests</span>
-            {onSelectCollectionView && (
+          <Collapsible open={testsOpen} onOpenChange={setTestsOpen}>
+            <div className="flex items-center gap-1 px-2 py-1 text-[11px] font-semibold text-vsc-text-muted">
+              <CollapsibleTrigger className="flex items-center gap-1 flex-1 min-w-0 cursor-pointer text-left bg-transparent border-none p-0 text-[11px] font-semibold text-vsc-text-muted hover:bg-vsc-hover">
+                <ChevronRight
+                  className={cn(
+                    'h-3 w-3 text-vsc-text-faint transition-transform',
+                    testsOpen && 'rotate-90',
+                  )}
+                />
+                <FlaskConical size={12} />
+                <span>Tests</span>
+              </CollapsibleTrigger>
+              {onSelectCollectionView && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={`ml-auto h-5 w-5 ${viewingCollection ? 'text-vsc-accent' : 'text-vsc-text-faint hover:text-vsc-text'}`}
+                  onClick={onSelectCollectionView}
+                  title={
+                    collectionRun && collectionRun.fetchLogs.length > 0
+                      ? `View collection logs (${collectionRun.fetchLogs.length} request${collectionRun.fetchLogs.length !== 1 ? 's' : ''})`
+                      : 'View collection logs'
+                  }
+                >
+                  <Wrench size={10} />
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="icon"
-                className={`ml-auto h-5 w-5 ${viewingCollection ? 'text-vsc-accent' : 'text-vsc-text-faint hover:text-vsc-text'}`}
-                onClick={onSelectCollectionView}
-                title={
-                  collectionRun && collectionRun.fetchLogs.length > 0
-                    ? `View collection logs (${collectionRun.fetchLogs.length} request${collectionRun.fetchLogs.length !== 1 ? 's' : ''})`
-                    : 'View collection logs'
-                }
+                className={`h-5 w-5 text-vsc-text-faint hover:text-vsc-text${onSelectCollectionView ? '' : ' ml-auto'}`}
+                onClick={onRefreshTests}
+                title="Re-collect tests"
               >
-                <Wrench size={10} />
+                <RefreshCw size={10} />
               </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              className={`h-5 w-5 text-vsc-text-faint hover:text-vsc-text${onSelectCollectionView ? '' : ' ml-auto'}`}
-              onClick={onRefreshTests}
-              title="Re-collect tests"
-            >
-              <RefreshCw size={10} />
-            </Button>
-          </div>
-
-          {!testTree && (
-            <div className="px-4 py-2 text-[10px] text-vsc-text-faint italic">
-              No test data yet
             </div>
-          )}
 
-          {testTree && treeItems.length === 0 && (
-            <div className="px-4 py-2 text-[10px] text-vsc-text-faint italic">
-              No tests found
-            </div>
-          )}
+            <CollapsibleContent>
+              {!testTree && (
+                <div className="px-4 py-2 text-[10px] text-vsc-text-faint italic">
+                  No test data yet
+                </div>
+              )}
 
-          {treeItems.map((def, i) => (
-            <TestTreeNode
-              key={`${'name' in def ? def.name : i}-${i}`}
-              def={def}
-              onRunTest={onRunTest}
-              testRunResults={testRunResults}
-              failedExpands={failedExpands}
-            />
-          ))}
+              {testTree && treeItems.length === 0 && (
+                <div className="px-4 py-2 text-[10px] text-vsc-text-faint italic">
+                  No tests found
+                </div>
+              )}
+
+              {treeItems.map((def, i) => (
+                <TestTreeNode
+                  key={`${'name' in def ? def.name : i}-${i}`}
+                  def={def}
+                  onRunTest={onRunTest}
+                  testRunResults={testRunResults}
+                  failedExpands={failedExpands}
+                />
+              ))}
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       </div>
     </div>

--- a/typescript2/pkg-playground/src/ResultDisplay.tsx
+++ b/typescript2/pkg-playground/src/ResultDisplay.tsx
@@ -18,6 +18,15 @@ export interface ResultDisplayProps {
   customRenderers?: Record<string, FC<ResultRendererProps>>;
 }
 
-export const ResultDisplay: FC<ResultDisplayProps> = ({ result, customRenderers }) => {
-  return <ValueRenderer value={result} customRenderers={customRenderers} displayMode="expanded" />;
+export const ResultDisplay: FC<ResultDisplayProps> = ({
+  result,
+  customRenderers,
+}) => {
+  return (
+    <ValueRenderer
+      value={result}
+      customRenderers={customRenderers}
+      displayMode="expanded"
+    />
+  );
 };

--- a/typescript2/pkg-playground/src/ValueRenderer.tsx
+++ b/typescript2/pkg-playground/src/ValueRenderer.tsx
@@ -10,7 +10,11 @@ import { useState, type FC } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { CopyButton } from './components/CopyButton';
 import { CodeBlock } from './components/ui/code-block';
-import { getBamlType, getResultRenderer, BAML_TYPE_KEY } from './result-renderers';
+import {
+  getBamlType,
+  getResultRenderer,
+  BAML_TYPE_KEY,
+} from './result-renderers';
 import type { ResultRendererProps, DisplayMode } from './result-renderers';
 
 function resolve(
@@ -40,17 +44,43 @@ export const ValueRenderer: FC<{
   depth?: number;
   path?: string;
   displayMode?: DisplayMode;
-}> = ({ value, customRenderers, depth = 0, path = '$', displayMode = 'auto' }) => {
+}> = ({
+  value,
+  customRenderers,
+  depth = 0,
+  path = '$',
+  displayMode = 'auto',
+}) => {
   const isInline = displayMode === 'inline';
   const [collapsed, setCollapsed] = useState(isInline || depth >= 2);
 
   // Primitives with type coloring (same for all modes)
-  if (value == null) return <span className="font-vsc-mono text-xs text-vsc-text-faint">null</span>;
-  if (typeof value === 'string') return <span className="font-vsc-mono text-xs text-green-400">"{value}"</span>;
-  if (typeof value === 'number') return <span className="font-vsc-mono text-xs text-cyan-400">{value}</span>;
-  if (typeof value === 'bigint') return <span className="font-vsc-mono text-xs text-cyan-400">{`${value}n`}</span>;
-  if (typeof value === 'boolean') return <span className="font-vsc-mono text-xs text-yellow-400">{String(value)}</span>;
-  if (typeof value !== 'object') return <span className="font-vsc-mono text-xs text-vsc-text">{stringifyValue(value)}</span>;
+  if (value == null)
+    return (
+      <span className="font-vsc-mono text-xs text-vsc-text-faint">null</span>
+    );
+  if (typeof value === 'string')
+    return (
+      <span className="font-vsc-mono text-xs text-green-400">"{value}"</span>
+    );
+  if (typeof value === 'number')
+    return <span className="font-vsc-mono text-xs text-cyan-400">{value}</span>;
+  if (typeof value === 'bigint')
+    return (
+      <span className="font-vsc-mono text-xs text-cyan-400">{`${value}n`}</span>
+    );
+  if (typeof value === 'boolean')
+    return (
+      <span className="font-vsc-mono text-xs text-yellow-400">
+        {String(value)}
+      </span>
+    );
+  if (typeof value !== 'object')
+    return (
+      <span className="font-vsc-mono text-xs text-vsc-text">
+        {stringifyValue(value)}
+      </span>
+    );
 
   // $baml.type dispatch
   const type = getBamlType(value);
@@ -70,7 +100,10 @@ export const ValueRenderer: FC<{
 
   // Array
   if (Array.isArray(value)) {
-    if (value.length === 0) return <span className="font-vsc-mono text-xs text-vsc-text-faint">[]</span>;
+    if (value.length === 0)
+      return (
+        <span className="font-vsc-mono text-xs text-vsc-text-faint">[]</span>
+      );
 
     // Inline mode: render items on a single line
     if (isInline) {
@@ -80,7 +113,12 @@ export const ValueRenderer: FC<{
           {value.map((item, i) => (
             <span key={i}>
               {i > 0 && ', '}
-              <ValueRenderer value={item} customRenderers={customRenderers} depth={depth + 1} displayMode="inline" />
+              <ValueRenderer
+                value={item}
+                customRenderers={customRenderers}
+                depth={depth + 1}
+                displayMode="inline"
+              />
             </span>
           ))}
           {']'}
@@ -93,17 +131,36 @@ export const ValueRenderer: FC<{
       <div className="group/node">
         <div className="flex items-center gap-0.5">
           {showToggle && (
-            <button onClick={() => setCollapsed(!collapsed)} className="p-0 text-vsc-text-muted hover:text-vsc-text">
-              <ChevronRight size={12} className={`transition-transform ${collapsed ? '' : 'rotate-90'}`} />
+            <button
+              onClick={() => setCollapsed(!collapsed)}
+              className="p-0 text-vsc-text-muted hover:text-vsc-text"
+            >
+              <ChevronRight
+                size={12}
+                className={`transition-transform ${collapsed ? '' : 'rotate-90'}`}
+              />
             </button>
           )}
-          <span className="font-vsc-mono text-xs text-vsc-text-faint">[{value.length}]</span>
-          <CopyButton text={stringifyValue(value, 2)} className="opacity-0 group-hover/node:opacity-100" iconSize={11} />
+          <span className="font-vsc-mono text-xs text-vsc-text-faint">
+            [{value.length}]
+          </span>
+          <CopyButton
+            text={stringifyValue(value, 2)}
+            className="opacity-0 group-hover/node:opacity-100"
+            iconSize={11}
+          />
         </div>
         {!collapsed && (
           <div className="space-y-1 pl-3 border-l border-vsc-border-subtle mt-0.5">
             {value.map((item, i) => (
-              <ValueRenderer key={i} value={item} customRenderers={customRenderers} depth={depth + 1} path={`${path}[${i}]`} displayMode={displayMode} />
+              <ValueRenderer
+                key={i}
+                value={item}
+                customRenderers={customRenderers}
+                depth={depth + 1}
+                path={`${path}[${i}]`}
+                displayMode={displayMode}
+              />
             ))}
           </div>
         )}
@@ -112,24 +169,36 @@ export const ValueRenderer: FC<{
   }
 
   // Plain object
-  const entries = Object.entries(value as Record<string, unknown>).filter(([k]) => k !== BAML_TYPE_KEY);
-  if (entries.length === 0) return <span className="font-vsc-mono text-xs text-vsc-text-faint">{'{}'}</span>;
+  const entries = Object.entries(value as Record<string, unknown>).filter(
+    ([k]) => k !== BAML_TYPE_KEY,
+  );
+  if (entries.length === 0)
+    return (
+      <span className="font-vsc-mono text-xs text-vsc-text-faint">{'{}'}</span>
+    );
 
   // Inline mode: render as a single-line summary
   if (isInline) {
-    const className = (value as Record<string, unknown>).$baml != null
-      ? getBamlType(value) ?? undefined
-      : undefined;
+    const className =
+      (value as Record<string, unknown>).$baml != null
+        ? (getBamlType(value) ?? undefined)
+        : undefined;
     const prefix = className ? `${className} ` : '';
     return (
       <span className="font-vsc-mono text-xs text-vsc-text">
-        {prefix}{'{ '}
+        {prefix}
+        {'{ '}
         {entries.map(([key, val], i) => (
           <span key={key}>
             {i > 0 && ', '}
             <span className="text-vsc-text-muted">{key}</span>
             {': '}
-            <ValueRenderer value={val} customRenderers={customRenderers} depth={depth + 1} displayMode="inline" />
+            <ValueRenderer
+              value={val}
+              customRenderers={customRenderers}
+              depth={depth + 1}
+              displayMode="inline"
+            />
           </span>
         ))}
         {' }'}
@@ -142,12 +211,24 @@ export const ValueRenderer: FC<{
     <div className="group/node">
       <div className="flex items-center gap-0.5">
         {showToggle && (
-          <button onClick={() => setCollapsed(!collapsed)} className="p-0 text-vsc-text-muted hover:text-vsc-text">
-            <ChevronRight size={12} className={`transition-transform ${collapsed ? '' : 'rotate-90'}`} />
+          <button
+            onClick={() => setCollapsed(!collapsed)}
+            className="p-0 text-vsc-text-muted hover:text-vsc-text"
+          >
+            <ChevronRight
+              size={12}
+              className={`transition-transform ${collapsed ? '' : 'rotate-90'}`}
+            />
           </button>
         )}
-        <span className="font-vsc-mono text-xs text-vsc-text-faint">{'{'}…{'}'} {entries.length} keys</span>
-        <CopyButton text={stringifyValue(value, 2)} className="opacity-0 group-hover/node:opacity-100" iconSize={11} />
+        <span className="font-vsc-mono text-xs text-vsc-text-faint">
+          {'{'}…{'}'} {entries.length} keys
+        </span>
+        <CopyButton
+          text={stringifyValue(value, 2)}
+          className="opacity-0 group-hover/node:opacity-100"
+          iconSize={11}
+        />
       </div>
       {!collapsed && (
         <div className="space-y-1 pl-3 mt-0.5">
@@ -155,17 +236,34 @@ export const ValueRenderer: FC<{
             const isComplex = val != null && typeof val === 'object';
             if (!isComplex) {
               return (
-                <div key={key} className="flex gap-1.5 items-baseline font-vsc-mono text-xs">
+                <div
+                  key={key}
+                  className="flex gap-1.5 items-baseline font-vsc-mono text-xs"
+                >
                   <span className="text-vsc-text-muted shrink-0">{key}:</span>
-                  <ValueRenderer value={val} customRenderers={customRenderers} depth={depth + 1} path={`${path}.${key}`} displayMode={displayMode} />
+                  <ValueRenderer
+                    value={val}
+                    customRenderers={customRenderers}
+                    depth={depth + 1}
+                    path={`${path}.${key}`}
+                    displayMode={displayMode}
+                  />
                 </div>
               );
             }
             return (
               <div key={key} className="space-y-0.5">
-                <div className="font-vsc-mono text-xs text-vsc-text-muted">{key}:</div>
+                <div className="font-vsc-mono text-xs text-vsc-text-muted">
+                  {key}:
+                </div>
                 <div className="pl-2">
-                  <ValueRenderer value={val} customRenderers={customRenderers} depth={depth + 1} path={`${path}.${key}`} displayMode={displayMode} />
+                  <ValueRenderer
+                    value={val}
+                    customRenderers={customRenderers}
+                    depth={depth + 1}
+                    path={`${path}.${key}`}
+                    displayMode={displayMode}
+                  />
                 </div>
               </div>
             );

--- a/typescript2/pkg-playground/src/components/ApiKeysDialog.tsx
+++ b/typescript2/pkg-playground/src/components/ApiKeysDialog.tsx
@@ -1,11 +1,18 @@
 import { useState, useMemo, useRef, type FC } from 'react';
-import { Eye, EyeOff, Trash2, Plus, Upload, AlertTriangle, Undo2, Terminal, ChevronDown, ChevronRight, Search } from 'lucide-react';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from './ui/dialog';
+  Eye,
+  EyeOff,
+  Trash2,
+  Plus,
+  Upload,
+  AlertTriangle,
+  Undo2,
+  Terminal,
+  ChevronDown,
+  ChevronRight,
+  Search,
+} from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Textarea } from './ui/textarea';
@@ -43,7 +50,17 @@ interface ApiKeysDialogProps {
 }
 
 export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
-  open, onOpenChange, envVars, requiredKeys, shellEnvVars, shellOverriddenKeys, shellDeletedKeys, onSetEnvVar, onDeleteEnvVar, onImportEnvVars, onRevertToShell,
+  open,
+  onOpenChange,
+  envVars,
+  requiredKeys,
+  shellEnvVars,
+  shellOverriddenKeys,
+  shellDeletedKeys,
+  onSetEnvVar,
+  onDeleteEnvVar,
+  onImportEnvVars,
+  onRevertToShell,
 }) => {
   const [showValues, setShowValues] = useState<Set<string>>(new Set());
   const [newKey, setNewKey] = useState('');
@@ -52,7 +69,9 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
   const [importText, setImportText] = useState('');
   const [shellExpanded, setShellExpanded] = useState(false);
   const [shellFilter, setShellFilter] = useState('');
-  const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
 
   const missingKeys = new Set([...requiredKeys].filter((k) => !envVars[k]));
 
@@ -67,7 +86,13 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
       if (!(k in shellEnvVars)) keys.add(k);
     }
     return [...keys].sort();
-  }, [envVars, requiredKeys, shellEnvVars, shellDeletedKeys, shellOverriddenKeys]);
+  }, [
+    envVars,
+    requiredKeys,
+    shellEnvVars,
+    shellDeletedKeys,
+    shellOverriddenKeys,
+  ]);
 
   // Shell keys not already shown in primary section
   const shellOnlyKeys = useMemo(() => {
@@ -89,7 +114,10 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
   const handleInlineEdit = (key: string, value: string) => {
     const existing = debounceTimers.current.get(key);
     if (existing) clearTimeout(existing);
-    debounceTimers.current.set(key, setTimeout(() => onSetEnvVar(key, value), 200));
+    debounceTimers.current.set(
+      key,
+      setTimeout(() => onSetEnvVar(key, value), 200),
+    );
   };
 
   const handleAdd = () => {
@@ -108,7 +136,10 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
       if (eqIdx === -1) continue;
       const key = trimmed.slice(0, eqIdx).trim();
       let value = trimmed.slice(eqIdx + 1).trim();
-      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
         value = value.slice(1, -1);
       }
       if (key) vars[key] = value;
@@ -125,23 +156,51 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
     const isOverridden = shellOverriddenKeys.has(key);
     const isDeleted = shellDeletedKeys.has(key);
     return (
-      <div key={key} className={`flex items-center gap-2 ${isDeleted ? 'opacity-50' : ''}`}>
+      <div
+        key={key}
+        className={`flex items-center gap-2 ${isDeleted ? 'opacity-50' : ''}`}
+      >
         <div className="flex items-center gap-1 shrink-0 w-[160px]">
-          {isMissing && !isDeleted && <AlertTriangle size={12} className="text-yellow-400" />}
-          {isFromShell && !isMissing && <Terminal size={10} className="text-vsc-description shrink-0" />}
-          <span className={`font-vsc-mono text-[11px] truncate ${isDeleted ? 'line-through text-vsc-description' : 'text-vsc-text'}`}>{key}</span>
+          {isMissing && !isDeleted && (
+            <AlertTriangle size={12} className="text-yellow-400" />
+          )}
+          {isFromShell && !isMissing && (
+            <Terminal size={10} className="text-vsc-description shrink-0" />
+          )}
+          <span
+            className={`font-vsc-mono text-[11px] truncate ${isDeleted ? 'line-through text-vsc-description' : 'text-vsc-text'}`}
+          >
+            {key}
+          </span>
           {isDeleted && (
-            <span className="text-[9px] text-vsc-red shrink-0" title="Deleted (was from shell)">deleted</span>
+            <span
+              className="text-[9px] text-vsc-red shrink-0"
+              title="Deleted (was from shell)"
+            >
+              deleted
+            </span>
           )}
           {isFromShell && !isOverridden && !isDeleted && (
-            <span className="text-[9px] text-vsc-description shrink-0" title="From shell environment">shell</span>
+            <span
+              className="text-[9px] text-vsc-description shrink-0"
+              title="From shell environment"
+            >
+              shell
+            </span>
           )}
           {isOverridden && !isDeleted && (
-            <span className="text-[9px] text-yellow-500 shrink-0" title="Overridden (shell value differs)">edited</span>
+            <span
+              className="text-[9px] text-yellow-500 shrink-0"
+              title="Overridden (shell value differs)"
+            >
+              edited
+            </span>
           )}
         </div>
         {isDeleted ? (
-          <div className="flex-1 text-[11px] font-vsc-mono text-vsc-description italic px-2">removed</div>
+          <div className="flex-1 text-[11px] font-vsc-mono text-vsc-description italic px-2">
+            removed
+          </div>
         ) : (
           <Input
             type="text"
@@ -154,16 +213,32 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
           />
         )}
         {!isDeleted && (
-          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => toggleShow(key)}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => toggleShow(key)}
+          >
             {showValues.has(key) ? <EyeOff size={12} /> : <Eye size={12} />}
           </Button>
         )}
         {isOverridden || isDeleted ? (
-          <Button variant="ghost" size="icon" className="h-7 w-7 text-vsc-link" onClick={() => onRevertToShell(key)} title="Revert to shell value">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-vsc-link"
+            onClick={() => onRevertToShell(key)}
+            title="Revert to shell value"
+          >
             <Undo2 size={12} />
           </Button>
         ) : (
-          <Button variant="ghost" size="icon" className="h-7 w-7 text-vsc-red" onClick={() => onDeleteEnvVar(key)}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-vsc-red"
+            onClick={() => onDeleteEnvVar(key)}
+          >
             <Trash2 size={12} />
           </Button>
         )}
@@ -183,14 +258,13 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
         <div className="flex-1 overflow-auto p-4 space-y-3">
           {/* Primary section: required + manually added */}
           {primaryKeys.length > 0 && (
-            <div className="space-y-2">
-              {primaryKeys.map(renderRow)}
-            </div>
+            <div className="space-y-2">{primaryKeys.map(renderRow)}</div>
           )}
 
           {primaryKeys.length === 0 && (
             <div className="text-[11px] text-vsc-description text-center py-2">
-              No variables required yet. Run a function to see which env vars are needed.
+              No variables required yet. Run a function to see which env vars
+              are needed.
             </div>
           )}
 
@@ -222,7 +296,9 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
               <Textarea
                 value={importText}
                 onChange={(e) => setImportText(e.target.value)}
-                placeholder={"Paste .env contents here...\nKEY=value\nANOTHER_KEY=value"}
+                placeholder={
+                  'Paste .env contents here...\nKEY=value\nANOTHER_KEY=value'
+                }
                 rows={5}
                 className="text-[11px] font-vsc-mono resize-none"
               />
@@ -230,13 +306,25 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
                 <Button variant="default" size="sm" onClick={handleImport}>
                   Import
                 </Button>
-                <Button variant="ghost" size="sm" onClick={() => { setImportMode(false); setImportText(''); }}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setImportMode(false);
+                    setImportText('');
+                  }}
+                >
                   Cancel
                 </Button>
               </div>
             </div>
           ) : (
-            <Button variant="link" size="sm" className="text-vsc-link text-[11px] gap-1 px-0" onClick={() => setImportMode(true)}>
+            <Button
+              variant="link"
+              size="sm"
+              className="text-vsc-link text-[11px] gap-1 px-0"
+              onClick={() => setImportMode(true)}
+            >
               <Upload size={12} /> Import from .env
             </Button>
           )}
@@ -248,7 +336,11 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
                 onClick={() => setShellExpanded((prev) => !prev)}
                 className="flex items-center gap-1 text-[11px] text-vsc-description hover:text-vsc-text w-full text-left py-1"
               >
-                {shellExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                {shellExpanded ? (
+                  <ChevronDown size={12} />
+                ) : (
+                  <ChevronRight size={12} />
+                )}
                 <Terminal size={10} />
                 <span>All shell environment ({shellVarCount})</span>
               </button>
@@ -257,7 +349,10 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
                 <div className="mt-2 space-y-2">
                   {/* Search filter */}
                   <div className="relative">
-                    <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-vsc-description" />
+                    <Search
+                      size={12}
+                      className="absolute left-2 top-1/2 -translate-y-1/2 text-vsc-description"
+                    />
                     <Input
                       placeholder="Filter variables..."
                       value={shellFilter}
@@ -269,21 +364,39 @@ export const ApiKeysDialog: FC<ApiKeysDialogProps> = ({
                   <div className="space-y-1 max-h-[200px] overflow-auto">
                     {shellOnlyKeys.map((key) => (
                       <div key={key} className="flex items-center gap-2 py-0.5">
-                        <span className="font-vsc-mono text-[10px] text-vsc-description shrink-0 w-[160px] truncate" title={key}>{key}</span>
+                        <span
+                          className="font-vsc-mono text-[10px] text-vsc-description shrink-0 w-[160px] truncate"
+                          title={key}
+                        >
+                          {key}
+                        </span>
                         <Input
                           type="text"
                           defaultValue={shellEnvVars[key]}
-                          onChange={(e) => handleInlineEdit(key, e.target.value)}
+                          onChange={(e) =>
+                            handleInlineEdit(key, e.target.value)
+                          }
                           className={`flex-1 text-[10px] font-vsc-mono h-6 ${showValues.has(key) ? '' : '[text-security:disc] [-webkit-text-security:disc]'}`}
                           {...apiKeyInputProps(key)}
                         />
-                        <Button variant="ghost" size="icon" className="h-5 w-5" onClick={() => toggleShow(key)}>
-                          {showValues.has(key) ? <EyeOff size={10} /> : <Eye size={10} />}
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-5 w-5"
+                          onClick={() => toggleShow(key)}
+                        >
+                          {showValues.has(key) ? (
+                            <EyeOff size={10} />
+                          ) : (
+                            <Eye size={10} />
+                          )}
                         </Button>
                       </div>
                     ))}
                     {shellOnlyKeys.length === 0 && shellFilter && (
-                      <div className="text-[10px] text-vsc-description text-center py-2">No matches</div>
+                      <div className="text-[10px] text-vsc-description text-center py-2">
+                        No matches
+                      </div>
                     )}
                   </div>
                 </div>

--- a/typescript2/pkg-playground/src/components/CopyButton.tsx
+++ b/typescript2/pkg-playground/src/components/CopyButton.tsx
@@ -1,7 +1,12 @@
 import { useState, useCallback, type FC, type RefObject } from 'react';
 import { Copy, Check, Loader2 } from 'lucide-react';
 import { Button } from './ui/button';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip';
 import { cn } from '../lib/utils';
 
 interface CopyButtonProps {
@@ -12,21 +17,30 @@ interface CopyButtonProps {
   iconSize?: number;
 }
 
-export const CopyButton: FC<CopyButtonProps> = ({ text, textRef, className = '', iconSize = 14 }) => {
+export const CopyButton: FC<CopyButtonProps> = ({
+  text,
+  textRef,
+  className = '',
+  iconSize = 14,
+}) => {
   const [state, setState] = useState<'idle' | 'copying' | 'copied'>('idle');
 
   const handleCopy = useCallback(() => {
     const content = textRef?.current?.innerText ?? text ?? '';
     setState('copying');
-    navigator.clipboard.writeText(content).then(() => {
-      setState('copied');
-      setTimeout(() => setState('idle'), 1500);
-    }, () => {
-      setState('idle');
-    });
+    navigator.clipboard.writeText(content).then(
+      () => {
+        setState('copied');
+        setTimeout(() => setState('idle'), 1500);
+      },
+      () => {
+        setState('idle');
+      },
+    );
   }, [text, textRef]);
 
-  const Icon = state === 'copied' ? Check : state === 'copying' ? Loader2 : Copy;
+  const Icon =
+    state === 'copied' ? Check : state === 'copying' ? Loader2 : Copy;
 
   return (
     <TooltipProvider>
@@ -35,13 +49,21 @@ export const CopyButton: FC<CopyButtonProps> = ({ text, textRef, className = '',
           <Button
             variant="ghost"
             size="icon"
-            className={cn('h-7 w-7 transition-opacity opacity-0 group-hover:opacity-100', className)}
+            className={cn(
+              'h-7 w-7 transition-opacity opacity-0 group-hover:opacity-100',
+              className,
+            )}
             onClick={handleCopy}
           >
-            <Icon size={iconSize} className={state === 'copying' ? 'animate-spin' : ''} />
+            <Icon
+              size={iconSize}
+              className={state === 'copying' ? 'animate-spin' : ''}
+            />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>{state === 'copied' ? 'Copied!' : 'Copy'}</TooltipContent>
+        <TooltipContent>
+          {state === 'copied' ? 'Copied!' : 'Copy'}
+        </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/typescript2/pkg-playground/src/components/ErrorDisplay.tsx
+++ b/typescript2/pkg-playground/src/components/ErrorDisplay.tsx
@@ -25,17 +25,30 @@ export function registerErrorRenderer(renderer: CustomErrorRenderer) {
 // Built-in renderers
 registerErrorRenderer({
   priority: 150,
-  test: (msg) => msg.includes('WASM panic') || msg.includes('unreachable executed') || msg.includes('RuntimeError: unreachable'),
+  test: (msg) =>
+    msg.includes('WASM panic') ||
+    msg.includes('unreachable executed') ||
+    msg.includes('RuntimeError: unreachable'),
   render: ({ message, onRetry }) => (
     <div className="space-y-2">
-      <div className="text-[11px] font-semibold text-vsc-error">Internal Error (WASM)</div>
+      <div className="text-[11px] font-semibold text-vsc-error">
+        Internal Error (WASM)
+      </div>
       <CodeBlock variant="error">
         {message.replace(/^.*WASM panic:\s*/, '')}
       </CodeBlock>
-      <div className="text-[10px] text-vsc-text-faint">Try reopening the playground if this persists.</div>
+      <div className="text-[10px] text-vsc-text-faint">
+        Try reopening the playground if this persists.
+      </div>
       {onRetry && (
-        <Button variant="link" size="sm" className="text-vsc-link text-[11px] gap-1 px-0" onClick={onRetry}>
-          <RefreshCw size={10} />Retry
+        <Button
+          variant="link"
+          size="sm"
+          className="text-vsc-link text-[11px] gap-1 px-0"
+          onClick={onRetry}
+        >
+          <RefreshCw size={10} />
+          Retry
         </Button>
       )}
     </div>
@@ -44,17 +57,31 @@ registerErrorRenderer({
 
 registerErrorRenderer({
   priority: 100,
-  test: (msg) => msg.startsWith('Failed to fetch media') || (msg.includes('Failed to fetch') && msg.includes('http')),
+  test: (msg) =>
+    msg.startsWith('Failed to fetch media') ||
+    (msg.includes('Failed to fetch') && msg.includes('http')),
   render: ({ message, onRetry }) => {
     const urlMatch = message.match(/https?:\/\/\S+/);
     return (
       <div className="space-y-2">
-        <div className="text-[11px] font-semibold text-vsc-error">Network Error</div>
+        <div className="text-[11px] font-semibold text-vsc-error">
+          Network Error
+        </div>
         <CodeBlock variant="error">{message}</CodeBlock>
-        {urlMatch && <div className="text-[10px] text-vsc-text-faint">URL: {urlMatch[0]}</div>}
+        {urlMatch && (
+          <div className="text-[10px] text-vsc-text-faint">
+            URL: {urlMatch[0]}
+          </div>
+        )}
         {onRetry && (
-          <Button variant="link" size="sm" className="text-vsc-link text-[11px] gap-1 px-0" onClick={onRetry}>
-            <RefreshCw size={10} />Retry
+          <Button
+            variant="link"
+            size="sm"
+            className="text-vsc-link text-[11px] gap-1 px-0"
+            onClick={onRetry}
+          >
+            <RefreshCw size={10} />
+            Retry
           </Button>
         )}
       </div>
@@ -69,8 +96,14 @@ registerErrorRenderer({
     <div className="space-y-2">
       <CodeBlock variant="error">{message}</CodeBlock>
       {onRetry && (
-        <Button variant="link" size="sm" className="text-vsc-link text-[11px] gap-1 px-0" onClick={onRetry}>
-          <RefreshCw size={10} />Retry
+        <Button
+          variant="link"
+          size="sm"
+          className="text-vsc-link text-[11px] gap-1 px-0"
+          onClick={onRetry}
+        >
+          <RefreshCw size={10} />
+          Retry
         </Button>
       )}
     </div>
@@ -84,7 +117,8 @@ interface ErrorDisplayProps {
 
 export const ErrorDisplay: FC<ErrorDisplayProps> = ({ error, onRetry }) => {
   const renderer = errorRenderers.find((r) => r.test(error));
-  if (!renderer) return <pre className="text-vsc-error text-[11px]">{error}</pre>;
+  if (!renderer)
+    return <pre className="text-vsc-error text-[11px]">{error}</pre>;
   return (
     <div className="group relative">
       {renderer.render({ message: error, onRetry })}

--- a/typescript2/pkg-playground/src/components/MetadataBadges.tsx
+++ b/typescript2/pkg-playground/src/components/MetadataBadges.tsx
@@ -18,9 +18,11 @@ function extractMetadata(logs: FetchLogEntry[]) {
     const h = log.responseHeaders;
     if (h) {
       if (!model && h['openai-model']) model = h['openai-model'];
-      if (!processingMs && h['openai-processing-ms']) processingMs = parseInt(h['openai-processing-ms'], 10);
+      if (!processingMs && h['openai-processing-ms'])
+        processingMs = parseInt(h['openai-processing-ms'], 10);
       if (!model && h['x-model']) model = h['x-model'];
-      const tokenHeader = h['x-total-tokens'] || h['x-ratelimit-remaining-tokens'];
+      const tokenHeader =
+        h['x-total-tokens'] || h['x-ratelimit-remaining-tokens'];
       if (!totalTokens && tokenHeader) totalTokens = parseInt(tokenHeader, 10);
     }
 
@@ -32,7 +34,10 @@ function extractMetadata(logs: FetchLogEntry[]) {
         if (totalTokens == null && body.usage) {
           const u = body.usage;
           if (typeof u.total_tokens === 'number') totalTokens = u.total_tokens;
-          else if (typeof u.input_tokens === 'number' && typeof u.output_tokens === 'number') {
+          else if (
+            typeof u.input_tokens === 'number' &&
+            typeof u.output_tokens === 'number'
+          ) {
             totalTokens = u.input_tokens + u.output_tokens;
           }
         }
@@ -45,7 +50,10 @@ function extractMetadata(logs: FetchLogEntry[]) {
   return { model, totalTokens, processingMs };
 }
 
-export const MetadataBadges: FC<MetadataBadgesProps> = ({ fetchLogs, durationMs }) => {
+export const MetadataBadges: FC<MetadataBadgesProps> = ({
+  fetchLogs,
+  durationMs,
+}) => {
   const { model, totalTokens, processingMs } = extractMetadata(fetchLogs);
   const latency = processingMs ?? (durationMs ? Math.round(durationMs) : null);
 
@@ -53,9 +61,33 @@ export const MetadataBadges: FC<MetadataBadgesProps> = ({ fetchLogs, durationMs 
 
   return (
     <div className="flex items-center gap-1.5 flex-wrap">
-      {model && <Badge variant="secondary" className="gap-0.5 text-[10px] font-vsc-mono"><Cpu size={10} />{model}</Badge>}
-      {latency != null && <Badge variant="secondary" className="gap-0.5 text-[10px] font-vsc-mono"><Clock size={10} />{latency}ms</Badge>}
-      {totalTokens != null && <Badge variant="secondary" className="gap-0.5 text-[10px] font-vsc-mono"><Hash size={10} />{totalTokens} tokens</Badge>}
+      {model && (
+        <Badge
+          variant="secondary"
+          className="gap-0.5 text-[10px] font-vsc-mono"
+        >
+          <Cpu size={10} />
+          {model}
+        </Badge>
+      )}
+      {latency != null && (
+        <Badge
+          variant="secondary"
+          className="gap-0.5 text-[10px] font-vsc-mono"
+        >
+          <Clock size={10} />
+          {latency}ms
+        </Badge>
+      )}
+      {totalTokens != null && (
+        <Badge
+          variant="secondary"
+          className="gap-0.5 text-[10px] font-vsc-mono"
+        >
+          <Hash size={10} />
+          {totalTokens} tokens
+        </Badge>
+      )}
     </div>
   );
 };

--- a/typescript2/pkg-playground/src/components/ui/badge.tsx
+++ b/typescript2/pkg-playground/src/components/ui/badge.tsx
@@ -1,39 +1,39 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
 
-import { cn } from "../../lib/utils"
+import { cn } from '../../lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
         secondary:
-          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+          'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
-          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+          'bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90',
         outline:
-          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 [a&]:hover:underline",
+          'border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        ghost: '[a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 [a&]:hover:underline',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
-  }
-)
+  },
+);
 
 function Badge({
   className,
-  variant = "default",
+  variant = 'default',
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
+}: React.ComponentProps<'span'> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "span"
+  const Comp = asChild ? Slot.Root : 'span';
 
   return (
     <Comp
@@ -42,7 +42,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/typescript2/pkg-playground/src/components/ui/button.tsx
+++ b/typescript2/pkg-playground/src/components/ui/button.tsx
@@ -1,55 +1,55 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
 
-import { cn } from "../../lib/utils"
+import { cn } from '../../lib/utils';
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-        success: "bg-vsc-green text-white shadow-xs hover:bg-vsc-green/90",
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+        success: 'bg-vsc-green text-white shadow-xs hover:bg-vsc-green/90',
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
-  variant = "default",
-  size = "default",
+  variant = 'default',
+  size = 'default',
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : 'button';
 
   return (
     <Comp
@@ -59,7 +59,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/typescript2/pkg-playground/src/components/ui/code-block.tsx
+++ b/typescript2/pkg-playground/src/components/ui/code-block.tsx
@@ -12,13 +12,14 @@ const CodeBlock = React.forwardRef<HTMLPreElement, CodeBlockProps>(
         ref={ref}
         className={cn(
           'whitespace-pre-wrap break-all font-vsc-mono text-xs leading-relaxed p-2 rounded bg-vsc-bg border border-vsc-border text-vsc-text overflow-auto max-h-[200px] m-0',
-          variant === 'error' && 'border-vsc-error/20 bg-vsc-error/5 text-vsc-error',
-          className
+          variant === 'error' &&
+            'border-vsc-error/20 bg-vsc-error/5 text-vsc-error',
+          className,
         )}
         {...props}
       />
     );
-  }
+  },
 );
 CodeBlock.displayName = 'CodeBlock';
 

--- a/typescript2/pkg-playground/src/components/ui/collapsible.tsx
+++ b/typescript2/pkg-playground/src/components/ui/collapsible.tsx
@@ -1,9 +1,9 @@
-import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+import { Collapsible as CollapsiblePrimitive } from 'radix-ui';
 
 function Collapsible({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
-  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
 }
 
 function CollapsibleTrigger({
@@ -14,7 +14,7 @@ function CollapsibleTrigger({
       data-slot="collapsible-trigger"
       {...props}
     />
-  )
+  );
 }
 
 function CollapsibleContent({
@@ -25,7 +25,7 @@ function CollapsibleContent({
       data-slot="collapsible-content"
       {...props}
     />
-  )
+  );
 }
 
-export { Collapsible, CollapsibleTrigger, CollapsibleContent }
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/typescript2/pkg-playground/src/components/ui/dialog.tsx
+++ b/typescript2/pkg-playground/src/components/ui/dialog.tsx
@@ -1,34 +1,34 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { XIcon } from "lucide-react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import * as React from 'react';
+import { XIcon } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
 
-import { cn } from "../../lib/utils"
-import { Button } from "./button"
+import { cn } from '../../lib/utils';
+import { Button } from './button';
 
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
@@ -39,12 +39,12 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
-        className
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -53,7 +53,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -61,8 +61,8 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "playground-root fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
-          className
+          'playground-root fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className,
         )}
         {...props}
       >
@@ -78,17 +78,17 @@ function DialogContent({
         )}
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogFooter({
@@ -96,15 +96,15 @@ function DialogFooter({
   showCloseButton = false,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
       )}
       {...props}
     >
@@ -115,7 +115,7 @@ function DialogFooter({
         </DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({
@@ -125,10 +125,10 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn('text-lg leading-none font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -138,10 +138,10 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -155,4 +155,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/typescript2/pkg-playground/src/components/ui/input.tsx
+++ b/typescript2/pkg-playground/src/components/ui/input.tsx
@@ -1,21 +1,21 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "../../lib/utils"
+import { cn } from '../../lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-vsc-input-border bg-vsc-input-bg text-vsc-input-fg px-3 py-1 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20",
-        className
+        'h-9 w-full min-w-0 rounded-md border border-vsc-input-border bg-vsc-input-bg text-vsc-input-fg px-3 py-1 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+        'aria-invalid:border-destructive aria-invalid:ring-destructive/20',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/typescript2/pkg-playground/src/components/ui/tabs.tsx
+++ b/typescript2/pkg-playground/src/components/ui/tabs.tsx
@@ -1,12 +1,12 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Tabs as TabsPrimitive } from "radix-ui"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
 
-import { cn } from "../../lib/utils"
+import { cn } from '../../lib/utils';
 
 function Tabs({
   className,
-  orientation = "horizontal",
+  orientation = 'horizontal',
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Root>) {
   return (
@@ -15,32 +15,32 @@ function Tabs({
       data-orientation={orientation}
       orientation={orientation}
       className={cn(
-        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
-        className
+        'group/tabs flex gap-2 data-[orientation=horizontal]:flex-col',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center text-muted-foreground group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  'group/tabs-list inline-flex w-fit items-center justify-center text-muted-foreground group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
   {
     variants: {
       variant: {
-        default: "gap-0 border-b border-vsc-border",
-        line: "gap-1 bg-transparent",
+        default: 'gap-0 border-b border-vsc-border',
+        line: 'gap-1 bg-transparent',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
-  }
-)
+  },
+);
 
 function TabsList({
   className,
-  variant = "default",
+  variant = 'default',
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.List> &
   VariantProps<typeof tabsListVariants>) {
@@ -51,7 +51,7 @@ function TabsList({
       className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
 function TabsTrigger({
@@ -62,12 +62,12 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-[11px] font-vsc-mono border-b-2 border-transparent cursor-pointer bg-transparent text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-vsc-accent data-[state=active]:text-foreground data-[state=active]:font-semibold",
-        className
+        'inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-[11px] font-vsc-mono border-b-2 border-transparent cursor-pointer bg-transparent text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-vsc-accent data-[state=active]:text-foreground data-[state=active]:font-semibold',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsContent({
@@ -77,10 +77,10 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn('flex-1 outline-none', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/typescript2/pkg-playground/src/components/ui/textarea.tsx
+++ b/typescript2/pkg-playground/src/components/ui/textarea.tsx
@@ -1,18 +1,18 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "../../lib/utils"
+import { cn } from '../../lib/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-md border border-vsc-input-border bg-vsc-input-bg text-vsc-input-fg px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20",
-        className
+        'flex field-sizing-content min-h-16 w-full rounded-md border border-vsc-input-border bg-vsc-input-bg text-vsc-input-fg px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Textarea }
+export { Textarea };

--- a/typescript2/pkg-playground/src/components/ui/toggle-group.tsx
+++ b/typescript2/pkg-playground/src/components/ui/toggle-group.tsx
@@ -25,12 +25,10 @@ function ToggleGroup<T extends string>({
           onClick={() => onValueChange(option.value)}
           className={cn(
             'rounded font-vsc-mono cursor-pointer transition-colors',
-            size === 'sm'
-              ? 'px-1.5 py-0.5 text-[10px]'
-              : 'px-2 py-1 text-xs',
+            size === 'sm' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-1 text-xs',
             value === option.value
               ? 'bg-vsc-accent text-vsc-accent-fg'
-              : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+              : 'text-muted-foreground hover:text-foreground hover:bg-accent',
           )}
         >
           {option.label}

--- a/typescript2/pkg-playground/src/components/ui/tooltip.tsx
+++ b/typescript2/pkg-playground/src/components/ui/tooltip.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { Tooltip as TooltipPrimitive } from "radix-ui"
+import * as React from 'react';
+import { Tooltip as TooltipPrimitive } from 'radix-ui';
 
-import { cn } from "../../lib/utils"
+import { cn } from '../../lib/utils';
 
 function TooltipProvider({
   delayDuration = 0,
@@ -15,19 +15,19 @@ function TooltipProvider({
       delayDuration={delayDuration}
       {...props}
     />
-  )
+  );
 }
 
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -42,8 +42,8 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "playground-root z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-          className
+          'playground-root z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          className,
         )}
         {...props}
       >
@@ -51,7 +51,7 @@ function TooltipContent({
         <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/typescript2/pkg-playground/src/envAtoms.ts
+++ b/typescript2/pkg-playground/src/envAtoms.ts
@@ -29,9 +29,10 @@ function readStoredEnvVars(): EnvVars {
   try {
     const store = storage();
     const localRaw = store?.getItem(ENV_VARS_STORAGE_KEY);
-    const sessionRaw = localRaw == null
-      ? window.sessionStorage.getItem(ENV_VARS_STORAGE_KEY)
-      : null;
+    const sessionRaw =
+      localRaw == null
+        ? window.sessionStorage.getItem(ENV_VARS_STORAGE_KEY)
+        : null;
     const raw = localRaw ?? sessionRaw;
     if (sessionRaw != null) {
       store?.setItem(ENV_VARS_STORAGE_KEY, sessionRaw);
@@ -40,7 +41,8 @@ function readStoredEnvVars(): EnvVars {
     if (!raw) return {};
 
     const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+      return {};
 
     const result: EnvVars = {};
     for (const [key, value] of Object.entries(parsed)) {
@@ -70,7 +72,11 @@ function writeStoredEnvVars(vars: EnvVars) {
   }
 }
 
-function syncEnvVarsToPort(port: RuntimePort | null, prev: EnvVars, next: EnvVars) {
+function syncEnvVarsToPort(
+  port: RuntimePort | null,
+  prev: EnvVars,
+  next: EnvVars,
+) {
   if (!port) return;
 
   for (const key of Object.keys(prev)) {
@@ -163,7 +169,9 @@ export function useEnvVars(port: RuntimePort): UseEnvVars {
   const envVarsRef = useRef(envVars);
 
   const [shellEnvVars, setShellEnvVars] = useAtom(shellEnvVarsAtom);
-  const [shellOverriddenKeys, setShellOverriddenKeys] = useAtom(shellOverriddenKeysAtom);
+  const [shellOverriddenKeys, setShellOverriddenKeys] = useAtom(
+    shellOverriddenKeysAtom,
+  );
   const [shellDeletedKeys, setShellDeletedKeys] = useAtom(shellDeletedKeysAtom);
   const shellEnvVarsRef = useRef(shellEnvVars);
 
@@ -178,7 +186,7 @@ export function useEnvVars(port: RuntimePort): UseEnvVars {
   useEffect(() => {
     setRuntimePort(port);
     return () => {
-      setRuntimePort((current) => current === port ? null : current);
+      setRuntimePort((current) => (current === port ? null : current));
     };
   }, [setRuntimePort, port]);
 
@@ -197,107 +205,132 @@ export function useEnvVars(port: RuntimePort): UseEnvVars {
     }
   }, [setEnvVars, port]);
 
-  const addEnvVar = useCallback((key: string, value: string) => {
-    setEnvVars((prev) => ({ ...prev, [key]: value }));
-    // If this key came from the shell and the value differs, mark as overridden.
-    const shellVal = shellEnvVarsRef.current[key];
-    if (shellVal !== undefined && shellVal !== value) {
-      setShellOverriddenKeys((prev) => {
-        if (prev.has(key)) return prev;
-        return new Set([...prev, key]);
-      });
-    } else if (shellVal === value) {
-      // Value matches shell — no longer overridden.
-      setShellOverriddenKeys((prev) => {
-        if (!prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.delete(key);
-        return next;
-      });
-    }
-  }, [setEnvVars, setShellOverriddenKeys]);
-
-  const removeEnvVar = useCallback((key: string) => {
-    setEnvVars((prev: EnvVars) => {
-      const { [key]: _, ...rest } = prev;
-      return rest;
-    });
-    // If this was a shell key, track it as deleted (so the UI can offer revert).
-    if (shellEnvVarsRef.current[key] !== undefined) {
-      setShellDeletedKeys((prev) => {
-        if (prev.has(key)) return prev;
-        return new Set([...prev, key]);
-      });
-      setShellOverriddenKeys((prev) => {
-        if (prev.has(key)) return prev;
-        return new Set([...prev, key]);
-      });
-    } else {
-      setShellOverriddenKeys((prev) => {
-        if (!prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.delete(key);
-        return next;
-      });
-    }
-  }, [setEnvVars, setShellOverriddenKeys, setShellDeletedKeys]);
-
-  const importEnvVars = useCallback((vars: EnvVars) => {
-    setEnvVars((prev) => ({ ...prev, ...vars }));
-  }, [setEnvVars]);
-
-  const addRequiredKey = useCallback((key: string) => {
-    setRequiredKeys((prev) => prev.has(key) ? prev : new Set([...prev, key]));
-  }, [setRequiredKeys]);
-
-  const addShellEnvVar = useCallback((key: string, value: string) => {
-    // Store as shell original.
-    setShellEnvVars((prev) => prev[key] === value ? prev : { ...prev, [key]: value });
-    // Only import into env vars if user hasn't already set a value.
-    setEnvVars((prev) => {
-      if (key in prev) return prev;
-      return { ...prev, [key]: value };
-    });
-  }, [setEnvVars, setShellEnvVars]);
-
-  const importShellEnvVars = useCallback((vars: EnvVars) => {
-    // Store all originals.
-    setShellEnvVars(vars);
-    // Merge into env vars, but don't overwrite existing user entries.
-    setEnvVars((prev) => {
-      const merged = { ...prev };
-      let changed = false;
-      for (const [key, value] of Object.entries(vars)) {
-        if (!(key in merged)) {
-          merged[key] = value;
-          changed = true;
-        }
+  const addEnvVar = useCallback(
+    (key: string, value: string) => {
+      setEnvVars((prev) => ({ ...prev, [key]: value }));
+      // If this key came from the shell and the value differs, mark as overridden.
+      const shellVal = shellEnvVarsRef.current[key];
+      if (shellVal !== undefined && shellVal !== value) {
+        setShellOverriddenKeys((prev) => {
+          if (prev.has(key)) return prev;
+          return new Set([...prev, key]);
+        });
+      } else if (shellVal === value) {
+        // Value matches shell — no longer overridden.
+        setShellOverriddenKeys((prev) => {
+          if (!prev.has(key)) return prev;
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
       }
-      return changed ? merged : prev;
-    });
-  }, [setEnvVars, setShellEnvVars]);
+    },
+    [setEnvVars, setShellOverriddenKeys],
+  );
 
-  const revertToShell = useCallback((key: string) => {
-    const shellVal = shellEnvVarsRef.current[key];
-    if (shellVal === undefined) return;
-    // Restore the shell value.
-    setEnvVars((prev) => ({ ...prev, [key]: shellVal }));
-    // Clear override and deleted flags.
-    setShellOverriddenKeys((prev) => {
-      if (!prev.has(key)) return prev;
-      const next = new Set(prev);
-      next.delete(key);
-      return next;
-    });
-    setShellDeletedKeys((prev) => {
-      if (!prev.has(key)) return prev;
-      const next = new Set(prev);
-      next.delete(key);
-      return next;
-    });
-    // Tell the server to remove the override so it falls back to process env.
-    port.postMessage({ type: 'deleteEnvVar', key });
-  }, [setEnvVars, setShellOverriddenKeys, setShellDeletedKeys, port]);
+  const removeEnvVar = useCallback(
+    (key: string) => {
+      setEnvVars((prev: EnvVars) => {
+        const { [key]: _, ...rest } = prev;
+        return rest;
+      });
+      // If this was a shell key, track it as deleted (so the UI can offer revert).
+      if (shellEnvVarsRef.current[key] !== undefined) {
+        setShellDeletedKeys((prev) => {
+          if (prev.has(key)) return prev;
+          return new Set([...prev, key]);
+        });
+        setShellOverriddenKeys((prev) => {
+          if (prev.has(key)) return prev;
+          return new Set([...prev, key]);
+        });
+      } else {
+        setShellOverriddenKeys((prev) => {
+          if (!prev.has(key)) return prev;
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      }
+    },
+    [setEnvVars, setShellOverriddenKeys, setShellDeletedKeys],
+  );
+
+  const importEnvVars = useCallback(
+    (vars: EnvVars) => {
+      setEnvVars((prev) => ({ ...prev, ...vars }));
+    },
+    [setEnvVars],
+  );
+
+  const addRequiredKey = useCallback(
+    (key: string) => {
+      setRequiredKeys((prev) =>
+        prev.has(key) ? prev : new Set([...prev, key]),
+      );
+    },
+    [setRequiredKeys],
+  );
+
+  const addShellEnvVar = useCallback(
+    (key: string, value: string) => {
+      // Store as shell original.
+      setShellEnvVars((prev) =>
+        prev[key] === value ? prev : { ...prev, [key]: value },
+      );
+      // Only import into env vars if user hasn't already set a value.
+      setEnvVars((prev) => {
+        if (key in prev) return prev;
+        return { ...prev, [key]: value };
+      });
+    },
+    [setEnvVars, setShellEnvVars],
+  );
+
+  const importShellEnvVars = useCallback(
+    (vars: EnvVars) => {
+      // Store all originals.
+      setShellEnvVars(vars);
+      // Merge into env vars, but don't overwrite existing user entries.
+      setEnvVars((prev) => {
+        const merged = { ...prev };
+        let changed = false;
+        for (const [key, value] of Object.entries(vars)) {
+          if (!(key in merged)) {
+            merged[key] = value;
+            changed = true;
+          }
+        }
+        return changed ? merged : prev;
+      });
+    },
+    [setEnvVars, setShellEnvVars],
+  );
+
+  const revertToShell = useCallback(
+    (key: string) => {
+      const shellVal = shellEnvVarsRef.current[key];
+      if (shellVal === undefined) return;
+      // Restore the shell value.
+      setEnvVars((prev) => ({ ...prev, [key]: shellVal }));
+      // Clear override and deleted flags.
+      setShellOverriddenKeys((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setShellDeletedKeys((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      // Tell the server to remove the override so it falls back to process env.
+      port.postMessage({ type: 'deleteEnvVar', key });
+    },
+    [setEnvVars, setShellOverriddenKeys, setShellDeletedKeys, port],
+  );
 
   return {
     envVars,

--- a/typescript2/pkg-playground/src/graph/GraphView.tsx
+++ b/typescript2/pkg-playground/src/graph/GraphView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+} from 'react';
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -13,7 +20,11 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
-import type { ControlFlowGraph, DeserializedRuntimeEvent, RunEntry } from '../worker-protocol';
+import type {
+  ControlFlowGraph,
+  DeserializedRuntimeEvent,
+  RunEntry,
+} from '../worker-protocol';
 import type { ResultRendererProps } from '../result-renderers';
 import { cfgToGraphNodes, graphToReactflow } from './convert';
 import { collectGraphNodeRuntime } from './runtime-output';
@@ -24,6 +35,9 @@ import type { WorkflowNode, WorkflowEdge } from './types';
 
 interface GraphViewProps {
   graph: ControlFlowGraph;
+  /** Function whose graph is displayed — keys the per-function layout
+   *  direction memory. */
+  functionName?: string | null;
   runtimeEvents?: DeserializedRuntimeEvent[];
   runStatus?: RunEntry['status'];
   runError?: string | null;
@@ -35,8 +49,41 @@ interface GraphViewProps {
 
 const EMPTY_RUNTIME_EVENTS: DeserializedRuntimeEvent[] = [];
 
+type LayoutDirection = 'horizontal' | 'vertical';
+
+const DIRECTION_STORAGE_PREFIX = 'baml-graph-direction:';
+
+/** Per-function layout direction, remembered across sessions. Vertical is
+ *  the default until the user toggles. */
+function storedDirection(functionName: string | null | undefined): LayoutDirection {
+  if (typeof window === 'undefined') return 'vertical';
+  try {
+    const v = window.localStorage.getItem(
+      DIRECTION_STORAGE_PREFIX + (functionName ?? ''),
+    );
+    return v === 'horizontal' || v === 'vertical' ? v : 'vertical';
+  } catch {
+    return 'vertical';
+  }
+}
+
+function storeDirection(
+  functionName: string | null | undefined,
+  direction: LayoutDirection,
+) {
+  try {
+    window.localStorage.setItem(
+      DIRECTION_STORAGE_PREFIX + (functionName ?? ''),
+      direction,
+    );
+  } catch {
+    /* private browsing / quota — direction just won't persist */
+  }
+}
+
 function GraphViewInner({
   graph,
+  functionName,
   runtimeEvents = EMPTY_RUNTIME_EVENTS,
   runStatus,
   runError,
@@ -47,7 +94,14 @@ function GraphViewInner({
 }: GraphViewProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState<WorkflowNode>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<WorkflowEdge>([]);
-  const [direction, setDirection] = useState<'horizontal' | 'vertical'>('horizontal');
+  // The component is remounted (keyed) per function, so the lazy initializer
+  // re-reads the remembered direction whenever the function changes.
+  const [direction, setDirection] = useState<LayoutDirection>(() =>
+    storedDirection(functionName),
+  );
+  // Set when the user toggles layout direction — the next completed layout
+  // re-fits the viewport so the rotated graph is fully visible.
+  const refitAfterLayoutRef = useRef(false);
   const selectedNodeIdRef = useRef(selectedNodeId);
 
   useEffect(() => {
@@ -56,7 +110,10 @@ function GraphViewInner({
 
   const graphModel = useMemo(() => {
     const { nodes: graphNodes, edges: graphEdges } = cfgToGraphNodes(graph);
-    const { nodes: rfNodes, edges: rfEdges } = graphToReactflow(graphNodes, graphEdges);
+    const { nodes: rfNodes, edges: rfEdges } = graphToReactflow(
+      graphNodes,
+      graphEdges,
+    );
     return { graphNodes, rfNodes, rfEdges };
   }, [graph]);
 
@@ -78,56 +135,64 @@ function GraphViewInner({
   const graphNodesRef = useRef(graphModel.graphNodes);
   graphNodesRef.current = graphModel.graphNodes;
 
-  const decorateNodesWithRuntime = useCallback((baseNodes: WorkflowNode[]): WorkflowNode[] => {
-    const {
-      runtimeEvents: latestRuntimeEvents,
-      runStatus: latestRunStatus,
-      runError: latestRunError,
-      runFunctionName: latestRunFunctionName,
-      customRenderers: latestCustomRenderers,
-    } = runtimeInputsRef.current;
-    const runtimeByNode = collectGraphNodeRuntime(graphNodesRef.current, latestRuntimeEvents, {
-      status: latestRunStatus,
-      error: latestRunError,
-      functionName: latestRunFunctionName,
-    });
-    const selectedId = selectedNodeIdRef.current == null
-      ? null
-      : String(selectedNodeIdRef.current);
+  const decorateNodesWithRuntime = useCallback(
+    (baseNodes: WorkflowNode[]): WorkflowNode[] => {
+      const {
+        runtimeEvents: latestRuntimeEvents,
+        runStatus: latestRunStatus,
+        runError: latestRunError,
+        runFunctionName: latestRunFunctionName,
+        customRenderers: latestCustomRenderers,
+      } = runtimeInputsRef.current;
+      const runtimeByNode = collectGraphNodeRuntime(
+        graphNodesRef.current,
+        latestRuntimeEvents,
+        {
+          status: latestRunStatus,
+          error: latestRunError,
+          functionName: latestRunFunctionName,
+        },
+      );
+      const selectedId =
+        selectedNodeIdRef.current == null
+          ? null
+          : String(selectedNodeIdRef.current);
 
-    return baseNodes.map((node) => {
-      const runtime = runtimeByNode.get(node.id);
-      if (!runtime) {
+      return baseNodes.map((node) => {
+        const runtime = runtimeByNode.get(node.id);
+        if (!runtime) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              result: undefined,
+              hasResult: undefined,
+              imageOutputs: [],
+              executionState: 'not-started' as const,
+              errorMessage: undefined,
+              customRenderers: latestCustomRenderers,
+              selected: node.id === selectedId,
+            },
+          };
+        }
+
         return {
           ...node,
           data: {
             ...node.data,
-            result: undefined,
-            hasResult: undefined,
-            imageOutputs: [],
-            executionState: 'not-started' as const,
-            errorMessage: undefined,
+            result: runtime.result,
+            hasResult: runtime.hasResult,
+            imageOutputs: runtime.imageOutputs,
+            executionState: runtime.executionState,
+            errorMessage: runtime.errorMessage,
             customRenderers: latestCustomRenderers,
             selected: node.id === selectedId,
           },
         };
-      }
-
-      return {
-        ...node,
-        data: {
-          ...node.data,
-          result: runtime.result,
-          hasResult: runtime.hasResult,
-          imageOutputs: runtime.imageOutputs,
-          executionState: runtime.executionState,
-          errorMessage: runtime.errorMessage,
-          customRenderers: latestCustomRenderers,
-          selected: node.id === selectedId,
-        },
-      };
-    });
-  }, []);
+      });
+    },
+    [],
+  );
 
   const layoutRunIdRef = useRef(0);
 
@@ -142,6 +207,13 @@ function GraphViewInner({
         if (layoutRunId !== layoutRunIdRef.current) return;
         setNodes(decorateNodesWithRuntime(laid));
         setEdges(laidEdges);
+        if (refitAfterLayoutRef.current) {
+          refitAfterLayoutRef.current = false;
+          // Wait a frame so ReactFlow has measured the re-laid nodes.
+          requestAnimationFrame(() => {
+            fitView({ padding: 0.2, minZoom: 0.3, maxZoom: 0.85, duration: 250 });
+          });
+        }
       })
       .catch((err) => {
         console.error('[GraphView] Layout failed:', err);
@@ -183,7 +255,7 @@ function GraphViewInner({
   }, [selectedNodeId, setNodes]);
 
   // Auto-pan viewport to center the selected node — only when it's off-screen
-  const { setCenter, getNode, getViewport } = useReactFlow();
+  const { setCenter, getNode, getViewport, fitView } = useReactFlow();
   const containerWidth = useStore((s) => s.width);
   const containerHeight = useStore((s) => s.height);
   const prevGraphRef = useRef(graph);
@@ -220,15 +292,25 @@ function GraphViewInner({
     const screenY = centerY * zoom + vy;
     const pad = 60;
     const isVisible =
-      screenX >= pad && screenX <= containerWidth - pad &&
-      screenY >= pad && screenY <= containerHeight - pad;
+      screenX >= pad &&
+      screenX <= containerWidth - pad &&
+      screenY >= pad &&
+      screenY <= containerHeight - pad;
 
     if (!isVisible) {
       // Pan to the node; if over-zoomed, ease back to 1.0
       const targetZoom = Math.min(zoom, 1.0);
       setCenter(centerX, centerY, { duration: 300, zoom: targetZoom });
     }
-  }, [selectedNodeId, graph, setCenter, getNode, getViewport, containerWidth, containerHeight]);
+  }, [
+    selectedNodeId,
+    graph,
+    setCenter,
+    getNode,
+    getViewport,
+    containerWidth,
+    containerHeight,
+  ]);
 
   const handleNodeClick: NodeMouseHandler<WorkflowNode> = useCallback(
     (_event, node) => {
@@ -264,12 +346,14 @@ function GraphViewInner({
           border: none !important;
           box-shadow: none !important;
         }
+        /* Nodes draw their own selection ring (nodeShadow); suppress the
+           wrapper's focus ring so selection doesn't render twice. */
         .react-flow__node:focus,
         .react-flow__node:focus-visible,
         .react-flow__node.selectable:focus,
         .react-flow__node.selectable:focus-visible {
           outline: none !important;
-          box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.55) !important;
+          box-shadow: none !important;
         }
         .react-flow.dark {
           --xy-controls-button-background-color-default: rgba(24, 24, 27, 0.92);
@@ -279,8 +363,16 @@ function GraphViewInner({
           --xy-controls-button-border-color-default: rgba(255, 255, 255, 0.10);
           --xy-controls-box-shadow-default: 0 8px 24px rgba(0, 0, 0, 0.24);
         }
+        .react-flow.light {
+          --xy-controls-button-background-color-default: rgba(255, 253, 246, 0.95);
+          --xy-controls-button-background-color-hover-default: #f4eee0;
+          --xy-controls-button-color-default: #1a1612;
+          --xy-controls-button-color-hover-default: #1a1612;
+          --xy-controls-button-border-color-default: #d8cfbd;
+          --xy-controls-box-shadow-default: 0 4px 14px rgba(26, 22, 18, 0.10);
+        }
         .react-flow__controls {
-          border: 1px solid rgba(255, 255, 255, 0.10);
+          border: 1px solid rgba(26, 22, 18, 0.14);
           border-radius: 8px;
           overflow: hidden;
           backdrop-filter: blur(8px);
@@ -308,20 +400,33 @@ function GraphViewInner({
         elevateEdgesOnSelect={false}
         panOnDrag={[0, 1, 2]}
         panOnScroll
+        panActivationKeyCode={null}
         fitView
         fitViewOptions={{ minZoom: 0.3, maxZoom: 0.85, padding: 0.2 }}
         proOptions={{ hideAttribution: true }}
-        colorMode="dark"
+        colorMode="light"
       >
         <Controls
           position="bottom-left"
           style={{ display: 'flex', flexDirection: 'row' }}
         />
-        <Background variant={BackgroundVariant.Dots} color="rgba(255,255,255,0.10)" gap={18} size={1} />
+        <Background
+          variant={BackgroundVariant.Dots}
+          color="rgba(42,37,32,0.12)"
+          gap={18}
+          size={1}
+        />
         <ColorfulMarkerDefinitions />
       </ReactFlow>
       <button
-        onClick={() => setDirection((d) => (d === 'horizontal' ? 'vertical' : 'horizontal'))}
+        onClick={() => {
+          refitAfterLayoutRef.current = true;
+          setDirection((d) => {
+            const next = d === 'horizontal' ? 'vertical' : 'horizontal';
+            storeDirection(functionName, next);
+            return next;
+          });
+        }}
         style={{
           position: 'absolute',
           top: 10,
@@ -334,24 +439,25 @@ function GraphViewInner({
           justifyContent: 'center',
           padding: 0,
           borderRadius: 8,
-          border: '1px solid rgba(255,255,255,0.10)',
-          background: 'rgba(24,24,27,0.75)',
+          border: '1px solid #D8CFBD',
+          background: 'rgba(255,253,246,0.92)',
           backdropFilter: 'blur(8px)',
           WebkitBackdropFilter: 'blur(8px)',
-          color: '#e4e4e7',
+          color: '#1A1612',
           cursor: 'pointer',
           fontSize: 14,
           lineHeight: 1,
-          boxShadow: '0 1px 2px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)',
+          boxShadow:
+            '0 1px 2px rgba(26,22,18,0.10), inset 0 1px 0 rgba(255,255,255,0.6)',
           transition: 'background 120ms ease, border-color 120ms ease',
         }}
         onMouseEnter={(e) => {
-          e.currentTarget.style.background = 'rgba(39,39,42,0.85)';
-          e.currentTarget.style.borderColor = 'rgba(255,255,255,0.18)';
+          e.currentTarget.style.background = '#F4EEE0';
+          e.currentTarget.style.borderColor = '#C9BFA9';
         }}
         onMouseLeave={(e) => {
-          e.currentTarget.style.background = 'rgba(24,24,27,0.75)';
-          e.currentTarget.style.borderColor = 'rgba(255,255,255,0.10)';
+          e.currentTarget.style.background = 'rgba(255,253,246,0.92)';
+          e.currentTarget.style.borderColor = '#D8CFBD';
         }}
         title={`Switch to ${direction === 'horizontal' ? 'vertical' : 'horizontal'} layout`}
         aria-label="Toggle layout direction"
@@ -365,7 +471,9 @@ function GraphViewInner({
 export function GraphView(props: GraphViewProps) {
   return (
     <ReactFlowProvider>
-      <GraphViewInner {...props} />
+      {/* Keyed per function so the remembered layout direction is re-read
+          when the displayed function changes. */}
+      <GraphViewInner key={props.functionName ?? ''} {...props} />
     </ReactFlowProvider>
   );
 }

--- a/typescript2/pkg-playground/src/graph/__tests__/runtime-output.test.ts
+++ b/typescript2/pkg-playground/src/graph/__tests__/runtime-output.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import type { BamlJsMedia, BamlJsValue } from '@b/pkg-proto';
 import type { DeserializedRuntimeEvent } from '../../worker-protocol';
 import type { GraphNode } from '../types';
-import { collectGraphNodeOutputs, collectGraphNodeRuntime } from '../runtime-output';
+import {
+  collectGraphNodeOutputs,
+  collectGraphNodeRuntime,
+} from '../runtime-output';
 
 const imageA: BamlJsMedia = {
   $baml: { type: '$media' },
@@ -37,7 +40,10 @@ const graphNodes: GraphNode[] = [
   },
 ];
 
-function functionStartEvent(name: string, spanId = `${name}-span`): DeserializedRuntimeEvent {
+function functionStartEvent(
+  name: string,
+  spanId = `${name}-span`,
+): DeserializedRuntimeEvent {
   return {
     spanId,
     rootSpanId: 'root',
@@ -78,7 +84,11 @@ function functionEndEvent(
 
 describe('collectGraphNodeOutputs', () => {
   it('maps mixed string/image function results to call-node image previews', () => {
-    const mixedResult: BamlJsValue = ['caption', imageA, { nested: imageB } as Record<string, BamlJsValue>];
+    const mixedResult: BamlJsValue = [
+      'caption',
+      imageA,
+      { nested: imageB } as Record<string, BamlJsValue>,
+    ];
     const outputs = collectGraphNodeOutputs(graphNodes, [
       functionEndEvent('GenerateImages', mixedResult),
     ]);
@@ -129,7 +139,11 @@ describe('collectGraphNodeOutputs', () => {
         label: 'GenerateImages(prompt)',
         type: 'scope',
         parent: '1',
-        metadata: { logFilterKey: 'call-2', sourceExpr: null, isContainer: false },
+        metadata: {
+          logFilterKey: 'call-2',
+          sourceExpr: null,
+          isContainer: false,
+        },
       },
     ];
 

--- a/typescript2/pkg-playground/src/graph/constants.ts
+++ b/typescript2/pkg-playground/src/graph/constants.ts
@@ -1,17 +1,20 @@
 /**
  * Shared state colors & visual tokens for the graph.
  *
- * The palette targets a modern, professional dark-mode aesthetic:
- *  - Subtle, low-contrast borders (the node sits on the canvas, not above it).
- *  - State is encoded via the accent (left rail / icon chip), not heavy borders.
- *  - Backgrounds use a soft dual-stop gradient for a refined depth effect.
+ * The palette targets the light "paper" aesthetic the playground panel ships
+ * with (warm off-whites, ink text, tan hairlines — the same family as the
+ * BAML site decks):
+ *  - Cards are paper with a visible hairline; they sit ON the canvas.
+ *  - State is encoded via the accent (left rail / icon chip) plus a gentle
+ *    background tint, not heavy borders.
+ *  - Shadows are soft and warm; nothing glows unless it is running.
  */
 export interface NodeStateStyle {
   /** Tinted hairline border; the node frame. */
   border: string;
   /** Top-of-gradient background — the brighter face of the card. */
   bgTop: string;
-  /** Bottom-of-gradient background — the darker face. */
+  /** Bottom-of-gradient background — the deeper face. */
   bgBottom: string;
   /** Solid accent color used for icon chips, badges, the left rail. */
   accent: string;
@@ -25,117 +28,117 @@ export interface NodeStateStyle {
 
 export const stateColors: Record<string, NodeStateStyle> = {
   'not-started': {
-    border: 'rgba(255,255,255,0.08)',
-    bgTop: 'rgba(46,46,52,0.85)',
-    bgBottom: 'rgba(32,32,38,0.85)',
-    accent: '#3f3f46',
+    border: '#D8CFBD',
+    bgTop: '#FFFDF6',
+    bgBottom: '#F8F2E4',
+    accent: '#8A8580',
     glow: 'rgba(0,0,0,0)',
-    text: '#e5e7eb',
-    textMuted: '#9ca3af',
+    text: '#1A1612',
+    textMuted: '#6F6A63',
   },
-  'running': {
-    border: 'rgba(59,130,246,0.45)',
-    bgTop: 'rgba(30,58,95,0.85)',
-    bgBottom: 'rgba(20,38,68,0.85)',
-    accent: '#3b82f6',
-    glow: 'rgba(59,130,246,0.35)',
-    text: '#dbeafe',
-    textMuted: '#93c5fd',
+  running: {
+    border: 'rgba(37,99,235,0.50)',
+    bgTop: '#F4F8FF',
+    bgBottom: '#E8F0FD',
+    accent: '#2563EB',
+    glow: 'rgba(37,99,235,0.20)',
+    text: '#1A1612',
+    textMuted: '#1D4ED8',
   },
-  'success': {
-    border: 'rgba(16,185,129,0.40)',
-    bgTop: 'rgba(20,55,46,0.85)',
-    bgBottom: 'rgba(14,40,32,0.85)',
-    accent: '#10b981',
-    glow: 'rgba(16,185,129,0.25)',
-    text: '#d1fae5',
-    textMuted: '#86efac',
+  success: {
+    border: 'rgba(4,120,87,0.45)',
+    bgTop: '#F0FAF4',
+    bgBottom: '#E1F3E9',
+    accent: '#047857',
+    glow: 'rgba(4,120,87,0.16)',
+    text: '#1A1612',
+    textMuted: '#047857',
   },
-  'error': {
-    border: 'rgba(244,63,94,0.45)',
-    bgTop: 'rgba(64,21,30,0.85)',
-    bgBottom: 'rgba(46,16,22,0.85)',
-    accent: '#f43f5e',
-    glow: 'rgba(244,63,94,0.30)',
-    text: '#fecdd3',
-    textMuted: '#fda4af',
+  error: {
+    border: 'rgba(180,35,24,0.45)',
+    bgTop: '#FDF1EF',
+    bgBottom: '#F9E3DF',
+    accent: '#B42318',
+    glow: 'rgba(180,35,24,0.16)',
+    text: '#1A1612',
+    textMuted: '#B42318',
   },
-  'cancelled': {
-    border: 'rgba(234,179,8,0.40)',
-    bgTop: 'rgba(58,45,18,0.85)',
-    bgBottom: 'rgba(42,32,12,0.85)',
-    accent: '#eab308',
-    glow: 'rgba(234,179,8,0.22)',
-    text: '#fef9c3',
-    textMuted: '#fde047',
+  cancelled: {
+    border: 'rgba(180,83,9,0.45)',
+    bgTop: '#FCF4E4',
+    bgBottom: '#F7EAD2',
+    accent: '#B45309',
+    glow: 'rgba(180,83,9,0.15)',
+    text: '#1A1612',
+    textMuted: '#B45309',
   },
-  'pending': {
-    border: 'rgba(245,158,11,0.40)',
-    bgTop: 'rgba(58,40,18,0.85)',
-    bgBottom: 'rgba(40,28,14,0.85)',
-    accent: '#f59e0b',
-    glow: 'rgba(245,158,11,0.25)',
-    text: '#fef3c7',
-    textMuted: '#fcd34d',
+  pending: {
+    border: 'rgba(180,83,9,0.40)',
+    bgTop: '#FCF4E4',
+    bgBottom: '#F7EAD2',
+    accent: '#D97706',
+    glow: 'rgba(217,119,6,0.16)',
+    text: '#1A1612',
+    textMuted: '#B45309',
   },
-  'skipped': {
-    border: 'rgba(255,255,255,0.06)',
-    bgTop: 'rgba(38,38,42,0.6)',
-    bgBottom: 'rgba(28,28,32,0.6)',
-    accent: '#52525b',
+  skipped: {
+    border: 'rgba(26,22,18,0.10)',
+    bgTop: 'rgba(251,247,237,0.65)',
+    bgBottom: 'rgba(244,238,224,0.65)',
+    accent: '#B9B2A3',
     glow: 'rgba(0,0,0,0)',
-    text: '#a1a1aa',
-    textMuted: '#71717a',
+    text: '#8A8580',
+    textMuted: '#B9B2A3',
   },
-  'cached': {
-    border: 'rgba(139,92,246,0.40)',
-    bgTop: 'rgba(40,28,60,0.85)',
-    bgBottom: 'rgba(28,20,46,0.85)',
-    accent: '#8b5cf6',
-    glow: 'rgba(139,92,246,0.25)',
-    text: '#ede9fe',
-    textMuted: '#c4b5fd',
+  cached: {
+    border: 'rgba(109,40,217,0.40)',
+    bgTop: '#F6F1FE',
+    bgBottom: '#EDE4FB',
+    accent: '#6D28D9',
+    glow: 'rgba(109,40,217,0.14)',
+    text: '#1A1612',
+    textMuted: '#6D28D9',
   },
 };
 
 /** Border-only map for GroupNode. */
 export const stateBorderColors: Record<string, string> = Object.fromEntries(
-  Object.entries(stateColors).map(([k, v]) => [k, v.border])
+  Object.entries(stateColors).map(([k, v]) => [k, v.border]),
 );
 
-/** Selection ring — used by all node types when selected/highlighted. */
+/** Selection ring — keyword blue; distinct from the green success state. */
 export const selectionRing = {
-  color: '#22d3ee',           // cyan-400
-  glow: 'rgba(34,211,238,0.35)',
+  color: '#2563EB',
+  glow: 'rgba(37,99,235,0.22)',
 };
 
 /**
  * Build a CSS background string for a node card.
- * Top→bottom soft gradient + ultra-subtle inner highlight on top edge.
+ * Top→bottom paper gradient + a soft white sheen on the top edge.
  */
 export function nodeBackground(s: NodeStateStyle): string {
   return [
-    `linear-gradient(rgba(255,255,255,0.04), rgba(255,255,255,0) 28%)`,
+    `linear-gradient(rgba(255,255,255,0.55), rgba(255,255,255,0) 30%)`,
     `linear-gradient(180deg, ${s.bgTop} 0%, ${s.bgBottom} 100%)`,
   ].join(', ');
 }
 
 /**
  * Build a layered box-shadow for a node card.
- *  - Selected: cyan ring + soft cyan glow.
- *  - Glowing state (running/success/error): tinted halo + crisp shadow.
- *  - Default: subtle floating shadow + 1px inset highlight on top.
+ *  - Selected: blue ring + soft blue halo.
+ *  - Glowing state (running/success/error): tinted halo + warm shadow.
+ *  - Default: soft warm floating shadow + bright inset top edge.
  */
 export function nodeShadow(s: NodeStateStyle, selected: boolean): string {
-  const inset = `inset 0 1px 0 rgba(255,255,255,0.05)`;
+  const inset = `inset 0 1px 0 rgba(255,255,255,0.65)`;
   if (selected) {
     return [
       `0 0 0 1.5px ${selectionRing.color}`,
-      `0 0 16px 0 ${selectionRing.glow}`,
-      `0 4px 12px rgba(0,0,0,0.35)`,
+      `0 0 14px 0 ${selectionRing.glow}`,
+      `0 3px 10px rgba(26,22,18,0.12)`,
       inset,
     ].join(', ');
   }
   const halo = s.glow === 'rgba(0,0,0,0)' ? '' : `0 0 0 1px ${s.glow}, `;
-  return `${halo}0 1px 2px rgba(0,0,0,0.30), 0 4px 12px rgba(0,0,0,0.20), ${inset}`;
+  return `${halo}0 1px 2px rgba(26,22,18,0.08), 0 3px 10px rgba(26,22,18,0.07), ${inset}`;
 }

--- a/typescript2/pkg-playground/src/graph/convert.ts
+++ b/typescript2/pkg-playground/src/graph/convert.ts
@@ -1,9 +1,18 @@
 import type { ControlFlowGraph, CfgNodeType } from '../worker-protocol';
-import type { GraphNode, GraphEdge, GraphNodeType, WorkflowNode, WorkflowEdge } from './types';
+import type {
+  GraphNode,
+  GraphEdge,
+  GraphNodeType,
+  WorkflowNode,
+  WorkflowEdge,
+} from './types';
 import { getMarkerColors } from './edges/Marker';
 
 // Stage 1: ControlFlowGraph JSON -> GraphNode[] / GraphEdge[]
-export function cfgToGraphNodes(cfg: ControlFlowGraph): { nodes: GraphNode[]; edges: GraphEdge[] } {
+export function cfgToGraphNodes(cfg: ControlFlowGraph): {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+} {
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
 
@@ -41,13 +50,22 @@ function cfgNodeTypeToGraphType(nt: CfgNodeType): GraphNodeType {
   // Preserve semantic type — whether a node is a group is determined
   // separately in graphToReactflow via isContainer.
   switch (nt) {
-    case 'functionRoot': return 'function';
-    case 'llmFunction': return 'llm_function';
-    case 'headerContextEnter': return 'header';
-    case 'branchGroup': return 'conditional';
-    case 'branchArm': return 'scope';
-    case 'loop': return 'loop';
-    case 'otherScope': return 'scope';
+    case 'functionRoot':
+      return 'function';
+    case 'llmFunction':
+      return 'llm_function';
+    case 'headerContextEnter':
+      return 'header';
+    case 'branchGroup':
+      return 'conditional';
+    case 'branchArm':
+      return 'scope';
+    case 'loop':
+      return 'loop';
+    case 'otherScope':
+      return 'scope';
+    case 'return':
+      return 'return';
   }
 }
 
@@ -148,11 +166,19 @@ function computeEdgeColor(
 
 function graphTypeToReactflowType(gt: GraphNodeType): string {
   switch (gt) {
-    case 'function': return 'base';
-    case 'llm_function': return 'llm';
-    case 'conditional': return 'diamond';
-    case 'loop': return 'hexagon';
-    case 'scope': return 'base';
-    case 'header': return 'base';
+    case 'function':
+      return 'base';
+    case 'llm_function':
+      return 'llm';
+    case 'conditional':
+      return 'diamond';
+    case 'loop':
+      return 'hexagon';
+    case 'scope':
+      return 'base';
+    case 'header':
+      return 'base';
+    case 'return':
+      return 'base';
   }
 }

--- a/typescript2/pkg-playground/src/graph/edges/BaseEdge.tsx
+++ b/typescript2/pkg-playground/src/graph/edges/BaseEdge.tsx
@@ -1,4 +1,9 @@
-import { BaseEdge as RFBaseEdge, type EdgeProps, type Edge, getSmoothStepPath } from '@xyflow/react';
+import {
+  BaseEdge as RFBaseEdge,
+  type EdgeProps,
+  type Edge,
+  getSmoothStepPath,
+} from '@xyflow/react';
 import { memo } from 'react';
 import { getMarkerColors } from './Marker';
 import type { WorkflowEdgeData } from '../types';
@@ -14,15 +19,20 @@ import type { WorkflowEdgeData } from '../types';
  * Ported from the typescript/ implementation — keeps edge routes faithful
  * to ELK's computed bend points instead of letting smoothstep guess.
  */
-function pathFromPoints(points: { x: number; y: number }[], radius = 12): string {
+function pathFromPoints(
+  points: { x: number; y: number }[],
+  radius = 12,
+): string {
   if (points.length < 2) return '';
   const parts: string[] = [`M ${points[0]!.x} ${points[0]!.y}`];
 
   const dist = (a: { x: number; y: number }, b: { x: number; y: number }) =>
     Math.hypot(a.x - b.x, a.y - b.y);
   const isPerpendicular = (
-    p1: { x: number; y: number }, p2: { x: number; y: number },
-    p3: { x: number; y: number }, p4: { x: number; y: number },
+    p1: { x: number; y: number },
+    p2: { x: number; y: number },
+    p3: { x: number; y: number },
+    p4: { x: number; y: number },
   ) => (p1.x === p2.x && p3.y === p4.y) || (p1.y === p2.y && p3.x === p4.x);
 
   for (let i = 1; i < points.length - 1; i++) {
@@ -36,13 +46,29 @@ function pathFromPoints(points: { x: number; y: number }[], radius = 12): string
     }
     const r = Math.min(dist(center, prev) / 2, dist(center, next) / 2, radius);
     const isHorizontalIn = prev.y === center.y;
-    const xDir = isHorizontalIn ? (prev.x < next.x ? -1 : 1) : (prev.x < next.x ? 1 : -1);
-    const yDir = isHorizontalIn ? (prev.y < next.y ? 1 : -1) : (prev.y < next.y ? -1 : 1);
+    const xDir = isHorizontalIn
+      ? prev.x < next.x
+        ? -1
+        : 1
+      : prev.x < next.x
+        ? 1
+        : -1;
+    const yDir = isHorizontalIn
+      ? prev.y < next.y
+        ? 1
+        : -1
+      : prev.y < next.y
+        ? -1
+        : 1;
 
     if (isHorizontalIn) {
-      parts.push(`L ${center.x + r * xDir},${center.y} Q ${center.x},${center.y} ${center.x},${center.y + r * yDir}`);
+      parts.push(
+        `L ${center.x + r * xDir},${center.y} Q ${center.x},${center.y} ${center.x},${center.y + r * yDir}`,
+      );
     } else {
-      parts.push(`L ${center.x},${center.y + r * yDir} Q ${center.x},${center.y} ${center.x + r * xDir},${center.y}`);
+      parts.push(
+        `L ${center.x},${center.y + r * yDir} Q ${center.x},${center.y} ${center.x + r * xDir},${center.y}`,
+      );
     }
   }
   const last = points[points.length - 1]!;
@@ -93,8 +119,8 @@ export const BaseEdge = memo<EdgeProps<Edge<WorkflowEdgeData>>>(
         path={edgePath}
         style={{
           stroke: edgeColor,
-          opacity: selected ? 1 : 0.7,
-          strokeWidth: selected ? 2 : 1.4,
+          opacity: selected ? 1 : 0.85,
+          strokeWidth: selected ? 2.2 : 1.6,
           strokeLinecap: 'round',
           strokeLinejoin: 'round',
           fill: 'none',

--- a/typescript2/pkg-playground/src/graph/edges/Marker.tsx
+++ b/typescript2/pkg-playground/src/graph/edges/Marker.tsx
@@ -1,14 +1,15 @@
 // Arrow marker colors for light and dark modes
 const kBaseMarkerColorDark = '#cbd5e1'; // slate-300
-const kYesMarkerColorDark = '#4ade80';  // green-400
-const kNoMarkerColorDark = '#f87171';   // red-400
+const kYesMarkerColorDark = '#4ade80'; // green-400
+const kNoMarkerColorDark = '#f87171'; // red-400
 
-const kBaseMarkerColorLight = '#0f172a'; // slate-900
-const kYesMarkerColorLight = '#16a34a';  // green-600
-const kNoMarkerColorLight = '#dc2626';   // red-600
+// Light mode is warm ink on paper — matches the playground panel theme.
+const kBaseMarkerColorLight = '#4A443B';
+const kYesMarkerColorLight = '#047857';
+const kNoMarkerColorLight = '#B42318';
 
 const kBaseMarkerColorsDark = ['#a78bfa', '#f472b6', '#fbbf24', '#60a5fa'];
-const kBaseMarkerColorsLight = ['#6d28d9', '#db2777', '#d97706', '#2563eb'];
+const kBaseMarkerColorsLight = ['#6D28D9', '#BE185D', '#B45309', '#1D4ED8'];
 
 export const kAllMarkerColors = [
   kBaseMarkerColorLight,
@@ -22,7 +23,13 @@ export const kAllMarkerColors = [
 ];
 
 export const getMarkerColors = () => {
-  const isDark = typeof document === 'undefined' || !document.body?.dataset?.vscodeThemeKind?.includes('light');
+  // Outside VS Code (no theme dataset) the panel is the light paper theme,
+  // so default to LIGHT; inside VS Code, follow the editor's theme kind.
+  const themeKind =
+    typeof document === 'undefined'
+      ? undefined
+      : document.body?.dataset?.vscodeThemeKind;
+  const isDark = themeKind ? !themeKind.includes('light') : false;
   return {
     base: isDark ? kBaseMarkerColorDark : kBaseMarkerColorLight,
     yes: isDark ? kYesMarkerColorDark : kYesMarkerColorLight,

--- a/typescript2/pkg-playground/src/graph/layout.ts
+++ b/typescript2/pkg-playground/src/graph/layout.ts
@@ -35,10 +35,11 @@ function nodeSize(node: WorkflowNode): { w: number; h: number } {
     if (imageCount > 0) {
       const visibleCount = Math.min(imageCount, NODE_IMAGE_PREVIEW_MAX);
       const previewRows = visibleCount === 1 ? 1 : Math.ceil(visibleCount / 2);
-      const previewHeight = visibleCount === 1
-        ? NODE_IMAGE_PREVIEW_SINGLE_HEIGHT
-        : previewRows * NODE_IMAGE_PREVIEW_TILE_HEIGHT
-          + (previewRows - 1) * NODE_IMAGE_PREVIEW_GAP;
+      const previewHeight =
+        visibleCount === 1
+          ? NODE_IMAGE_PREVIEW_SINGLE_HEIGHT
+          : previewRows * NODE_IMAGE_PREVIEW_TILE_HEIGHT +
+            (previewRows - 1) * NODE_IMAGE_PREVIEW_GAP;
       return {
         w: Math.max(base.w, NODE_IMAGE_PREVIEW_WIDTH),
         h: base.h + previewHeight + 14,
@@ -87,7 +88,13 @@ function buildElkNodes(
     const elkNode: ElkNode = { id: node.id };
 
     if (isGroup) {
-      const children = buildElkNodes(allNodes, direction, edgesByOwner, portsByNode, node.id);
+      const children = buildElkNodes(
+        allNodes,
+        direction,
+        edgesByOwner,
+        portsByNode,
+        node.id,
+      );
       elkNode.layoutOptions = {
         'elk.algorithm': 'layered',
         'elk.direction': isHorizontal ? 'RIGHT' : 'DOWN',
@@ -140,7 +147,10 @@ function buildElkNodes(
 // Placing each edge on the deepest group containing both endpoints
 // gives ELK correct local context for layer ordering and spacing.
 
-function getAncestorChain(nodeId: string, nodeById: Map<string, WorkflowNode>): string[] {
+function getAncestorChain(
+  nodeId: string,
+  nodeById: Map<string, WorkflowNode>,
+): string[] {
   const chain: string[] = [];
   let cur = nodeById.get(nodeId);
   while (cur) {
@@ -176,8 +186,12 @@ export async function layoutGraph(
 
   const isHorizontal = direction === 'horizontal';
   const nodeIds = new Set(nodes.map((n) => n.id));
-  const validEdges = edges.filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target));
-  const groupNodeIds = new Set(nodes.filter((n) => n.type === 'group').map((n) => n.id));
+  const validEdges = edges.filter(
+    (e) => nodeIds.has(e.source) && nodeIds.has(e.target),
+  );
+  const groupNodeIds = new Set(
+    nodes.filter((n) => n.type === 'group').map((n) => n.id),
+  );
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
 
   // Count outgoing/incoming edges per (non-group) node so we can declare
@@ -200,7 +214,10 @@ export async function layoutGraph(
   // Per-edge port index counters — give each edge a unique slot.
   const sourceIdx = new Map<string, number>();
   const targetIdx = new Map<string, number>();
-  const edgePortIds = new Map<string, { sourcePort: string; targetPort: string }>();
+  const edgePortIds = new Map<
+    string,
+    { sourcePort: string; targetPort: string }
+  >();
 
   // Distribute edges to their LCA group for better within-group layout.
   const edgesByOwner = new Map<string, ElkExtendedEdge[]>();
@@ -252,7 +269,10 @@ export async function layoutGraph(
 
   // Extract node positions. ELK returns parent-relative coordinates,
   // which is exactly what ReactFlow expects for nodes inside groups.
-  const positionMap = new Map<string, { x: number; y: number; w: number; h: number }>();
+  const positionMap = new Map<
+    string,
+    { x: number; y: number; w: number; h: number }
+  >();
 
   function extractPositions(elkNodes: ElkNode[] | undefined) {
     if (!elkNodes) return;
@@ -270,7 +290,10 @@ export async function layoutGraph(
   extractPositions(layouted.children);
 
   // ── Compute absolute positions for handle selection ─────────────────
-  const absPositions = new Map<string, { x: number; y: number; w: number; h: number }>();
+  const absPositions = new Map<
+    string,
+    { x: number; y: number; w: number; h: number }
+  >();
   for (const n of nodes) {
     let absX = positionMap.get(n.id)?.x ?? 0;
     let absY = positionMap.get(n.id)?.y ?? 0;
@@ -301,10 +324,15 @@ export async function layoutGraph(
     endPoint?: { x: number; y: number };
     bendPoints?: { x: number; y: number }[];
   };
-  const elkEdgeOwners = new Map<string, { ownerId: string; sections: ElkSection[] }>();
+  const elkEdgeOwners = new Map<
+    string,
+    { ownerId: string; sections: ElkSection[] }
+  >();
   function collectElkEdges(elkNode: ElkNode, ownerId: string) {
     if (elkNode.edges) {
-      for (const e of elkNode.edges as Array<ElkExtendedEdge & { sections?: ElkSection[] }>) {
+      for (const e of elkNode.edges as Array<
+        ElkExtendedEdge & { sections?: ElkSection[] }
+      >) {
         const sections = e.sections ?? [];
         if (sections.length > 0) elkEdgeOwners.set(e.id, { ownerId, sections });
       }
@@ -330,14 +358,21 @@ export async function layoutGraph(
     if (elkInfo) {
       // Owner offset: edges owned by 'root' need no offset; edges owned
       // by a group are shifted by that group's absolute position.
-      const ownerAbs = elkInfo.ownerId === 'root'
-        ? { x: 0, y: 0 }
-        : absPositions.get(elkInfo.ownerId) ?? { x: 0, y: 0 };
+      const ownerAbs =
+        elkInfo.ownerId === 'root'
+          ? { x: 0, y: 0 }
+          : (absPositions.get(elkInfo.ownerId) ?? { x: 0, y: 0 });
       const ox = ownerAbs.x;
       const oy = ownerAbs.y;
       const points = elkInfo.sections.flatMap((sec) => {
-        const start = { x: (sec.startPoint?.x ?? 0) + ox, y: (sec.startPoint?.y ?? 0) + oy };
-        const end = { x: (sec.endPoint?.x ?? 0) + ox, y: (sec.endPoint?.y ?? 0) + oy };
+        const start = {
+          x: (sec.startPoint?.x ?? 0) + ox,
+          y: (sec.startPoint?.y ?? 0) + oy,
+        };
+        const end = {
+          x: (sec.endPoint?.x ?? 0) + ox,
+          y: (sec.endPoint?.y ?? 0) + oy,
+        };
         const bends = (sec.bendPoints ?? []).map((p) => ({
           x: p.x + ox,
           y: p.y + oy,
@@ -363,8 +398,8 @@ export async function layoutGraph(
     // Fallback: no ELK route available — keep direction-heuristic handles
     // so getSmoothStepPath at least picks a reasonable side.
     if (!srcPos || !tgtPos) return { ...edge, sourceHandle, targetHandle };
-    const dx = (tgtPos.x + tgtPos.w / 2) - (srcPos.x + srcPos.w / 2);
-    const dy = (tgtPos.y + tgtPos.h / 2) - (srcPos.y + srcPos.h / 2);
+    const dx = tgtPos.x + tgtPos.w / 2 - (srcPos.x + srcPos.w / 2);
+    const dy = tgtPos.y + tgtPos.h / 2 - (srcPos.y + srcPos.h / 2);
     let sH: string;
     let tH: string;
     if (Math.abs(dx) >= Math.abs(dy)) {

--- a/typescript2/pkg-playground/src/graph/nodes/BaseNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/BaseNode.tsx
@@ -1,6 +1,11 @@
 import { type NodeProps } from '@xyflow/react';
 import { type ComponentType, memo } from 'react';
-import { nodeBackground, nodeShadow, selectionRing, stateColors } from '../constants';
+import {
+  nodeBackground,
+  nodeShadow,
+  selectionRing,
+  stateColors,
+} from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 import { NodeOutputPreview } from './NodeOutputPreview';
@@ -15,30 +20,62 @@ const StateIcon = ({ state }: { state: string }) => {
         fill="none"
         stroke="white"
         strokeWidth="3"
-        style={{ animation: 'baml-graph-spin 800ms linear infinite', transformOrigin: 'center' }}
+        style={{
+          animation: 'baml-graph-spin 800ms linear infinite',
+          transformOrigin: 'center',
+        }}
       >
         <circle cx="12" cy="12" r="10" opacity="0.25" />
-        <path d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" fill="white" opacity="0.85" />
+        <path
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          fill="white"
+          opacity="0.85"
+        />
       </svg>
     );
   }
   if (state === 'success') {
     return (
-      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3.5" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="white"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M5 13l4 4L19 7" />
       </svg>
     );
   }
   if (state === 'error') {
     return (
-      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round">
+      <svg
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="white"
+        strokeWidth="3"
+        strokeLinecap="round"
+      >
         <path d="M6 18L18 6M6 6l12 12" />
       </svg>
     );
   }
   if (state === 'cancelled') {
     return (
-      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3.5" strokeLinecap="round">
+      <svg
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="white"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+      >
         <path d="M6 12h12" />
       </svg>
     );
@@ -74,7 +111,8 @@ export const BaseNode: ComponentType<NodeProps> = memo(({ data }) => {
           height: '100%',
           boxSizing: 'border-box',
           color: colors.text,
-          fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+          fontFamily:
+            'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
           transition: 'box-shadow 120ms ease, border-color 120ms ease',
         }}
       >

--- a/typescript2/pkg-playground/src/graph/nodes/DiamondNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/DiamondNode.tsx
@@ -1,7 +1,12 @@
 import { type NodeProps } from '@xyflow/react';
 import { GitBranch } from 'lucide-react';
 import { type ComponentType, memo } from 'react';
-import { nodeBackground, nodeShadow, selectionRing, stateColors } from '../constants';
+import {
+  nodeBackground,
+  nodeShadow,
+  selectionRing,
+  stateColors,
+} from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 
@@ -33,7 +38,8 @@ export const DiamondNode: ComponentType<NodeProps> = memo(({ data }) => {
           height: '100%',
           boxSizing: 'border-box',
           color: colors.text,
-          fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+          fontFamily:
+            'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
           transition: 'box-shadow 120ms ease, border-color 120ms ease',
         }}
       >
@@ -49,7 +55,11 @@ export const DiamondNode: ComponentType<NodeProps> = memo(({ data }) => {
             boxShadow: 'inset 0 0 0 1px rgba(245,158,11,0.35)',
           }}
         >
-          <GitBranch size={12} color="#fbbf24" style={{ transform: 'rotate(180deg)' }} />
+          <GitBranch
+            size={12}
+            color="#fbbf24"
+            style={{ transform: 'rotate(180deg)' }}
+          />
         </span>
         <div
           style={{

--- a/typescript2/pkg-playground/src/graph/nodes/GroupNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/GroupNode.tsx
@@ -17,15 +17,17 @@ import { NodeHandles } from './NodeHandles';
 export const GroupNode: ComponentType<NodeProps> = memo(({ data, id }) => {
   const d = data as WorkflowNodeData;
   const isHighlighted = d.selected;
-  const stateStyle = stateColors[d.executionState] ?? stateColors['not-started'];
+  const stateStyle =
+    stateColors[d.executionState] ?? stateColors['not-started'];
   const stateAccent = stateStyle.accent;
-  const isStateful = d.executionState !== 'not-started' && d.executionState !== 'skipped';
+  const isStateful =
+    d.executionState !== 'not-started' && d.executionState !== 'skipped';
 
   const borderColor = isHighlighted
     ? selectionRing.color
     : isStateful
       ? stateStyle.border
-      : 'rgba(255,255,255,0.10)';
+      : 'rgba(26,22,18,0.28)';
 
   return (
     <div
@@ -38,7 +40,7 @@ export const GroupNode: ComponentType<NodeProps> = memo(({ data, id }) => {
         // Frame-only: no fill, so the canvas reads through. Nested groups
         // never stack into a darker patch — they just compose hairline frames.
         background: 'transparent',
-        border: `1px solid ${borderColor}`,
+        border: `1.5px ${isStateful || isHighlighted ? 'solid' : 'dashed'} ${borderColor}`,
         boxShadow: isHighlighted
           ? `0 0 0 1px ${selectionRing.glow}`
           : undefined,
@@ -65,18 +67,19 @@ export const GroupNode: ComponentType<NodeProps> = memo(({ data, id }) => {
           fontWeight: 600,
           fontSize: 11,
           letterSpacing: '-0.005em',
-          color: isHighlighted ? '#ecfeff' : '#e4e4e7',
+          color: isHighlighted ? '#1D4ED8' : '#1A1612',
           background: isHighlighted
-            ? 'rgba(8,47,73,0.85)'
-            : 'rgba(24,24,27,0.85)',
-          border: `1px solid ${isHighlighted ? selectionRing.color : 'rgba(255,255,255,0.10)'}`,
+            ? 'rgba(234,241,254,0.94)'
+            : 'rgba(255,253,246,0.94)',
+          border: `1px solid ${isHighlighted ? selectionRing.color : '#D8CFBD'}`,
           backdropFilter: 'blur(8px)',
           WebkitBackdropFilter: 'blur(8px)',
           boxShadow: isHighlighted
-            ? `0 0 0 2px ${selectionRing.glow}, 0 1px 2px rgba(0,0,0,0.4)`
-            : '0 1px 2px rgba(0,0,0,0.4)',
+            ? `0 0 0 2px ${selectionRing.glow}, 0 1px 2px rgba(26,22,18,0.15)`
+            : '0 1px 2px rgba(26,22,18,0.12)',
           transition: 'all 150ms ease',
-          fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+          fontFamily:
+            'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
         }}
       >
         {/* State accent dot (only for stateful runs) */}
@@ -102,8 +105,8 @@ export const GroupNode: ComponentType<NodeProps> = memo(({ data, id }) => {
               marginLeft: 2,
               padding: '1px 6px',
               borderRadius: 999,
-              background: 'rgba(59,130,246,0.18)',
-              color: '#93c5fd',
+              background: 'rgba(37,99,235,0.10)',
+              color: '#1D4ED8',
               fontSize: 10,
               fontWeight: 600,
               fontVariantNumeric: 'tabular-nums',

--- a/typescript2/pkg-playground/src/graph/nodes/HexagonNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/HexagonNode.tsx
@@ -1,7 +1,12 @@
 import { type NodeProps } from '@xyflow/react';
 import { Repeat } from 'lucide-react';
 import { type ComponentType, memo } from 'react';
-import { nodeBackground, nodeShadow, selectionRing, stateColors } from '../constants';
+import {
+  nodeBackground,
+  nodeShadow,
+  selectionRing,
+  stateColors,
+} from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 
@@ -33,7 +38,8 @@ export const HexagonNode: ComponentType<NodeProps> = memo(({ data }) => {
           height: '100%',
           boxSizing: 'border-box',
           color: colors.text,
-          fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+          fontFamily:
+            'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
           transition: 'box-shadow 120ms ease, border-color 120ms ease',
         }}
       >

--- a/typescript2/pkg-playground/src/graph/nodes/LLMNode.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/LLMNode.tsx
@@ -1,7 +1,12 @@
 import { type NodeProps } from '@xyflow/react';
 import { Sparkles } from 'lucide-react';
 import { type ComponentType, memo } from 'react';
-import { nodeBackground, nodeShadow, selectionRing, stateColors } from '../constants';
+import {
+  nodeBackground,
+  nodeShadow,
+  selectionRing,
+  stateColors,
+} from '../constants';
 import type { WorkflowNodeData } from '../types';
 import { NodeHandles } from './NodeHandles';
 import { NodeOutputPreview } from './NodeOutputPreview';
@@ -15,8 +20,8 @@ export const LLMNode: ComponentType<NodeProps> = memo(({ data }) => {
   const base = stateColors[d.executionState] ?? stateColors['not-started'];
   const colors = {
     ...base,
-    accent: '#a78bfa',
-    border: isHighlighted ? selectionRing.color : 'rgba(167,139,250,0.35)',
+    accent: '#6D28D9',
+    border: isHighlighted ? selectionRing.color : 'rgba(109,40,217,0.40)',
   };
 
   return (
@@ -36,7 +41,8 @@ export const LLMNode: ComponentType<NodeProps> = memo(({ data }) => {
           height: '100%',
           boxSizing: 'border-box',
           color: colors.text,
-          fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+          fontFamily:
+            'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
           transition: 'box-shadow 120ms ease, border-color 120ms ease',
         }}
       >
@@ -51,15 +57,19 @@ export const LLMNode: ComponentType<NodeProps> = memo(({ data }) => {
               fontSize: 9,
               fontWeight: 700,
               letterSpacing: '0.06em',
-              background: 'rgba(167,139,250,0.15)',
-              color: '#c4b5fd',
-              boxShadow: 'inset 0 0 0 1px rgba(167,139,250,0.35)',
+              background: 'rgba(109,40,217,0.10)',
+              color: '#6D28D9',
+              boxShadow: 'inset 0 0 0 1px rgba(109,40,217,0.30)',
             }}
           >
             <Sparkles
               size={9}
               strokeWidth={2.5}
-              style={isRunning ? { animation: 'baml-graph-spin 900ms linear infinite' } : undefined}
+              style={
+                isRunning
+                  ? { animation: 'baml-graph-spin 900ms linear infinite' }
+                  : undefined
+              }
             />
             LLM
           </span>
@@ -67,7 +77,7 @@ export const LLMNode: ComponentType<NodeProps> = memo(({ data }) => {
             style={{
               fontSize: 12,
               fontWeight: 600,
-              color: '#ddd6fe',
+              color: colors.text,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',

--- a/typescript2/pkg-playground/src/graph/nodes/NodeHandles.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/NodeHandles.tsx
@@ -13,14 +13,44 @@ const S = { opacity: 0, width: 6, height: 6 } as const;
 export function NodeHandles() {
   return (
     <>
-      <Handle id="left-target" type="target" position={Position.Left} style={S} />
-      <Handle id="right-target" type="target" position={Position.Right} style={S} />
+      <Handle
+        id="left-target"
+        type="target"
+        position={Position.Left}
+        style={S}
+      />
+      <Handle
+        id="right-target"
+        type="target"
+        position={Position.Right}
+        style={S}
+      />
       <Handle id="top-target" type="target" position={Position.Top} style={S} />
-      <Handle id="bottom-target" type="target" position={Position.Bottom} style={S} />
-      <Handle id="left-source" type="source" position={Position.Left} style={S} />
-      <Handle id="right-source" type="source" position={Position.Right} style={S} />
+      <Handle
+        id="bottom-target"
+        type="target"
+        position={Position.Bottom}
+        style={S}
+      />
+      <Handle
+        id="left-source"
+        type="source"
+        position={Position.Left}
+        style={S}
+      />
+      <Handle
+        id="right-source"
+        type="source"
+        position={Position.Right}
+        style={S}
+      />
       <Handle id="top-source" type="source" position={Position.Top} style={S} />
-      <Handle id="bottom-source" type="source" position={Position.Bottom} style={S} />
+      <Handle
+        id="bottom-source"
+        type="source"
+        position={Position.Bottom}
+        style={S}
+      />
     </>
   );
 }

--- a/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
@@ -43,10 +43,27 @@ export function NodeOutputPreview({
           padding: 8,
         }}
       >
-        <div style={{ color: '#fda4af', fontSize: 10, fontWeight: 700, marginBottom: 4, textTransform: 'uppercase' }}>
+        <div
+          style={{
+            color: '#fda4af',
+            fontSize: 10,
+            fontWeight: 700,
+            marginBottom: 4,
+            textTransform: 'uppercase',
+          }}
+        >
           Error
         </div>
-        <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word', color: '#fecdd3', fontSize: 10, lineHeight: 1.35 }}>
+        <pre
+          style={{
+            margin: 0,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            color: '#fecdd3',
+            fontSize: 10,
+            lineHeight: 1.35,
+          }}
+        >
           {errorMessage}
         </pre>
       </div>
@@ -59,7 +76,8 @@ export function NodeOutputPreview({
         className="nodrag nopan"
         style={{
           display: 'grid',
-          gridTemplateColumns: visible.length === 1 ? '1fr' : 'repeat(2, minmax(0, 1fr))',
+          gridTemplateColumns:
+            visible.length === 1 ? '1fr' : 'repeat(2, minmax(0, 1fr))',
           gap: NODE_IMAGE_PREVIEW_GAP,
           marginTop: 6,
           width: '100%',
@@ -68,7 +86,8 @@ export function NodeOutputPreview({
       >
         {visible.map((image, index) => {
           const src = mediaToSrc(image);
-          const isLastWithRemainder = index === visible.length - 1 && remaining > 0;
+          const isLastWithRemainder =
+            index === visible.length - 1 && remaining > 0;
 
           return (
             <div
@@ -76,9 +95,10 @@ export function NodeOutputPreview({
               style={{
                 position: 'relative',
                 width: '100%',
-                height: visible.length === 1
-                  ? NODE_IMAGE_PREVIEW_SINGLE_HEIGHT
-                  : NODE_IMAGE_PREVIEW_TILE_HEIGHT,
+                height:
+                  visible.length === 1
+                    ? NODE_IMAGE_PREVIEW_SINGLE_HEIGHT
+                    : NODE_IMAGE_PREVIEW_TILE_HEIGHT,
                 borderRadius: 6,
                 overflow: 'hidden',
                 background: '#09090b',
@@ -101,7 +121,13 @@ export function NodeOutputPreview({
                   }}
                 />
               ) : (
-                <span style={{ color: '#9ca3af', fontSize: 10, fontFamily: 'monospace' }}>
+                <span
+                  style={{
+                    color: '#9ca3af',
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                  }}
+                >
                   &lt;image&gt;
                 </span>
               )}
@@ -144,10 +170,22 @@ export function NodeOutputPreview({
           padding: 8,
         }}
       >
-        <div style={{ color: '#9ca3af', fontSize: 10, fontWeight: 700, marginBottom: 4, textTransform: 'uppercase' }}>
+        <div
+          style={{
+            color: '#9ca3af',
+            fontSize: 10,
+            fontWeight: 700,
+            marginBottom: 4,
+            textTransform: 'uppercase',
+          }}
+        >
           Output
         </div>
-        <ValueRenderer value={result} displayMode="expanded" customRenderers={customRenderers} />
+        <ValueRenderer
+          value={result}
+          displayMode="expanded"
+          customRenderers={customRenderers}
+        />
       </div>
     );
   }

--- a/typescript2/pkg-playground/src/graph/runtime-output.ts
+++ b/typescript2/pkg-playground/src/graph/runtime-output.ts
@@ -22,18 +22,26 @@ export interface GraphRunState {
   functionName?: string | null;
 }
 
-function nodeMatchesFunctionName(node: GraphNode, functionName: string): boolean {
+function nodeMatchesFunctionName(
+  node: GraphNode,
+  functionName: string,
+): boolean {
   const label = node.label.trim();
   if (label === functionName) return true;
   if (label.startsWith(`${functionName}(`)) return true;
 
   const namespacedName = functionName.split('.').pop();
-  return namespacedName != null
-    && namespacedName !== functionName
-    && (label === namespacedName || label.startsWith(`${namespacedName}(`));
+  return (
+    namespacedName != null &&
+    namespacedName !== functionName &&
+    (label === namespacedName || label.startsWith(`${namespacedName}(`))
+  );
 }
 
-function findOutputNodeIds(graphNodes: GraphNode[], functionName: string): string[] {
+function findOutputNodeIds(
+  graphNodes: GraphNode[],
+  functionName: string,
+): string[] {
   const exact = graphNodes
     .filter((node) => node.label.trim() === functionName)
     .map((node) => node.id);
@@ -44,7 +52,10 @@ function findOutputNodeIds(graphNodes: GraphNode[], functionName: string): strin
     .map((node) => node.id);
 }
 
-function findOutputNodeId(graphNodes: GraphNode[], functionName: string): string | null {
+function findOutputNodeId(
+  graphNodes: GraphNode[],
+  functionName: string,
+): string | null {
   return findOutputNodeIds(graphNodes, functionName)[0] ?? null;
 }
 
@@ -59,7 +70,10 @@ const statePriority: Record<NodeExecutionState, number> = {
   error: 6,
 };
 
-function mergeState(current: NodeExecutionState | undefined, next: NodeExecutionState): NodeExecutionState {
+function mergeState(
+  current: NodeExecutionState | undefined,
+  next: NodeExecutionState,
+): NodeExecutionState {
   if (current == null) return next;
   return statePriority[next] > statePriority[current] ? next : current;
 }
@@ -73,9 +87,13 @@ function updateRuntime(
   map.set(nodeId, {
     result: 'result' in patch ? patch.result : prev?.result,
     hasResult: 'hasResult' in patch ? patch.hasResult : prev?.hasResult,
-    imageOutputs: 'imageOutputs' in patch ? (patch.imageOutputs ?? []) : prev?.imageOutputs ?? [],
+    imageOutputs:
+      'imageOutputs' in patch
+        ? (patch.imageOutputs ?? [])
+        : (prev?.imageOutputs ?? []),
     executionState: patch.executionState,
-    errorMessage: 'errorMessage' in patch ? patch.errorMessage : prev?.errorMessage,
+    errorMessage:
+      'errorMessage' in patch ? patch.errorMessage : prev?.errorMessage,
   });
 }
 
@@ -86,7 +104,8 @@ function applySuccessfulRunFallback(
   for (const node of graphNodes) {
     if (map.has(node.id)) continue;
 
-    const hasSourceBackedRuntimeNode = node.parent == null || node.metadata.sourceExpr != null;
+    const hasSourceBackedRuntimeNode =
+      node.parent == null || node.metadata.sourceExpr != null;
     if (!hasSourceBackedRuntimeNode) continue;
 
     updateRuntime(map, node.id, {
@@ -142,8 +161,8 @@ export function collectGraphNodeRuntime(
       });
     } else if (kind?.$case === 'functionEnd') {
       const mappedNodeId = nodeIdBySpanId.get(evt.spanId);
-      const nodeId = mappedNodeId
-        ?? findOutputNodeId(graphNodes, kind.functionEnd.name);
+      const nodeId =
+        mappedNodeId ?? findOutputNodeId(graphNodes, kind.functionEnd.name);
       if (mappedNodeId != null) {
         decrementActiveNodeCount(mappedNodeId);
       }
@@ -155,8 +174,12 @@ export function collectGraphNodeRuntime(
       updateRuntime(direct, nodeId, {
         result: kind.functionEnd.result,
         hasResult: kind.functionEnd.result != null,
-        imageOutputs: kind.functionEnd.result == null ? [] : findImageMedia(kind.functionEnd.result),
-        executionState: remainingActiveCount > 0 ? 'running' : error ? 'error' : 'success',
+        imageOutputs:
+          kind.functionEnd.result == null
+            ? []
+            : findImageMedia(kind.functionEnd.result),
+        executionState:
+          remainingActiveCount > 0 ? 'running' : error ? 'error' : 'success',
         errorMessage: error,
       });
     }
@@ -170,11 +193,13 @@ export function collectGraphNodeRuntime(
     const fallbackNodeId = runState.functionName
       ? findOutputNodeId(graphNodes, runState.functionName)
       : null;
-    const errorTargets = activeNodeIds.length > 0
-      ? activeNodeIds
-      : fallbackNodeId != null && (activeNodeCounts.get(fallbackNodeId) ?? 0) === 0
-        ? [fallbackNodeId]
-        : [];
+    const errorTargets =
+      activeNodeIds.length > 0
+        ? activeNodeIds
+        : fallbackNodeId != null &&
+            (activeNodeCounts.get(fallbackNodeId) ?? 0) === 0
+          ? [fallbackNodeId]
+          : [];
 
     for (const nodeId of errorTargets) {
       updateRuntime(direct, nodeId, {
@@ -200,7 +225,10 @@ export function collectGraphNodeRuntime(
           ...(prev?.imageOutputs ?? []),
           ...(runtime.imageOutputs ?? []),
         ],
-        executionState: mergeState(prev?.executionState, runtime.executionState),
+        executionState: mergeState(
+          prev?.executionState,
+          runtime.executionState,
+        ),
         errorMessage: runtime.errorMessage ?? prev?.errorMessage,
       });
       parentId = parentById.get(parentId);

--- a/typescript2/pkg-playground/src/graph/types.ts
+++ b/typescript2/pkg-playground/src/graph/types.ts
@@ -1,4 +1,7 @@
-import type { Node as ReactFlowNode, Edge as ReactFlowEdge } from '@xyflow/react';
+import type {
+  Node as ReactFlowNode,
+  Edge as ReactFlowEdge,
+} from '@xyflow/react';
 import type { BamlJsMedia, BamlJsValue } from '@b/pkg-proto';
 import type { FC } from 'react';
 import type { ResultRendererProps } from '../result-renderers';
@@ -11,7 +14,8 @@ export type GraphNodeType =
   | 'conditional'
   | 'loop'
   | 'scope'
-  | 'header';
+  | 'header'
+  | 'return';
 
 export interface GraphNode {
   id: string;

--- a/typescript2/pkg-playground/src/index.ts
+++ b/typescript2/pkg-playground/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 // Execution panel + transport abstraction
 export { ExecutionPanel } from './ExecutionPanel';
 export type { ExecutionPanelProps } from './ExecutionPanel';
@@ -17,7 +19,11 @@ export {
 export type { ResultRendererProps } from './result-renderers';
 export { ResultDisplay } from './ResultDisplay';
 export type { ResultDisplayProps } from './ResultDisplay';
-export { HttpRequestCurlRenderer, httpRequestToCurl, isHttpRequest } from './renderers/HttpRequestCurl';
+export {
+  HttpRequestCurlRenderer,
+  httpRequestToCurl,
+  isHttpRequest,
+} from './renderers/HttpRequestCurl';
 
 // Worker protocol types (needed by worker implementations and consumers)
 export type {

--- a/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
+++ b/typescript2/pkg-playground/src/ports/WebSocketRuntimePort.ts
@@ -12,7 +12,13 @@
  */
 
 import type { RuntimePort } from '../runtime-port';
-import type { WorkerOutMessage, WorkerInMessage, PlaygroundNotification, LogLevel, LogDecoration } from '../worker-protocol';
+import type {
+  WorkerOutMessage,
+  WorkerInMessage,
+  PlaygroundNotification,
+  LogLevel,
+  LogDecoration,
+} from '../worker-protocol';
 import { decodeCallResult, RuntimeEvent } from '@b/pkg-proto';
 import { truncateMessage, normalizeLogLevel } from '../shared/log-decorations';
 import { formatValue } from '../shared/format-value';
@@ -21,33 +27,92 @@ import { isPlaygroundProtocolCompatible } from '../protocol';
 
 /** Server → Client message shapes (must match playground_ws.rs WsOutMessage) */
 type WsOutMessage =
-  | { type: 'hello'; toolchainVersion: string; playgroundProtocol: number; minClientPlaygroundProtocol: number; capabilities: string[] }
+  | {
+      type: 'hello';
+      toolchainVersion: string;
+      playgroundProtocol: number;
+      minClientPlaygroundProtocol: number;
+      capabilities: string[];
+    }
   | { type: 'ready' }
   | { type: 'playgroundNotification'; notification: PlaygroundNotification }
   | { type: 'callFunctionResult'; id: number; result: string }
-  | { type: 'callFunctionError'; id: number; error: string; cancelled?: boolean }
+  | {
+      type: 'callFunctionError';
+      id: number;
+      error: string;
+      cancelled?: boolean;
+    }
   | { type: 'nextFunctionCallResult'; id: number; callId: number }
   | { type: 'nextFunctionCallError'; id: number; error: string }
   | { type: 'envVarRequest'; id: number; variable: string }
   | { type: 'processEnvVars'; vars: Record<string, string> }
   | { type: 'envVarFromShell'; variable: string; value: string }
   | { type: 'knownEnvVarNames'; names: string[] }
-  | { type: 'inputRequest'; id: number; prompt: string | undefined; callId: number }
+  | {
+      type: 'inputRequest';
+      id: number;
+      prompt: string | undefined;
+      callId: number;
+    }
   | { type: 'inputResolved'; id: number; callId: number }
-  | { type: 'fetchLogNew'; callId: number; id: number; method: string; url: string; requestHeaders: Record<string, string>; requestBody: string }
-  | { type: 'fetchLogUpdate'; callId: number; logId: number; status?: number; durationMs?: number; responseBody?: string; error?: string; responseHeaders?: Record<string, string> }
-  | { type: 'controlFlowGraphResult'; functionName: string; graph: unknown | null }
+  | {
+      type: 'fetchLogNew';
+      callId: number;
+      id: number;
+      method: string;
+      url: string;
+      requestHeaders: Record<string, string>;
+      requestBody: string;
+    }
+  | {
+      type: 'fetchLogUpdate';
+      callId: number;
+      logId: number;
+      status?: number;
+      durationMs?: number;
+      responseBody?: string;
+      error?: string;
+      responseHeaders?: Record<string, string>;
+    }
+  | {
+      type: 'controlFlowGraphResult';
+      functionName: string;
+      graph: unknown | null;
+    }
   | { type: 'cursorContext'; context: unknown }
   | { type: 'runtimeEvent'; data: string; callId: number };
 
 /** Client → Server message shapes (must match playground_ws.rs WsInMessage) */
 type WsInMessage =
   | { type: 'nextFunctionCall'; id: number }
-  | { type: 'callFunction'; id: number; project: string; name: string; argsProto: string }
+  | {
+      type: 'callFunction';
+      id: number;
+      project: string;
+      name: string;
+      argsProto: string;
+    }
   | { type: 'cancelCall'; id: number; project: string }
-  | { type: 'callTestFunction'; id: number; project: string; generation: number; testName: string }
-  | { type: 'expandTestSet'; project: string; generation: number; testsetName: string }
-  | { type: 'envVarResponse'; id: number; value: string | undefined; variable?: string }
+  | {
+      type: 'callTestFunction';
+      id: number;
+      project: string;
+      generation: number;
+      testName: string;
+    }
+  | {
+      type: 'expandTestSet';
+      project: string;
+      generation: number;
+      testsetName: string;
+    }
+  | {
+      type: 'envVarResponse';
+      id: number;
+      value: string | undefined;
+      variable?: string;
+    }
   | { type: 'inputResponse'; id: number; value: string; callId: number }
   | { type: 'setEnvVar'; key: string; value: string }
   | { type: 'deleteEnvVar'; key: string }
@@ -67,7 +132,10 @@ export class WebSocketRuntimePort implements RuntimePort {
   private disposed = false;
   private reconnectDelay = 500;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private decorationsByLine = new Map<number, { level: LogLevel; message: string; count: number }>();
+  private decorationsByLine = new Map<
+    number,
+    { level: LogLevel; message: string; count: number }
+  >();
   private textEncoder = new TextEncoder();
   private playgroundCompatible = true;
   private nextFunctionCallRequestId = 1;
@@ -151,7 +219,10 @@ export class WebSocketRuntimePort implements RuntimePort {
       this.reconnectTimer = null;
       this.connect();
     }, this.reconnectDelay);
-    this.reconnectDelay = Math.min(this.reconnectDelay * 2, MAX_RECONNECT_DELAY);
+    this.reconnectDelay = Math.min(
+      this.reconnectDelay * 2,
+      MAX_RECONNECT_DELAY,
+    );
   }
 
   postMessage(msg: WorkerInMessage): void {
@@ -285,7 +356,12 @@ export class WebSocketRuntimePort implements RuntimePort {
           testsetName: msg.testsetName,
         };
       case 'inputResponse':
-        return { type: 'inputResponse', id: msg.id, value: msg.value, callId: msg.callId };
+        return {
+          type: 'inputResponse',
+          id: msg.id,
+          value: msg.value,
+          callId: msg.callId,
+        };
       case 'clearHandles':
         return null; // handles live in the Rust process; no TS-side cleanup needed
       case 'dispose':
@@ -302,7 +378,10 @@ export class WebSocketRuntimePort implements RuntimePort {
   private fromServer(raw: WsOutMessage): WorkerOutMessage | null {
     switch (raw.type) {
       case 'hello':
-        this.playgroundCompatible = isPlaygroundProtocolCompatible(raw.playgroundProtocol, raw.minClientPlaygroundProtocol);
+        this.playgroundCompatible = isPlaygroundProtocolCompatible(
+          raw.playgroundProtocol,
+          raw.minClientPlaygroundProtocol,
+        );
         if (!this.playgroundCompatible) {
           return {
             type: 'runtimeEventError',
@@ -316,15 +395,21 @@ export class WebSocketRuntimePort implements RuntimePort {
         }
         return { type: 'ready' };
       case 'playgroundNotification':
-        return { type: 'playgroundNotification', notification: raw.notification };
+        return {
+          type: 'playgroundNotification',
+          notification: raw.notification,
+        };
       case 'callFunctionResult': {
         try {
           const bytes = base64ToUint8Array(raw.result);
-          const decoded = decodeCallResult(bytes, (key, handleType, typeName) => ({
-            handle_key: key,
-            handle_type: handleType,
-            type_name: typeName,
-          }));
+          const decoded = decodeCallResult(
+            bytes,
+            (key, handleType, typeName) => ({
+              handle_key: key,
+              handle_type: handleType,
+              type_name: typeName,
+            }),
+          );
           return {
             type: 'callFunctionResult',
             id: raw.id,
@@ -339,7 +424,12 @@ export class WebSocketRuntimePort implements RuntimePort {
         }
       }
       case 'callFunctionError':
-        return { type: 'callFunctionError', id: raw.id, error: raw.error, cancelled: raw.cancelled };
+        return {
+          type: 'callFunctionError',
+          id: raw.id,
+          error: raw.error,
+          cancelled: raw.cancelled,
+        };
       case 'nextFunctionCallResult':
         return { type: 'nextFunctionCallResult', id: raw.id, callId: raw.callId };
       case 'nextFunctionCallError':
@@ -349,11 +439,20 @@ export class WebSocketRuntimePort implements RuntimePort {
       case 'processEnvVars':
         return { type: 'processEnvVars', vars: raw.vars };
       case 'envVarFromShell':
-        return { type: 'envVarFromShell', variable: raw.variable, value: raw.value };
+        return {
+          type: 'envVarFromShell',
+          variable: raw.variable,
+          value: raw.value,
+        };
       case 'knownEnvVarNames':
         return { type: 'knownEnvVarNames', names: raw.names };
       case 'inputRequest':
-        return { type: 'inputRequest', id: raw.id, prompt: raw.prompt, callId: raw.callId };
+        return {
+          type: 'inputRequest',
+          id: raw.id,
+          prompt: raw.prompt,
+          callId: raw.callId,
+        };
       case 'inputResolved':
         return { type: 'inputResolved', id: raw.id, callId: raw.callId };
       case 'fetchLogNew':
@@ -380,17 +479,25 @@ export class WebSocketRuntimePort implements RuntimePort {
           logId: raw.logId,
           patch: {
             ...(raw.status !== undefined ? { status: raw.status } : {}),
-            ...(raw.durationMs !== undefined ? { durationMs: raw.durationMs } : {}),
-            ...(raw.responseBody !== undefined ? { responseBody: raw.responseBody } : {}),
+            ...(raw.durationMs !== undefined
+              ? { durationMs: raw.durationMs }
+              : {}),
+            ...(raw.responseBody !== undefined
+              ? { responseBody: raw.responseBody }
+              : {}),
             ...(raw.error !== undefined ? { error: raw.error } : {}),
-            ...(raw.responseHeaders !== undefined ? { responseHeaders: raw.responseHeaders } : {}),
+            ...(raw.responseHeaders !== undefined
+              ? { responseHeaders: raw.responseHeaders }
+              : {}),
           },
         };
       case 'controlFlowGraphResult':
         return {
           type: 'controlFlowGraphResult',
           functionName: raw.functionName,
-          graph: (raw.graph ?? null) as import('../worker-protocol').ControlFlowGraph | null,
+          graph: (raw.graph ?? null) as
+            | import('../worker-protocol').ControlFlowGraph
+            | null,
         };
       case 'cursorContext':
         return {
@@ -403,7 +510,11 @@ export class WebSocketRuntimePort implements RuntimePort {
           const event = RuntimeEvent.decode(bytes);
           const deserialized = deserializeRuntimeEvent(event);
           // Forward the decoded event via the buffer-or-dispatch path
-          this.deliver({ type: 'runtimeEventNew', event: deserialized, callId: raw.callId ?? null });
+          this.deliver({
+            type: 'runtimeEventNew',
+            event: deserialized,
+            callId: raw.callId ?? null,
+          });
 
           // Extract log decorations (same logic as baml-lsp-worker.ts)
           const kind = deserialized.event;

--- a/typescript2/pkg-playground/src/protocol.ts
+++ b/typescript2/pkg-playground/src/protocol.ts
@@ -1,8 +1,13 @@
 export const BAML_PLAYGROUND_PROTOCOL_MIN = 1;
 export const BAML_PLAYGROUND_PROTOCOL_MAX = 1;
 
-export function isPlaygroundProtocolCompatible(serverProtocol: number, minClientProtocol: number): boolean {
-  return serverProtocol >= BAML_PLAYGROUND_PROTOCOL_MIN
-    && serverProtocol <= BAML_PLAYGROUND_PROTOCOL_MAX
-    && BAML_PLAYGROUND_PROTOCOL_MAX >= minClientProtocol;
+export function isPlaygroundProtocolCompatible(
+  serverProtocol: number,
+  minClientProtocol: number,
+): boolean {
+  return (
+    serverProtocol >= BAML_PLAYGROUND_PROTOCOL_MIN &&
+    serverProtocol <= BAML_PLAYGROUND_PROTOCOL_MAX &&
+    BAML_PLAYGROUND_PROTOCOL_MAX >= minClientProtocol
+  );
 }

--- a/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
+++ b/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
@@ -38,7 +38,8 @@ function safeHeredoc(body: string): string {
   while (
     body.includes(`\n${tag}\n`) ||
     body.startsWith(`${tag}\n`) ||
-    body.endsWith(`\n${tag}`)
+    body.endsWith(`\n${tag}`) ||
+    body === tag
   ) {
     tag += '_';
   }

--- a/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
+++ b/typescript2/pkg-playground/src/renderers/HttpRequestCurl.tsx
@@ -35,7 +35,11 @@ export function isHttpRequest(value: unknown): value is HttpRequestShape {
 
 function safeHeredoc(body: string): string {
   let tag = 'EOF';
-  while (body.includes(`\n${tag}\n`) || body.startsWith(`${tag}\n`) || body.endsWith(`\n${tag}`)) {
+  while (
+    body.includes(`\n${tag}\n`) ||
+    body.startsWith(`${tag}\n`) ||
+    body.endsWith(`\n${tag}`)
+  ) {
     tag += '_';
   }
   return tag;
@@ -76,7 +80,9 @@ function toCurl(req: HttpRequestShape): string {
       const heredoc = safeHeredoc(formatted);
       parts.push('-d @-');
       parts.push(`'${url.replace(/'/g, "'\\''")}'`);
-      return parts.join(' \\\n  ') + ` <<'${heredoc}'\n${formatted}\n${heredoc}`;
+      return (
+        parts.join(' \\\n  ') + ` <<'${heredoc}'\n${formatted}\n${heredoc}`
+      );
     }
   }
   parts.push(`'${url.replace(/'/g, "'\\''")}'`);
@@ -96,14 +102,20 @@ function toJsFetch(req: HttpRequestShape): string {
   if (Object.keys(headers).length > 0) {
     const headersStr = Object.entries(headers)
       .filter(([, v]) => v != null)
-      .map(([k, v]) => `    '${escapeJsSingle(k)}': '${escapeJsSingle(String(v))}'`)
+      .map(
+        ([k, v]) =>
+          `    '${escapeJsSingle(k)}': '${escapeJsSingle(String(v))}'`,
+      )
       .join(',\n');
     opts.push(`  headers: {\n${headersStr}\n  }`);
   }
   if (body != null && body !== '') {
     const preserve = preserveExactBody(req);
     const formatted = preserve ? body : prettyBody(body);
-    const escaped = formatted.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+    const escaped = formatted
+      .replace(/\\/g, '\\\\')
+      .replace(/`/g, '\\`')
+      .replace(/\$/g, '\\$');
     opts.push(`  body: \`${escaped}\``);
   }
   return `fetch('${escapeJsSingle(url)}', {\n${opts.join(',\n')}\n});`;
@@ -124,7 +136,10 @@ function toPythonRequests(req: HttpRequestShape): string {
   if (Object.keys(headers).length > 0) {
     const headersStr = Object.entries(headers)
       .filter(([, v]) => v != null)
-      .map(([k, v]) => `        '${escapePySingle(k)}': '${escapePySingle(String(v))}'`)
+      .map(
+        ([k, v]) =>
+          `        '${escapePySingle(k)}': '${escapePySingle(String(v))}'`,
+      )
       .join(',\n');
     kwargs.push(`    headers={\n${headersStr}\n    }`);
   }
@@ -144,7 +159,11 @@ function toPythonRequests(req: HttpRequestShape): string {
 }
 
 function escapeGoString(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
 }
 
 function toGo(req: HttpRequestShape): string {
@@ -152,8 +171,14 @@ function toGo(req: HttpRequestShape): string {
   const url = req.url ?? '';
   const headers = req.headers ?? {};
   const body = req.body ?? '';
-  const bodyFormatted = body ? (preserveExactBody(req) ? body : prettyBody(body)) : '';
-  const bodyArg = body ? `strings.NewReader("${escapeGoString(bodyFormatted)}")` : 'nil';
+  const bodyFormatted = body
+    ? preserveExactBody(req)
+      ? body
+      : prettyBody(body)
+    : '';
+  const bodyArg = body
+    ? `strings.NewReader("${escapeGoString(bodyFormatted)}")`
+    : 'nil';
   const lines: string[] = [
     `req, err := http.NewRequest("${method}", "${escapeGoString(url)}", ${bodyArg})`,
     'if err != nil { log.Fatal(err) }',
@@ -162,7 +187,10 @@ function toGo(req: HttpRequestShape): string {
     lines.push('defer req.Body.Close()');
   }
   for (const [k, v] of Object.entries(headers)) {
-    if (v != null) lines.push(`req.Header.Set("${escapeGoString(k)}", "${escapeGoString(String(v))}")`);
+    if (v != null)
+      lines.push(
+        `req.Header.Set("${escapeGoString(k)}", "${escapeGoString(String(v))}")`,
+      );
   }
   lines.push('resp, err := http.DefaultClient.Do(req)');
   lines.push('if err != nil { log.Fatal(err) }');
@@ -177,17 +205,32 @@ function toGo(req: HttpRequestShape): string {
 }
 
 function escapeRustString(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
 }
 
-const REQWEST_SHORTCUT_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head']);
+const REQWEST_SHORTCUT_METHODS = new Set([
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'head',
+]);
 
 function toRust(req: HttpRequestShape): string {
   const method = (req.method ?? 'GET').toLowerCase();
   const url = req.url ?? '';
   const headers = req.headers ?? {};
   const body = req.body ?? '';
-  const bodyFormatted = body ? (preserveExactBody(req) ? body : prettyBody(body)) : '';
+  const bodyFormatted = body
+    ? preserveExactBody(req)
+      ? body
+      : prettyBody(body)
+    : '';
   const clientCall = REQWEST_SHORTCUT_METHODS.has(method)
     ? `client.${method}("${escapeRustString(url)}")`
     : `client.request("${method.toUpperCase()}".parse().unwrap(), "${escapeRustString(url)}")`;
@@ -196,7 +239,10 @@ function toRust(req: HttpRequestShape): string {
     `let response = ${clientCall}`,
   ];
   for (const [k, v] of Object.entries(headers)) {
-    if (v != null) lines.push(`    .header("${escapeRustString(k)}", "${escapeRustString(String(v))}")`);
+    if (v != null)
+      lines.push(
+        `    .header("${escapeRustString(k)}", "${escapeRustString(String(v))}")`,
+      );
   }
   if (body) {
     const preserve = preserveExactBody(req);
@@ -216,10 +262,18 @@ function toRust(req: HttpRequestShape): string {
     }
   }
   lines.push('    .send()?;');
-  return '// reqwest = { version = "0.11", features = ["blocking"] }\n\n' + lines.join('\n');
+  return (
+    '// reqwest = { version = "0.11", features = ["blocking"] }\n\n' +
+    lines.join('\n')
+  );
 }
 
-export type HttpRequestSnippetFormat = 'curl' | 'fetch' | 'python' | 'go' | 'rust';
+export type HttpRequestSnippetFormat =
+  | 'curl'
+  | 'fetch'
+  | 'python'
+  | 'go'
+  | 'rust';
 
 const FORMATS: { id: HttpRequestSnippetFormat; label: string }[] = [
   { id: 'curl', label: 'curl' },
@@ -237,7 +291,10 @@ const FORMAT_TO_LANGUAGE: Record<HttpRequestSnippetFormat, string> = {
   rust: 'rust',
 };
 
-function formatSnippet(req: HttpRequestShape, format: HttpRequestSnippetFormat): string {
+function formatSnippet(
+  req: HttpRequestShape,
+  format: HttpRequestSnippetFormat,
+): string {
   switch (format) {
     case 'curl':
       return toCurl(req);
@@ -262,7 +319,10 @@ export function httpRequestToCurl(req: HttpRequestShape): string {
 const preCls =
   'whitespace-pre font-vsc-mono text-xs leading-relaxed p-3 rounded bg-vsc-bg border border-vsc-border text-vsc-text overflow-auto max-h-[400px] m-0';
 
-export const HttpRequestCurlRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
+export const HttpRequestCurlRenderer: FC<ResultRendererProps> = ({
+  value,
+  displayMode,
+}) => {
   const [copied, setCopied] = useState(false);
   const [format, setFormat] = useState<HttpRequestSnippetFormat>('curl');
   const httpReq = isHttpRequest(value) ? value : null;
@@ -287,7 +347,11 @@ export const HttpRequestCurlRenderer: FC<ResultRendererProps> = ({ value, displa
   }
 
   if (displayMode === 'inline') {
-    return <span className="font-vsc-mono text-xs text-vsc-text">{httpReq.method} {httpReq.url}</span>;
+    return (
+      <span className="font-vsc-mono text-xs text-vsc-text">
+        {httpReq.method} {httpReq.url}
+      </span>
+    );
   }
 
   return (

--- a/typescript2/pkg-playground/src/renderers/Media.tsx
+++ b/typescript2/pkg-playground/src/renderers/Media.tsx
@@ -8,13 +8,20 @@ import { Badge } from '../components/ui/badge';
 import { CodeBlock } from '../components/ui/code-block';
 import { isBamlMedia, mediaLabel, mediaToSrc } from '../shared/media-values';
 
-export const MediaRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
+export const MediaRenderer: FC<ResultRendererProps> = ({
+  value,
+  displayMode,
+}) => {
   if (!isBamlMedia(value)) {
     return <CodeBlock>{JSON.stringify(value, null, 2)}</CodeBlock>;
   }
 
   if (displayMode === 'inline') {
-    return <span className="font-vsc-mono text-xs text-vsc-text-faint">&lt;{value.media_type}&gt;</span>;
+    return (
+      <span className="font-vsc-mono text-xs text-vsc-text-faint">
+        &lt;{value.media_type}&gt;
+      </span>
+    );
   }
 
   const src = mediaToSrc(value);
@@ -23,7 +30,9 @@ export const MediaRenderer: FC<ResultRendererProps> = ({ value, displayMode }) =
   if (value.media_type === 'image' && src) {
     return (
       <div className="space-y-1">
-        <Badge variant="secondary" className="gap-1 text-[11px] font-vsc-mono">{label}</Badge>
+        <Badge variant="secondary" className="gap-1 text-[11px] font-vsc-mono">
+          {label}
+        </Badge>
         <img
           src={src}
           alt="media"
@@ -36,7 +45,9 @@ export const MediaRenderer: FC<ResultRendererProps> = ({ value, displayMode }) =
   if (value.media_type === 'audio' && src) {
     return (
       <div className="space-y-1">
-        <Badge variant="secondary" className="gap-1 text-[11px] font-vsc-mono">{label}</Badge>
+        <Badge variant="secondary" className="gap-1 text-[11px] font-vsc-mono">
+          {label}
+        </Badge>
         <audio controls src={src} className="w-full" />
       </div>
     );
@@ -45,16 +56,25 @@ export const MediaRenderer: FC<ResultRendererProps> = ({ value, displayMode }) =
   if (value.media_type === 'video' && src) {
     return (
       <div className="space-y-1">
-        <Badge variant="secondary" className="gap-1 text-[11px] font-vsc-mono">{label}</Badge>
-        <video controls src={src} className="max-w-full max-h-[300px] rounded border border-vsc-border" />
+        <Badge variant="secondary" className="gap-1 text-[11px] font-vsc-mono">
+          {label}
+        </Badge>
+        <video
+          controls
+          src={src}
+          className="max-w-full max-h-[300px] rounded border border-vsc-border"
+        />
       </div>
     );
   }
 
   // File reference or unsupported content_type — show badge with path/url
-  const ref = value.content_type === 'url' ? value.url
-    : value.content_type === 'file' ? value.file
-    : '(base64)';
+  const ref =
+    value.content_type === 'url'
+      ? value.url
+      : value.content_type === 'file'
+        ? value.file
+        : '(base64)';
   return (
     <Badge variant="secondary" className="gap-1 text-[11px] font-vsc-mono">
       {label}: {ref}

--- a/typescript2/pkg-playground/src/renderers/PromptAst.tsx
+++ b/typescript2/pkg-playground/src/renderers/PromptAst.tsx
@@ -3,7 +3,11 @@
  */
 
 import type { FC } from 'react';
-import type { BamlJsPromptAst, BamlJsPromptAstSimple, BamlJsPromptAstMessage } from '@b/pkg-proto';
+import type {
+  BamlJsPromptAst,
+  BamlJsPromptAstSimple,
+  BamlJsPromptAstMessage,
+} from '@b/pkg-proto';
 import type { ResultRendererProps } from '../result-renderers';
 import { MediaRenderer } from './Media';
 import { CodeBlock } from '../components/ui/code-block';
@@ -45,12 +49,18 @@ const MessageBlock: FC<{ msg: BamlJsPromptAstMessage }> = ({ msg }) => {
   return (
     <div className="rounded border border-vsc-border overflow-hidden">
       <div className="flex items-center gap-1.5 px-2 py-1 bg-vsc-surface border-b border-vsc-border-subtle">
-        <span className={`font-semibold text-[11px] uppercase tracking-wide ${roleColor}`}>
+        <span
+          className={`font-semibold text-[11px] uppercase tracking-wide ${roleColor}`}
+        >
           {msg.role}
         </span>
       </div>
       <div className="px-2 py-1.5 text-xs leading-relaxed text-vsc-text">
-        {msg.content ? <SimpleContent node={msg.content} /> : <span className="text-vsc-text-faint">(empty)</span>}
+        {msg.content ? (
+          <SimpleContent node={msg.content} />
+        ) : (
+          <span className="text-vsc-text-faint">(empty)</span>
+        )}
       </div>
     </div>
   );
@@ -75,13 +85,20 @@ const AstNode: FC<{ node: BamlJsPromptAst }> = ({ node }) => {
   }
 };
 
-export const PromptAstRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
+export const PromptAstRenderer: FC<ResultRendererProps> = ({
+  value,
+  displayMode,
+}) => {
   if (!isPromptAst(value)) {
     return <CodeBlock>{JSON.stringify(value, null, 2)}</CodeBlock>;
   }
 
   if (displayMode === 'inline') {
-    return <span className="font-vsc-mono text-xs text-vsc-text-faint">&lt;prompt_ast&gt;</span>;
+    return (
+      <span className="font-vsc-mono text-xs text-vsc-text-faint">
+        &lt;prompt_ast&gt;
+      </span>
+    );
   }
 
   return (

--- a/typescript2/pkg-playground/src/renderers/ShellOutput.tsx
+++ b/typescript2/pkg-playground/src/renderers/ShellOutput.tsx
@@ -53,15 +53,24 @@ function inlineSummary(code: number, stdout: string, stderr: string): string {
   const parts = [`shell exit ${code}.`];
   const stdoutLines = stdout ? stdout.split('\n').filter(Boolean).length : 0;
   const stderrLines = stderr ? stderr.split('\n').filter(Boolean).length : 0;
-  if (stdoutLines > 0) parts.push(`stdout: ${stdoutLines} ${stdoutLines === 1 ? 'line' : 'lines'}.`);
-  if (stderrLines > 0) parts.push(`stderr: ${stderrLines} ${stderrLines === 1 ? 'line' : 'lines'}.`);
+  if (stdoutLines > 0)
+    parts.push(
+      `stdout: ${stdoutLines} ${stdoutLines === 1 ? 'line' : 'lines'}.`,
+    );
+  if (stderrLines > 0)
+    parts.push(
+      `stderr: ${stderrLines} ${stderrLines === 1 ? 'line' : 'lines'}.`,
+    );
   if (stdoutLines === 0 && stderrLines === 0) parts.push('no output.');
   return parts.join(' ');
 }
 
 type OutputTab = 'stdout' | 'stderr';
 
-const OutputTabs: FC<{ stdout: string; stderr: string }> = ({ stdout, stderr }) => {
+const OutputTabs: FC<{ stdout: string; stderr: string }> = ({
+  stdout,
+  stderr,
+}) => {
   const [tab, setTab] = useState<OutputTab>('stdout');
   const content = tab === 'stdout' ? stdout : stderr;
   const empty = !content;
@@ -84,11 +93,13 @@ const OutputTabs: FC<{ stdout: string; stderr: string }> = ({ stdout, stderr }) 
       {empty ? (
         <div className="text-[11px] text-vsc-text-faint italic pl-1">empty</div>
       ) : (
-        <pre className={`whitespace-pre-wrap p-1.5 rounded overflow-auto max-h-[300px] m-0 text-xs ${
-          isErr
-            ? 'bg-red-500/5 border border-red-500/20 text-red-300'
-            : 'bg-vsc-bg border border-vsc-border text-vsc-text'
-        }`}>
+        <pre
+          className={`whitespace-pre-wrap p-1.5 rounded overflow-auto max-h-[300px] m-0 text-xs ${
+            isErr
+              ? 'bg-red-500/5 border border-red-500/20 text-red-300'
+              : 'bg-vsc-bg border border-vsc-border text-vsc-text'
+          }`}
+        >
           {content}
         </pre>
       )}
@@ -96,11 +107,18 @@ const OutputTabs: FC<{ stdout: string; stderr: string }> = ({ stdout, stderr }) 
   );
 };
 
-export const ShellOutputRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
+export const ShellOutputRenderer: FC<ResultRendererProps> = ({
+  value,
+  displayMode,
+}) => {
   const [expanded, setExpanded] = useState(false);
   const shell = isShellOutput(value) ? value : null;
   if (!shell) {
-    return <pre className="font-vsc-mono text-xs text-vsc-text">{JSON.stringify(value, null, 2)}</pre>;
+    return (
+      <pre className="font-vsc-mono text-xs text-vsc-text">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
   }
 
   const ok = shell.exit_code === 0;
@@ -114,7 +132,9 @@ export const ShellOutputRenderer: FC<ResultRendererProps> = ({ value, displayMod
     return (
       <span className="font-vsc-mono text-xs inline-flex items-center gap-1.5">
         <span className="text-vsc-text-muted">baml.sys.ShellOutput</span>
-        <span className={`px-1.5 py-0.5 rounded text-[10px] font-semibold ${ok ? 'bg-green-500/15 text-green-400' : 'bg-red-500/15 text-red-400'}`}>
+        <span
+          className={`px-1.5 py-0.5 rounded text-[10px] font-semibold ${ok ? 'bg-green-500/15 text-green-400' : 'bg-red-500/15 text-red-400'}`}
+        >
           exit_code: {code}
         </span>
       </span>
@@ -127,7 +147,9 @@ export const ShellOutputRenderer: FC<ResultRendererProps> = ({ value, displayMod
       {/* Header: class name + exit code */}
       <div className="flex items-center gap-2">
         <span className="text-vsc-text-muted">baml.sys.ShellOutput</span>
-        <span className={`px-1.5 py-0.5 rounded text-[10px] font-semibold ${ok ? 'bg-green-500/15 text-green-400' : 'bg-red-500/15 text-red-400'}`}>
+        <span
+          className={`px-1.5 py-0.5 rounded text-[10px] font-semibold ${ok ? 'bg-green-500/15 text-green-400' : 'bg-red-500/15 text-red-400'}`}
+        >
           exit_code: {code}
         </span>
       </div>

--- a/typescript2/pkg-playground/src/renderers/TestReport.tsx
+++ b/typescript2/pkg-playground/src/renderers/TestReport.tsx
@@ -24,7 +24,10 @@ function isTestReport(value: unknown): value is TestReportShape {
   return typeof o.outcome === 'string';
 }
 
-const outcomeIcon: Record<string, { icon: typeof CheckCircle2; color: string; label: string }> = {
+const outcomeIcon: Record<
+  string,
+  { icon: typeof CheckCircle2; color: string; label: string }
+> = {
   pass: { icon: CheckCircle2, color: 'text-green-500', label: 'Passed' },
   fail: { icon: XCircle, color: 'text-red-500', label: 'Failed' },
   error: { icon: AlertCircle, color: 'text-orange-500', label: 'Error' },
@@ -35,13 +38,24 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
-export const TestReportRenderer: FC<ResultRendererProps> = ({ value, displayMode }) => {
+export const TestReportRenderer: FC<ResultRendererProps> = ({
+  value,
+  displayMode,
+}) => {
   if (!isTestReport(value)) {
-    return <pre className="whitespace-pre font-vsc-mono text-xs p-3 rounded bg-vsc-bg border border-vsc-border text-vsc-text overflow-auto max-h-[400px] m-0">{JSON.stringify(value, null, 2)}</pre>;
+    return (
+      <pre className="whitespace-pre font-vsc-mono text-xs p-3 rounded bg-vsc-bg border border-vsc-border text-vsc-text overflow-auto max-h-[400px] m-0">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
   }
 
   if (displayMode === 'inline') {
-    return <span className="font-vsc-mono text-xs text-vsc-text">{value.outcome} ({value.runs?.length ?? 0} runs)</span>;
+    return (
+      <span className="font-vsc-mono text-xs text-vsc-text">
+        {value.outcome} ({value.runs?.length ?? 0} runs)
+      </span>
+    );
   }
 
   const info = outcomeIcon[value.outcome ?? ''] ?? outcomeIcon.error;
@@ -54,7 +68,9 @@ export const TestReportRenderer: FC<ResultRendererProps> = ({ value, displayMode
       {/* Overall outcome */}
       <div className="flex items-center gap-2">
         <Icon size={20} className={info.color} />
-        <span className={cn('text-sm font-semibold', info.color)}>{info.label}</span>
+        <span className={cn('text-sm font-semibold', info.color)}>
+          {info.label}
+        </span>
         {totalDuration > 0 && (
           <span className="flex items-center gap-1 text-xs text-vsc-text-faint ml-auto">
             <Clock size={12} />
@@ -75,7 +91,9 @@ export const TestReportRenderer: FC<ResultRendererProps> = ({ value, displayMode
                 className="flex items-center gap-2 text-xs font-vsc-mono py-0.5 px-2 rounded bg-vsc-bg-alt"
               >
                 <RunIcon size={12} className={runInfo.color} />
-                <span className={cn('text-[11px]', runInfo.color)}>{runInfo.label}</span>
+                <span className={cn('text-[11px]', runInfo.color)}>
+                  {runInfo.label}
+                </span>
                 {(run.duration_ms ?? 0) > 0 && (
                   <span className="text-vsc-text-faint ml-auto">
                     {formatDuration(run.duration_ms!)}

--- a/typescript2/pkg-playground/src/result-renderers.ts
+++ b/typescript2/pkg-playground/src/result-renderers.ts
@@ -37,14 +37,19 @@ const registry = new Map<string, FC<ResultRendererProps>>();
  * Register a React component to render results of a given BAML type.
  * Example: registerResultRenderer('baml.http.Request', HttpRequestCurlRenderer);
  */
-export function registerResultRenderer(type: string, Component: FC<ResultRendererProps>): void {
+export function registerResultRenderer(
+  type: string,
+  Component: FC<ResultRendererProps>,
+): void {
   registry.set(type, Component);
 }
 
 /**
  * Get the renderer component for a BAML type, or undefined if none registered.
  */
-export function getResultRenderer(type: string): FC<ResultRendererProps> | undefined {
+export function getResultRenderer(
+  type: string,
+): FC<ResultRendererProps> | undefined {
   return registry.get(type);
 }
 
@@ -52,6 +57,9 @@ export function getResultRenderer(type: string): FC<ResultRendererProps> | undef
  * Return all currently registered (type, Component) pairs.
  * Used by ResultDisplay to resolve renderers.
  */
-export function getRegisteredResultRenderers(): Map<string, FC<ResultRendererProps>> {
+export function getRegisteredResultRenderers(): Map<
+  string,
+  FC<ResultRendererProps>
+> {
   return new Map(registry);
 }

--- a/typescript2/pkg-playground/src/shared/__tests__/companion-functions.test.ts
+++ b/typescript2/pkg-playground/src/shared/__tests__/companion-functions.test.ts
@@ -3,7 +3,11 @@ import { companionFunctionName } from '../companion-functions';
 
 describe('companion-functions', () => {
   it('uses the compiler companion naming convention', () => {
-    expect(companionFunctionName('ClassifySentiment', 'render_prompt')).toBe('ClassifySentiment$render_prompt');
-    expect(companionFunctionName('ClassifySentiment', 'build_request')).toBe('ClassifySentiment$build_request');
+    expect(companionFunctionName('ClassifySentiment', 'render_prompt')).toBe(
+      'ClassifySentiment$render_prompt',
+    );
+    expect(companionFunctionName('ClassifySentiment', 'build_request')).toBe(
+      'ClassifySentiment$build_request',
+    );
   });
 });

--- a/typescript2/pkg-playground/src/shared/__tests__/format-value.test.ts
+++ b/typescript2/pkg-playground/src/shared/__tests__/format-value.test.ts
@@ -42,7 +42,11 @@ describe('formatValue', () => {
   });
 
   it('formats prompt_ast', () => {
-    const value = { $baml: { type: '$prompt_ast' }, content_type: 'simple', value: {} };
+    const value = {
+      $baml: { type: '$prompt_ast' },
+      content_type: 'simple',
+      value: {},
+    };
     expect(formatValue(value, 'inline-hint')).toBe('<prompt_ast>');
   });
 

--- a/typescript2/pkg-playground/src/shared/__tests__/media-values.test.ts
+++ b/typescript2/pkg-playground/src/shared/__tests__/media-values.test.ts
@@ -38,7 +38,10 @@ describe('media-values', () => {
   });
 
   it('extracts nested image media while ignoring non-image media', () => {
-    const value = ['caption', { first: imageUrl, nested: [audio, imageBase64] }];
+    const value = [
+      'caption',
+      { first: imageUrl, nested: [audio, imageBase64] },
+    ];
     expect(findImageMedia(value)).toEqual([imageUrl, imageBase64]);
   });
 });

--- a/typescript2/pkg-playground/src/shared/companion-functions.ts
+++ b/typescript2/pkg-playground/src/shared/companion-functions.ts
@@ -1,5 +1,8 @@
 export type LlmCompanionFunction = 'render_prompt' | 'build_request';
 
-export function companionFunctionName(functionName: string, companion: LlmCompanionFunction): string {
+export function companionFunctionName(
+  functionName: string,
+  companion: LlmCompanionFunction,
+): string {
   return `${functionName}$${companion}`;
 }

--- a/typescript2/pkg-playground/src/shared/deserialize-event.ts
+++ b/typescript2/pkg-playground/src/shared/deserialize-event.ts
@@ -1,11 +1,16 @@
 import { deserializeValue, type RuntimeEvent } from '@b/pkg-proto';
-import type { DeserializedRuntimeEvent, DeserializedEventKind } from '../worker-protocol';
+import type {
+  DeserializedRuntimeEvent,
+  DeserializedEventKind,
+} from '../worker-protocol';
 
 function wrapHandle(key: bigint, handleType: number, typeName: string) {
   return { handle_key: key, handle_type: handleType, type_name: typeName };
 }
 
-export function deserializeRuntimeEvent(event: RuntimeEvent): DeserializedRuntimeEvent {
+export function deserializeRuntimeEvent(
+  event: RuntimeEvent,
+): DeserializedRuntimeEvent {
   let deserializedKind: DeserializedEventKind | undefined;
   const kind = event.event?.kind;
   if (kind) {
@@ -15,7 +20,9 @@ export function deserializeRuntimeEvent(event: RuntimeEvent): DeserializedRuntim
           $case: 'functionStart',
           functionStart: {
             name: kind.functionStart.name,
-            args: kind.functionStart.args.map((arg) => deserializeValue(arg, wrapHandle)),
+            args: kind.functionStart.args.map((arg) =>
+              deserializeValue(arg, wrapHandle),
+            ),
           },
         };
         break;
@@ -36,7 +43,9 @@ export function deserializeRuntimeEvent(event: RuntimeEvent): DeserializedRuntim
         deserializedKind = {
           $case: 'log',
           log: {
-            data: kind.log.data ? deserializeValue(kind.log.data, wrapHandle) : null,
+            data: kind.log.data
+              ? deserializeValue(kind.log.data, wrapHandle)
+              : null,
             level: kind.log.level,
             source: kind.log.source,
           },
@@ -47,7 +56,9 @@ export function deserializeRuntimeEvent(event: RuntimeEvent): DeserializedRuntim
           $case: 'custom',
           custom: {
             name: kind.custom.name,
-            data: kind.custom.data ? deserializeValue(kind.custom.data, wrapHandle) : null,
+            data: kind.custom.data
+              ? deserializeValue(kind.custom.data, wrapHandle)
+              : null,
           },
         };
         break;

--- a/typescript2/pkg-playground/src/shared/format-value.ts
+++ b/typescript2/pkg-playground/src/shared/format-value.ts
@@ -5,7 +5,10 @@ import { getBamlType } from '../result-renderers';
  * Format a BamlJsValue as a compact string for non-React contexts
  * (e.g. Monaco editor inline decorations).
  */
-export function formatValue(value: BamlJsValue | null | undefined, mode: 'inline-hint'): string {
+export function formatValue(
+  value: BamlJsValue | null | undefined,
+  mode: 'inline-hint',
+): string {
   if (value == null) return 'null';
   if (typeof value === 'string') return JSON.stringify(value);
   if (typeof value === 'number') return String(value);

--- a/typescript2/pkg-playground/src/shared/log-decorations.ts
+++ b/typescript2/pkg-playground/src/shared/log-decorations.ts
@@ -9,9 +9,14 @@ export function truncateMessage(msg: string, maxLen: number = 60): string {
 /** Map log level string to our LogLevel type. */
 export function normalizeLogLevel(level: string): LogLevel {
   switch (level.toLowerCase()) {
-    case 'error': return 'error';
-    case 'warn': case 'warning': return 'warn';
-    case 'debug': return 'debug';
-    default: return 'info';
+    case 'error':
+      return 'error';
+    case 'warn':
+    case 'warning':
+      return 'warn';
+    case 'debug':
+      return 'debug';
+    default:
+      return 'info';
   }
 }

--- a/typescript2/pkg-playground/src/shared/media-values.ts
+++ b/typescript2/pkg-playground/src/shared/media-values.ts
@@ -21,7 +21,9 @@ export function mediaToSrc(media: BamlJsMedia): string | null {
 }
 
 export function mediaLabel(media: BamlJsMedia): string {
-  return media.mime_type ? `${media.media_type} (${media.mime_type})` : media.media_type;
+  return media.mime_type
+    ? `${media.media_type} (${media.mime_type})`
+    : media.media_type;
 }
 
 export function findImageMedia(
@@ -34,7 +36,8 @@ export function findImageMedia(
   const seen = new WeakSet<object>();
 
   function visit(current: unknown, depth: number) {
-    if (images.length >= maxItems || current == null || depth > maxDepth) return;
+    if (images.length >= maxItems || current == null || depth > maxDepth)
+      return;
 
     if (isBamlMedia(current)) {
       if (current.media_type === 'image') images.push(current);
@@ -51,7 +54,9 @@ export function findImageMedia(
       return;
     }
 
-    for (const [key, child] of Object.entries(current as Record<string, unknown>)) {
+    for (const [key, child] of Object.entries(
+      current as Record<string, unknown>,
+    )) {
       if (key === '$baml') continue;
       visit(child, depth + 1);
     }

--- a/typescript2/pkg-playground/src/styles/playground.css
+++ b/typescript2/pkg-playground/src/styles/playground.css
@@ -46,7 +46,10 @@
   --destructive-foreground: var(--vscode-editor-foreground, #cccccc);
 
   /* Borders + inputs */
-  --border: var(--vscode-panel-border, var(--vscode-editorWidget-border, #2b2b2b));
+  --border: var(
+    --vscode-panel-border,
+    var(--vscode-editorWidget-border, #2b2b2b)
+  );
   --input: var(--vscode-input-border, transparent);
   --ring: var(--vscode-focusBorder, #007fd4);
 }
@@ -84,8 +87,14 @@
   /* ─ Backward-compat vsc-* tokens (migrate off incrementally) ─ */
   --color-vsc-bg: var(--vscode-editor-background, #1f1f1f);
   --color-vsc-surface: var(--vscode-sideBar-background, #181818);
-  --color-vsc-panel: var(--vscode-panel-background, var(--vscode-editor-background, #1f1f1f));
-  --color-vsc-border: var(--vscode-panel-border, var(--vscode-editorWidget-border, #2b2b2b));
+  --color-vsc-panel: var(
+    --vscode-panel-background,
+    var(--vscode-editor-background, #1f1f1f)
+  );
+  --color-vsc-border: var(
+    --vscode-panel-border,
+    var(--vscode-editorWidget-border, #2b2b2b)
+  );
   --color-vsc-border-subtle: var(--vscode-widget-border, #2b2b2b);
   --color-vsc-text: var(--vscode-editor-foreground, #cccccc);
   --color-vsc-text-bright: var(--vscode-foreground, #cccccc);
@@ -98,7 +107,10 @@
   --color-vsc-green: var(--vscode-testing-iconPassed, #3fb950);
   --color-vsc-red: var(--vscode-errorForeground, #f85149);
   --color-vsc-yellow: var(--vscode-editorWarning-foreground, #d29922);
-  --color-vsc-yellow-subtle: var(--vscode-inputValidation-warningBackground, rgba(210, 153, 34, 0.15));
+  --color-vsc-yellow-subtle: var(
+    --vscode-inputValidation-warningBackground,
+    rgba(210, 153, 34, 0.15)
+  );
   --color-vsc-input-bg: var(--vscode-input-background, #313131);
   --color-vsc-input-fg: var(--vscode-input-foreground, #cccccc);
   --color-vsc-input-border: var(--vscode-input-border, transparent);
@@ -111,8 +123,22 @@
   --color-vsc-list-hoverBg: var(--vscode-list-hoverBackground, #2a2d2e);
 
   /* ─ Fonts ─ */
-  --font-vsc: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif);
-  --font-vsc-mono: var(--vscode-editor-font-family, "SF Mono", "Fira Code", Consolas, monospace);
+  --font-vsc: var(
+    --vscode-font-family,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Helvetica,
+    Arial,
+    sans-serif
+  );
+  --font-vsc-mono: var(
+    --vscode-editor-font-family,
+    "SF Mono",
+    "Fira Code",
+    Consolas,
+    monospace
+  );
 }
 
 /* ── Scoped preflight reset ────────────────────────────────────────── */
@@ -127,9 +153,9 @@
   }
 
   .playground-root button,
-  .playground-root [type='button'],
-  .playground-root [type='reset'],
-  .playground-root [type='submit'] {
+  .playground-root [type="button"],
+  .playground-root [type="reset"],
+  .playground-root [type="submit"] {
     appearance: none;
     background-color: transparent;
     background-image: none;

--- a/typescript2/pkg-playground/src/wasm-panic/install.ts
+++ b/typescript2/pkg-playground/src/wasm-panic/install.ts
@@ -30,8 +30,11 @@ export function installWasmPanicHook(): void {
     const firstArg = args[0];
     if (typeof firstArg === 'string') {
       // Rust panics via console_error_panic_hook typically start with "panicked at"
-      if (firstArg.includes('panicked at') || firstArg.includes('wasm-bindgen')) {
-        const message = args.map(a => String(a)).join(' ');
+      if (
+        firstArg.includes('panicked at') ||
+        firstArg.includes('wasm-bindgen')
+      ) {
+        const message = args.map((a) => String(a)).join(' ');
         registry.set_message(message);
         // Notify immediately when panic is detected
         if (panicCallback) {

--- a/typescript2/pkg-playground/src/wasm-panic/panic.ts
+++ b/typescript2/pkg-playground/src/wasm-panic/panic.ts
@@ -19,7 +19,10 @@ export function getWasmPanicRegistry(): WasmPanicRegistry {
   return globalWithWasm.BAML_WASM_PANIC_REGISTRY;
 }
 
-export function getWasmError(error: WasmPanic): { message: string; stack: string } {
+export function getWasmError(error: WasmPanic): {
+  message: string;
+  stack: string;
+} {
   const registry = getWasmPanicRegistry();
   const panicMessage = registry.get();
   const message = panicMessage || error.message || 'Unknown WASM panic';

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -6,7 +6,12 @@
  * gives exhaustive switch narrowing.
  */
 
-import type { BamlJsValue, PlainHandleDescriptor, SourceLocation, TagEntry } from '@b/pkg-proto';
+import type {
+  BamlJsValue,
+  PlainHandleDescriptor,
+  SourceLocation,
+  TagEntry,
+} from '@b/pkg-proto';
 
 /** Runtime event with BamlOutboundValue fields deserialized to BamlJsValue. */
 export interface DeserializedRuntimeEvent {
@@ -19,9 +24,23 @@ export interface DeserializedRuntimeEvent {
 }
 
 export type DeserializedEventKind =
-  | { $case: 'functionStart'; functionStart: { name: string; args: BamlJsValue[] } }
-  | { $case: 'functionEnd'; functionEnd: { name: string; durationMs: number; result: BamlJsValue | null; error?: string | null } }
-  | { $case: 'log'; log: { data: BamlJsValue | null; level: string; source?: SourceLocation } }
+  | {
+      $case: 'functionStart';
+      functionStart: { name: string; args: BamlJsValue[] };
+    }
+  | {
+      $case: 'functionEnd';
+      functionEnd: {
+        name: string;
+        durationMs: number;
+        result: BamlJsValue | null;
+        error?: string | null;
+      };
+    }
+  | {
+      $case: 'log';
+      log: { data: BamlJsValue | null; level: string; source?: SourceLocation };
+    }
   | { $case: 'custom'; custom: { name: string; data: BamlJsValue | null } }
   | { $case: 'setTags'; setTags: { tags: TagEntry[] } };
 
@@ -50,10 +69,11 @@ interface SourceNavigationTargetBase {
   endOffset?: number;
 }
 
-export type SourceNavigationTarget = SourceNavigationTargetBase & (
-  | { fileId: number; filePath?: string }
-  | { filePath: string; fileId?: number }
-);
+export type SourceNavigationTarget = SourceNavigationTargetBase &
+  (
+    | { fileId: number; filePath?: string }
+    | { filePath: string; fileId?: number }
+  );
 
 // ---------------------------------------------------------------------------
 // Shared domain types
@@ -101,9 +121,20 @@ export type PlaygroundNotification =
   | { type: 'listProjects'; projects: string[] }
   | { type: 'updateProject'; project: string; update: ProjectUpdate }
   | { type: 'openPlayground'; project: string; functionName?: string }
-  | { type: 'controlFlowGraphResult'; functionName: string; graph: ControlFlowGraph | null }
+  | {
+      type: 'controlFlowGraphResult';
+      functionName: string;
+      graph: ControlFlowGraph | null;
+    }
   | { type: 'cursorContext'; context: CursorContext }
-  | { type: 'testCollectionResult'; project: string; generation: number; callId: number; data: number[]; expandError?: { testsetName: string; message: string } }
+  | {
+      type: 'testCollectionResult';
+      project: string;
+      generation: number;
+      callId: number;
+      data: number[];
+      expandError?: { testsetName: string; message: string };
+    }
   | { type: 'runtimeEvent'; data: number[]; callId?: number };
 
 // ---------------------------------------------------------------------------
@@ -117,7 +148,8 @@ export type CfgNodeType =
   | 'branchGroup'
   | 'branchArm'
   | 'loop'
-  | 'otherScope';
+  | 'otherScope'
+  | 'return';
 
 export interface CfgNode {
   id: number;
@@ -129,6 +161,10 @@ export interface CfgNode {
   nodeType: CfgNodeType;
   llmClient?: string;
   calleeName?: string;
+  /** ALL functions called anywhere inside this node's expression subtree
+   *  (e.g. an if-condition `Abs(LineTotal(x))` reports both). Superset of
+   *  calleeName. Absent on older runtimes. */
+  calleeNames?: string[];
   isContainer: boolean;
 }
 
@@ -212,24 +248,46 @@ export type WorkerOutMessage =
   | { type: 'ready' }
   | { type: 'playgroundNotification'; notification: PlaygroundNotification }
   | { type: 'diagnostics'; entries: DiagnosticEntry[] }
-  | { type: 'callFunctionResult'; id: number; result: BamlJsValue<PlainHandleDescriptor> }
-  | { type: 'callFunctionError'; id: number; error: string; cancelled?: boolean }
+  | {
+      type: 'callFunctionResult';
+      id: number;
+      result: BamlJsValue<PlainHandleDescriptor>;
+    }
+  | {
+      type: 'callFunctionError';
+      id: number;
+      error: string;
+      cancelled?: boolean;
+    }
   | { type: 'nextFunctionCallResult'; id: number; callId: number }
   | { type: 'nextFunctionCallError'; id: number; error: string }
   | { type: 'fetchLogNew'; entry: FetchLogEntry }
   | { type: 'fetchLogUpdate'; logId: number; patch: Partial<FetchLogEntry> }
-  | { type: 'runtimeEventNew'; event: DeserializedRuntimeEvent; callId: number | null }
+  | {
+      type: 'runtimeEventNew';
+      event: DeserializedRuntimeEvent;
+      callId: number | null;
+    }
   | { type: 'runtimeEventError'; error: string }
   | { type: 'envVarRequest'; id: number; variable: string }
   | { type: 'processEnvVars'; vars: Record<string, string> }
   | { type: 'envVarFromShell'; variable: string; value: string }
   | { type: 'knownEnvVarNames'; names: string[] }
-  | { type: 'inputRequest'; id: number; prompt: string | undefined; callId: number }
+  | {
+      type: 'inputRequest';
+      id: number;
+      prompt: string | undefined;
+      callId: number;
+    }
   | { type: 'inputResolved'; id: number; callId: number }
   | { type: 'vfsFileChanged'; path: string; content: string }
   | { type: 'vfsFileDeleted'; path: string }
   | { type: 'buildTime'; value: string }
-  | { type: 'controlFlowGraphResult'; functionName: string; graph: ControlFlowGraph | null }
+  | {
+      type: 'controlFlowGraphResult';
+      functionName: string;
+      graph: ControlFlowGraph | null;
+    }
   | { type: 'cursorContext'; context: CursorContext }
   | { type: 'logDecorations'; decorations: LogDecoration[] }
   | { type: 'clearLogDecorations' }
@@ -241,10 +299,21 @@ export type WorkerOutMessage =
 
 export type WorkerInMessage =
   | { type: 'nextFunctionCall'; id: number }
-  | { type: 'callFunction'; id: number; name: string; argsProto: Uint8Array; project: string }
+  | {
+      type: 'callFunction';
+      id: number;
+      name: string;
+      argsProto: Uint8Array;
+      project: string;
+    }
   | { type: 'cancelCall'; id: number; project: string }
   | { type: 'clearHandles'; runIds: number[] }
-  | { type: 'envVarResponse'; id: number; value: string | undefined; variable?: string }
+  | {
+      type: 'envVarResponse';
+      id: number;
+      value: string | undefined;
+      variable?: string;
+    }
   | { type: 'inputResponse'; id: number; value: string; callId: number }
   | { type: 'setEnvVar'; key: string; value: string }
   | { type: 'deleteEnvVar'; key: string }
@@ -253,8 +322,19 @@ export type WorkerInMessage =
   | { type: 'requestControlFlowGraph'; project: string; functionName: string }
   | { type: 'cursorPosition'; file: string; line: number; column: number }
   | { type: 'requestCollectTests'; project: string }
-  | { type: 'callTestFunction'; id: number; project: string; generation: number; testName: string }
-  | { type: 'expandTestSet'; project: string; generation: number; testsetName: string }
+  | {
+      type: 'callTestFunction';
+      id: number;
+      project: string;
+      generation: number;
+      testName: string;
+    }
+  | {
+      type: 'expandTestSet';
+      project: string;
+      generation: number;
+      testsetName: string;
+    }
   | { type: 'filesChanged'; files: Record<string, string> }
   | { type: 'dispose' };
 

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -120,7 +120,13 @@ export interface ProjectUpdate {
 export type PlaygroundNotification =
   | { type: 'listProjects'; projects: string[] }
   | { type: 'updateProject'; project: string; update: ProjectUpdate }
-  | { type: 'openPlayground'; project: string; functionName?: string }
+  | {
+      type: 'openPlayground';
+      project: string;
+      functionName?: string;
+      testName?: string;
+      testsetName?: string;
+    }
   | {
       type: 'controlFlowGraphResult';
       functionName: string;

--- a/typescript2/pkg-playground/wasm.version
+++ b/typescript2/pkg-playground/wasm.version
@@ -1,0 +1,1 @@
+0.1.0-canary.90ffe2cae

--- a/typescript2/pkg-proto/src/encode.ts
+++ b/typescript2/pkg-proto/src/encode.ts
@@ -74,7 +74,7 @@ function serializeValue(val: unknown): InboundValue {
       typeof (bamlMarker as Record<string, unknown>).type === 'string'
     ) {
       const typeStr = (bamlMarker as { type: string }).type;
-      const sepIdx = typeStr.indexOf('::');
+      const sepIdx = typeStr.lastIndexOf('::');
       const className =
         sepIdx >= 0 ? typeStr.slice(sepIdx + 2) : typeStr;
       const fields: InboundMapEntry[] = Object.entries(val)

--- a/typescript2/pkg-proto/src/encode.ts
+++ b/typescript2/pkg-proto/src/encode.ts
@@ -62,6 +62,34 @@ function serializeValue(val: unknown): InboundValue {
     if (isBamlSerializable(val)) {
       return val.toBaml();
     }
+    // Honour a `$baml: { type: 'ClassName' }` (or `'Namespace::ClassName'`)
+    // marker so JSON shaped like `decodeCallResult` output round-trips back as
+    // a `classValue`. Without this, every plain object would serialize as a
+    // map, making typed function calls (e.g. `(inv: Invoice)`) fail with
+    // "expected instance, got map" inside the runtime.
+    const bamlMarker = (val as Record<string, unknown>)['$baml'];
+    if (
+      bamlMarker &&
+      typeof bamlMarker === 'object' &&
+      typeof (bamlMarker as Record<string, unknown>).type === 'string'
+    ) {
+      const typeStr = (bamlMarker as { type: string }).type;
+      const sepIdx = typeStr.indexOf('::');
+      const className =
+        sepIdx >= 0 ? typeStr.slice(sepIdx + 2) : typeStr;
+      const fields: InboundMapEntry[] = Object.entries(val)
+        .filter(([k]) => k !== '$baml')
+        .map(([k, v]) => ({
+          key: { $case: 'stringKey' as const, stringKey: k },
+          value: serializeValue(v),
+        }));
+      return {
+        value: {
+          $case: 'classValue',
+          classValue: { name: className, fields },
+        },
+      };
+    }
     // Plain object → map with string keys
     const entries: InboundMapEntry[] = Object.entries(val).map(
       ([k, v]) => ({

--- a/typescript2/pnpm-lock.yaml
+++ b/typescript2/pnpm-lock.yaml
@@ -875,9 +875,6 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/runtime@1.7.1':
-    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
-
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
@@ -4991,11 +4988,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -7223,11 +7215,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.7.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
@@ -7409,6 +7396,11 @@ snapshots:
       eslint: 10.4.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.23.5':
@@ -7478,6 +7470,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@floating-ui/react-dom@2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -7486,7 +7484,7 @@ snapshots:
 
   '@floating-ui/react@0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@floating-ui/utils': 0.2.10
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7696,7 +7694,7 @@ snapshots:
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -8529,7 +8527,7 @@ snapshots:
 
   '@redux-devtools/extension@3.3.0(redux@5.0.1)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       immutable: 4.3.7
       redux: 5.0.1
 
@@ -9059,7 +9057,7 @@ snapshots:
 
   '@typescript-eslint/utils@8.50.1(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.50.1
       '@typescript-eslint/types': 8.50.1
       '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.3)
@@ -11549,8 +11547,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.12: {}
 
   napi-build-utils@2.0.0:
@@ -11756,7 +11752,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -11843,7 +11839,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -11855,7 +11851,7 @@ snapshots:
 
   postcss@8.5.6:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12023,7 +12019,7 @@ snapshots:
 
   react-base16-styling@0.9.1:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@types/base16': 1.0.5
       '@types/lodash': 4.17.21
       base16: 1.0.0
@@ -12044,7 +12040,7 @@ snapshots:
 
   react-error-boundary@5.0.0(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       react: 18.3.1
 
   react-is@16.13.1: {}
@@ -12053,7 +12049,7 @@ snapshots:
 
   react-json-tree@0.18.0(@types/react@18.3.26)(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@types/lodash': 4.17.21
       '@types/react': 18.3.26
       react: 18.3.1
@@ -12100,7 +12096,7 @@ snapshots:
 
   react-textarea-autosize@8.5.9(@types/react@18.3.26)(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       react: 18.3.1
       use-composed-ref: 1.4.0(@types/react@18.3.26)(react@18.3.1)
       use-latest: 1.3.0(@types/react@18.3.26)(react@18.3.1)

--- a/typescript2/pnpm-workspace.yaml
+++ b/typescript2/pnpm-workspace.yaml
@@ -7,9 +7,24 @@ packages:
 allowBuilds:
   '@bufbuild/buf': true
   '@mongodb-js/zstd': true
+  # downloads a prebuilt binary; @posthog/nextjs-config shells out to it
+  '@posthog/cli': true
+  # telemetry only
+  '@scarf/scarf': false
+  # native binding for Tailwind v4
+  '@tailwindcss/oxide': true
+  # postinstall is only an advisory VERCEL_ANALYTICS_ID env check
+  '@vercel/speed-insights': false
+  # postinstall only prints a funding banner
+  core-js: false
   esbuild: true
   msw: true
-  node-liblzma: true
+  # native build needs system liblzma headers, which CI/Vercel images lack.
+  # Was `pnpm.neverBuiltDependencies` in package.json before pnpm 11 stopped
+  # reading that field; just-bash (app-promptfiddle) works without it.
+  node-liblzma: false
+  # selects/downloads prebuilt libvips; Next image optimization needs it
+  sharp: true
   unrs-resolver: true
 
 catalog:


### PR DESCRIPTION
## Summary

This PR extracts the non-website work from `dhilan/website-v1` onto current `canary` so those improvements can land without the large `typescript2/app-website` import.

Changes include:
- BAML language-side updates for describe/LSP/control-flow visualization/project/wasm playground plumbing.
- `typescript2/pkg-playground` UI/runtime/protocol updates, including server-assigned function call IDs and graph/runtime rendering improvements.
- `@b/pkg-proto` call argument encoding support needed by the playground call path.
- Non-website package/workspace and lockfile updates.

Notably excluded:
- `typescript2/app-website` is not present in the diff.

## Validation

- `cargo nextest run -p baml_cli describe_command_tests --no-fail-fast`
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter @b/pkg-playground test`
- `pnpm --filter @b/pkg-proto test`
- `git diff --check origin/canary...HEAD`

## Diff Shape

- `82 files changed, 5969 insertions(+), 2151 deletions(-)`
- `0` files under `typescript2/app-website`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler visualization, LSP inlay resolution, and WASM↔JS protocol paths used by the playground; behavior changes are broad but covered by expanded Rust/TS tests rather than security-critical areas.
> 
> **Overview**
> This PR lands **non-website** improvements from a larger branch: playground/LSP plumbing, control-flow visualization, and deploy tooling—without the `app-website` import.
> 
> **Playground & LSP:** Code lenses and `OpenPlayground` now support **tests and testsets** (`testName` / `testsetName`) through the VS Code extension, native LSP, and WASM bridge. Inlay hints extend to **method bodies**, **desugared test/testset lambdas**, and **correct call-site scopes** (avoiding wrong parameter names); synthetic `register_test*` calls stay hidden.
> 
> **Control-flow graphs:** AST building adds **`NodeType::Return`**, **`for`-in** loops, **terminal returns** (no edges after `return`), **`calleeNames`** on nested calls, and synthetic **`else`** arms on else-if chains. Visualization **prunes** to `//#` headers and LLM sites (with edge **splicing** through dropped nodes), keeps returns visible in rendered scopes, and fixes **terminal subtrees** so early returns don’t fan out to successors. **Project expansion** marks LLM calls, relabels calls from function-level `//#` headers, and skips inlining under **return-of-call** nodes.
> 
> **WASM/JS boundary:** LSP and playground notifications that carry `serde_json::Value` now serialize via **plain JSON** so `arbitrary_precision` numbers don’t break positions and graph node IDs in the browser.
> 
> **Tooling:** Root **`.vercelignore`** trims monorepo uploads; **`prep-wasm-publish.mjs`** stages `@boundaryml/bridge-wasm`; `@b/pkg-playground` can resolve **TypeScript sources** directly for local dev. Describe CLI tests assert **tighter `--budget`** behavior for method sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d324efc224c13ec7b83004e2122b90a4d72ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discover and run tests and testsets from code lenses; playground opens can target tests/testsets.
  * Playground open payloads now include explicit test/testset targeting and display titles.

* **Control-flow Visualization**
  * Visualizations now show explicit return nodes, surface callee names, and prune unrelated structure for clearer graphs.

* **UI/UX Improvements**
  * Sidebar split into collapsible Functions and Tests sections.
  * Graph view: light theme, refreshed node/edge visuals, and remembered layout direction per function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->