### PR TITLE
fix(compiler2): test-body `let` locals lose their runtime type tag

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -2009,9 +2009,15 @@ fn synthesize_register_call(
 
             // Args: (name_expr, lambda, runner_or_null)
             let name_arg = lower_expr_body::lower_runner_element(ctx, name_element);
-            // Use a unique synthetic span for the lambda so the HIR scope builder
-            // can distinguish this lambda's scope from other synthesized lambdas.
-            let lambda_span = ctx.next_lambda_span();
+            // Use the test body's real CST range as the lambda's span so HIR
+            // scope lookup resolves names inside the body correctly. The body's
+            // statements carry real source offsets, so a synthetic span (disjoint
+            // from those offsets) would make `scope_at_offset` miss the lambda
+            // scope, and every `let`-bound local would fail to resolve (reading
+            // the local would fall back to a null placeholder). The range is
+            // unique per test block, so distinct lambda scopes stay
+            // distinguishable. Mirrors the testset collector lambda below.
+            let lambda_span = body_node.text_range();
             let lambda_arg = ctx.alloc_expr(Expr::Lambda(Box::new(lambda_def)), lambda_span);
             let runner_arg = lower_runner_element(runner_element.as_ref(), ctx, span);
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -249,35 +249,13 @@ pub(crate) fn lower_runner_element(
 /// directly into the same arena (no IIFE indirection needed).
 pub(crate) struct InitTestContext {
     inner: LoweringContext,
-    /// Counter for generating unique synthetic spans for lambda expressions.
-    /// Synthesized lambdas all share span `0..0`, which causes the HIR scope
-    /// builder and MIR lowering to confuse them. Each lambda gets a unique
-    /// synthetic span at offset `(counter * 2)..(counter * 2 + 1)` to make
-    /// them distinguishable.
-    synthetic_lambda_counter: u32,
 }
 
 impl InitTestContext {
     pub(crate) fn new() -> Self {
         let mut inner = LoweringContext::new();
         inner.names_in_scope.insert("registry".to_string());
-        Self {
-            inner,
-            synthetic_lambda_counter: 0,
-        }
-    }
-
-    /// Generate a unique synthetic span for a lambda expression.
-    /// Each call returns a different 1-byte span to ensure that HIR Lambda
-    /// scopes can be distinguished by their `range` field.
-    pub(crate) fn next_lambda_span(&mut self) -> text_size::TextRange {
-        let offset = self.synthetic_lambda_counter;
-        self.synthetic_lambda_counter += 1;
-        // Use offsets starting at 1 to avoid collision with the default 0..0 span
-        // used for the function itself and non-lambda expressions.
-        let start = text_size::TextSize::from((offset + 1) * 2);
-        let end = start + text_size::TextSize::from(1);
-        text_size::TextRange::new(start, end)
+        Self { inner }
     }
 
     pub(crate) fn alloc_expr(&mut self, expr: Expr, span: text_size::TextRange) -> ExprId {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__04_5_mir.snap
@@ -35,9 +35,13 @@ fn user.$init_test_main(registry: testing.TestCollector) -> null {
 fn .<lambda($init_test_main, 0)>() -> null {
     // Locals:
     let _0: null // _0 // return
+    let _1: int // x
+    let _2: int
 
     bb0: {
-        _0 = call const fn assert.equal(const null, const 3_i64) -> [bb1];
+        _1 = const 3_i64;
+        _2 = copy _1;
+        _0 = call const fn assert.equal(copy _2, const 3_i64) -> [bb1];
     }
 
     bb1: {
@@ -49,9 +53,13 @@ fn .<lambda($init_test_main, 0)>() -> null {
 fn .<lambda($init_test_main, 1)>() -> null {
     // Locals:
     let _0: null // _0 // return
+    let _1: string // result
+    let _2: string
 
     bb0: {
-        _0 = call const fn assert.not_null(const null) -> [bb1];
+        _1 = const "hello";
+        _2 = copy _1;
+        _0 = call const fn assert.not_null(copy _2) -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__04_5_mir.snap
@@ -28,9 +28,13 @@ fn user.$init_test_main(registry: testing.TestCollector) -> null {
 fn .<lambda($init_test_main, 0)>() -> null {
     // Locals:
     let _0: null // _0 // return
+    let _1: string // result
+    let _2: string
 
     bb0: {
-        _0 = call const fn assert.not_null(const null) -> [bb1];
+        _1 = const "hello";
+        _2 = copy _1;
+        _0 = call const fn assert.not_null(copy _2) -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/bex_engine/tests/collect_tests.rs
+++ b/baml_language/crates/bex_engine/tests/collect_tests.rs
@@ -822,3 +822,113 @@ async fn collect_tests_expand_nested_testsets_full_depth() {
     let final_ser = serialize_registry(&engine, registry).await;
     final_ser.expect("final serialize should succeed");
 }
+
+/// A `let`-bound local inside a `test` body must resolve to its binding so the
+/// value keeps its runtime type. Regression guard: the test-body lambda was once
+/// given a synthetic span disjoint from the body's real source offsets, so HIR
+/// offset-based name resolution never found the `let n` binding — `n` resolved to
+/// a null placeholder and `n + 1` crashed with
+/// `CannotApplyBinOp { left: Object(Any), right: Int, op: Add }`.
+#[tokio::test]
+async fn test_body_let_local_resolves_to_binding() {
+    let source = r#"
+        test "t" {
+            let n: int = 5;
+            assert.equal(n + 1, 6);
+            let r = "x";
+            assert.equal(r, "x");
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    let report = run_named_test(&engine, registry, "t")
+        .await
+        .expect("run_test should not crash on a let-bound local");
+    assert_outcome(&report, "pass");
+}
+
+/// Extract the `outcome` string from a `testing.TestReport` instance.
+fn report_outcome(report: &BexExternalValue) -> String {
+    let BexExternalValue::Instance { class_name, fields } = report else {
+        panic!("expected TestReport instance, got: {report:?}");
+    };
+    assert_eq!(class_name, "testing.TestReport");
+    match fields.get("outcome") {
+        Some(BexExternalValue::String(outcome)) => outcome.to_string(),
+        Some(BexExternalValue::Union { value, .. }) => match value.as_ref() {
+            BexExternalValue::String(outcome) => outcome.to_string(),
+            other => panic!("expected string outcome inside union, got: {other:?}"),
+        },
+        other => panic!("expected string outcome field, got: {other:?}"),
+    }
+}
+
+fn assert_outcome(report: &BexExternalValue, expected: &str) {
+    assert_eq!(report_outcome(report), expected, "unexpected test outcome");
+}
+
+/// Two `test` blocks may reuse the same `let` binding name without conflict —
+/// each test body lowers to its own lambda scope, so the bindings are isolated.
+#[tokio::test]
+async fn test_bodies_reuse_same_let_name_without_conflict() {
+    let source = r#"
+        test "a" { let x: int = 1; assert.equal(x, 1); }
+        test "b" { let x: int = 2; assert.equal(x, 2); }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    let a = run_named_test(&engine, registry.clone(), "a")
+        .await
+        .expect("run_test a should succeed");
+    assert_outcome(&a, "pass");
+
+    let b = run_named_test(&engine, registry, "b")
+        .await
+        .expect("run_test b should succeed");
+    assert_outcome(&b, "pass");
+}
+
+/// `let` resolution honors lexical scoping across a testset and its inner tests:
+/// a testset-level `let` is captured by inner tests, an inner `let` shadows the
+/// testset's binding of the same name, and a sibling test that does not shadow
+/// still sees the testset-level binding.
+#[tokio::test]
+async fn testset_let_capture_and_shadowing_resolve_correctly() {
+    let source = r#"
+        testset "s" {
+            let base: int = 10;
+            let v: string = "outer";
+            test "capture" { let x: int = base + 1; assert.equal(x, 11); }
+            test "shadow" { let v: string = "inner"; assert.equal(v, "inner"); }
+            test "ref_outer" { assert.equal(v, "outer"); }
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    // Inner tests are registered under full path names once the set is expanded.
+    expand_testset(&engine, registry.clone(), "s")
+        .await
+        .expect("expand_set should succeed");
+
+    for name in ["s/capture", "s/shadow", "s/ref_outer"] {
+        let report = run_named_test(&engine, registry.clone(), name)
+            .await
+            .unwrap_or_else(|e| panic!("run_test {name} should succeed: {e:?}"));
+        assert_outcome(&report, "pass");
+    }
+}


### PR DESCRIPTION
## Summary

Inside a `test "..." { ... }` body, every `let`-bound local silently failed to
resolve. The reference fell back to a `null` placeholder, so the value lost its
runtime type tag (boxed as `Object(Any)`). Any later use crashed the VM or
silently mis-compared — i.e. the most idiomatic test pattern
`let r = f(args); assert.equal(r, expected)` was broken.

### Broke before

```baml
test "t" { let n: int = 5; assert.equal(n + 1, 6); }
# FAIL ::t => CannotApplyBinOp { left: Object(Any), right: Int, op: Add }

test "t" { let r = "x"; assert.equal(r, "x") }
# FAIL — the let local boxed as Any never compares equal to the typed literal "x"
```

The buggy lowering is visible in the MIR — the `let` binding vanished and the
reference became `const null`:

```
fn .<lambda($init_test_main, 0)>() -> null {
    bb0: { _0 = call const fn assert.not_null(const null) -> [bb1]; }
}
```

### Works now

```baml
test "arith"           { let n: int = 5;            assert.equal(n + 1, 6); }          # PASS
test "eq_literal"      { let r = "x";               assert.equal(r, "x"); }            # PASS
test "method_dispatch" { let xs: int[] = [1,2,3];   assert.equal(xs.length(), 3); }    # PASS
test "pass_to_fn"      { let xs: int[] = [1,2,3];   assert.equal(takes_list(xs), 3); } # PASS
```

Corrected MIR — the local is bound and read with its real type:

```
fn .<lambda($init_test_main, 0)>() -> null {
    let _1: string // result
    let _2: string
    bb0: {
        _1 = const "hello";
        _2 = copy _1;
        _0 = call const fn assert.not_null(copy _2) -> [bb1];
    }
}
```

## Root cause

A `test` block lowers to a `registry.register_test(name, lambda, runner)` call
whose lambda body is the block. The lambda expression was allocated with a
unique **synthetic** 1-byte span (`next_lambda_span`), disjoint from the real
source offsets carried by the body's statements.

HIR registers the lambda's scope at that synthetic span, but name resolution
(`resolve_name_at_in_scope` → `scope_at_offset`) looks names up by their **real
offset**. So resolving a `let`-bound local inside the body never landed in the
lambda scope: the binding wasn't found, the reference fell back to a null
placeholder, and the local lost its runtime type tag.

The identical code in a normal function body or in a `testset` body worked,
because the testset collector lambda already uses the body's real CST range as
its span.

## Fix

Use the body block's real CST range as the test lambda's span — exactly as the
testset collector lambda does. The range is unique per test block, so distinct
lambda scopes stay distinguishable, and offset-based name resolution now finds
the body's locals. The now-unused `next_lambda_span` / `synthetic_lambda_counter`
are removed.

This was the only `Expr::Lambda` site with a span disjoint from its body; all
others (user lambdas, spawn bodies, nested test/testset register calls, testset
collectors) already use real ranges that contain their body offsets.

## Tests

- `test_body_let_local_resolves_to_binding` — the primary repro (arithmetic +
  equality-vs-literal).
- `test_bodies_reuse_same_let_name_without_conflict` — two tests reusing the
  same binding name stay isolated.
- `testset_let_capture_and_shadowing_resolve_correctly` — testset-level `let`
  captured by inner tests, inner `let` shadows the testset binding, and a
  non-shadowing sibling still sees the outer binding.
- Two MIR snapshots that had captured the buggy `assert(const null)` lowering
  are updated to the corrected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scope lookup and name resolution for local bindings within test blocks.

* **Tests**
  * Added integration test coverage for let binding resolution, variable scoping in tests and testsets, and proper shadowing behavior across test blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->