### PR TITLE
shebang: make .baml files executable via `baml run --file`

### DIFF
--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -377,6 +377,10 @@ impl RunArgs {
             return self.print_list(&engine, &scripts, &namespaces, &self.output_format);
         }
 
+        if self.file.is_some() && self.target.is_none() && self.functions.is_empty() {
+            return self.run_single_target("main", reporter);
+        }
+
         // No target → print help and exit non-zero. (Implicit `main` no
         // longer exists.)
         if self.target.is_none() && self.functions.is_empty() {

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -915,6 +915,162 @@ fn test_without_baml_toml_using_baml_src_returns_no_tests_code() {
     );
 }
 
+// ============================================================================
+// `baml run --file` script mode + shebang execution
+// ============================================================================
+
+/// Executing an actual `#!` script through the OS kernel: the implicit
+/// `main` entry point runs, and arguments passed after a `--` separator at
+/// the call site (`./script.baml -- alpha …`) flow into `baml.sys.argv()`.
+/// (There is no bare-shebang passthrough, so the `--` is required.)
+#[cfg(unix)]
+#[test]
+fn run_file_script_mode_passes_args_after_separator_as_argv() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let built = common::ensure_built();
+    let cli = built.baml_cli.display();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let script = tmp.path().join("script.baml");
+    std::fs::write(
+        &script,
+        format!(
+            "#!/usr/bin/env -S BAML_CLI_ALLOW_DIRECT=1 {cli} run --file\n\
+             function main() -> string[] {{\n    baml.sys.argv()\n}}\n"
+        ),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).unwrap();
+
+    // The kernel turns `./script.baml -- alpha --beta gamma` into
+    // `… run --file <script> -- alpha --beta gamma`.
+    let output = Command::new(&script)
+        .args(["--", "alpha", "--beta", "gamma"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("execute the shebang script directly");
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 running a shebang script, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The tokens after `--` land in argv verbatim — including the `--beta`
+    // flag, which is NOT consumed as a run-level option.
+    for needle in ["alpha", "--beta", "gamma", "main"] {
+        assert!(
+            stdout.contains(needle),
+            "Expected argv to contain `{needle}`, got:\n{stdout}"
+        );
+    }
+}
+
+/// A shebang can name a *specific* function to run, not just `main`: the
+/// function name goes in the shebang before `--file`
+/// (`#! … run greet --file`), and the kernel appends the script path as the
+/// `--file` value. The named function runs; `main` does not.
+#[cfg(unix)]
+#[test]
+fn shebang_can_name_a_specific_function() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let built = common::ensure_built();
+    let cli = built.baml_cli.display();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let script = tmp.path().join("multi.baml");
+    // `run greet --file` selects `greet`; the kernel appends this script's
+    // path right after `--file`, so it becomes the `--file` value.
+    std::fs::write(
+        &script,
+        format!(
+            "#!/usr/bin/env -S BAML_CLI_ALLOW_DIRECT=1 {cli} run greet --file\n\
+             function greet() -> string {{\n    \"greetings from the named function\"\n}}\n\
+             function main() -> string {{\n    \"this is main, not greet\"\n}}\n"
+        ),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).unwrap();
+
+    let output = Command::new(&script)
+        .current_dir(tmp.path())
+        .output()
+        .expect("execute the shebang script directly");
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0 dispatching a named function from a shebang, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("greetings from the named function"),
+        "Expected `greet` output, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("this is main"),
+        "Expected `greet` to run, not `main`, got:\n{stdout}"
+    );
+}
+
+/// The real thing: make a `.baml` file executable with a `#!` line pointing
+/// at the built CLI, then run it directly so the OS kernel drives the
+/// shebang. Proves the feature end-to-end on Unix. The `env -S` line also
+/// sets `BAML_CLI_ALLOW_DIRECT=1`, exactly as the committed demo does, to
+/// silence the direct-invocation advisory.
+#[cfg(unix)]
+#[test]
+fn executable_baml_script_runs_via_kernel_shebang() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let built = common::ensure_built();
+    let cli = built.baml_cli.display();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let script = tmp.path().join("greet.baml");
+    std::fs::write(
+        &script,
+        format!(
+            "#!/usr/bin/env -S BAML_CLI_ALLOW_DIRECT=1 {cli} run --file\n\
+             function main() -> string {{\n    \"hello from a shebang script\"\n}}\n"
+        ),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).unwrap();
+
+    // No arguments: bare-shebang passthrough is unsupported, so the script
+    // takes none. The kernel drives `#! … run --file <this script>`.
+    let output = Command::new(&script)
+        .current_dir(tmp.path())
+        .output()
+        .expect("execute the shebang script directly");
+
+    assert!(
+        output.status.success(),
+        "Expected the executable .baml to run, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("hello from a shebang script"),
+        "Expected the script's output, got:\n{stdout}"
+    );
+}
+
 /// Generators are declared in `baml.toml`'s `[generator.<name>]` sections,
 /// so a manifest-less `baml_src/`-only project has nowhere to declare one:
 /// `baml generate` reports the missing-generator hint rather than producing

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -845,6 +845,14 @@ impl<'a> Parser<'a> {
             }
             return true;
         }
+        // A `#!` shebang is treated just like `//`, so .baml files can be shebang'd
+        //   #!/usr/bin/env -S baml run --file
+        if i + 1 < self.tokens.len()
+            && self.tokens[i].kind == TokenKind::Hash
+            && self.tokens[i + 1].kind == TokenKind::Not
+        {
+            return true;
+        }
         false
     }
 
@@ -7809,6 +7817,65 @@ mod tests {
         assert!(
             errors.is_empty(),
             "expected no parse errors, got: {errors:#?}"
+        );
+    }
+
+    /// A leading `#!` shebang line parses as a comment, so the file behind
+    /// it is valid BAML — this is what makes `.baml` files executable via
+    /// `#!/usr/bin/env -S baml run --file`.
+    #[test]
+    fn leading_shebang_is_treated_as_a_line_comment() {
+        let source =
+            "#!/usr/bin/env -S baml run --file\nfunction main() -> string {\n  \"hi\"\n}\n";
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        // The shebang is emitted as a LINE_COMMENT trivia token, and the
+        // function after it is parsed normally.
+        let has_line_comment = root.descendants_with_tokens().any(|elem| {
+            matches!(
+                elem,
+                rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::LINE_COMMENT
+                    && t.text().starts_with("#!")
+            )
+        });
+        assert!(has_line_comment, "shebang should lex as a LINE_COMMENT");
+        assert_eq!(
+            SourceFile::cast(root)
+                .map(|sf| sf.items().count())
+                .unwrap_or(0),
+            1,
+            "the function after the shebang should still parse"
+        );
+    }
+
+    /// Parsing must stay lossless: the original source — shebang included —
+    /// reconstructs exactly from the syntax tree. If `baml fmt` ever dropped
+    /// or moved the shebang, the file would stop being executable.
+    #[test]
+    fn shebang_round_trips_losslessly() {
+        let source = "#!/usr/bin/env -S baml run --file\nfunction main() -> string { \"hi\" }\n";
+        let (root, _errors) = parse_source(source);
+        assert_eq!(root.text().to_string(), source);
+    }
+
+    /// `#!` is only a comment delimiter outside string bodies — a `#!`
+    /// inside a regular string stays literal, never swallowing the rest of
+    /// the line.
+    #[test]
+    fn hash_bang_inside_string_is_not_a_comment() {
+        let source = "function main() -> string {\n  \"a #! b\"\n}\n";
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        let has_line_comment = root.descendants_with_tokens().any(|elem| {
+            matches!(
+                elem,
+                rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::LINE_COMMENT
+            )
+        });
+        assert!(
+            !has_line_comment,
+            "`#!` inside a string must not be treated as a comment"
         );
     }
 

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -81,6 +81,23 @@ pub enum FormatterError {
 mod lambda_format_tests {
     use super::*;
 
+    /// A `#!` shebang must survive formatting verbatim as the first line —
+    /// otherwise `baml fmt` would silently break an executable `.baml`
+    /// script. The shebang is treated as a leading line comment.
+    #[test]
+    fn test_shebang_preserved_as_first_line() {
+        let source =
+            "#!/usr/bin/env -S baml run --file\nfunction main() -> string {\n    \"hi\"\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should accept a shebang");
+        assert!(
+            formatted.starts_with("#!/usr/bin/env -S baml run --file\n"),
+            "shebang must remain the literal first line, got:\n{formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
     #[test]
     fn test_lambda_basic_formatting() {
         let source = "function test_annotated() -> int {\n    let double = (x: int) -> int { x * 2 }\n    double(21)\n}\n";


### PR DESCRIPTION
## What

Make a `.baml` file executable as a Unix script, run by the locally built CLI:

```baml
#!/usr/bin/env -S BAML_CLI_ALLOW_DIRECT=1 ./target/debug/baml-cli run --file
function main() -> void {
  baml.io.println("hello from an executable .baml script");
}
```

```bash
cargo build -p baml_cli
chmod +x demos/shebang/greet.baml
./demos/shebang/greet.baml      # run from baml_language/
```

## How (additive)

1. **`#!` is a line comment, same as `//`** (`baml_compiler_parser`): one `Hash Not` case in `is_line_comment_at`. `#!…` becomes a `LINE_COMMENT` everywhere — tolerated by the editor/LSP, `fmt`, `run`, and `pack`, preserved losslessly so `fmt` keeps it as line 1. Safe because `#!` is never otherwise valid BAML (`#` only opens raw strings) and comment detection is off inside string bodies.
2. **`run --file` script-mode** (`baml_cli`): when `--file <PATH>` is given with no explicit target/`-f`, the file's `main` runs. To pass arguments (available via `baml.sys.argv()`), use an explicit `--` separator: `baml run --file app.baml -- a b`. Bare-shebang argument passthrough is intentionally **not** supported for now — a shebang script runs `main` with no args.
3. **Demo + tests**: `demos/shebang/greet.baml`, parser tests (`#!` leading / in-string / lossless), an `fmt` test (shebang stays line 1), and e2e tests in `crates/baml_cli/tests/exit_code_e2e.rs` (script-mode main, explicit-`--` argv, bare-arg rejection, function dispatch from a shebang file, and a real kernel-driven `#!` run on Unix).

## Notes

- `main`'s return value prints (consistent with `pack` — both share `dispatch_target`); use `-> void` for clean stdout and `baml.sys.exit(code)` for the exit status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for executable `.baml` scripts with Unix shebang support, enabling direct script execution
  * Command-line arguments can be passed after a `--` separator and accessed within scripts
  * Shebang lines in `.baml` files are now properly recognized and preserved during parsing and formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->