### PR TITLE
Allow baml fmt to format directory paths

### DIFF
--- a/baml_language/crates/baml_cli/src/format.rs
+++ b/baml_language/crates/baml_cli/src/format.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     fs,
     path::{Path, PathBuf},
 };
@@ -161,6 +162,8 @@ fn expand_explicit_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
         }
     }
 
+    let mut seen = HashSet::new();
+    expanded.retain(|path| seen.insert(path.clone()));
     expanded
 }
 
@@ -231,5 +234,27 @@ mod tests {
             baml_fmt::format(nested_source, &FormatOptions::default()).unwrap()
         );
         assert_eq!(fs::read_to_string(ignored).unwrap(), ignored_source);
+    }
+
+    #[test]
+    fn explicit_overlapping_paths_are_deduplicated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let baml_src = tmp.path().join("baml_src");
+        let nested_dir = baml_src.join("nested");
+        fs::create_dir_all(&nested_dir).unwrap();
+
+        let main = baml_src.join("main.baml");
+        let nested = nested_dir.join("nested.baml");
+        fs::write(&main, "function main() -> string { \"hello\" }\n").unwrap();
+        fs::write(&nested, "function nested() -> int { 1 }\n").unwrap();
+
+        let expanded = expand_explicit_paths(&[
+            baml_src.clone(),
+            main.clone(),
+            nested_dir.clone(),
+            nested.clone(),
+        ]);
+
+        assert_eq!(expanded, vec![main, nested]);
     }
 }

--- a/baml_language/crates/baml_cli/src/format.rs
+++ b/baml_language/crates/baml_cli/src/format.rs
@@ -40,13 +40,9 @@ impl FormatArgs {
         // project-marker rule keeps `baml fmt` from silently rewriting
         // every `.baml` under cwd from an unrelated directory; with no
         // marker there's simply nothing to format (a no-op success).
-        let discovered;
-        let paths: &[PathBuf] = if self.paths.is_empty() {
+        let paths = if self.paths.is_empty() {
             match discover_project_files(&self.from)? {
-                Some(files) => {
-                    discovered = files;
-                    &discovered
-                }
+                Some(files) => files,
                 None => {
                     // No `baml.toml` / `baml_src/` here — there's nothing to
                     // format, so don't fail. A no-op success beats a hard
@@ -57,14 +53,20 @@ impl FormatArgs {
                 }
             }
         } else {
-            &self.paths
+            expand_explicit_paths(&self.paths)
         };
 
         if paths.is_empty() {
-            crate::reporter::print_error(format_args!(
-                "no .baml files found in {}",
-                self.from.display()
-            ));
+            let search_root = if self.paths.is_empty() {
+                self.from.display().to_string()
+            } else {
+                self.paths
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            crate::reporter::print_error(format_args!("no .baml files found in {}", search_root));
             return Ok(crate::ExitCode::Other);
         }
 
@@ -80,7 +82,7 @@ impl FormatArgs {
         };
 
         let mut num_failures: usize = 0;
-        for path in paths {
+        for path in &paths {
             if let Some(r) = &reporter {
                 r.spin("Formatting", path.display().to_string());
             }
@@ -148,6 +150,20 @@ impl FormatArgs {
     }
 }
 
+fn expand_explicit_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut expanded = Vec::new();
+
+    for path in paths {
+        if path.is_dir() {
+            expanded.extend(discover_baml_files(path));
+        } else {
+            expanded.push(path.clone());
+        }
+    }
+
+    expanded
+}
+
 /// Walk a project root and return every `.baml` file inside it. Requires a
 /// `baml.toml` or `baml_src/` marker so `baml fmt` doesn't accidentally
 /// rewrite every `.baml` under cwd from an unrelated directory, and prefers
@@ -172,4 +188,48 @@ fn discover_project_files(from: &Path) -> Result<Option<Vec<PathBuf>>> {
 
     let walk_root = if has_baml_src { baml_src } else { canonical };
     Ok(Some(discover_baml_files(&walk_root)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn explicit_directory_formats_baml_files_recursively() {
+        let tmp = tempfile::tempdir().unwrap();
+        let baml_src = tmp.path().join("baml_src");
+        let nested_dir = baml_src.join("nested");
+        fs::create_dir_all(&nested_dir).unwrap();
+
+        let main = baml_src.join("main.baml");
+        let nested = nested_dir.join("nested.baml");
+        let ignored = nested_dir.join("ignored.txt");
+        let main_source = "function main() -> string { \"hello\" }\n";
+        let nested_source = "function nested() -> int { 1 }\n";
+        let ignored_source = "function ignored() -> int { 1 }\n";
+
+        fs::write(&main, main_source).unwrap();
+        fs::write(&nested, nested_source).unwrap();
+        fs::write(&ignored, ignored_source).unwrap();
+
+        let args = FormatArgs {
+            paths: vec![baml_src],
+            from: tmp.path().to_path_buf(),
+            dry_run: false,
+        };
+        let exit_code = args.run().unwrap();
+
+        assert!(matches!(exit_code, crate::ExitCode::Success));
+        assert_eq!(
+            fs::read_to_string(&main).unwrap(),
+            baml_fmt::format(main_source, &FormatOptions::default()).unwrap()
+        );
+        assert_eq!(
+            fs::read_to_string(&nested).unwrap(),
+            baml_fmt::format(nested_source, &FormatOptions::default()).unwrap()
+        );
+        assert_eq!(fs::read_to_string(ignored).unwrap(), ignored_source);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
- [ ] This PR fixes/closes #[issue number]

## The error

Before this change, passing a directory to `baml fmt` made the formatter try to read the directory itself as a file.

BAML snippet:

```baml
function main() -> string { "hello" }
```

Reproduction command:

```sh
rm -rf /tmp/baml_fmt_dir_repro
mkdir -p /tmp/baml_fmt_dir_repro/baml_src
printf 'function main() -> string { "hello" }\n' > /tmp/baml_fmt_dir_repro/baml_src/main.baml
cargo run -q -p baml_cli -- fmt /tmp/baml_fmt_dir_repro/baml_src/
```

Observed output before the fix:

```text
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
  Formatting /tmp/baml_fmt_dir_repro/baml_src/
error: failed to read /tmp/baml_fmt_dir_repro/baml_src/: Is a directory (os error 21)
error: formatted 0 of 1 file(s); 1 failed

EXIT_STATUS=4
```

## Root cause

`baml_language/crates/baml_cli/src/format.rs::FormatArgs::run` already discovered project files when no positional paths were provided, but explicit positional paths were passed directly to `fs::read_to_string`. When a positional path was a directory, the formatting loop treated that directory as a single file and failed with `Is a directory`.

## The fix

- Added `expand_explicit_paths` in `crates/baml_cli/src/format.rs`.
- Explicit file paths are preserved exactly as before.
- Explicit directory paths now expand through `baml_workspace::discover_baml_files`, recursively collecting sorted `.baml` files under that directory.
- Added a regression test proving one directory argument formats both a top-level and nested `.baml` file while ignoring non-BAML files.

## Verification

Manual reproduction after the fix:

```text
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
  Formatting /tmp/baml_fmt_dir_repro/baml_src/main.baml
    Finished formatted 1 file(s) in 0s

EXIT_STATUS=0

--- formatted file ---
function main() -> string {
    "hello"
}
```

Commands run from `baml_language/`:

```sh
cargo test -p baml_cli explicit_directory_formats_baml_files_recursively -- --nocapture
cargo test
cargo test --workspace --exclude bridge_nodejs --exclude bridge_python --lib
cargo fmt --all
cargo clippy --all-targets -- -D warnings
```

Results:

- New regression test passed: `1 passed; 0 failed`.
- Full workspace `cargo test` passed after running the documented SDK setup for local plain-cargo execution:
  - `mise reshim` so `uv`/`ruff` were on PATH.
  - `./sdk_tests/crates/typescript_node/setup.sh` so TypeScript fixture dependencies were installed; this is normally handled by nextest setup scripts, while plain `cargo test` skips it.
- No snapshot failures occurred during the full `cargo test`; no snapshots were regenerated.
- Runnable workspace lib tests passed with `bridge_nodejs` and `bridge_python` excluded because both crates document `test = false` and cannot link standalone Rust lib-test binaries against Node/Python C API symbols in this environment.
- `cargo fmt --all` passed with no remaining diff.
- `cargo clippy --all-targets -- -D warnings` passed.
- CodeRabbit CLI was installed, but `CODERABBIT_API_KEY` was missing in the environment, so CodeRabbit authentication/review could not be run.

## Changes

Directory arguments to `baml fmt` now recursively format all `.baml` files under the directory.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in Linux cloud agent environment

## Screenshots

Not applicable.

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes

All code changes are scoped to `baml_language/`. The legacy `engine/` directory was not modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1024b014-557e-42f7-9025-773910022a5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1024b014-557e-42f7-9025-773910022a5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `baml fmt` now accepts directory arguments and recursively formats all `.baml` files found within them.
  * When mixing directories and files, inputs are deduplicated to avoid repeated formatting while preserving a consistent order.

* **Bug Fixes**
  * “No .baml files found” errors now more accurately reference the relevant search root based on how inputs were provided.

* **Tests**
  * Added coverage for recursive directory formatting, `.baml` filtering, and stable deduplication of overlapping inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->