### PR TITLE
fix(bex_str): stop flatten() from emptying shared Concat nodes

### DIFF
--- a/baml_language/crates/bex_str/src/bex_str.rs
+++ b/baml_language/crates/bex_str/src/bex_str.rs
@@ -373,25 +373,23 @@ impl ConcatNode {
                     buf.extend_from_slice(&parent.data[o..o + l]);
                 }
                 BexStr::Concat(c) => {
-                    let mut inner_guard = c.state.lock().unwrap();
+                    let inner_guard = c.state.lock().unwrap();
                     match &*inner_guard {
                         ConcatState::Flattened(f) => {
                             buf.extend_from_slice(&f.data);
                         }
-                        ConcatState::Deferred { .. } => {
-                            let inner_old = std::mem::replace(
-                                &mut *inner_guard,
-                                ConcatState::Flattened(Arc::new(FlatStr {
-                                    hash: AtomicU64::new(0),
-                                    char_count: 0,
-                                    data: Box::new([]),
-                                })),
-                            );
+                        ConcatState::Deferred { left, right } => {
+                            // Clone the child handles (O(1): Arc bump or inline
+                            // memcpy) and leave this node's `Deferred` state
+                            // intact. The node may be shared (Arc refcount > 1,
+                            // e.g. `let n = a + b; let p = n + c`); destructively
+                            // emptying it here would corrupt every *other*
+                            // reference to it. (B-262 / B-233)
+                            let left = left.clone();
+                            let right = right.clone();
                             drop(inner_guard);
-                            if let ConcatState::Deferred { left, right } = inner_old {
-                                stack.push(right);
-                                stack.push(left);
-                            }
+                            stack.push(right);
+                            stack.push(left);
                         }
                     }
                 }

--- a/baml_language/crates/bex_str/src/tests.rs
+++ b/baml_language/crates/bex_str/src/tests.rs
@@ -214,3 +214,90 @@ fn char_count_concat() {
     assert_eq!(c.char_count(), 6);
     assert_eq!(c.len(), 9);
 }
+
+// ── Shared-Concat-node flatten regression (B-262 / B-233) ──────────────────
+//
+// Concatenation only defers into a `Concat` node when the result exceeds
+// `INLINE_CAPACITY` (54 bytes); shorter results are eagerly copied to `Inline`
+// and can't be shared. So these tests use >54-byte operands to force the
+// `Concat` path, then check that flattening a *parent* does not corrupt a
+// child node that is still referenced elsewhere.
+
+/// A `Concat` reused as the left child of another `Concat` must keep its own
+/// value after the parent is flattened. The old `flatten()` destructively
+/// emptied shared inner nodes, so `child` would read back as `""`.
+#[test]
+fn shared_concat_child_survives_parent_flatten() {
+    // 55 bytes → Concat (just over the 54-byte inline boundary).
+    let child = BexStr::concat(BexStr::from("x".repeat(40)), BexStr::from("y".repeat(15)));
+    assert!(
+        matches!(child, BexStr::Concat(_)),
+        "operand must be a Concat"
+    );
+    let expected_child = "x".repeat(40) + &"y".repeat(15);
+
+    // Parent references `child` as its left operand (Arc clone → shared node).
+    let parent = BexStr::concat(child.clone(), BexStr::from("#"));
+
+    // Flatten the parent; this used to empty the shared `child` node.
+    assert_eq!(parent.as_str(), format!("{expected_child}#"));
+
+    // The original child must be intact — both by content and by equality.
+    assert_eq!(child.as_str(), expected_child);
+    assert_eq!(child.len(), 55);
+    assert_eq!(child, BexStr::from(expected_child.as_str()));
+}
+
+/// Equality against a freshly-built literal after a shared flatten — mirrors
+/// the `registry.baml` `t.name == full_name` lookup that produced
+/// "Test not found".
+#[test]
+fn shared_concat_equality_after_parent_flatten() {
+    let name = BexStr::concat(
+        BexStr::from("testset_".repeat(4)),          // 32 bytes
+        BexStr::from("/the_test_name_that_is_long"), // 27 bytes → 59 total
+    );
+    let expected = "testset_".repeat(4) + "/the_test_name_that_is_long";
+
+    // hash_prefix = name + "#", then a `starts_with`-style flatten of it.
+    let hash_prefix = BexStr::concat(name.clone(), BexStr::from("#"));
+    let _ = hash_prefix.as_str(); // force flatten (what starts_with does)
+
+    // name must still compare equal to its literal value.
+    assert_eq!(name, BexStr::from(expected.as_str()));
+    assert!(
+        !name.as_str().is_empty(),
+        "shared name was emptied by flatten"
+    );
+}
+
+/// Two parents sharing one child: flattening the first must not corrupt the
+/// child for the second.
+#[test]
+fn two_parents_share_one_concat_child() {
+    let child = BexStr::concat(BexStr::from("a".repeat(50)), BexStr::from("b".repeat(10)));
+    let expected = "a".repeat(50) + &"b".repeat(10);
+
+    let p1 = BexStr::concat(child.clone(), BexStr::from("-1"));
+    let p2 = BexStr::concat(child.clone(), BexStr::from("-2"));
+
+    assert_eq!(p1.as_str(), format!("{expected}-1"));
+    // Second parent and the child are still correct after p1 flattened.
+    assert_eq!(p2.as_str(), format!("{expected}-2"));
+    assert_eq!(child.as_str(), expected);
+}
+
+/// Nested sharing: a shared grandchild deep in the tree must also survive.
+#[test]
+fn shared_concat_grandchild_survives_flatten() {
+    let leaf = BexStr::concat(BexStr::from("g".repeat(30)), BexStr::from("h".repeat(30)));
+    let expected_leaf = "g".repeat(30) + &"h".repeat(30);
+
+    let mid = BexStr::concat(leaf.clone(), BexStr::from("|mid"));
+    let top = BexStr::concat(mid.clone(), BexStr::from("|top"));
+
+    assert_eq!(top.as_str(), format!("{expected_leaf}|mid|top"));
+    // Both the intermediate and the shared leaf survive.
+    assert_eq!(mid.as_str(), format!("{expected_leaf}|mid"));
+    assert_eq!(leaf.as_str(), expected_leaf);
+}


### PR DESCRIPTION
## Problem

`baml test` silently lost testset tests whose qualified id (`testset/test`) exceeds ~54 bytes: they registered with an empty name, showed up in `test --list` as `::`, and failed at runtime with `Test not found:` (B-262, dup of B-233).

## Root cause

`ConcatNode::flatten()` in `crates/bex_str/src/bex_str.rs` destructively replaced each **inner** deferred node's state with an empty `FlatStr` while folding its bytes into the parent's buffer. That is safe only when the inner node is uniquely owned — but a `Concat` is an `Arc` and is routinely shared:

```
let n = a + b;     // Concat node
let p = n + c;     // p's left child shares n's Arc
p.as_str();        // flattens p -> empties the shared n
```

Only strings >54 bytes trigger it, since shorter concats are eagerly copied to `Inline`. In `registry.baml`, `hash_prefix = full_name + "#"` is flattened by a subsequent `starts_with`, emptying `full_name` before it is registered.

## Fix

The inner-node walk now clones the child handles (O(1) Arc bump / inline memcpy) and leaves the shared node's `Deferred` state intact instead of emptying it. Top-level memoization is unchanged.

## Tests

Adds `bex_str` regression tests: shared child survives parent flatten, equality after a parent flatten (the registry lookup shape), two parents sharing one child, and a nested grandchild. All four failed with `left: ""` before the fix.

- `cargo nextest run -p bex_str -p bex_vm -p bex_engine` → 338 passed
- Original `baml test` repro now passes (long testset test registers and runs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where string concatenation operations would incorrectly modify shared nested structures, resulting in potential data corruption when the same structure was used across multiple concatenations.

* **Tests**
  * Added comprehensive regression tests to ensure string concatenation properly handles shared nested structures in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->