### PR TITLE
fix(baml-cli): correct inaccurate keyword docs in baml describe

### DIFF
--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -140,7 +140,7 @@ generator:
   summary: "Configures code generation for a target language."
   syntax: |
     generator python {
-      output_type python/pydantic
+      output_type "python/pydantic"
       output_dir "../generated"
     }
 
@@ -155,15 +155,20 @@ test:
     }
 
 testset:
-  summary: "Defines a set of test cases that share configuration."
+  summary: "Groups related tests, optionally sharing setup, under a quoted name."
   syntax: |
-    testset MySuite {
-      functions [ExtractResume]
-      cases [
-        { args { text "case 1" } },
-        { args { text "case 2" } },
-      ]
+    testset "math suite" {
+      let answer = 42
+
+      test "adds" {
+        assert.equal(answer, 42)
+      }
+
+      test "is positive" {
+        assert.is_true(answer > 0)
+      }
     }
+  details: "A testset is named with a string (`testset \"name\" { ... }`), not a bare identifier. Its body holds `let` setup bindings plus nested `test` (and further `testset`) blocks; setup bindings are visible to the nested tests. Pick a runner with an optional `with` clause: `testset \"name\" with <runner> { ... }`. This is unrelated to the old config-block style — there are no `functions`/`cases` keys."
 
 template_string:
   summary: "Defines a reusable prompt template with Jinja2 syntax."
@@ -283,10 +288,10 @@ else:
 for:
   summary: "Iterates over elements of an array."
   syntax: |
-    for item in items {
+    for (let item in items) {
       process(item)
     }
-  details: "At top level, `for` is also used by out-of-body interface implementations: `implements Interface for Type { ... }`."
+  details: "The loop header is parenthesized and the binding is introduced with `let`: `for (let item in items) { ... }`. At top level, `for` is also used by out-of-body interface implementations: `implements Interface for Type { ... }`."
 
 while:
   summary: "Repeats a block as long as the condition is true."
@@ -304,14 +309,14 @@ let:
 in:
   summary: "Used with `for` loops to iterate over a collection."
   syntax: |
-    for item in [1, 2, 3] {
+    for (let item in [1, 2, 3]) {
       item
     }
 
 break:
   summary: "Exits the innermost `for` or `while` loop immediately."
   syntax: |
-    for item in items {
+    for (let item in items) {
       if item == target {
         break
       }
@@ -320,7 +325,7 @@ break:
 continue:
   summary: "Skips the rest of the current loop iteration and continues with the next."
   syntax: |
-    for item in items {
+    for (let item in items) {
       if item.is_empty() {
         continue
       }
@@ -335,12 +340,11 @@ return:
     }
 
 watch:
-  summary: "Observes a stream of values as they arrive."
+  summary: "Binds a value and re-runs dependent work as it updates over time."
   syntax: |
-    watch stream {
-      on_value(value) { process(value) }
-      on_done(final) { handle(final) }
-    }
+    watch let user_input = SimulateHumanGuess(history);
+    watch let WPoint { x } = current_point;
+  details: "`watch` is a prefix on a `let` binding: `watch let <pattern> = <expr>;`. The binding is reactive — code depending on it re-evaluates as the watched value changes. It binds the same patterns as `let` (names or destructuring), and unlike a plain `let` it cannot take an `else` clause."
 
 throw:
   summary: "Raises an error value, unwinding to the nearest `catch`."
@@ -357,26 +361,31 @@ throws:
     }
 
 catch:
-  summary: "Catches a specific error type from a preceding expression."
+  summary: "Handles selected error types thrown by a preceding expression."
   syntax: |
-    let result = risky_call() catch errors.Timeout {
-      default_value
+    let result = risky_call() catch (e) {
+      errors.Timeout => default_value,
+      errors.NotFound => other_value,
     }
+  details: "`expr catch (e) { ErrorType => handler, ... }` binds the caught error to `e` and dispatches on its type. Only the listed error types are handled; any other error keeps propagating, so `catch` need not be exhaustive. Chain a `catch_all` to handle the rest."
 
 catch_all:
-  summary: "Catches any error from a preceding expression."
+  summary: "Handles every error a preceding expression can throw (exhaustive)."
   syntax: |
-    let result = risky_call() catch_all {
-      fallback_value
+    let result = risky_call() catch_all (e) {
+      _ => fallback_value,
     }
+  details: "`expr catch_all (e) { ... }` binds the caught error to `e` and must cover every error type the expression can throw — either list them all or end with the wildcard `_ => ...`. The compiler reports a non-exhaustive `catch_all` if a throw type is left unhandled."
 
 match:
   summary: "Pattern matching — branches based on the shape or type of a value."
   syntax: |
-    match value {
-      x is string => handle_string(x),
-      x is int    => handle_int(x),
+    match (value) {
+      let x: string => handle_string(x),
+      let x: int    => handle_int(x),
+      _             => fallback,
     }
+  details: "The scrutinee is parenthesized: `match (value) { ... }`. Each arm is `pattern => expr`. Patterns include literals (`0`, `\"ok\"`), a binding with a type (`let x: int`) which both matches and narrows, the wildcard `_`, and optional guards (`let n: int if n > 0 => ...`). Use `let x: T => ...`, not `x is T => ...`, for type-based arms. Arms must be exhaustive, and a `_` arm is only allowed when earlier arms leave something uncovered."
 
 is:
   summary: "Tests whether a value matches a type or pattern."
@@ -509,7 +518,7 @@ implement:
 
     implement Label for int {
       function label(self) -> string {
-        return self.to_string()
+        return "${self}"
       }
     }
   details: "The formatter prints the canonical spelling as `implements`."
@@ -519,7 +528,7 @@ impl:
   syntax: |
     implements Label for int {
       function label(self) -> string {
-        return self.to_string()
+        return "${self}"
       }
     }
   details: "BAML accepts `implements` and the singular `implement`; it does not use `impl`."
@@ -636,7 +645,7 @@ default:
     class LoudGreeter {
       implements Greeter {
         function greet(self) -> string {
-          return default.greet().to_upper()
+          return default.greet().to_upper_case()
         }
       }
     }
@@ -645,10 +654,9 @@ default:
 check:
   summary: "Explains how to ask the CLI to validate a project."
   syntax: |
-    baml run --from .
-    baml run --from . --list
-    baml fmt --from .
-  details: "There is no standalone `baml check` command in this CLI. Commands such as `baml run`, `baml run --list`, and `baml fmt` load and check the project before doing their main work. Use `baml run --list` when you want a quick compile-and-signature view without running a specific function."
+    baml check --from .
+    baml run --list --from .
+  details: "`baml check` compiles the project and reports compiler errors without running anything — the most direct way to validate. Other commands (`baml run`, `baml run --list`, `baml fmt`, `baml test`) also load and check the project before their main work. Use `baml run --list` when you additionally want the compiled function signatures."
 
 spawn:
   summary: "Launches a concurrent task that runs in the background."
@@ -665,20 +673,50 @@ await:
     let result = await future
 
 dynamic:
-  summary: "Marks a class as dynamic — fields can be added at runtime."
+  summary: "Prefix inside a `type_builder` block that makes a class/enum extensible at runtime."
   syntax: |
-    class DynamicConfig dynamic {
-      // fields can be added dynamically
+    test MyTest {
+      functions [Fn]
+      type_builder {
+        dynamic class DynamicInner {
+          c string
+        }
+        dynamic enum DynamicEnum {
+          P
+          Q
+        }
+      }
+      args { from_text "test" }
     }
+  details: "`dynamic` is a prefix on a `class` or `enum` declared inside a test's `type_builder` block (`dynamic class Foo { ... }`), not a class suffix. It marks the type so the type-builder API can add fields/variants at runtime. See `baml describe type_builder`."
 
 type_builder:
-  summary: "Marks a class for use with the type builder API."
+  summary: "Block inside a `test` that declares extra types for that test."
   syntax: |
-    class Flexible type_builder {
-      // ...
+    test MyTest {
+      functions [Fn]
+      type_builder {
+        class InnerClass { b int }
+        dynamic class DynamicInner { c string }
+        enum InnerEnum { X Y }
+        type MyAlias = string | int
+      }
+      args { from_text "test" }
     }
+  details: "`type_builder { ... }` appears inside a `test` body and may contain `class`, `enum`, and `type` declarations, optionally prefixed with `dynamic`. It is not a modifier on a top-level class. See `baml describe dynamic`."
 
 with:
-  summary: "Attaches context or configuration to an expression."
+  summary: "Optional clause that attaches a runner to a test/testset or options to a spawn."
   syntax: |
-    call_llm_function(MyFunc, args) with { client: MyClient }
+    test "uses a quorum runner" with testing.Quorum(5, 3) {
+      assert.is_true(true)
+    }
+
+    testset "suite" with my_runner {
+      test "case" { assert.is_true(true) }
+    }
+
+    let task = spawn with baml.spawn.options(group = g) {
+      do_work()
+    }
+  details: "`with` is a contextual keyword, not a general operator — it is only special right after a `test`/`testset` name (selecting the test runner expression) or after `spawn` (passing `baml.spawn.options(...)`). Everywhere else `with` is an ordinary identifier and may be used as a variable or field name."

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_check.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_check.snap
@@ -5,8 +5,7 @@ expression: output
 check — Explains how to ask the CLI to validate a project.
 
 Syntax:
-  baml run --from .
-  baml run --from . --list
-  baml fmt --from .
+  baml check --from .
+  baml run --list --from .
 
-There is no standalone `baml check` command in this CLI. Commands such as `baml run`, `baml run --list`, and `baml fmt` load and check the project before doing their main work. Use `baml run --list` when you want a quick compile-and-signature view without running a specific function.
+`baml check` compiles the project and reports compiler errors without running anything — the most direct way to validate. Other commands (`baml run`, `baml run --list`, `baml fmt`, `baml test`) also load and check the project before their main work. Use `baml run --list` when you additionally want the compiled function signatures.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_impl.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_impl.snap
@@ -7,7 +7,7 @@ impl — Rust-style shorthand is not BAML syntax; use `implements`.
 Syntax:
   implements Label for int {
     function label(self) -> string {
-      return self.to_string()
+      return "${self}"
     }
   }
 


### PR DESCRIPTION
Several `baml describe <keyword>` entries documented syntax that does not compile or features that do not exist. Verified each example against the compiler (baml check / baml run --list) and the repo's grammar fixtures, then corrected:

- generator: output_type "python/pydantic" (slashed value needs quotes)
- testset:   testset "name" { test "..." {...} } (not a functions/cases block)
- for/in/break/continue: for (let x in items) (parens + let)
- match:     match (value) { let x: T => ... } (parens; let-typed arms, not `x is T`)
- watch:     watch let x = expr; (reactive binding, not an on_value/on_done block)
- catch:     expr catch (e) { ErrType => ... }
- catch_all: expr catch_all (e) { _ => ... } (exhaustive)
- with:      runner clause on test/testset and options on spawn
- dynamic/type_builder: dynamic class inside a test's type_builder block
- default:   .to_upper_case() (real string method)
- implement/impl: "${self}" (int has no to_string)
- check:     document the now-existing `baml check` command

Update the render_keyword_check and render_keyword_impl snapshots to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed BAML keyword documentation with clarified syntax examples for generators, testsets, loops, reactive bindings, and error handling
  * Enhanced pattern-matching and type-builder documentation with updated examples
  * Added CLI guidance for the baml check command and documented runtime-extensibility features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->