### PR TITLE
Preserve long BAML test names across concat flattening

### DIFF
--- a/baml_language/crates/bex_engine/tests/collect_tests.rs
+++ b/baml_language/crates/bex_engine/tests/collect_tests.rs
@@ -383,6 +383,46 @@ async fn collect_tests_testset_let_used_in_test_name_concat() {
     );
 }
 
+#[tokio::test]
+async fn collect_tests_preserves_long_test_names_over_concat_boundary() {
+    let long_name = "a".repeat(41);
+    let expected_path = format!("levenshtein distance/{long_name}");
+    let source = format!(
+        r#"
+        testset "levenshtein distance" {{
+            test "equal strings return 0" {{
+                assert.is_true(true)
+            }}
+            test "kitten to sitting returns 3" {{
+                assert.is_true(true)
+            }}
+            test "{long_name}" {{
+                assert.is_true(true)
+            }}
+        }}
+    "#
+    );
+
+    let engine = make_engine(&source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    let expanded = expand_testset(&engine, registry.clone(), "levenshtein distance")
+        .await
+        .expect("expand_set should succeed");
+    let repr = format!("{expanded:?}");
+    assert!(
+        repr.contains(&expected_path),
+        "expected serialized registry to contain {expected_path:?}: {repr}"
+    );
+
+    run_named_test(&engine, registry, &expected_path)
+        .await
+        .expect("long test name should remain runnable");
+}
+
 /// If-condition reading a let-bound bool in a testset body.
 #[tokio::test]
 async fn collect_tests_testset_let_then_if_condition() {

--- a/baml_language/crates/bex_str/src/bex_str.rs
+++ b/baml_language/crates/bex_str/src/bex_str.rs
@@ -373,25 +373,14 @@ impl ConcatNode {
                     buf.extend_from_slice(&parent.data[o..o + l]);
                 }
                 BexStr::Concat(c) => {
-                    let mut inner_guard = c.state.lock().unwrap();
+                    let inner_guard = c.state.lock().unwrap();
                     match &*inner_guard {
                         ConcatState::Flattened(f) => {
                             buf.extend_from_slice(&f.data);
                         }
-                        ConcatState::Deferred { .. } => {
-                            let inner_old = std::mem::replace(
-                                &mut *inner_guard,
-                                ConcatState::Flattened(Arc::new(FlatStr {
-                                    hash: AtomicU64::new(0),
-                                    char_count: 0,
-                                    data: Box::new([]),
-                                })),
-                            );
-                            drop(inner_guard);
-                            if let ConcatState::Deferred { left, right } = inner_old {
-                                stack.push(right);
-                                stack.push(left);
-                            }
+                        ConcatState::Deferred { left, right } => {
+                            stack.push(right.clone());
+                            stack.push(left.clone());
                         }
                     }
                 }

--- a/baml_language/crates/bex_str/src/tests.rs
+++ b/baml_language/crates/bex_str/src/tests.rs
@@ -145,6 +145,24 @@ fn concat_flatten_idempotent() {
 }
 
 #[test]
+fn flattening_parent_concat_preserves_shared_child_concat() {
+    let name = "a".repeat(41);
+    let full_name = BexStr::concat(
+        BexStr::from("levenshtein distance/"),
+        BexStr::from(name.as_str()),
+    );
+    let expected = format!("levenshtein distance/{name}");
+    assert_eq!(full_name.len(), expected.len());
+    assert_eq!(full_name.as_str(), expected);
+
+    // This mirrors the test registry's `hash_prefix = full_name + "#"` path:
+    // flattening the derived parent must not corrupt the stored full name.
+    let hash_prefix = BexStr::concat(full_name.clone(), BexStr::from("#"));
+    assert_eq!(hash_prefix.as_str(), format!("{expected}#"));
+    assert_eq!(full_name.as_str(), expected);
+}
+
+#[test]
 fn empty_concat_variants() {
     let e = BexStr::empty();
     let a = BexStr::from("hello");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
- [ ] This PR fixes/closes #[issue number]

## The error
A testset with a fully-qualified test path over the concat inline boundary could serialize the final test as an empty name.

Failing repro:

```baml
testset "levenshtein distance" {
  test "equal strings return 0" {
    assert.is_true(true)
  }
  test "kitten to sitting returns 3" {
    assert.is_true(true)
  }
  test "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
    assert.is_true(true)
  }
}
```

Before the fix, `cargo run --quiet --bin baml-cli -- test --from /workspace/baml_language/tmp-long-name-repro-levenshtein-distance --list` produced:

```text
Selected 3 test(s)
  levenshtein distance::equal strings return 0  (<testset>)
  levenshtein distance::kitten to sitting returns 3  (<testset>)
  ::  (<testset>)
```

Running the tests failed at runtime:

```text
PASS levenshtein distance::equal strings return 0
PASS levenshtein distance::kitten to sitting returns 3
FAIL ::
  => UnhandledThrow { value: String("Test not found: "), trace: [StackFrame { function_name: "testing.TestRegistry.run_test", file_path: "<builtin>/testing/registry.baml", function_span: Span { file_id: FileId(44), range: 4402..5061 }, error_line: 150 }] }
error: test failures — 2 passed, 1 failed, 3 total
```

Filtering the actual name selected no tests:

```text
Finished no tests selected
```

## Root cause
The bug was in `baml_language/crates/bex_str/src/bex_str.rs`, specifically `ConcatNode::flatten`.

When flattening a parent `BexStr::Concat`, the iterative flattening logic replaced nested deferred concat nodes with a temporary flattened empty string before pushing their children onto the work stack. If that nested concat was shared elsewhere through `BexStr::clone`, the shared original value was permanently mutated to the empty placeholder.

The test registry hits that path in `testing/registry.baml` while registering test names: it stores `full_name`, then builds/compares a derived `hash_prefix = full_name + "#"`. For long fully-qualified names, both values share the same concat node. Flattening the derived prefix could therefore empty the stored `full_name`, which serialized as `::` and later failed lookup in `TestRegistry.run_test`.

## The fix
`ConcatNode::flatten` now traverses nested deferred concat nodes by cloning their left/right child `BexStr` values onto the local work stack instead of mutating those child concat nodes to an empty placeholder. Only the concat node being flattened stores its final flattened result.

Added regression coverage:

- `bex_str::tests::flattening_parent_concat_preserves_shared_child_concat` covers the shared-child concat corruption directly.
- `bex_engine::collect_tests_preserves_long_test_names_over_concat_boundary` covers the test registry path by expanding and running a 41-character test name under `testset "levenshtein distance"`.

## Verification
Reproduction after the fix:

```text
$ cargo run --quiet --bin baml-cli -- test --from "/workspace/baml_language/tmp-long-name-repro-levenshtein-distance" --list
Selected 3 test(s)
  levenshtein distance::equal strings return 0  (<testset>)
  levenshtein distance::kitten to sitting returns 3  (<testset>)
  levenshtein distance::aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  (<testset>)

$ cargo run --quiet --bin baml-cli -- test --from "/workspace/baml_language/tmp-long-name-repro-levenshtein-distance" -i 'levenshtein distance::aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
PASS levenshtein distance::aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
Finished 1 passed, 0 failed, 1 total

$ cargo run --quiet --bin baml-cli -- test --from "/workspace/baml_language/tmp-long-name-repro-levenshtein-distance"
PASS levenshtein distance::equal strings return 0
PASS levenshtein distance::kitten to sitting returns 3
PASS levenshtein distance::aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
Finished 3 passed, 0 failed, 3 total
```

Commands run from `baml_language/`:

```text
cargo test -p bex_str flattening_parent_concat_preserves_shared_child_concat
cargo test -p bex_engine collect_tests_preserves_long_test_names_over_concat_boundary
cargo test -p bex_str --lib
cargo test
cargo-insta pending-snapshots
cargo fmt --all
cargo clippy --all-targets -- -D warnings
```

Results:

- Targeted regressions: passed.
- `cargo test -p bex_str --lib`: 23 passed.
- Full `cargo test`: passed, final exit code 0.
- `cargo-insta pending-snapshots`: `No pending snapshots.`
- `cargo fmt --all`: passed.
- `cargo clippy --all-targets -- -D warnings`: passed.

Notes:

- I attempted workspace-forced `cargo test --lib`, but forcing standalone lib tests builds addon crates that intentionally opt out of that mode. `bridge_nodejs` cannot link standalone N-API symbols, and `bridge_python` cannot link `-lpython3.12` in this environment. The actual full workspace `cargo test` passed after running the documented SDK setup.
- CodeRabbit CLI was installed, but `CODERABBIT_API_KEY` was missing from the environment, so `coderabbit auth login --api-key "$CODERABBIT_API_KEY"` / `coderabbit review --plain --base canary` could not be run.

## Changes
- Preserve shared concat children when flattening `BexStr::Concat`.
- Add direct and registry-level regression tests for long test names.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in Linux cloud agent environment

## Screenshots
N/A

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A; no docs change needed for this internal bug fix)
- [x] My changes generate no new warnings

## Additional Notes
All code changes are inside `baml_language/`; the legacy `engine/` directory was not modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8b9e7c9-fe85-46df-a131-ee106f773e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8b9e7c9-fe85-46df-a131-ee106f773e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for long dynamically constructed test names across concat boundaries.
  * Added test coverage for string flattening behavior with shared concatenations.

* **Refactor**
  * Optimized nested concat node handling during string flattening operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->