### PR TITLE
Resolve unqualified builtin class methods in baml describe

### DIFF
--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -10,6 +10,7 @@ use clap::Args;
 
 use crate::project_load::load_project_or_default;
 
+/// Parsed documentation entry for a BAML keyword topic.
 #[derive(serde::Deserialize)]
 struct BamlKeywordDoc {
     summary: String,
@@ -19,6 +20,7 @@ struct BamlKeywordDoc {
     details: Option<String>,
 }
 
+/// Parsed documentation entry for a TypeScript/JavaScript keyword topic.
 #[derive(serde::Deserialize)]
 struct TsKeywordDoc {
     message: String,
@@ -255,6 +257,7 @@ fn resolve_unqualified_builtin_member<'db>(
 }
 
 impl DescribeArgs {
+    /// Run the describe command and return the CLI exit code.
     pub fn run(&self) -> Result<crate::ExitCode> {
         // Introspection never requires a `baml.toml`: with no project, we
         // fall back to a stdlib-only "default state" so `baml describe

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -205,7 +205,11 @@ pub fn dispatch<'db>(db: &'db ProjectDatabase, name: &str) -> Option<ResolvedTar
 
     // User package.
     let user_pkg = baml_compiler2_hir::package::PackageId::new(db, baml_db::Name::new("user"));
-    baml_lsp2_actions::resolve_target(db, user_pkg, name)
+    if let Some(target) = baml_lsp2_actions::resolve_target(db, user_pkg, name) {
+        return Some(target);
+    }
+
+    resolve_unqualified_builtin_member(db, name)
 }
 
 /// Map a lowercase primitive/keyword alias to the path of its builtin `baml`
@@ -227,6 +231,27 @@ fn builtin_alias_class_path(name: &str) -> Option<&'static str> {
         "json" => "json.json",
         _ => return None,
     })
+}
+
+/// Resolve `Array.reduce`/`String.split`-style builtin class member lookups.
+///
+/// Bare builtin class names are discoverable through the describe fallback, but
+/// dotted member paths need a structural target before rendering can drill into
+/// the method. This retry is intentionally after user-package lookup so a user
+/// class named `Array` still owns `Array.foo`; `baml.Array.foo` remains the
+/// explicit builtin spelling.
+fn resolve_unqualified_builtin_member<'db>(
+    db: &'db ProjectDatabase,
+    name: &str,
+) -> Option<ResolvedTarget<'db>> {
+    let (class_name, _) = name.split_once('.')?;
+    let baml_pkg = baml_compiler2_hir::package::PackageId::new(db, baml_db::Name::new("baml"));
+    let baml_items = baml_compiler2_hir::package::package_items(db, baml_pkg);
+    let root_ns: Vec<baml_db::Name> = Vec::new();
+    let class_name = baml_db::Name::new(class_name);
+
+    baml_items.lookup_type(&root_ns, &class_name)?;
+    baml_lsp2_actions::resolve_target(db, baml_pkg, name)
 }
 
 impl DescribeArgs {

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -834,6 +834,37 @@ fn describe_builtin_method_drill_in_via_alias() {
     );
 }
 
+/// Drilling into builtin methods by their class name (`Array.reduce`,
+/// `String.split`, `Map.get`) resolves the unqualified class against the stdlib.
+#[test]
+fn describe_builtin_method_drill_in_via_class_name() {
+    let db = simple_project();
+
+    let cases = [
+        (
+            "Array.reduce",
+            "function reduce(self, reducer: (A, T) -> A throws E, initial: A) -> A throws E",
+        ),
+        (
+            "String.split",
+            "function split(self, delimiter: string) -> string[]",
+        ),
+        ("Map.get", "function get(self, key: K) -> V | null"),
+    ];
+
+    for (name, expected_signature) in cases {
+        let output = describe_via_dispatch(&db, name);
+        assert!(
+            output.contains(expected_signature),
+            "expected resolved builtin method signature for `{name}`:\n{output}",
+        );
+        assert!(
+            !output.starts_with("NOT FOUND") && !output.starts_with("NO DESCRIPTION"),
+            "`{name}` should resolve via the unqualified builtin class name:\n{output}",
+        );
+    }
+}
+
 // ── definition_line_range tests ──────────────────────────────────────────────
 
 #[test]

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -865,6 +865,40 @@ fn describe_builtin_method_drill_in_via_class_name() {
     }
 }
 
+/// User-defined class methods still resolve before the stdlib fallback, even
+/// when the class name matches a builtin class such as `Array`.
+#[test]
+fn describe_user_defined_class_method_takes_precedence_over_builtin_fallback() {
+    let db = make_db(&[(
+        "shadow_builtin.baml",
+        r#"
+/// A user-defined class that intentionally shares a builtin class name.
+class Array {
+    value string
+
+    /// Return a user-defined reduction marker.
+    function reduce(self) -> string {
+        "user reduce"
+    }
+}
+"#,
+    )]);
+
+    let output = describe_via_dispatch(&db, "Array.reduce");
+    assert!(
+        output.contains("function reduce(self) -> string"),
+        "expected user-defined method signature:\n{output}",
+    );
+    assert!(
+        output.contains("\"user reduce\""),
+        "user-defined method body should be rendered:\n{output}",
+    );
+    assert!(
+        !output.contains("reducer: (A, T) -> A throws E"),
+        "builtin `Array.reduce` must not shadow the user-defined class method:\n{output}",
+    );
+}
+
 // ── definition_line_range tests ──────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Resolve unqualified builtin class methods in `baml describe`

## Summary
`baml describe <Class>.<method>` failed for builtin stdlib classes when the class name was unqualified. `baml describe Array.reduce`, `String.split`, and `Map.get` all returned `No symbol found` (exit code 4), even though the methods exist in the stdlib and the bare class names (`baml describe Array`) resolved fine.

Bare builtin class names are already discoverable through the describe fallback, but dotted member paths need a structural target before the renderer can drill into the method. This PR adds a retry that resolves the unqualified class against the `baml` stdlib package and then looks up the member.

The retry runs **after** user-package resolution, so user-defined classes and their methods keep working and keep precedence — a user class named `Array` still owns `Array.reduce`, and `baml.Array.reduce` remains the explicit builtin spelling.

## Output the user sees

### Builtin class methods — the fix
Before (on `canary`) these returned `No symbol found`. Now:

```text
$ baml describe Array.reduce
method reduce  <builtin>/baml/containers.baml:342-344

function reduce(self, reducer: (A, T) -> A throws E, initial: A) -> A throws E

container:
  class            Array                            <builtin>/baml/containers.baml:2

references (0):
```

```text
$ baml describe String.split
method split  <builtin>/baml/string.baml:121-123

function split(self, delimiter: string) -> string[]

container:
  class            String                           <builtin>/baml/string.baml:5

references (0):
```

```text
$ baml describe Map.get
method get  <builtin>/baml/containers.baml:505-507

function get(self, key: K) -> V | null

container:
  class            Map                              <builtin>/baml/containers.baml:457

references (0):
```

### User-defined classes and methods — unchanged, still resolve
User symbols continue to resolve exactly as before (and are listed with their methods):

```text
$ baml describe Point
class Point  baml_src/main.baml:2-10

/// A point in 2D space.
class Point {
    x: int,
    y: int,
}

methods:
  /// Euclidean distance from the origin.
  function magnitude(self) -> float  baml_src/main.baml:7-9

references (0):
```

```text
$ baml describe Point.magnitude
method magnitude  baml_src/main.baml:7-9

  /// Euclidean distance from the origin.
  function magnitude(self) -> float {
    0.0
  }

container:
  class            Point                            baml_src/main.baml:2

references (0):
```

### Precedence — user definitions win over the builtin fallback
With a user-defined `class Array { function reduce(self) -> string }`, the user method resolves; the explicit `baml.` spelling still reaches the builtin:

```text
$ baml describe Array.reduce          # user class shadows the builtin
method reduce  baml_src/shadow.baml:6-8

  /// Return a user-defined reduction marker.
  function reduce(self) -> string {
    "user reduce"
  }

container:
  class            Array                            baml_src/shadow.baml:2

references (0):
```

```text
$ baml describe baml.Array.reduce     # explicit builtin still works
method reduce  <builtin>/baml/containers.baml:342-344

function reduce(self, reducer: (A, T) -> A throws E, initial: A) -> A throws E

container:
  class            Array                            <builtin>/baml/containers.baml:2

references (0):
```

A method that genuinely does not exist still reports the same error as before:

```text
$ baml describe Array.no_such_method
No symbol found: Array.no_such_method  # exit code 4
```

## Changes
- `describe_command::dispatch` now falls back to `resolve_unqualified_builtin_member` after user-package resolution. The new helper splits `Class.member`, confirms `Class` exists as a stdlib type, then resolves the dotted path against the `baml` package.
- Added doc comments on the touched describe-command internals (`BamlKeywordDoc`, `TsKeywordDoc`, the `dispatch` fallback, `DescribeArgs::run`).

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed (all output above captured from the built `baml-cli` binary)

New regression tests in `describe_command_tests.rs`:
- `describe_builtin_method_drill_in_via_class_name` — `Array.reduce`, `String.split`, `Map.get` resolve to the expected signatures via the unqualified class name.
- `describe_user_defined_class_method_takes_precedence_over_builtin_fallback` — a user-defined `class Array { function reduce(...) }` resolves to the user method, and the builtin fallback does not shadow it.

```text
$ cargo test --package baml_cli --lib
test result: ok. 217 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Notes
- Scoped CLI dispatch bug fix; no stdlib or documentation files changed.
<!-- CURSOR_AGENT_PR_BODY_END -->


<div><a href="https://cursor.com/agents/bc-5b31ee47-5364-4315-8c88-d4711bb54ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b31ee47-5364-4315-8c88-d4711bb54ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `baml describe` resolution for built-in member methods referenced via unqualified names (e.g., `Array.reduce`, `String.split`), ensuring correct signatures are shown instead of fallback “not found” results.

* **Tests**
  * Added snapshot-style tests covering built-in method drill-in resolution and precedence when a user-defined class shares a built-in class name.

* **Documentation**
  * Enhanced doc comments clarifying BAML and TS/JS crosswalk entries for keyword-topic structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
