### PR TITLE
feat(openai-responses): surface response_id + document previous_response_id passthrough

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/mod.rs
@@ -319,6 +319,11 @@ pub struct LLMCompleteResponseMetadata {
     pub output_tokens: Option<u64>,
     pub total_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
+    /// Provider-assigned response id, when the API returns one (e.g. the OpenAI
+    /// Responses API `id`). Surfaced so stateless callers can capture it and pass
+    /// it back as `previous_response_id` on the next turn to resume server-side
+    /// state. `None` for providers/endpoints that don't return a response id.
+    pub response_id: Option<String>,
 }
 
 // This is how the response gets logged if you print the result to the console.

--- a/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/response_handler.rs
@@ -87,6 +87,7 @@ pub fn parse_anthropic_response<C: WithClient + RequestBuilder>(
         request_options: client.request_options().clone(),
         model: response.model,
         metadata: LLMCompleteResponseMetadata {
+            response_id: None,
             baml_is_complete: is_done(&response.stop_reason),
             finish_reason: response.stop_reason.clone(),
             prompt_tokens: Some(response.usage.input_tokens),
@@ -224,6 +225,7 @@ mod tests {
             model: model_name,
             request_options: client.request_options().clone(),
             metadata: LLMCompleteResponseMetadata {
+                response_id: None,
                 baml_is_complete: true,
                 finish_reason: Some("end_turn".to_string()),
                 prompt_tokens: Some(321),

--- a/engine/baml-runtime/src/internal/llm_client/primitive/aws/aws_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/aws/aws_client.rs
@@ -1019,6 +1019,7 @@ impl WithStreamChat for AwsClient {
                     model: self.properties.model.clone(),
                     request_options,
                     metadata: LLMCompleteResponseMetadata {
+                        response_id: None,
                         baml_is_complete: false,
                         finish_reason: None,
                         prompt_tokens: None,
@@ -1460,6 +1461,7 @@ impl WithChat for AwsClient {
                 request_options,
                 model: self.properties.model.clone(),
                 metadata: LLMCompleteResponseMetadata {
+                    response_id: None,
                     baml_is_complete: matches!(
                         response.stop_reason,
                         bedrock::types::StopReason::StopSequence

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs
@@ -91,6 +91,7 @@ pub fn parse_google_response<C: WithClient + RequestBuilder>(
         request_options: client.request_options().clone(),
         model: model_name,
         metadata: LLMCompleteResponseMetadata {
+            response_id: None,
             baml_is_complete: candidate
                 .finish_reason
                 .as_ref()
@@ -333,6 +334,7 @@ mod tests {
             model: "gemini-1.5-flash".to_string(),
             request_options: client.request_options().clone(),
             metadata: LLMCompleteResponseMetadata {
+                response_id: None,
                 baml_is_complete: true,
                 finish_reason: Some("STOP".to_string()),
                 prompt_tokens: Some(166),

--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/openai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/openai_client.rs
@@ -129,7 +129,13 @@ impl ProviderStrategy {
     ) -> Result<serde_json::Value> {
         match self {
             ProviderStrategy::ResponsesApi => {
-                // Start with all properties passed through
+                // Start with all properties passed through. Responses-API request fields set as
+                // client options — e.g. `previous_response_id` (resume server-side state from a
+                // prior turn) and `store` — are forwarded verbatim to the request body. Combined
+                // with the surfaced `response_id` in the response metadata
+                // (LLMCompleteResponseMetadata.response_id), a caller can chain turns: read
+                // response_id from turn N, pass it as previous_response_id into turn N+1. BAML
+                // stays stateless — it forwards what the caller provides; it does not auto-track ids.
                 let mut body = properties.clone();
 
                 let input = match prompt {

--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/response_handler.rs
@@ -83,6 +83,7 @@ pub fn parse_openai_response<C: WithClient + RequestBuilder>(
         model: response.model,
         request_options: client.request_options().clone(),
         metadata: LLMCompleteResponseMetadata {
+            response_id: None,
             baml_is_complete: match response.choices.first() {
                 Some(c) => c.finish_reason.as_ref().is_some_and(|f| f == "stop"),
                 None => false,
@@ -237,6 +238,7 @@ mod tests {
             model: "gpt-4o-2024-08-06".to_string(),
             request_options: client.request_options().clone(),
             metadata: LLMCompleteResponseMetadata {
+                response_id: None,
                 baml_is_complete: true,
                 finish_reason: Some("stop".to_string()),
                 prompt_tokens: Some(128),
@@ -338,6 +340,7 @@ pub fn parse_openai_responses_response<C: WithClient + RequestBuilder>(
         model: response.model,
         request_options: client.request_options().clone(),
         metadata: LLMCompleteResponseMetadata {
+            response_id: Some(response.id),
             baml_is_complete: response.status == "completed",
             finish_reason: Some(response.status),
             prompt_tokens: usage.map(|u| u.prompt_tokens),
@@ -547,6 +550,7 @@ mod responses_tests {
             model: "gpt-4.1-2025-04-14".to_string(),
             request_options: client.request_options().clone(),
             metadata: LLMCompleteResponseMetadata {
+                response_id: Some("resp_67ccd2bed1ec8190b14f964abc0542670bb6a6b452d3795b".to_string()),
                 baml_is_complete: true,
                 finish_reason: Some("completed".to_string()),
                 prompt_tokens: Some(36),
@@ -848,6 +852,7 @@ mod responses_tests {
             model: "gpt-5-2025-08-07".to_string(),
             request_options: client.request_options().clone(),
             metadata: LLMCompleteResponseMetadata {
+                response_id: Some("resp_68d21b0cb6908190a158e3c0e30a0b4c08c9448688b650fd".to_string()),
                 baml_is_complete: true,
                 finish_reason: Some("completed".to_string()),
                 prompt_tokens: Some(480),
@@ -970,6 +975,7 @@ mod responses_tests {
             model: "gpt-5-mini-2025-08-07".to_string(),
             request_options: client.request_options().clone(),
             metadata: LLMCompleteResponseMetadata {
+                response_id: Some("resp_0zcvUwjYtvOrllY9du6zPhINkdB0vdIjoT6WWeGBoXgGrdxRoKtv0I".to_string()),
                 baml_is_complete: true,
                 finish_reason: Some("completed".to_string()),
                 prompt_tokens: Some(480),

--- a/engine/baml-runtime/src/internal/llm_client/primitive/stream_request.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/stream_request.rs
@@ -153,6 +153,7 @@ pub async fn make_stream_request(
                         model: model_name.clone().unwrap_or("<unknown>".to_string()),
                         request_options: params.clone(),
                         metadata: LLMCompleteResponseMetadata {
+                            response_id: None,
                             baml_is_complete: false,
                             finish_reason: None,
                             prompt_tokens: None,

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/response_handler.rs
@@ -94,6 +94,7 @@ pub fn parse_vertex_response<C: WithClient + RequestBuilder>(
         request_options: client.request_options().clone(),
         model: model_name.unwrap_or("<unknown>".to_string()),
         metadata: LLMCompleteResponseMetadata {
+            response_id: None,
             baml_is_complete: response.candidates[0].finish_reason == Some("STOP".to_string()),
             finish_reason: response.candidates[0]
                 .finish_reason
@@ -275,6 +276,7 @@ mod tests {
             model: model_name,
             request_options: client.request_options().clone(),
             metadata: LLMCompleteResponseMetadata {
+                response_id: None,
                 baml_is_complete: true,
                 finish_reason: Some("STOP".to_string()),
                 prompt_tokens: Some(79),

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -1268,6 +1268,7 @@ impl BamlRuntime {
                             latency: web_time::Duration::from_millis(0),
                             content: String::new(),
                             metadata: LLMCompleteResponseMetadata {
+                                response_id: None,
                                 baml_is_complete: true,
                                 finish_reason: None,
                                 prompt_tokens: None,
@@ -1371,6 +1372,7 @@ impl BamlRuntime {
             start_time: SystemTime::now(),
             latency: Duration::from_millis(2025),
             metadata: LLMCompleteResponseMetadata {
+                response_id: None,
                 baml_is_complete: true,
                 finish_reason: Some("stop".to_string()),
                 prompt_tokens: Some(50),

--- a/engine/baml-runtime/src/test_constraints.rs
+++ b/engine/baml-runtime/src/test_constraints.rs
@@ -331,6 +331,7 @@ mod tests {
             start_time: web_time::SystemTime::UNIX_EPOCH,
             latency: web_time::Duration::from_millis(500),
             metadata: LLMCompleteResponseMetadata {
+                response_id: None,
                 baml_is_complete: true,
                 finish_reason: None,
                 prompt_tokens: None,


### PR DESCRIPTION
## What

Enables **resumable / stateful multi-turn** use of the OpenAI **Responses API**
(`provider "openai-responses"`) — without BAML holding any session state.

Today the Responses API's server-side conversation state (via `previous_response_id`)
isn't reachable from BAML: the response `id` is parsed but dropped, so a caller has
no way to chain turns. This PR closes that, keeping BAML stateless (the caller
supplies and chains ids; BAML never tracks or auto-injects them).

## Changes

**1. Surface the response id (output side).**
`parse_openai_responses_response` already deserializes `ResponsesApiResponse.id` but
discarded it. Added `response_id: Option<String>` to `LLMCompleteResponseMetadata`
and populate it from the Responses API `id`. It's `None` for every other
provider/endpoint (chat/completions, Anthropic, Google, Vertex, AWS, streaming).

**2. Document `previous_response_id` / `store` passthrough (input side).**
These already forward to the request body via the existing `properties.clone()` in
the `ResponsesApi` `build_body` — added an in-code comment so it's discoverable.

**Together:** read `response_id` from turn N's metadata → pass it as
`previous_response_id` into turn N+1 → server-side session resumes.

```baml
client<llm> CoralResp {
  provider openai-responses
  options { model "gpt-..." }
}
// turn 1: capture response_id from the run metadata
// turn 2: set previous_response_id = <that id> (e.g. via ClientRegistry options) → resumes
```

## Design note

This deliberately keeps BAML **stateless / pure-function**: BAML forwards what the
caller provides and surfaces what the API returns — it does **not** track response
ids or auto-inject `previous_response_id`. That's left to the caller (or an
application-layer/proxy that maps a session → last id), consistent with BAML's
existing design philosophy.

## Tests

Updated the three `parse_openai_responses_*` unit tests to assert the surfaced id.

> ⚠️ Opened as **draft**: I wasn't able to run the full `engine` Rust build/test
> suite in my environment. The change is mechanical (one new `Option<String>`
> metadata field, populated at the Responses parser, `None` at all other
> constructor sites), but please let CI validate the build/tests. Happy to adjust
> field placement / naming to match maintainer preference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added response tracking capability across all supported language model providers. Response identifiers are now captured and can be referenced in subsequent API calls to maintain conversation context and continuity in multi-turn interactions.

* **Tests**
  * Updated test cases and fixtures to validate the new response tracking functionality across all provider implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->