### PR TITLE
Add Requesty LLM provider

### DIFF
--- a/baml_language/crates/sys_llm/src/auth_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/auth_request/mod.rs
@@ -34,6 +34,7 @@ pub(crate) async fn auth_request(
         | LlmProvider::AzureOpenAi
         | LlmProvider::Ollama
         | LlmProvider::OpenRouter
+        | LlmProvider::Requesty
         | LlmProvider::OpenAiResponses
         | LlmProvider::AiGatewayImages => auth_openai(request, client, provider),
         LlmProvider::AwsBedrock => {
@@ -303,6 +304,27 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(req.headers.get("authorization").unwrap(), "Bearer sk-or");
+    }
+
+    #[tokio::test]
+    async fn requesty_uses_bearer() {
+        let client = make_client(
+            "requesty",
+            PrimitiveClientOptions {
+                api_key: Some("sk-req".to_string()),
+                ..Default::default()
+            },
+        );
+        let mut req = fake_request();
+        auth_request(
+            LlmProvider::Requesty,
+            &mut req,
+            &client,
+            Arc::new(::sys_types::runtime_io::NoopRuntimeIo),
+        )
+        .await
+        .unwrap();
+        assert_eq!(req.headers.get("authorization").unwrap(), "Bearer sk-req");
     }
 
     #[tokio::test]

--- a/baml_language/crates/sys_llm/src/baml_std.rs
+++ b/baml_language/crates/sys_llm/src/baml_std.rs
@@ -164,6 +164,7 @@ fn apply_provider_defaults(provider: LlmProvider, options: &mut PrimitiveClientO
             LlmProvider::AiGatewayImages => Some("https://ai-gateway.vercel.sh/v4/ai".into()),
             LlmProvider::Ollama => Some("http://localhost:11434".into()),
             LlmProvider::OpenRouter => Some("https://openrouter.ai/api/v1".into()),
+            LlmProvider::Requesty => Some("https://router.requesty.ai/v1".into()),
             LlmProvider::GoogleAi => {
                 Some("https://generativelanguage.googleapis.com/v1beta".into())
             }
@@ -187,6 +188,7 @@ fn apply_provider_defaults(provider: LlmProvider, options: &mut PrimitiveClientO
             | LlmProvider::OpenAiResponses
             | LlmProvider::AiGatewayImages
             | LlmProvider::OpenRouter
+            | LlmProvider::Requesty
             | LlmProvider::AzureOpenAi => "system",
             _ => "user",
         };
@@ -231,6 +233,7 @@ fn apply_provider_defaults(provider: LlmProvider, options: &mut PrimitiveClientO
             | LlmProvider::AzureOpenAi
             | LlmProvider::Ollama
             | LlmProvider::OpenRouter
+            | LlmProvider::Requesty
             | LlmProvider::OpenAiResponses
             | LlmProvider::AiGatewayImages => sys_types::generated::owned::llm::MediaUrlHandler {
                 image: Some("send_url".into()),

--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -40,7 +40,8 @@ pub(crate) async fn build_request(
         | LlmProvider::OpenAiGeneric
         | LlmProvider::AzureOpenAi
         | LlmProvider::Ollama
-        | LlmProvider::OpenRouter => openai::chat_completions::build_request(client, &prompt),
+        | LlmProvider::OpenRouter
+        | LlmProvider::Requesty => openai::chat_completions::build_request(client, &prompt),
         LlmProvider::OpenAiResponses => openai::responses::build_request(client, &prompt),
         LlmProvider::AiGatewayImages => openai::images::build_request(client, &prompt),
         LlmProvider::Anthropic => anthropic::build_request(client, &prompt),

--- a/baml_language/crates/sys_llm/src/model_features.rs
+++ b/baml_language/crates/sys_llm/src/model_features.rs
@@ -63,6 +63,7 @@ impl ModelFeatures {
             | LlmProvider::AzureOpenAi
             | LlmProvider::Ollama
             | LlmProvider::OpenRouter
+            | LlmProvider::Requesty
             | LlmProvider::OpenAiResponses
             | LlmProvider::AiGatewayImages => Self {
                 max_one_system_prompt: false,

--- a/baml_language/crates/sys_llm/src/parse_response/mod.rs
+++ b/baml_language/crates/sys_llm/src/parse_response/mod.rs
@@ -148,7 +148,8 @@ pub(crate) fn parse_response(
         | LlmProvider::OpenAiGeneric
         | LlmProvider::AzureOpenAi
         | LlmProvider::Ollama
-        | LlmProvider::OpenRouter => openai::chat_completions::parse_openai_response(body),
+        | LlmProvider::OpenRouter
+        | LlmProvider::Requesty => openai::chat_completions::parse_openai_response(body),
 
         LlmProvider::Anthropic => anthropic::parse_anthropic_response(body),
         LlmProvider::AwsBedrock => bedrock::parse_bedrock_response(body),
@@ -243,6 +244,7 @@ mod tests {
             LlmProvider::AzureOpenAi,
             LlmProvider::Ollama,
             LlmProvider::OpenRouter,
+            LlmProvider::Requesty,
         ] {
             let resp = parse_response(provider, OPENAI_CHAT_BODY).unwrap();
             assert_eq!(resp.content, "ok");

--- a/baml_language/crates/sys_llm/src/provider.rs
+++ b/baml_language/crates/sys_llm/src/provider.rs
@@ -25,6 +25,10 @@ pub enum LlmProvider {
     #[strum(serialize = "openrouter")]
     OpenRouter,
 
+    /// Requesty (OpenAI-compatible, router.requesty.ai)
+    #[strum(serialize = "requesty")]
+    Requesty,
+
     /// `OpenAI` Responses API
     #[strum(serialize = "openai-responses")]
     OpenAiResponses,

--- a/baml_language/crates/sys_llm/src/specialize_prompt/mod.rs
+++ b/baml_language/crates/sys_llm/src/specialize_prompt/mod.rs
@@ -48,6 +48,7 @@ fn provider_promotes_media_to_user(provider: LlmProvider) -> bool {
             | LlmProvider::AzureOpenAi
             | LlmProvider::Ollama
             | LlmProvider::OpenRouter
+            | LlmProvider::Requesty
             | LlmProvider::OpenAiResponses
             | LlmProvider::Anthropic
     )

--- a/baml_language/crates/sys_llm/src/stream_accumulator.rs
+++ b/baml_language/crates/sys_llm/src/stream_accumulator.rs
@@ -83,7 +83,7 @@ pub fn new_accumulator(provider_str: &str) -> Result<ResourceHandle, LlmOpError>
                 message: format!(
                     "Streaming is not yet implemented for provider '{provider_str}'. \
                      Supported providers: openai, openai-generic, azure-openai, ollama, \
-                     openrouter, anthropic."
+                     openrouter, requesty, anthropic."
                 ),
             });
         }

--- a/baml_language/crates/sys_llm/src/stream_accumulator.rs
+++ b/baml_language/crates/sys_llm/src/stream_accumulator.rs
@@ -76,6 +76,7 @@ pub fn new_accumulator(provider_str: &str) -> Result<ResourceHandle, LlmOpError>
         | LlmProvider::AzureOpenAi
         | LlmProvider::Ollama
         | LlmProvider::OpenRouter
+        | LlmProvider::Requesty
         | LlmProvider::Anthropic => {}
         _ => {
             return Err(LlmOpError::NotImplemented {
@@ -155,7 +156,8 @@ fn extract_delta(state: &mut AccumulatorState, data: &serde_json::Value) {
         | LlmProvider::OpenAiGeneric
         | LlmProvider::AzureOpenAi
         | LlmProvider::Ollama
-        | LlmProvider::OpenRouter => {
+        | LlmProvider::OpenRouter
+        | LlmProvider::Requesty => {
             if let Some(model) = data.get("model").and_then(|m| m.as_str()) {
                 state.model = Some(model.to_string());
             }

--- a/fern/03-reference/baml/clients/providers/openai-generic.mdx
+++ b/fern/03-reference/baml/clients/providers/openai-generic.mdx
@@ -32,6 +32,7 @@ A non-exhaustive list of providers you can use with `openai-generic`:
 | LM Studio | [LM Studio](/ref/llm-client-providers/lmstudio) |
 | Ollama | [Ollama](/ref/llm-client-providers/ollama) |
 | OpenRouter | [OpenRouter](/ref/llm-client-providers/openrouter) |
+| Requesty | [Requesty](/ref/llm-client-providers/requesty) |
 | Vercel AI Gateway | [Vercel AI Gateway](/ref/llm-client-providers/vercel-ai-gateway) |
 | Tinfoil | [Tinfoil](/ref/llm-client-providers/tinfoil) |
 | TogetherAI | [TogetherAI](/ref/llm-client-providers/together) |

--- a/fern/03-reference/baml/clients/providers/requesty.mdx
+++ b/fern/03-reference/baml/clients/providers/requesty.mdx
@@ -1,0 +1,50 @@
+---
+title: requesty
+---
+
+The `requesty` provider offers native integration with [Requesty](https://requesty.ai), an OpenAI-compatible router that provides access to models from multiple providers through a single endpoint.
+
+Example:
+
+```baml BAML
+client<llm> MyClient {
+  provider requesty
+  options {
+    model "openai/gpt-4o-mini"
+  }
+}
+```
+
+<Note>
+  You can also use [`openai-generic`](openai-generic) with Requesty by manually setting the `base_url`. The `requesty` provider simplifies this by providing sensible defaults.
+</Note>
+
+## Requesty-specific options
+
+The `requesty` provider extends [`openai-generic`](openai-generic) with Requesty-specific defaults. See [`openai-generic`](openai-generic) for the full list of supported options.
+
+<ParamField path="api_key" type="string">
+  **Default: `env.REQUESTY_API_KEY`**
+
+  Create a key at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys).
+</ParamField>
+
+<ParamField path="base_url" type="string">
+  **Default: `https://router.requesty.ai/v1`**
+</ParamField>
+
+<ParamField path="model" type="string" required>
+  The model to use, in Requesty's `provider/model-name` format.
+
+| Model | Description |
+|-------|-------------|
+| `openai/gpt-4o-mini` | Fast, cost-effective |
+| `openai/gpt-4o` | OpenAI GPT-4o |
+| `anthropic/claude-3-5-sonnet-latest` | Claude 3.5 Sonnet |
+| `google/gemini-2.0-flash-001` | Gemini 2.0 Flash |
+
+For the complete list, see the [Requesty model list](https://app.requesty.ai/router/list).
+</ParamField>
+
+For all other options (`temperature`, `max_tokens`, `headers`, etc.), see [`openai-generic`](openai-generic) and the [Requesty documentation](https://docs.requesty.ai).
+

--- a/fern/03-reference/baml/clients/providers/requesty.mdx
+++ b/fern/03-reference/baml/clients/providers/requesty.mdx
@@ -1,5 +1,6 @@
 ---
-title: requesty
+title: Requesty
+subtitle: OpenAI-compatible router with multi-provider access
 ---
 
 The `requesty` provider offers native integration with [Requesty](https://requesty.ai), an OpenAI-compatible router that provides access to models from multiple providers through a single endpoint.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -804,6 +804,9 @@ navigation:
           - page: "OpenRouter"
             slug: openrouter
             path: 03-reference/baml/clients/providers/openrouter.mdx
+          - page: "Requesty"
+            slug: requesty
+            path: 03-reference/baml/clients/providers/requesty.mdx
           - page: "openai-generic"
             path: 03-reference/baml/clients/providers/openai-generic.mdx
           - page: "Microsoft Foundry (openai-generic)"

--- a/fern/snippets/client-constructor.mdx
+++ b/fern/snippets/client-constructor.mdx
@@ -27,6 +27,7 @@ A non-exhaustive list of providers you can use with `openai-generic`:
 | LM Studio | [LM Studio](/ref/llm-client-providers/lmstudio) |
 | Ollama | [Ollama](/ref/llm-client-providers/ollama) |
 | OpenRouter | [OpenRouter](/ref/llm-client-providers/openrouter) |
+| Requesty | [Requesty](/ref/llm-client-providers/requesty) |
 | Vercel AI Gateway | [Vercel AI Gateway](/ref/llm-client-providers/vercel-ai-gateway) |
 | TogetherAI | [TogetherAI](/ref/llm-client-providers/together) |
 | Unify AI | [Unify AI](/ref/llm-client-providers/unify) |


### PR DESCRIPTION
## Summary

Adds a dedicated native `requesty` LLM provider to the `sys_llm` crate, mirroring the existing `openrouter` provider. [Requesty](https://requesty.ai) is an OpenAI-compatible router (`https://router.requesty.ai/v1`), so the new variant reuses the existing OpenAI chat-completions build/parse/auth code paths — no new transport logic is introduced.

## Changes

Code (`baml_language/crates/sys_llm/src/`):
- `provider.rs` — new `LlmProvider::Requesty` enum variant (strum id `requesty`).
- `baml_std.rs` — default `base_url` (`https://router.requesty.ai/v1`), `default_role`, and media URL handler defaults.
- `auth_request/mod.rs` — routed through `auth_openai` (Bearer); added `requesty_uses_bearer` unit test.
- `build_request/mod.rs` — routed through `openai::chat_completions::build_request`.
- `parse_response/mod.rs` — routed through `openai::chat_completions::parse_openai_response`; added to the parse-coverage test list.
- `model_features.rs` — OpenAI-style feature defaults.
- `specialize_prompt/mod.rs` — media-to-user promotion.
- `stream_accumulator.rs` — streaming model/usage handling (both match arms).

Docs (`fern/`):
- `03-reference/baml/clients/providers/requesty.mdx` — new provider reference page (mirrors `openrouter.mdx`), links to requesty.ai, docs.requesty.ai, app.requesty.ai/api-keys, app.requesty.ai/router/list.
- `docs.yml` — navigation entry.
- `snippets/client-constructor.mdx` and `03-reference/baml/clients/providers/openai-generic.mdx` — added Requesty to the provider tables.

## Verification
- `cargo check -p sys_llm` — clean.
- `cargo test -p sys_llm` — 425 passed, 0 failed (includes new `requesty_uses_bearer` and the extended `parse_response` coverage).
- `cargo clippy -p sys_llm` — no warnings.
- `cargo fmt -p sys_llm` — no changes.
- Live test against `https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini`: HTTP 200, valid completion returned (model resolved to `gpt-4o-mini-2024-07-18`). `GET /v1/models` returns 200. This exercises the same OpenAI-compatible Bearer-auth path the provider uses.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it is not a fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Requesty as a supported LLM provider with OpenAI-compatible request/response handling.
  * Enabled Requesty streaming, with consistent SSE delta parsing.
  * Applied Requesty-appropriate provider defaults and prompt specialization behavior (including multi-system prompt handling and media promotion).
* **Bug Fixes**
  * Fixed Requesty authentication to send `Authorization: Bearer <api_key>` when an API key is configured.
* **Documentation**
  * Added Requesty provider reference docs and linked it from the LLM provider tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->