### PR TITLE
Allow `baml run -e` leading-hyphen expressions via clap parsing

### DIFF
--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -111,12 +111,24 @@ pub(crate) enum Commands {
 }
 
 impl RuntimeCli {
-    /// Parse CLI arguments, unhiding all subcommands if the BAML_INTERNAL environment variable is set.
+    /// Parse CLI arguments and optionally unhide internal subcommands.
+    ///
+    /// Parameters:
+    /// - `argv`: Raw process argument vector (`argv[0]` program name followed by CLI tokens).
+    ///
+    /// Returns:
+    /// - A fully parsed [`RuntimeCli`] value.
+    ///
+    /// Errors/Panics:
+    /// - Does not return recoverable errors. On parse failures this calls clap's
+    ///   `err.exit()` and terminates the process, matching normal CLI behavior.
+    /// - Does not panic.
     ///
     /// This should be used for CLI invocations instead of `RuntimeCli::parse_from`.
     pub fn parse_from_smart(argv: Vec<String>) -> Self {
         use clap::FromArgMatches;
 
+        let argv = normalize_run_expression_argv(argv);
         let mut command = RuntimeCli::command();
 
         if baml_internal_env_is_truthy() {
@@ -179,6 +191,115 @@ impl RuntimeCli {
             Commands::Format(args) => args.run(),
         }
     }
+}
+
+/// Rewrite `baml run -e` argv so the expression consumes the remaining tail.
+///
+/// Parameters:
+/// - `argv`: Raw process argument vector.
+///
+/// Returns:
+/// - A normalized argument vector where `run -e ...` / `run --expression ...`
+///   becomes a single `--expression=<joined expression>` token and everything
+///   after the expression flag is treated as expression source text.
+///
+/// Errors/Panics:
+/// - Does not return errors.
+/// - Does not panic.
+fn normalize_run_expression_argv(argv: Vec<String>) -> Vec<String> {
+    let Some(run_index) = find_run_subcommand_index(&argv) else {
+        return argv;
+    };
+    let run_args = &argv[run_index + 1..];
+    let Some((flag_offset, expression_parts)) = extract_run_expression_parts(run_args) else {
+        return argv;
+    };
+
+    if expression_parts.is_empty() {
+        return argv;
+    }
+
+    let expression = expression_parts.join(" ");
+    let expression_flag_index = run_index + 1 + flag_offset;
+    let mut normalized = argv[..expression_flag_index].to_vec();
+    normalized.push(format!("--expression={expression}"));
+    normalized
+}
+
+/// Find the `run` subcommand index while honoring top-level global flags.
+///
+/// Parameters:
+/// - `argv`: Raw process argument vector.
+///
+/// Returns:
+/// - `Some(index)` when the command resolves to `run`, else `None`.
+///
+/// Errors/Panics:
+/// - Does not return errors.
+/// - Does not panic.
+fn find_run_subcommand_index(argv: &[String]) -> Option<usize> {
+    let mut i = 1;
+    while i < argv.len() {
+        let token = argv[i].as_str();
+        if token == "run" {
+            return Some(i);
+        }
+        if token == "--features" {
+            i += 2;
+            continue;
+        }
+        if token.starts_with("--features=") {
+            i += 1;
+            continue;
+        }
+        if token.starts_with('-') {
+            i += 1;
+            continue;
+        }
+        return None;
+    }
+    None
+}
+
+/// Extract expression tokens for `run -e` / `run --expression` forms.
+///
+/// Parameters:
+/// - `run_args`: Tokens after the `run` subcommand.
+///
+/// Returns:
+/// - `Some((flag_offset, parts))` where `flag_offset` is the expression flag's
+///   position within `run_args` and `parts` is the expression token list after
+///   removing a leading compatibility `--` separator.
+/// - `None` when no expression flag is present.
+///
+/// Errors/Panics:
+/// - Does not return errors.
+/// - Does not panic.
+fn extract_run_expression_parts(run_args: &[String]) -> Option<(usize, Vec<String>)> {
+    let mut i = 0;
+    while i < run_args.len() {
+        let token = run_args[i].as_str();
+        let mut parts = if token == "-e" || token == "--expression" {
+            run_args[i + 1..].to_vec()
+        } else if let Some(value) = token.strip_prefix("--expression=") {
+            let mut parts = vec![value.to_string()];
+            parts.extend_from_slice(&run_args[i + 1..]);
+            parts
+        } else if token.starts_with("-e") && token != "-e" {
+            let mut parts = vec![token[2..].to_string()];
+            parts.extend_from_slice(&run_args[i + 1..]);
+            parts
+        } else {
+            i += 1;
+            continue;
+        };
+
+        if parts.first().is_some_and(|value| value == "--") {
+            parts.remove(0);
+        }
+        return Some((i, parts));
+    }
+    None
 }
 
 fn baml_internal_env_is_truthy() -> bool {
@@ -249,5 +370,40 @@ mod tests {
             help.contains("Project root to check. Defaults to the current directory"),
             "{help}"
         );
+    }
+
+    /// `run -e` should consume all remaining tokens as expression source.
+    #[test]
+    fn run_expression_consumes_remaining_tokens() {
+        let cli = RuntimeCli::parse_from_smart(vec![
+            "baml-cli".into(),
+            "run".into(),
+            "-e".into(),
+            "-7".into(),
+            "%".into(),
+            "3".into(),
+        ]);
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+        assert_eq!(args.expression.as_deref(), Some("-7 % 3"));
+    }
+
+    /// Legacy `-e -- ...` still works after expression-tail normalization.
+    #[test]
+    fn run_expression_compat_separator_is_ignored() {
+        let cli = RuntimeCli::parse_from_smart(vec![
+            "baml-cli".into(),
+            "run".into(),
+            "-e".into(),
+            "--".into(),
+            "-7".into(),
+            "%".into(),
+            "3".into(),
+        ]);
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+        assert_eq!(args.expression.as_deref(), Some("-7 % 3"));
     }
 }

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -128,7 +128,6 @@ impl RuntimeCli {
     pub fn parse_from_smart(argv: Vec<String>) -> Self {
         use clap::FromArgMatches;
 
-        let argv = normalize_run_expression_argv(argv);
         let mut command = RuntimeCli::command();
 
         if baml_internal_env_is_truthy() {
@@ -191,105 +190,6 @@ impl RuntimeCli {
             Commands::Format(args) => args.run(),
         }
     }
-}
-
-/// Rewrite legacy `baml run -e -- ...` argv into a single expression value.
-///
-/// Parameters:
-/// - `argv`: Raw process argument vector.
-///
-/// Returns:
-/// - A normalized argument vector when the compatibility separator form is
-///   used (`run -e -- ...` or `run --expression -- ...`), where the expression
-///   tail becomes `--expression=<joined expression>`.
-/// - The original argument vector for all other forms.
-///
-/// Errors/Panics:
-/// - Does not return errors.
-/// - Does not panic.
-fn normalize_run_expression_argv(argv: Vec<String>) -> Vec<String> {
-    let Some(run_index) = find_run_subcommand_index(&argv) else {
-        return argv;
-    };
-    let run_args = &argv[run_index + 1..];
-    let Some((flag_offset, expression_parts)) = extract_run_expression_compat_parts(run_args)
-    else {
-        return argv;
-    };
-
-    if expression_parts.is_empty() {
-        return argv;
-    }
-
-    let expression = expression_parts.join(" ");
-    let expression_flag_index = run_index + 1 + flag_offset;
-    let mut normalized = argv[..expression_flag_index].to_vec();
-    normalized.push(format!("--expression={expression}"));
-    normalized
-}
-
-/// Find the `run` subcommand index while honoring top-level global flags.
-///
-/// Parameters:
-/// - `argv`: Raw process argument vector.
-///
-/// Returns:
-/// - `Some(index)` when the command resolves to `run`, else `None`.
-///
-/// Errors/Panics:
-/// - Does not return errors.
-/// - Does not panic.
-fn find_run_subcommand_index(argv: &[String]) -> Option<usize> {
-    let mut i = 1;
-    while i < argv.len() {
-        let token = argv[i].as_str();
-        if token == "run" {
-            return Some(i);
-        }
-        if token == "--features" {
-            i += 2;
-            continue;
-        }
-        if token.starts_with("--features=") {
-            i += 1;
-            continue;
-        }
-        if token.starts_with('-') {
-            i += 1;
-            continue;
-        }
-        return None;
-    }
-    None
-}
-
-/// Extract expression tokens for the compatibility `run -e -- ...` form.
-///
-/// Parameters:
-/// - `run_args`: Tokens after the `run` subcommand.
-///
-/// Returns:
-/// - `Some((flag_offset, parts))` where `flag_offset` is the expression flag's
-///   position within `run_args` and `parts` is the expression token list after
-///   the compatibility `--` separator.
-/// - `None` when no compatibility separator form is present.
-///
-/// Errors/Panics:
-/// - Does not return errors.
-/// - Does not panic.
-fn extract_run_expression_compat_parts(run_args: &[String]) -> Option<(usize, Vec<String>)> {
-    let mut i = 0;
-    while i < run_args.len() {
-        let token = run_args[i].as_str();
-        if token == "-e" || token == "--expression" {
-            if run_args.get(i + 1).is_some_and(|next| next == "--") {
-                return Some((i, run_args[i + 2..].to_vec()));
-            }
-            return None;
-        }
-        i += 1;
-    }
-    None
 }
 
 fn baml_internal_env_is_truthy() -> bool {
@@ -378,23 +278,5 @@ mod tests {
         };
         assert_eq!(args.expression.as_deref(), Some("-7 % 3"));
         assert_eq!(args.from, std::path::PathBuf::from("project"));
-    }
-
-    /// Legacy `-e -- ...` still works after expression-tail normalization.
-    #[test]
-    fn run_expression_compat_separator_is_ignored() {
-        let cli = RuntimeCli::parse_from_smart(vec![
-            "baml-cli".into(),
-            "run".into(),
-            "-e".into(),
-            "--".into(),
-            "-7".into(),
-            "%".into(),
-            "3".into(),
-        ]);
-        let Commands::Run(args) = cli.command else {
-            panic!("expected run command");
-        };
-        assert_eq!(args.expression.as_deref(), Some("-7 % 3"));
     }
 }

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -193,15 +193,16 @@ impl RuntimeCli {
     }
 }
 
-/// Rewrite `baml run -e` argv so the expression consumes the remaining tail.
+/// Rewrite legacy `baml run -e -- ...` argv into a single expression value.
 ///
 /// Parameters:
 /// - `argv`: Raw process argument vector.
 ///
 /// Returns:
-/// - A normalized argument vector where `run -e ...` / `run --expression ...`
-///   becomes a single `--expression=<joined expression>` token and everything
-///   after the expression flag is treated as expression source text.
+/// - A normalized argument vector when the compatibility separator form is
+///   used (`run -e -- ...` or `run --expression -- ...`), where the expression
+///   tail becomes `--expression=<joined expression>`.
+/// - The original argument vector for all other forms.
 ///
 /// Errors/Panics:
 /// - Does not return errors.
@@ -211,7 +212,8 @@ fn normalize_run_expression_argv(argv: Vec<String>) -> Vec<String> {
         return argv;
     };
     let run_args = &argv[run_index + 1..];
-    let Some((flag_offset, expression_parts)) = extract_run_expression_parts(run_args) else {
+    let Some((flag_offset, expression_parts)) = extract_run_expression_compat_parts(run_args)
+    else {
         return argv;
     };
 
@@ -261,7 +263,7 @@ fn find_run_subcommand_index(argv: &[String]) -> Option<usize> {
     None
 }
 
-/// Extract expression tokens for `run -e` / `run --expression` forms.
+/// Extract expression tokens for the compatibility `run -e -- ...` form.
 ///
 /// Parameters:
 /// - `run_args`: Tokens after the `run` subcommand.
@@ -269,35 +271,23 @@ fn find_run_subcommand_index(argv: &[String]) -> Option<usize> {
 /// Returns:
 /// - `Some((flag_offset, parts))` where `flag_offset` is the expression flag's
 ///   position within `run_args` and `parts` is the expression token list after
-///   removing a leading compatibility `--` separator.
-/// - `None` when no expression flag is present.
+///   the compatibility `--` separator.
+/// - `None` when no compatibility separator form is present.
 ///
 /// Errors/Panics:
 /// - Does not return errors.
 /// - Does not panic.
-fn extract_run_expression_parts(run_args: &[String]) -> Option<(usize, Vec<String>)> {
+fn extract_run_expression_compat_parts(run_args: &[String]) -> Option<(usize, Vec<String>)> {
     let mut i = 0;
     while i < run_args.len() {
         let token = run_args[i].as_str();
-        let mut parts = if token == "-e" || token == "--expression" {
-            run_args[i + 1..].to_vec()
-        } else if let Some(value) = token.strip_prefix("--expression=") {
-            let mut parts = vec![value.to_string()];
-            parts.extend_from_slice(&run_args[i + 1..]);
-            parts
-        } else if token.starts_with("-e") && token != "-e" {
-            let mut parts = vec![token[2..].to_string()];
-            parts.extend_from_slice(&run_args[i + 1..]);
-            parts
-        } else {
-            i += 1;
-            continue;
-        };
-
-        if parts.first().is_some_and(|value| value == "--") {
-            parts.remove(0);
+        if token == "-e" || token == "--expression" {
+            if run_args.get(i + 1).is_some_and(|next| next == "--") {
+                return Some((i, run_args[i + 2..].to_vec()));
+            }
+            return None;
         }
-        return Some((i, parts));
+        i += 1;
     }
     None
 }
@@ -372,21 +362,22 @@ mod tests {
         );
     }
 
-    /// `run -e` should consume all remaining tokens as expression source.
+    /// `run -e` accepts hyphen-prefixed values without consuming run flags.
     #[test]
-    fn run_expression_consumes_remaining_tokens() {
+    fn run_expression_accepts_hyphen_prefixed_value_and_preserves_run_flags() {
         let cli = RuntimeCli::parse_from_smart(vec![
             "baml-cli".into(),
             "run".into(),
             "-e".into(),
-            "-7".into(),
-            "%".into(),
-            "3".into(),
+            "-7 % 3".into(),
+            "--from".into(),
+            "project".into(),
         ]);
         let Commands::Run(args) = cli.command else {
             panic!("expected run command");
         };
         assert_eq!(args.expression.as_deref(), Some("-7 % 3"));
+        assert_eq!(args.from, std::path::PathBuf::from("project"));
     }
 
     /// Legacy `-e -- ...` still works after expression-tail normalization.

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -131,7 +131,7 @@ pub struct RunArgs {
 
     /// Evaluate a BAML expression. Use -e @file to read from a file, -e - for stdin.
     /// Mutually exclusive with positional `<TARGET>` and `-f`.
-    #[arg(short = 'e', long = "expression")]
+    #[arg(short = 'e', long = "expression", allow_hyphen_values = true)]
     pub expression: Option<String>,
 
     /// Standalone single-file source. Loads only this file (no project


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The error
`baml run -e` rejected expressions that begin with `-`.

A follow-up patch introduced argv rewriting logic (`run -e -- ...` normalization), and review requested removing that workaround in favor of clap’s native handling.

## Root cause
`RunArgs.expression` was parsed without clap’s leading-hyphen opt-in.

## The fix
- Keep `RunArgs.expression` configured with clap’s `allow_hyphen_values = true` (the approach recommended in <https://github.com/clap-rs/clap/issues/1245>).
- Remove the argv normalization workaround from `RuntimeCli::parse_from_smart`.
- Delete the compatibility-only helper functions and the test that depended on argv rewriting.
- Keep parser coverage that verifies:
  - `run -e` accepts hyphen-prefixed expression values
  - run-level flags like `--from` are still parsed (not swallowed)

## Verification
From `baml_language/`:

```bash
cargo fmt --all -- --config imports_granularity="Crate" --config group_imports="StdExternalCrate"
cargo test -p baml_cli --lib run_expression_accepts_hyphen_prefixed_value_and_preserves_run_flags
cargo test -p baml_cli --lib
```

All passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a268e0e2-fb81-41d3-ac16-f8dfb04ad02f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a268e0e2-fb81-41d3-ac16-f8dfb04ad02f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI argument parsing for the `run -e/--expression` option to accept legacy hyphen-prefixed expression values (e.g., `-7 % 3`) without misparsing.
  * Added a CLI parsing test to ensure expression arguments still correctly interact with subsequent `run` flags (e.g., `--from project`).
* **Documentation**
  * Expanded CLI parsing documentation to better describe parameters, return behavior, and termination/error semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->