### PR TITLE
Negative indexing

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/containers.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/containers.baml
@@ -14,6 +14,7 @@ class Array<T> {
   /// [10, 20, 30].at(0)    // 10
   /// [10, 20, 30].at(-1)   // 30
   /// [10, 20, 30].at(99)   // null
+  /// [10, 20, 30].at(-99)  // null
   /// ```
   function at(self, index: int) -> T? throws never {
     $rust_function
@@ -34,14 +35,16 @@ class Array<T> {
   /// Removes and returns the element at `index`, or `null` if out of bounds.
   /// Mutates `self` in place.
   ///
+  /// Negative indices count from the end: `-1` is the last element.
+  ///
   /// `O(n)` because subsequent elements shift backward. For `O(1)` removal from
   /// the back use `pop`.
   ///
   /// # Examples
   /// ```
   /// let xs = [10, 20, 30];
-  /// xs.remove_at(1)   // 20
-  /// xs                // [10, 30]
+  /// xs.remove_at(1)   // 20   xs is now [10, 30]
+  /// xs.remove_at(-1)  // 30   removes the last element; xs is now [10]
   /// xs.remove_at(99)  // null
   /// ```
   //baml:mut_self
@@ -161,12 +164,14 @@ class Array<T> {
 
   /// Returns a sub-array from index `start` (inclusive) to `end` (exclusive).
   ///
-  /// Negative indices count from the end. Out-of-range indices are clamped.
+  /// Negative indices count from the end. Out-of-range indices are clamped, and
+  /// an `end` that resolves at or before `start` yields an empty array.
   ///
   /// # Examples
   /// ```
   /// [1, 2, 3, 4].slice(1, 3)   // [2, 3]
   /// [1, 2, 3].slice(-2, 3)     // [2, 3]
+  /// [1, 2, 3].slice(2, 1)      // []
   /// ```
   function slice(self, start: int, end: int) -> T[] throws never {
     $rust_function
@@ -415,15 +420,15 @@ class Array<T> {
   /// Mutates `self` in place.
   ///
   /// `idx` may equal `length()`, in which case the call is equivalent to
-  /// `push(item)`. Throws `InvalidArgument` if `idx < 0` or `idx > length()`.
+  /// `push(item)`. Negative indices count from the end, so `-1` inserts before
+  /// the last element. Throws `InvalidArgument` if `idx` is outside the range
+  /// `[-length(), length()]`.
   ///
   /// # Examples
   /// ```
   /// let xs = [1, 2, 4];
-  /// xs.insert(3, 2)        // 4   (new length)
-  /// xs                     // [1, 2, 3, 4]
-  /// xs.insert(99, xs.length())  // append; new length 5
-  /// xs.insert(0, -1)       // throws — negative idx
+  /// xs.insert(3, 2)        // 4   inserts 3 at index 2; xs is now [1, 2, 3, 4]
+  /// xs.insert(9, -1)       // 5   inserts before the last; xs is now [1, 2, 3, 9, 4]
   /// xs.insert(0, 100)      // throws — idx beyond length
   /// ```
   //baml:mut_self
@@ -435,16 +440,17 @@ class Array<T> {
   /// `replace`. Mutates `self` in place. The replacement may be longer or
   /// shorter than `count`; the array grows or shrinks accordingly.
   ///
-  /// Throws `InvalidArgument` if `start < 0` or `start > length()`. If
-  /// `start + count` would exceed `length()`, `count` is clamped to
-  /// `length() - start`. `count` must be non-negative.
+  /// A negative `start` counts from the end. Throws `InvalidArgument` if `start`
+  /// is outside the range `[-length(), length()]`. If `start + count` would
+  /// exceed `length()`, `count` is clamped to `length() - start`. `count` must
+  /// be non-negative.
   ///
   /// # Examples
   /// ```
   /// let xs = [0, 1, 2, 3, 4];
   /// xs.splice(1, 2, [9, 9, 9])   // xs is now [0, 9, 9, 9, 3, 4]
   /// xs.splice(0, 0, [-1])        // pure insertion: [-1, 0, 9, 9, 9, 3, 4]
-  /// xs.splice(0, 1, [])          // pure removal: [0, 9, 9, 9, 3, 4]
+  /// xs.splice(-1, 1, [])         // removes the last element: [-1, 0, 9, 9, 9, 3]
   /// xs.splice(99, 0, [])         // throws — start out of range
   /// ```
   //baml:mut_self

--- a/baml_language/crates/baml_builtins2/baml_std/baml/string.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/string.baml
@@ -140,19 +140,20 @@ class String {
 
   /// Returns the substring between two **character** offsets `[start, end)`.
   ///
-  /// Both `start` and `end` are codepoint indices, matching `length()`. They
-  /// are clamped to the range `[0, length()]`, and `end` is further clamped
-  /// so that `end >= start`. Out-of-bounds indices are silently clamped —
-  /// this method never throws.
+  /// Both `start` and `end` are codepoint indices, matching `length()`. Negative
+  /// indices count from the end. The resolved offsets are clamped to
+  /// `[0, length()]`, and an `end` that resolves at or before `start` yields an
+  /// empty string. Never throws.
   ///
   /// # Examples
   /// ```
   /// "hello world".substring(0, 5)   // "hello"
   /// "hello".substring(2, 100)       // "llo" (end clamped)
+  /// "hello".substring(-3, -1)       // "ll" (counts from the end)
   /// "😀hello".substring(0, 1)       // "😀"
   /// "😀hello".substring(1, 4)       // "hel"
   /// ```
-  function substring(self, start: int, end: int) -> string throws root.errors.InvalidArgument {
+  function substring(self, start: int, end: int) -> string throws never {
     $rust_function
   }
 
@@ -178,18 +179,20 @@ class String {
   /// Returns the character at the given **codepoint index** as a
   /// one-character string.
   ///
-  /// Returns an empty string if `index >= length()`. Throws
-  /// `InvalidArgument` if `index` is negative.
+  /// Negative indices count from the end: `-1` is the last character. Raises
+  /// `IndexOutOfBounds` when the index is out of range after counting from the
+  /// end, so a successful call always returns exactly one character.
   ///
   /// # Examples
   /// ```
   /// "hello".char_at(0)   // "h"
   /// "héllo".char_at(1)   // "é"
-  /// "héllo".char_at(2)   // "l"
   /// "😀hello".char_at(0) // "😀"
-  /// "hi".char_at(99)     // ""
+  /// "hello".char_at(-1)  // "o"
+  /// "hi".char_at(99)     // raises IndexOutOfBounds
   /// ```
-  function char_at(self, index: int) -> string throws root.errors.InvalidArgument {
+  //baml:fallible
+  function char_at(self, index: int) -> string throws never {
     $rust_function
   }
 

--- a/baml_language/crates/baml_builtins2/baml_std/baml/uint8array.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/uint8array.baml
@@ -49,10 +49,11 @@ class Uint8Array {
     $rust_function
   }
 
-  /// Returns a new `uint8array` containing the bytes in the given range.
+  /// Returns a new `uint8array` with the bytes from `start` (inclusive) to
+  /// `end` (exclusive).
   ///
-  /// - `start` is clamped to the range `[0, length]`.
-  /// - `end` is clamped to the range `[start, length]`.
+  /// Negative indices count from the end. Out-of-range indices are clamped, and
+  /// an `end` that resolves at or before `start` yields an empty array.
   function slice(self, start: int, end: int) -> uint8array throws never {
     $rust_function
   }

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -11,7 +11,7 @@ function         _float_total_cmp                 <builtin>/baml/comparable.baml
 function         _is_primitive_array              <builtin>/baml/comparable.baml:151
 function         _rust_sort                       <builtin>/baml/comparable.baml:172
 class            Array                            <builtin>/baml/containers.baml:2
-class            Map                              <builtin>/baml/containers.baml:457
+class            Map                              <builtin>/baml/containers.baml:463
 function         deep_copy                        <builtin>/baml/core.baml:3
 function         deep_equals                      <builtin>/baml/core.baml:9
 class            Float                            <builtin>/baml/float.baml:2

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
@@ -2,7 +2,7 @@
 source: crates/baml_cli/src/describe_command_tests.rs
 expression: "describe_via_dispatch(&db, \"string\")"
 ---
-class String  (string)  <builtin>/baml/string.baml:5-475
+class String  (string)  <builtin>/baml/string.baml:5-478
 
 /// A UTF-8 encoded string.
 ///
@@ -34,7 +34,7 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:104-106
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:109-111
-  … 56 more lines (re-run with a higher --budget)
+  … 55 more lines (re-run with a higher --budget)
 
 static_methods:
   … 4 more lines (re-run with a higher --budget)

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
@@ -2,7 +2,7 @@
 source: crates/baml_cli/src/describe_command_tests.rs
 expression: output
 ---
-class String  (string)  <builtin>/baml/string.baml:5-475
+class String  (string)  <builtin>/baml/string.baml:5-478
 
 /// A UTF-8 encoded string.
 ///
@@ -34,7 +34,7 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:104-106
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:109-111
-  … 56 more lines (re-run with a higher --budget)
+  … 55 more lines (re-run with a higher --budget)
 
 static_methods:
   … 4 more lines (re-run with a higher --budget)

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
@@ -2,7 +2,7 @@
 source: crates/baml_cli/src/describe_command_tests.rs
 expression: output
 ---
-class String  (string)  <builtin>/baml/string.baml:5-475
+class String  (string)  <builtin>/baml/string.baml:5-478
 
 /// A UTF-8 encoded string.
 ///
@@ -34,7 +34,7 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:104-106
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:109-111
-  … 56 more lines (re-run with a higher --budget)
+  … 55 more lines (re-run with a higher --budget)
 
 static_methods:
   … 4 more lines (re-run with a higher --budget)

--- a/baml_language/crates/baml_lsp2_actions/src/snapshots/baml_lsp2_actions__describe_tests__describe_builtin_string_with_compiler2_visible_files.snap
+++ b/baml_language/crates/baml_lsp2_actions/src/snapshots/baml_lsp2_actions__describe_tests__describe_builtin_string_with_compiler2_visible_files.snap
@@ -37,13 +37,12 @@ methods:
   /// Splits the string into lines, recognizing both `\n` and `\r\n` as line
   function lines(self) -> string[]
   /// Returns the substring between two **character** offsets `[start, end)`.
-  function substring(self, start: int, end: int) -> string throws root.errors.InvalidArgument
+  function substring(self, start: int, end: int) -> string
   /// Replaces the first occurrence of `search` with `replacement`.
   function replace(self, search: string, replacement: string) -> string
   /// Returns the **character index** of the first occurrence of `search`, or
   function index_of(self, search: string) -> int
-  /// Returns the character at the given **codepoint index** as a
-  function char_at(self, index: int) -> string throws root.errors.InvalidArgument
+  function char_at(self, index: int) -> string
   /// Returns a new string that repeats `self` the given number of times.
   function repeat(self, count: int) -> string
   /// Returns true if the string contains the given `substring`.

--- a/baml_language/crates/baml_tests/baml_src/ns_arrays/arrays.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_arrays/arrays.baml
@@ -423,9 +423,16 @@ test "array_remove_at_out_of_bounds_returns_null_and_keeps_array" {
     assert.is_true(baml.deep_equals(xs, expected))
 }
 
-test "array_remove_at_negative_returns_null_and_keeps_array" {
+test "array_remove_at_negative_counts_from_end" {
     let xs = [10, 20, 30];
-    assert.equal(xs.remove_at(-1), null);
+    assert.equal(xs.remove_at(-1), 30);
+    let expected = [10, 20];
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+test "array_remove_at_past_start_returns_null_and_keeps_array" {
+    let xs = [10, 20, 30];
+    assert.equal(xs.remove_at(-4), null);
     let expected = [10, 20, 30];
     assert.is_true(baml.deep_equals(xs, expected))
 }
@@ -525,10 +532,18 @@ test "array_insert_empty_array_at_zero" {
     assert.is_true(baml.deep_equals(xs, expected))
 }
 
-test "array_insert_negative_throws" {
+// idx -1 counts from the end → inserts before the last element.
+test "array_insert_negative_counts_from_end" {
+    let xs = [1, 2, 3];
+    assert.equal(xs.insert(9, -1), 4);
+    let expected = [1, 2, 9, 3];
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+test "array_insert_past_start_throws" {
     {
         let xs = [1, 2, 3];
-        xs.insert(0, -1);
+        xs.insert(0, -4);
         baml.sys.panic("expected insert to throw")
     } catch (e) {
         baml.errors.InvalidArgument => null
@@ -595,10 +610,18 @@ test "array_splice_replace_with_longer" {
     assert.is_true(baml.deep_equals(xs, expected))
 }
 
-test "array_splice_negative_start_throws" {
+// start -2 counts from the end → replaces starting at index length - 2.
+test "array_splice_negative_start_counts_from_end" {
+    let xs = [0, 1, 2, 3, 4];
+    xs.splice(-2, 1, [9, 9]);
+    let expected = [0, 1, 2, 9, 9, 4];
+    assert.is_true(baml.deep_equals(xs, expected))
+}
+
+test "array_splice_past_start_throws" {
     {
         let xs = [1, 2, 3];
-        xs.splice(-1, 0, []);
+        xs.splice(-4, 0, []);
         baml.sys.panic("expected splice to throw")
     } catch (e) {
         baml.errors.InvalidArgument => null
@@ -843,4 +866,136 @@ test "array_flat_map_uneven_inner_lengths" {
         }),
         [1, 20, 21, 22, 3]
     ))
+}
+
+// ─── at ────────────────────────────────────────────────────────────────────────
+
+test "array_at_positive" {
+    assert.equal([10, 20, 30].at(0), 10);
+    assert.equal([10, 20, 30].at(2), 30)
+}
+
+// -1 is the last element; -3 is the first.
+test "array_at_negative_counts_from_end" {
+    assert.equal([10, 20, 30].at(-1), 30);
+    assert.equal([10, 20, 30].at(-3), 10)
+}
+
+test "array_at_past_end_is_null" {
+    assert.equal([10, 20, 30].at(3), null);
+    assert.equal([10, 20, 30].at(99), null)
+}
+
+// -4 normalizes to -1, before the start → null (no panic, unlike `[]`).
+test "array_at_past_start_is_null" {
+    assert.equal([10, 20, 30].at(-4), null)
+}
+
+test "array_at_empty_is_null" {
+    let xs: int[] = [];
+    assert.equal(xs.at(0), null);
+    assert.equal(xs.at(-1), null)
+}
+
+// ─── subscript [] read ─────────────────────────────────────────────────────────
+
+// A bare `[...][i]` in a test block is swallowed by the value-boxing path and
+// never throws, so the indexing is wrapped in a function (see the file header).
+function array_index_read(idx: int) -> int {
+    let xs = [10, 20, 30];
+    xs[idx]
+}
+
+test "array_index_read_positive" {
+    assert.equal(array_index_read(0), 10)
+}
+
+// -1 is the last element; -3 is the first.
+test "array_index_read_negative_counts_from_end" {
+    assert.equal(array_index_read(-1), 30);
+    assert.equal(array_index_read(-3), 10)
+}
+
+test "array_index_read_past_end_panics" {
+    {
+        array_index_read(3);
+        baml.sys.panic("expected index out of bounds")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
+// -4 normalizes to -1, before the start → panic (unlike `at`, which is null).
+test "array_index_read_past_start_panics" {
+    {
+        array_index_read(-4);
+        baml.sys.panic("expected index out of bounds")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
+// ─── subscript [] write ────────────────────────────────────────────────────────
+
+function array_index_write(idx: int) -> int[] {
+    let xs = [10, 20, 30];
+    xs[idx] = 99;
+    xs
+}
+
+// Writing through a negative index targets the element counted from the end.
+test "array_index_write_negative_counts_from_end" {
+    assert.is_true(baml.deep_equals(array_index_write(-1), [10, 20, 99]))
+}
+
+test "array_index_write_past_end_panics" {
+    {
+        array_index_write(3);
+        baml.sys.panic("expected index out of bounds")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
+test "array_index_write_past_start_panics" {
+    {
+        array_index_write(-4);
+        baml.sys.panic("expected index out of bounds")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
+// ─── slice ─────────────────────────────────────────────────────────────────────
+
+test "array_slice_basic" {
+    assert.is_true(baml.deep_equals([1, 2, 3, 4].slice(1, 3), [2, 3]))
+}
+
+test "array_slice_negative_start" {
+    assert.is_true(baml.deep_equals([1, 2, 3].slice(-2, 3), [2, 3]))
+}
+
+test "array_slice_negative_end" {
+    assert.is_true(baml.deep_equals([1, 2, 3, 4].slice(0, -1), [1, 2, 3]))
+}
+
+test "array_slice_negative_both" {
+    assert.is_true(baml.deep_equals([1, 2, 3, 4, 5].slice(-3, -1), [3, 4]))
+}
+
+// An `end` that resolves at or before `start` yields an empty array.
+test "array_slice_end_before_start_is_empty" {
+    assert.is_true(baml.deep_equals([1, 2, 3].slice(2, 1), []));
+    assert.is_true(baml.deep_equals([1, 2, 3].slice(-1, -2), []))
+}
+
+// Out-of-range bounds clamp to `[0, length]`.
+test "array_slice_clamps_out_of_range" {
+    assert.is_true(baml.deep_equals([1, 2, 3].slice(-100, 100), [1, 2, 3]))
+}
+
+test "array_slice_empty_array" {
+    let xs: int[] = [];
+    assert.is_true(baml.deep_equals(xs.slice(-1, 5), []))
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_byte_strings/byte_strings.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_byte_strings/byte_strings.baml
@@ -93,8 +93,14 @@ function byte_strings_index_oob() -> int {
     b"a"[5]
 }
 
-function byte_strings_index_neg() -> int {
+// b"a" = [97]; [-1] counts from the end → the last (only) byte.
+function byte_strings_index_neg_in_bounds() -> int {
     b"a"[-1]
+}
+
+// [-2] is past the start of a length-1 array (it normalizes to -1).
+function byte_strings_index_before_start() -> int {
+    b"a"[-2]
 }
 
 // B8. Helper function defined inline alongside main — used by literal_as_call_argument.
@@ -143,8 +149,14 @@ test "at_out_of_bounds" {
     assert.equal(b"abc".at(10), null)
 }
 
+// b"abc" = [97, 98, 99]; .at(-1) counts from the end → the last byte.
 test "at_negative_index" {
-    assert.equal(b"abc".at(-1), null)
+    assert.equal(b"abc".at(-1), 99)
+}
+
+// Past the start (b"abc".at(-4) normalizes to -1) → null, like Array.at.
+test "at_negative_out_of_bounds" {
+    assert.equal(b"abc".at(-4), null)
 }
 
 // ─── B3. Uint8Array.zeroes (literal only) ─────────────────────────────────────
@@ -178,9 +190,15 @@ test "index_out_of_bounds" {
     }
 }
 
-test "index_negative" {
+// [-1] counts from the end and lands in bounds → the last byte (no panic).
+test "index_negative_in_bounds" {
+    assert.equal(byte_strings_index_neg_in_bounds(), 97)
+}
+
+// An index past the start raises IndexOutOfBounds, unlike Array.at.
+test "index_before_start" {
     {
-        byte_strings_index_neg();
+        byte_strings_index_before_start();
         baml.sys.panic("expected throw")
     } catch (e) {
         baml.panics.IndexOutOfBounds => null

--- a/baml_language/crates/baml_tests/baml_src/ns_exceptions/exceptions.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_exceptions/exceptions.baml
@@ -442,7 +442,9 @@ test "catch_map_key_not_found" {
     assert.is_true(baml.deep_equals(catch_map_key_not_found_fn(), -1))
 }
 
-function s5_bad_2() -> int { let a = [1, 2]; a[-1] }
+// `-3` counts from the end past the start of a length-2 array (it normalizes
+// to `-1`), so it is out of bounds. (`a[-1]` would resolve to the last element.)
+function s5_bad_2() -> int { let a = [1, 2]; a[-3] }
 
 function catch_negative_index_as_index_out_of_bounds_fn() -> int {
     s5_bad_2() catch (e) { baml.panics.IndexOutOfBounds => -1 }

--- a/baml_language/crates/baml_tests/baml_src/ns_strings/strings.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_strings/strings.baml
@@ -19,8 +19,8 @@ function strings_concat() -> string {
 // non-string-literal expression; otherwise the parser treats the opening `{` as
 // a map literal when the first token is a string literal.
 
-function strings_char_at_negative() -> string {
-    "hi".char_at(-1)
+function strings_char_at(index: int) -> string {
+    "hello".char_at(index)
 }
 
 function strings_from_utf8_invalid() -> string {
@@ -175,8 +175,15 @@ test "string_substring_after_emoji" {
     assert.is_true(baml.deep_equals("😀hello".substring(1, 4), "hel"))
 }
 
+// Negative indices count from the end (length 5): -3 → 2, -1 → 4.
+test "string_substring_negative_counts_from_end" {
+    assert.is_true(baml.deep_equals("hello".substring(-3, 4), "ll"));
+    assert.is_true(baml.deep_equals("hello".substring(-3, -1), "ll"))
+}
+
+// A negative index past the start clamps to 0.
 test "string_substring_negative_clamps_to_zero" {
-    assert.is_true(baml.deep_equals("hello".substring(-3, 4), "hell"))
+    assert.is_true(baml.deep_equals("hello".substring(-100, 4), "hell"))
 }
 
 test "string_substring_empty_when_start_past_end" {
@@ -204,21 +211,39 @@ test "string_char_at_after_emoji" {
     assert.is_true(baml.deep_equals("😀hello".char_at(1), "h"))
 }
 
-// char_at past the end returns empty string.
-test "string_char_at_end_returns_empty" {
-    assert.is_true(baml.deep_equals("hi".char_at(2), ""))
-}
-
-test "string_char_at_past_end_returns_empty" {
-    assert.is_true(baml.deep_equals("hi".char_at(99), ""))
-}
-
-test "string_char_at_negative_throws" {
+// char_at at or past the end raises IndexOutOfBounds ("hello" has length 5).
+test "string_char_at_at_length_panics" {
     {
-        let _ = strings_char_at_negative();
+        strings_char_at(5);
         baml.sys.panic("expected char_at to throw")
     } catch (e) {
-        baml.errors.InvalidArgument => null
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
+test "string_char_at_past_end_panics" {
+    {
+        strings_char_at(99);
+        baml.sys.panic("expected char_at to throw")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
+// Negative indices count from the end: -1 is the last character.
+test "string_char_at_negative_counts_from_end" {
+    assert.is_true(baml.deep_equals("hello".char_at(-1), "o"));
+    // "héllo" = h é l l o; -4 normalizes to codepoint 1.
+    assert.is_true(baml.deep_equals("héllo".char_at(-4), "é"))
+}
+
+// Past the start (normalizes before index 0) also raises IndexOutOfBounds.
+test "string_char_at_past_start_panics" {
+    {
+        strings_char_at(-6);
+        baml.sys.panic("expected char_at to throw")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/arrays.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/arrays.snap
@@ -249,380 +249,512 @@ function arrays.$init_test_ns_arrays_arrays(registry: testing.TestCollector) -> 
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_remove_at_negative_returns_null_and_keeps_array"
+    load_const "array_remove_at_negative_counts_from_end"
     make_closure .<lambda($init_test_ns_arrays_arrays, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_remove_at_empty_returns_null"
+    load_const "array_remove_at_past_start_returns_null_and_keeps_array"
     make_closure .<lambda($init_test_ns_arrays_arrays, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_shift_returns_first_element"
+    load_const "array_remove_at_empty_returns_null"
     make_closure .<lambda($init_test_ns_arrays_arrays, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_shift_modifies_array_in_place"
+    load_const "array_shift_returns_first_element"
     make_closure .<lambda($init_test_ns_arrays_arrays, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_shift_empty_returns_null"
+    load_const "array_shift_modifies_array_in_place"
     make_closure .<lambda($init_test_ns_arrays_arrays, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_shift_repeated_drains_array"
+    load_const "array_shift_empty_returns_null"
     make_closure .<lambda($init_test_ns_arrays_arrays, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_unshift_returns_new_length"
+    load_const "array_shift_repeated_drains_array"
     make_closure .<lambda($init_test_ns_arrays_arrays, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_unshift_inserts_at_front"
+    load_const "array_unshift_returns_new_length"
     make_closure .<lambda($init_test_ns_arrays_arrays, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_unshift_empty_array"
+    load_const "array_unshift_inserts_at_front"
     make_closure .<lambda($init_test_ns_arrays_arrays, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_insert_in_middle"
+    load_const "array_unshift_empty_array"
     make_closure .<lambda($init_test_ns_arrays_arrays, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_insert_at_zero"
+    load_const "array_insert_in_middle"
     make_closure .<lambda($init_test_ns_arrays_arrays, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_insert_at_length_appends"
+    load_const "array_insert_at_zero"
     make_closure .<lambda($init_test_ns_arrays_arrays, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_insert_returns_new_length"
+    load_const "array_insert_at_length_appends"
     make_closure .<lambda($init_test_ns_arrays_arrays, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_insert_empty_array_at_zero"
+    load_const "array_insert_returns_new_length"
     make_closure .<lambda($init_test_ns_arrays_arrays, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_insert_negative_throws"
+    load_const "array_insert_empty_array_at_zero"
     make_closure .<lambda($init_test_ns_arrays_arrays, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_insert_past_length_throws"
+    load_const "array_insert_negative_counts_from_end"
     make_closure .<lambda($init_test_ns_arrays_arrays, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_replaces_range"
+    load_const "array_insert_past_start_throws"
     make_closure .<lambda($init_test_ns_arrays_arrays, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_pure_insertion"
+    load_const "array_insert_past_length_throws"
     make_closure .<lambda($init_test_ns_arrays_arrays, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_pure_removal"
+    load_const "array_splice_replaces_range"
     make_closure .<lambda($init_test_ns_arrays_arrays, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_count_clamped_to_length"
+    load_const "array_splice_pure_insertion"
     make_closure .<lambda($init_test_ns_arrays_arrays, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_at_length_appends"
+    load_const "array_splice_pure_removal"
     make_closure .<lambda($init_test_ns_arrays_arrays, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_replace_with_longer"
+    load_const "array_splice_count_clamped_to_length"
     make_closure .<lambda($init_test_ns_arrays_arrays, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_negative_start_throws"
+    load_const "array_splice_at_length_appends"
     make_closure .<lambda($init_test_ns_arrays_arrays, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_start_past_length_throws"
+    load_const "array_splice_replace_with_longer"
     make_closure .<lambda($init_test_ns_arrays_arrays, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_splice_negative_count_throws"
+    load_const "array_splice_negative_start_counts_from_end"
     make_closure .<lambda($init_test_ns_arrays_arrays, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_some_finds_match"
+    load_const "array_splice_past_start_throws"
     make_closure .<lambda($init_test_ns_arrays_arrays, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_some_no_match"
+    load_const "array_splice_start_past_length_throws"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 91)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_splice_negative_count_throws"
     make_closure .<lambda($init_test_ns_arrays_arrays, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
+    load_const "array_some_finds_match"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 93)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_some_no_match"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 95)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
     load_const "array_some_empty_is_false"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 94)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_short_circuits"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 96)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_some_propagates_error"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 98)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_all_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 100)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_one_fails"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 102)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_empty_is_true"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 104)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_every_short_circuits_on_false"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 106)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_returns_first_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 108)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_returns_null_when_no_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 110)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 113)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_empty_is_null"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 112)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 115)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_index_returns_first_index"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 114)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 117)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_index_returns_null_when_no_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 116)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 119)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_short_circuits"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 118)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 121)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_returns_last_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 120)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 123)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_returns_null_when_no_match"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 122)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 125)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_index_returns_last_index"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 124)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 127)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_iterates_back_to_front"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 126)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 129)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_find_last_empty_is_null"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 128)>, 0
-    load_const null
-    call testing.TestCollector.register_test
-    pop 1
-    load_var registry
-    load_const "array_includes_present"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 130)>, 0
-    load_const null
-    call testing.TestCollector.register_test
-    pop 1
-    load_var registry
-    load_const "array_includes_absent"
     make_closure .<lambda($init_test_ns_arrays_arrays, 131)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_includes_empty"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 132)>, 0
-    load_const null
-    call testing.TestCollector.register_test
-    pop 1
-    load_var registry
-    load_const "array_includes_strings"
+    load_const "array_includes_present"
     make_closure .<lambda($init_test_ns_arrays_arrays, 133)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_index_of_present"
+    load_const "array_includes_absent"
     make_closure .<lambda($init_test_ns_arrays_arrays, 134)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_index_of_first_match"
+    load_const "array_includes_empty"
     make_closure .<lambda($init_test_ns_arrays_arrays, 135)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_index_of_absent"
+    load_const "array_includes_strings"
     make_closure .<lambda($init_test_ns_arrays_arrays, 136)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_last_index_of_returns_last_match"
+    load_const "array_index_of_present"
     make_closure .<lambda($init_test_ns_arrays_arrays, 137)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_last_index_of_absent"
+    load_const "array_index_of_first_match"
     make_closure .<lambda($init_test_ns_arrays_arrays, 138)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_reduce_sum"
+    load_const "array_index_of_absent"
     make_closure .<lambda($init_test_ns_arrays_arrays, 139)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "array_reduce_with_nonzero_initial"
+    load_const "array_last_index_of_returns_last_match"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 140)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_last_index_of_absent"
     make_closure .<lambda($init_test_ns_arrays_arrays, 141)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
+    load_const "array_reduce_sum"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 142)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_reduce_with_nonzero_initial"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 144)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
     load_const "array_reduce_empty_returns_initial"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 143)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 146)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_visits_every_element"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 145)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 148)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_reduce_concat_strings"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 147)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 150)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_doubles_each_element"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 149)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 152)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_with_empty_inner_arrays"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 151)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 154)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_empty_input"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 153)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 156)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
     load_const "array_flat_map_uneven_inner_lengths"
-    make_closure .<lambda($init_test_ns_arrays_arrays, 155)>, 0
+    make_closure .<lambda($init_test_ns_arrays_arrays, 158)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_at_positive"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 160)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_at_negative_counts_from_end"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 161)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_at_past_end_is_null"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 162)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_at_past_start_is_null"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 163)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_at_empty_is_null"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 164)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_index_read_positive"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 165)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_index_read_negative_counts_from_end"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 166)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_index_read_past_end_panics"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 167)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_index_read_past_start_panics"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 168)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_index_write_negative_counts_from_end"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 169)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_index_write_past_end_panics"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 170)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_index_write_past_start_panics"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 171)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_slice_basic"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 172)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_slice_negative_start"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 173)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_slice_negative_end"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 174)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_slice_negative_both"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 175)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_slice_end_before_start_is_empty"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 176)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_slice_clamps_out_of_range"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 177)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_slice_empty_array"
+    make_closure .<lambda($init_test_ns_arrays_arrays, 178)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -878,6 +1010,29 @@ function arrays.SortableItem.baml.Comparable.compare(self: arrays.SortableItem, 
     store_var _4
     load_var2 3 4
     call baml.Comparable$for$int.compare
+    return
+}
+
+function arrays.array_index_read(idx: int) -> int {
+    load_const 10
+    load_const 20
+    load_const 30
+    alloc_array 3
+    load_var idx
+    load_array_element
+    return
+}
+
+function arrays.array_index_write(idx: int) -> int[] {
+    load_const 10
+    load_const 20
+    load_const 30
+    alloc_array 3
+    store_var xs
+    load_var2 2 1
+    load_const 99
+    store_array_element
+    load_var xs
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/byte_strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/byte_strings.snap
@@ -63,104 +63,116 @@ function byte_strings.$init_test_ns_byte_strings_byte_strings(registry: testing.
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "zeroes_basic"
+    load_const "at_negative_out_of_bounds"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "index_read"
+    load_const "zeroes_basic"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "index_write"
+    load_const "index_read"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "index_write_out_of_range"
+    load_const "index_write"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "index_out_of_bounds"
+    load_const "index_write_out_of_range"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "index_negative"
+    load_const "index_out_of_bounds"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "return_uint8array"
+    load_const "index_negative_in_bounds"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "equality_same_content"
+    load_const "index_before_start"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "equality_different_content"
+    load_const "return_uint8array"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "equality_empty"
+    load_const "equality_same_content"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "equality_different_lengths"
+    load_const "equality_different_content"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "equality_different_lengths_reversed"
+    load_const "equality_empty"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "inequality_same"
+    load_const "equality_different_lengths"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "inequality_different"
+    load_const "equality_different_lengths_reversed"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "b_as_identifier"
+    load_const "inequality_same"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "literal_as_call_argument"
+    load_const "inequality_different"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "index_read_direct"
+    load_const "b_as_identifier"
     make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 26)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "literal_as_call_argument"
+    make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 27)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "index_read_direct"
+    make_closure .<lambda($init_test_ns_byte_strings_byte_strings, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -173,7 +185,16 @@ function byte_strings.byte_strings_b_as_identifier() -> int {
     return
 }
 
-function byte_strings.byte_strings_index_neg() -> int {
+function byte_strings.byte_strings_index_before_start() -> int {
+    load_const b"\x61"
+    call baml.deep_copy
+    load_const 2
+    unary_op -
+    load_array_element
+    return
+}
+
+function byte_strings.byte_strings_index_neg_in_bounds() -> int {
     load_const b"\x61"
     call baml.deep_copy
     load_const 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/exceptions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/exceptions.snap
@@ -2949,7 +2949,7 @@ function exceptions.s5_bad_2() -> int {
     load_const 1
     load_const 2
     alloc_array 2
-    load_const 1
+    load_const 3
     unary_op -
     load_array_element
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/strings.snap
@@ -153,764 +153,776 @@ function strings.$init_test_ns_strings_strings(registry: testing.TestCollector) 
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_substring_negative_clamps_to_zero"
+    load_const "string_substring_negative_counts_from_end"
     make_closure .<lambda($init_test_ns_strings_strings, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_substring_empty_when_start_past_end"
+    load_const "string_substring_negative_clamps_to_zero"
     make_closure .<lambda($init_test_ns_strings_strings, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_substring_out_of_bounds_clamps"
+    load_const "string_substring_empty_when_start_past_end"
     make_closure .<lambda($init_test_ns_strings_strings, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_at_multibyte"
+    load_const "string_substring_out_of_bounds_clamps"
     make_closure .<lambda($init_test_ns_strings_strings, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_at_after_multibyte"
+    load_const "string_char_at_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_at_emoji"
+    load_const "string_char_at_after_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_at_after_emoji"
+    load_const "string_char_at_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_at_end_returns_empty"
+    load_const "string_char_at_after_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_at_past_end_returns_empty"
+    load_const "string_char_at_at_length_panics"
     make_closure .<lambda($init_test_ns_strings_strings, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_at_negative_throws"
+    load_const "string_char_at_past_end_panics"
     make_closure .<lambda($init_test_ns_strings_strings, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_index_of_returns_codepoint_index"
+    load_const "string_char_at_negative_counts_from_end"
     make_closure .<lambda($init_test_ns_strings_strings, 35)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_index_of_after_emoji"
+    load_const "string_char_at_past_start_panics"
     make_closure .<lambda($init_test_ns_strings_strings, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat"
+    load_const "string_index_of_returns_codepoint_index"
     make_closure .<lambda($init_test_ns_strings_strings, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat_zero"
+    load_const "string_index_of_after_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat_negative"
+    load_const "string_repeat"
     make_closure .<lambda($init_test_ns_strings_strings, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_ascii"
+    load_const "string_repeat_zero"
     make_closure .<lambda($init_test_ns_strings_strings, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_multibyte"
+    load_const "string_repeat_negative"
     make_closure .<lambda($init_test_ns_strings_strings, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_emoji"
+    load_const "string_char_count_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_empty"
+    load_const "string_char_count_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_removes_leading_only"
+    load_const "string_char_count_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_end_removes_trailing_only"
+    load_const "string_char_count_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_handles_newlines_and_tabs"
+    load_const "string_trim_start_removes_leading_only"
     make_closure .<lambda($init_test_ns_strings_strings, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_end_no_whitespace_unchanged"
+    load_const "string_trim_end_removes_trailing_only"
     make_closure .<lambda($init_test_ns_strings_strings, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_empty"
+    load_const "string_trim_start_handles_newlines_and_tabs"
     make_closure .<lambda($init_test_ns_strings_strings, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_lf"
+    load_const "string_trim_end_no_whitespace_unchanged"
     make_closure .<lambda($init_test_ns_strings_strings, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_crlf"
+    load_const "string_trim_start_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_trailing_newline_no_empty"
+    load_const "string_lines_lf"
     make_closure .<lambda($init_test_ns_strings_strings, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_empty_string"
+    load_const "string_lines_crlf"
     make_closure .<lambda($init_test_ns_strings_strings, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_just_newline"
+    load_const "string_lines_trailing_newline_no_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_ascii"
+    load_const "string_lines_empty_string"
     make_closure .<lambda($init_test_ns_strings_strings, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_multibyte"
+    load_const "string_lines_just_newline"
     make_closure .<lambda($init_test_ns_strings_strings, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_empty"
+    load_const "string_to_utf8_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_ascii_round_trip"
+    load_const "string_to_utf8_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_multibyte_round_trip"
+    load_const "string_to_utf8_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_invalid_throws"
+    load_const "string_from_utf8_ascii_round_trip"
     make_closure .<lambda($init_test_ns_strings_strings, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_empty"
+    load_const "string_from_utf8_multibyte_round_trip"
     make_closure .<lambda($init_test_ns_strings_strings, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_ascii"
+    load_const "string_from_utf8_invalid_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_multibyte"
+    load_const "string_from_utf8_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_emoji"
+    load_const "string_from_code_points_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_empty"
+    load_const "string_from_code_points_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_negative_throws"
+    load_const "string_from_code_points_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_surrogate_throws"
+    load_const "string_from_code_points_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_too_large_throws"
+    load_const "string_from_code_points_negative_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_ascii_digits"
+    load_const "string_from_code_points_surrogate_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_unicode_roman"
+    load_const "string_from_code_points_too_large_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_mixed_false"
+    load_const "string_is_numeric_ascii_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_letters_false"
+    load_const "string_is_numeric_unicode_roman"
     make_closure .<lambda($init_test_ns_strings_strings, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_empty_true"
+    load_const "string_is_numeric_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_ascii"
+    load_const "string_is_numeric_letters_false"
     make_closure .<lambda($init_test_ns_strings_strings, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_accented"
+    load_const "string_is_numeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_cjk"
+    load_const "string_is_alphabetic_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_with_digit_false"
+    load_const "string_is_alphabetic_accented"
     make_closure .<lambda($init_test_ns_strings_strings, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_with_space_false"
+    load_const "string_is_alphabetic_cjk"
     make_closure .<lambda($init_test_ns_strings_strings, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_empty_true"
+    load_const "string_is_alphabetic_with_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_letters_and_digits"
+    load_const "string_is_alphabetic_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_accented_with_digit"
+    load_const "string_is_alphabetic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_with_space_false"
+    load_const "string_is_alphanumeric_letters_and_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_with_punct_false"
+    load_const "string_is_alphanumeric_accented_with_digit"
     make_closure .<lambda($init_test_ns_strings_strings, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_empty_true"
+    load_const "string_is_alphanumeric_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_all_upper"
+    load_const "string_is_alphanumeric_with_punct_false"
     make_closure .<lambda($init_test_ns_strings_strings, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_mixed_false"
+    load_const "string_is_alphanumeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_digit_false"
+    load_const "string_is_uppercase_all_upper"
     make_closure .<lambda($init_test_ns_strings_strings, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_empty_true"
+    load_const "string_is_uppercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_all_lower"
+    load_const "string_is_uppercase_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_mixed_false"
+    load_const "string_is_uppercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_accented_lower"
+    load_const "string_is_lowercase_all_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_empty_true"
+    load_const "string_is_lowercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_spaces"
+    load_const "string_is_lowercase_accented_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_mixed_ws"
+    load_const "string_is_lowercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_unicode_nbsp"
+    load_const "string_is_whitespace_spaces"
     make_closure .<lambda($init_test_ns_strings_strings, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_with_letter_false"
+    load_const "string_is_whitespace_mixed_ws"
     make_closure .<lambda($init_test_ns_strings_strings, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_empty_true"
+    load_const "string_is_whitespace_unicode_nbsp"
     make_closure .<lambda($init_test_ns_strings_strings, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_newline_tab"
+    load_const "string_is_whitespace_with_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_letter_false"
+    load_const "string_is_whitespace_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 98)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_empty_true"
+    load_const "string_is_control_newline_tab"
     make_closure .<lambda($init_test_ns_strings_strings, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_letters"
+    load_const "string_is_control_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 100)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_accented"
+    load_const "string_is_control_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_with_space_false"
+    load_const "string_is_graphic_letters"
     make_closure .<lambda($init_test_ns_strings_strings, 102)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_with_newline_false"
+    load_const "string_is_graphic_accented"
     make_closure .<lambda($init_test_ns_strings_strings, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_empty_true"
+    load_const "string_is_graphic_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 104)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_pure_ascii"
+    load_const "string_is_graphic_with_newline_false"
     make_closure .<lambda($init_test_ns_strings_strings, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_with_accent_false"
+    load_const "string_is_graphic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 106)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_with_emoji_false"
+    load_const "string_is_ascii_pure_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_chars"
+    load_const "string_is_ascii_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 108)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_empty_true"
+    load_const "string_is_ascii_with_emoji_false"
     make_closure .<lambda($init_test_ns_strings_strings, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_digits"
+    load_const "string_is_ascii_control_chars"
     make_closure .<lambda($init_test_ns_strings_strings, 110)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_unicode_numeral_false"
+    load_const "string_is_ascii_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_letter_false"
+    load_const "string_is_ascii_numeric_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 112)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_empty_true"
+    load_const "string_is_ascii_numeric_unicode_numeral_false"
     make_closure .<lambda($init_test_ns_strings_strings, 113)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_letters"
+    load_const "string_is_ascii_numeric_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 114)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_accented_false"
+    load_const "string_is_ascii_numeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 115)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_with_digit_false"
+    load_const "string_is_ascii_alphabetic_letters"
     make_closure .<lambda($init_test_ns_strings_strings, 116)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_empty_true"
+    load_const "string_is_ascii_alphabetic_accented_false"
     make_closure .<lambda($init_test_ns_strings_strings, 117)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_basic"
+    load_const "string_is_ascii_alphabetic_with_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 118)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_accented_false"
+    load_const "string_is_ascii_alphabetic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 119)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_with_space_false"
+    load_const "string_is_ascii_alphanumeric_basic"
     make_closure .<lambda($init_test_ns_strings_strings, 120)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_empty_true"
+    load_const "string_is_ascii_alphanumeric_accented_false"
     make_closure .<lambda($init_test_ns_strings_strings, 121)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_pure_upper"
+    load_const "string_is_ascii_alphanumeric_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 122)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_mixed_false"
+    load_const "string_is_ascii_alphanumeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 123)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_with_accent_false"
+    load_const "string_is_ascii_uppercase_pure_upper"
     make_closure .<lambda($init_test_ns_strings_strings, 124)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_empty_true"
+    load_const "string_is_ascii_uppercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 125)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_pure_lower"
+    load_const "string_is_ascii_uppercase_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 126)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_mixed_false"
+    load_const "string_is_ascii_uppercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 127)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_with_accent_false"
+    load_const "string_is_ascii_lowercase_pure_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 128)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_empty_true"
+    load_const "string_is_ascii_lowercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 129)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_basic"
+    load_const "string_is_ascii_lowercase_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 130)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_form_feed"
+    load_const "string_is_ascii_lowercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 131)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_nbsp_false"
+    load_const "string_is_ascii_whitespace_basic"
     make_closure .<lambda($init_test_ns_strings_strings, 132)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_letter_false"
+    load_const "string_is_ascii_whitespace_form_feed"
     make_closure .<lambda($init_test_ns_strings_strings, 133)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_empty_true"
+    load_const "string_is_ascii_whitespace_nbsp_false"
     make_closure .<lambda($init_test_ns_strings_strings, 134)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_low_range"
+    load_const "string_is_ascii_whitespace_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 135)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_del"
+    load_const "string_is_ascii_whitespace_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 136)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_letter_false"
+    load_const "string_is_ascii_control_low_range"
     make_closure .<lambda($init_test_ns_strings_strings, 137)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_empty_true"
+    load_const "string_is_ascii_control_del"
     make_closure .<lambda($init_test_ns_strings_strings, 138)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_letters"
+    load_const "string_is_ascii_control_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 139)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_punctuation"
+    load_const "string_is_ascii_control_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 140)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_space_false"
+    load_const "string_is_ascii_graphic_letters"
     make_closure .<lambda($init_test_ns_strings_strings, 141)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_control_false"
+    load_const "string_is_ascii_graphic_punctuation"
     make_closure .<lambda($init_test_ns_strings_strings, 142)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_accented_false"
+    load_const "string_is_ascii_graphic_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 143)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_empty_true"
+    load_const "string_is_ascii_graphic_control_false"
     make_closure .<lambda($init_test_ns_strings_strings, 144)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_lower"
+    load_const "string_is_ascii_graphic_accented_false"
     make_closure .<lambda($init_test_ns_strings_strings, 145)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_upper"
+    load_const "string_is_ascii_graphic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 146)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_mixed_case_with_digits"
+    load_const "string_is_ascii_hex_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 147)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_g_false"
+    load_const "string_is_ascii_hex_upper"
     make_closure .<lambda($init_test_ns_strings_strings, 148)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_x_prefix_false"
+    load_const "string_is_ascii_hex_mixed_case_with_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 149)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_empty_true"
+    load_const "string_is_ascii_hex_g_false"
     make_closure .<lambda($init_test_ns_strings_strings, 150)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_replace"
+    load_const "string_is_ascii_hex_x_prefix_false"
     make_closure .<lambda($init_test_ns_strings_strings, 151)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_hex_empty_true"
+    make_closure .<lambda($init_test_ns_strings_strings, 152)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_replace"
+    make_closure .<lambda($init_test_ns_strings_strings, 153)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -918,10 +930,9 @@ function strings.$init_test_ns_strings_strings(registry: testing.TestCollector) 
     return
 }
 
-function strings.strings_char_at_negative() -> string {
-    load_const "hi"
-    load_const 1
-    unary_op -
+function strings.strings_char_at(index: int) -> string {
+    load_const "hello"
+    load_var index
     call baml.String.char_at
     return
 }

--- a/baml_language/crates/bex_vm/src/array_index.rs
+++ b/baml_language/crates/bex_vm/src/array_index.rs
@@ -1,0 +1,134 @@
+//! Negative-index resolution for sequence operations (`at`, subscript `[]`,
+//! `slice`, `remove_at`, `insert`, and `splice`) on arrays and byte arrays.
+//!
+//! All of them follow the JavaScript/Python convention: a negative index counts
+//! back from the end, so `-1` is the last element. They differ only in how an
+//! index that still falls outside the sequence is handled:
+//!
+//! - [`resolve_index`] (used by `at`, subscript `[]`, and `remove_at`) requires
+//!   an exact in-bounds element offset in `[0, len)`. `at`/`remove_at` map the
+//!   out-of-range `None` to `null`; the subscript operator maps it to an
+//!   `IndexOutOfBounds` panic.
+//! - [`resolve_insert_index`] (used by `insert` and `splice`'s `start`) accepts
+//!   the *insertion* range `[0, len]` — the end slot is valid because it denotes
+//!   "after the last element". Callers surface the out-of-range `None` as an
+//!   `InvalidArgument` error.
+//! - [`resolve_slice_bound`] (used by `slice`) clamps each bound into
+//!   `[0, len]` instead of failing, so an out-of-range bound saturates to the
+//!   nearest end.
+
+/// Counts a possibly-negative `index` back from the end of a `len`-element
+/// sequence, returning the resolved position — which may itself still be out of
+/// range (negative, or `>= len`). A non-negative `index` passes through
+/// unchanged. Callers apply their own bounds check to the result.
+///
+/// Returns `None` only when `len` does not fit in `i64`, which never happens for
+/// a real slice (its length cannot exceed `isize::MAX`).
+fn count_from_end(index: i64, len: usize) -> Option<i64> {
+    let len_i64 = i64::try_from(len).ok()?;
+    // `index < 0` ⟹ `index + len_i64` moves toward zero, so it cannot overflow.
+    Some(if index < 0 { index + len_i64 } else { index })
+}
+
+/// Resolves a possibly-negative element index against a sequence of length
+/// `len`, counting negatives back from the end.
+///
+/// Returns the non-negative offset when the index lands in `[0, len)`, or
+/// `None` when it falls outside the sequence even after counting from the end
+/// (e.g. `-len - 1`, or any index `>= len`).
+pub(crate) fn resolve_index(index: i64, len: usize) -> Option<usize> {
+    // `try_from` rejects the below-start case (`< 0`); the filter rejects the
+    // past-end case (`>= len`).
+    usize::try_from(count_from_end(index, len)?)
+        .ok()
+        .filter(|&i| i < len)
+}
+
+/// Resolves a possibly-negative *insertion* index against a sequence of length
+/// `len`, counting negatives back from the end.
+///
+/// Like [`resolve_index`], but the end position `len` is in range: insertion
+/// accepts `[0, len]` because inserting *at* `len` appends after the last
+/// element. Returns the position when it lands in `[0, len]`, or `None` when it
+/// falls outside even after counting from the end (callers surface this as an
+/// `InvalidArgument` error). Used by `insert` and `splice`'s `start`.
+pub(crate) fn resolve_insert_index(index: i64, len: usize) -> Option<usize> {
+    // As `resolve_index`, but `<= len`: the end slot is a valid insertion point.
+    usize::try_from(count_from_end(index, len)?)
+        .ok()
+        .filter(|&i| i <= len)
+}
+
+/// Resolves a possibly-negative `slice` bound against a sequence of length
+/// `len`, counting negatives back from the end and then clamping the result
+/// into `[0, len]`.
+///
+/// Unlike [`resolve_index`], an out-of-range bound saturates to the nearest
+/// endpoint rather than failing, matching JavaScript's `Array.prototype.slice`.
+pub(crate) fn resolve_slice_bound(bound: i64, len: usize) -> usize {
+    // `count_from_end` is not reused here: an out-of-range bound clamps rather
+    // than fails, so the impossible `len > i64::MAX` case clamps too.
+    let len_i64 = i64::try_from(len).unwrap_or(i64::MAX);
+    // `bound < 0` ⟹ the sum moves toward zero, so it cannot overflow.
+    let resolved = if bound < 0 { bound + len_i64 } else { bound };
+    // The clamp lands in `[0, len]`, which always fits back into `usize`.
+    usize::try_from(resolved.clamp(0, len_i64)).unwrap_or(len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_index_positive_in_bounds() {
+        assert_eq!(resolve_index(0, 3), Some(0));
+        assert_eq!(resolve_index(2, 3), Some(2));
+    }
+
+    #[test]
+    fn resolve_index_negative_counts_from_end() {
+        assert_eq!(resolve_index(-1, 3), Some(2));
+        assert_eq!(resolve_index(-3, 3), Some(0));
+    }
+
+    #[test]
+    fn resolve_index_out_of_bounds_is_none() {
+        assert_eq!(resolve_index(3, 3), None); // past the end
+        assert_eq!(resolve_index(-4, 3), None); // past the start
+        assert_eq!(resolve_index(0, 0), None); // empty sequence
+        assert_eq!(resolve_index(-1, 0), None); // empty sequence, negative
+        assert_eq!(resolve_index(i64::MAX, 3), None);
+        assert_eq!(resolve_index(i64::MIN, 3), None);
+    }
+
+    #[test]
+    fn resolve_insert_index_allows_the_end_slot() {
+        // Positive: `[0, len]` inclusive — `len` appends.
+        assert_eq!(resolve_insert_index(0, 3), Some(0));
+        assert_eq!(resolve_insert_index(3, 3), Some(3));
+        assert_eq!(resolve_insert_index(0, 0), Some(0)); // empty: only the end slot
+        // Negative counts from the end and reaches `[0, len - 1]`.
+        assert_eq!(resolve_insert_index(-1, 3), Some(2));
+        assert_eq!(resolve_insert_index(-3, 3), Some(0));
+    }
+
+    #[test]
+    fn resolve_insert_index_out_of_range_is_none() {
+        assert_eq!(resolve_insert_index(4, 3), None); // past the end slot
+        assert_eq!(resolve_insert_index(-4, 3), None); // past the start
+        assert_eq!(resolve_insert_index(-1, 0), None); // empty, negative
+        assert_eq!(resolve_insert_index(i64::MAX, 3), None);
+        assert_eq!(resolve_insert_index(i64::MIN, 3), None);
+    }
+
+    #[test]
+    fn resolve_slice_bound_counts_from_end_and_clamps() {
+        assert_eq!(resolve_slice_bound(1, 4), 1);
+        assert_eq!(resolve_slice_bound(-2, 4), 2);
+        assert_eq!(resolve_slice_bound(-100, 4), 0); // clamped to the start
+        assert_eq!(resolve_slice_bound(100, 4), 4); // clamped to the end
+        assert_eq!(resolve_slice_bound(0, 0), 0);
+        assert_eq!(resolve_slice_bound(i64::MIN, 4), 0);
+        assert_eq!(resolve_slice_bound(i64::MAX, 4), 4);
+    }
+}

--- a/baml_language/crates/bex_vm/src/lib.rs
+++ b/baml_language/crates/bex_vm/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 //! The instructions that the VM runs are defined in [`bex_vm_types::bytecode::Instruction`] enum.
 
+pub(crate) mod array_index;
 pub mod debug;
 pub mod errors;
 pub mod indexable;

--- a/baml_language/crates/bex_vm/src/package_baml/array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/array.rs
@@ -7,6 +7,7 @@ use num_bigint::BigInt;
 use super::{BamlClassArray, Continuation, NativeCallResult, PackageBamlImpl, make_to_json_callee};
 use crate::{
     BexVm,
+    array_index::{resolve_index, resolve_insert_index, resolve_slice_bound},
     errors::{VmBamlError, VmInternalError, VmRustFnError},
 };
 
@@ -777,9 +778,8 @@ impl BamlClassArray for PackageBamlImpl {
         array.len() as i64
     }
 
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     fn at(array: &[Value], index: i64) -> Option<Value> {
-        array.get(index as usize).copied()
+        resolve_index(index, array.len()).map(|i| array[i])
     }
 
     fn concat(array: &[Value], other: &[Value]) -> Vec<Value> {
@@ -791,14 +791,8 @@ impl BamlClassArray for PackageBamlImpl {
     }
 
     fn remove_at(array: &mut Vec<Value>, index: i64) -> Option<Value> {
-        let Ok(index) = usize::try_from(index) else {
-            return None;
-        };
-        if index >= array.len() {
-            None
-        } else {
-            Some(array.remove(index))
-        }
+        let index = resolve_index(index, array.len())?;
+        Some(array.remove(index))
     }
 
     fn reverse(array: &[Value]) -> Vec<Value> {
@@ -807,16 +801,10 @@ impl BamlClassArray for PackageBamlImpl {
         result
     }
 
-    #[allow(
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_possible_wrap
-    )]
     fn slice(array: &[Value], start: i64, end: i64) -> Vec<Value> {
-        let len = array.len() as i64;
-        let start = start.max(0).min(len) as usize;
-        let end = end.max(0).min(len) as usize;
-        let end = end.max(start);
+        let start = resolve_slice_bound(start, array.len());
+        // An `end` resolving before `start` yields an empty slice.
+        let end = resolve_slice_bound(end, array.len()).max(start);
         array[start..end].to_vec()
     }
 
@@ -853,36 +841,21 @@ impl BamlClassArray for PackageBamlImpl {
         array.len() as i64
     }
 
-    #[allow(
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_possible_wrap
-    )]
+    #[allow(clippy::cast_possible_wrap)]
     fn insert(array: &mut Vec<Value>, item: &Value, idx: i64) -> Result<i64, VmRustFnError> {
         let len = array.len();
-        let Ok(idx_usize) = usize::try_from(idx) else {
+        // A negative `idx` counts from the end; `[0, len]` is the valid range
+        // (inserting at `len` appends).
+        let Some(idx) = resolve_insert_index(idx, len) else {
             return Err(VmBamlError::InvalidArgument {
-                message: format!("array.insert: idx ({idx}) is negative"),
+                message: format!("array.insert: idx ({idx}) is out of range for length {len}"),
             }
             .into());
         };
-        if idx_usize > len {
-            return Err(VmBamlError::InvalidArgument {
-                message: format!(
-                    "array.insert: idx ({idx_usize}) is beyond the array length ({len})"
-                ),
-            }
-            .into());
-        }
-        array.insert(idx_usize, *item);
+        array.insert(idx, *item);
         Ok(array.len() as i64)
     }
 
-    #[allow(
-        clippy::unused_unit,
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation
-    )]
     fn splice(
         array: &mut Vec<Value>,
         start: i64,
@@ -890,28 +863,21 @@ impl BamlClassArray for PackageBamlImpl {
         replace: &[Value],
     ) -> Result<(), VmRustFnError> {
         let len = array.len();
-        let Ok(start_usize) = usize::try_from(start) else {
+        // A negative `start` counts from the end; `[0, len]` is the valid range.
+        let Some(start) = resolve_insert_index(start, len) else {
             return Err(VmBamlError::InvalidArgument {
-                message: format!("array.splice: start ({start}) is negative"),
+                message: format!("array.splice: start ({start}) is out of range for length {len}"),
             }
             .into());
         };
-        if start_usize > len {
-            return Err(VmBamlError::InvalidArgument {
-                message: format!(
-                    "array.splice: start ({start_usize}) is beyond the array length ({len})"
-                ),
-            }
-            .into());
-        }
-        let Ok(count_usize) = usize::try_from(count) else {
+        let Ok(count) = usize::try_from(count) else {
             return Err(VmBamlError::InvalidArgument {
                 message: format!("array.splice: count ({count}) is negative"),
             }
             .into());
         };
-        let end = start_usize.saturating_add(count_usize).min(len);
-        array.splice(start_usize..end, replace.iter().copied());
+        let end = start.saturating_add(count).min(len);
+        array.splice(start..end, replace.iter().copied());
         Ok(())
     }
 

--- a/baml_language/crates/bex_vm/src/package_baml/string.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/string.rs
@@ -4,7 +4,8 @@ use bex_vm_types::types::Value;
 
 use super::{BamlClassString, PackageBamlImpl};
 use crate::{
-    BexVm,
+    BexVm, VmPanic,
+    array_index::{resolve_index, resolve_slice_bound},
     errors::{VmBamlError, VmRustFnError},
 };
 
@@ -105,11 +106,13 @@ impl BamlClassString for PackageBamlImpl {
             .collect()
     }
 
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-    fn substring(string: &BexStr, start: i64, end: i64) -> Result<BexStr, VmRustFnError> {
-        let start = usize::try_from(start.max(0)).unwrap_or(usize::MAX);
-        let end = usize::try_from(end.max(0)).unwrap_or(usize::MAX);
-        Ok(string.substring_by_char(start, end))
+    fn substring(string: &BexStr, start: i64, end: i64) -> BexStr {
+        // Codepoint-indexed, not byte-indexed; a negative index counts from the end.
+        let len = string.char_count();
+        let start = resolve_slice_bound(start, len);
+        // An `end` resolving before `start` yields an empty string.
+        let end = resolve_slice_bound(end, len).max(start);
+        string.substring_by_char(start, end)
     }
 
     fn replace(string: &BexStr, search: &BexStr, replacement: &BexStr) -> BexStr {
@@ -128,15 +131,13 @@ impl BamlClassString for PackageBamlImpl {
     }
 
     fn char_at(string: &BexStr, index: i64) -> Result<BexStr, VmRustFnError> {
-        let Ok(index) = usize::try_from(index) else {
-            return Err(VmBamlError::InvalidArgument {
-                message: format!("at: index {index} is negative"),
-            }
-            .into());
-        };
-        Ok(string
-            .char_at_codepoint(index)
-            .unwrap_or_else(BexStr::empty))
+        // Codepoint-indexed, not byte-indexed. A negative index counts from the
+        // end; an out-of-bounds index raises `IndexOutOfBounds` (like `array[i]`),
+        // so success always yields exactly one codepoint.
+        let len = string.char_count();
+        resolve_index(index, len)
+            .and_then(|i| string.char_at_codepoint(i))
+            .ok_or_else(|| VmPanic::IndexOutOfBounds { index, length: len }.into())
     }
 
     fn repeat(string: &BexStr, count: i64) -> BexStr {

--- a/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/uint8array.rs
@@ -3,6 +3,7 @@ use bex_vm_types::Value;
 use super::{BamlClassUint8Array, PackageBamlImpl, json::raise_serialize_no_path};
 use crate::{
     BexVm, VmPanic,
+    array_index::{resolve_index, resolve_slice_bound},
     errors::{VmBamlError, VmRustFnError},
 };
 
@@ -23,10 +24,7 @@ impl BamlClassUint8Array for PackageBamlImpl {
     }
 
     fn at(uint8array: &[u8], index: i64) -> Option<i64> {
-        let Ok(index) = usize::try_from(index) else {
-            return None;
-        };
-        uint8array.get(index).map(|&b| i64::from(b))
+        resolve_index(index, uint8array.len()).map(|i| i64::from(uint8array[i]))
     }
 
     #[allow(clippy::cast_possible_wrap)]
@@ -57,16 +55,10 @@ impl BamlClassUint8Array for PackageBamlImpl {
         uint8array.iter().copied().rev().collect()
     }
 
-    #[allow(
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_possible_wrap
-    )]
     fn slice(uint8array: &[u8], start: i64, end: i64) -> Vec<u8> {
-        let len = uint8array.len() as i64;
-        let start = start.clamp(0, len);
-        let end = end.clamp(start, len) as usize;
-        let start = start as usize;
+        let start = resolve_slice_bound(start, uint8array.len());
+        // An `end` resolving before `start` yields an empty slice.
+        let end = resolve_slice_bound(end, uint8array.len()).max(start);
         uint8array[start..end].to_vec()
     }
 

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -6125,7 +6125,6 @@ impl BexVm {
                     let index_value = self.stack.ensure_pop();
                     let array_value = self.stack.ensure_pop();
                     let array_obj_index = self.as_object_ptr(array_value, ObjectType::Array)?;
-                    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                     let Some(i) = index_value.as_int() else {
                         return Err(VmInternalError::TypeError {
                             expected: bex_vm_types::types::Type::Int,
@@ -6136,26 +6135,25 @@ impl BexVm {
                     // Acquire the array's read lock for the duration of the
                     // bounds-check + element load so it stays atomic against
                     // a racing `push`/grow. Guard drops at the end of the
-                    // inner scope before any `&mut self` call.
-                    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                    // inner scope before any `&mut self` call. A negative index
+                    // counts from the end; one that still lands outside the
+                    // array reports the original index in the panic.
                     let load_result: Result<Value, (i64, usize)> = {
                         match self.get_object(array_obj_index) {
                             Object::Array(arr) => {
                                 let guard = arr.lock();
                                 let len = guard.len();
-                                if i < 0 || (i as usize) >= len {
-                                    Err((i, len))
-                                } else {
-                                    Ok(guard[i as usize])
+                                match crate::array_index::resolve_index(i, len) {
+                                    Some(idx) => Ok(guard[idx]),
+                                    None => Err((i, len)),
                                 }
                             }
                             Object::Uint8Array(bytes) => {
                                 let guard = bytes.lock();
                                 let len = guard.len();
-                                if i < 0 || (i as usize) >= len {
-                                    Err((i, len))
-                                } else {
-                                    Ok(Value::int(i64::from(guard[i as usize])))
+                                match crate::array_index::resolve_index(i, len) {
+                                    Some(idx) => Ok(Value::int(i64::from(guard[idx]))),
+                                    None => Err((i, len)),
                                 }
                             }
                             other => {
@@ -6220,7 +6218,6 @@ impl BexVm {
                     let index_value = self.stack.ensure_pop();
                     let array_value = self.stack.ensure_pop();
                     let array_object_index = self.as_object_ptr(array_value, ObjectType::Array)?;
-                    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                     let Some(i) = index_value.as_int() else {
                         return Err(VmInternalError::TypeError {
                             expected: bex_vm_types::types::Type::Int,
@@ -6232,19 +6229,22 @@ impl BexVm {
                         new_value.as_int().map(|v| (v.cast_unsigned() & 0xFF) as u8);
                     // Acquire the array's write lock for bounds-check + old
                     // read + new write atomically. Guard drops at end of
-                    // inner scope before any `&mut self` ops.
-                    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                    let store_result: Result<Value, (i64, usize)> = {
+                    // inner scope before any `&mut self` ops. A negative index
+                    // counts from the end; the resolved offset flows out for the
+                    // watch path below, while an out-of-range index reports the
+                    // original index in the panic.
+                    let store_result: Result<(Value, usize), (i64, usize)> = {
                         match self.get_object(array_object_index) {
                             Object::Array(arr) => {
                                 let mut guard = arr.lock_mut();
                                 let len = guard.len();
-                                if i < 0 || (i as usize) >= len {
-                                    Err((i, len))
-                                } else {
-                                    let old = guard[i as usize];
-                                    guard[i as usize] = new_value;
-                                    Ok(old)
+                                match crate::array_index::resolve_index(i, len) {
+                                    Some(idx) => {
+                                        let old = guard[idx];
+                                        guard[idx] = new_value;
+                                        Ok((old, idx))
+                                    }
+                                    None => Err((i, len)),
                                 }
                             }
                             Object::Uint8Array(bytes) => {
@@ -6257,12 +6257,13 @@ impl BexVm {
                                 };
                                 let mut guard = bytes.lock_mut();
                                 let len = guard.len();
-                                if i < 0 || (i as usize) >= len {
-                                    Err((i, len))
-                                } else {
-                                    let old = Value::int(i64::from(guard[i as usize]));
-                                    guard[i as usize] = byte_v;
-                                    Ok(old)
+                                match crate::array_index::resolve_index(i, len) {
+                                    Some(idx) => {
+                                        let old = Value::int(i64::from(guard[idx]));
+                                        guard[idx] = byte_v;
+                                        Ok((old, idx))
+                                    }
+                                    None => Err((i, len)),
                                 }
                             }
                             other => {
@@ -6274,7 +6275,7 @@ impl BexVm {
                             }
                         }
                     };
-                    let old_value = match store_result {
+                    let (old_value, index) = match store_result {
                         Ok(v) => v,
                         Err((idx, len)) => {
                             return Err(VmError::Thrown(self.panic_to_exception_value(
@@ -6285,8 +6286,6 @@ impl BexVm {
                             )));
                         }
                     };
-                    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                    let index = i as usize;
                     let watched_node = NodeId::HeapObject(array_object_index);
                     self.update_watched_node(
                         watched_node,

--- a/baml_language/crates/bex_vm_types/src/errors.rs
+++ b/baml_language/crates/bex_vm_types/src/errors.rs
@@ -21,7 +21,9 @@ pub enum VmPanic {
     #[error("division by zero: {left:?} / {right:?}")]
     DivisionByZero { left: Value, right: Value },
 
-    #[error("array index out of bounds: {index} of {length}")]
+    // Raised by array/byte-array subscripting and `string.char_at`, so the
+    // message stays generic ("index", not "array index").
+    #[error("index out of bounds: {index} of {length}")]
     IndexOutOfBounds { index: i64, length: usize },
 
     #[error("invalid field access: field {field_index} of {field_count}")]


### PR DESCRIPTION
Operations on Arrays, uint8arrays, and strings should now accept negative indices which represent distance from the end (like Python).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added/standardized negative index support across array, string, and byte-array operations, including updated behavior for `at`, `remove_at`, `insert`, `splice`, `substring`, `char_at`, and `slice` (including clamping/empty-result rules where applicable).

* **Bug Fixes**
  - Updated out-of-range handling to raise `IndexOutOfBounds` for invalid `char_at`/indexing cases, and clarified `substring` as non-throwing.

* **Documentation**
  - Expanded standard-library docs and examples for negative index semantics and edge cases.

* **Tests**
  - Updated and extended test coverage for new negative-index, bounds, and slicing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->