### PR TITLE
Disclose 'baml-' skill name prefix in `baml agent install` help and summary

### DIFF
--- a/baml_language/crates/baml_cli/src/agent_command.rs
+++ b/baml_language/crates/baml_cli/src/agent_command.rs
@@ -28,7 +28,16 @@ pub(crate) enum AgentCommand {
     Install(AgentInstallArgs),
 }
 
+/// Install or refresh the latest BAML agent skills in this project.
+///
+/// On install, each skill's `name:` frontmatter field is prefixed with `baml-`
+/// (so upstream `core` is installed as `baml-core`). This namespaces the skills
+/// to avoid collisions in the agent skill registry, and is the only difference
+/// from the upstream skill files.
 #[derive(Args, Clone, Debug)]
+#[command(
+    after_long_help = "Note: skill names are prefixed with 'baml-' on install to avoid registry collisions (e.g. upstream 'core' becomes 'baml-core')."
+)]
 pub(crate) struct AgentInstallArgs {
     /// Directory where project-local agent skills should be installed.
     ///
@@ -577,12 +586,47 @@ fn write_atomic(path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
-fn print_success(root: &Path) -> Result<()> {
-    writeln!(
-        std::io::stdout(),
-        "Installed BAML agent skills in {}\n\nClaude Code:\n  .claude/skills/baml-*/SKILL.md\n\nCodex / OpenCode:\n  .agents/skills/baml-*/SKILL.md\n\nRestart any already-running agent session to pick them up.",
+/// Print the post-install summary to stdout.
+///
+/// Lists the destination paths for the installed skills and discloses that
+/// skill names are prefixed with `baml-` to avoid registry collisions, so the
+/// difference from upstream skill files is documented rather than silent.
+///
+/// # Parameters
+/// - `root`: the project root the skills were installed under.
+///
+/// # Errors
+/// Returns an error if writing to stdout fails.
+/// Build the post-install summary text shown after a successful install.
+///
+/// The message lists the destination glob paths and discloses the `baml-`
+/// name-prefix transformation so it is documented rather than silent.
+///
+/// # Parameters
+/// - `root`: the project root the skills were installed under.
+///
+/// # Returns
+/// The summary string (without a trailing newline).
+fn success_message(root: &Path) -> String {
+    format!(
+        "Installed BAML agent skills in {}\n\nClaude Code:\n  .claude/skills/baml-*/SKILL.md\n\nCodex / OpenCode:\n  .agents/skills/baml-*/SKILL.md\n\nNote: skill names are prefixed with 'baml-' on install to avoid registry collisions (e.g. upstream 'core' becomes 'baml-core').\n\nRestart any already-running agent session to pick them up.",
         root.display()
-    )?;
+    )
+}
+
+/// Print the post-install summary to stdout.
+///
+/// Lists the destination paths for the installed skills and discloses that
+/// skill names are prefixed with `baml-` to avoid registry collisions, so the
+/// difference from upstream skill files is documented rather than silent.
+///
+/// # Parameters
+/// - `root`: the project root the skills were installed under.
+///
+/// # Errors
+/// Returns an error if writing to stdout fails.
+fn print_success(root: &Path) -> Result<()> {
+    writeln!(std::io::stdout(), "{}", success_message(root))?;
     Ok(())
 }
 
@@ -782,6 +826,18 @@ mod tests {
         std::env::set_current_dir(old).unwrap();
 
         assert_eq!(root, explicit.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn success_message_discloses_baml_name_prefix() {
+        let message = success_message(Path::new("/tmp/project"));
+        assert!(
+            message.contains(
+                "skill names are prefixed with 'baml-' on install to avoid registry collisions"
+            ),
+            "{message}"
+        );
+        assert!(message.contains("Installed BAML agent skills in /tmp/project"));
     }
 
     fn skill(name: &str) -> String {

--- a/baml_language/crates/baml_cli/src/agent_command.rs
+++ b/baml_language/crates/baml_cli/src/agent_command.rs
@@ -586,17 +586,6 @@ fn write_atomic(path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
-/// Print the post-install summary to stdout.
-///
-/// Lists the destination paths for the installed skills and discloses that
-/// skill names are prefixed with `baml-` to avoid registry collisions, so the
-/// difference from upstream skill files is documented rather than silent.
-///
-/// # Parameters
-/// - `root`: the project root the skills were installed under.
-///
-/// # Errors
-/// Returns an error if writing to stdout fails.
 /// Build the post-install summary text shown after a successful install.
 ///
 /// The message lists the destination glob paths and discloses the `baml-`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
Fixes the undocumented `baml-` name-prefix transformation applied by `baml agent install`.

## The error

`baml agent install` (and `--latest` / `--from`) silently rewrites every installed skill's `name:` frontmatter field, prefixing it with `baml-`. This is the *only* content difference between an installed skill and its upstream source, yet nothing in the CLI disclosed it.

Reproduction (legacy `plugins/baml/skills/<name>/SKILL.md` layout, the same shape `BoundaryML/baml-skill` ships):

```
$ cat upstream/plugins/baml/skills/core/SKILL.md
---
name: core
description: Core skill.
---
# core

$ baml agent install --from ./upstream
Installed BAML agent skills in /tmp/repro/proj

Claude Code:
  .claude/skills/baml-*/SKILL.md

Codex / OpenCode:
  .agents/skills/baml-*/SKILL.md

Restart any already-running agent session to pick them up.

$ cat .claude/skills/baml-core/SKILL.md
---
name: baml-core      # <-- silently changed from `core`
description: Core skill.
---
# core
```

Diff against upstream:

```
2c2
< name: core
---
> name: baml-core
```

`baml agent install --help` made no mention of the prefix, and the install summary output listed destination paths but never noted the transformation — so anyone diffing installed skills against upstream had to investigate the `name:` diff before discovering it was an intentional, harmless namespace prefix.

## Root cause

The prefix is applied intentionally in `baml_language/crates/baml_cli/src/agent_command.rs`:

- `skill_archive_path()` maps the legacy `plugins/baml/skills/<name>/SKILL.md` layout to `SkillArchivePath::Legacy { name: format!("baml-{legacy_name}") }`.
- `normalize_skills()` → `normalize_legacy_skill_content()` → `replace_frontmatter_name()` then rewrites the frontmatter `name:` to the `baml-`-prefixed value.

The behavior is correct (it namespaces skills to avoid registry collisions). The gap was purely disclosure: neither `AgentInstallArgs` help text nor `print_success()` mentioned it.

## The fix

Documentation-only change, scoped to `agent_command.rs`:

- Added a doc comment to `AgentInstallArgs` (surfaced as `--help` long help) explaining that each skill's `name:` is prefixed with `baml-` (e.g. `core` → `baml-core`) and that this is the only difference from upstream files.
- Added `after_long_help` to the command with the concise note: `Note: skill names are prefixed with 'baml-' on install to avoid registry collisions (e.g. upstream 'core' becomes 'baml-core').`
- Added the same note to the install summary output by extracting a documented `success_message()` helper (used by `print_success()`), so the disclosure appears after every install.
- Added a unit test (`success_message_discloses_baml_name_prefix`) asserting the disclosure is present.

No functional behavior changed — the prefix is still applied exactly as before; it is now documented in `--help` and in the install summary.

> Note: the issue also suggests a one-line note in the upstream `BoundaryML/baml-skill` README. That lives in a separate repository and is out of scope for this `baml_language/` change; only the CLI disclosure is addressed here.

## Verification

Commands run from `baml_language/`:

```
$ baml-cli agent install --help
Install or refresh the latest BAML agent skills in this project.

On install, each skill's `name:` frontmatter field is prefixed with `baml-` (so upstream `core` is installed as `baml-core`). This namespaces the skills to avoid collisions in the agent skill registry, and is the only difference from the upstream skill files.

Usage: baml agent install [OPTIONS]
...
Note: skill names are prefixed with 'baml-' on install to avoid registry collisions (e.g. upstream 'core' becomes 'baml-core').

$ baml-cli agent install --from ./upstream
Installed BAML agent skills in /tmp/repro/proj

Claude Code:
  .claude/skills/baml-*/SKILL.md

Codex / OpenCode:
  .agents/skills/baml-*/SKILL.md

Note: skill names are prefixed with 'baml-' on install to avoid registry collisions (e.g. upstream 'core' becomes 'baml-core').

Restart any already-running agent session to pick them up.
```

CI gates run locally from `baml_language/`:

- `cargo test -p baml_cli agent` — 12 passed, incl. the new `success_message_discloses_baml_name_prefix`.
- `cargo test --workspace` — all 192 test-result blocks passed. The only failures were `sdk_test_python_pydantic2` / `sdk_test_typescript_node` harness tests, which require the `uv` Python tool that is not installed in this environment (`failed to spawn 'uv run ...': No such file or directory`); these are environmental and unrelated to this doc-only change. Re-running with those packages excluded passed cleanly (exit 0, 0 failures).
- No insta snapshot tests failed.
- `cargo fmt --all` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean across the workspace.

CodeRabbit: `CODERABBIT_API_KEY` was not present in this environment, so `coderabbit auth login` / `coderabbit review` could not authenticate or run. Per the task guidance I'm noting this explicitly and proceeding; I did do a manual self-review of the diff and removed a duplicated docstring that the first refactor pass left above the `success_message` helper.

## PR Checklist
- [x] Unit test added (`success_message_discloses_baml_name_prefix`)
- [x] Self-review performed
- [x] Documentation updated (CLI `--help` + install summary)
- [x] No new warnings (clippy `-D warnings` clean)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2c39bbe-99b6-49ae-9000-56cce402eee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2c39bbe-99b6-49ae-9000-56cce402eee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the `install` command's help text with documentation about the `baml-` prefix applied to skill names.
  * Updated post-install success message to explicitly display how installed skill names are transformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->