### PR TITLE
fix(cli): avoid rewriting unchanged BAML agent skills

### DIFF
--- a/baml_language/crates/baml_cli/src/agent_command.rs
+++ b/baml_language/crates/baml_cli/src/agent_command.rs
@@ -482,6 +482,14 @@ fn install_skills_to(root: &Path, relative_skills_dir: PathBuf, skills: &[Skill]
     fs::create_dir_all(&skills_dir)
         .with_context(|| format!("failed to create {}", skills_dir.display()))?;
 
+    let skills_to_install = skills
+        .iter()
+        .filter(|skill| skill_needs_install(&skills_dir, skill))
+        .collect::<Result<Vec<_>>>()?;
+    if skills_to_install.is_empty() {
+        return Ok(());
+    }
+
     let tmp_dir = skills_dir.join(format!(".baml-agent-install-{}", std::process::id()));
     if tmp_dir.exists() {
         fs::remove_dir_all(&tmp_dir)
@@ -491,14 +499,14 @@ fn install_skills_to(root: &Path, relative_skills_dir: PathBuf, skills: &[Skill]
         .with_context(|| format!("failed to create {}", tmp_dir.display()))?;
 
     let result = (|| -> Result<()> {
-        for skill in skills {
+        for skill in &skills_to_install {
             let skill_dir = tmp_dir.join(&skill.name);
             fs::create_dir_all(&skill_dir)
                 .with_context(|| format!("failed to create {}", skill_dir.display()))?;
             write_atomic(&skill_dir.join("SKILL.md"), &skill.content)?;
         }
 
-        for skill in skills {
+        for skill in &skills_to_install {
             replace_skill_dir(&skills_dir, &tmp_dir, skill)?;
         }
         Ok(())
@@ -511,6 +519,15 @@ fn install_skills_to(root: &Path, relative_skills_dir: PathBuf, skills: &[Skill]
             Err(err).context("failed to clean up temporary BAML agent skill directory")
         }
         (Ok(()), _) => Ok(()),
+    }
+}
+
+fn skill_needs_install(skills_dir: &Path, skill: &Skill) -> Result<bool> {
+    let path = skills_dir.join(&skill.name).join("SKILL.md");
+    match fs::read_to_string(&path) {
+        Ok(existing) => Ok(existing != skill.content),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(err) => Err(err).with_context(|| format!("failed to read {}", path.display())),
     }
 }
 
@@ -827,6 +844,47 @@ mod tests {
             "{message}"
         );
         assert!(message.contains("Installed BAML agent skills in /tmp/project"));
+    }
+
+    #[test]
+    fn reinstall_does_not_replace_unchanged_skill_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let skills = vec![Skill {
+            name: "baml-core".to_string(),
+            content: skill("baml-core"),
+        }];
+
+        install_skills(root, &skills).unwrap();
+        let sidecar = root.join(".agents/skills/baml-core/extra.txt");
+        fs::write(&sidecar, "keep").unwrap();
+
+        install_skills(root, &skills).unwrap();
+
+        assert_eq!(fs::read_to_string(&sidecar).unwrap(), "keep");
+    }
+
+    #[test]
+    fn install_reports_existing_skill_read_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let skill_path = root.join(".agents/skills/baml-core/SKILL.md");
+        fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+        fs::write(&skill_path, &[0xff, 0xfe]).unwrap();
+
+        let err = format!(
+            "{:#}",
+            install_skills(
+                root,
+                &[Skill {
+                    name: "baml-core".to_string(),
+                    content: skill("baml-core"),
+                }]
+            )
+            .unwrap_err()
+        );
+        assert!(err.contains("failed to read"), "{err}");
+        assert!(err.contains(".agents/skills/baml-core/SKILL.md"), "{err}");
     }
 
     fn skill(name: &str) -> String {

--- a/baml_language/crates/baml_cli/src/agent_command.rs
+++ b/baml_language/crates/baml_cli/src/agent_command.rs
@@ -482,10 +482,12 @@ fn install_skills_to(root: &Path, relative_skills_dir: PathBuf, skills: &[Skill]
     fs::create_dir_all(&skills_dir)
         .with_context(|| format!("failed to create {}", skills_dir.display()))?;
 
-    let skills_to_install = skills
-        .iter()
-        .filter(|skill| skill_needs_install(&skills_dir, skill))
-        .collect::<Result<Vec<_>>>()?;
+    let mut skills_to_install = Vec::new();
+    for skill in skills {
+        if skill_needs_install(&skills_dir, skill)? {
+            skills_to_install.push(skill);
+        }
+    }
     if skills_to_install.is_empty() {
         return Ok(());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

- only rewrites `baml-*` skill directories when `SKILL.md` content differs
- preserves unchanged installed skill directories (including sidecar files) across re-installs
- surfaces non-`NotFound` read errors when inspecting existing installed `SKILL.md`
- adds unit tests for unchanged-directory preservation and read-error reporting

## Testing
Please describe how you tested these changes

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in local linux dev environment

Commands run:
- `cargo run -p baml_cli --bin baml-cli -- agent install --dir /tmp/baml-agent-install-smoke`
- `BAML_HOME=/tmp/baml-home-test cargo run -p baml --bin baml -- toolchain use canary`
- `BAML_HOME=/tmp/baml-home-test cargo run -p baml --bin baml -- agent install --dir /tmp/baml-agent-install-wrapper-smoke`
- `cargo test -p baml_cli agent_command -- --nocapture`
- `cargo test --lib` *(fails in this environment when linking `bridge_nodejs` tests due missing Node-API symbols)*
- reinstall preservation smoke:
  - install skills
  - create `.agents/skills/baml-core/extra.txt`
  - reinstall skills
  - verify sidecar file remains

## Screenshots
If applicable, add screenshots to help explain your changes

N/A

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

`cargo test --lib` reaches this change successfully and only fails later in unrelated `bridge_nodejs` linking due environment-level Node-API library availability.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1781802432639359?thread_ts=1781802432.639359&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-9bf4264a-4d58-574f-93ea-645ec790d27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bf4264a-4d58-574f-93ea-645ec790d27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

