### PR TITLE
fix(baml_fmt): emit `{}` for empty map literals instead of `{  }`

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -9,7 +9,7 @@ use crate::{
         Token, Type, UnaryOp, tokens as t,
     },
     printer::{PrintInfo, PrintMultiLine, Printable, Printer, Shape},
-    trivia_classifier::TriviaSliceExt,
+    trivia_classifier::{EmittableTrivia, TriviaSliceExt},
 };
 
 #[derive(Debug)]
@@ -3728,9 +3728,18 @@ impl MapLiteral {
     /// Returns the width of the expression if it fits on a single line.
     /// Returns `None` if it can never be single-lined.
     pub(crate) fn single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
-        // { k1: v1, k2: v2 }
-        let mut len = const { "{  }".len() };
         let (_, open_trailing) = input.trivia.get_for_range_split(self.open_brace.span());
+        let (close_leading, _) = input.trivia.get_for_range_split(self.close_brace.span());
+        // A populated map carries two interior padding spaces (`{ k1: v1 }`);
+        // an empty map is just `{}`. Keep this in sync with `try_print_single_line`.
+        let has_content = !self.fields.is_empty()
+            || open_trailing.iter().any(EmittableTrivia::is_comment)
+            || close_leading.iter().any(EmittableTrivia::is_comment);
+        let mut len = if has_content {
+            const { "{  }".len() }
+        } else {
+            const { "{}".len() }
+        };
         for t in open_trailing {
             len += t.single_line_len(input.input)?;
         }
@@ -3770,7 +3779,6 @@ impl MapLiteral {
                 }
             }
         }
-        let (close_leading, _) = input.trivia.get_for_range_split(self.close_brace.span());
         for t in close_leading {
             len += t.single_line_len(input.input)?;
         }
@@ -3780,9 +3788,19 @@ impl MapLiteral {
     /// Should be passed a sub-printer to avoid printing trivia in the outer printer
     /// in the event that the printer is unable to fit the map literal on a single line.
     fn try_print_single_line(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
-        printer.print_raw_token(&self.open_brace);
-        printer.print_str(" ");
         let (_, open_trailing) = printer.trivia.get_for_range_split(self.open_brace.span());
+        let (close_leading, _) = printer.trivia.get_for_range_split(self.close_brace.span());
+        // An empty map renders as `{}` with no interior padding. The padding
+        // spaces are only added when there is something to surround: fields or
+        // an interior comment (the only trivia that prints on a single line).
+        let has_content = !self.fields.is_empty()
+            || open_trailing.iter().any(EmittableTrivia::is_comment)
+            || close_leading.iter().any(EmittableTrivia::is_comment);
+
+        printer.print_raw_token(&self.open_brace);
+        if has_content {
+            printer.print_str(" ");
+        }
         printer.try_print_trivia_single_line_squished(open_trailing)?;
 
         for (i, (field, comma)) in self.fields.iter().enumerate() {
@@ -3817,9 +3835,10 @@ impl MapLiteral {
                 printer.try_print_trivia_single_line_squished(comma_trailing)?;
             }
         }
-        let (close_leading, _) = printer.trivia.get_for_range_split(self.close_brace.span());
         printer.try_print_trivia_single_line_squished(close_leading)?;
-        printer.print_str(" ");
+        if has_content {
+            printer.print_str(" ");
+        }
         printer.print_raw_token(&self.close_brace);
 
         if printer.output.len() > shape.width {

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -674,3 +674,45 @@ mod const_format_tests {
         assert_formats_to(source, source);
     }
 }
+
+#[cfg(test)]
+mod map_literal_format_tests {
+    //! Formatter tests for map literals, focused on the empty-map case.
+    //! A non-empty map renders with interior padding (`{ "k": 1 }`), but an
+    //! *empty* map must collapse to `{}` with no padding — the printer used to
+    //! emit `{  }` because it added the leading/trailing space unconditionally.
+
+    use super::*;
+
+    fn assert_formats_to(source: &str, expected: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed on map literal");
+        assert_eq!(
+            formatted, expected,
+            "formatter output didn't match expected\n--- got ---\n{formatted}\n--- want ---\n{expected}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    #[test]
+    fn test_empty_map_has_no_interior_padding() {
+        // Regression for B-234: an empty map literal must format as `{}`, not `{  }`.
+        let source = "function f() -> int {\n    {};\n    0\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_non_empty_map_keeps_interior_padding() {
+        // Guard the established behavior: non-empty maps keep `{ ... }` padding.
+        let source = "function f() -> int {\n    { \"a\": 1 };\n    0\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_empty_map_with_block_comment_keeps_padding() {
+        // An interior comment is real content, so the padding stays.
+        let source = "function f() -> int {\n    { /* keep */ };\n    0\n}\n";
+        assert_formats_to(source, source);
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_annotation/baml_tests__compiles__type_annotation__10_formatter__type_positions.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_annotation/baml_tests__compiles__type_annotation__10_formatter__type_positions.snap
@@ -39,6 +39,6 @@ function test_union(function_name: string) -> string {
 
 // Map value
 function test_map(function_name: string) -> string {
-    let m: map<string, type> = {  };
+    let m: map<string, type> = {};
     return "ok";
 }


### PR DESCRIPTION
## Summary

`baml fmt` emitted `{  }` (two spaces) for **empty** map literals instead of `{}`.

`MapLiteral::try_print_single_line` printed the interior padding space after `{` and before `}` unconditionally, so with no fields in between the output was `{  }`. This gates the padding on whether there's something to surround — fields or an interior comment — so:

- empty map → `{}`
- populated map → `{ "k": 1 }` (unchanged)
- comment-only map → `{ /* c */ }` (padding preserved)

`MapLiteral::single_line_width` mirrors the same logic so width/fit estimates stay consistent (`{}` is 2 wide, not 4).

## Tests

- New `map_literal_format_tests` in `baml_fmt` covering the empty case (regression), the non-empty padding guard, and the comment-only case.
- An existing corpus fixture (`compiles/type_annotation/type_positions.baml`) already exercised an empty map; its formatter snapshot now correctly shows `{}`.
- `baml_fmt` suite green; all 187 `10_formatter` snapshot tests green; clippy `--all-targets` and rustfmt clean.

Fixes B-234.

## Note (out of scope)

`ObjectInitializer` has the identical unconditional-padding pattern, so an empty `Name {}` would format as `Name { }`. Left untouched here since the issue is specifically about map literals — happy to follow up if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated map literal formatting to produce cleaner output for empty maps (`{}` without spacing) while preserving formatting and readability for non-empty maps and maps containing comments.

* **Tests**
  * Added comprehensive test coverage for map literal formatting scenarios, including empty maps, non-empty maps, and maps with interior comments, with verification of formatter idempotency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->