### PR TITLE
Prevent baml fmt from reindenting multiline #"..."# raw strings

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/tokens.rs
+++ b/baml_language/crates/baml_fmt/src/ast/tokens.rs
@@ -666,76 +666,23 @@ impl KnownKind for RawString {
     }
 }
 impl Printable for RawString {
-    fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+    /// Prints a raw-string token byte-for-byte, without any interior normalization.
+    ///
+    /// ## Parameters
+    /// - `_shape`: Unused layout constraints for this token.
+    /// - `printer`: Output sink that receives the raw token bytes.
+    ///
+    /// ## Returns
+    /// A [`PrintInfo`] whose `multi_lined` flag reflects whether the token text
+    /// contains at least one newline.
+    ///
+    /// ## Errors and panics
+    /// This method does not return errors and does not panic.
+    fn print(&self, _shape: Shape, printer: &mut Printer) -> PrintInfo {
         let text = &printer.input[self.span()];
         let multi_lined = text.contains('\n');
-        if !multi_lined {
-            // print as-is
-            printer.print_raw_token(self);
-            return PrintInfo { multi_lined };
-        }
-
-        // we need to re-organize the interior
-        let (Some(start_quote), Some(end_quote)) = (text.find('"'), text.rfind('"')) else {
-            // should never happen, but print as-is if it does
-            printer.print_raw_token(self);
-            return PrintInfo { multi_lined };
-        };
-        if end_quote <= start_quote {
-            // should never happen, but print as-is if it does
-            printer.print_raw_token(self);
-            return PrintInfo { multi_lined };
-        }
-
-        let interior = &text[start_quote + 1..end_quote].trim();
-        let mut lines = interior.lines();
-        let Some(first_line) = lines.next() else {
-            // Interior is empty after trim (e.g. `#"\n"#`) — print as-is.
-            printer.print_raw_token(self);
-            return PrintInfo { multi_lined };
-        };
-        let min_indent = lines
-            .clone()
-            .map(|line| {
-                let count = line.bytes().take_while(|c| *c == b' ').count();
-                if count == line.len() {
-                    // it is all spaces
-                    usize::MAX
-                } else {
-                    count
-                }
-            })
-            .min()
-            .unwrap_or(0);
-
-        let inner_base_indent = shape.indent + printer.config.indent_width;
-        printer.print_str(&text[..=start_quote]);
-        printer.print_newline();
-        printer.print_spaces(inner_base_indent);
-        printer.print_str(first_line.trim_start_matches(' '));
-        for line in lines {
-            if line.len() <= min_indent {
-                // This line must be all spaces since otherwise it would have affected `min_indent`.
-                // So we can print an empty line.
-                printer.print_newline();
-                continue;
-            }
-
-            let (removed_indent, line) = line.split_at(min_indent);
-            debug_assert!(
-                removed_indent.bytes().all(|c| c == b' '),
-                "should not have removed non-indent"
-            );
-            debug_assert!(!line.is_empty(), "should have been handled above");
-
-            printer.print_newline();
-            printer.print_spaces(inner_base_indent);
-            printer.print_str(line);
-        }
-        printer.print_newline();
-        printer.print_spaces(shape.indent);
-        printer.print_str(&text[end_quote..]);
-
+        // Raw strings are opaque by design: formatter must not rewrite their body.
+        printer.print_raw_token(self);
         PrintInfo { multi_lined }
     }
     fn leftmost_token(&self) -> TextRange {

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -256,6 +256,30 @@ mod backtick_format_tests {
 }
 
 #[cfg(test)]
+mod raw_string_format_tests {
+    use super::*;
+
+    /// Verifies multiline `#"... "#` raw-string contents remain byte-for-byte
+    /// intact while surrounding code is still formatted.
+    #[test]
+    fn raw_string_multiline_contents_are_opaque() {
+        let source = "function get_text() -> string {\n  let s = #\"\nno_indent\n\"#;\n  s\n}\n";
+        let expected =
+            "function get_text() -> string {\n    let s = #\"\nno_indent\n\"#;\n    s\n}\n";
+        let options = FormatOptions::default();
+
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert_eq!(
+            formatted, expected,
+            "formatter must not re-indent inside raw-string delimiters"
+        );
+
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+}
+
+#[cfg(test)]
 mod pattern_format_tests {
     use super::*;
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/config_dictionary/baml_tests__compiles__config_dictionary__10_formatter__valid_dictionary.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/config_dictionary/baml_tests__compiles__config_dictionary__10_formatter__valid_dictionary.snap
@@ -12,10 +12,8 @@ client<llm> MyClient {
         key2: "some random value",
         hello: "world",
         thing: "hello",
-        block_string: #"
-            hello there my frien
-            d
-        "#,
+        block_string: #"hello there my frien
+                d"#,
         inline_raw_string: #"inline "raw" string,,"#,
         "string key": "value with spaces",
         booleanValue: true,
@@ -49,8 +47,8 @@ client<llm> MyClient {
             },
         ],
         block_string: #"
-            hello there my friend
-            {# a comment in a prompt #}
-        "#,
+      hello there my friend
+      {# a comment in a prompt #}
+    "#,
     },
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__10_formatter__json_llm_return_type.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__10_formatter__json_llm_return_type.snap
@@ -16,8 +16,8 @@ client<llm> TestClient {
 function ExtractAny() -> json {
     client: TestClient
     prompt: #"
-        Return whatever JSON you like.
+      Return whatever JSON you like.
 
-        {{ ctx.output_format }}
+      {{ ctx.output_format }}
     "#
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__10_formatter__main.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 11892
 ---
 client<llm> OpenAIImageResponses {
     provider: openai-responses,
@@ -20,29 +19,29 @@ client<llm> OpenAIImageResponses {
 function GenerateImage(prompt: string) -> image {
     client: OpenAIImageResponses
     prompt: #"
-        Generate an image for this prompt:
-        {{ prompt }}
+    Generate an image for this prompt:
+    {{ prompt }}
 
-        {{ ctx.output_format }}
-    "#
+    {{ ctx.output_format }}
+  "#
 }
 
 function GenerateImageSet(prompt: string) -> image[] {
     client: OpenAIImageResponses
     prompt: #"
-        Generate multiple distinct image outputs for this prompt:
-        {{ prompt }}
+    Generate multiple distinct image outputs for this prompt:
+    {{ prompt }}
 
-        {{ ctx.output_format }}
-    "#
+    {{ ctx.output_format }}
+  "#
 }
 
 function GenerateMixedImageNarrative(prompt: string) -> (image | string)[] {
     client: OpenAIImageResponses
     prompt: #"
-        Generate a short narrative with text captions and image outputs for:
-        {{ prompt }}
+    Generate a short narrative with text captions and image outputs for:
+    {{ prompt }}
 
-        {{ ctx.output_format }}
-    "#
+    {{ ctx.output_format }}
+  "#
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/string_methods/baml_tests__compiles__string_methods__10_formatter__string_methods.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/string_methods/baml_tests__compiles__string_methods__10_formatter__string_methods.snap
@@ -4,17 +4,17 @@ source: crates/baml_tests/src/generated_tests.rs
 // Test: string method calls should produce no diagnostics
 
 template_string Sep(n: int) #"
-    {{- "{:,}".format(n) -}}
+  {{- "{:,}".format(n) -}}
 "#
 
 template_string Upper(s: string) #"
-    {{ s.upper() }}
+  {{ s.upper() }}
 "#
 
 template_string StartsWith(s: string) #"
-    {% if s.startswith("hello") %}yes{% endif %}
+  {% if s.startswith("hello") %}yes{% endif %}
 "#
 
 template_string Split(s: string) #"
-    {% for part in s.split(",") %}{{ part }}{% endfor %}
+  {% for part in s.split(",") %}{{ part }}{% endfor %}
 "#

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_function/baml_tests__diagnostic_errors__simple_function__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/simple_function/baml_tests__diagnostic_errors__simple_function__10_formatter__main.snap
@@ -4,8 +4,8 @@ source: crates/baml_tests/src/generated_tests.rs
 function HelloWorld(name: string) -> string {
     client: GPT4
     prompt: #"
-        Say hello to {{name}}
-    "#
+    Say hello to {{name}}
+  "#
 }
 
 class User {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes

### The error
Failing repro input:

```baml
function get_text() -> string {
  let s = #"
no_indent
"#;
  s
}
```

Pre-fix command/output:

```bash
$ cargo run -p baml_cli --bin baml-cli -- fmt tmp_fmt_repro/baml_src/main.baml
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
  Formatting tmp_fmt_repro/baml_src/main.baml
    Finished formatted 1 file(s) in 0s
```

Pre-fix formatted file (incorrect/corrupted raw-string contents):

```baml
function get_text() -> string {
    let s = #"
        no_indent
    "#;
    s
}
```

### Root cause
`baml_language/crates/baml_fmt/src/ast/tokens.rs` in `impl Printable for RawString` (`print`) was parsing raw-string token text and reformatting its interior (`trim`, dedent, and re-indent based on surrounding shape). That logic mutated bytes between `#"` and `"#`, which must remain opaque.

### The fix
- Replaced `RawString::print` formatting logic with byte-for-byte emission via `printer.print_raw_token(self)`.
- Kept `PrintInfo.multi_lined` behavior unchanged by still detecting newline presence from original token text.
- Added regression test `raw_string_format_tests::raw_string_multiline_contents_are_opaque` in `baml_language/crates/baml_fmt/src/lib.rs` that matches the reported failure and asserts both corrected output and idempotency.

## Testing

### Verification
Commands run from `baml_language/`:

```bash
cargo build -p baml_fmt
cargo run -p baml_cli --bin baml-cli -- fmt tmp_fmt_repro/baml_src/main.baml
cargo test -p baml_fmt raw_string_format_tests::raw_string_multiline_contents_are_opaque
cargo test -p baml_fmt --lib
cargo fmt --all
```

Post-fix formatter command/output:

```bash
$ cargo run -p baml_cli --bin baml-cli -- fmt tmp_fmt_repro/baml_src/main.baml
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
  Formatting tmp_fmt_repro/baml_src/main.baml
    Finished formatted 1 file(s) in 0s
```

Post-fix formatted file (correct, raw-string body preserved):

```baml
function get_text() -> string {
    let s = #"
no_indent
"#;
    s
}
```

Additional targeted test output:

```bash
running 1 test
test raw_string_format_tests::raw_string_multiline_contents_are_opaque ... ok
```

Library test suite output:

```bash
test result: ok. 62 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### CodeRabbit self-review
Attempted to run CodeRabbit per instructions, but this environment does not have `CODERABBIT_API_KEY` set (`coderabbit auth login --api-key "$CODERABBIT_API_KEY"` -> `API key cannot be empty`).

## Screenshots
[Add screenshots here...]

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
- Scope intentionally limited to `baml_language/` formatter behavior for multiline `#"..."#` raw-string literals.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0aeb7951-18b6-4ca9-b40d-4a36f13e6500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0aeb7951-18b6-4ca9-b40d-4a36f13e6500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Raw strings are now preserved exactly as written during formatting, without any re-indentation or reorganization of their contents.

* **Tests**
  * Added tests to verify that raw string contents remain unchanged during formatting and that the formatter output is consistent and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->