### PR TITLE
fix(compiler2): reject unsound local reassignment and validate index subscripts (B-236)

### DIFF
--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -4536,7 +4536,7 @@ impl LoweringContext<'_> {
             }
 
             AstExpr::OptionalIndex { base, index } => {
-                self.lower_optional_index(expr_id, base, index, dest);
+                self.lower_optional_index(base, index, dest);
             }
 
             AstExpr::OptionalCall { callee, args } => {
@@ -4545,7 +4545,7 @@ impl LoweringContext<'_> {
             }
 
             AstExpr::Index { base, index } => {
-                self.lower_index(expr_id, base, index, dest);
+                self.lower_index(base, index, dest);
             }
 
             AstExpr::Block { stmts, tail_expr } => {
@@ -5744,13 +5744,7 @@ impl LoweringContext<'_> {
     }
 
     /// Lower `obj?.[index]` — null-check obj, then index or produce null.
-    fn lower_optional_index(
-        &mut self,
-        expr_id: AstExprId,
-        base: AstExprId,
-        index: AstExprId,
-        dest: Place,
-    ) {
+    fn lower_optional_index(&mut self, base: AstExprId, index: AstExprId, dest: Place) {
         let base_op = self.lower_to_operand(base);
 
         let is_null = Rvalue::BinaryOp {
@@ -5770,7 +5764,7 @@ impl LoweringContext<'_> {
                 .branch(Operand::Copy(Place::Local(test_local)), bb_null, bb_access);
 
             self.builder.set_current_block(bb_access);
-            self.lower_optional_index_access(expr_id, base, index, dest, bb_null);
+            self.lower_optional_index_access(base, index, dest, bb_null);
         } else {
             let bb_null = self.builder.create_block();
             let bb_join = self.builder.create_block();
@@ -5779,7 +5773,7 @@ impl LoweringContext<'_> {
                 .branch(Operand::Copy(Place::Local(test_local)), bb_null, bb_access);
 
             self.builder.set_current_block(bb_access);
-            self.lower_optional_index_access(expr_id, base, index, dest.clone(), bb_null);
+            self.lower_optional_index_access(base, index, dest.clone(), bb_null);
             if !self.builder.is_current_terminated() {
                 self.builder.goto(bb_join);
             }
@@ -5800,18 +5794,21 @@ impl LoweringContext<'_> {
     /// needs the extra check; a non-null index lowers straight to the access.
     fn lower_optional_index_access(
         &mut self,
-        expr_id: AstExprId,
         base: AstExprId,
         index: AstExprId,
         dest: Place,
         bb_null: BlockId,
     ) {
+        let base_ty = self.expr_ty(base);
+        let base_op = self.lower_to_operand(base);
         let index_ty = self.expr_ty(index);
+        // Lower the index once and reuse it for both the null check and the
+        // access, so a side-effectful subscript isn't evaluated twice.
+        let index_op = self.lower_to_operand(index);
         if index_ty != index_ty.strip_null() {
-            let index_op = self.lower_to_operand(index);
             let is_null = Rvalue::BinaryOp {
                 op: BinOp::Eq,
-                left: index_op,
+                left: index_op.clone(),
                 right: Operand::Constant(Constant::Null),
             };
             let test_local = self.builder.temp(RuntimeTy::Bool {
@@ -5823,7 +5820,7 @@ impl LoweringContext<'_> {
                 .branch(Operand::Copy(Place::Local(test_local)), bb_null, bb_real);
             self.builder.set_current_block(bb_real);
         }
-        self.lower_index(expr_id, base, index, dest);
+        self.emit_index_access(base_op, &base_ty, index_op, index_ty, dest);
     }
 
     /// Lower `func?.(args)` — null-check callee, then call or produce null.
@@ -8269,12 +8266,25 @@ impl<'db> LoweringContext<'db> {
         (!candidates.is_empty()).then_some(candidates)
     }
 
-    fn lower_index(&mut self, _expr_id: AstExprId, base: AstExprId, index: AstExprId, dest: Place) {
+    fn lower_index(&mut self, base: AstExprId, index: AstExprId, dest: Place) {
         let base_ty = self.expr_ty(base);
         let base_op = self.lower_to_operand(base);
-        let index_op = self.lower_to_operand(index);
         let index_ty = self.expr_ty(index);
+        let index_op = self.lower_to_operand(index);
+        self.emit_index_access(base_op, &base_ty, index_op, index_ty, dest);
+    }
 
+    /// Emit the element read for `base[index]` from already-lowered operands.
+    /// Shared by `lower_index` and `lower_optional_index_access` so a
+    /// side-effectful index expression is evaluated exactly once.
+    fn emit_index_access(
+        &mut self,
+        base_op: Operand,
+        base_ty: &RuntimeTy,
+        index_op: Operand,
+        index_ty: RuntimeTy,
+        dest: Place,
+    ) {
         let base_local = self.operand_to_local(base_op, base_ty.clone());
         let index_local = self.operand_to_local(index_op, index_ty);
 

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -5770,7 +5770,7 @@ impl LoweringContext<'_> {
                 .branch(Operand::Copy(Place::Local(test_local)), bb_null, bb_access);
 
             self.builder.set_current_block(bb_access);
-            self.lower_index(expr_id, base, index, dest);
+            self.lower_optional_index_access(expr_id, base, index, dest, bb_null);
         } else {
             let bb_null = self.builder.create_block();
             let bb_join = self.builder.create_block();
@@ -5779,7 +5779,7 @@ impl LoweringContext<'_> {
                 .branch(Operand::Copy(Place::Local(test_local)), bb_null, bb_access);
 
             self.builder.set_current_block(bb_access);
-            self.lower_index(expr_id, base, index, dest.clone());
+            self.lower_optional_index_access(expr_id, base, index, dest.clone(), bb_null);
             if !self.builder.is_current_terminated() {
                 self.builder.goto(bb_join);
             }
@@ -5791,6 +5791,39 @@ impl LoweringContext<'_> {
 
             self.builder.set_current_block(bb_join);
         }
+    }
+
+    /// Lower the access half of `base?.[index]`, with the base already known
+    /// non-null. `?.[]` is the null-safe index operator, so a null *subscript*
+    /// must short-circuit the whole expression to null (via `bb_null`) rather
+    /// than abort the VM — mirroring the base guard. Only a nullable-typed index
+    /// needs the extra check; a non-null index lowers straight to the access.
+    fn lower_optional_index_access(
+        &mut self,
+        expr_id: AstExprId,
+        base: AstExprId,
+        index: AstExprId,
+        dest: Place,
+        bb_null: BlockId,
+    ) {
+        let index_ty = self.expr_ty(index);
+        if index_ty != index_ty.strip_null() {
+            let index_op = self.lower_to_operand(index);
+            let is_null = Rvalue::BinaryOp {
+                op: BinOp::Eq,
+                left: index_op,
+                right: Operand::Constant(Constant::Null),
+            };
+            let test_local = self.builder.temp(RuntimeTy::Bool {
+                attr: TyAttr::default(),
+            });
+            self.builder.assign(Place::local(test_local), is_null);
+            let bb_real = self.builder.create_block();
+            self.builder
+                .branch(Operand::Copy(Place::Local(test_local)), bb_null, bb_real);
+            self.builder.set_current_block(bb_real);
+        }
+        self.lower_index(expr_id, base, index, dest);
     }
 
     /// Lower `func?.(args)` — null-check callee, then call or produce null.

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -4346,7 +4346,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         index: ExprId,
     ) -> Ty {
         let base_ty = self.infer_expr(base, body);
-        self.infer_expr(index, body);
+        let index_ty = self.infer_expr(index, body);
         let inner = crate::narrowing::remove_null(&base_ty);
         let (resolve_ty, rewrap) = if inner != base_ty
             && !matches!(base_ty, Ty::Unknown { attr: _ } | Ty::Error { attr: _ })
@@ -4368,6 +4368,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         } else {
             (base_ty, false)
         };
+        self.check_index_key_type(&resolve_ty, &index_ty, index, false);
         let elem_ty = match resolve_ty {
             Ty::List(elem_ty, _) | Ty::EvolvingList(elem_ty, _) => *elem_ty,
             Ty::Map {
@@ -4401,6 +4402,60 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    /// Validate that `index_ty` is an acceptable subscript for `container`: the
+    /// runtime indexes a list/byte-array by `int` and a map by its key type
+    /// (`string`). There is no key coercion — `list["a"]` or `map[0]` aborts the
+    /// VM at runtime — so reject a mistyped subscript at compile time. A no-op
+    /// for non-containers and for error-recovery index types.
+    fn check_index_key_type(
+        &mut self,
+        container: &Ty,
+        index_ty: &Ty,
+        index_id: ExprId,
+        allow_null: bool,
+    ) {
+        // The runtime has no null subscript (`a[null]` aborts the VM with the
+        // confusing `got any`), so a plain `a[i]` requires a non-null index.
+        // The optional form `a?.[i]` only guards the *base*, but its index is
+        // typically nullable-by-type yet non-null in the narrowed chain context
+        // (e.g. `node?.children?.[node?.value]`); strip null there to avoid a
+        // false positive.
+        let widened = index_ty.clone().widen_fresh();
+        let index_ty = if allow_null {
+            crate::narrowing::remove_null(&widened)
+        } else {
+            widened
+        };
+        if matches!(index_ty, Ty::Unknown { .. } | Ty::Error { .. }) {
+            return;
+        }
+        let expected_key = match container {
+            Ty::List(..) | Ty::EvolvingList(..) | Ty::Uint8Array { .. } => Ty::Int {
+                attr: TyAttr::default(),
+            },
+            // An empty evolving map (`{}`, key `never`) adopts string keys; any
+            // other map carries its declared (string) key type.
+            Ty::Map { key, .. } | Ty::EvolvingMap(key, _, _) => {
+                if matches!(**key, Ty::Never { .. }) {
+                    Ty::string()
+                } else {
+                    (**key).clone()
+                }
+            }
+            _ => return,
+        };
+        if !self.is_subtype(&index_ty, &expected_key) {
+            self.context.report(
+                TirTypeError::TypeMismatch {
+                    expected: expected_key,
+                    got: index_ty,
+                },
+                index_id,
+                Vec::new(),
+            );
+        }
+    }
+
     #[inline(never)]
     fn infer_optional_index_expr(
         &mut self,
@@ -4411,7 +4466,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) -> Ty {
         // Optional chaining: a?.[expr] — short-circuits to null if a is null.
         let base_ty = self.infer_expr(base, body);
-        self.infer_expr(index, body);
+        let index_ty = self.infer_expr(index, body);
         let base_info = self.analyze_optional_base(&base_ty);
         // E2: warn if base is not nullable
         if !base_info.is_nullable() && !matches!(base_ty, Ty::Unknown { .. } | Ty::Error { .. }) {
@@ -4430,6 +4485,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 attr: TyAttr::default(),
             }
         } else {
+            self.check_index_key_type(&base_info.inner, &index_ty, index, true);
             let elem_ty = match &base_info.inner {
                 Ty::List(elem_ty, _) | Ty::EvolvingList(elem_ty, _) => elem_ty.as_ref().clone(),
                 Ty::Map {
@@ -6144,6 +6200,29 @@ impl<'db> TypeInferenceBuilder<'db> {
                         }
                     }
                 } else {
+                    // No annotated declared type. Member/index/`$id` targets are
+                    // handled structurally elsewhere; an *unannotated local*,
+                    // though, still carries a flow type in `current_ty` that a
+                    // reassignment must stay compatible with. Without this guard
+                    // `let x = {}; x = []` keeps `x` map-typed while it holds an
+                    // array at runtime, so indexing it aborts the VM with
+                    // "expected map, got array" (B-236).
+                    if let Expr::Path(segments) = &body.exprs[*target]
+                        && segments.len() == 1
+                        && segments[0].as_str() != "$id"
+                        && let Some(current_ty) =
+                            self.locals.get(&segments[0]).map(|b| b.current_ty.clone())
+                        && !self.reassignment_is_compatible(&value_ty, &current_ty)
+                    {
+                        self.context.report(
+                            TirTypeError::TypeMismatch {
+                                expected: current_ty,
+                                got: value_ty.clone(),
+                            },
+                            *value,
+                            Vec::new(),
+                        );
+                    }
                     self.infer_expr(*target, body);
                     self.infer_expr(*value, body);
                 }
@@ -6362,6 +6441,45 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         }
         None
+    }
+
+    /// Whether reassigning a value of type `value_ty` to an *unannotated* local
+    /// currently typed `current_ty` is sound (B-236).
+    ///
+    /// A concrete local requires the new value to be a subtype — its static
+    /// type and the runtime value must not diverge. An *empty evolving*
+    /// container (`[]` / `{}`, whose element/key/value types are `never`) is
+    /// special: it has not yet committed to an element type, so it may still
+    /// adopt any value of the *same container kind* — `let a = []; a = [1, 2,
+    /// 3]` keeps working — but never across kinds (`let x = {}; x = []` is the
+    /// crash). Cross-kind and unrelated-type reassignments are rejected.
+    fn reassignment_is_compatible(&self, value_ty: &Ty, current_ty: &Ty) -> bool {
+        // Error recovery / a diverging RHS: don't pile on additional errors.
+        if matches!(
+            value_ty,
+            Ty::Unknown { .. } | Ty::Error { .. } | Ty::Never { .. }
+        ) || matches!(current_ty, Ty::Unknown { .. } | Ty::Error { .. })
+        {
+            return true;
+        }
+        if self.is_subtype(value_ty, current_ty) {
+            return true;
+        }
+        match current_ty {
+            // Empty evolving list: accepts any list-shaped value.
+            Ty::List(inner, _) | Ty::EvolvingList(inner, _)
+                if matches!(**inner, Ty::Never { .. }) =>
+            {
+                matches!(value_ty, Ty::List(..) | Ty::EvolvingList(..))
+            }
+            // Empty evolving map: accepts any map-shaped value.
+            Ty::Map { key, value, .. } | Ty::EvolvingMap(key, value, _)
+                if matches!(**key, Ty::Never { .. }) && matches!(**value, Ty::Never { .. }) =>
+            {
+                matches!(value_ty, Ty::Map { .. } | Ty::EvolvingMap(..))
+            }
+            _ => false,
+        }
     }
 
     /// True when `expr` is the bare `$id` special form (the runtime-identity
@@ -13668,6 +13786,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let is_evolving = matches!(local_ty, Ty::EvolvingList(_, _));
                 let container_attr = container_attr.clone();
                 let index_ty = self.infer_expr(index_id, body);
+                self.check_index_key_type(&local_ty, &index_ty, index_id, false);
                 let val_ty = self.infer_expr(value_id, body);
                 let widened_val = val_ty.clone().widen_fresh();
 
@@ -13705,6 +13824,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let is_evolving = matches!(local_ty, Ty::EvolvingMap(_, _, _));
                 let container_attr = container_attr.clone();
                 let index_ty = self.infer_expr(index_id, body);
+                self.check_index_key_type(&local_ty, &index_ty, index_id, false);
                 let value_ty = self.infer_expr(value_id, body);
                 let widened_key = index_ty.clone().widen_fresh();
                 let widened_val = value_ty.clone().widen_fresh();
@@ -13725,27 +13845,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                     };
                     self.assign_local(local_name.clone(), new_ty.clone());
                     self.sync_let_binding_type(&local_name, new_ty);
-                } else {
-                    if !self.is_subtype(&widened_key, key_ty) {
-                        self.context.report(
-                            TirTypeError::TypeMismatch {
-                                expected: *key_ty.clone(),
-                                got: widened_key,
-                            },
-                            index_id,
-                            Vec::new(),
-                        );
-                    }
-                    if !self.is_subtype(&widened_val, val_ty) {
-                        self.context.report(
-                            TirTypeError::TypeMismatch {
-                                expected: *val_ty.clone(),
-                                got: widened_val.clone(),
-                            },
-                            value_id,
-                            Vec::new(),
-                        );
-                    }
+                } else if !self.is_subtype(&widened_val, val_ty) {
+                    // The key was validated by `check_index_key_type` above.
+                    self.context.report(
+                        TirTypeError::TypeMismatch {
+                            expected: *val_ty.clone(),
+                            got: widened_val.clone(),
+                        },
+                        value_id,
+                        Vec::new(),
+                    );
                 }
 
                 self.record_expr_type(base_id, local_ty);

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/arrays.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/arrays.baml
@@ -42,4 +42,57 @@ function ArrayAssignments() -> int {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// error: type mismatch: expected int[], got string[]
+//     ╭─[ invalid_assignment_arrays.baml:18:5 ]
+//     │
+//  18 │     d = ["a", "b"];
+//     │        ─────┬─────
+//     │             ╰─────── type mismatch: expected int[], got string[]
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected string[], got int[]
+//     ╭─[ invalid_assignment_arrays.baml:22:5 ]
+//     │
+//  22 │     e = [1, 2];
+//     │        ───┬───
+//     │           ╰───── type mismatch: expected string[], got int[]
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected int, got int[]
+//     ╭─[ invalid_assignment_arrays.baml:26:5 ]
+//     │
+//  26 │     f = [1, 2, 3];
+//     │        ─────┬────
+//     │             ╰────── type mismatch: expected int, got int[]
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected int[], got 42
+//     ╭─[ invalid_assignment_arrays.baml:30:6 ]
+//     │
+//  30 │     g = 42;
+//     │         ─┬
+//     │          ╰── type mismatch: expected int[], got 42
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected int[], got "array"
+//     ╭─[ invalid_assignment_arrays.baml:34:6 ]
+//     │
+//  34 │     h = "array";
+//     │         ───┬───
+//     │            ╰───── type mismatch: expected int[], got "array"
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected string, got int[]
+//     ╭─[ invalid_assignment_arrays.baml:38:5 ]
+//     │
+//  38 │     i = [4, 5, 6];
+//     │        ─────┬────
+//     │             ╰────── type mismatch: expected string, got int[]
+//     │
+//     │ Note: Error code: E0001
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/class_arrays.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/class_arrays.baml
@@ -49,26 +49,44 @@ function ClassArrayAssignments() -> int {
 //     ╭─[ invalid_assignment_class_arrays.baml:25:6 ]
 //     │
 //  25 │     p1 = [Animal { species: "Bird", legs: 2 }];
-//     │         ───────────────────┬──────────────────  
+//     │         ───────────────────┬──────────────────
 //     │                            ╰──────────────────── type mismatch: expected Person[], got Animal[]
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯
 // error: type mismatch: expected Animal[], got Person[]
 //     ╭─[ invalid_assignment_class_arrays.baml:29:6 ]
 //     │
 //  29 │     a1 = [Person { name: "D", age: 4 }];
-//     │         ───────────────┬───────────────  
+//     │         ───────────────┬───────────────
 //     │                        ╰───────────────── type mismatch: expected Animal[], got Person[]
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯
 // error: type mismatch: expected Person[], got Person
 //     ╭─[ invalid_assignment_class_arrays.baml:33:7 ]
 //     │
 //  33 │     p2 = Person { name: "F", age: 6 };
-//     │          ──────────────┬─────────────  
+//     │          ──────────────┬─────────────
 //     │                        ╰─────────────── type mismatch: expected Person[], got Person
-//     │ 
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected Person, got Person[]
+//     ╭─[ invalid_assignment_class_arrays.baml:37:6 ]
+//     │
+//  37 │     p3 = [Person { name: "H", age: 8 }];
+//     │         ───────────────┬───────────────
+//     │                        ╰───────────────── type mismatch: expected Person, got Person[]
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected int[], got Person[]
+//     ╭─[ invalid_assignment_class_arrays.baml:41:8 ]
+//     │
+//  41 │     nums = [Person { name: "I", age: 9 }];
+//     │           ───────────────┬───────────────
+//     │                          ╰───────────────── type mismatch: expected int[], got Person[]
+//     │
 //     │ Note: Error code: E0001
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/classes.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/classes.baml
@@ -45,4 +45,48 @@ function ClassAssignments() -> int {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// error: type mismatch: expected Person, got Animal
+//     ╭─[ invalid_assignment_classes.baml:25:7 ]
+//     │
+//  25 │     p2 = Animal { species: "Bird", legs: 2 };
+//     │          ─────────────────┬─────────────────
+//     │                           ╰─────────────────── type mismatch: expected Person, got Animal
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected Animal, got Person
+//     ╭─[ invalid_assignment_classes.baml:29:7 ]
+//     │
+//  29 │     a2 = Person { name: "Dave", age: 40 };
+//     │          ────────────────┬───────────────
+//     │                          ╰───────────────── type mismatch: expected Animal, got Person
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected Person, got "not a person"
+//     ╭─[ invalid_assignment_classes.baml:33:7 ]
+//     │
+//  33 │     p3 = "not a person";
+//     │          ───────┬──────
+//     │                 ╰──────── type mismatch: expected Person, got "not a person"
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected Person, got 42
+//     ╭─[ invalid_assignment_classes.baml:37:7 ]
+//     │
+//  37 │     p4 = 42;
+//     │          ─┬
+//     │           ╰── type mismatch: expected Person, got 42
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected int, got Person
+//     ╭─[ invalid_assignment_classes.baml:41:6 ]
+//     │
+//  41 │     n = Person { name: "Grace", age: 32 };
+//     │         ────────────────┬────────────────
+//     │                         ╰────────────────── type mismatch: expected int, got Person
+//     │
+//     │ Note: Error code: E0001
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/maps.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/maps.baml
@@ -52,35 +52,44 @@ function MapAssignments() -> int {
 //     ╭─[ invalid_assignment_maps.baml:28:5 ]
 //     │
 //  28 │     d = {"y": "wrong"};
-//     │        ───────┬───────  
+//     │        ───────┬───────
 //     │               ╰───────── type mismatch: expected map<string, int>, got map<string, string>
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯
 // error: type mismatch: expected map<string, Person>, got map<string, Animal>
 //     ╭─[ invalid_assignment_maps.baml:32:5 ]
 //     │
 //  32 │     e = {"a": Animal { species: "Cat", legs: 4 }};
-//     │        ─────────────────────┬────────────────────  
+//     │        ─────────────────────┬────────────────────
 //     │                             ╰────────────────────── type mismatch: expected map<string, Person>, got map<string, Animal>
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯
 // error: type mismatch: expected map<string, int>, got "not a map"
 //     ╭─[ invalid_assignment_maps.baml:36:6 ]
 //     │
 //  36 │     f = "not a map";
-//     │         ─────┬─────  
+//     │         ─────┬─────
 //     │              ╰─────── type mismatch: expected map<string, int>, got "not a map"
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯
 // error: type mismatch: expected map<string, int>, got 123
 //     ╭─[ invalid_assignment_maps.baml:40:6 ]
 //     │
 //  40 │     g = 123;
-//     │         ─┬─  
+//     │         ─┬─
 //     │          ╰─── type mismatch: expected map<string, int>, got 123
-//     │ 
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected string, got map<string, int>
+//     ╭─[ invalid_assignment_maps.baml:44:5 ]
+//     │
+//  44 │     h = {"k": 7};
+//     │        ────┬────
+//     │            ╰────── type mismatch: expected string, got map<string, int>
+//     │
 //     │ Note: Error code: E0001
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/nested_arrays.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/nested_arrays.baml
@@ -48,26 +48,35 @@ function NestedArrayAssignments() -> int {
 //     ╭─[ invalid_assignment_nested_arrays.baml:28:5 ]
 //     │
 //  28 │     d = [3, 4, 5];
-//     │        ─────┬────  
+//     │        ─────┬────
 //     │             ╰────── type mismatch: expected int[][], got int[]
-//     │ 
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected int[], got int[][]
+//     ╭─[ invalid_assignment_nested_arrays.baml:32:5 ]
+//     │
+//  32 │     e = [[4, 5], [6, 7]];
+//     │        ────────┬────────
+//     │                ╰────────── type mismatch: expected int[], got int[][]
+//     │
 //     │ Note: Error code: E0001
 // ────╯
 // error: type mismatch: expected string[][], got int[][]
 //     ╭─[ invalid_assignment_nested_arrays.baml:36:5 ]
 //     │
 //  36 │     f = [[1, 2]];
-//     │        ────┬────  
+//     │        ────┬────
 //     │            ╰────── type mismatch: expected string[][], got int[][]
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯
 // error: type mismatch: expected Person[][], got Animal[][]
 //     ╭─[ invalid_assignment_nested_arrays.baml:40:5 ]
 //     │
 //  40 │     g = [[Animal { species: "Cat", legs: 4 }]];
-//     │        ───────────────────┬───────────────────  
+//     │        ───────────────────┬───────────────────
 //     │                           ╰───────────────────── type mismatch: expected Person[][], got Animal[][]
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/nominal_typing.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/nominal_typing.baml
@@ -67,21 +67,57 @@ function NominalTypingAssignments() -> int {
 
 //----
 //- diagnostics
+// error: type mismatch: expected Person, got Human
+//     ╭─[ invalid_assignment_nominal_typing.baml:43:7 ]
+//     │
+//  43 │     p2 = Human { name: "F", age: 6 };
+//     │          ─────────────┬─────────────
+//     │                       ╰─────────────── type mismatch: expected Person, got Human
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected Human, got Person
+//     ╭─[ invalid_assignment_nominal_typing.baml:47:7 ]
+//     │
+//  47 │     h2 = Person { name: "H", age: 8 };
+//     │          ──────────────┬─────────────
+//     │                        ╰─────────────── type mismatch: expected Human, got Person
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected Animal, got Creature
+//     ╭─[ invalid_assignment_nominal_typing.baml:51:7 ]
+//     │
+//  51 │     a2 = Creature { species: "Lizard", legs: 4 };
+//     │          ───────────────────┬───────────────────
+//     │                             ╰───────────────────── type mismatch: expected Animal, got Creature
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected Creature, got Animal
+//     ╭─[ invalid_assignment_nominal_typing.baml:55:7 ]
+//     │
+//  55 │     c2 = Animal { species: "Spider", legs: 8 };
+//     │          ──────────────────┬──────────────────
+//     │                            ╰──────────────────── type mismatch: expected Creature, got Animal
+//     │
+//     │ Note: Error code: E0001
+// ────╯
 // error: type mismatch: expected Person[], got Human[]
 //     ╭─[ invalid_assignment_nominal_typing.baml:59:10 ]
 //     │
 //  59 │     people = [Human { name: "J", age: 10 }];
-//     │             ───────────────┬───────────────  
+//     │             ───────────────┬───────────────
 //     │                            ╰───────────────── type mismatch: expected Person[], got Human[]
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯
 // error: type mismatch: expected Human[], got Person[]
 //     ╭─[ invalid_assignment_nominal_typing.baml:63:10 ]
 //     │
 //  63 │     humans = [Person { name: "L", age: 12 }];
-//     │             ────────────────┬───────────────  
+//     │             ────────────────┬───────────────
 //     │                             ╰───────────────── type mismatch: expected Human[], got Person[]
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/primitives.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/invalid_assignment/primitives.baml
@@ -49,4 +49,66 @@ function PrimitiveAssignments() -> int {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// error: type mismatch: expected int, got "oops"
+//     ╭─[ invalid_assignment_primitives.baml:21:6 ]
+//     │
+//  21 │     e = "oops";
+//     │         ───┬──
+//     │            ╰──── type mismatch: expected int, got "oops"
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected string, got 42
+//     ╭─[ invalid_assignment_primitives.baml:25:6 ]
+//     │
+//  25 │     f = 42;
+//     │         ─┬
+//     │          ╰── type mismatch: expected string, got 42
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected bool, got 123
+//     ╭─[ invalid_assignment_primitives.baml:29:6 ]
+//     │
+//  29 │     g = 123;
+//     │         ─┬─
+//     │          ╰─── type mismatch: expected bool, got 123
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected int, got false
+//     ╭─[ invalid_assignment_primitives.baml:33:6 ]
+//     │
+//  33 │     h = false;
+//     │         ──┬──
+//     │           ╰──── type mismatch: expected int, got false
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected float, got "pi"
+//     ╭─[ invalid_assignment_primitives.baml:37:6 ]
+//     │
+//  37 │     i = "pi";
+//     │         ──┬─
+//     │           ╰─── type mismatch: expected float, got "pi"
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected bool, got "true"
+//     ╭─[ invalid_assignment_primitives.baml:41:6 ]
+//     │
+//  41 │     j = "true";
+//     │         ───┬──
+//     │            ╰──── type mismatch: expected bool, got "true"
+//     │
+//     │ Note: Error code: E0001
+// ────╯
+// error: type mismatch: expected string, got true
+//     ╭─[ invalid_assignment_primitives.baml:45:6 ]
+//     │
+//  45 │     k = true;
+//     │         ──┬─
+//     │           ╰─── type mismatch: expected string, got true
+//     │
+//     │ Note: Error code: E0001
+// ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/loops/for.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/loops/for.baml
@@ -60,12 +60,21 @@ function SumUnknownType(xs: int, b: string) -> int {
 
 //----
 //- diagnostics
+// error: type mismatch: expected int, got string
+//     ╭─[ loops_for.baml:16:12 ]
+//     │
+//  16 │        result = x;
+//     │                 ┬
+//     │                 ╰── type mismatch: expected int, got string
+//     │
+//     │ Note: Error code: E0001
+// ────╯
 // error: cannot iterate over type `int`
 //     ╭─[ loops_for.baml:28:16 ]
 //     │
 //  28 │     for (let x in xs) {
-//     │                   ─┬  
+//     │                   ─┬
 //     │                    ╰── cannot iterate over type `int`
-//     │ 
+//     │
 //     │ Note: Error code: E0006
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/maps/key_and_value_typecheck.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/maps/key_and_value_typecheck.baml
@@ -49,26 +49,35 @@ function UseMapTypecheck() -> int {
 //    ╭─[ maps_key_and_value_typecheck.baml:3:14 ]
 //    │
 //  3 │     { (1 + 1): "2" }
-//    │              ┬  
+//    │              ┬
 //    │              ╰── Expected expression, found ':'
-//    │ 
+//    │
 //    │ Note: Error code: E0010
 // ───╯
 // error: type mismatch: expected map<int, string>, got "2"
 //    ╭─[ maps_key_and_value_typecheck.baml:3:16 ]
 //    │
 //  3 │     { (1 + 1): "2" }
-//    │                ─┬─  
+//    │                ─┬─
 //    │                 ╰─── type mismatch: expected map<int, string>, got "2"
-//    │ 
+//    │
 //    │ Note: Error code: E0001
 // ───╯
+// error: type mismatch: expected int, got string
+//     ╭─[ maps_key_and_value_typecheck.baml:18:9 ]
+//     │
+//  18 │     map["string"]
+//     │         ────┬───
+//     │             ╰───── type mismatch: expected int, got string
+//     │
+//     │ Note: Error code: E0001
+// ────╯
 // error: type mismatch: expected int, got string
 //     ╭─[ maps_key_and_value_typecheck.baml:18:5 ]
 //     │
 //  18 │     map["string"]
-//     │     ──────┬──────  
+//     │     ──────┬──────
 //     │           ╰──────── type mismatch: expected int, got string
-//     │ 
+//     │
 //     │ Note: Error code: E0001
 // ────╯

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -690,3 +690,205 @@ function demo() -> ((x: int) -> int) -> int {
         "expected function-valued return annotation to preserve callback forwarding surface, got:\n{output}"
     );
 }
+
+/// Helper: does compiling `source` produce a `type mismatch` diagnostic?
+fn has_type_mismatch(source: &str) -> bool {
+    let mut db = make_db();
+    db.add_file("test.baml", source);
+    baml_project::collect_compiler2_diagnostics(&db)
+        .iter()
+        .any(|diag| diag.message.contains("type mismatch"))
+}
+
+// ─── B-236: reassigning an unannotated local across container kinds ──────────
+//
+// `let x = {}` gives `x` an (evolving) map type. Reassigning the empty array
+// `[]` used to be accepted silently: `x` stayed map-typed while it held an
+// array at runtime, so indexing it aborted the VM with `expected map, got
+// array`. Reassignment must instead be rejected at compile time.
+
+#[test]
+fn reassign_empty_map_local_to_array_is_rejected() {
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let x = {};
+    x = [];
+    return 0;
+}"#
+        ),
+        "reassigning [] into a map-typed local should report a type mismatch"
+    );
+}
+
+#[test]
+fn reassign_empty_array_local_to_map_is_rejected() {
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let x = [];
+    x = {};
+    return 0;
+}"#
+        ),
+        "reassigning {{}} into a list-typed local should report a type mismatch"
+    );
+}
+
+#[test]
+fn reassign_if_else_with_empty_array_else_branch_is_rejected() {
+    // The exact ticket shape: the empty array lives in an if/else else-branch.
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let x = {};
+    x = if false { {"a": 1} } else { [] };
+    return x["a"];
+}"#
+        ),
+        "if/else result mixing a map then-branch with an empty-array else-branch \
+         must not be assignable to a map-typed local"
+    );
+}
+
+#[test]
+fn reassign_unannotated_scalar_local_to_incompatible_type_is_rejected() {
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let n = 1;
+    n = "hello";
+    return 0;
+}"#
+        ),
+        "reassigning a string into an int-typed local should report a type mismatch"
+    );
+}
+
+#[test]
+fn empty_array_local_still_evolves_via_reassignment() {
+    // Regression guard: an *empty* evolving list must still accept a populated
+    // list of the same kind — only cross-kind reassignment is rejected.
+    assert!(
+        !has_type_mismatch(
+            r#"function main() -> int {
+    let a = [];
+    a = [1, 2, 3];
+    return 0;
+}"#
+        ),
+        "reassigning a populated list into an empty-list local must stay allowed"
+    );
+}
+
+// ─── Index-key type validation ───────────────────────────────────────────────
+//
+// The runtime does no key coercion: a list is subscripted by an `int` and a
+// map by a `string`. A wrong-typed subscript used to slip past the checker and
+// abort the VM (`expected int, got string` / `expected string, got int`).
+
+#[test]
+fn list_indexed_by_string_key_is_rejected() {
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let x = [1, 2, 3];
+    return x["a"];
+}"#
+        ),
+        "indexing a list with a string key should report a type mismatch"
+    );
+}
+
+#[test]
+fn list_index_assign_with_string_key_is_rejected() {
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let x = [];
+    x["a"] = 1;
+    return 0;
+}"#
+        ),
+        "index-assigning a list with a string key should report a type mismatch"
+    );
+}
+
+#[test]
+fn map_indexed_by_int_key_is_rejected() {
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let m = {"a": 1};
+    return m[0];
+}"#
+        ),
+        "indexing a map with an int key should report a type mismatch"
+    );
+}
+
+#[test]
+fn empty_map_index_assign_with_int_key_is_rejected() {
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let m = {};
+    m[0] = 1;
+    return 0;
+}"#
+        ),
+        "index-assigning an empty map with an int key should report a type mismatch"
+    );
+}
+
+#[test]
+fn well_typed_index_access_is_accepted() {
+    // Regression guard: int-keyed list and string-keyed map (incl. evolving
+    // empties) must stay valid.
+    assert!(
+        !has_type_mismatch(
+            r#"function main() -> int {
+    let x = [];
+    x[0] = 1;
+    let m = {};
+    m["k"] = 2;
+    return x[0] + m["k"];
+}"#
+        ),
+        "int-keyed list and string-keyed map access must stay allowed"
+    );
+}
+
+#[test]
+fn list_indexed_by_nullable_int_is_rejected() {
+    // A subscript must be non-null — the runtime has no null index (it aborts
+    // with the confusing `type error: ... got any`).
+    assert!(
+        has_type_mismatch(
+            r#"function main() -> int {
+    let arr = [1, 2, 3];
+    let i: int? = null;
+    return arr[i];
+}"#
+        ),
+        "indexing a list with a nullable int should report a type mismatch"
+    );
+}
+
+#[test]
+fn narrowed_nullable_index_is_accepted() {
+    // Regression guard: a nullable index narrowed to non-null must stay valid.
+    assert!(
+        !has_type_mismatch(
+            r#"function main() -> int {
+    let arr = [1, 2, 3];
+    let i: int? = 0;
+    if i != null {
+        return arr[i];
+    }
+    return 0;
+}"#
+        ),
+        "a nullable index narrowed to non-null must stay allowed"
+    );
+}

--- a/baml_language/crates/baml_tests/tests/type_error_repro.rs
+++ b/baml_language/crates/baml_tests/tests/type_error_repro.rs
@@ -1,23 +1,25 @@
-//! Minimal reproduction tests for "type error: expected int, got any".
+//! Regression tests for array indexing with null / wrong-typed subscripts.
 //!
-//! These tests isolate the components of the tic-tac-toe bug:
-//! - Array indexing with non-int values
-//! - Null values used as array indices
-//! - User-defined function argument type checking gaps
-//! - The confusing "any" error message for null values
+//! These isolate components of the tic-tac-toe bug, where a list indexed by a
+//! null (or otherwise non-int) value used to slip past the checker and abort
+//! the VM with the confusing `type error: expected int, got any`. The subscript
+//! is now validated at compile time, so these are rejected with a clear
+//! diagnostic before they ever run.
 
 use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
 
 // ============================================================================
-// §1 — Array indexing with null produces "got any" instead of "got null"
+// §1 — A null array index is rejected at compile time (plain `[]`)
 // ============================================================================
 
-/// Direct reproduction: index an array with a null value.
-/// This should produce a type error, but the error message says "got any"
-/// instead of "got null".
+/// Previously this compiled and aborted the VM at runtime with the confusing
+/// `got any`. It is now a compile-time type mismatch (`got int | null`), so
+/// `baml_test!` fails compilation before execution.
 #[tokio::test]
-async fn array_index_with_null_says_got_any() {
-    let output = baml_test!(
+#[should_panic(expected = "type mismatch: expected int, got int | null")]
+async fn array_index_with_null_is_rejected_at_compile_time() {
+    let _ = baml_test!(
         r#"
         function main() -> string {
             let arr = ["a", "b", "c"];
@@ -26,12 +28,48 @@ async fn array_index_with_null_says_got_any() {
         }
     "#
     );
+}
 
-    let err = output.result.unwrap_err();
-    let msg = err.to_string();
-    // This is the current (confusing) behavior: "got any" instead of "got null"
+// ============================================================================
+// §2 — The optional index `?.[]` is null-safe in the *index* too
+// ============================================================================
+
+/// `?.[]` is the null-safe index operator, so a null subscript short-circuits
+/// the whole expression to null instead of aborting the VM (it used to crash
+/// with `got any`). The base guard and the index guard are symmetric.
+#[tokio::test]
+async fn optional_index_with_null_index_returns_null() {
+    let output = baml_test!(
+        r#"
+        function main() -> int? {
+            let arr: int[]? = [10, 20, 30];
+            let i: int? = null;
+            arr?.[i]
+        }
+    "#
+    );
     assert!(
-        msg.contains("type error"),
-        "expected a type error, got: {msg}"
+        matches!(output.result, Ok(BexExternalValue::Null)),
+        "expected null (not a crash), got: {:?}",
+        output.result
+    );
+}
+
+/// A valid (non-null) index through `?.[]` still returns the element.
+#[tokio::test]
+async fn optional_index_with_valid_index_returns_element() {
+    let output = baml_test!(
+        r#"
+        function main() -> int? {
+            let arr: int[]? = [10, 20, 30];
+            let i: int? = 1;
+            arr?.[i]
+        }
+    "#
+    );
+    assert!(
+        matches!(output.result, Ok(BexExternalValue::Int(20))),
+        "expected 20, got: {:?}",
+        output.result
     );
 }


### PR DESCRIPTION
## Summary

Fixes [B-236](https://linear.app/boundaryml2/issue/B-236): an empty `[]` in an if/else else-branch crashed the VM with `expected map, got array`. Investigating it surfaced a small family of related index/assignment soundness holes — all programs that compiled but aborted the VM at runtime. All are now caught at compile time (or made null-safe).

## Root causes & fixes

**1. Unannotated-local reassignment was unchecked (the B-236 crash).**
`let x = {}` gives `x` a (evolving) map type; reassigning `[]` (directly or via `if/else`) was silently accepted, so `x` stayed map-typed while holding an array at runtime → `as_map` abort. Reassignments to an unannotated local are now validated against the local's current flow type. An *empty evolving* container (`[]` / `{}`, element `never`) may still adopt a value of the **same kind** (`let a = []; a = [1,2,3]` keeps working), but cross-kind and unrelated-type reassignments are rejected. Generalizes to scalars (`int ← string`), classes, and nominal typing.

**2. Index key type was never validated.**
`list["s"]` and `map[0]` aborted the VM (`expected int, got string` / `expected string, got int`). A list / byte-array now requires an `int` subscript and a map its declared key type.

**3. Null subscript aborted the VM with a confusing `got any`.**
Plain `a[i]` with a nullable `i` is now a compile error (must narrow). The null-safe `a?.[i]` only guarded the *base*; it now also short-circuits to `null` on a null *index* (only when the index type is nullable), symmetric with the base guard. This keeps valid chains like `node?.children?.[node?.value]` working and makes `b?.items?.[b?.idx]` return `null` instead of crashing.

Net rule: `[]` requires a non-null, correctly-typed subscript; `?.[]` is fully null-safe.

## Tests
- TIR diagnostic tests for every rejected/accepted case (reassignment, index kind, nullable index) — written test-first.
- Runtime tests for `?.[]` null-safety (returns `null`, not a crash).
- Regenerated 10 LSP diagnostic fixtures that had encoded the missing diagnostics.
- Full workspace suite green (5887 passed), `baml_src` corpus green (1919), fmt + clippy clean.

## Files
- `crates/baml_compiler2_tir/src/builder.rs` — reassignment check + index-key validation
- `crates/baml_compiler2_mir/src/lower.rs` — null-safe index guard for `?.[]`
- `crates/baml_tests/...` — regression tests
- `crates/baml_lsp2_actions_tests/test_files/...` — regenerated goldens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexing type validation: list/byte-array indices must be non-null integers, and map indices must be non-null strings (including better handling of optional/nullable indices).
  * Fixed indexing/null-safety behavior so optional indexing correctly short-circuits to `null` when the index is null.
  * Strengthened reassignment checks for evolving locals to prevent incompatible container-kind changes and clearer type-mismatch enforcement.
  * Refined type-mismatch diagnostics for invalid assignments and indexing across arrays, maps, classes, and primitives.

* **Tests**
  * Expanded and updated LSP and compiler regression fixtures to cover these scenarios and expected diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->