### PR TITLE
baml fmt: enforce two-space canonical indentation in CLI output

### DIFF
--- a/baml_language/crates/baml_cli/src/format.rs
+++ b/baml_language/crates/baml_cli/src/format.rs
@@ -11,6 +11,9 @@ use clap::Args;
 
 use crate::reporter::Reporter;
 
+/// Canonical indentation width used by `baml fmt`.
+const CANONICAL_INDENT_WIDTH: usize = 2;
+
 #[derive(Args, Debug)]
 pub struct FormatArgs {
     #[arg(
@@ -28,13 +31,24 @@ pub struct FormatArgs {
     #[arg(
         short = 'n',
         long = "dry-run",
-        help = "Write formatter changes to stdout instead of files.",
+        help = "Write formatter changes to stdout instead of files (formatter canonical style uses 2-space indentation).",
         default_value = "false"
     )]
     pub dry_run: bool,
 }
 
 impl FormatArgs {
+    /// Formats selected BAML files using the CLI's canonical style.
+    ///
+    /// This method reads each selected file, formats it with
+    /// [`baml_fmt`], and either writes the result back to disk or emits it
+    /// to stdout in dry-run mode.
+    ///
+    /// Returns an [`crate::ExitCode`] indicating success or failure.
+    ///
+    /// # Errors
+    /// Returns an error when path resolution or project discovery fails before
+    /// file-level formatting begins.
     pub fn run(&self) -> Result<crate::ExitCode> {
         // Cargo-style default: with no positional paths, discover every
         // `.baml` file under the project root and format the lot. The
@@ -98,7 +112,10 @@ impl FormatArgs {
                     continue;
                 }
             };
-            let options = FormatOptions::default();
+            let options = FormatOptions {
+                indent_width: CANONICAL_INDENT_WIDTH,
+                ..FormatOptions::default()
+            };
             match baml_fmt::format(&source, &options) {
                 Ok(formatted) => {
                     if self.dry_run {
@@ -199,6 +216,14 @@ mod tests {
 
     use super::*;
 
+    /// Ensures recursive explicit-path formatting applies the CLI canonical
+    /// formatting options to every discovered `.baml` file.
+    ///
+    /// This test has no parameters and no return value.
+    ///
+    /// # Panics
+    /// Panics if formatting fails, if discovered files are not rewritten, or
+    /// if non-BAML files are mutated.
     #[test]
     fn explicit_directory_formats_baml_files_recursively() {
         let tmp = tempfile::tempdir().unwrap();
@@ -227,11 +252,25 @@ mod tests {
         assert!(matches!(exit_code, crate::ExitCode::Success));
         assert_eq!(
             fs::read_to_string(&main).unwrap(),
-            baml_fmt::format(main_source, &FormatOptions::default()).unwrap()
+            baml_fmt::format(
+                main_source,
+                &FormatOptions {
+                    indent_width: CANONICAL_INDENT_WIDTH,
+                    ..FormatOptions::default()
+                }
+            )
+            .unwrap()
         );
         assert_eq!(
             fs::read_to_string(&nested).unwrap(),
-            baml_fmt::format(nested_source, &FormatOptions::default()).unwrap()
+            baml_fmt::format(
+                nested_source,
+                &FormatOptions {
+                    indent_width: CANONICAL_INDENT_WIDTH,
+                    ..FormatOptions::default()
+                }
+            )
+            .unwrap()
         );
         assert_eq!(fs::read_to_string(ignored).unwrap(), ignored_source);
     }

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -1489,8 +1489,19 @@ impl RunArgs {
 pub(crate) const FORMAT_HINT: &str =
     "Your code is unformatted — run `baml fmt` to format it. Continuing.";
 
+/// Returns whether source differs from canonical CLI formatting.
+///
+/// Parameters:
+/// - `source`: Raw BAML source text to check.
+///
+/// Returns `true` when formatting would rewrite `source`, otherwise `false`.
+///
+/// This helper does not panic and treats formatter errors as "no hint needed."
 pub(crate) fn source_needs_format_hint(source: &str) -> bool {
-    let options = baml_fmt::FormatOptions::default();
+    let options = baml_fmt::FormatOptions {
+        indent_width: 2,
+        ..baml_fmt::FormatOptions::default()
+    };
     match baml_fmt::format(source, &options) {
         Ok(formatted) => formatted != source,
         Err(_) => false,
@@ -1617,9 +1628,17 @@ mod tests {
         }
     }
 
+    /// Confirms the formatter hint is suppressed for canonically formatted
+    /// source.
+    ///
+    /// This test has no parameters and no return value.
+    ///
+    /// # Panics
+    /// Panics if `source_needs_format_hint` flags valid two-space-indented
+    /// source as unformatted.
     #[test]
     fn source_needs_format_hint_returns_false_for_formatted_source() {
-        let source = "function main() -> string {\n    \"ok\"\n}\n";
+        let source = "function main() -> string {\n  \"ok\"\n}\n";
         assert!(!source_needs_format_hint(source));
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The error

Repro source (`baml_src/main.baml`):

```baml
function add(a: int, b: int) -> int {
  a + b
}
```

Before this change, running formatter through the internal CLI binary:

```bash
cargo run -p baml_cli --bin baml-cli -- fmt demo/baml_src/tmp_fmt_indent_repro.baml
```

produced:

```text
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
  Formatting demo/baml_src/tmp_fmt_indent_repro.baml
    Finished formatted 1 file(s) in 0s
```

and rewrote the body indentation from 2 spaces to 4 spaces:

```baml
function add(a: int, b: int) -> int {
    a + b
}
```

This conflicted with existing SKILL.md examples that use 2-space indentation.

## Root cause

`baml fmt` in `baml_language` uses `crates/baml_cli/src/format.rs::FormatArgs::run`, which called `FormatOptions::default()` (4-space indent in `baml_fmt`).

`baml run`/`baml pack` format-hint detection in `crates/baml_cli/src/run_command.rs::source_needs_format_hint` also used `FormatOptions::default()`, so hinting behavior was tied to the same 4-space style.

## The fix

- Updated `crates/baml_cli/src/format.rs` so `baml fmt` always formats with canonical 2-space indentation by setting:
  - `const CANONICAL_INDENT_WIDTH: usize = 2`
  - `FormatOptions { indent_width: CANONICAL_INDENT_WIDTH, ..FormatOptions::default() }`
- Updated CLI help text to explicitly state formatter canonical style uses 2-space indentation.
- Updated `crates/baml_cli/src/run_command.rs::source_needs_format_hint` to use the same 2-space canonical options, keeping advisory behavior consistent with `baml fmt` output.
- Updated affected tests in `format.rs` and `run_command.rs` to assert the new canonical indentation behavior.

## Verification

From `baml_language/`:

1. Build changed crate:

```bash
cargo build -p baml_cli
```

2. Targeted tests:

```bash
cargo test -p baml_cli --lib
```

3. Repro after fix:

```bash
cargo run -p baml_cli --bin baml-cli -- fmt demo/baml_src/tmp_fmt_indent_repro.baml
```

Output:

```text
warning: using the internal BAML toolchain binary directly is not recommended. Use `baml` instead.
  Formatting demo/baml_src/tmp_fmt_indent_repro.baml
    Finished formatted 1 file(s) in 0s
```

Post-format file content remains 2-space-indented:

```baml
function add(a: int, b: int) -> int {
  a + b
}
```

4. Rust formatting:

```bash
cargo fmt --all
```

## CodeRabbit self-review

Attempted required CodeRabbit step, but `CODERABBIT_API_KEY` was not present in this environment (`coderabbit auth login --api-key "$CODERABBIT_API_KEY"` returned `API key cannot be empty`), so automated CodeRabbit review could not be run locally in this agent session.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1d2ff1c-5701-46b3-9fa1-711f7fe7a3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1d2ff1c-5701-46b3-9fa1-711f7fe7a3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

