### PR TITLE
fix(baml_fmt): wrap over-long lines instead of leaving them un-split

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -685,8 +685,12 @@ impl ParenExpr {
 
 impl Printable for ParenExpr {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -936,8 +940,12 @@ impl BinaryExpr {
 
 impl Printable for BinaryExpr {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -2558,8 +2566,12 @@ impl CallArgs {
 
 impl Printable for CallArgs {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -2650,8 +2662,12 @@ impl PrintMultiLine for IndexArgs<'_> {
 
 impl Printable for IndexArgs<'_> {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -2761,8 +2777,12 @@ impl IndexExpr {
 impl Printable for IndexExpr {
     /// The main way to call this should be through [`PrintChain`]
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -3396,8 +3416,12 @@ impl ArrayInitializer {
 
 impl Printable for ArrayInitializer {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -3620,8 +3644,12 @@ impl ObjectInitializer {
 
 impl Printable for ObjectInitializer {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -3865,8 +3893,12 @@ impl MapLiteral {
 
 impl Printable for MapLiteral {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -4866,8 +4898,12 @@ impl PrintChain<'_> {
 
 impl Printable for PrintChain<'_> {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let single_line_shape = Shape {
+            width: printer.clamp_single_line_width(shape.width),
+            ..shape
+        };
         printer
-            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .try_sub_printer(|p| self.try_print_single_line(&single_line_shape, p))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -78,6 +78,103 @@ pub enum FormatterError {
 }
 
 #[cfg(test)]
+mod line_width_format_tests {
+    //! Regression tests for the single-line/multi-line decision honoring the
+    //! configured line width even when a same-line *prefix* has already been
+    //! printed (e.g. `let x = `, a call's callee, a `: T` type annotation).
+    //!
+    //! Previously the width budget handed to a child expression ignored the
+    //! prefix already on the line, so over-long lines slipped through
+    //! un-wrapped. The fix clamps the single-line budget to the space actually
+    //! remaining on the line — which must *not* tip over into over-splitting
+    //! lines that genuinely fit.
+
+    use super::*;
+
+    fn line_lengths(s: &str) -> Vec<usize> {
+        s.lines().map(str::len).collect()
+    }
+
+    /// A bare call whose arguments push the line past the 100-column limit must
+    /// wrap, even though the callee + args measured in isolation each "fit".
+    #[test]
+    fn overlong_bare_call_wraps() {
+        let source = "function f() -> int {\n    foo_bar_baz(argument_one, argument_two, argument_three, argument_four, argument_five, arg_sixxxxxxxxxxxxx)\n    0\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert!(
+            formatted.contains("foo_bar_baz(\n"),
+            "expected the over-long call to wrap its arguments; got:\n{formatted}"
+        );
+        assert!(
+            line_lengths(&formatted)
+                .iter()
+                .all(|&len| len <= options.line_width),
+            "no line should exceed the width limit; got:\n{formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// `let NAME = call(...)` must account for the `let NAME = ` prefix when
+    /// deciding whether the initializer fits on the line.
+    #[test]
+    fn overlong_let_initializer_wraps() {
+        let source = "function f() -> int {\n    let value = compute_something(with_a_long_argument_name, and_another_long_argument_name_here_xxxxxxxxxxxx)\n    0\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert!(
+            formatted.contains("compute_something(\n"),
+            "expected the over-long let initializer to wrap; got:\n{formatted}"
+        );
+        assert!(
+            line_lengths(&formatted)
+                .iter()
+                .all(|&len| len <= options.line_width),
+            "no line should exceed the width limit; got:\n{formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// A call that lands exactly on (or under) the limit must stay on one line —
+    /// the clamp must never over-split content that fits.
+    #[test]
+    fn call_that_fits_is_not_oversplit() {
+        // The call statement (with trailing `;`) is exactly 100 columns wide.
+        let source = "function f() -> int {\n    foo_bar_baz(argument_one, argument_two, argument_three, argument_four, argument_five, arg_sixx)\n    0\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert!(
+            formatted.contains(
+                "foo_bar_baz(argument_one, argument_two, argument_three, argument_four, argument_five, arg_sixx);"
+            ),
+            "a call that fits within the limit must not be split; got:\n{formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// A short value initializer that *together with* its prefix overflows the
+    /// line must wrap the value onto its own line. (Here the type-annotation
+    /// prefix alone is unavoidably long, so the opening `= {` line can still
+    /// exceed the limit — what matters is that the prefix length is taken into
+    /// account at all, so the value expands instead of trailing off the line.)
+    #[test]
+    fn short_value_after_long_prefix_wraps_value() {
+        let source = "function f() -> int {\n    let very_long_variable_name_for_testing_wrapping: map<string, int | string | bool | float | null> = { \"key\": 42 }\n    0\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert!(
+            formatted.contains("= {\n") && formatted.contains("\"key\": 42,\n"),
+            "expected the value to expand onto its own line; got:\n{formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+}
+
+#[cfg(test)]
 mod lambda_format_tests {
     use super::*;
 

--- a/baml_language/crates/baml_fmt/src/printer.rs
+++ b/baml_language/crates/baml_fmt/src/printer.rs
@@ -357,6 +357,35 @@ impl<'a> Printer<'a> {
             .saturating_sub(self.current_line_len())
     }
 
+    /// Clamps a requested single-line width budget to the space actually
+    /// remaining on the current line.
+    ///
+    /// `Shape::width` is nominally the content budget excluding base
+    /// indentation, but parents routinely print a same-line prefix (`let x = `,
+    /// a call's callee, a binary operator's left-hand side, …) and then hand
+    /// the child the *unreduced* budget. Measuring the child against that stale
+    /// budget lets over-long lines slip through un-wrapped. Clamping to the real
+    /// remaining width accounts for whatever has already been emitted on the
+    /// line, so the single-line/multi-line decision reflects the actual layout.
+    ///
+    /// This can only ever *shrink* the budget down to the true remaining space,
+    /// so it fixes under-splitting (over-long lines) without ever introducing
+    /// over-splitting: when the requested width already fits the line, it is
+    /// returned unchanged.
+    ///
+    /// The sentinel `usize::MAX` (see [`Shape::unlimited_single_line`]) is
+    /// preserved untouched: it marks a nested measurement where the caller does
+    /// its own width accounting against the full output, so it must not be
+    /// clamped to the (meaningless) current line of a scratch sub-printer.
+    #[must_use]
+    pub fn clamp_single_line_width(&self, width: usize) -> usize {
+        if width == usize::MAX {
+            usize::MAX
+        } else {
+            width.min(self.current_line_remaining_width())
+        }
+    }
+
     /// The current length of the output.
     #[must_use]
     pub const fn len(&self) -> usize {

--- a/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__10_formatter__closures.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__10_formatter__closures.snap
@@ -73,7 +73,10 @@ function test_bound_mapper() -> string[] {
 
 // Test 2: Unbound method in map
 function test_unbound_in_map() -> string[] {
-    let employees = [Employee { first: "Alice", last: "Smith" }, Employee { first: "Bob", last: "Jones" }];
+    let employees = [
+        Employee { first: "Alice", last: "Smith" },
+        Employee { first: "Bob", last: "Jones" },
+    ];
     employees.map(Employee.full_name)
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__10_formatter__main.snap
@@ -76,7 +76,9 @@ function GenericDestructureNamespaceQualifiedLet() -> int {
 }
 
 function GenericTypePatternQualifiedMatch() -> int {
-    let boxed: root.llm.openai.Box<int> | root.llm.openai.Box<string> = root.llm.openai.Box<int> { value: 50 };
+    let boxed: root.llm.openai.Box<int> | root.llm.openai.Box<string> = root.llm.openai.Box<int> {
+        value: 50,
+    };
 
     match (boxed) {
         root.llm.openai.Box<string> => 0,
@@ -85,7 +87,9 @@ function GenericTypePatternQualifiedMatch() -> int {
 }
 
 function GenericTypePatternNamespaceQualifiedMatch() -> int {
-    let boxed: llm.openai.Box<int> | llm.openai.Box<string> = llm.openai.Box<string> { value: "ready" };
+    let boxed: llm.openai.Box<int> | llm.openai.Box<string> = llm.openai.Box<string> {
+        value: "ready",
+    };
 
     match (boxed) {
         llm.openai.Box<int> => 0,
@@ -94,14 +98,18 @@ function GenericTypePatternNamespaceQualifiedMatch() -> int {
 }
 
 function DeepGenericDestructureQualifiedLet() -> int {
-    let outer: root.llm.openai.Outer<int> = root.llm.openai.Outer<int> { inner: root.llm.openai.Box<int> { value: 52 } };
+    let outer: root.llm.openai.Outer<int> = root.llm.openai.Outer<int> {
+        inner: root.llm.openai.Box<int> { value: 52 },
+    };
 
     let root.llm.openai.Outer<int> { inner: root.llm.openai.Box<int> { value } } = outer;
     value
 }
 
 function DeepGenericDestructureNamespaceQualifiedLet() -> int {
-    let outer: llm.openai.Outer<string> = llm.openai.Outer<string> { inner: llm.openai.Box<string> { value: "done" } };
+    let outer: llm.openai.Outer<string> = llm.openai.Outer<string> {
+        inner: llm.openai.Box<string> { value: "done" },
+    };
 
     let llm.openai.Outer<string> { inner: llm.openai.Box<string> { value } } = outer;
     value.length()

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__loop_stmts.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__loop_stmts.snap
@@ -299,7 +299,9 @@ function LoopStmts(items: int[], flag: bool) -> int {
     /* 1 for leading */
     for ( /* 4 open paren trailing */
         /* 5 init leading */
-        let /* 6 let trailing */ extremely_long_loop_counter_variable = /* 9 equals trailing *//* 10 init value leading */a * a + result * result/* 11 init value trailing */; /* 12 semi1 trailing */
+        let /* 6 let trailing */ extremely_long_loop_counter_variable = /* 9 equals trailing *//* 10 init value leading */a
+            * a
+            + result * result/* 11 init value trailing */; /* 12 semi1 trailing */
         /* 13 condition leading */
         extremely_long_loop_counter_variable < 1000000 && flag && a > 0/* 14 condition trailing */; /* 15 semi2 trailing */
         /* 16 update leading */
@@ -480,7 +482,9 @@ function LoopStmts(items: int[], flag: bool) -> int {
     let complex_init = a + result;
 
     // ===== Long let with type annotation exceeding limit =====
-    let very_long_variable_name_for_testing_wrapping: map<string, int | string | bool | float | null> = { "key": 42 };
+    let very_long_variable_name_for_testing_wrapping: map<string, int | string | bool | float | null> = {
+        "key": 42,
+    };
 
     // ===== Very long let with expression exceeding limit =====
     let another_extremely_long_variable_name = a * a
@@ -494,7 +498,9 @@ function LoopStmts(items: int[], flag: bool) -> int {
         + result * a * result;
 
     // ===== Long let with nested generic type exceeding limit =====
-    let deeply_typed: map<string, map<string, map<string, int | string | bool>>> = { "outer": { "inner": { "deep": 42 } } };
+    let deeply_typed: map<string, map<string, map<string, int | string | bool>>> = {
+        "outer": { "inner": { "deep": 42 } },
+    };
 
     // ===== Trivia on let statement (line comments) =====
     // 1 let keyword leading
@@ -506,13 +512,17 @@ function LoopStmts(items: int[], flag: bool) -> int {
 
     // ===== Trivia on wrapping let with long type (line comments) =====
     // 1 let leading
-    let very_long_variable_name_for_testing_wrapping: map<string, int | string | bool | float | null> = { "key": 42 }; // 13 semicolon trailing
+    let very_long_variable_name_for_testing_wrapping: map<string, int | string | bool | float | null> = {
+        "key": 42,
+    }; // 13 semicolon trailing
 
     ///////////////////
 
     // ===== Trivia on wrapping let with long type (block comments) =====
     /* 1 let leading */
-    let /* 2 let trailing */ very_long_variable_name_for_testing_wrapping /* 4 name trailing */ /* 5 colon leading */: /* 6 colon trailing */ /* 7 type leading */ map<string, int | string | bool | float | null> = /* 10 equals trailing *//* 11 value leading */{ "key": 42 }/* 12 value trailing */; /* 13 semicolon trailing */
+    let /* 2 let trailing */ very_long_variable_name_for_testing_wrapping /* 4 name trailing */ /* 5 colon leading */: /* 6 colon trailing */ /* 7 type leading */ map<string, int | string | bool | float | null> = /* 10 equals trailing *//* 11 value leading */{
+        "key": 42,
+    }/* 12 value trailing */; /* 13 semicolon trailing */
 
     ///////////////////
 
@@ -532,7 +542,8 @@ function LoopStmts(items: int[], flag: bool) -> int {
 
     // ===== Trivia on wrapping let with long expression (block comments) =====
     /* 1 let leading */
-    let /* 2 let trailing */ another_extremely_long_variable_name = /* 6 equals trailing *//* 7 value leading */a * a
+    let /* 2 let trailing */ another_extremely_long_variable_name = /* 6 equals trailing *//* 7 value leading */a
+        * a
         + result * result
         + a * result
         + a

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__10_formatter__patterns_class_destructure.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__10_formatter__patterns_class_destructure.snap
@@ -36,7 +36,11 @@ function class_destructure_unknown_field_in_let() -> int {
 }
 
 function class_destructure_duplicate_field_key_in_let() -> int {
-    let Person { age: let first, age: let second } = Person { age: 1, flexible_age: 2, address: Address { zip: 3 } };
+    let Person { age: let first, age: let second } = Person {
+        age: 1,
+        flexible_age: 2,
+        address: Address { zip: 3 },
+    };
     first + second
 }
 
@@ -47,22 +51,36 @@ function class_destructure_duplicate_field_key_with_wildcards() -> int {
 }
 
 function class_destructure_duplicate_binding_name_across_fields() -> int {
-    let Person { age, flexible_age: let age } = Person { age: 1, flexible_age: 2, address: Address { zip: 3 } };
+    let Person { age, flexible_age: let age } = Person {
+        age: 1,
+        flexible_age: 2,
+        address: Address { zip: 3 },
+    };
     0
 }
 
 function nested_class_destructure_duplicate_binding_name_in_field_chain() -> int {
-    let SameNameOuter { field: let field: SameNameInner { field } } = SameNameOuter { field: SameNameInner { field: 1 }, other: SameNameInner { field: 2 } };
+    let SameNameOuter { field: let field: SameNameInner { field } } = SameNameOuter {
+        field: SameNameInner { field: 1 },
+        other: SameNameInner { field: 2 },
+    };
     0
 }
 
 function nested_class_destructure_duplicate_binding_name_across_nested_fields() -> int {
-    let SameNameOuter { field: SameNameInner { field }, other: SameNameInner { field } } = SameNameOuter { field: SameNameInner { field: 1 }, other: SameNameInner { field: 2 } };
+    let SameNameOuter { field: SameNameInner { field }, other: SameNameInner { field } } = SameNameOuter {
+        field: SameNameInner { field: 1 },
+        other: SameNameInner { field: 2 },
+    };
     0
 }
 
 function nested_class_destructure_unknown_field_in_let() -> int {
-    let Person { address: Address { missing } } = Person { age: 1, flexible_age: 2, address: Address { zip: 3 } };
+    let Person { address: Address { missing } } = Person {
+        age: 1,
+        flexible_age: 2,
+        address: Address { zip: 3 },
+    };
     0
 }
 
@@ -134,7 +152,11 @@ function for_top_level_class_narrows_union_element_is_refutable() -> int {
 }
 
 function let_class_field_type_narrower_than_field_is_refutable() -> int {
-    let Person { flexible_age: int } = Person { age: 1, flexible_age: 2, address: Address { zip: 3 } };
+    let Person { flexible_age: int } = Person {
+        age: 1,
+        flexible_age: 2,
+        address: Address { zip: 3 },
+    };
     1
 }
 
@@ -144,7 +166,11 @@ function let_class_field_literal_narrower_than_field_is_refutable() -> int {
 }
 
 function nested_class_field_type_narrower_than_field_is_refutable() -> int {
-    let Person { address: Address { zip: 1 } } = Person { age: 1, flexible_age: 2, address: Address { zip: 3 } };
+    let Person { address: Address { zip: 1 } } = Person {
+        age: 1,
+        flexible_age: 2,
+        address: Address { zip: 3 },
+    };
     1
 }
 
@@ -213,7 +239,11 @@ function nested_class_destructure_field_pattern_type_mismatch() -> int {
 }
 
 function class_destructure_unknown_renamed_field_span() -> int {
-    let Person { missing: let renamed } = Person { age: 1, flexible_age: 2, address: Address { zip: 3 } };
+    let Person { missing: let renamed } = Person {
+        age: 1,
+        flexible_age: 2,
+        address: Address { zip: 3 },
+    };
     renamed
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

`baml fmt` was leaving lines that exceed the 100-column limit on a single line instead of wrapping them.

The root cause: the single-line/multi-line decision compares a child element's printed length against `Shape::width`, but `width` ignored any **same-line prefix** already emitted before the child — e.g. `let x = `, a call's callee (`foo_bar_baz(`), or a `: T` type annotation. Because each piece "fit" when measured in isolation against the full content budget, over-long lines slipped through un-wrapped.

For example, before this change:

```baml
function f() -> int {
    foo_bar_baz(argument_one, argument_two, argument_three, argument_four, argument_five, arg_sixxxxxxxxxxxxx);  // 111 cols, not wrapped
}
```

### Fix

- Add `Printer::clamp_single_line_width`, which clamps a requested single-line budget down to the space **actually remaining** on the current line (`current_line_remaining_width`). The `usize::MAX` "unlimited" sentinel used during nested measurement is left untouched.
- Apply it at every single-line decision wrapper (`ParenExpr`, `BinaryExpr`, `CallArgs`, `IndexArgs`, `IndexExpr`, `ArrayInitializer`, `ObjectInitializer`, `MapLiteral`, and `PrintChain`). The clamp runs on the real printer, so it transparently accounts for whatever prefix (statement keyword, callee, type annotation, …) is already on the line.

Because the clamp can only ever **shrink** the budget down to the true remaining width — never below it — it fixes under-splitting (over-long lines) **without introducing over-splitting**: content that genuinely fits within the limit is still kept on one line. Multi-line layout still receives the original, unclamped shape, so inner indentation is unaffected.

## Testing

- [x] Unit tests added/updated — new `line_width_format_tests` module in `baml_fmt` covering: over-long bare calls wrap, over-long `let` initializers wrap, calls that fit (exactly 100 cols) are **not** over-split, and short values after an unavoidably-long prefix expand their value. All assert idempotency.
- [x] `cargo test -p baml_fmt` — 65 passed.
- [x] `cargo test -p baml_tests test_10_formatter` — 189 formatter snapshot tests pass. 4 corpus snapshots updated where previously-overlong lines now wrap correctly (the `format_checks/loop_stmts` fixture even labels these cases "exceeding limit"; the old snapshots had captured the buggy non-wrapping output).
- [x] `cargo clippy -p baml_fmt` — clean.

## PR Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1781895182863419?thread_ts=1781895182.863419&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-4d264e54-7c3b-5f46-b915-be83d00141c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d264e54-7c3b-5f46-b915-be83d00141c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed code formatter to properly respect configured line width settings when formatting complex expressions.
  * Improved line wrapping behavior to correctly account for indentation and code context when determining if expressions should wrap to multiple lines.
  * Enhanced formatting consistency to ensure no formatted line exceeds the configured line width limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->