### PR TITLE
bumped patch version

### DIFF
--- a/baml_language/crates/baml_version/src/lib.rs
+++ b/baml_language/crates/baml_version/src/lib.rs
@@ -1,6 +1,6 @@
 //! Stamped BAML language product version.
 
-pub const CANONICAL_VERSION: &str = "0.12.0";
-pub const PYPI_VERSION: &str = "0.12.0";
+pub const CANONICAL_VERSION: &str = "0.12.1";
+pub const PYPI_VERSION: &str = "0.12.1";
 pub const CHANNEL: &str = "canary";
-pub const STABLE_VERSION: &str = "0.12.0";
+pub const STABLE_VERSION: &str = "0.12.1";

--- a/baml_language/release.toml
+++ b/baml_language/release.toml
@@ -1,2 +1,2 @@
 [release]
-canary_version = "0.12.0"
+canary_version = "0.12.1"

--- a/baml_language/sdks/nodejs/bridge_nodejs/package.json
+++ b/baml_language/sdks/nodejs/bridge_nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaryml/baml-core-node",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/baml_language/sdks/python/pyproject.toml
+++ b/baml_language/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baml_core"
-version = "0.12.0"
+version = "0.12.1"
 description = "BAML python bindings (new system, bex_engine)"
 authors = [{ "name" = "Boundary", "email" = "contact@boundaryml.com" }]
 license = "Apache-2.0"

--- a/baml_language/sdks/python/src/baml_core/__init__.py
+++ b/baml_language/sdks/python/src/baml_core/__init__.py
@@ -45,7 +45,7 @@ from .typemap import (
 # Flush buffered trace events on process exit so nothing is lost.
 atexit.register(flush_events)
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 
 # ---------------------------------------------------------------------------

--- a/typescript2/app-vscode-ext/package.json
+++ b/typescript2/app-vscode-ext/package.json
@@ -2,7 +2,7 @@
   "name": "baml-language",
   "displayName": "BAML",
   "description": "BAML language support — syntax highlighting, hover, completions, diagnostics, go-to-definition",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publisher": "Boundary",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version from 0.12.0 to 0.12.1 across all SDKs and tools, including Python SDK, Node.js SDK, and VS Code extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->