### PR TITLE
[codex] Improve callback throws diagnostics

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -663,7 +663,7 @@ impl fmt::Display for TirTypeError {
                 } else {
                     write!(
                         f,
-                        "Add an explicit `throws` to the callback, catch the call, or make the callback non-throwing."
+                        "The callback type does not say what it can throw. If `{callback_name}` is an infallible host callback, annotate it with `throws never`; otherwise catch the call or let the enclosing function declare/propagate the callback's throws."
                     )
                 }
             }

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -6097,7 +6097,7 @@ fn source_aware_tir_type_error_message(
                 )
             } else {
                 format!(
-                    "this body may throw through callback `{callback_name}`, but declared throws is `{}`. Add an explicit `throws` to the callback, catch the call, or make the callback non-throwing.",
+                    "this body may throw through callback `{callback_name}`, but declared throws is `{}`. The callback type does not say what it can throw. If `{callback_name}` is an infallible host callback, annotate it with `throws never`; otherwise catch the call or let the enclosing function declare/propagate the callback's throws.",
                     ty(declared)
                 )
             }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__04_tir.snap
@@ -38,7 +38,7 @@ function user.return_closure(handler: (value: int) -> string throws never) -> (v
           handler(value)
         }
   }
-  !! 727..769: this body may throw through callback `handler`, but declared throws is `never`. Add an explicit `throws` to the callback, catch the call, or make the callback non-throwing.
+  !! 727..769: this body may throw through callback `handler`, but declared throws is `never`. The callback type does not say what it can throw. If `handler` is an infallible host callback, annotate it with `throws never`; otherwise catch the call or let the enclosing function declare/propagate the callback's throws.
 }
 lambda user.return_closure {
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__05_diagnostics.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 === COMPILER2 DIAGNOSTICS ===
-  [type] error: this body may throw through callback `handler`, but declared throws is `never`. Add an explicit `throws` to the callback, catch the call, or make the callback non-throwing.
+  [type] error: this body may throw through callback `handler`, but declared throws is `never`. The callback type does not say what it can throw. If `handler` is an infallible host callback, annotate it with `throws never`; otherwise catch the call or let the enclosing function declare/propagate the callback's throws.
     ╭─[ function_type_throws.baml:28:9 ]
     │
  28 │   return (value: int) -> string { handler(value) }
     │         ─────────────────────┬────────────────────  
-    │                              ╰────────────────────── this body may throw through callback `handler`, but declared throws is `never`. Add an explicit `throws` to the callback, catch the call, or make the callback non-throwing.
+    │                              ╰────────────────────── this body may throw through callback `handler`, but declared throws is `never`. The callback type does not say what it can throw. If `handler` is an infallible host callback, annotate it with `throws never`; otherwise catch the call or let the enclosing function declare/propagate the callback's throws.
     │ 
     │ Note: Error code: E0096
 ────╯

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -246,6 +246,28 @@ function f(s: Sentiment) -> string {
 }
 
 #[test]
+fn unknown_field_access_uses_narrowing_diagnostic() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "\
+function load(raw: unknown) -> string {
+  return raw.email.to_lower_case();
+}",
+    );
+
+    let output = render_tir(&db, file);
+    assert!(
+        output.contains("cannot access field `email` on `unknown`"),
+        "expected unknown-specific field access diagnostic, got:\n{output}"
+    );
+    assert!(
+        !output.contains("type `unknown` has no member `email`"),
+        "unknown field access should not use the generic missing-member wording:\n{output}"
+    );
+}
+
+#[test]
 fn binary_op_int_add() {
     let mut db = make_db();
     let file = db.add_file(

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
@@ -463,9 +463,9 @@ fn function_type_throws_direct_callback_violation_is_humanized() {
     );
     assert!(
         output.contains(
-            "Add an explicit `throws` to the callback, catch the call, or make the callback non-throwing."
+            "The callback type does not say what it can throw. If `cb` is an infallible host callback, annotate it with `throws never`; otherwise catch the call or let the enclosing function declare/propagate the callback's throws."
         ),
-        "expected direct callback violation to use callback-oriented wording, got:\n{output}"
+        "expected direct callback violation to frame `throws never` as the infallible-host-callback case, got:\n{output}"
     );
 }
 


### PR DESCRIPTION
## Summary

- clarify callback throws contract diagnostics when a callable parameter has an unspecified throw surface
- frame `throws never` as the infallible host-callback case, not a blanket requirement for BAML functions
- add a regression for field access on `unknown` to preserve the existing specialized diagnostic wording

## Validation

- `cargo nextest run -p baml_fmt linear_formatter_regression_tests::keyword_path_segments_format --no-capture`
- `cargo nextest run -p baml_tests compiler2_tir::inference::unknown_field_access_uses_narrowing_diagnostic --no-capture`
- `cargo nextest run -p baml_tests compiler2_tir::phase8_exceptions::function_type_throws_direct_callback_violation_is_humanized --no-capture`
- `cargo fmt --check`
- `SKIP=no-commit-to-branch prek run --all-files --show-diff-on-failure --hook-stage manual`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing diagnostic text and test/snapshot updates only; no type-checking or runtime behavior changes.
> 
> **Overview**
> **Callback throws contract violations** now give clearer fix-it text when the callable’s type does not specify what it can throw (`concrete_throws` is missing). Instead of a generic “add an explicit `throws` to the callback”, the message explains that the callback type is underspecified and points users to **`throws never` for infallible host callbacks**, or to catch the call / widen the enclosing function’s throws otherwise. The same wording is wired in **TIR display** (`infer_context.rs`) and **LSP humanization** (`baml_lsp2_actions`).
> 
> Tests and snapshots for void-return / function-type-throws scenarios were updated to match. A new **`unknown_field_access_uses_narrowing_diagnostic`** regression asserts field access on `unknown` keeps the specialized `cannot access field … on unknown` message (not the generic “has no member” wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a781c042e4a1a8bcb19b0d8a1ab9407de4c01f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for callback throw contract violations, with clearer guidance for infallible host callbacks and how to handle thrown values.
  * Refined diagnostics for unknown field access so the message is more specific and less misleading.
* **Tests**
  * Added coverage for the updated unknown-field diagnostic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->