### PR TITLE
fix(jsonish): keep literal ] inside object string values from closing the string

### DIFF
--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -417,7 +417,14 @@ impl JsonParseState {
                             if keys.len() == values.len() {
                                 (true, false, false)
                             } else {
-                                (false, true, true)
+                                // We're parsing an object *value*: the only structural
+                                // characters that can legitimately follow it are ',' or
+                                // '}'. It is never inside an array, so `in_array` must be
+                                // false -- otherwise a literal ']' inside the string value
+                                // (e.g. "arr = [\"x\", \"y\"]") wrongly closes the string
+                                // and the rest of the input gets merged into this object,
+                                // dropping sibling array elements. See issue #3307.
+                                (false, true, false)
                             }
                         }
                         JsonCollection::Array(_, _) => (false, false, true),

--- a/engine/baml-lib/jsonish/src/tests/test_unions.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_unions.rs
@@ -451,3 +451,24 @@ fn test_try_cast_union_early_return_preserves_incomplete_flag() {
         has_incomplete_no_hint, has_incomplete_with_hint
     );
 }
+
+// Regression for issue #3307: a literal ']' inside a string object value used to
+// prematurely close the string in the fixing parser, merging the next array element
+// into the same object and silently dropping it. Both WriteTool entries must survive.
+const ISSUE_3307_FILE: &str = r#"
+enum WriteKind { WRITE }
+
+class WriteTool {
+  action WriteKind
+  target string
+  content string
+}
+"#;
+
+test_deserializer!(
+  test_issue_3307_bracket_in_string_drops_element,
+  ISSUE_3307_FILE,
+  r#"[{"action": "WRITE", "target": "a", "content": "arr = ["x", "y"]"}, {"action": "WRITE", "target": "b", "content": "z"}]"#,
+  TypeIR::union(vec![TypeIR::class("WriteTool")]).as_list(),
+  [{"action": "WRITE", "target": "a", "content": "arr = [\"x\", \"y\"]"}, {"action": "WRITE", "target": "b", "content": "z"}]
+);


### PR DESCRIPTION
## Problem

Fixes #3307. `b.parse` intermittently returns `[]` (or a shorter list) for arrays whose object string values contain a literal `]`.

## Root cause

In `should_close_string` (`engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs`), the context tuple for an object **value** was `(in_object_key=false, in_object_value=true, in_array=true)`. With `in_array = true`, a literal `]` inside a string value hits the `] if in_array` branch and closes the string early.

Concretely, parsing:

```
[{"action": "WRITE", "target": "a", "content": "arr = ["x", "y"]"}, {"action": "WRITE", "target": "b", "content": "z"}]
```

closes `content` at `arr = ["x", "y` and then treats `]"}, {"action"` as the next key of the **same** object. The two array elements get merged into one object and the second element is silently dropped — the parser returns a 1-element list instead of 2 (and in more corrupted inputs, `[]`).

## Fix

An object value can only be legitimately followed by `,` or `}`, never `]`, so `in_array` must be `false` in that context. Changing the tuple from `(false, true, true)` to `(false, true, false)` stops a literal `]` from prematurely closing an object-value string.

## Tests

- New regression test `test_issue_3307_bracket_in_string_drops_element` — fails before the change, passes after.
- All 483 existing `jsonish` tests still pass (no regressions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a JSON parser issue where special characters (like `]`) appearing within string values could cause premature parsing termination, resulting in loss of subsequent data elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->