### PR TITLE
prof: replace minstant with raw-tick clock; convert ticks→ns in the consumer

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1228,7 +1228,6 @@ dependencies = [
  "bex_vm_types",
  "crossbeam-utils",
  "loom",
- "minstant",
  "prost",
  "prost-build",
  "protoc-bin-vendored",
@@ -2234,16 +2233,6 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4465,16 +4454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minstant"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb9b5c752f145ac5046bccc3c4f62892e3c950c1d1eab80c5949cd68a2078db"
-dependencies = [
- "ctor 0.1.26",
- "web-time",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,7 +4515,7 @@ checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "ctor 1.0.6",
+ "ctor",
  "futures",
  "napi-build",
  "napi-sys",
@@ -4560,7 +4539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
 dependencies = [
  "convert_case",
- "ctor 1.0.6",
+ "ctor",
  "napi-derive-backend",
  "proc-macro2",
  "quote",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -171,8 +171,6 @@ logos = { version = "0.15" }
 loom = { version = "0.7" }
 lsp-server = "0.7.6"
 lsp-types = "0.95.0"
-# Calibrated-TSC clock for profiling timestamps (bex_events::prof::clock).
-minstant = { version = "0.1" }
 notify = "7.0"
 once_cell = "1.19"
 ouroboros = "0.18.5"

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -193,13 +193,13 @@ impl Drop for SpawnProfCloser {
                 status: FunctionEndStatus::Cancelled,
                 thread_id,
                 call_id: self.entry_call_id,
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
         }
         self.engine.prof_emit(&RawRecord::EndThread {
             status: ThreadEndStatus::Cancelled,
             thread_id,
-            ts_ns: bex_events::prof::clock::now_ns(),
+            ts_ticks: bex_events::prof::clock::now_ticks(),
         });
     }
 }
@@ -1482,7 +1482,7 @@ impl BexEngine {
                 status,
                 thread_id: BexThreadId(vm.prof_thread_id),
                 call_id: BexCallId(call_id),
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
         }
     }
@@ -1512,7 +1512,7 @@ impl BexEngine {
                 status,
                 thread_id,
                 call_id: BexCallId(call_id),
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
         }
         for call_id in vm.prof_open_call_ids() {
@@ -1520,7 +1520,7 @@ impl BexEngine {
                 status,
                 thread_id,
                 call_id: BexCallId(call_id),
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
         }
     }
@@ -2012,7 +2012,7 @@ impl BexEngine {
                 thread_id: BexThreadId(thread.vm.prof_thread_id),
                 parent_thread_id: BexThreadId(0), // engine-root thread
                 parent_call_id: BexCallId(0),
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
                 name: b"",
             });
         }
@@ -3129,7 +3129,7 @@ impl BexEngine {
             self.prof_emit(&bex_events::prof::record::RawRecord::EndThread {
                 status,
                 thread_id: BexThreadId(prof_thread_id),
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
         }
         result
@@ -3621,7 +3621,7 @@ impl BexEngine {
                             thread_id: BexThreadId(child_prof_thread_id),
                             parent_thread_id: BexThreadId(thread.vm.prof_thread_id),
                             parent_call_id: BexCallId(thread.vm.current_call_id()),
-                            ts_ns: bex_events::prof::clock::now_ns(),
+                            ts_ticks: bex_events::prof::clock::now_ticks(),
                             name: bex_events::prof::record::capped_name_bytes(name),
                         });
                     }

--- a/baml_language/crates/bex_events/Cargo.toml
+++ b/baml_language/crates/bex_events/Cargo.toml
@@ -29,12 +29,10 @@ uuid = { workspace = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = [ "js" ] }
 
-# The profiling clock (prof::clock) needs a TSC-calibrated time source; wasm32
-# compiles a stub instead (profiling is forced off there — plan §2.2). miri
-# also gets the stub: minstant's `#[ctor]` probes the TSC with `_rdtsc`, which
-# miri cannot execute, and it runs before any test gets to opt out.
-[target.'cfg(not(any(target_arch = "wasm32", miri)))'.dependencies]
-minstant = { workspace = true }
+# The profiling clock (prof::clock) reads raw hardware ticks in-tree (rdtsc /
+# CNTVCT_EL0 / Instant fallback) — no external time-source dependency, and
+# crucially no pre-main ctor. wasm32 compiles a stub (profiling is forced off
+# there — plan §2.2); miri gets the stub too: it cannot execute `rdtsc`/`mrs`.
 
 # The .bamlprof consumer (thread + file writer + protobuf transcode) is
 # native-only; wasm32 has no consumer thread (profiling forced off there).

--- a/baml_language/crates/bex_events/benches/prof_clock.rs
+++ b/baml_language/crates/bex_events/benches/prof_clock.rs
@@ -34,7 +34,9 @@ fn main() {
     println!("prof_clock bench ({} iterations per row)", 20_000_000);
     measure("prof::clock::now_ticks", bex_events::prof::clock::now_ticks);
     let conv = bex_events::prof::clock::TickConverter::from_clock();
-    measure("TickConverter::to_ns(now_ticks)", || {
+    // End-to-end read+convert; the delta vs the now_ticks row is the
+    // consumer-side conversion cost in isolation.
+    measure("now_ticks + TickConverter::to_ns", || {
         conv.to_ns(bex_events::prof::clock::now_ticks())
     });
     measure("std::time::Instant::now", || {

--- a/baml_language/crates/bex_events/benches/prof_clock.rs
+++ b/baml_language/crates/bex_events/benches/prof_clock.rs
@@ -1,7 +1,9 @@
 //! Clock micro-bench (plan §4.2 / PR1 gate): ns per timestamp read.
 //!
 //! The profiling design budgets ~25 ns per call pair, dominated by two clock
-//! reads — i.e. it assumes ≤10 ns per read. Run with:
+//! reads — i.e. it assumes ≤10 ns per read of `now_ticks` (the producer hot
+//! path; raw `rdtsc` / `CNTVCT_EL0`, no conversion). The converter row is
+//! the consumer-side tick→ns cost, off every producer path. Run with:
 //! `cargo bench -p bex_events --bench prof_clock`
 #![expect(
     clippy::print_stdout,
@@ -27,13 +29,13 @@ fn measure(name: &str, mut f: impl FnMut() -> u64) {
 }
 
 fn main() {
-    // Pays minstant's one-time TSC calibration before measuring.
+    // Pins the clock anchor (source detection; no calibration runs here).
     bex_events::prof::clock::init();
     println!("prof_clock bench ({} iterations per row)", 20_000_000);
-    measure("prof::clock::now_ns", bex_events::prof::clock::now_ns);
-    measure("minstant::Instant::now", || {
-        black_box(minstant::Instant::now());
-        0
+    measure("prof::clock::now_ticks", bex_events::prof::clock::now_ticks);
+    let conv = bex_events::prof::clock::TickConverter::from_clock();
+    measure("TickConverter::to_ns(now_ticks)", || {
+        conv.to_ns(bex_events::prof::clock::now_ticks())
     });
     measure("std::time::Instant::now", || {
         black_box(Instant::now());

--- a/baml_language/crates/bex_events/src/prof/clock.rs
+++ b/baml_language/crates/bex_events/src/prof/clock.rs
@@ -24,7 +24,7 @@
 //! module is a stub: profiling is forced off there, and the concurrency
 //! tests stamp their own tick values.
 
-// Raw counter reads (`rdtsc`, `mrs`) and one mach FFI call.
+// Raw counter reads (`rdtsc`, `mrs`).
 #![allow(unsafe_code)]
 
 pub use imp::{base_ticks, init, meta, now_ticks, started_at_epoch_ns};

--- a/baml_language/crates/bex_events/src/prof/clock.rs
+++ b/baml_language/crates/bex_events/src/prof/clock.rs
@@ -8,9 +8,10 @@
 //! anchor capture is two clock reads plus (on x86) a `cpuid` probe.
 //!
 //! The consumer owns conversion via [`TickConverter`]: exact rational rates
-//! where the platform provides them (`CNTFRQ_EL0`, `mach_timebase_info`),
-//! and a two-point calibration refined across its own wake cadence for the
-//! x86 TSC. Disk timestamps (`timestamp_ns`) therefore stay nanoseconds —
+//! where the platform states them (`CNTFRQ_EL0` for the aarch64 generic
+//! timer), and a two-point calibration refined across its own wake cadence
+//! for the x86 TSC. Disk timestamps (`timestamp_ns`) therefore stay
+//! nanoseconds —
 //! readers rebase to wall time as
 //! `wall(event) = started_at_epoch_ns + timestamp_ns`, unchanged.
 //!
@@ -47,7 +48,7 @@ pub enum ClockKind {
 pub struct ClockMeta {
     pub kind: ClockKind,
     /// Exact ns-per-tick as a `(numer, denom)` rational, when the platform
-    /// states it (`CNTFRQ_EL0`, `mach_timebase_info`, ns-backed fallback).
+    /// states it (`CNTFRQ_EL0` on aarch64, ns-backed `Instant` fallback).
     /// `None` means the rate must be measured — x86 TSC, where the consumer
     /// calibrates against the OS clock.
     pub ns_per_tick: Option<(u64, u64)>,
@@ -144,49 +145,31 @@ mod imp {
 
     /// Exact ns-per-tick for the aarch64 generic timer, or `None` if it
     /// cannot be determined (falls back to `Instant`).
+    ///
+    /// The rate must describe the counter we actually stamp with —
+    /// `CNTVCT_EL0` — so we read its architectural frequency from
+    /// `CNTFRQ_EL0` on every OS, macOS included. We deliberately do **not**
+    /// use `mach_timebase_info`: that states the rate of `mach_absolute_time`,
+    /// which is only incidentally equal to the `CNTVCT_EL0` rate on M1–M3
+    /// (both 24 MHz). On M4/M5 `CNTVCT_EL0` runs at 1 GHz while
+    /// `mach_absolute_time` stays at 24 MHz, so applying the mach rational
+    /// (125/3) to raw `CNTVCT_EL0` reads inflates every timestamp ~41.7×.
     #[cfg(target_arch = "aarch64")]
     fn cntvct_ns_per_tick() -> Option<(u64, u64)> {
-        #[cfg(target_os = "macos")]
-        {
-            // mach_absolute_time ticks at the generic-timer rate on Apple
-            // Silicon; mach_timebase_info states ns = ticks * numer / denom
-            // exactly (125/3 on M1–M3, 1/1 on ~1 GHz timebases).
-            #[repr(C)]
-            struct MachTimebaseInfo {
-                numer: u32,
-                denom: u32,
-            }
-            unsafe extern "C" {
-                fn mach_timebase_info(info: *mut MachTimebaseInfo) -> libc_int;
-            }
-            #[allow(non_camel_case_types)]
-            type libc_int = i32;
-            let mut info = MachTimebaseInfo { numer: 0, denom: 0 };
-            // SAFETY: out-pointer to a properly sized struct; the call has
-            // no other preconditions.
-            let rc = unsafe { mach_timebase_info(&raw mut info) };
-            if rc == 0 && info.numer != 0 && info.denom != 0 {
-                return Some((u64::from(info.numer), u64::from(info.denom)));
-            }
-            None
+        // CNTFRQ_EL0 states the CNTVCT_EL0 frequency in Hz.
+        let freq: u64;
+        // SAFETY: EL0-readable system register; no memory or flags.
+        unsafe {
+            core::arch::asm!(
+                "mrs {f}, cntfrq_el0",
+                f = out(reg) freq,
+                options(nomem, nostack, preserves_flags)
+            );
         }
-        #[cfg(not(target_os = "macos"))]
-        {
-            // CNTFRQ_EL0 states the counter frequency in Hz.
-            let freq: u64;
-            // SAFETY: EL0-readable system register; no memory or flags.
-            unsafe {
-                core::arch::asm!(
-                    "mrs {f}, cntfrq_el0",
-                    f = out(reg) freq,
-                    options(nomem, nostack, preserves_flags)
-                );
-            }
-            if freq == 0 {
-                return None;
-            }
-            Some((1_000_000_000, freq))
+        if freq == 0 {
+            return None;
         }
+        Some((1_000_000_000, freq))
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/baml_language/crates/bex_events/src/prof/clock.rs
+++ b/baml_language/crates/bex_events/src/prof/clock.rs
@@ -111,7 +111,7 @@ mod imp {
     fn detect() -> (Source, Option<(u64, u64)>) {
         #[cfg(target_arch = "x86_64")]
         {
-            if has_invariant_tsc() {
+            if tsc_is_trustworthy() {
                 return (Source::Tsc, None);
             }
         }
@@ -124,10 +124,37 @@ mod imp {
         (Source::Instant, Some((1, 1)))
     }
 
-    /// Invariant-TSC probe: CPUID.80000007H:EDX[8]. Constant-rate,
-    /// never-stopping, cross-core-synchronized TSC is the property the
-    /// per-thread sort contract needs (one logical thread's records are
-    /// stamped from several OS threads).
+    /// Whether the TSC is safe to use for cross-thread-comparable stamps
+    /// (one logical thread's records are stamped from several OS threads,
+    /// so the per-thread sort contract needs cross-core comparability).
+    ///
+    /// CPUID.80000007H:EDX[8] only guarantees constant-rate / never-stop —
+    /// NOT cross-core/cross-socket synchronization. On Linux we therefore
+    /// also defer to the kernel, which measures TSC sync across CPUs at
+    /// boot and only offers `tsc` as a clocksource when it holds (the same
+    /// check minstant used). Elsewhere the CPUID bit is the best signal
+    /// available; modern single-socket parts ship synchronized.
+    #[cfg(target_arch = "x86_64")]
+    fn tsc_is_trustworthy() -> bool {
+        if !has_invariant_tsc() {
+            return false;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            std::fs::read_to_string(
+                "/sys/devices/system/clocksource/clocksource0/available_clocksource",
+            )
+            .map(|s| s.contains("tsc"))
+            .unwrap_or(false)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            true
+        }
+    }
+
+    /// Invariant-TSC probe: CPUID.80000007H:EDX[8] (constant rate, does not
+    /// stop in deep C-states).
     #[cfg(target_arch = "x86_64")]
     // `__cpuid` is an unsafe fn on the pinned stable toolchain but safe on
     // newer ones — keep the block, silence the newer toolchains' lint.

--- a/baml_language/crates/bex_events/src/prof/clock.rs
+++ b/baml_language/crates/bex_events/src/prof/clock.rs
@@ -1,81 +1,293 @@
-//! The profiling clock: nanoseconds since a process-global zero point.
+//! The profiling clock: raw hardware ticks on the producer side, converted
+//! to nanoseconds by the consumer at transcode time.
 //!
-//! Record timestamps (`ts_ns`) are `u64` nanoseconds relative to the zero
-//! point; the file header carries [`started_at_epoch_ns`] so readers rebase to
-//! wall time as `wall(event) = started_at_epoch_ns + ts_ns`.
+//! Producers stamp records with [`now_ticks`] — a raw counter read (`rdtsc`
+//! on `x86_64`, `CNTVCT_EL0` on aarch64, a monotonic-`Instant` fallback
+//! elsewhere or when the TSC is not invariant). No tick→ns conversion, no
+//! calibration, and no pre-main ctor runs on any producer path; the one-time
+//! anchor capture is two clock reads plus (on x86) a `cpuid` probe.
 //!
-//! Backed by `minstant` (calibrated TSC where available, OS monotonic clock
-//! otherwise). The design's ~25 ns per call-pair budget assumes ≤10 ns per
-//! read — `benches/prof_clock.rs` measures it (`quanta` is the designated
-//! fallback if `minstant` misbehaves on some target).
+//! The consumer owns conversion via [`TickConverter`]: exact rational rates
+//! where the platform provides them (`CNTFRQ_EL0`, `mach_timebase_info`),
+//! and a two-point calibration refined across its own wake cadence for the
+//! x86 TSC. Disk timestamps (`timestamp_ns`) therefore stay nanoseconds —
+//! readers rebase to wall time as
+//! `wall(event) = started_at_epoch_ns + timestamp_ns`, unchanged.
 //!
-//! On wasm32 this module is a stub: profiling is forced off there (no
-//! consumer thread, no TSC), and a js-backed clock is part of the deferred
-//! cooperative-drain design.
+//! Tick values are absolute counter reads (since boot for TSC/CNTVCT, since
+//! the process zero point for the `Instant` fallback); the converter
+//! subtracts the process base. The per-call-pair budget (~25 ns) assumes
+//! ≤10 ns per read — `benches/prof_clock.rs` measures it.
+//!
+//! On wasm32 (and under miri, which cannot execute `rdtsc`/`mrs`) this
+//! module is a stub: profiling is forced off there, and the concurrency
+//! tests stamp their own tick values.
 
-pub use imp::{init, now_ns, started_at_epoch_ns};
+// Raw counter reads (`rdtsc`, `mrs`) and one mach FFI call.
+#![allow(unsafe_code)]
+
+pub use imp::{base_ticks, init, meta, now_ticks, started_at_epoch_ns};
+
+/// Which hardware source backs [`now_ticks`]. Recorded in the `.bamlprof`
+/// header for diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockKind {
+    /// `x86_64` invariant TSC (`rdtsc`); rate calibrated by the consumer.
+    Tsc,
+    /// aarch64 generic timer (`CNTVCT_EL0`); exact architectural rate.
+    Cntvct,
+    /// `std::time::Instant` fallback; ticks are nanoseconds, rate (1, 1).
+    Instant,
+    /// wasm32/miri stub; ticks are whatever the test stamped.
+    Stub,
+}
+
+/// Static facts about the active clock source.
+#[derive(Debug, Clone, Copy)]
+pub struct ClockMeta {
+    pub kind: ClockKind,
+    /// Exact ns-per-tick as a `(numer, denom)` rational, when the platform
+    /// states it (`CNTFRQ_EL0`, `mach_timebase_info`, ns-backed fallback).
+    /// `None` means the rate must be measured — x86 TSC, where the consumer
+    /// calibrates against the OS clock.
+    pub ns_per_tick: Option<(u64, u64)>,
+}
 
 #[cfg(not(any(target_arch = "wasm32", miri)))]
 mod imp {
     use std::sync::OnceLock;
 
-    struct Zero {
-        instant: minstant::Instant,
-        epoch_ns: u128,
+    use super::{ClockKind, ClockMeta};
+
+    enum Source {
+        #[cfg(target_arch = "x86_64")]
+        Tsc,
+        #[cfg(target_arch = "aarch64")]
+        Cntvct,
+        Instant,
     }
 
-    fn zero() -> &'static Zero {
-        static ZERO: OnceLock<Zero> = OnceLock::new();
-        ZERO.get_or_init(|| {
-            let anchor = minstant::Anchor::new();
-            let instant = minstant::Instant::now();
-            Zero {
-                instant,
-                epoch_ns: u128::from(instant.as_unix_nanos(&anchor)),
-            }
+    struct Anchor {
+        source: Source,
+        /// First raw read of the chosen source; the converter's base.
+        base_ticks: u64,
+        /// Wall-clock time of the zero point (adjacent to `base_ticks`).
+        base_unix_ns: u128,
+        /// Zero point for the `Instant` fallback's tick domain.
+        zero_instant: std::time::Instant,
+        meta: ClockMeta,
+    }
+
+    fn anchor() -> &'static Anchor {
+        static ANCHOR: OnceLock<Anchor> = OnceLock::new();
+        ANCHOR.get_or_init(|| {
+            let (source, ns_per_tick) = detect();
+            let kind = match source {
+                #[cfg(target_arch = "x86_64")]
+                Source::Tsc => ClockKind::Tsc,
+                #[cfg(target_arch = "aarch64")]
+                Source::Cntvct => ClockKind::Cntvct,
+                Source::Instant => ClockKind::Instant,
+            };
+            let zero_instant = std::time::Instant::now();
+            let base_unix_ns = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos());
+            let mut anchor = Anchor {
+                source,
+                base_ticks: 0,
+                base_unix_ns,
+                zero_instant,
+                meta: ClockMeta { kind, ns_per_tick },
+            };
+            anchor.base_ticks = raw_ticks(&anchor);
+            anchor
         })
     }
 
-    /// Pins the zero point (and pays minstant's one-time TSC calibration).
-    ///
-    /// Call once at engine startup; later `now_ns` reads are then just a
-    /// clock read plus a subtraction. Lazily initialized on first use either
-    /// way.
-    pub fn init() {
-        let _ = zero();
+    /// Pick the tick source for this process (and its exact rate, when the
+    /// platform states one). Runs once, inside the anchor init.
+    fn detect() -> (Source, Option<(u64, u64)>) {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if has_invariant_tsc() {
+                return (Source::Tsc, None);
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            if let Some(rate) = cntvct_ns_per_tick() {
+                return (Source::Cntvct, Some(rate));
+            }
+        }
+        (Source::Instant, Some((1, 1)))
     }
 
-    /// Nanoseconds since the process zero point.
-    ///
-    /// `u64` overflows after ~584 years of uptime; truncation is fine.
+    /// Invariant-TSC probe: CPUID.80000007H:EDX[8]. Constant-rate,
+    /// never-stopping, cross-core-synchronized TSC is the property the
+    /// per-thread sort contract needs (one logical thread's records are
+    /// stamped from several OS threads).
+    #[cfg(target_arch = "x86_64")]
+    // `__cpuid` is an unsafe fn on the pinned stable toolchain but safe on
+    // newer ones — keep the block, silence the newer toolchains' lint.
+    #[allow(unused_unsafe)]
+    fn has_invariant_tsc() -> bool {
+        // SAFETY: cpuid is unprivileged and universally available on x86_64.
+        unsafe {
+            let max_ext = core::arch::x86_64::__cpuid(0x8000_0000).eax;
+            if max_ext < 0x8000_0007 {
+                return false;
+            }
+            core::arch::x86_64::__cpuid(0x8000_0007).edx & (1 << 8) != 0
+        }
+    }
+
+    /// Exact ns-per-tick for the aarch64 generic timer, or `None` if it
+    /// cannot be determined (falls back to `Instant`).
+    #[cfg(target_arch = "aarch64")]
+    fn cntvct_ns_per_tick() -> Option<(u64, u64)> {
+        #[cfg(target_os = "macos")]
+        {
+            // mach_absolute_time ticks at the generic-timer rate on Apple
+            // Silicon; mach_timebase_info states ns = ticks * numer / denom
+            // exactly (125/3 on M1–M3, 1/1 on ~1 GHz timebases).
+            #[repr(C)]
+            struct MachTimebaseInfo {
+                numer: u32,
+                denom: u32,
+            }
+            unsafe extern "C" {
+                fn mach_timebase_info(info: *mut MachTimebaseInfo) -> libc_int;
+            }
+            #[allow(non_camel_case_types)]
+            type libc_int = i32;
+            let mut info = MachTimebaseInfo { numer: 0, denom: 0 };
+            // SAFETY: out-pointer to a properly sized struct; the call has
+            // no other preconditions.
+            let rc = unsafe { mach_timebase_info(&raw mut info) };
+            if rc == 0 && info.numer != 0 && info.denom != 0 {
+                return Some((u64::from(info.numer), u64::from(info.denom)));
+            }
+            None
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            // CNTFRQ_EL0 states the counter frequency in Hz.
+            let freq: u64;
+            // SAFETY: EL0-readable system register; no memory or flags.
+            unsafe {
+                core::arch::asm!(
+                    "mrs {f}, cntfrq_el0",
+                    f = out(reg) freq,
+                    options(nomem, nostack, preserves_flags)
+                );
+            }
+            if freq == 0 {
+                return None;
+            }
+            Some((1_000_000_000, freq))
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[inline]
+    fn cntvct() -> u64 {
+        let ticks: u64;
+        // SAFETY: CNTVCT_EL0 is EL0-readable on every supported OS; the
+        // read touches no memory and preserves flags. No `isb` barrier: a
+        // few ns of speculation skew is irrelevant for span timestamps and
+        // the barrier would cost more than the read.
+        unsafe {
+            core::arch::asm!(
+                "mrs {t}, cntvct_el0",
+                t = out(reg) ticks,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        ticks
+    }
+
     #[inline]
     #[expect(
         clippy::cast_possible_truncation,
         reason = "u128 nanos since process start; wraps after ~584 years"
     )]
-    pub fn now_ns() -> u64 {
-        zero().instant.elapsed().as_nanos() as u64
+    fn raw_ticks(a: &Anchor) -> u64 {
+        match a.source {
+            #[cfg(target_arch = "x86_64")]
+            // SAFETY: rdtsc is unprivileged; gated on invariant-TSC detect.
+            Source::Tsc => unsafe { core::arch::x86_64::_rdtsc() },
+            #[cfg(target_arch = "aarch64")]
+            Source::Cntvct => cntvct(),
+            Source::Instant => a.zero_instant.elapsed().as_nanos() as u64,
+        }
+    }
+
+    /// Pins the anchor (source detection + zero point). Cheap: two clock
+    /// reads and, on x86, a `cpuid` probe — there is no calibration here.
+    ///
+    /// Called from ring acquisition; `now_ticks` also forces it, so every
+    /// stamped tick is `>= base_ticks` regardless of call order.
+    pub fn init() {
+        let _ = anchor();
+    }
+
+    /// Raw ticks of the active source. Absolute counter reads (since boot
+    /// for TSC/CNTVCT); the consumer's [`super::TickConverter`] subtracts
+    /// the process base and applies the rate.
+    #[inline]
+    pub fn now_ticks() -> u64 {
+        // Forcing the anchor first guarantees ticks >= base_ticks for every
+        // value that ever reaches a record (engine stamps can happen before
+        // ring acquisition, so init-on-acquire alone is not enough).
+        let a = anchor();
+        raw_ticks(a)
+    }
+
+    /// First raw tick of this process — the converter's zero point.
+    pub fn base_ticks() -> u64 {
+        anchor().base_ticks
+    }
+
+    /// Static facts about the active source (kind + exact rate if known).
+    pub fn meta() -> ClockMeta {
+        anchor().meta
     }
 
     /// Wall-clock time of the zero point, in nanoseconds since the Unix
     /// epoch. Written into the `.bamlprof` file header.
     pub fn started_at_epoch_ns() -> u128 {
-        zero().epoch_ns
+        anchor().base_unix_ns
     }
 }
 
-// wasm32: profiling is forced off, nothing reads the clock. miri: minstant
-// cannot run there (its ctor probes the TSC), and the concurrency tests miri
-// executes stamp their own ts values.
+// wasm32: profiling is forced off, nothing reads the clock. miri: rdtsc and
+// `mrs` are intrinsics/asm miri cannot execute, and the concurrency tests
+// miri runs stamp their own tick values.
 #[cfg(any(target_arch = "wasm32", miri))]
 mod imp {
+    use super::{ClockKind, ClockMeta};
+
     /// No-op in stub builds (profiling is forced off).
     pub fn init() {}
 
     /// Always `0` in stub builds (nothing reads this).
     #[inline]
-    pub fn now_ns() -> u64 {
+    pub fn now_ticks() -> u64 {
         0
+    }
+
+    /// Always `0` in stub builds.
+    pub fn base_ticks() -> u64 {
+        0
+    }
+
+    /// Stub meta: tick == ns so any converter built from it is an identity.
+    pub fn meta() -> ClockMeta {
+        ClockMeta {
+            kind: ClockKind::Stub,
+            ns_per_tick: Some((1, 1)),
+        }
     }
 
     /// Always `0` in stub builds (nothing reads this).
@@ -84,8 +296,171 @@ mod imp {
     }
 }
 
-// minstant's TSC/cpuid probing uses intrinsics miri cannot execute, so the
-// clock is exercised under real builds only.
+/// How trustworthy the tick→ns rate is. Recorded in the `.bamlprof` header.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockQuality {
+    /// Platform-stated rational rate (CNTVCT, Instant, Stub).
+    Exact,
+    /// x86 TSC rate refined over a ≥1 s window on the consumer thread.
+    Calibrated,
+    /// x86 TSC rate from the initial ~2 ms two-point estimate only
+    /// (~0.1% rate error; affects at most the first second of events).
+    Coarse,
+}
+
+/// Consumer-side tick→ns conversion.
+///
+/// Built on the consumer thread ([`TickConverter::from_clock`]); producers
+/// never touch it. Conversion is piecewise-linear: when the x86 TSC rate is
+/// refined, the new segment starts at the previous segment's converted
+/// value for the switch tick, so per-thread `timestamp_ns` stays monotone
+/// across the swap, and ticks older than the switch keep converting through
+/// the previous segment (in-flight ring events drain up to seconds late).
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone)]
+pub struct TickConverter {
+    kind: ClockKind,
+    seg_base_ticks: u64,
+    seg_base_ns: u64,
+    /// ns-per-tick as (numer, denom).
+    rate: (u64, u64),
+    /// Previous segment `(base_ticks, base_ns, rate)`, kept after a
+    /// refinement so pre-switch ticks still convert on their original line.
+    prev: Option<(u64, u64, (u64, u64))>,
+    refined: bool,
+    /// First calibration sample (x86 TSC only): adjacent OS-clock + tick
+    /// reads taken at converter construction.
+    sample0: Option<(std::time::Instant, u64)>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl TickConverter {
+    /// Identity conversion (tests): synthetic tick values pass through.
+    pub fn identity() -> Self {
+        TickConverter {
+            kind: ClockKind::Instant,
+            seg_base_ticks: 0,
+            seg_base_ns: 0,
+            rate: (1, 1),
+            prev: None,
+            refined: true,
+            sample0: None,
+        }
+    }
+
+    /// Build from the process clock. Call on the consumer thread only: for
+    /// the x86 TSC this blocks ~2 ms taking a coarse two-point rate
+    /// estimate (producers only buffer meanwhile); exact-rate sources
+    /// return immediately.
+    pub fn from_clock() -> Self {
+        let m = meta();
+        match m.ns_per_tick {
+            Some(rate) => TickConverter {
+                kind: m.kind,
+                seg_base_ticks: base_ticks(),
+                seg_base_ns: 0,
+                rate,
+                prev: None,
+                refined: true,
+                sample0: None,
+            },
+            None => {
+                // x86 TSC: two-point coarse estimate over ~2 ms.
+                let sample0 = (std::time::Instant::now(), now_ticks());
+                std::thread::sleep(std::time::Duration::from_millis(2));
+                let elapsed_ns = sample0.0.elapsed().as_nanos();
+                let tick_delta = now_ticks().wrapping_sub(sample0.1).max(1);
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "~2ms window; fits u64 by construction"
+                )]
+                let rate = (elapsed_ns as u64, tick_delta);
+                TickConverter {
+                    kind: m.kind,
+                    seg_base_ticks: base_ticks(),
+                    seg_base_ns: 0,
+                    rate,
+                    prev: None,
+                    refined: false,
+                    sample0: Some(sample0),
+                }
+            }
+        }
+    }
+
+    /// Convert a raw tick stamp to nanoseconds since the process zero point
+    /// (the domain `started_at_epoch_ns` rebases to wall time).
+    #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "ns since process start; wraps after ~584 years"
+    )]
+    pub fn to_ns(&self, ticks: u64) -> u64 {
+        if ticks < self.seg_base_ticks {
+            if let Some((base_ticks, base_ns, (numer, denom))) = self.prev {
+                let dt = u128::from(ticks.saturating_sub(base_ticks));
+                return base_ns + (dt * u128::from(numer) / u128::from(denom)) as u64;
+            }
+        }
+        let dt = u128::from(ticks.saturating_sub(self.seg_base_ticks));
+        self.seg_base_ns + (dt * u128::from(self.rate.0) / u128::from(self.rate.1)) as u64
+    }
+
+    /// Refine the x86 TSC rate once the window since `sample0` spans ≥1 s.
+    /// Installs the new rate with anchor continuity (see type docs). Cheap
+    /// no-op for exact-rate sources or once refined; call at heartbeat
+    /// cadence.
+    pub fn maybe_refine(&mut self) {
+        if self.refined {
+            return;
+        }
+        let Some((i0, t0)) = self.sample0 else {
+            self.refined = true;
+            return;
+        };
+        let window_ns = i0.elapsed().as_nanos();
+        if window_ns < 1_000_000_000 {
+            return;
+        }
+        let now_t = now_ticks();
+        let tick_delta = now_t.wrapping_sub(t0).max(1);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "refine window is seconds; fits u64"
+        )]
+        let new_rate = (window_ns as u64, tick_delta);
+        let switch_ns = self.to_ns(now_t);
+        self.prev = Some((self.seg_base_ticks, self.seg_base_ns, self.rate));
+        self.seg_base_ticks = now_t;
+        self.seg_base_ns = switch_ns;
+        self.rate = new_rate;
+        self.refined = true;
+    }
+
+    pub fn kind(&self) -> ClockKind {
+        self.kind
+    }
+
+    /// ns-per-tick rational currently in effect (header diagnostics).
+    pub fn rate(&self) -> (u64, u64) {
+        self.rate
+    }
+
+    pub fn quality(&self) -> ClockQuality {
+        match self.kind {
+            ClockKind::Tsc => {
+                if self.refined {
+                    ClockQuality::Calibrated
+                } else {
+                    ClockQuality::Coarse
+                }
+            }
+            ClockKind::Cntvct | ClockKind::Instant | ClockKind::Stub => ClockQuality::Exact,
+        }
+    }
+}
+
 #[cfg(all(test, not(miri), not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
@@ -93,28 +468,128 @@ mod tests {
     #[test]
     fn monotonic_nondecreasing() {
         init();
-        let mut prev = now_ns();
+        let mut prev = now_ticks();
         for _ in 0..10_000 {
-            let next = now_ns();
+            let next = now_ticks();
             assert!(next >= prev, "clock went backwards: {prev} -> {next}");
             prev = next;
         }
     }
 
     #[test]
-    fn zero_point_matches_wall_clock() {
+    fn cross_thread_ordering() {
+        // The property prof_gate actually depends on: a stamp taken on one
+        // OS thread, handed off, then re-stamped on another thread must not
+        // go backwards (invariant TSC / system-wide CNTVCT).
         init();
+        let (tx, rx) = std::sync::mpsc::sync_channel::<u64>(0);
+        let handle = std::thread::spawn(move || {
+            for t_a in rx {
+                let t_b = now_ticks();
+                assert!(t_b >= t_a, "cross-thread regression: {t_a} -> {t_b}");
+            }
+        });
+        for _ in 0..1_000 {
+            if tx.send(now_ticks()).is_err() {
+                break;
+            }
+        }
+        drop(tx);
+        handle.join().expect("stamping thread panicked");
+    }
+
+    #[test]
+    fn zero_point_matches_wall_clock() {
+        // Deliberately goes through the conversion path: with raw ticks a
+        // direct arithmetic check could silently pass on garbage (a small
+        // elapsed value keeps even a ~3x unit error inside tolerance).
+        init();
+        let conv = TickConverter::from_clock();
         let wall_now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let prof_now = started_at_epoch_ns() + u128::from(now_ns());
+        let prof_now = started_at_epoch_ns() + u128::from(conv.to_ns(now_ticks()));
         let drift = wall_now.abs_diff(prof_now);
-        // Generous tolerance: calibration error + scheduling between the two
-        // reads. Catches "anchor is garbage", not clock-quality regressions.
+        // Generous tolerance: coarse-rate error + scheduling between the
+        // reads. Catches "anchor or rate is garbage", not clock quality.
         assert!(
             drift < 5_000_000_000,
             "prof clock and wall clock disagree by {drift} ns"
         );
+    }
+
+    #[test]
+    fn converter_rate_sane() {
+        // Convert a measured ~50ms window and require agreement within 10%:
+        // catches a wrong rational (e.g. mach timebase numer/denom swapped)
+        // on any platform, which the 5s wall tolerance above would miss.
+        init();
+        let conv = TickConverter::from_clock();
+        let wall = std::time::Instant::now();
+        let t0 = now_ticks();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let t1 = now_ticks();
+        let wall_ns = u64::try_from(wall.elapsed().as_nanos()).expect("window fits u64");
+        let conv_ns = conv.to_ns(t1) - conv.to_ns(t0);
+        let err = conv_ns.abs_diff(wall_ns);
+        assert!(
+            err * 10 < wall_ns,
+            "converted window {conv_ns} ns vs wall {wall_ns} ns"
+        );
+    }
+
+    #[test]
+    fn identity_passthrough() {
+        let conv = TickConverter::identity();
+        for v in [0u64, 1, 42, 10_000, u64::MAX] {
+            assert_eq!(conv.to_ns(v), v);
+        }
+    }
+
+    #[test]
+    fn refinement_keeps_monotonicity() {
+        // A deliberately-wrong coarse rate, then a refine: converted values
+        // sampled across the boundary must never step backwards, and ticks
+        // older than the switch keep converting through the old segment.
+        let mut conv = TickConverter {
+            kind: ClockKind::Tsc,
+            seg_base_ticks: 0,
+            seg_base_ns: 0,
+            rate: (3, 1), // 3 ns/tick, deliberately ~3x off
+            prev: None,
+            refined: false,
+            sample0: Some((std::time::Instant::now(), now_ticks())),
+        };
+        let before_switch = now_ticks();
+        let ns_before = conv.to_ns(before_switch);
+        // Force the refine path regardless of wall time elapsed.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        conv.sample0 = Some((
+            std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(2))
+                .expect("process started more than 2s after boot"),
+            conv.sample0.unwrap().1,
+        ));
+        conv.maybe_refine();
+        assert!(conv.refined, "refine did not trigger");
+        // Old-tick conversion is unchanged (previous segment).
+        assert_eq!(conv.to_ns(before_switch), ns_before);
+        // Post-switch ticks continue from at least the switch value.
+        let after = now_ticks();
+        assert!(
+            conv.to_ns(after) >= ns_before,
+            "monotonicity broken across rate swap"
+        );
+    }
+
+    #[test]
+    fn pre_base_ticks_clamp() {
+        init();
+        let conv = TickConverter::from_clock();
+        // A tick below the process base (defensive: should never be
+        // emitted) clamps to the segment base instead of underflowing.
+        assert_eq!(conv.to_ns(0), 0);
+        assert_eq!(conv.to_ns(base_ticks()), 0);
     }
 }

--- a/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
+++ b/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
@@ -575,7 +575,7 @@ mod stress {
                             call_id: BexCallId(seq),
                             parent_call_id: BexCallId(seq.saturating_sub(1)),
                             function_id: FunctionId(u32::try_from(engine).unwrap()),
-                            ts_ns: seq,
+                            ts_ticks: seq,
                         }
                         .encode(&mut buf);
                         // SAFETY: the claiming thread is alive for the whole call (no TLS

--- a/baml_language/crates/bex_events/src/prof/config.rs
+++ b/baml_language/crates/bex_events/src/prof/config.rs
@@ -49,7 +49,7 @@ pub const DEFAULT_WAKE_INTERVAL: Duration = Duration::from_millis(50);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProfConfig {
     /// Master switch ([`ENV_PROFILE`]); default-on (follow-up 16). Always
-    /// `false` on wasm32: there is no consumer thread or TSC clock there
+    /// `false` on wasm32: there is no consumer thread or tick clock there
     /// (cooperative drain is a designed but deferred follow-up).
     pub enabled: bool,
     /// Ring segment size in bytes ([`ENV_SEG_BYTES`]).
@@ -104,7 +104,7 @@ impl ProfConfig {
                 v == "1" || v.eq_ignore_ascii_case("true")
             })
             .unwrap_or(defaults.enabled);
-        // No consumer thread and no TSC clock on wasm32; the switch is forced
+        // No consumer thread and no tick clock on wasm32; the switch is forced
         // off regardless of the environment (plan §2.2).
         let enabled = enabled && cfg!(not(target_arch = "wasm32"));
 

--- a/baml_language/crates/bex_events/src/prof/consumer.rs
+++ b/baml_language/crates/bex_events/src/prof/consumer.rs
@@ -37,7 +37,8 @@ use std::{
 };
 
 use crate::prof::{
-    EngineProfileMetadata, clock,
+    EngineProfileMetadata,
+    clock::{self, TickConverter},
     config::ProfConfig,
     file::{ProfileWriter, build_header},
     pb,
@@ -81,6 +82,28 @@ pub(crate) struct ConsumerEnv {
     pub(crate) ctx: &'static RingCtx,
     pub(crate) dir: PathBuf,
     pub(crate) wake_interval: Duration,
+    pub(crate) clock: ClockMode,
+}
+
+/// How the consumer obtains its tick→ns converter.
+pub(crate) enum ClockMode {
+    /// Build from the process clock (production). For the x86 TSC this
+    /// takes the ~2 ms coarse two-point estimate — on the consumer thread,
+    /// never on a producer.
+    Detect,
+    /// Use the given converter as-is (tests: identity keeps synthetic tick
+    /// values byte-stable through the roundtrip).
+    #[cfg_attr(not(test), allow(dead_code))]
+    Fixed(TickConverter),
+}
+
+impl ClockMode {
+    fn build(&self) -> TickConverter {
+        match self {
+            ClockMode::Detect => TickConverter::from_clock(),
+            ClockMode::Fixed(conv) => conv.clone(),
+        }
+    }
 }
 
 static CONTROL_TX: OnceLock<mpsc::Sender<ControlMsg>> = OnceLock::new();
@@ -96,6 +119,7 @@ pub(crate) fn ensure_started() {
             ctx: crate::prof::registry::global_ctx(),
             dir: cfg.profile_dir.clone(),
             wake_interval: cfg.wake_interval,
+            clock: ClockMode::Detect,
         };
         std::thread::Builder::new()
             .name("bex-prof-consumer".into())
@@ -145,7 +169,7 @@ pub fn engine_closed(engine_id: u64) {
 /// The consumer loop: §3.4 sweep + §3.6 wake protocol + control messages.
 pub(crate) fn consumer_main(control: &mpsc::Receiver<ControlMsg>, env: &ConsumerEnv) {
     env.ctx.wake().register_consumer();
-    let mut state = ConsumerState::new(env.dir.clone());
+    let mut state = ConsumerState::new(env.dir.clone(), env.clock.build());
     loop {
         while let Ok(msg) = control.try_recv() {
             match msg {
@@ -195,6 +219,8 @@ pub(crate) fn consumer_main(control: &mpsc::Receiver<ControlMsg>, env: &Consumer
 
 struct ConsumerState {
     dir: PathBuf,
+    /// Tick→ns conversion for every disk timestamp (events + heartbeats).
+    conv: TickConverter,
     /// `None` = opening or writing failed permanently (already reported).
     writers: HashMap<u64, Option<ProfileWriter>>,
     /// Engines whose files were closed (8 bytes per engine, forever): a
@@ -209,9 +235,10 @@ struct ConsumerState {
 }
 
 impl ConsumerState {
-    fn new(dir: PathBuf) -> ConsumerState {
+    fn new(dir: PathBuf, conv: TickConverter) -> ConsumerState {
         ConsumerState {
             dir,
+            conv,
             writers: HashMap::new(),
             closed_engines: std::collections::HashSet::new(),
             closed_reported: std::collections::HashSet::new(),
@@ -242,6 +269,10 @@ impl ConsumerState {
             }
             return;
         }
+        // Cloned out of `self` so the converter can be read while the
+        // writer (a `&mut self` borrow) is held; one clone per drained
+        // range, not per record.
+        let conv = self.conv.clone();
         let Some(writer) = self.writer_for(engine_id) else {
             return;
         };
@@ -249,7 +280,7 @@ impl ConsumerState {
         for rec in record::iter(bytes) {
             match rec {
                 Ok(raw) => {
-                    let event = to_disk_event(&raw);
+                    let event = to_disk_event(&raw, &conv);
                     io_result = writer.write_event(&event);
                     if io_result.is_err() {
                         break;
@@ -288,6 +319,7 @@ impl ConsumerState {
                     engine_id,
                     self.started_at_epoch_ns,
                     meta.as_ref(),
+                    &self.conv,
                 );
                 match ProfileWriter::create(
                     &self.dir,
@@ -326,7 +358,10 @@ impl ConsumerState {
             return;
         }
         self.last_heartbeat = Instant::now();
-        let ts = clock::now_ns();
+        // Heartbeat cadence is the designated ≥1 s refinement slot for the
+        // x86 TSC rate (no-op for exact-rate sources / once refined).
+        self.conv.maybe_refine();
+        let ts = self.conv.to_ns(clock::now_ticks());
         let event = pb::DiskEventV1 {
             event: Some(pb::disk_event_v1::Event::Heartbeat(pb::Heartbeat {
                 timestamp_ns: ts,
@@ -393,9 +428,10 @@ impl ConsumerState {
     }
 }
 
-/// Transcoding is a pure encoding change — content identical to the ring
-/// record, with the `0 = none` conventions becoming `Option`s (v2 §4).
-fn to_disk_event(raw: &RawRecord<'_>) -> pb::DiskEventV1 {
+/// Transcoding converts raw ticks to nanoseconds (`conv`); everything else
+/// is a pure encoding change — content identical to the ring record, with
+/// the `0 = none` conventions becoming `Option`s (v2 §4).
+fn to_disk_event(raw: &RawRecord<'_>, conv: &TickConverter) -> pb::DiskEventV1 {
     use pb::disk_event_v1::Event;
     let event = match *raw {
         RawRecord::CallFunction {
@@ -404,19 +440,19 @@ fn to_disk_event(raw: &RawRecord<'_>) -> pb::DiskEventV1 {
             call_id,
             parent_call_id,
             function_id,
-            ts_ns,
+            ts_ticks,
         } => Event::CallFunction(pb::CallFunction {
             thread_id: thread_id.0,
             call_id: call_id.0,
             parent_call_id: (parent_call_id.0 != 0).then_some(parent_call_id.0),
             function_id: function_id.0,
-            timestamp_ns: ts_ns,
+            timestamp_ns: conv.to_ns(ts_ticks),
         }),
         RawRecord::EndFunction {
             status,
             thread_id,
             call_id,
-            ts_ns,
+            ts_ticks,
         } => Event::EndFunction(pb::EndFunction {
             thread_id: thread_id.0,
             call_id: call_id.0,
@@ -426,26 +462,26 @@ fn to_disk_event(raw: &RawRecord<'_>) -> pb::DiskEventV1 {
                 FunctionEndStatus::Cancelled => pb::FunctionEndStatus::Cancelled,
                 FunctionEndStatus::Exited => pb::FunctionEndStatus::Exited,
             } as i32,
-            timestamp_ns: ts_ns,
+            timestamp_ns: conv.to_ns(ts_ticks),
         }),
         RawRecord::StartThread {
             flags: _,
             thread_id,
             parent_thread_id,
             parent_call_id,
-            ts_ns,
+            ts_ticks,
             name,
         } => Event::StartThread(pb::StartThread {
             thread_id: thread_id.0,
             parent_thread_id: (parent_thread_id.0 != 0).then_some(parent_thread_id.0),
             parent_call_id: (parent_call_id.0 != 0).then_some(parent_call_id.0),
             name: (!name.is_empty()).then(|| String::from_utf8_lossy(name).into_owned()),
-            timestamp_ns: ts_ns,
+            timestamp_ns: conv.to_ns(ts_ticks),
         }),
         RawRecord::EndThread {
             status,
             thread_id,
-            ts_ns,
+            ts_ticks,
         } => Event::EndThread(pb::EndThread {
             thread_id: thread_id.0,
             status: match status {
@@ -453,18 +489,18 @@ fn to_disk_event(raw: &RawRecord<'_>) -> pb::DiskEventV1 {
                 ThreadEndStatus::Cancelled => pb::ThreadEndStatus::Cancelled,
                 ThreadEndStatus::Errored => pb::ThreadEndStatus::Errored,
             } as i32,
-            timestamp_ns: ts_ns,
+            timestamp_ns: conv.to_ns(ts_ticks),
         }),
         RawRecord::SetFunctionId {
             thread_id,
             call_id,
             id,
-            ts_ns,
+            ts_ticks,
         } => Event::SetFunctionId(pb::SetFunctionId {
             thread_id: thread_id.0,
             call_id: call_id.0,
             id: id.to_vec(),
-            timestamp_ns: ts_ns,
+            timestamp_ns: conv.to_ns(ts_ticks),
         }),
     };
     pb::DiskEventV1 { event: Some(event) }
@@ -532,6 +568,7 @@ mod tests {
             ctx,
             dir: dir.clone(),
             wake_interval: Duration::from_millis(1),
+            clock: ClockMode::Fixed(TickConverter::identity()),
         };
         std::thread::Builder::new()
             .name("test-prof-consumer".into())
@@ -606,7 +643,7 @@ mod tests {
                 thread_id: BexThreadId(1),
                 parent_thread_id: BexThreadId(0),
                 parent_call_id: BexCallId(0),
-                ts_ns: 1,
+                ts_ticks: 1,
                 name: b"worker",
             });
             for seq in 1..=PAIRS {
@@ -616,27 +653,27 @@ mod tests {
                     call_id: BexCallId(seq),
                     parent_call_id: BexCallId(seq - 1),
                     function_id: FunctionId(7),
-                    ts_ns: seq * 2,
+                    ts_ticks: seq * 2,
                 });
             }
             push(RawRecord::SetFunctionId {
                 thread_id: BexThreadId(1),
                 call_id: BexCallId(PAIRS),
                 id: [0xAB; 16],
-                ts_ns: PAIRS * 2 + 1,
+                ts_ticks: PAIRS * 2 + 1,
             });
             for seq in (1..=PAIRS).rev() {
                 push(RawRecord::EndFunction {
                     status: FunctionEndStatus::Ok,
                     thread_id: BexThreadId(1),
                     call_id: BexCallId(seq),
-                    ts_ns: 10_000 + seq,
+                    ts_ticks: 10_000 + seq,
                 });
             }
             push(RawRecord::EndThread {
                 status: ThreadEndStatus::Completed,
                 thread_id: BexThreadId(1),
-                ts_ns: 99_999,
+                ts_ticks: 99_999,
             });
         })
         .join()
@@ -695,10 +732,13 @@ mod tests {
             thread_id: BexThreadId(9),
             parent_thread_id: BexThreadId(0),
             parent_call_id: BexCallId(0),
-            ts_ns: 5,
+            ts_ticks: 5,
             name: b"",
         };
-        match to_disk_event(&raw).event.unwrap() {
+        match to_disk_event(&raw, &TickConverter::identity())
+            .event
+            .unwrap()
+        {
             Event::StartThread(st) => {
                 assert_eq!(st.parent_thread_id, None);
                 assert_eq!(st.parent_call_id, None);
@@ -712,9 +752,12 @@ mod tests {
             call_id: BexCallId(1),
             parent_call_id: BexCallId(0),
             function_id: FunctionId(0),
-            ts_ns: 5,
+            ts_ticks: 5,
         };
-        match to_disk_event(&raw).event.unwrap() {
+        match to_disk_event(&raw, &TickConverter::identity())
+            .event
+            .unwrap()
+        {
             Event::CallFunction(cf) => assert_eq!(cf.parent_call_id, None),
             other => panic!("wrong variant {other:?}"),
         }
@@ -722,9 +765,12 @@ mod tests {
             status: FunctionEndStatus::Errored,
             thread_id: BexThreadId(9),
             call_id: BexCallId(1),
-            ts_ns: 5,
+            ts_ticks: 5,
         };
-        match to_disk_event(&raw).event.unwrap() {
+        match to_disk_event(&raw, &TickConverter::identity())
+            .event
+            .unwrap()
+        {
             Event::EndFunction(ef) => {
                 assert_eq!(ef.status, pb::FunctionEndStatus::Errored as i32);
             }
@@ -757,19 +803,20 @@ mod tests {
                 call_id: BexCallId(seq),
                 parent_call_id: BexCallId(seq.saturating_sub(1)),
                 function_id: FunctionId(1),
-                ts_ns: seq,
+                ts_ticks: seq,
             }
             .encode(&mut buf);
             // SAFETY: claiming thread, alive throughout.
             unsafe { handle.push(&buf[..len]) };
         }
 
-        let mut state = ConsumerState::new(dir.clone());
+        let mut state = ConsumerState::new(dir.clone(), TickConverter::identity());
         let env = ConsumerEnv {
             registry,
             ctx,
             dir: dir.clone(),
             wake_interval: Duration::from_millis(1),
+            clock: ClockMode::Fixed(TickConverter::identity()),
         };
         let start = Instant::now();
         while state.sweep_once(&env) {}
@@ -808,6 +855,7 @@ mod tests {
             ctx,
             dir: dir.clone(),
             wake_interval: Duration::from_millis(1),
+            clock: ClockMode::Fixed(TickConverter::identity()),
         };
         std::thread::Builder::new()
             .name("soak-prof-consumer".into())
@@ -826,7 +874,7 @@ mod tests {
                         call_id: BexCallId(seq + 1),
                         parent_call_id: BexCallId(seq),
                         function_id: FunctionId(1),
-                        ts_ns: round * per_round + seq,
+                        ts_ticks: round * per_round + seq,
                     }
                     .encode(&mut buf);
                     // SAFETY: claiming thread, alive for the whole closure.

--- a/baml_language/crates/bex_events/src/prof/file.rs
+++ b/baml_language/crates/bex_events/src/prof/file.rs
@@ -89,12 +89,28 @@ pub(crate) fn build_header(
     engine_id: u64,
     started_at_epoch_ns: u128,
     meta: Option<&crate::prof::EngineProfileMetadata>,
+    clock: &crate::prof::clock::TickConverter,
 ) -> pb::EventFileHeaderV1 {
+    use crate::prof::clock::{ClockKind, ClockQuality};
+    let (tick_ns_numer, tick_ns_denom) = clock.rate();
     pb::EventFileHeaderV1 {
         process_id: process_id.to_vec(),
         engine_id,
         program_id: meta.map(|m| m.program_id.clone()).unwrap_or_default(),
         started_at_epoch_ns: started_at_epoch_ns.to_le_bytes().to_vec(),
+        clock_kind: match clock.kind() {
+            ClockKind::Tsc => pb::ClockKind::Tsc,
+            ClockKind::Cntvct => pb::ClockKind::Cntvct,
+            ClockKind::Instant => pb::ClockKind::Instant,
+            ClockKind::Stub => pb::ClockKind::Stub,
+        } as i32,
+        tick_ns_numer,
+        tick_ns_denom,
+        clock_quality: match clock.quality() {
+            ClockQuality::Exact => pb::ClockQuality::Exact,
+            ClockQuality::Calibrated => pb::ClockQuality::Calibrated,
+            ClockQuality::Coarse => pb::ClockQuality::Coarse,
+        } as i32,
         function_table: Some(pb::FunctionMetadataTable {
             functions: meta
                 .map(|m| {

--- a/baml_language/crates/bex_events/src/prof/mod.rs
+++ b/baml_language/crates/bex_events/src/prof/mod.rs
@@ -93,7 +93,7 @@ pub struct FunctionMetaEntry {
     pub kind: String,
 }
 
-// wasm32: profiling is forced off (no consumer thread, no TSC clock); the
+// wasm32: profiling is forced off (no consumer thread, no tick clock); the
 // producer-facing surface compiles to no-ops so dual-target callers don't
 // need their own cfgs.
 #[cfg(target_arch = "wasm32")]

--- a/baml_language/crates/bex_events/src/prof/proto/bamlprof.proto
+++ b/baml_language/crates/bex_events/src/prof/proto/bamlprof.proto
@@ -4,9 +4,10 @@
 // length-delimited DiskEventV1 messages. One file per engine per process:
 // <process_id>-<started_at>-<engine>.bamlprof under the profiles directory.
 //
-// Content mirrors the raw ring records exactly (transcoding is a pure
-// encoding change, no enrichment); `0 = none` ring conventions become
-// optional fields here.
+// Content mirrors the raw ring records (no enrichment), with one
+// transformation: ring records carry raw clock ticks, and the consumer
+// converts them to nanoseconds at transcode — `timestamp_ns` fields here are
+// always nanoseconds. `0 = none` ring conventions become optional fields.
 //
 // Ordering: events appear in per-ring drain order, and one logical thread's
 // events can arrive via several rings (tasks migrate OS threads), so FILE
@@ -133,6 +134,42 @@ message EventFileHeaderV1 {
   // Per-run runtime metadata, not stable across recompiles; the FQN is the
   // cross-run key.
   FunctionMetadataTable function_table = 5;
+  // Diagnostics about the tick source behind event timestamps. Purely
+  // informational: ring records carry raw ticks, but the consumer converts
+  // to nanoseconds before writing, so `timestamp_ns` fields are always ns
+  // and nothing needs these to interpret them.
+  ClockKind clock_kind = 6;
+  // ns-per-tick rational (numer/denom) in effect when this header was
+  // written. For CLOCK_KIND_TSC this is the estimate at header time; the
+  // rate is refined ~1 s into the run (see ClockQuality).
+  uint64 tick_ns_numer = 7;
+  uint64 tick_ns_denom = 8;
+  ClockQuality clock_quality = 9;
+}
+
+// Which hardware source produced event timestamps (header diagnostics).
+enum ClockKind {
+  CLOCK_KIND_UNSPECIFIED = 0;
+  // x86_64 invariant TSC (rdtsc), consumer-calibrated rate.
+  CLOCK_KIND_TSC = 1;
+  // aarch64 generic timer (CNTVCT_EL0), exact architectural rate.
+  CLOCK_KIND_CNTVCT = 2;
+  // Monotonic OS-clock fallback; ticks are nanoseconds.
+  CLOCK_KIND_INSTANT = 3;
+  // Test/stub builds.
+  CLOCK_KIND_STUB = 4;
+}
+
+// How trustworthy the tick->ns rate was at header-write time.
+enum ClockQuality {
+  CLOCK_QUALITY_UNSPECIFIED = 0;
+  // Platform-stated exact rational (CNTVCT, INSTANT, STUB).
+  CLOCK_QUALITY_EXACT = 1;
+  // TSC rate refined over a >=1 s window.
+  CLOCK_QUALITY_CALIBRATED = 2;
+  // TSC rate from the initial ~2 ms estimate only (~0.1% rate error,
+  // affecting at most the first ~1 s of events).
+  CLOCK_QUALITY_COARSE = 3;
 }
 
 message FunctionMetadataTable {

--- a/baml_language/crates/bex_events/src/prof/record.rs
+++ b/baml_language/crates/bex_events/src/prof/record.rs
@@ -100,8 +100,9 @@ pub enum RawRecord<'a> {
         parent_call_id: BexCallId,
         /// Per-run function id (see the header's function table; 0 = unattributable).
         function_id: FunctionId,
-        /// Nanoseconds since the process zero point ([`crate::prof::clock`]).
-        ts_ns: u64,
+        /// Raw clock ticks ([`crate::prof::clock::now_ticks`]); the consumer
+        /// converts to nanoseconds at transcode.
+        ts_ticks: u64,
     },
     /// Tag `0x02`: a function call ended (return, unwind, or cancel drain).
     EndFunction {
@@ -111,8 +112,8 @@ pub enum RawRecord<'a> {
         thread_id: BexThreadId,
         /// Matches the `CallFunction` it closes.
         call_id: BexCallId,
-        /// Nanoseconds since the process zero point.
-        ts_ns: u64,
+        /// Raw clock ticks; converted to ns by the consumer at transcode.
+        ts_ticks: u64,
     },
     /// Tag `0x03`: a logical thread started (root or spawn).
     StartThread {
@@ -124,8 +125,8 @@ pub enum RawRecord<'a> {
         parent_thread_id: BexThreadId,
         /// Spawning call in the parent thread; `0` = none.
         parent_call_id: BexCallId,
-        /// Nanoseconds since the process zero point.
-        ts_ns: u64,
+        /// Raw clock ticks; converted to ns by the consumer at transcode.
+        ts_ticks: u64,
         /// User-defined thread name, ≤ [`MAX_THREAD_NAME_LEN`] bytes of UTF-8
         /// (validated only at transcode time).
         name: &'a [u8],
@@ -136,8 +137,8 @@ pub enum RawRecord<'a> {
         status: ThreadEndStatus,
         /// Logical BEX thread id.
         thread_id: BexThreadId,
-        /// Nanoseconds since the process zero point.
-        ts_ns: u64,
+        /// Raw clock ticks; converted to ns by the consumer at transcode.
+        ts_ticks: u64,
     },
     /// Tag `0x05`: `$id` override for a call (reserved for the M1 language
     /// surface; the shape is fixed so the ring format doesn't change).
@@ -148,8 +149,8 @@ pub enum RawRecord<'a> {
         call_id: BexCallId,
         /// The override UUID bytes (`baml.id.new()`).
         id: [u8; 16],
-        /// Nanoseconds since the process zero point.
-        ts_ns: u64,
+        /// Raw clock ticks; converted to ns by the consumer at transcode.
+        ts_ticks: u64,
     },
 }
 
@@ -207,7 +208,7 @@ impl RawRecord<'_> {
                 call_id,
                 parent_call_id,
                 function_id,
-                ts_ns,
+                ts_ticks,
             } => {
                 w.u8(TAG_CALL_FUNCTION);
                 w.u8(flags);
@@ -215,26 +216,26 @@ impl RawRecord<'_> {
                 w.u64(call_id.0);
                 w.u64(parent_call_id.0);
                 w.u32(function_id.0);
-                w.u64(ts_ns);
+                w.u64(ts_ticks);
             }
             RawRecord::EndFunction {
                 status,
                 thread_id,
                 call_id,
-                ts_ns,
+                ts_ticks,
             } => {
                 w.u8(TAG_END_FUNCTION);
                 w.u8(status as u8);
                 w.u64(thread_id.0);
                 w.u64(call_id.0);
-                w.u64(ts_ns);
+                w.u64(ts_ticks);
             }
             RawRecord::StartThread {
                 flags,
                 thread_id,
                 parent_thread_id,
                 parent_call_id,
-                ts_ns,
+                ts_ticks,
                 name,
             } => {
                 let name = &name[..name.len().min(MAX_THREAD_NAME_LEN)];
@@ -243,7 +244,7 @@ impl RawRecord<'_> {
                 w.u64(thread_id.0);
                 w.u64(parent_thread_id.0);
                 w.u64(parent_call_id.0);
-                w.u64(ts_ns);
+                w.u64(ts_ticks);
                 #[expect(
                     clippy::cast_possible_truncation,
                     reason = "name.len() <= MAX_THREAD_NAME_LEN = 256"
@@ -254,24 +255,24 @@ impl RawRecord<'_> {
             RawRecord::EndThread {
                 status,
                 thread_id,
-                ts_ns,
+                ts_ticks,
             } => {
                 w.u8(TAG_END_THREAD);
                 w.u8(status as u8);
                 w.u64(thread_id.0);
-                w.u64(ts_ns);
+                w.u64(ts_ticks);
             }
             RawRecord::SetFunctionId {
                 thread_id,
                 call_id,
                 id,
-                ts_ns,
+                ts_ticks,
             } => {
                 w.u8(TAG_SET_FUNCTION_ID);
                 w.u64(thread_id.0);
                 w.u64(call_id.0);
                 w.bytes(&id);
-                w.u64(ts_ns);
+                w.u64(ts_ticks);
             }
         }
         debug_assert_eq!(w.pos, self.encoded_len());
@@ -291,7 +292,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
             call_id: BexCallId(r.u64()?),
             parent_call_id: BexCallId(r.u64()?),
             function_id: FunctionId(r.u32()?),
-            ts_ns: r.u64()?,
+            ts_ticks: r.u64()?,
         },
         TAG_END_FUNCTION => RawRecord::EndFunction {
             status: match r.u8()? {
@@ -303,14 +304,14 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
             },
             thread_id: BexThreadId(r.u64()?),
             call_id: BexCallId(r.u64()?),
-            ts_ns: r.u64()?,
+            ts_ticks: r.u64()?,
         },
         TAG_START_THREAD => {
             let flags = r.u8()?;
             let thread_id = BexThreadId(r.u64()?);
             let parent_thread_id = BexThreadId(r.u64()?);
             let parent_call_id = BexCallId(r.u64()?);
-            let ts_ns = r.u64()?;
+            let ts_ticks = r.u64()?;
             let name_len = r.u16()?;
             if usize::from(name_len) > MAX_THREAD_NAME_LEN {
                 return Err(DecodeError::NameTooLong(name_len));
@@ -320,7 +321,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
                 thread_id,
                 parent_thread_id,
                 parent_call_id,
-                ts_ns,
+                ts_ticks,
                 name: r.bytes(usize::from(name_len))?,
             }
         }
@@ -332,7 +333,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
                 bad => return Err(DecodeError::InvalidStatus(bad)),
             },
             thread_id: BexThreadId(r.u64()?),
-            ts_ns: r.u64()?,
+            ts_ticks: r.u64()?,
         },
         TAG_SET_FUNCTION_ID => RawRecord::SetFunctionId {
             thread_id: BexThreadId(r.u64()?),
@@ -343,7 +344,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
                 id.copy_from_slice(bytes);
                 id
             },
-            ts_ns: r.u64()?,
+            ts_ticks: r.u64()?,
         },
         bad => return Err(DecodeError::UnknownTag(bad)),
     };
@@ -482,24 +483,24 @@ mod tests {
                 call_id: BexCallId(v.wrapping_add(1)),
                 parent_call_id: BexCallId(v / 2),
                 function_id: FunctionId(v as u32),
-                ts_ns: v,
+                ts_ticks: v,
             });
             roundtrip(RawRecord::EndFunction {
                 status: FunctionEndStatus::Ok,
                 thread_id: BexThreadId(v),
                 call_id: BexCallId(v),
-                ts_ns: v,
+                ts_ticks: v,
             });
             roundtrip(RawRecord::EndThread {
                 status: ThreadEndStatus::Cancelled,
                 thread_id: BexThreadId(v),
-                ts_ns: v,
+                ts_ticks: v,
             });
             roundtrip(RawRecord::SetFunctionId {
                 thread_id: BexThreadId(v),
                 call_id: BexCallId(v),
                 id: [v as u8; 16],
-                ts_ns: v,
+                ts_ticks: v,
             });
         }
         for status in [
@@ -511,18 +512,18 @@ mod tests {
                 status,
                 thread_id: BexThreadId(7),
                 call_id: BexCallId(9),
-                ts_ns: 11,
+                ts_ticks: 11,
             });
         }
         roundtrip(RawRecord::EndThread {
             status: ThreadEndStatus::Completed,
             thread_id: BexThreadId(7),
-            ts_ns: 11,
+            ts_ticks: 11,
         });
         roundtrip(RawRecord::EndThread {
             status: ThreadEndStatus::Errored,
             thread_id: BexThreadId(7),
-            ts_ns: 11,
+            ts_ticks: 11,
         });
     }
 
@@ -535,7 +536,7 @@ mod tests {
                 thread_id: BexThreadId(2),
                 parent_thread_id: BexThreadId(0),
                 parent_call_id: BexCallId(3),
-                ts_ns: 4,
+                ts_ticks: 4,
                 name: &name,
             });
         }
@@ -549,7 +550,7 @@ mod tests {
             thread_id: BexThreadId(1),
             parent_thread_id: BexThreadId(0),
             parent_call_id: BexCallId(0),
-            ts_ns: 0,
+            ts_ticks: 0,
             name: &name,
         };
         let mut buf = [0u8; MAX_RECORD_LEN];
@@ -571,14 +572,14 @@ mod tests {
             call_id: BexCallId(1),
             parent_call_id: BexCallId(0),
             function_id: FunctionId(0),
-            ts_ns: 0,
+            ts_ticks: 0,
         };
         assert_eq!(call.encode(&mut buf), 38);
         let end = RawRecord::EndFunction {
             status: FunctionEndStatus::Ok,
             thread_id: BexThreadId(1),
             call_id: BexCallId(1),
-            ts_ns: 0,
+            ts_ticks: 0,
         };
         assert_eq!(end.encode(&mut buf), 26);
         let start_thread = RawRecord::StartThread {
@@ -586,21 +587,21 @@ mod tests {
             thread_id: BexThreadId(1),
             parent_thread_id: BexThreadId(0),
             parent_call_id: BexCallId(0),
-            ts_ns: 0,
+            ts_ticks: 0,
             name: b"",
         };
         assert_eq!(start_thread.encode(&mut buf), 36);
         let end_thread = RawRecord::EndThread {
             status: ThreadEndStatus::Completed,
             thread_id: BexThreadId(1),
-            ts_ns: 0,
+            ts_ticks: 0,
         };
         assert_eq!(end_thread.encode(&mut buf), 18);
         let set_id = RawRecord::SetFunctionId {
             thread_id: BexThreadId(1),
             call_id: BexCallId(1),
             id: [0; 16],
-            ts_ns: 0,
+            ts_ticks: 0,
         };
         assert_eq!(set_id.encode(&mut buf), 41);
     }
@@ -616,7 +617,7 @@ mod tests {
             status: FunctionEndStatus::Ok,
             thread_id: BexThreadId(1),
             call_id: BexCallId(1),
-            ts_ns: 0,
+            ts_ticks: 0,
         }
         .encode(&mut buf);
         buf[1] = 4; // first byte past the status range {Ok,Errored,Cancelled,Exited}
@@ -631,7 +632,7 @@ mod tests {
             thread_id: BexThreadId(1),
             parent_thread_id: BexThreadId(0),
             parent_call_id: BexCallId(0),
-            ts_ns: 0,
+            ts_ticks: 0,
             name: b"hi",
         }
         .encode(&mut buf);
@@ -651,21 +652,21 @@ mod tests {
                 call_id: BexCallId(3),
                 parent_call_id: BexCallId(4),
                 function_id: FunctionId(5),
-                ts_ns: 6,
+                ts_ticks: 6,
             },
             RawRecord::StartThread {
                 flags: 0,
                 thread_id: BexThreadId(1),
                 parent_thread_id: BexThreadId(2),
                 parent_call_id: BexCallId(3),
-                ts_ns: 4,
+                ts_ticks: 4,
                 name: &name,
             },
             RawRecord::SetFunctionId {
                 thread_id: BexThreadId(1),
                 call_id: BexCallId(2),
                 id: [3; 16],
-                ts_ns: 4,
+                ts_ticks: 4,
             },
         ];
         for rec in records {
@@ -690,7 +691,7 @@ mod tests {
                 thread_id: BexThreadId(1),
                 parent_thread_id: BexThreadId(0),
                 parent_call_id: BexCallId(0),
-                ts_ns: 1,
+                ts_ticks: 1,
                 name,
             },
             RawRecord::CallFunction {
@@ -699,18 +700,18 @@ mod tests {
                 call_id: BexCallId(1),
                 parent_call_id: BexCallId(0),
                 function_id: FunctionId(7),
-                ts_ns: 2,
+                ts_ticks: 2,
             },
             RawRecord::EndFunction {
                 status: FunctionEndStatus::Ok,
                 thread_id: BexThreadId(1),
                 call_id: BexCallId(1),
-                ts_ns: 3,
+                ts_ticks: 3,
             },
             RawRecord::EndThread {
                 status: ThreadEndStatus::Completed,
                 thread_id: BexThreadId(1),
-                ts_ns: 4,
+                ts_ticks: 4,
             },
         ];
         let mut packed = Vec::new();

--- a/baml_language/crates/bex_events/src/prof/registry.rs
+++ b/baml_language/crates/bex_events/src/prof/registry.rs
@@ -219,6 +219,10 @@ mod global {
                 return unsafe { RingHandle::new(ring) };
             }
             let cfg = ProfConfig::global();
+            // Pin the clock anchor (source detection + zero point — cheap,
+            // no calibration). Belt-and-braces: now_ticks() also forces it,
+            // which is the real every-stamp-postdates-the-anchor invariant.
+            crate::prof::clock::init();
             // The consumer drains every registered ring; it must exist
             // before the first event can pile up. No-op when profiling is
             // off (tests drive private registries as their own consumers).

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2981,7 +2981,7 @@ impl BexVm {
                 call_id: BexCallId(call_id),
                 parent_call_id: BexCallId(parent_call_id),
                 function_id: ProfFunctionId(function_id),
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
         }
         (call_id, parent_call_id)
@@ -3013,7 +3013,7 @@ impl BexVm {
                 status,
                 thread_id: BexThreadId(self.prof_thread_id),
                 call_id: BexCallId(call_id),
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
         }
     }
@@ -3089,7 +3089,7 @@ impl BexVm {
                 call_id: BexCallId(call_id),
                 parent_call_id: BexCallId(parent_call_id),
                 function_id: ProfFunctionId(function_id),
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
             self.pending_sysop_call_id = Some(call_id);
         }
@@ -3104,7 +3104,7 @@ impl BexVm {
                 thread_id: BexThreadId(self.prof_thread_id),
                 call_id: BexCallId(call_id),
                 id,
-                ts_ns: bex_events::prof::clock::now_ns(),
+                ts_ticks: bex_events::prof::clock::now_ticks(),
             });
         }
     }
@@ -3113,13 +3113,13 @@ impl BexVm {
     /// completed inline (`Done`/`Error`) — `YieldToCall` natives are
     /// continuation-based and stay transparent in the event stream (their
     /// callback calls attribute to the bytecode caller); tracking them
-    /// through the CPS frames is a follow-up. `ts_start` is captured before
+    /// through the CPS frames is a follow-up. `start_ticks` is captured before
     /// the native ran, so the pair still spans its real duration.
     #[inline]
     fn prof_emit_native_pair(
         &mut self,
         function_id: u32,
-        ts_start: u64,
+        start_ticks: u64,
         status: bex_events::prof::record::FunctionEndStatus,
     ) {
         // Mint before the ring gate: call ids are `$id` semantics and must
@@ -3137,14 +3137,14 @@ impl BexVm {
             call_id: BexCallId(call_id),
             parent_call_id: BexCallId(parent_call_id),
             function_id: ProfFunctionId(function_id),
-            ts_ns: ts_start,
+            ts_ticks: start_ticks,
         }
         .encode_to(&mut buf);
         let end_len = bex_events::prof::record::RawRecord::EndFunction {
             status,
             thread_id: BexThreadId(self.prof_thread_id),
             call_id: BexCallId(call_id),
-            ts_ns: bex_events::prof::clock::now_ns(),
+            ts_ticks: bex_events::prof::clock::now_ticks(),
         }
         .encode_to(&mut buf[call_len..]);
         // SAFETY: same D5a contract as prof_push_record.
@@ -3420,8 +3420,8 @@ impl BexVm {
                 // completes inline (Done/Error) — YieldToCall natives are
                 // continuation-based and stay transparent (see
                 // prof_emit_native_pair).
-                let native_ts_start = if self.prof_ring.is_some() {
-                    bex_events::prof::clock::now_ns()
+                let native_ticks_start = if self.prof_ring.is_some() {
+                    bex_events::prof::clock::now_ticks()
                 } else {
                     0
                 };
@@ -3435,7 +3435,7 @@ impl BexVm {
                     NativeCallResult::Done(v) => {
                         self.prof_emit_native_pair(
                             callee_function_id,
-                            native_ts_start,
+                            native_ticks_start,
                             bex_events::prof::record::FunctionEndStatus::Ok,
                         );
                         self.stack.push(v);
@@ -3444,7 +3444,7 @@ impl BexVm {
                         // Status by error class: baml.sys.exit's own pair
                         // closes Exited, a cancel panic Cancelled (§7 1–3).
                         let status = self.prof_native_error_status(&e);
-                        self.prof_emit_native_pair(callee_function_id, native_ts_start, status);
+                        self.prof_emit_native_pair(callee_function_id, native_ticks_start, status);
                         return Err(self.native_error_to_vm_error(e));
                     }
                     NativeCallResult::YieldToCall {


### PR DESCRIPTION
## Problem

`minstant-0.1.7` registers a `#[ctor]` static initializer that busy-spins **≥20 ms calibrating the TSC before `main()` in every process that links `bex_events`** — packed binaries, `baml-cli`, the LSP, and every nextest test process — even with `BAML_PROFILE=0`. Its calibration loop (`_cycles_per_sec`) requires ≥10 ms per sample window and ≥2 converging windows by construction.

Measured impact: an empty packed program (`function main() -> int { return 0; }`) ran **10.8 ms pre-tracing → 31.3 ms** on canary. This constant per-process tax was the dominant end-to-end regression from the tracing merge (#3740) — it inflated every short-running benchmark by +50–145% and is a large chunk of the test-suite wall-time increase.

Secondary problems: minstant only uses the TSC on Linux x86 (Macs silently fall back to the OS clock), and the producer hot path paid a tick→ns conversion on every clock read.

## Fix

- **Producers stamp raw ticks** (`clock::now_ticks()`): `rdtsc` on x86_64 (gated on a CPUID invariant-TSC probe), `mrs CNTVCT_EL0` on aarch64, monotonic-`Instant` fallback otherwise. No conversion, no calibration, no ctor on any producer path. The anchor is forced inside `now_ticks()`, so every stamped tick postdates the process base regardless of init order.
- **The consumer owns tick→ns conversion** (`TickConverter`, built on the consumer thread): exact rational rates where the platform states them (`mach_timebase_info` on macOS — Apple Silicon's 125/3 handled exactly; `CNTFRQ_EL0` on Linux ARM); for the x86 TSC, a ~2 ms two-point estimate at consumer start, refined once across a ≥1 s window at heartbeat cadence with piecewise-linear anchor continuity (per-thread `timestamp_ns` stays monotone across the rate swap; late-draining ring events convert through the previous segment).
- **Disk format unchanged**: `.bamlprof` timestamps remain nanoseconds; `wall(event) = started_at_epoch_ns + timestamp_ns` holds; `prof_gate` needed zero source changes. The header gains informational `clock_kind` / tick-rate rational / `clock_quality` fields (proto3-additive).
- `minstant` (and the `ctor@0.1.x` it pulled in) removed from the workspace.

## Measured (Linux x86, 32-core dev box)

| Metric | before | after |
|---|---|---|
| Empty packed binary startup (profiling on) | 31.3 ms | **15.2 ms** |
| Same, `BAML_PROFILE=0`, vs pre-tracing baseline | +20.5 ms | **+1.1 ms** |
| `now_ticks` read (prof_clock bench) | 8.45 ns (minstant) | **8.33 ns** |
| Tracing on-vs-off, divan pure-call-1m | ~42 ns/call-pair | **~24 ns/call-pair** |

The per-pair improvement comes from the two tick→ns conversions leaving the VM hot path. End-to-end (speedtest corpus, packed binaries): small/loop-heavy workloads return to ≈pre-tracing (+3–11%); remaining overhead concentrates proportionally to traced call volume.

## Verification

- `cargo test -p bex_events` (51), `cargo test -p bex_engine --test prof_gate` (17/17)
- Full CI mirror: `rustup run 1.93.0 cargo test -p bex_events -p bex_vm -p bex_engine --all-features` — all green
- loom (`--cfg baml_loom`, 34) and miri (33) prof suites
- clippy `--all-targets` clean; wasm32 `cargo check` clean
- `.init_array` back to 53 entries (the ctor is gone); `cargo tree -i minstant` / `-i ctor@0.1.26` → no matches
- New unit tests: cross-thread tick ordering, converter rate sanity (catches a swapped mach timebase rational), refinement monotonicity across the rate swap, pre-base clamp, identity passthrough

## Notes for reviewers

- ARM paths are validated by compilation + unit tests that will exercise them on the macOS-ARM CI leg (`converter_rate_sane` fails loudly on a wrong rational). Known monitor-don't-block risk: 24 MHz CNTVCT granularity on M1–M3 slightly raises timestamp-tie probability in prof_gate's large streams; ties are stable-sort-safe.
- The consumer blocks ~2 ms once at startup for the coarse TSC estimate (x86 only, profiling on only); events transcoded in the first ~1 s carry ~0.1% rate error, recorded as `CLOCK_QUALITY_COARSE` in the header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Profiling now stamps raw hardware ticks and converts them to nanoseconds on the consumer side for improved consistency and monotonicity.
  * Trace file headers record clock diagnostics (clock kind, tick→ns rate, and quality) so exported traces include clock metadata.

* **Chores**
  * Removed an external timing dependency; benchmarks and tests updated to measure ticks and conversion separately.
  * Profiling is stubbed/disabled on unsupported targets (e.g., wasm/miri).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->