### PR TITLE
fix(pack): Linux pack corrupts binaries — embedded note overlaps host .bss

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -110,8 +110,22 @@ jobs:
       # Snapshot tests live in `baml_tests` and are exercised end-to-end by
       # the dedicated `snapshot-tests` job. The `sdk_test_*` crates need uv
       # and run in the dedicated `sdk-tests` matrix below. Skip both here.
+      # `pack_e2e` is excluded here and run as its own step below: its harness
+      # builds `baml-pack-host` once and shares it across the suite via a
+      # process-global OnceLock, which nextest's process-per-test model would
+      # defeat (every test would rebuild the host).
       - name: "Run tests with nextest"
-        run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/)'
+        run: cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/) and not binary(=pack_e2e)'
+        working-directory: baml_language
+
+      # The only Linux coverage of `baml pack`'s ELF embed/extract path. The
+      # team develops on macOS, where libsui takes the Mach-O path, so an ELF
+      # writer bug (see crates/baml_cli/src/pack_elf.rs) shipped uncaught. The
+      # bug lives in ELF layout, not codegen, so it reproduces in debug too —
+      # running here (reusing the build above) keeps the gate cheap. `cargo
+      # test`, not nextest, lets the harness build the host once.
+      - name: "Run pack e2e tests (linux)"
+        run: cargo test -p baml_cli --test pack_e2e --all-features
         working-directory: baml_language
 
       - name: "Upload test results on failure"

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "indicatif",
  "insta",
  "libsui",
+ "object 0.36.3",
  "regex",
  "reqwest",
  "sdkgen_python_pydantic2",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -174,6 +174,10 @@ lsp-types = "0.95.0"
 # Calibrated-TSC clock for profiling timestamps (bex_events::prof::clock).
 minstant = { version = "0.1" }
 notify = "7.0"
+# Pinned to the exact version libsui depends on so `baml pack`'s ELF note
+# writer (crates/baml_cli/src/pack_elf.rs) and libsui's reader share one
+# `object` build. See pack_elf.rs for why we don't use `libsui::Elf::append`.
+object = { version = "=0.36.3", default-features = false, features = [ "build", "read_core", "elf", "std" ] }
 once_cell = "1.19"
 ouroboros = "0.18.5"
 parking_lot = { version = "0.12" }

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -41,6 +41,7 @@ ctrlc = { workspace = true }
 flate2 = { workspace = true }
 indicatif = { workspace = true }
 libsui = { workspace = true }
+object = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod ide_command;
 pub(crate) mod init_command;
 pub(crate) mod lsp;
 pub(crate) mod pack_command;
+pub(crate) mod pack_elf;
 pub(crate) mod project_load;
 pub mod reporter;
 pub(crate) mod run_command;

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -492,9 +492,25 @@ fn read_host_binary(target_triple: &str, reporter: &Reporter) -> Result<Vec<u8>>
         .ok_or_else(|| anyhow!("Cannot determine directory of current executable"))?;
     let host_name = host_binary_name(target_triple);
     let host_path = dir.join(&host_name);
-    if target_triple == release_host_target_triple()? && host_path.exists() {
+    let is_native = target_triple == release_host_target_triple()?;
+    if is_native && host_path.exists() {
         return std::fs::read(&host_path)
             .with_context(|| format!("Failed to read {}", host_path.display()));
+    }
+
+    // A workspace-built host sits next to the CLI but we're skipping it
+    // because the requested `--target` isn't this machine's platform, so we
+    // download a release host for that target instead. Surface it: a dev who
+    // expected their local host embedded would otherwise silently get
+    // released bytes — exactly the kind of skip that hides host-side bugs
+    // from local testing. (No local host => nothing skipped; stay quiet, the
+    // "Downloading" line below already explains the fetch.)
+    if !is_native && host_path.exists() {
+        reporter.warning(format_args!(
+            "ignoring local `{}` (built for this machine) — packing for `{target_triple}` \
+             downloads a matching release host instead.",
+            host_path.display()
+        ));
     }
 
     // Cargo emits `Downloading <crate>` when it has to fetch a missing
@@ -570,8 +586,10 @@ fn write_executable(
     target_triple: &str,
 ) -> Result<()> {
     if target_triple.contains("linux") {
-        libsui::Elf::new(host_bytes)
-            .append(PACK_SECTION_NAME, data, writer)
+        // Not `libsui::Elf::append`: it places the embedded note at a virtual
+        // address that can overlap the host's `.bss`, corrupting the envelope
+        // (and the host's BSS globals) at startup. See `pack_elf`.
+        crate::pack_elf::append_note(host_bytes, PACK_SECTION_NAME, data, writer)
             .context("Failed to write ELF binary")?;
     } else if target_triple.contains("windows") {
         libsui::PortableExecutable::from(host_bytes)

--- a/baml_language/crates/baml_cli/src/pack_elf.rs
+++ b/baml_language/crates/baml_cli/src/pack_elf.rs
@@ -1,0 +1,255 @@
+//! ELF note injection for `baml pack` on Linux.
+//!
+//! # Why this exists (and isn't just `libsui::Elf::append`)
+//!
+//! `baml pack` embeds the `PackEnvelope` as an ELF note section
+//! (`.note.sui`) so the packed host can read it back at startup via
+//! `libsui::find_section` (which walks `PT_NOTE` segments in memory through
+//! `dl_iterate_phdr`). libsui 0.14.0's writer, `Elf::append`, has a layout
+//! bug that corrupts the embedded data whenever the host binary's last
+//! writable `PT_LOAD` segment has a large `.bss`:
+//!
+//!   - It appends `.note.sui` to that last RW `PT_LOAD` and derives the
+//!     section's virtual address purely from its *file* offset
+//!     (`sh_addr = seg.p_vaddr + (sh_offset - seg.p_offset)`).
+//!   - That ignores `.bss` (`SHT_NOBITS`), whose *memory* image extends past
+//!     its (zero-length) *file* image — i.e. the segment's `p_memsz` is
+//!     larger than its `p_filesz`.
+//!   - When `.bss` is big enough, the note's virtual address lands *inside*
+//!     the `.bss` memory range. The program's zero-initialized globals then
+//!     alias the embedded envelope: at startup they read the note's bytes as
+//!     their initial values (garbage globals → SIGSEGV) and overwrite the
+//!     envelope (so `find_section` reads corrupt data → borsh fails with
+//!     "invalid utf-8" / "Unexpected variant tag").
+//!
+//! This reproduces 100% deterministically whenever `baml-pack-host` is built
+//! in the same cargo invocation as `baml_cli` (`cargo build -p baml_cli -p
+//! baml_pack_host`): feature unification across the shared dependency tree
+//! pulls more static state into the host, inflating `.bss` past the overlap
+//! threshold. Built alone, the host's `.bss` is small enough to fit under the
+//! page boundary and the bug stays hidden — which is how it shipped (the
+//! team develops on macOS, where libsui takes the Mach-O path).
+//!
+//! # The fix
+//!
+//! We can't grow the program header table to give the note its own fresh
+//! `PT_LOAD` — release hosts pack the phdr table flush against `.interp`,
+//! leaving zero slack, and `object`'s ELF builder refuses to relocate alloc
+//! sections to make room. So we keep libsui's strategy (reuse the existing
+//! `PT_NOTE` phdr, append `.note.sui` to the last RW `PT_LOAD`) and change
+//! exactly one thing: place the note past the segment's whole *memory* image
+//! (`p_offset + p_memsz`), not just past its file bytes, so its virtual
+//! address always clears `.bss`. The note's on-wire format is byte-for-byte
+//! identical to libsui's, so the unmodified `libsui::find_section` reader
+//! still parses it.
+//!
+//! The writer logic mirrors `libsui::Elf::append` (MIT-licensed, Divy
+//! Srivastava / the Deno authors); the placement math is the only deviation.
+
+use std::io::Write;
+
+use anyhow::{Result, anyhow};
+use object::{
+    build::elf as e,
+    elf::{PF_R, PT_NOTE, SHF_ALLOC, SHT_NOBITS, SHT_NOTE},
+    endian::Endianness,
+    read::elf::{FileHeader, ProgramHeader},
+};
+
+/// Note name (NUL-terminated) and vendor type tag, matching libsui's reader
+/// so `libsui::find_section` parses what we write.
+const ELF_NOTE_NAME: &[u8] = b"SUI\0";
+const ELF_NOTE_TYPE_SECTION_DATA: u32 = 0x5355_4901;
+
+fn align_up(value: u64, align: u64) -> u64 {
+    if align <= 1 {
+        value
+    } else {
+        (value + (align - 1)) & !(align - 1)
+    }
+}
+
+/// Build the ELF note payload (header + name + descriptor). The descriptor
+/// is `u16 name_len | section_name | section_data`, identical to
+/// `libsui::build_elf_note_payload`, so the host's `libsui::find_section` →
+/// `parse_elf_note_desc` reads it back unchanged.
+fn build_elf_note_payload(section_name: &str, section_data: &[u8]) -> Vec<u8> {
+    let name_len = u16::try_from(section_name.len()).expect("section name too long");
+
+    let mut desc = Vec::with_capacity(2 + section_name.len() + section_data.len());
+    desc.extend_from_slice(&name_len.to_le_bytes());
+    desc.extend_from_slice(section_name.as_bytes());
+    desc.extend_from_slice(section_data);
+
+    let mut note = Vec::new();
+    note.extend_from_slice(&(ELF_NOTE_NAME.len() as u32).to_le_bytes());
+    note.extend_from_slice(&(desc.len() as u32).to_le_bytes());
+    note.extend_from_slice(&ELF_NOTE_TYPE_SECTION_DATA.to_le_bytes());
+    note.extend_from_slice(ELF_NOTE_NAME);
+    note.resize(align_up(note.len() as u64, 4) as usize, 0);
+    note.extend_from_slice(&desc);
+    note.resize(align_up(note.len() as u64, 4) as usize, 0);
+    note
+}
+
+/// Append `data` to `host` (a 64-bit ELF) as a `.note.sui` section and write
+/// the result to `writer`. Drop-in replacement for `libsui::Elf::append`
+/// with the `.bss`-overlap fix documented at the module level.
+pub fn append_note<W: Write>(
+    host: &[u8],
+    section_name: &str,
+    data: &[u8],
+    writer: &mut W,
+) -> Result<()> {
+    let note_data = build_elf_note_payload(section_name, data);
+
+    // Existing `PT_NOTE` section headers are not preserved by the builder
+    // once we repurpose the note segment; copy their contents into
+    // `.note.sui` so the original notes (e.g. `.note.gnu.build-id`) survive.
+    let combined_note_data = {
+        let existing = object::read::elf::ElfFile64::<Endianness, _>::parse(host)
+            .ok()
+            .and_then(|elf_file| {
+                let endian = elf_file.endian();
+                let header = elf_file.elf_header();
+                let segments = header.program_headers(endian, host).ok()?;
+                for segment in segments {
+                    if segment.p_type(endian) != PT_NOTE {
+                        continue;
+                    }
+                    let data = segment.data(endian, host).ok()?;
+                    if !data.is_empty() {
+                        return Some(data);
+                    }
+                }
+                None
+            });
+        if let Some(existing) = existing {
+            let mut combined = Vec::with_capacity(existing.len() + note_data.len());
+            combined.extend_from_slice(existing);
+            combined.extend_from_slice(&note_data);
+            combined
+        } else {
+            note_data
+        }
+    };
+
+    let mut builder =
+        e::Builder::read(host).map_err(|err| anyhow!("Failed to parse host ELF: {err}"))?;
+
+    let section = builder.sections.add();
+    section.name = ".note.sui".into();
+    section.sh_type = SHT_NOTE;
+    section.sh_flags = u64::from(SHF_ALLOC);
+    section.sh_addralign = 4;
+    section.data = e::SectionData::Note(combined_note_data.into());
+    let section_id = section.id();
+
+    builder.set_section_sizes();
+
+    // Highest file offset any non-NOBITS section reaches.
+    let mut max_end = 0u64;
+    for existing in builder.sections.iter() {
+        if existing.delete {
+            continue;
+        }
+        let filesz = if existing.sh_type == SHT_NOBITS {
+            0
+        } else {
+            existing.sh_size
+        };
+        max_end = max_end.max(existing.sh_offset + filesz);
+    }
+
+    // The note rides along in the last (by file extent) PT_LOAD segment.
+    let load_segment_id = builder
+        .segments
+        .iter()
+        .filter(|segment| segment.is_load())
+        .max_by_key(|segment| segment.p_offset + segment.p_filesz)
+        .map(|segment| segment.id());
+
+    {
+        let section = builder.sections.get_mut(section_id);
+        let (align, min_offset) = if let Some(load_segment_id) = load_segment_id {
+            let seg = builder.segments.get(load_segment_id);
+            let align = seg.p_align.max(section.sh_addralign).max(1);
+            // *** The fix. ***
+            // The carrier segment's memory image (`p_memsz`) can exceed its
+            // file image (`p_filesz`) because of a trailing `.bss`
+            // (`SHT_NOBITS`). Placing the note right after the file bytes
+            // (libsui's behavior) gives it a virtual address inside that
+            // NOBITS tail, so the program's zero-init globals alias — and
+            // clobber — the embedded envelope. Push the note past the
+            // segment's full memory image so its mapped range clears `.bss`.
+            (align, seg.p_offset + seg.p_memsz)
+        } else {
+            (section.sh_addralign.max(1), 0)
+        };
+        section.sh_offset = align_up(max_end.max(min_offset), align);
+        section.sh_addr = if let Some(load_segment_id) = load_segment_id {
+            let seg = builder.segments.get(load_segment_id);
+            seg.p_vaddr + (section.sh_offset - seg.p_offset)
+        } else {
+            0
+        };
+    }
+
+    // Extend the carrier segment to cover the note in both file and memory.
+    if let Some(load_segment_id) = load_segment_id {
+        let section = builder.sections.get_mut(section_id);
+        let section_end = section.sh_offset + section.sh_size;
+        let mem_end = section.sh_addr + section.sh_size;
+        let seg = builder.segments.get_mut(load_segment_id);
+        if section_end > seg.p_offset + seg.p_filesz {
+            seg.p_filesz = section_end - seg.p_offset;
+        }
+        if mem_end > seg.p_vaddr + seg.p_memsz {
+            seg.p_memsz = mem_end - seg.p_vaddr;
+        }
+        if !seg.sections.contains(&section_id) {
+            seg.sections.push(section_id);
+        }
+    }
+
+    // Repoint the existing PT_NOTE phdr at `.note.sui` (or add one if the
+    // host had none — rare, but matches libsui). Reusing the slot avoids
+    // growing the program header table, which release hosts pack flush
+    // against `.interp` with no room to spare.
+    let note_segment_id = builder
+        .segments
+        .iter()
+        .find(|segment| segment.p_type == PT_NOTE)
+        .map(|segment| segment.id());
+
+    let section = builder.sections.get_mut(section_id);
+    let (sh_offset, sh_addr, sh_size) = (section.sh_offset, section.sh_addr, section.sh_size);
+    let segment = match note_segment_id {
+        Some(id) => {
+            let segment = builder.segments.get_mut(id);
+            segment.sections.clear();
+            segment.sections.push(section_id);
+            segment
+        }
+        None => {
+            let segment = builder.segments.add();
+            segment.sections.push(section_id);
+            segment
+        }
+    };
+    segment.p_type = PT_NOTE;
+    segment.p_flags = PF_R;
+    segment.p_align = 4;
+    segment.p_offset = sh_offset;
+    segment.p_vaddr = sh_addr;
+    segment.p_paddr = sh_addr;
+    segment.p_filesz = sh_size;
+    segment.p_memsz = sh_size;
+
+    let mut out = Vec::new();
+    builder
+        .write(&mut out)
+        .map_err(|err| anyhow!("Failed to write packed ELF: {err}"))?;
+    writer.write_all(&out)?;
+    Ok(())
+}


### PR DESCRIPTION
## What

`baml pack` produced **broken executables on Linux** whenever the embedded
`baml-pack-host` was built in the same cargo invocation as `baml_cli`
(`cargo build -p baml_cli -p baml_pack_host`). The packed binary failed at
startup with `Failed to deserialize pack envelope: invalid utf-8` /
`Unexpected variant tag: N`, sometimes SIGSEGV. Built alone, the host packed
fine. 100% deterministic, stable and nightly.

## Root cause

`libsui 0.14.0`'s ELF note **writer**, `Elf::append`, places the embedded
`.note.sui` section at a virtual address derived from its **file** offset:

```rust
sh_offset = align_up(max_file_end, align);
sh_addr   = seg.p_vaddr + (sh_offset - seg.p_offset);   // file-frame math
```

That's only valid when file layout and memory layout line up 1:1 in the
carrier segment — which they don't once there's a `.bss`. `.bss`
(`SHT_NOBITS`) occupies **memory but zero file bytes**, so the carrier RW
`PT_LOAD` has `p_memsz > p_filesz`. Deriving `sh_addr` from the file offset
puts the note at a virtual address **below where `.bss` ends in memory**, so
the note and the program's zero-initialized globals are assigned the **same
virtual addresses**. At startup the globals read the note bytes as their
initial values (garbage → SIGSEGV) and overwrite the envelope, so the host's
`libsui::find_section` reads corrupt data and borsh fails.

The pair build trips it because feature unification across `baml_cli`'s dep
tree inflates the host's `.bss` past the page-boundary threshold; the solo
host's `.bss` stays under it. macOS never hits it — libsui takes the Mach-O
path there.

Measured discriminator:

| host | `.bss` range | libsui `.note.sui` vaddr | result |
|------|--------------|--------------------------|--------|
| pair (14.2 MB) | `[0xd8a3a0, 0xd8d27c)` | `0xd8b000` (**inside .bss**) | broken |
| solo (9.6 MB)  | ends `0x924c38`        | `0x925000` (clear)          | works  |

## Fix

New module `baml_cli::pack_elf::append_note` replaces `libsui::Elf::append`
on the **Linux path only** (`pack_command.rs`). It mirrors libsui's logic but
places the note past the carrier segment's whole **memory** image
(`p_offset + p_memsz`) instead of just its file bytes, so the note's vaddr
always clears `.bss`. The one-line behavioral change is in `pack_elf.rs`:

```rust
// place the note past the segment's whole MEMORY image, not just its file bytes
(align, seg.p_offset + seg.p_memsz)
...
section.sh_offset = align_up(max_end.max(min_offset), align);
```

We can't give the note its own fresh `PT_LOAD` (release hosts pack the phdr
table flush against `.interp`, and `object`'s ELF builder won't relocate
alloc sections to make room), so we keep libsui's approach of reusing the
existing `PT_NOTE` phdr. The note's wire format is byte-identical, so the
**unmodified** `libsui::find_section` reader still parses it. It's a no-op
when the carrier has no `.bss` tail, so no change to the solo case.

The Windows (PE) and macOS (Mach-O) writers, and the host-side reader, all
stay on stock libsui — only the ELF writer placement math changed.

After the fix the pair host packs a working binary (note at `0xd8e000`, past
`.bss` end `0xd8d27c`).

## Also in this PR

- **CI** (`cargo-tests.reusable.yaml`): run `pack_e2e` as a dedicated Linux
  step — the only coverage of the ELF embed/extract path — and exclude it
  from the nextest sweep, where its build-the-host-once harness (process-
  global `OnceLock`) fights nextest's process-per-test model. This is the gate
  that should have caught the bug; the team develops on macOS.
- **pack**: warn when a local workspace host exists but is skipped for a
  cross-target pack, instead of silently downloading a release host (scoped so
  it never fires for end users).

## Testing

`cargo test -p baml_cli --test pack_e2e` — **7/7 on Linux** (was 0/7), under
both `cargo test` and `nextest`, in debug and release. `baml_cli` lib tests
215/215. Re-verified end-to-end: rebuilt CLI, packed with the 14 MB pair host,
binary runs and prints its result; `readelf` confirms `.note.sui` no longer
overlaps `.bss`.

## Follow-up

The placement bug is in libsui itself; worth upstreaming so the wider
ecosystem (incl. `deno compile`) gets the fix. Tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced `baml pack` to distinguish between native and non-native targets, now warning users when ignoring locally-cached host binaries in favor of downloading the correct platform-specific release.
  * Fixed potential memory corruption in Linux executable packing by ensuring embedded notes don't overlap with memory regions at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->