### PR TITLE
Suppress internal toolchain warning when invoked as baml

### DIFF
--- a/baml_language/crates/baml_cli/src/main.rs
+++ b/baml_language/crates/baml_cli/src/main.rs
@@ -3,7 +3,7 @@
 // TODO: baml_runtime is disabled for now
 // use baml_runtime::RuntimeCliDefaults;
 
-use std::io::Write as _;
+use std::{ffi::OsStr, io::Write as _, path::Path};
 
 fn main() {
     // TODO: baml_log is disabled for now
@@ -32,14 +32,70 @@ fn warn_if_direct_invocation() {
     if env_flag("BAML_WRAPPER_EXEC") || env_flag("BAML_CLI_ALLOW_DIRECT") {
         return;
     }
+    if is_canonical_baml_invocation(std::env::args_os().next().as_deref()) {
+        return;
+    }
     let _ = writeln!(
         std::io::stderr(),
         "warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead."
     );
 }
 
+fn is_canonical_baml_invocation(invocation: Option<&OsStr>) -> bool {
+    invocation.is_some_and(|invocation| {
+        let file_name = Path::new(invocation).file_name().unwrap_or(invocation);
+        canonical_baml_executable_name(file_name)
+    })
+}
+
+fn canonical_baml_executable_name(file_name: &OsStr) -> bool {
+    #[cfg(windows)]
+    {
+        Path::new(file_name)
+            .file_stem()
+            .is_some_and(|stem| stem == OsStr::new("baml"))
+    }
+
+    #[cfg(not(windows))]
+    {
+        file_name == OsStr::new("baml")
+    }
+}
+
 fn env_flag(name: &str) -> bool {
     std::env::var(name)
         .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true"))
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::is_canonical_baml_invocation;
+
+    #[test]
+    fn canonical_baml_invocation_is_not_direct() {
+        assert!(is_canonical_baml_invocation(Some(OsStr::new("baml"))));
+        assert!(is_canonical_baml_invocation(Some(OsStr::new(
+            "/home/user/.baml/toolchains/nightly/bin/baml",
+        ))));
+    }
+
+    #[test]
+    fn internal_cli_invocation_is_direct() {
+        assert!(!is_canonical_baml_invocation(Some(OsStr::new("baml-cli",))));
+        assert!(!is_canonical_baml_invocation(Some(OsStr::new(
+            "/home/user/.baml/toolchains/nightly/bin/baml-cli",
+        ))));
+        assert!(!is_canonical_baml_invocation(None));
+    }
+
+    #[test]
+    fn executable_extension_only_counts_as_baml_on_windows() {
+        assert_eq!(
+            is_canonical_baml_invocation(Some(OsStr::new("baml.exe"))),
+            cfg!(windows),
+        );
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

## The error

A correctly provisioned `baml` command can resolve to the internal toolchain CLI through the nightly/cache path while still being invoked under the canonical command name `baml`. Before this change, that printed a self-contradictory warning on every command.

Failing BAML used for local reproduction:

```baml
// sdk_tests/fixtures/function_calls/baml_src/main.baml
function hello_world() -> "hello world" {
  "hello world"
}
```

Pre-fix local reproduction simulated a PATH entry named `baml` pointing at the compiler2 `baml-cli` binary:

```console
$ tmpdir=$(mktemp -d "/tmp/baml-warning-run.XXXXXX")
$ mkdir -p "$tmpdir/bin"
$ ln -s "/workspace/baml_language/target/debug/baml-cli" "$tmpdir/bin/baml"
$ PATH="$tmpdir/bin:$PATH" baml run -e 'hello_world()'
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
   Compiling expression
     Running expression
"hello world"
    Finished expression in 5s
```

I also confirmed direct `baml-cli --version` emitted the same warning pre-fix:

```console
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
baml-cli 0.12.1
```

## Root cause

`baml_language/crates/baml_cli/src/main.rs::warn_if_direct_invocation` only checked the existing environment opt-outs (`BAML_WRAPPER_EXEC` and `BAML_CLI_ALLOW_DIRECT`) and then printed the warning unconditionally. It did not inspect the process invocation name, so an executable reached through a canonical `baml` PATH entry still received the "Use `baml` instead" warning.

The wrapper in `baml_language/crates/baml/src/main.rs::pass_through` already suppresses this via `BAML_WRAPPER_EXEC`, but the compiler2 CLI itself did not handle the case where `argv[0]` is already `baml`.

## The fix

`warn_if_direct_invocation` now suppresses the warning when `std::env::args_os().next()` has executable name `baml` (or `baml.exe` on Windows). Direct internal CLI invocations such as `baml-cli` or a full cache path ending in `baml-cli` still warn unless one of the existing env opt-outs is set.

Added focused unit tests in `baml_language/crates/baml_cli/src/main.rs` for:

- canonical `baml` invocation names
- direct `baml-cli` invocation names
- platform-specific `.exe` handling

## Verification

Post-fix reproduction with a PATH entry named `baml`:

```console
$ PATH="$tmpdir/bin:$PATH" baml --version
baml-cli 0.12.1

$ PATH="$tmpdir/bin:$PATH" baml run -e 'hello_world()'
   Compiling expression
     Running expression
"hello world"
    Finished expression in 5s

$ /workspace/baml_language/target/debug/baml-cli --version
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
baml-cli 0.12.1
```

Commands run from `baml_language/`:

```console
cargo fmt --all
PATH="/home/ubuntu/.local/share/mise/installs/node/22.22.3/bin:/home/ubuntu/.local/share/mise/installs/uv/0.11.3/uv-x86_64-unknown-linux-musl:/home/ubuntu/.local/share/mise/installs/cargo-cargo-insta/1.48.0/bin:$PATH" cargo test
PATH="/home/ubuntu/.local/share/mise/installs/cargo-cargo-insta/1.48.0/bin:$PATH" cargo insta pending-snapshots
PATH="/home/ubuntu/.local/share/mise/installs/node/22.22.3/bin:/home/ubuntu/.local/share/mise/installs/uv/0.11.3/uv-x86_64-unknown-linux-musl:/home/ubuntu/.local/share/mise/installs/cargo-cargo-insta/1.48.0/bin:$PATH" cargo clippy --all-targets -- -D warnings
cargo test -p baml_cli --lib
cargo test -p baml_cli --bin baml-cli
```

Results:

- `cargo fmt --all` passed.
- Full workspace `cargo test` passed.
- `cargo insta pending-snapshots` reported `No pending snapshots.`
- `cargo clippy --all-targets -- -D warnings` passed.
- `cargo test -p baml_cli --lib` and `cargo test -p baml_cli --bin baml-cli` passed.

Additional environment notes:

- `./scripts/setup-dev.sh` was attempted as requested, but failed while installing `cargo-shear@latest` because its `ra_ap_*` dependencies require rustc 1.95 while this environment has rustc 1.93. Other installed mise tools were used by adding their install paths explicitly.
- `cargo test --lib` across the entire workspace was also attempted; it failed while linking `bridge_python` because this environment lacks `libpython3.12` (`rust-lld: error: unable to find library -lpython3.12`). The full workspace `cargo test` gate passed.
- CodeRabbit CLI was installed, but `CODERABBIT_API_KEY` is missing in this environment. `coderabbit review --plain --base canary` therefore could not authenticate and returned: `Non-interactive environment detected. Use --api-key for authentication.`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b3dd995-e1d8-4fb6-aab4-ef1f669b9876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b3dd995-e1d8-4fb6-aab4-ef1f669b9876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

