### PR TITLE
feat(cli): `baml describe` topics for SDKs and patterns

### DIFF
--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -720,3 +720,106 @@ with:
       do_work()
     }
   details: "`with` is a contextual keyword, not a general operator — it is only special right after a `test`/`testset` name (selecting the test runner expression) or after `spawn` (passing `baml.spawn.options(...)`). Everywhere else `with` is an ordinary identifier and may be used as a variable or field name."
+
+# ── Cross-language SDKs (baml generate) ──────────────────────────────────────
+
+baml_sdk:
+  summary: "Call your BAML functions from another language via a generated SDK."
+  syntax: |
+    # 1. declare a generator in baml.toml
+    [generator.app]
+    output_type = "python/pydantic"   # python/pydantic | python/pydantic/v1 | typescript/node
+    output_dir  = "../app"
+    naming_convention = "preserve-case"   # preserve-case | language
+
+    # 2. generate the typed client
+    baml generate
+  details: |
+    `baml generate` reads every [generator.<name>] section in baml.toml and emits
+    a typed `baml_sdk` package into each output_dir. Install the runtime for your
+    language, import the generated package, and call your functions with native
+    types. Per-language install + usage:
+
+      baml describe python
+      baml describe typescript
+
+python:
+  summary: "Use BAML from Python via a generated Pydantic v2 SDK."
+  syntax: |
+    pip install baml_core                  # the runtime (Python 3.10+)
+
+    # baml.toml — declare a generator:
+    [generator.app]
+    output_type = "python/pydantic"        # or "python/pydantic/v1"
+    output_dir  = "../app"
+    naming_convention = "preserve-case"
+
+    baml generate                          # emits the `baml_sdk` package into output_dir
+  details: |
+    You install `baml_core` (the runtime); you import `baml_sdk` (the generated
+    code). Functions become top-level Python functions; classes/enums become
+    Pydantic models:
+
+      import baml_sdk                       # initializes the BAML runtime
+      from baml_sdk import ClassifyTicket
+      ticket = ClassifyTicket("login is broken")   # typed in, typed Pydantic out
+
+    See also: `baml describe baml_sdk`, `baml describe typescript`.
+
+typescript:
+  summary: "Use BAML from TypeScript / Node.js via a generated SDK."
+  syntax: |
+    npm install @boundaryml/baml-core-node   # the runtime
+
+    # baml.toml — declare a generator:
+    [generator.app]
+    output_type = "typescript/node"
+    output_dir  = "../app"
+    naming_convention = "preserve-case"
+
+    baml generate                            # emits the `baml_sdk` package into output_dir
+  details: |
+    Import the generated package (its index initializes the runtime), then call
+    the exported functions with native TypeScript types (LLM calls are async):
+
+      import "./app/baml_sdk/index.js";
+      import { ClassifyTicket } from "./app/baml_sdk/index.js";
+      const ticket = await ClassifyTicket("login is broken");
+
+    See also: `baml describe baml_sdk`, `baml describe python`.
+
+# ── Pattern matching (alias topics for `match`) ──────────────────────────────
+
+patterns:
+  summary: "Where patterns appear: match arms, the `is` operator, and `if let`."
+  syntax: |
+    // match — over values and/or types; first matching arm wins, must be exhaustive
+    match (v) {
+      0 => "zero",                          // literal value, no binding
+      1 | 2 | 3 => "small",                 // or-pattern
+      let n: int if n < 0 => "neg",         // typed binding + guard
+      Rect { w: let w, h: let h } => w * h, // class destructure, bind fields
+      [let first, ..] => first,             // array: head + rest
+      let c: Circle => c.r,                 // typed binding (matches + narrows)
+      _ => "other",                         // wildcard
+    }
+
+    // is — returns bool and narrows inside the branch
+    if (v is Circle) { /* v is Circle here */ }
+
+    // if let — bind one pattern, else fall through
+    if let r: Rect = v { r.w } else if let c: Circle = v { c.r } else { 0 }
+  details: |
+    Pattern forms: literals (`0`, `"ok"`); `let x` (bind), `let x: T` (bind +
+    narrow), `_` (wildcard); class destructure `T { field: <pattern> }`; array
+    `[a, ..]` / `[.., z]`; or-patterns `A | B` (bindings must line up); guards
+    `<pattern> if cond`. `match` must be exhaustive — a `_` arm is allowed only
+    when earlier arms leave a gap. Same topic: `baml describe match`.
+
+pattern:
+  summary: "Pattern matching — see `baml describe patterns` (or `match`)."
+  syntax: |
+    match (v) { let x: T => ..., A { f: let y } => y, _ => ... }
+    if (v is T) { ... }
+    if let x: T = v { ... } else { ... }
+  details: "Full guide: `baml describe patterns`. Match-arm reference: `baml describe match`."

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -1082,6 +1082,42 @@ fn render_keyword_spawn() {
 }
 
 #[test]
+fn render_keyword_baml_sdk() {
+    let output = capture_keyword("baml_sdk");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn render_keyword_python() {
+    let output = capture_keyword("python");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn render_keyword_typescript() {
+    let output = capture_keyword("typescript");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn render_keyword_patterns() {
+    let output = capture_keyword("patterns");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn dispatch_language_topic_resolves_to_keyword() {
+    // Language/SDK + pattern topics route to keyword docs, not package resolution.
+    let db = simple_project();
+    for name in ["python", "typescript", "baml_sdk", "patterns", "pattern"] {
+        assert!(
+            matches!(dispatch(&db, name), Some(ResolvedTarget::Keyword(_))),
+            "`{name}` should resolve to a keyword topic"
+        );
+    }
+}
+
+#[test]
 fn render_keyword_interface() {
     let output = capture_keyword("interface");
     insta::assert_snapshot!(output);

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_baml_sdk.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_baml_sdk.snap
@@ -1,0 +1,23 @@
+---
+source: crates/baml_cli/src/describe_command_tests.rs
+expression: output
+---
+baml_sdk — Call your BAML functions from another language via a generated SDK.
+
+Syntax:
+  # 1. declare a generator in baml.toml
+  [generator.app]
+  output_type = "python/pydantic"   # python/pydantic | python/pydantic/v1 | typescript/node
+  output_dir  = "../app"
+  naming_convention = "preserve-case"   # preserve-case | language
+  
+  # 2. generate the typed client
+  baml generate
+
+`baml generate` reads every [generator.<name>] section in baml.toml and emits
+a typed `baml_sdk` package into each output_dir. Install the runtime for your
+language, import the generated package, and call your functions with native
+types. Per-language install + usage:
+
+  baml describe python
+  baml describe typescript

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_patterns.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_patterns.snap
@@ -1,0 +1,29 @@
+---
+source: crates/baml_cli/src/describe_command_tests.rs
+expression: output
+---
+patterns — Where patterns appear: match arms, the `is` operator, and `if let`.
+
+Syntax:
+  // match — over values and/or types; first matching arm wins, must be exhaustive
+  match (v) {
+    0 => "zero",                          // literal value, no binding
+    1 | 2 | 3 => "small",                 // or-pattern
+    let n: int if n < 0 => "neg",         // typed binding + guard
+    Rect { w: let w, h: let h } => w * h, // class destructure, bind fields
+    [let first, ..] => first,             // array: head + rest
+    let c: Circle => c.r,                 // typed binding (matches + narrows)
+    _ => "other",                         // wildcard
+  }
+  
+  // is — returns bool and narrows inside the branch
+  if (v is Circle) { /* v is Circle here */ }
+  
+  // if let — bind one pattern, else fall through
+  if let r: Rect = v { r.w } else if let c: Circle = v { c.r } else { 0 }
+
+Pattern forms: literals (`0`, `"ok"`); `let x` (bind), `let x: T` (bind +
+narrow), `_` (wildcard); class destructure `T { field: <pattern> }`; array
+`[a, ..]` / `[.., z]`; or-patterns `A | B` (bindings must line up); guards
+`<pattern> if cond`. `match` must be exhaustive — a `_` arm is allowed only
+when earlier arms leave a gap. Same topic: `baml describe match`.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_python.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_python.snap
@@ -1,0 +1,26 @@
+---
+source: crates/baml_cli/src/describe_command_tests.rs
+expression: output
+---
+python — Use BAML from Python via a generated Pydantic v2 SDK.
+
+Syntax:
+  pip install baml_core                  # the runtime (Python 3.10+)
+  
+  # baml.toml — declare a generator:
+  [generator.app]
+  output_type = "python/pydantic"        # or "python/pydantic/v1"
+  output_dir  = "../app"
+  naming_convention = "preserve-case"
+  
+  baml generate                          # emits the `baml_sdk` package into output_dir
+
+You install `baml_core` (the runtime); you import `baml_sdk` (the generated
+code). Functions become top-level Python functions; classes/enums become
+Pydantic models:
+
+  import baml_sdk                       # initializes the BAML runtime
+  from baml_sdk import ClassifyTicket
+  ticket = ClassifyTicket("login is broken")   # typed in, typed Pydantic out
+
+See also: `baml describe baml_sdk`, `baml describe typescript`.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_typescript.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_typescript.snap
@@ -1,0 +1,25 @@
+---
+source: crates/baml_cli/src/describe_command_tests.rs
+expression: output
+---
+typescript — Use BAML from TypeScript / Node.js via a generated SDK.
+
+Syntax:
+  npm install @boundaryml/baml-core-node   # the runtime
+  
+  # baml.toml — declare a generator:
+  [generator.app]
+  output_type = "typescript/node"
+  output_dir  = "../app"
+  naming_convention = "preserve-case"
+  
+  baml generate                            # emits the `baml_sdk` package into output_dir
+
+Import the generated package (its index initializes the runtime), then call
+the exported functions with native TypeScript types (LLM calls are async):
+
+  import "./app/baml_sdk/index.js";
+  import { ClassifyTicket } from "./app/baml_sdk/index.js";
+  const ticket = await ClassifyTicket("login is broken");
+
+See also: `baml describe baml_sdk`, `baml describe python`.


### PR DESCRIPTION
## What

`baml describe <topic>` had no entry for cross-language SDK usage or for pattern matching — querying `python`, `typescript`, `baml_sdk`, `pattern`, or `patterns` returned **"No symbol found"**. This adds them so the CLI can teach how to call BAML from another language and how pattern matching works.

All five are **data-only** entries in `baml_keywords.yaml`, rendered by the existing keyword path (no Rust dispatch changes).

## Topics added

- **`baml_sdk`** — overview: declare a `[generator.<name>]` in `baml.toml`, run `baml generate`, import the typed `baml_sdk`; points to the per-language topics.
- **`python`** — `pip install baml_core`, generator config, `baml generate`, then `from baml_sdk import ...` (Pydantic models).
- **`typescript`** — `npm install @boundaryml/baml-core-node`, generator config, import the generated `baml_sdk` (LLM calls are async).
- **`patterns`** — match arms (literals, `let x: T`, class destructure, or-patterns, guards, `_`), the `is` operator, and `if let`.
- **`pattern`** — short pointer to `patterns` / `match`.

## Accuracy

- Package names verified against `sdks/python/pyproject.toml` (`baml_core`) and the `typescript/node` generator runtime (`@boundaryml/baml-core-node`).
- Generator fields (`output_type`, `output_dir`, `naming_convention`) and the `python/pydantic | python/pydantic/v1 | typescript/node` targets taken from `baml_codegen_types`.
- Usage forms (`from baml_sdk import …`, `import "./baml_sdk/index.js"`) taken from `sdk_tests`.

## Tests

- Snapshot tests for the four rendered topics + a dispatch test asserting all five resolve to `ResolvedTarget::Keyword`.
- `cargo test -p baml_cli --lib` → 248 passed; `describe_command_tests` → 86 passed.

## Example output

```
$ baml describe python
python — Use BAML from Python via a generated Pydantic v2 SDK.

Syntax:
  pip install baml_core                  # the runtime (Python 3.10+)
  [generator.app]
  output_type = "python/pydantic"
  output_dir  = "../app"
  naming_convention = "preserve-case"
  baml generate
  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and snapshot tests only; CLI behavior is limited to serving new keyword help text.
> 
> **Overview**
> **`baml describe`** now answers topics that previously returned “No symbol found” by extending **`baml_keywords.yaml`** with five keyword entries—no new Rust dispatch logic; existing keyword lookup picks them up before package resolution.
> 
> New **cross-language SDK** topics cover declaring a **`[generator.*]`** in `baml.toml`, running **`baml generate`**, and per-language usage: **`baml_sdk`** (overview), **`python`** (`baml_core` + generated `baml_sdk`), and **`typescript`** (`@boundaryml/baml-core-node`, async calls). New **pattern** topics add **`patterns`** (match, `is`, `if let`, guards, destructuring) and **`pattern`** as a short pointer to **`patterns`** / **`match`**.
> 
> Tests add insta snapshots for **`baml_sdk`**, **`python`**, **`typescript`**, and **`patterns`**, plus **`dispatch_language_topic_resolves_to_keyword`** so all five names resolve to **`ResolvedTarget::Keyword`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de0ed1870000027218f159a6634a09552a71fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new documentation topics for cross-language SDK usage, including general SDK guidance plus Python and TypeScript setup and usage.
  * Added new pattern-matching documentation covering syntax, matching behavior, exhaustiveness, and wildcards.
* **Tests**
  * Expanded coverage for the new documentation topics to ensure they are discoverable through the command-line help experience.
  * Added checks confirming these topics resolve correctly to keyword documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->