### PR TITLE
fix(bex_str): correct SWAR continuation-byte mask in codepoint indexing

### DIFF
--- a/baml_language/crates/bex_str/src/bex_str.rs
+++ b/baml_language/crates/bex_str/src/bex_str.rs
@@ -623,7 +623,13 @@ fn byte_offset_of_nth_codepoint(bytes: &[u8], n: usize) -> usize {
         let word = u64::from_ne_bytes(bytes[i..i + 8].try_into().unwrap());
         let hi = word & 0x8080_8080_8080_8080;
         let lo = word & 0x4040_4040_4040_4040;
-        let cont_mask = hi & !lo;
+        // A continuation byte is `10xxxxxx`: bit 7 set, bit 6 clear. We read
+        // only bit 7 below (`>> 7`), so the bit-6 information has to be shifted
+        // up into the bit-7 lane — `!(lo << 1)` clears bit 7 for multibyte
+        // *leading* bytes (`11xxxxxx`), leaving only true continuations.
+        // (`hi & !lo` left bit 7 untouched, counting every multibyte lead as a
+        // continuation and undercounting codepoint starts by one per char.)
+        let cont_mask = hi & !(lo << 1);
         let num_leading = 8 - (cont_mask >> 7).count_ones() as usize;
 
         if remaining <= num_leading {

--- a/baml_language/crates/bex_str/src/tests.rs
+++ b/baml_language/crates/bex_str/src/tests.rs
@@ -301,3 +301,63 @@ fn shared_concat_grandchild_survives_flatten() {
     assert_eq!(mid.as_str(), format!("{expected_leaf}|mid"));
     assert_eq!(leaf.as_str(), expected_leaf);
 }
+
+// ── Codepoint-indexed ops vs the std oracle ────────────────────────────
+//
+// `byte_offset_of_nth_codepoint` walks the bytes 8 at a time (SWAR). The fast
+// path is only exercised by strings with a full 8-byte word that *contains* a
+// multibyte char AND a target index past that word — short ASCII fixtures stay
+// in the scalar tail and never hit it. These cases all clear that bar, so they
+// pin `char_at` / `substring` against `str::chars()`, which is correct by
+// construction for valid UTF-8.
+#[test]
+fn codepoint_ops_match_std_oracle() {
+    // The std reference: the byte range of codepoints `[a, b)`, with the same
+    // clamping `substring_by_char` documents.
+    fn expected_substring(s: &str, a: usize, b: usize) -> String {
+        let chars: Vec<char> = s.chars().collect();
+        let len = chars.len();
+        let a = a.min(len);
+        let b = b.min(len).max(a);
+        chars[a..b].iter().collect()
+    }
+
+    let cases = [
+        // The dogfood repro: `é` (C3 A9) sits inside the first 8-byte word, and
+        // every index from 4 on lands past it. `char_at(10)` returned "b", and
+        // `char_at(15)` (in bounds!) panicked OOB before the fix.
+        "0123é56789abcdef",
+        "abcdefghé0123456789",       // multibyte just after the first full word
+        "配信サービスxyz0123456789", // 3-byte CJK spanning word boundaries
+        "🪙abcdefghijklmnop",        // 4-byte leading codepoint
+        "aé bé cé dé eé fé gé hé",   // many 2-byte chars across many words
+        // Long enough to be a Flat (not Inline), mixed scripts.
+        "mixed_файлов_مرحبا_🪙_padding_to_force_a_flat_allocation_here!!",
+    ];
+
+    for s in cases {
+        let bex = BexStr::from(s);
+        let count = s.chars().count();
+        assert_eq!(bex.char_count(), count, "char_count for {s:?}");
+
+        // char_at over every index, including the last (the OOB-panic boundary)
+        // and one past the end (must be None).
+        for n in 0..=count {
+            let got = bex.char_at_codepoint(n).map(|c| c.as_str().to_owned());
+            let want = s.chars().nth(n).map(|c| c.to_string());
+            assert_eq!(got, want, "char_at({n}) for {s:?}");
+        }
+
+        // substring over every codepoint range, plus past-the-end clamps.
+        for a in 0..=count + 1 {
+            for b in a..=count + 1 {
+                let got = bex.substring_by_char(a, b);
+                assert_eq!(
+                    got.as_str(),
+                    expected_substring(s, a, b),
+                    "substring_by_char({a}, {b}) for {s:?}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

`BexStr::char_at` / `substring` (codepoint-indexed) returned the **wrong codepoint** on real-world unicode strings, and panicked out-of-bounds on a valid in-range index — which **SIGABRTs the host process** through the SDKs under `panic = "abort"`. Found via the bridge dogfood (config-migrator), which had to rewrite its YAML parser to byte-level ops to dodge it.

## Root cause

`byte_offset_of_nth_codepoint` (`crates/bex_str/src/bex_str.rs`) walks the bytes 8 at a time (SWAR) and counts codepoint-start bytes by masking off continuation bytes (`10xxxxxx` = bit 7 set, bit 6 clear):

```rust
let hi = word & 0x8080_8080_8080_8080;   // bit 7 per byte
let lo = word & 0x4040_4040_4040_4040;   // bit 6 per byte
let cont_mask = hi & !lo;                 // BUG
let num_leading = 8 - (cont_mask >> 7).count_ones();
```

The count reads only **bit 7** of each lane (`>> 7`), but `!lo` only ever clears **bit 6** — so at bit 7 the `& !lo` is a no-op and `cont_mask>>7 == hi>>7`. Every high-bit byte (continuations **and** multibyte leading bytes) was counted as a continuation, undercounting codepoint starts by one per multibyte char per fully-SWAR'd word. The scalar tail uses the correct predicate `(b & 0xC0) != 0x80`, so short ASCII fixtures never hit it — it only triggers when a multibyte char sits inside a complete 8-byte word and the index is past it.

## Fix

```rust
let cont_mask = hi & !(lo << 1);
```

`lo << 1` shifts bit 6 into the bit-7 lane, so `!(lo << 1)` clears bit 7 exactly for multibyte leads, leaving only true continuations under the `>> 7` popcount. This is the standard "count bytes where `(b & 0xC0) != 0x80`" UTF-8 identity, now matching the function's own scalar tail.

## Test

`codepoint_ops_match_std_oracle` brute-forces `char_at` and `substring_by_char` against `str::chars()` for every index/range over six multibyte strings (≥16 bytes, multibyte chars inside full SWAR words). Red before the fix, green after; full bex_str suite (27 tests) passes.

For `"0123é56789abcdef"`:

| repro | before | after |
|---|---|---|
| `char_at(10)` | `"b"` (silent wrong) | `"a"` |
| `substring(9,12)` | `"abc"` (silent wrong) | `"89a"` |
| `char_at(15)` | panic → host SIGABRT | `"f"` |

## Out of scope

The Python release wheel still inherits `panic = "abort"` instead of the `release-bridge-python` (unwind) profile that the Node addon already uses — so engine panics can still abort the interpreter rather than surface as a catchable `BamlPanic`. Tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of character-indexed text operations for multi-byte Unicode characters.

* **Tests**
  * Added comprehensive test coverage validating character operations against standard library behavior across various UTF-8 strings and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->