### PR TITLE
Print CLI version in generate output

### DIFF
--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -16,7 +16,9 @@ use baml_project::ProjectDatabase;
 use clap::Args;
 use sdkgen_python_pydantic2::{NamingConvention, OutputType};
 
-use crate::{project_load::load_project_from_reporting, reporter::Reporter};
+use crate::{
+    commands::release_version, project_load::load_project_from_reporting, reporter::Reporter,
+};
 
 #[derive(Args, Clone, Debug)]
 pub struct GenerateArgs {
@@ -43,6 +45,10 @@ struct GeneratorDef {
 impl GenerateArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
         let reporter = Reporter::new();
+        reporter.status(
+            "Generating",
+            format!("clients with CLI version: {}", release_version()),
+        );
         let (db, from, baml_files) = load_project_from_reporting(&self.from, &reporter)?;
         if baml_files.is_empty() {
             reporter.abandon();

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -227,6 +227,15 @@ fn generate_valid_project_returns_zero_exit_code() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&format!(
+            "Generating clients with CLI version: {}",
+            baml_version::CANONICAL_VERSION
+        )),
+        "Expected generate output to include CLI version, got: {stderr}",
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Emit a `Generating clients with CLI version: ...` status line at the start of `baml generate`.
- Add an end-to-end assertion that the generate command includes the version in stderr output.

## Testing
- Run the focused `cargo nextest` e2e test for a successful generate flow.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing status text and a test assertion only; no changes to codegen or exit-code behavior.
> 
> **Overview**
> **`baml generate`** now prints an early status line on stderr: `Generating clients with CLI version: <version>`, using the same **`release_version()`** helper as the CLI’s `--version` string.
> 
> An e2e test for a successful generate run asserts that stderr includes that line, aligned with **`baml_version::CANONICAL_VERSION`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a8da500f521b15b6dc202aaa299a6aed7d34b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `baml generate` command now displays the current CLI version in its status output during generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->