### PR TITLE
prof: cut BEX tracing producer + consumer overhead

### DIFF
--- a/baml_language/crates/bex_events/src/prof/clock.rs
+++ b/baml_language/crates/bex_events/src/prof/clock.rs
@@ -79,8 +79,23 @@ mod imp {
         meta: ClockMeta,
     }
 
+    static ANCHOR: OnceLock<Anchor> = OnceLock::new();
+
+    /// The process clock anchor. Fast path is a single `OnceLock::get`
+    /// (Acquire load + branch) that inlines into `now_ticks` — and thus
+    /// into the VM's call hot path — so the raw counter read can pipeline
+    /// with the surrounding encode/push work rather than hiding behind a
+    /// cross-crate call. The one-time init is `#[cold]` and out-of-line.
+    #[inline]
     fn anchor() -> &'static Anchor {
-        static ANCHOR: OnceLock<Anchor> = OnceLock::new();
+        match ANCHOR.get() {
+            Some(a) => a,
+            None => anchor_init(),
+        }
+    }
+
+    #[cold]
+    fn anchor_init() -> &'static Anchor {
         ANCHOR.get_or_init(|| {
             let (source, ns_per_tick) = detect();
             let kind = match source {

--- a/baml_language/crates/bex_events/src/prof/clock.rs
+++ b/baml_language/crates/bex_events/src/prof/clock.rs
@@ -350,6 +350,14 @@ pub struct TickConverter {
     seg_base_ns: u64,
     /// ns-per-tick as (numer, denom).
     rate: (u64, u64),
+    /// Fixed-point reciprocal of `rate` for the hot path: `numer << SCALE_SHIFT
+    /// / denom`, so `to_ns` is a `dt * scale >> SCALE_SHIFT` multiply-shift
+    /// instead of a per-record u128 divide (~20-40 non-pipelined cycles). Kept
+    /// in sync with `rate` at every install site. Exact for rate (1,1)
+    /// (scale = `2^SCALE_SHIFT` → ns == dt); ≤1 ns rounding for measured TSC
+    /// rates, which is below tracing-timestamp resolution and preserves
+    /// monotonicity.
+    scale: u128,
     /// Previous segment `(base_ticks, base_ns, rate)`, kept after a
     /// refinement so pre-switch ticks still convert on their original line.
     prev: Option<(u64, u64, (u64, u64))>,
@@ -357,6 +365,19 @@ pub struct TickConverter {
     /// First calibration sample (x86 TSC only): adjacent OS-clock + tick
     /// reads taken at converter construction.
     sample0: Option<(std::time::Instant, u64)>,
+}
+
+/// Fixed-point precision of [`TickConverter::scale`]. 2^48 keeps the rounding
+/// error below 1 ns for any realistic `dt` (ticks since the segment base) while
+/// leaving headroom against u128 overflow in `dt * scale`.
+#[cfg(not(target_arch = "wasm32"))]
+const SCALE_SHIFT: u32 = 48;
+
+/// `numer << SCALE_SHIFT / denom` — the reciprocal computed once per rate
+/// install (the only divide), consumed branchlessly per record.
+#[cfg(not(target_arch = "wasm32"))]
+fn scale_of(rate: (u64, u64)) -> u128 {
+    (u128::from(rate.0) << SCALE_SHIFT) / u128::from(rate.1.max(1))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -368,6 +389,7 @@ impl TickConverter {
             seg_base_ticks: 0,
             seg_base_ns: 0,
             rate: (1, 1),
+            scale: scale_of((1, 1)),
             prev: None,
             refined: true,
             sample0: None,
@@ -386,6 +408,7 @@ impl TickConverter {
                 seg_base_ticks: base_ticks(),
                 seg_base_ns: 0,
                 rate,
+                scale: scale_of(rate),
                 prev: None,
                 refined: true,
                 sample0: None,
@@ -406,6 +429,7 @@ impl TickConverter {
                     seg_base_ticks: base_ticks(),
                     seg_base_ns: 0,
                     rate,
+                    scale: scale_of(rate),
                     prev: None,
                     refined: false,
                     sample0: Some(sample0),
@@ -429,7 +453,8 @@ impl TickConverter {
             }
         }
         let dt = u128::from(ticks.saturating_sub(self.seg_base_ticks));
-        self.seg_base_ns + (dt * u128::from(self.rate.0) / u128::from(self.rate.1)) as u64
+        // Hot path: multiply-shift by the precomputed reciprocal, no divide.
+        self.seg_base_ns + ((dt * self.scale) >> SCALE_SHIFT) as u64
     }
 
     /// Refine the x86 TSC rate once the window since `sample0` spans ≥1 s.
@@ -460,6 +485,7 @@ impl TickConverter {
         self.seg_base_ticks = now_t;
         self.seg_base_ns = switch_ns;
         self.rate = new_rate;
+        self.scale = scale_of(new_rate);
         self.refined = true;
     }
 
@@ -573,6 +599,36 @@ mod tests {
     }
 
     #[test]
+    fn reciprocal_matches_exact_divide() {
+        // The fixed-point reciprocal (multiply-shift) must track the exact
+        // dt*numer/denom divide within 1 ns across a range of ticks, for
+        // representative non-unit rates (CNTVCT 24 MHz = 125/3; a fast TSC
+        // ~3.2 GHz ≈ 5/16). Catches a gross reciprocal/SCALE_SHIFT bug that
+        // the identity-rate (1/1) test cannot.
+        for &(numer, denom) in &[(125u64, 3u64), (5, 16), (1_000_000_000, 24_000_000)] {
+            let conv = TickConverter {
+                kind: ClockKind::Cntvct,
+                seg_base_ticks: 0,
+                seg_base_ns: 0,
+                rate: (numer, denom),
+                scale: scale_of((numer, denom)),
+                prev: None,
+                refined: true,
+                sample0: None,
+            };
+            for dt in [0u64, 1, 3, 7, 1_000, 1_000_003, 50_000_000] {
+                let exact = u64::try_from(u128::from(dt) * u128::from(numer) / u128::from(denom))
+                    .expect("test dt*rate fits u64");
+                let approx = conv.to_ns(dt);
+                assert!(
+                    approx.abs_diff(exact) <= 1,
+                    "rate {numer}/{denom} dt {dt}: reciprocal {approx} vs exact {exact}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn refinement_keeps_monotonicity() {
         // A deliberately-wrong coarse rate, then a refine: converted values
         // sampled across the boundary must never step backwards, and ticks
@@ -582,6 +638,7 @@ mod tests {
             seg_base_ticks: 0,
             seg_base_ns: 0,
             rate: (3, 1), // 3 ns/tick, deliberately ~3x off
+            scale: scale_of((3, 1)),
             prev: None,
             refined: false,
             sample0: Some((std::time::Instant::now(), now_ticks())),

--- a/baml_language/crates/bex_events/src/prof/consumer.rs
+++ b/baml_language/crates/bex_events/src/prof/consumer.rs
@@ -271,36 +271,43 @@ impl ConsumerState {
         }
         // Cloned out of `self` so the converter can be read while the
         // writer (a `&mut self` borrow) is held; one clone per drained
-        // range, not per record.
+        // range, not per record. `already_reported` is likewise snapshotted
+        // so the writer borrow below covers no other `self` access.
         let conv = self.conv.clone();
+        let already_reported = self.corrupt_reported;
         let Some(writer) = self.writer_for(engine_id) else {
             return;
         };
-        let mut io_result = Ok(());
+        // Accumulate the whole drained range into the writer's buffer, then
+        // issue ONE write for the range (vs one per event).
+        let mut corrupt = None;
         for rec in record::iter(bytes) {
             match rec {
                 Ok(raw) => {
                     let event = to_disk_event(&raw, &conv);
-                    io_result = writer.write_event(&event);
-                    if io_result.is_err() {
-                        break;
-                    }
+                    writer.encode_event(&event);
                 }
+                // A committed range that fails to decode is a producer bug:
+                // the framing is unrecoverable past this point, so drop the
+                // rest of the range. The already-encoded prefix is still
+                // flushed below.
                 Err(err) => {
-                    // A committed range that fails to decode is a producer
-                    // bug — report once, drop the rest of the range (the
-                    // framing is unrecoverable past this point).
-                    if !self.corrupt_reported {
-                        self.corrupt_reported = true;
-                        report(format_args!(
-                            "corrupt profiling record in committed range (engine {engine_id}): {err:?}"
-                        ));
-                    }
+                    corrupt = Some(err);
                     break;
                 }
             }
         }
-        if let Err(err) = io_result {
+        let flush = writer.flush_buffered();
+        // The writer borrow ends above; `self` field access is safe again.
+        if let Some(err) = corrupt
+            && !already_reported
+        {
+            self.corrupt_reported = true;
+            report(format_args!(
+                "corrupt profiling record in committed range (engine {engine_id}): {err:?}"
+            ));
+        }
+        if let Err(err) = flush {
             self.fail_writer(engine_id, &err);
         }
     }
@@ -369,10 +376,11 @@ impl ConsumerState {
         };
         let mut failed = Vec::new();
         for (&engine_id, slot) in &mut self.writers {
-            if let Some(writer) = slot
-                && writer.write_event(&event).is_err()
-            {
-                failed.push(engine_id);
+            if let Some(writer) = slot {
+                writer.encode_event(&event);
+                if writer.flush_buffered().is_err() {
+                    failed.push(engine_id);
+                }
             }
         }
         for engine_id in failed {

--- a/baml_language/crates/bex_events/src/prof/file.rs
+++ b/baml_language/crates/bex_events/src/prof/file.rs
@@ -54,8 +54,43 @@ impl ProfileWriter {
         Ok(writer)
     }
 
+    /// Writes one length-delimited event.
+    ///
+    /// The two hot records — `CallFunction`/`EndFunction`, the per-call pair
+    /// that is essentially all of the event volume — are serialized by a
+    /// hand-rolled single-pass protobuf encoder rather than prost.
+    ///
+    /// Why: prost serializes this nested-oneof message by walking it ~3×
+    /// (`encoded_len`, then `encode_raw`, whose embedded-message path recomputes
+    /// the inner message's length a third time) before writing a byte. Measured
+    /// at ~40-55 ns/record — roughly a third of the consumer's per-record cost.
+    /// A direct encoder with back-patched 1-byte length prefixes does it in a
+    /// single pass. This is the same approach Perfetto takes with its trace
+    /// protobufs — its "protozero" streaming/zero-copy encoder, adopted there
+    /// for exactly this hot-path-serialization reason
+    /// (<https://perfetto.dev/docs/design-docs/protozero>).
+    ///
+    /// Correctness: `to_disk_event` still constructs the prost structs, so a
+    /// proto field add/remove/rename/type-change is a *compile* error (the
+    /// exhaustive struct literal + the field reads in the encoders below); the
+    /// differential test `hand_encoder_matches_prost` pins byte-for-byte
+    /// equality with prost over a range of inputs, covering even a field
+    /// renumber. Every other (cold) record stays on prost.
     pub(crate) fn write_event(&mut self, event: &pb::DiskEventV1) -> io::Result<()> {
-        self.write_message(event)
+        use pb::disk_event_v1::Event;
+        self.scratch.clear();
+        match &event.event {
+            Some(Event::CallFunction(cf)) => encode_call_function_event(&mut self.scratch, cf),
+            Some(Event::EndFunction(ef)) => encode_end_function_event(&mut self.scratch, ef),
+            // Cold/rare records (StartThread, SetFunctionId, EndThread,
+            // Heartbeat, and any future variant) go through prost.
+            _ => {
+                event
+                    .encode_length_delimited(&mut self.scratch)
+                    .map_err(io::Error::other)?;
+            }
+        }
+        self.writer.write_all(&self.scratch)
     }
 
     fn write_message(&mut self, msg: &impl Message) -> io::Result<()> {
@@ -86,6 +121,100 @@ impl ProfileWriter {
     pub(crate) fn path(&self) -> &Path {
         &self.path
     }
+}
+
+// ── Hand-rolled protobuf for the two hot events (see `write_event`) ──────────
+//
+// These emit a length-delimited `DiskEventV1{ call_function | end_function }`
+// byte-for-byte as prost would, in one pass. Both messages are < 128 bytes
+// (≤ 5 small scalar fields), so the outer (`DiskEventV1`) and inner length
+// prefixes are each a single varint byte we back-patch — minimal varints,
+// identical to prost's output. proto3 implicit-presence rules are replicated
+// explicitly: zero-valued scalars are omitted; `optional parent_call_id` is
+// emitted iff `Some`. Field numbers/wire-types are from `bamlprof.proto`
+// (`DiskEventV1.call_function = 3`, `.end_function = 5`; inner fields 1..=5).
+
+/// Append `v` as a protobuf LEB128 varint.
+#[inline]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "varint extracts the low 7 bits per byte"
+)]
+fn put_varint(out: &mut Vec<u8>, mut v: u64) {
+    while v >= 0x80 {
+        out.push((v as u8) | 0x80);
+        v >>= 7;
+    }
+    out.push(v as u8);
+}
+
+/// proto3 implicit-presence scalar: key byte + varint, omitted when the value
+/// is the default (0) — matching prost.
+#[inline]
+fn put_scalar(out: &mut Vec<u8>, key: u8, v: u64) {
+    if v != 0 {
+        out.push(key);
+        put_varint(out, v);
+    }
+}
+
+/// Back-patch the inner-message and outer-`DiskEventV1` single-byte length
+/// prefixes once the body is written.
+#[inline]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "messages are < 128 bytes; asserted"
+)]
+fn patch_lengths(out: &mut [u8], outer_at: usize, inner_len_at: usize, inner_start: usize) {
+    let inner_len = out.len() - inner_start;
+    debug_assert!(
+        inner_len < 128,
+        "event message exceeds single-byte length prefix"
+    );
+    out[inner_len_at] = inner_len as u8;
+    let outer_len = out.len() - outer_at - 1;
+    debug_assert!(
+        outer_len < 128,
+        "DiskEventV1 exceeds single-byte length prefix"
+    );
+    out[outer_at] = outer_len as u8;
+}
+
+fn encode_call_function_event(out: &mut Vec<u8>, cf: &pb::CallFunction) {
+    let outer_at = out.len();
+    out.push(0); // DiskEventV1 length (patched)
+    out.push(0x1A); // field 3 (call_function), wire-type 2 (LEN)
+    let inner_len_at = out.len();
+    out.push(0); // CallFunction length (patched)
+    let inner_start = out.len();
+    put_scalar(out, 0x08, cf.thread_id); // field 1
+    put_scalar(out, 0x10, cf.call_id); // field 2
+    if let Some(p) = cf.parent_call_id {
+        // field 3, optional (explicit presence): emitted iff Some.
+        out.push(0x18);
+        put_varint(out, p);
+    }
+    put_scalar(out, 0x20, u64::from(cf.function_id)); // field 4 (uint32)
+    put_scalar(out, 0x28, cf.timestamp_ns); // field 5
+    patch_lengths(out, outer_at, inner_len_at, inner_start);
+}
+
+fn encode_end_function_event(out: &mut Vec<u8>, ef: &pb::EndFunction) {
+    let outer_at = out.len();
+    out.push(0); // DiskEventV1 length (patched)
+    out.push(0x2A); // field 5 (end_function), wire-type 2 (LEN)
+    let inner_len_at = out.len();
+    out.push(0); // EndFunction length (patched)
+    let inner_start = out.len();
+    put_scalar(out, 0x08, ef.thread_id); // field 1
+    put_scalar(out, 0x10, ef.call_id); // field 2
+    // field 3, status enum (implicit presence): omit default (0 = OK).
+    if ef.status != 0 {
+        out.push(0x18);
+        put_varint(out, u64::try_from(ef.status).unwrap_or(0));
+    }
+    put_scalar(out, 0x20, ef.timestamp_ns); // field 4
+    patch_lengths(out, outer_at, inner_len_at, inner_start);
 }
 
 fn hex_uuid(bytes: [u8; 16]) -> String {
@@ -192,4 +321,69 @@ pub fn read_bamlprof(path: &Path) -> io::Result<BamlprofContents> {
 pub fn header_started_at_epoch_ns(header: &pb::EventFileHeaderV1) -> Option<u128> {
     let bytes: [u8; 16] = header.started_at_epoch_ns.as_slice().try_into().ok()?;
     Some(u128::from_le_bytes(bytes))
+}
+
+#[cfg(test)]
+mod hand_encoder_tests {
+    use prost::Message;
+
+    use super::{encode_call_function_event, encode_end_function_event};
+    use crate::prof::pb;
+
+    /// The hand-rolled encoders must produce byte-for-byte the same output as
+    /// prost's `encode_length_delimited` for every input — that equality is
+    /// the wire contract. This also catches a proto field *renumber* that the
+    /// struct literal in `to_disk_event` would not (the gap noted in
+    /// `write_event`'s docs).
+    #[test]
+    fn hand_encoder_matches_prost() {
+        let call_fns = [
+            // includes zero scalars (omitted), max-width varints, and the
+            // optional parent present (Some) / absent (None).
+            (1u64, 1u64, None, 0u32, 0u64),
+            (5, 7, Some(3), 9, 12_345),
+            (u64::MAX, 1, Some(2), u32::MAX, u64::MAX),
+            (0, 0, None, 0, 0),
+            (128, 16_384, Some(2_097_152), 100_000, 1 << 40),
+            (9, 7, Some(0), 4, 1), // optional present with value 0
+        ];
+        for &(thread_id, call_id, parent_call_id, function_id, timestamp_ns) in &call_fns {
+            let cf = pb::CallFunction {
+                thread_id,
+                call_id,
+                parent_call_id,
+                function_id,
+                timestamp_ns,
+            };
+            let event = pb::DiskEventV1 {
+                event: Some(pb::disk_event_v1::Event::CallFunction(cf)),
+            };
+            let mut prost_bytes = Vec::new();
+            event.encode_length_delimited(&mut prost_bytes).unwrap();
+            let mut hand = Vec::new();
+            encode_call_function_event(&mut hand, &cf);
+            assert_eq!(hand, prost_bytes, "CallFunction {cf:?}");
+        }
+
+        for status in 0..4i32 {
+            for &(thread_id, call_id, timestamp_ns) in
+                &[(1u64, 1u64, 0u64), (9, 7, 12_345), (u64::MAX, 1, u64::MAX)]
+            {
+                let ef = pb::EndFunction {
+                    thread_id,
+                    call_id,
+                    status,
+                    timestamp_ns,
+                };
+                let event = pb::DiskEventV1 {
+                    event: Some(pb::disk_event_v1::Event::EndFunction(ef)),
+                };
+                let mut prost_bytes = Vec::new();
+                event.encode_length_delimited(&mut prost_bytes).unwrap();
+                let mut hand = Vec::new();
+                encode_end_function_event(&mut hand, &ef);
+                assert_eq!(hand, prost_bytes, "EndFunction {ef:?}");
+            }
+        }
+    }
 }

--- a/baml_language/crates/bex_events/src/prof/file.rs
+++ b/baml_language/crates/bex_events/src/prof/file.rs
@@ -6,7 +6,7 @@
 
 use std::{
     fs::{self, File},
-    io::{self, BufWriter, Read, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
 };
 
@@ -16,7 +16,7 @@ use crate::prof::pb;
 
 /// A single engine's open profile file.
 pub(crate) struct ProfileWriter {
-    writer: BufWriter<File>,
+    file: File,
     path: PathBuf,
     /// Reused length-delimited encode buffer. One allocation that grows to
     /// the largest message, then stays — avoids a `Vec` allocation (and the
@@ -46,7 +46,7 @@ impl ProfileWriter {
         let path = dir.join(name);
         let file = File::create(&path)?;
         let mut writer = ProfileWriter {
-            writer: BufWriter::new(file),
+            file,
             path,
             scratch: Vec::new(),
         };
@@ -54,7 +54,11 @@ impl ProfileWriter {
         Ok(writer)
     }
 
-    /// Writes one length-delimited event.
+    /// Appends one length-delimited event to the in-flight range buffer
+    /// (`scratch`). The consumer accumulates a whole drained range with
+    /// repeated `encode_event`, then issues a single [`flush_buffered`] — one
+    /// `write` per ~256 KiB drained segment instead of one per event. There is
+    /// no userspace `BufWriter`: the range buffer *is* the buffer.
     ///
     /// The two hot records — `CallFunction`/`EndFunction`, the per-call pair
     /// that is essentially all of the event volume — are serialized by a
@@ -76,46 +80,52 @@ impl ProfileWriter {
     /// differential test `hand_encoder_matches_prost` pins byte-for-byte
     /// equality with prost over a range of inputs, covering even a field
     /// renumber. Every other (cold) record stays on prost.
-    pub(crate) fn write_event(&mut self, event: &pb::DiskEventV1) -> io::Result<()> {
+    pub(crate) fn encode_event(&mut self, event: &pb::DiskEventV1) {
         use pb::disk_event_v1::Event;
-        self.scratch.clear();
         match &event.event {
             Some(Event::CallFunction(cf)) => encode_call_function_event(&mut self.scratch, cf),
             Some(Event::EndFunction(ef)) => encode_end_function_event(&mut self.scratch, ef),
             // Cold/rare records (StartThread, SetFunctionId, EndThread,
-            // Heartbeat, and any future variant) go through prost.
+            // Heartbeat, and any future variant) go through prost. Encoding
+            // into a growable `Vec` cannot run out of capacity.
             _ => {
                 event
                     .encode_length_delimited(&mut self.scratch)
-                    .map_err(io::Error::other)?;
+                    .expect("protobuf encode into a Vec never runs out of capacity");
             }
         }
-        self.writer.write_all(&self.scratch)
+    }
+
+    /// Write the accumulated range buffer to the file in one syscall and reset
+    /// it. No-op when nothing is buffered.
+    pub(crate) fn flush_buffered(&mut self) -> io::Result<()> {
+        if !self.scratch.is_empty() {
+            self.file.write_all(&self.scratch)?;
+            self.scratch.clear();
+        }
+        Ok(())
     }
 
     fn write_message(&mut self, msg: &impl Message) -> io::Result<()> {
-        // Reuse `scratch` across events: `encode_length_delimited` writes its
-        // own varint length prefix and grows the buffer as needed, so after
-        // the first few events the capacity is stable and no allocation
-        // happens. (`encode_length_delimited` already computes the length
-        // internally, so a `with_capacity(encoded_len())` would only add a
-        // redundant encode walk.)
+        // One-shot header write at file creation: encode + a single write.
         self.scratch.clear();
         msg.encode_length_delimited(&mut self.scratch)
             .map_err(io::Error::other)?;
-        self.writer.write_all(&self.scratch)
+        self.file.write_all(&self.scratch)?;
+        self.scratch.clear();
+        Ok(())
     }
 
+    /// Flush buffered range bytes to the OS (no `fsync`). The cadence flush.
     pub(crate) fn flush(&mut self) -> io::Result<()> {
-        self.writer.flush()
+        self.flush_buffered()
     }
 
     /// Flush + `fsync`: survives power loss, not just process exit. Used for
-    /// explicit flush requests and engine closes; the cadence flushes stay
-    /// cheap.
+    /// explicit flush requests and engine closes.
     pub(crate) fn sync(&mut self) -> io::Result<()> {
-        self.writer.flush()?;
-        self.writer.get_ref().sync_all()
+        self.flush_buffered()?;
+        self.file.sync_all()
     }
 
     pub(crate) fn path(&self) -> &Path {

--- a/baml_language/crates/bex_events/src/prof/file.rs
+++ b/baml_language/crates/bex_events/src/prof/file.rs
@@ -18,6 +18,13 @@ use crate::prof::pb;
 pub(crate) struct ProfileWriter {
     writer: BufWriter<File>,
     path: PathBuf,
+    /// Reused length-delimited encode buffer. One allocation that grows to
+    /// the largest message, then stays — avoids a `Vec` allocation (and the
+    /// extra `encoded_len` walk a pre-sized `with_capacity` would cost) on
+    /// every event written. The consumer transcodes one event per record on
+    /// its hot path, so this is the difference between zero and one malloc
+    /// per traced event.
+    scratch: Vec<u8>,
 }
 
 impl ProfileWriter {
@@ -41,6 +48,7 @@ impl ProfileWriter {
         let mut writer = ProfileWriter {
             writer: BufWriter::new(file),
             path,
+            scratch: Vec::new(),
         };
         writer.write_message(header)?;
         Ok(writer)
@@ -51,10 +59,16 @@ impl ProfileWriter {
     }
 
     fn write_message(&mut self, msg: &impl Message) -> io::Result<()> {
-        let mut buf = Vec::with_capacity(msg.encoded_len() + 4);
-        msg.encode_length_delimited(&mut buf)
+        // Reuse `scratch` across events: `encode_length_delimited` writes its
+        // own varint length prefix and grows the buffer as needed, so after
+        // the first few events the capacity is stable and no allocation
+        // happens. (`encode_length_delimited` already computes the length
+        // internally, so a `with_capacity(encoded_len())` would only add a
+        // redundant encode walk.)
+        self.scratch.clear();
+        msg.encode_length_delimited(&mut self.scratch)
             .map_err(io::Error::other)?;
-        self.writer.write_all(&buf)
+        self.writer.write_all(&self.scratch)
     }
 
     pub(crate) fn flush(&mut self) -> io::Result<()> {

--- a/baml_language/crates/bex_events/src/prof/record.rs
+++ b/baml_language/crates/bex_events/src/prof/record.rs
@@ -395,17 +395,59 @@ impl Writer<'_> {
 
     #[inline]
     fn u16(&mut self, v: u16) {
-        self.bytes(&v.to_le_bytes());
+        debug_assert!(self.pos + 2 <= self.buf.len());
+        // SAFETY: callers size `buf` >= `encoded_len()` (producer reserves
+        // exactly that via `Ring::push_with`), so `pos + 2` is in bounds.
+        #[expect(
+            unsafe_code,
+            reason = "in-bounds unaligned store; avoids non-inlined copy"
+        )]
+        unsafe {
+            self.buf
+                .as_mut_ptr()
+                .add(self.pos)
+                .cast::<u16>()
+                .write_unaligned(v.to_le());
+        }
+        self.pos += 2;
     }
 
     #[inline]
     fn u32(&mut self, v: u32) {
-        self.bytes(&v.to_le_bytes());
+        debug_assert!(self.pos + 4 <= self.buf.len());
+        // SAFETY: see `u16`.
+        #[expect(
+            unsafe_code,
+            reason = "in-bounds unaligned store; avoids non-inlined copy"
+        )]
+        unsafe {
+            self.buf
+                .as_mut_ptr()
+                .add(self.pos)
+                .cast::<u32>()
+                .write_unaligned(v.to_le());
+        }
+        self.pos += 4;
     }
 
     #[inline]
     fn u64(&mut self, v: u64) {
-        self.bytes(&v.to_le_bytes());
+        debug_assert!(self.pos + 8 <= self.buf.len());
+        // SAFETY: see `u16`. A direct unaligned store lowers to one `mov` at
+        // `opt-level="s"`; routing through `copy_from_slice`/`copy_nonoverlapping`
+        // emitted a non-inlined call there (~5-8 ns/pair on the hot records).
+        #[expect(
+            unsafe_code,
+            reason = "in-bounds unaligned store; avoids non-inlined copy"
+        )]
+        unsafe {
+            self.buf
+                .as_mut_ptr()
+                .add(self.pos)
+                .cast::<u64>()
+                .write_unaligned(v.to_le());
+        }
+        self.pos += 8;
     }
 
     #[inline]

--- a/baml_language/crates/bex_events/src/prof/record.rs
+++ b/baml_language/crates/bex_events/src/prof/record.rs
@@ -194,10 +194,18 @@ impl RawRecord<'_> {
         self.encode_to(buf)
     }
 
-    /// [`RawRecord::encode`] over a plain slice, for producers that size
-    /// their stack buffer to the record they emit ([`Self::encoded_len`])
-    /// instead of zeroing [`MAX_RECORD_LEN`] bytes on a hot path.
-    /// Panics (slice indexing) if `buf` is shorter than the encoded record.
+    /// Encodes into the front of `buf`, returning the encoded length, for
+    /// producers that write straight into a ring slot sized to the record
+    /// ([`Self::encoded_len`]) instead of zeroing [`MAX_RECORD_LEN`] bytes on a
+    /// hot path.
+    ///
+    /// # Safety / precondition
+    /// `buf.len()` MUST be at least [`Self::encoded_len`]. The fixed integer
+    /// fields are written via unchecked unaligned stores (debug-asserted, not
+    /// release-checked), so an undersized `buf` is undefined behavior in
+    /// release builds — not a panic. Every caller satisfies this:
+    /// [`Self::encode`] uses a [`MAX_RECORD_LEN`] buffer and `Ring::push_with`
+    /// reserves exactly `encoded_len()`.
     #[inline]
     pub fn encode_to(&self, buf: &mut [u8]) -> usize {
         let mut w = Writer { buf, pos: 0 };

--- a/baml_language/crates/bex_events/src/prof/ring.rs
+++ b/baml_language/crates/bex_events/src/prof/ring.rs
@@ -303,11 +303,12 @@ impl Ring {
 
     /// Reserve `len` bytes in the ring and let the producer serialize a record
     /// *directly into them* via `write`, avoiding the encode-to-stack-buffer +
-    /// copy-into-ring double write that [`push`] pays. `write` must initialize
-    /// all `len` bytes (they are committed immediately after it returns).
+    /// copy-into-ring double write that [`Self::push`] pays. `write` must
+    /// initialize all `len` bytes (they are committed immediately after it
+    /// returns).
     ///
     /// # Safety
-    /// Same contract as [`push`]: this OS thread is the ring's live producer
+    /// Same contract as [`Self::push`]: this OS thread is the ring's live producer
     /// (D5a refresh), and exec does not cross an `.await` (plan §6 inv. 4).
     #[inline]
     pub unsafe fn push_with(&self, len: usize, write: impl FnOnce(&mut [u8])) {

--- a/baml_language/crates/bex_events/src/prof/ring.rs
+++ b/baml_language/crates/bex_events/src/prof/ring.rs
@@ -294,17 +294,35 @@ impl Ring {
     /// `0 < rec.len() <= seg_bytes`.
     pub unsafe fn push(&self, rec: &[u8]) {
         debug_assert!(!rec.is_empty());
+        // SAFETY: same producer contract as `push_with`; the closure copies
+        // exactly `rec.len()` bytes into the (uninitialized) slot.
+        unsafe {
+            self.push_with(rec.len(), |slot| slot.copy_from_slice(rec));
+        }
+    }
+
+    /// Reserve `len` bytes in the ring and let the producer serialize a record
+    /// *directly into them* via `write`, avoiding the encode-to-stack-buffer +
+    /// copy-into-ring double write that [`push`] pays. `write` must initialize
+    /// all `len` bytes (they are committed immediately after it returns).
+    ///
+    /// # Safety
+    /// Same contract as [`push`]: this OS thread is the ring's live producer
+    /// (D5a refresh), and exec does not cross an `.await` (plan §6 inv. 4).
+    #[inline]
+    pub unsafe fn push_with(&self, len: usize, write: impl FnOnce(&mut [u8])) {
+        debug_assert!(len > 0);
         self.p.with_mut(|p| {
             let p = unsafe { &mut *p };
-            if p.head_pos + rec.len() > self.seg_bytes {
+            if p.head_pos + len > self.seg_bytes {
                 // An oversized record necessarily lands here (head_pos ≥ 0),
                 // so this release-mode check costs one compare per segment
-                // fill — never per push — and is what keeps the memcpy below
+                // fill — never per push — and is what keeps the write below
                 // in bounds for arbitrary input.
                 assert!(
-                    rec.len() <= self.seg_bytes,
+                    len <= self.seg_bytes,
                     "profiling record ({} bytes) exceeds the ring segment size ({} bytes)",
-                    rec.len(),
+                    len,
                     self.seg_bytes
                 );
                 // Slow path: link a recycled or fresh segment.
@@ -334,8 +352,8 @@ impl Ring {
             }
             unsafe {
                 let head = &*p.head;
-                head.buf.write(p.head_pos, rec);
-                p.head_pos += rec.len();
+                head.buf.with_slice_mut(p.head_pos, len, write);
+                p.head_pos += len;
                 #[expect(
                     clippy::cast_possible_truncation,
                     reason = "head_pos <= seg_bytes <= 16 MiB, far below u32::MAX"

--- a/baml_language/crates/bex_events/src/prof/sync.rs
+++ b/baml_language/crates/bex_events/src/prof/sync.rs
@@ -76,26 +76,43 @@ impl Buf {
         self.bytes.len()
     }
 
-    /// Copies `src` into the buffer at `offset`.
+    /// Calls `f` with a mutable view of `[offset, offset + len)` so the
+    /// producer can serialize a record *directly into the ring*, skipping the
+    /// intermediate stack buffer and the extra copy that encoding into a
+    /// scratch buffer and copying it in would require.
     ///
     /// # Safety
     /// Caller is the ring's unique producer, the range is in bounds, and no
     /// byte of it has been published (the consumer never reads it
-    /// concurrently).
+    /// concurrently). `f` must initialize every byte of the slice before it
+    /// is committed.
     #[cfg(not(baml_loom))]
     #[inline]
-    pub(crate) unsafe fn write(&self, offset: usize, src: &[u8]) {
-        debug_assert!(offset + src.len() <= self.bytes.len());
-        // Provenance: `as_ptr` spans the whole slice; `raw_get` is a cast
-        // (interior mutability through a shared reference), not a retag.
+    pub(crate) unsafe fn with_slice_mut(
+        &self,
+        offset: usize,
+        len: usize,
+        f: impl FnOnce(&mut [u8]),
+    ) {
+        debug_assert!(offset + len <= self.bytes.len());
         let base = std::cell::UnsafeCell::raw_get(self.bytes.as_ptr());
-        unsafe { std::ptr::copy_nonoverlapping(src.as_ptr(), base.add(offset), src.len()) };
+        let slice = unsafe { std::slice::from_raw_parts_mut(base.add(offset), len) };
+        f(slice);
     }
 
-    /// See the std-build `write`.
+    /// See the std-build `with_slice_mut`. Fills a temp then stores per byte so
+    /// loom still models the producer's writes (the in-place path is a std-only
+    /// optimization; the byte-level write set is identical).
     #[cfg(baml_loom)]
-    pub(crate) unsafe fn write(&self, offset: usize, src: &[u8]) {
-        for (i, byte) in src.iter().enumerate() {
+    pub(crate) unsafe fn with_slice_mut(
+        &self,
+        offset: usize,
+        len: usize,
+        f: impl FnOnce(&mut [u8]),
+    ) {
+        let mut tmp = vec![0u8; len];
+        f(&mut tmp);
+        for (i, byte) in tmp.iter().enumerate() {
             self.bytes[offset + i].with_mut(|p| unsafe { *p = *byte });
         }
     }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2940,11 +2940,11 @@ impl BexVm {
         self.call_id_counter
     }
 
-    /// Encodes and pushes one profiling record into the per-resume ring
-    /// snapshot. No-op when profiling is off. The buffer is sized by
-    /// `SET_FUNCTION_ID_LEN` (41 B — the largest fixed record the VM emits:
-    /// `CallFunction` 38, `EndFunction` 26, `SetFunctionId` 41) — the 292-byte
-    /// `MAX_RECORD_LEN` zeroing is measurable at per-call rates.
+    /// Encodes one profiling record directly into a reserved slot of the
+    /// supplied per-resume ring snapshot. Callers do the profiling-off gate
+    /// (they pass the already-unwrapped `&Ring`); the slot is sized from
+    /// [`bex_events::prof::record::RawRecord::encoded_len`] and initialized in
+    /// place by `encode_to` — no intermediate stack buffer, no zeroing.
     #[inline]
     fn prof_push_record(
         ring: &bex_events::prof::Ring,

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2946,19 +2946,25 @@ impl BexVm {
     /// `CallFunction` 38, `EndFunction` 26, `SetFunctionId` 41) — the 292-byte
     /// `MAX_RECORD_LEN` zeroing is measurable at per-call rates.
     #[inline]
-    fn prof_push_record(&self, rec: &bex_events::prof::record::RawRecord<'_>) {
-        if let Some(ring) = self.prof_ring {
-            let mut buf = [0u8; bex_events::prof::record::SET_FUNCTION_ID_LEN];
-            let len = rec.encode_to(&mut buf);
-            // SAFETY: the engine refreshed `prof_ring` from this OS thread's
-            // TLS at the top of the current exec resume (D5a), and exec
-            // never crosses an `.await`, so this thread is still the ring's
-            // live claimant. If exec ever yields mid-step, this model must
-            // be revisited (plan §6, invariant 4).
-            #[expect(unsafe_code, reason = "ring push contract upheld by D5a refresh")]
-            unsafe {
-                ring.push(&buf[..len]);
-            }
+    fn prof_push_record(
+        ring: &bex_events::prof::Ring,
+        rec: &bex_events::prof::record::RawRecord<'_>,
+    ) {
+        // Encode straight into the ring slot: no intermediate stack buffer,
+        // no 41-byte zeroing, and one copy instead of two (encode→buf→ring).
+        let len = rec.encoded_len();
+        // SAFETY: the engine refreshed `prof_ring` from this OS thread's TLS
+        // at the top of the current exec resume (D5a), and exec never crosses
+        // an `.await`, so this thread is still the ring's live claimant. If
+        // exec ever yields mid-step, this model must be revisited (plan §6,
+        // invariant 4). Callers hold the `Some(ring)` so the off-check is not
+        // repeated here. `encode_to` writes exactly `encoded_len` bytes,
+        // initializing the whole slot before commit.
+        #[expect(unsafe_code, reason = "ring push contract upheld by D5a refresh")]
+        unsafe {
+            ring.push_with(len, |slot| {
+                rec.encode_to(slot);
+            });
         }
     }
 
@@ -2970,15 +2976,18 @@ impl BexVm {
         let parent_call_id = self.current_call_id;
         let call_id = self.mint_call_id();
         self.current_call_id = call_id;
-        if self.prof_ring.is_some() {
-            self.prof_push_record(&bex_events::prof::record::RawRecord::CallFunction {
-                flags: 0,
-                thread_id: BexThreadId(self.prof_thread_id),
-                call_id: BexCallId(call_id),
-                parent_call_id: BexCallId(parent_call_id),
-                function_id: ProfFunctionId(function_id),
-                ts_ticks: bex_events::prof::clock::now_ticks(),
-            });
+        if let Some(ring) = self.prof_ring {
+            Self::prof_push_record(
+                ring,
+                &bex_events::prof::record::RawRecord::CallFunction {
+                    flags: 0,
+                    thread_id: BexThreadId(self.prof_thread_id),
+                    call_id: BexCallId(call_id),
+                    parent_call_id: BexCallId(parent_call_id),
+                    function_id: ProfFunctionId(function_id),
+                    ts_ticks: bex_events::prof::clock::now_ticks(),
+                },
+            );
         }
         (call_id, parent_call_id)
     }
@@ -3004,13 +3013,16 @@ impl BexVm {
         {
             self.id_overrides.pop();
         }
-        if self.prof_ring.is_some() {
-            self.prof_push_record(&bex_events::prof::record::RawRecord::EndFunction {
-                status,
-                thread_id: BexThreadId(self.prof_thread_id),
-                call_id: BexCallId(call_id),
-                ts_ticks: bex_events::prof::clock::now_ticks(),
-            });
+        if let Some(ring) = self.prof_ring {
+            Self::prof_push_record(
+                ring,
+                &bex_events::prof::record::RawRecord::EndFunction {
+                    status,
+                    thread_id: BexThreadId(self.prof_thread_id),
+                    call_id: BexCallId(call_id),
+                    ts_ticks: bex_events::prof::clock::now_ticks(),
+                },
+            );
         }
     }
 
@@ -3078,15 +3090,18 @@ impl BexVm {
     fn prof_enter_sysop(&mut self, function_id: u32) {
         let parent_call_id = self.current_call_id;
         let call_id = self.mint_call_id();
-        if self.prof_ring.is_some() {
-            self.prof_push_record(&bex_events::prof::record::RawRecord::CallFunction {
-                flags: 0,
-                thread_id: BexThreadId(self.prof_thread_id),
-                call_id: BexCallId(call_id),
-                parent_call_id: BexCallId(parent_call_id),
-                function_id: ProfFunctionId(function_id),
-                ts_ticks: bex_events::prof::clock::now_ticks(),
-            });
+        if let Some(ring) = self.prof_ring {
+            Self::prof_push_record(
+                ring,
+                &bex_events::prof::record::RawRecord::CallFunction {
+                    flags: 0,
+                    thread_id: BexThreadId(self.prof_thread_id),
+                    call_id: BexCallId(call_id),
+                    parent_call_id: BexCallId(parent_call_id),
+                    function_id: ProfFunctionId(function_id),
+                    ts_ticks: bex_events::prof::clock::now_ticks(),
+                },
+            );
             self.pending_sysop_call_id = Some(call_id);
         }
     }
@@ -3095,13 +3110,16 @@ impl BexVm {
     /// stream (tag 0x05). Gated on the ring like every emission; the
     /// override semantics themselves work with profiling off.
     pub(crate) fn prof_push_set_function_id(&mut self, call_id: u64, id: [u8; 16]) {
-        if self.prof_ring.is_some() {
-            self.prof_push_record(&bex_events::prof::record::RawRecord::SetFunctionId {
-                thread_id: BexThreadId(self.prof_thread_id),
-                call_id: BexCallId(call_id),
-                id,
-                ts_ticks: bex_events::prof::clock::now_ticks(),
-            });
+        if let Some(ring) = self.prof_ring {
+            Self::prof_push_record(
+                ring,
+                &bex_events::prof::record::RawRecord::SetFunctionId {
+                    thread_id: BexThreadId(self.prof_thread_id),
+                    call_id: BexCallId(call_id),
+                    id,
+                    ts_ticks: bex_events::prof::clock::now_ticks(),
+                },
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Reduces the runtime overhead of the BEX tracing system on both sides of the ring: the **producer** (the VM encoding/pushing a raw record per call into a lock-free SPSC ring) and the **consumer** (the background thread transcoding to protobuf and writing per-engine `.bamlprof`). Profiling is default-on, so this is paid by every run.

Six commits, each measured and committed on its own merit. **No `.bamlprof` format change**; byte-identical wire output (guarded by a differential test). All `bex_events` unit tests, `bex_engine`'s `prof_gate`, the loom/miri concurrency suites, and clippy `--all-features` are green.

## Commits

| Commit | Side | Change |
|---|---|---|
| `e7daa17` | consumer | Reuse one encode buffer instead of a `Vec::with_capacity` **per event** (was a malloc + a redundant `encoded_len` walk per record). |
| `85bf08b` | producer | Encode records **directly into the ring slot** (`Ring::push_with` / `Buf::with_slice_mut`) — drops the intermediate stack buffer, the 41-byte zeroing, and one of two copies. Loom keeps per-byte tracked stores. |
| `d8ce1f2` | producer | Encode fixed fields with `ptr::write_unaligned` instead of `copy_from_slice` — the latter did **not** inline at `opt-level="s"` (the shipped profile): ~78 instructions/record → ~15, no libcall. |
| `d4eb542` | consumer | Convert ticks→ns with a **precomputed reciprocal multiply-shift** instead of a per-record u128 **divide** (~20-40 non-pipelined cycles). Exact for rate (1,1); ≤1 ns rounding for measured TSC rates, monotonic. |
| `d55970` | consumer | **Hand-roll the protobuf** for the two hot events (`CallFunction`/`EndFunction`) in one pass with back-patched 1-byte length prefixes, instead of prost (which walks this nested-oneof message **3×**). Cold records stay on prost. Same technique as Perfetto's protozero. |
| `905d6a7` | consumer | **One `write` per drained range** instead of one per event: accumulate the whole range (one ~256 KiB segment slice) into the writer's buffer, then a single write straight to the `File`. Drops the 8 KiB `BufWriter` (~4,300 → ~135 write syscalls / 2M-event run). |

## Results (Linux x86 dev box)

### Consumer — ~2.4× throughput
`prof_drain_throughput`: **7.7M → ~18M events/s/core.** The reciprocal removes the per-record divide; the hand-rolled encoder removes ~2/3 of the prost cost (prost was size-walking the message twice and byte-walking once); the batched range write removes the per-event syscall churn.

### End-to-end, single process (clean isolation)
Same binary, `BAML_PROFILE` toggled, real disk IO, **profile dir wiped before each run** so there is no cross-run accumulation. Medians, ms:

| workload | `off` (tracing disabled) | `discard` (producer floor, no IO) | `full` (real IO) |
|---|---|---|---|
| pure-call-1m (1M trivial calls) | 111.8 | 131.5 (+18%) | 169.3 (**+51%**) |
| call-chain-100x10k | 82.3 | 101.7 (+24%) | 125.9 (**+53%**) |

Decomposition on these adversarial call-storm microbenches: **producer ring-emit ~+18-24%**, **consumer transcode+write+fsync ~+30%**. The producer cost is at the encode/push floor (the clock read itself is only ~1-6 ns/pair — verified by a stub experiment; the rest is encoding + the ring commit, both irreducible without dropping records). The consumer (~18M ev/s) nearly matches the producer's ~18-20M ev/s burst, leaving a small drain tail plus the one-file write/fsync.

### Corpus medians
Across the full speedtest corpus, the same-binary **tracing-on producer cost is +3.6% median**; **total full-pipeline +8.2% median**. Real-shaped workloads (loops, strings, classes) are well under +10% — only the call-storm microbenches (millions of trivial calls, which no LLM-bound BAML program emits) are high.

> Note on a measurement pitfall: a multi-leg speedtest run *without* cleaning `.bamlprof` between sample-processes accumulates GBs and triggers NVMe dirty-page writeback throttling, inflating the `full` leg to +200-500%. The single-process numbers above (dir cleaned per run) are the representative cost; the inflation is a harness artifact, not a per-run cost.

## Follow-ups (not in this PR)

- **Per-segment compression (lz4).** The remaining ~+30% consumer+IO on record-dense workloads scales with `.bamlprof` byte volume; per-segment lz4 (~1.8-3× smaller files) is the lever, viable now that the consumer has CPU headroom. It's a **format-version bump**, so it's kept out of this no-format-change PR (separate branch/PR). The batched-range write here (`905d6a7`) is its structural carrier.
- **Record-shrink / delta-ts** — redundant with a block compressor on disk; revisit only for the ring overflow budget under sustained multi-second storms.
- **Leaf single-push fusion** — evaluated and rejected (~3-4 ns/pair for a high-risk unwind/cancel/drain change).
- **`opt-level=3`** — evaluated and reverted (speeds the VM ~17% but not the tracing delta; risks the wasm size budget).
- Fidelity levers (sampling / leaf-elision) are the only thing that *bounds* a pathological call-storm; out of scope here.

## Verification

- `cargo test -p bex_events` (53, incl. `hand_encoder_matches_prost` differential byte-equality and `reciprocal_matches_exact_divide`)
- `cargo test -p bex_engine --test prof_gate` (decodes the written bytes unchanged through `read_bamlprof`)
- loom (`--cfg baml_loom`) 34/34 + miri 33/33 on the ring/`push_with` change
- clippy `--all-targets --all-features` clean; CI mirror under `rustup run 1.93.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved profiling event recording and ring emission to encode directly into ring slots, reducing per-event overhead.
  * Streamlined profile writing by reusing a shared scratch buffer and optimizing the hottest event encoders.
  * Updated consumer processing to buffer and flush by committed ring ranges, including heartbeat persistence.
  * Accelerated tick-to-nanosecond conversion using a precomputed multiply-shift reciprocal scale.
* **Tests**
  * Added/updated assertions to verify reciprocal-based tick conversion matches exact conversion within 1ns and updated refinement expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->