### PR TITLE
Validate generated Node loader version

### DIFF
--- a/baml_language/crates/bridge_ctypes/README.md
+++ b/baml_language/crates/bridge_ctypes/README.md
@@ -6,9 +6,15 @@ cargo build -p bridge_ctypes
 #   -> target/.../build/bridge_ctypes-*/out/baml_core.cffi.v1.rs
 #   -> sdks/python/src/baml_core/cffi/v1/*_pb2.py(i)
 
-# Node / TypeScript (protobufjs)
-cd sdks/nodejs/bridge_nodejs && pnpm build:debug    # or: pnpm build:proto
+# Node / TypeScript (protobufjs + napi loader)
+cd sdks/nodejs/bridge_nodejs && pnpm build:debug
 #   -> sdks/nodejs/bridge_nodejs/typescript_src/proto/baml_cffi.{js,d.ts}
+#   -> sdks/nodejs/bridge_nodejs/dist/native.js
+#
+# scripts/baml-language-version bump/set/sync install the pinned Node bridge
+# dependencies and run this automatically after version bumps because napi
+# stamps package.json's version into dist/native.js. build:proto alone is only
+# sufficient for proto schema-only changes.
 
 # TypeScript (ts-proto / buf) — typescript2/pkg-proto consumer
 cd typescript2/pkg-proto && pnpm generate

--- a/scripts/baml-language-version
+++ b/scripts/baml-language-version
@@ -21,6 +21,7 @@ PYPROJECT = ROOT / "baml_language" / "sdks" / "python" / "pyproject.toml"
 PY_INIT = ROOT / "baml_language" / "sdks" / "python" / "src" / "baml_core" / "__init__.py"
 VSIX_PACKAGE = ROOT / "typescript2" / "app-vscode-ext" / "package.json"
 NODE_PACKAGE = ROOT / "baml_language" / "sdks" / "nodejs" / "bridge_nodejs" / "package.json"
+NODE_NATIVE_JS = ROOT / "baml_language" / "sdks" / "nodejs" / "bridge_nodejs" / "dist" / "native.js"
 WRAPPER_CARGO_TOML = ROOT / "baml_language" / "crates" / "baml" / "Cargo.toml"
 
 SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
@@ -358,8 +359,36 @@ def stamp(plan: ReleasePlan) -> None:
     PY_INIT.write_text(text, encoding="utf-8")
 
 
+def regenerate_node_bridge() -> None:
+    if not NODE_PACKAGE.exists():
+        return
+
+    try:
+        subprocess.run(
+            ["pnpm", "install", "--frozen-lockfile", "--ignore-workspace", "--ignore-scripts"],
+            cwd=NODE_PACKAGE.parent,
+            check=True,
+        )
+        subprocess.run(
+            ["pnpm", "build:debug"],
+            cwd=NODE_PACKAGE.parent,
+            check=True,
+        )
+    except FileNotFoundError:
+        fail("pnpm is required to install and regenerate the Node bridge after a canary version bump")
+    except subprocess.CalledProcessError as exc:
+        fail(
+            "failed to install or regenerate the Node bridge after stamping versions. "
+            "Run `cd baml_language/sdks/nodejs/bridge_nodejs && "
+            "pnpm install --frozen-lockfile --ignore-workspace --ignore-scripts && pnpm build:debug` "
+            "for details.",
+            code=exc.returncode,
+        )
+
+
 def sync_canary() -> None:
     stamp(make_plan("canary"))
+    regenerate_node_bridge()
 
 
 def check_release() -> None:
@@ -384,6 +413,29 @@ def check_release() -> None:
     }
     if NODE_PACKAGE.exists():
         checks["node package version"] = f'"version": "{expected.canonical_version}"' in NODE_PACKAGE.read_text(encoding="utf-8")
+        if not NODE_NATIVE_JS.exists():
+            mismatches.append(
+                "node native loader version guards: "
+                f"{NODE_NATIVE_JS.relative_to(ROOT)} is missing. Run "
+                "`scripts/baml-language-version sync` and commit the generated output."
+            )
+        else:
+            native_text = NODE_NATIVE_JS.read_text(encoding="utf-8")
+            native_versions = sorted(
+                set(re.findall(r"bindingPackageVersion !== '([^']+)'", native_text))
+            )
+            if not native_versions:
+                mismatches.append(
+                    "node native loader version guards: no napi version guards found in "
+                    f"{NODE_NATIVE_JS.relative_to(ROOT)}"
+                )
+            elif native_versions != [expected.canonical_version]:
+                mismatches.append(
+                    "node native loader version guards: "
+                    f"{NODE_NATIVE_JS.relative_to(ROOT)} embeds {', '.join(native_versions)}; "
+                    f"expected {expected.canonical_version}. Run "
+                    "`scripts/baml-language-version sync` and commit the generated output."
+                )
 
     for name, ok in checks.items():
         if not ok:


### PR DESCRIPTION
## Summary

- Regenerate the Node bridge from `scripts/baml-language-version bump/set/sync` so the checked-in napi loader is refreshed with the stamped package version.
- Extend `scripts/baml-language-version check` to validate `dist/native.js` version guards, including a missing-loader failure that points maintainers back to `scripts/baml-language-version sync`.
- Update bridge regeneration docs to call out that `build:proto` alone is insufficient after version bumps because the napi loader embeds the package version.

## Why

The Node bridge generated napi loader embeds package-version guards. When release metadata was bumped without regenerating `dist/native.js`, CI could later detect stale generated output. This keeps Node aligned with the existing version-script flow for Python, VSIX, and Rust stamped version surfaces.

## Validation

- `scripts/baml-language-version check`
- `git diff --check`
- Confirmed simulated `bump --patch` regenerates `dist/native.js` guards to the new package version, then reverted the simulated bump before committing.
- Confirmed missing `dist/native.js` now fails `check` with `scripts/baml-language-version sync` remediation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Node/TypeScript bridge build procedures with clarified regeneration steps and version-stamping explanations.

* **Chores**
  * Improved internal version validation and synchronization for Node bridge artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->