### PR TITLE
feat(cli): syntax highlighting + hyperlinks for `baml describe`

### DIFF
--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -37,10 +37,10 @@ pub(crate) struct RuntimeCli {
     #[arg(
         long,
         value_enum,
-        default_value_t = crate::describe_highlight::ColorChoice::Auto,
+        default_value_t = crate::paint::ColorChoice::Auto,
         global = true
     )]
-    pub color: crate::describe_highlight::ColorChoice,
+    pub color: crate::paint::ColorChoice,
 
     /// Specifies a subcommand to run.
     #[command(subcommand)]
@@ -184,7 +184,7 @@ impl RuntimeCli {
 
     pub fn run(&self) -> Result<crate::ExitCode> {
         // Resolve color/hyperlink output once, before any subcommand writes.
-        crate::describe_highlight::init_color(self.color);
+        crate::paint::init_color(self.color);
         match &self.command {
             Commands::Init(args) => args.run(),
             Commands::New(args) => args.run(),

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -30,6 +30,18 @@ pub(crate) struct RuntimeCli {
     #[arg(long = "features", value_name = "FEATURE", global = true)]
     pub features: Vec<String>,
 
+    /// When to use colored / hyperlinked output: auto (default), always, or never.
+    ///
+    /// `auto` enables color on an interactive terminal and disables it when the
+    /// output is piped or captured by a known AI coding agent.
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = crate::describe_highlight::ColorChoice::Auto,
+        global = true
+    )]
+    pub color: crate::describe_highlight::ColorChoice,
+
     /// Specifies a subcommand to run.
     #[command(subcommand)]
     pub(crate) command: Commands,
@@ -171,6 +183,8 @@ impl RuntimeCli {
     }
 
     pub fn run(&self) -> Result<crate::ExitCode> {
+        // Resolve color/hyperlink output once, before any subcommand writes.
+        crate::describe_highlight::init_color(self.color);
         match &self.command {
             Commands::Init(args) => args.run(),
             Commands::New(args) => args.run(),

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -777,16 +777,20 @@ fn write_highlighted_body(
         .map_or(first, |e| e + 1);
     let lines = &all[first..last];
 
-    if lines.len() <= available_for_body || available_for_body < 3 {
+    if lines.len() <= available_for_body {
         for line in lines {
             writeln!(w, "{line}")?;
         }
         return Ok(lines.len());
     }
 
-    // Head + tail with a skip marker, split purely on line count.
-    let head = (available_for_body - 1) / 2;
-    let tail = (available_for_body - 1) - head;
+    // Doesn't fit: show a head/tail window with a skip marker, split purely on
+    // line count. One line is reserved for the marker; `saturating_sub` keeps a
+    // tiny budget (0..=2) from underflowing or dumping the whole body, and
+    // biasing `head` upward favors showing the declaration line.
+    let window = available_for_body.saturating_sub(1);
+    let head = window.div_ceil(2);
+    let tail = window - head;
     for line in &lines[..head] {
         writeln!(w, "{line}")?;
     }

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -619,7 +619,7 @@ pub fn write_description(
         // Colored TTY output renders the verbatim definition slice through the
         // compiler's semantic tokens. Plain output (pipes, JSON, tests) keeps
         // the existing cleaned/truncated behavior byte-for-byte.
-        if console::colors_enabled() {
+        if colors {
             lines_used += write_highlighted_body(w, &hl, desc, available_for_body)?;
         } else {
             let was_truncated = body_lines.len() > available_for_body;
@@ -906,12 +906,9 @@ fn write_method_section(
             continue;
         }
         if let Some(doc) = &m.docstring {
-            let line = format!("/// {doc}");
-            if console::colors_enabled() {
-                writeln!(w, "  {}", console::style(line).color256(244))?;
-            } else {
-                writeln!(w, "  {line}")?;
-            }
+            // `highlight_str` self-gates on color and renders `///` lines as comments.
+            let doc_line = crate::describe_highlight::highlight_str(&format!("/// {doc}"));
+            writeln!(w, "  {doc_line}")?;
         }
         let text = m.file.text(db);
         let (start, end) =
@@ -923,11 +920,7 @@ fn write_method_section(
             &m_path.display().to_string(),
             &format!("{start}-{end}"),
         );
-        let sig = if console::colors_enabled() {
-            crate::describe_highlight::highlight_str(&m.signature)
-        } else {
-            m.signature.clone()
-        };
+        let sig = crate::describe_highlight::highlight_str(&m.signature);
         writeln!(w, "  {sig}  {loc}")?;
         remaining = remaining.saturating_sub(unit_cost);
     }
@@ -946,7 +939,6 @@ pub fn write_listing(
     entries: &[baml_lsp2_actions::ListingEntry],
     project_root: &std::path::Path,
 ) -> std::io::Result<()> {
-    let colors = console::colors_enabled();
     for entry in entries {
         let abs = std::path::Path::new(&entry.file_path);
         let rel = relative_path(abs, project_root);
@@ -955,24 +947,33 @@ pub fn write_listing(
             &rel.display().to_string(),
             &entry.line.to_string(),
         );
-        if colors {
-            writeln!(
-                w,
-                "{} {} {}",
-                crate::describe_highlight::kind_style(entry.kind)
-                    .apply_to(format!("{:<16}", entry.kind.as_str())),
-                crate::describe_highlight::highlight_name_padded(&entry.fqn(), entry.kind, 32),
-                loc,
-            )?;
-        } else {
-            writeln!(w, "{:<16} {:<32} {}", entry.kind.as_str(), entry.fqn(), loc)?;
-        }
+        write_symbol_row(w, "", entry.kind, &entry.fqn(), &loc)?;
     }
     Ok(())
 }
 
-/// Write one indented `kind  name  location` row (dependencies / container),
-/// colored by kind on a TTY. `location` is preformatted (e.g. `path:line`).
+/// Write one `kind  name  location` row, colored by kind on a TTY. `indent` is
+/// prepended verbatim and `location` is preformatted (e.g. `path:line`).
+fn write_symbol_row(
+    w: &mut impl std::io::Write,
+    indent: &str,
+    kind: baml_lsp2_actions::DefinitionKind,
+    name: &str,
+    location: &str,
+) -> std::io::Result<()> {
+    if console::colors_enabled() {
+        writeln!(
+            w,
+            "{indent}{} {} {location}",
+            crate::describe_highlight::kind_style(kind).apply_to(format!("{:<16}", kind.as_str())),
+            crate::describe_highlight::highlight_name_padded(name, kind, 32),
+        )
+    } else {
+        writeln!(w, "{indent}{:<16} {:<32} {location}", kind.as_str(), name)
+    }
+}
+
+/// Write an indented dependency / container row, colored by kind on a TTY.
 fn write_kind_row(
     w: &mut impl std::io::Write,
     kind: baml_lsp2_actions::DefinitionKind,
@@ -982,17 +983,7 @@ fn write_kind_row(
     line: usize,
 ) -> std::io::Result<()> {
     let loc = crate::describe_highlight::location(abs_path, rel_display, &line.to_string());
-    if console::colors_enabled() {
-        writeln!(
-            w,
-            "  {} {} {}",
-            crate::describe_highlight::kind_style(kind).apply_to(format!("{:<16}", kind.as_str())),
-            crate::describe_highlight::highlight_name_padded(name, kind, 32),
-            loc,
-        )
-    } else {
-        writeln!(w, "  {:<16} {:<32} {}", kind.as_str(), name, loc)
-    }
+    write_symbol_row(w, "  ", kind, name, &loc)
 }
 
 /// Convert listing entries to JSON array.

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -8,7 +8,10 @@ use baml_lsp2_actions::{ResolvedTarget, SymbolDescription, describe};
 use baml_project::ProjectDatabase;
 use clap::Args;
 
-use crate::project_load::load_project_or_default;
+use crate::{
+    project_load::load_project_or_default,
+    util::{line_number_at_offset, relative_path},
+};
 
 /// Parsed documentation entry for a BAML keyword topic.
 #[derive(serde::Deserialize)]
@@ -162,19 +165,11 @@ fn print_did_you_mean(db: &ProjectDatabase, name: &str) {
     if !suggestions.is_empty() {
         eprintln!();
         eprintln!("Did you mean:");
-        // did-you-mean goes to stderr, so gate on the stderr color flag (not the
-        // stdout one) — otherwise codes leak into a redirected stderr, or color
-        // is dropped when only stdout is redirected.
-        let colors = console::colors_enabled_stderr();
+        // did-you-mean writes to stderr, so use a stderr-bound painter (gets the
+        // stderr color decision, never stdout's).
+        let painter = crate::paint::Painter::stderr();
         for (s, kind) in suggestions {
-            if colors {
-                eprintln!(
-                    "  {}",
-                    crate::describe_highlight::highlight_fqn_opt(&s, kind)
-                );
-            } else {
-                eprintln!("  {s}");
-            }
+            eprintln!("  {}", painter.fqn_opt(&s, kind));
         }
     }
 }
@@ -474,13 +469,14 @@ impl DescribeArgs {
 
 /// Render keyword documentation to a writer.
 pub fn write_keyword(w: &mut impl std::io::Write, name: &str) -> std::io::Result<()> {
+    let painter = crate::paint::Painter::stdout();
     if let Some(doc) = BAML_KEYWORDS.get(name) {
-        writeln!(w, "{} — {}", console::style(name).magenta(), doc.summary)?;
+        writeln!(w, "{} — {}", painter.keyword(name), doc.summary)?;
         if let Some(ref syntax) = doc.syntax {
             writeln!(w)?;
             writeln!(w, "Syntax:")?;
             for line in syntax.trim_end().lines() {
-                writeln!(w, "  {}", crate::describe_highlight::highlight_str(line))?;
+                writeln!(w, "  {}", painter.fragment(line))?;
             }
         }
         if let Some(ref details) = doc.details {
@@ -488,14 +484,10 @@ pub fn write_keyword(w: &mut impl std::io::Write, name: &str) -> std::io::Result
             writeln!(w, "{details}")?;
         }
     } else if let Some(doc) = TS_KEYWORDS.get(name) {
-        writeln!(w, "{} — {}", console::style(name).magenta(), doc.message)?;
+        writeln!(w, "{} — {}", painter.keyword(name), doc.message)?;
         if let Some(ref see) = doc.see {
             writeln!(w)?;
-            writeln!(
-                w,
-                "See: baml describe {}",
-                crate::describe_highlight::highlight_str(see)
-            )?;
+            writeln!(w, "See: baml describe {}", painter.fragment(see))?;
         }
     }
     Ok(())
@@ -560,28 +552,16 @@ pub fn write_description(
     // like `root.ns.Foo`).
     let kind_str = desc.kind.as_str();
     let rel_path = relative_path(&file_path, project_root);
-    let colors = console::colors_enabled();
-    let hl = crate::describe_highlight::Highlighter::new(db);
+    let painter = crate::paint::Painter::stdout();
+    let colors = painter.enabled();
+    let hl = crate::paint::Highlighter::new(db);
     let fqn_part = desc
         .canonical_fqn
         .as_deref()
-        .map(|f| {
-            if colors {
-                format!(
-                    "  ({})",
-                    crate::describe_highlight::highlight_fqn(f, desc.kind)
-                )
-            } else {
-                format!("  ({f})")
-            }
-        })
+        .map(|f| format!("  ({})", painter.fqn(f, desc.kind)))
         .unwrap_or_default();
-    let name_display = if colors {
-        crate::describe_highlight::highlight_fqn(&desc.name, desc.kind)
-    } else {
-        desc.name.clone()
-    };
-    let loc = crate::describe_highlight::location(
+    let name_display = painter.fqn(&desc.name, desc.kind);
+    let loc = painter.location(
         &file_path,
         &rel_path.display().to_string(),
         &format!("{start_line}-{end_line}"),
@@ -589,8 +569,8 @@ pub fn write_description(
 
     writeln!(
         w,
-        "{kind} {name_display}{fqn_part}  {loc}",
-        kind = console::style(kind_str).magenta(),
+        "{} {name_display}{fqn_part}  {loc}",
+        painter.keyword(kind_str)
     )?;
 
     let mut lines_used = 1;
@@ -671,6 +651,7 @@ pub fn write_description(
     remaining = write_method_section(
         w,
         db,
+        &painter,
         project_root,
         "methods",
         &desc.instance_methods,
@@ -681,6 +662,7 @@ pub fn write_description(
     remaining = write_method_section(
         w,
         db,
+        &painter,
         project_root,
         "static_methods",
         &desc.static_methods,
@@ -698,6 +680,7 @@ pub fn write_description(
         let c_line = line_number_at_offset(c.file.text(db), c.name_span.start().into());
         write_kind_row(
             w,
+            &painter,
             c.kind,
             &c.name,
             &c_abs,
@@ -723,6 +706,7 @@ pub fn write_description(
             let dep_line = line_number_at_offset(dep.file.text(db), dep.name_span.start().into());
             write_kind_row(
                 w,
+                &painter,
                 dep.kind,
                 &dep.name,
                 &dep_abs,
@@ -758,12 +742,12 @@ pub fn write_description(
         } else {
             r.line_text.trim().to_string()
         };
-        let loc = crate::describe_highlight::location(
+        let loc = painter.location(
             &ref_abs,
             &ref_path.display().to_string(),
             &r.line_number.to_string(),
         );
-        writeln!(w, "  {}  {}", loc, preview)?;
+        writeln!(w, "  {loc}  {preview}")?;
         remaining -= 1;
     }
     write_elision_marker(w, elided)?;
@@ -778,7 +762,7 @@ pub fn write_description(
 /// run is never split). Returns the number of output lines consumed.
 fn write_highlighted_body(
     w: &mut impl std::io::Write,
-    hl: &crate::describe_highlight::Highlighter,
+    hl: &crate::paint::Highlighter,
     desc: &SymbolDescription,
     available_for_body: usize,
 ) -> std::io::Result<usize> {
@@ -887,6 +871,7 @@ pub(crate) fn definition_line_range(
 fn write_method_section(
     w: &mut impl std::io::Write,
     db: &ProjectDatabase,
+    painter: &crate::paint::Painter,
     project_root: &std::path::Path,
     label: &str,
     methods: &[describe::MethodRef],
@@ -906,8 +891,8 @@ fn write_method_section(
             continue;
         }
         if let Some(doc) = &m.docstring {
-            // `highlight_str` self-gates on color and renders `///` lines as comments.
-            let doc_line = crate::describe_highlight::highlight_str(&format!("/// {doc}"));
+            // `fragment` renders `///` lines as comments (and self-gates on color).
+            let doc_line = painter.fragment(&format!("/// {doc}"));
             writeln!(w, "  {doc_line}")?;
         }
         let text = m.file.text(db);
@@ -915,12 +900,12 @@ fn write_method_section(
             definition_line_range(text, m.item_range.start().into(), m.item_range.end().into());
         let m_abs = m.file.path(db);
         let m_path = relative_path(&m_abs, project_root);
-        let loc = crate::describe_highlight::location(
+        let loc = painter.location(
             &m_abs,
             &m_path.display().to_string(),
             &format!("{start}-{end}"),
         );
-        let sig = crate::describe_highlight::highlight_str(&m.signature);
+        let sig = painter.fragment(&m.signature);
         writeln!(w, "  {sig}  {loc}")?;
         remaining = remaining.saturating_sub(unit_cost);
     }
@@ -939,51 +924,46 @@ pub fn write_listing(
     entries: &[baml_lsp2_actions::ListingEntry],
     project_root: &std::path::Path,
 ) -> std::io::Result<()> {
+    let painter = crate::paint::Painter::stdout();
     for entry in entries {
         let abs = std::path::Path::new(&entry.file_path);
         let rel = relative_path(abs, project_root);
-        let loc = crate::describe_highlight::location(
-            abs,
-            &rel.display().to_string(),
-            &entry.line.to_string(),
-        );
-        write_symbol_row(w, "", entry.kind, &entry.fqn(), &loc)?;
+        let loc = painter.location(abs, &rel.display().to_string(), &entry.line.to_string());
+        write_symbol_row(w, &painter, "", entry.kind, &entry.fqn(), &loc)?;
     }
     Ok(())
 }
 
-/// Write one `kind  name  location` row, colored by kind on a TTY. `indent` is
-/// prepended verbatim and `location` is preformatted (e.g. `path:line`).
+/// Write one `kind  name  location` row, colored by kind. `indent` is prepended
+/// verbatim and `location` is preformatted (e.g. `path:line`).
 fn write_symbol_row(
     w: &mut impl std::io::Write,
+    painter: &crate::paint::Painter,
     indent: &str,
     kind: baml_lsp2_actions::DefinitionKind,
     name: &str,
     location: &str,
 ) -> std::io::Result<()> {
-    if console::colors_enabled() {
-        writeln!(
-            w,
-            "{indent}{} {} {location}",
-            crate::describe_highlight::kind_style(kind).apply_to(format!("{:<16}", kind.as_str())),
-            crate::describe_highlight::highlight_name_padded(name, kind, 32),
-        )
-    } else {
-        writeln!(w, "{indent}{:<16} {:<32} {location}", kind.as_str(), name)
-    }
+    writeln!(
+        w,
+        "{indent}{} {} {location}",
+        painter.kind_label(kind, 16),
+        painter.name_padded(name, kind, 32),
+    )
 }
 
-/// Write an indented dependency / container row, colored by kind on a TTY.
+/// Write an indented dependency / container row, colored by kind.
 fn write_kind_row(
     w: &mut impl std::io::Write,
+    painter: &crate::paint::Painter,
     kind: baml_lsp2_actions::DefinitionKind,
     name: &str,
     abs_path: &std::path::Path,
     rel_display: &str,
     line: usize,
 ) -> std::io::Result<()> {
-    let loc = crate::describe_highlight::location(abs_path, rel_display, &line.to_string());
-    write_symbol_row(w, "  ", kind, name, &loc)
+    let loc = painter.location(abs_path, rel_display, &line.to_string());
+    write_symbol_row(w, painter, "  ", kind, name, &loc)
 }
 
 /// Convert listing entries to JSON array.
@@ -1005,17 +985,6 @@ fn listing_to_json(
             })
         })
         .collect()
-}
-
-/// Compute 1-based line number from byte offset.
-fn line_number_at_offset(text: &str, offset: usize) -> usize {
-    let offset = offset.min(text.len());
-    text[..offset].chars().filter(|&c| c == '\n').count() + 1
-}
-
-/// Make a path relative to the project root.
-fn relative_path(path: &std::path::Path, root: &std::path::Path) -> std::path::PathBuf {
-    path.strip_prefix(root).unwrap_or(path).to_path_buf()
 }
 
 /// Find the 0-based line index within a body where a span starts.

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -65,34 +65,49 @@ pub struct DescribeArgs {
 /// Used to power "did you mean?" hints when a path doesn't resolve. Returns up
 /// to `limit` candidates sorted by Jaro-Winkler similarity (descending).
 pub fn suggest_similar(db: &ProjectDatabase, name: &str, limit: usize) -> Vec<String> {
+    suggest_similar_kinded(db, name, limit)
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect()
+}
+
+/// Like [`suggest_similar`], but pairs each suggestion with its definition kind
+/// (`None` for namespace/package paths) so callers can color the leaf by kind.
+pub fn suggest_similar_kinded(
+    db: &ProjectDatabase,
+    name: &str,
+    limit: usize,
+) -> Vec<(String, Option<baml_lsp2_actions::DefinitionKind>)> {
     use baml_compiler2_hir::package::{PackageId, package_items};
 
-    let mut all_paths: Vec<String> = Vec::new();
+    type Kind = Option<baml_lsp2_actions::DefinitionKind>;
+    let mut all_paths: Vec<(String, Kind)> = Vec::new();
 
-    // User package: items + namespace dotted paths.
+    // User package: items (kinded) + namespace dotted paths (no kind).
     let user_pkg = PackageId::new(db, baml_db::Name::new("user"));
     for entry in baml_lsp2_actions::list_package_items(db, user_pkg) {
-        all_paths.push(entry.fqn());
+        all_paths.push((entry.fqn(), Some(entry.kind)));
     }
     let user_pkg_items = package_items(db, user_pkg);
     for ns_path in user_pkg_items.namespaces.keys() {
         if !ns_path.is_empty() {
-            all_paths.push(
+            all_paths.push((
                 ns_path
                     .iter()
                     .map(baml_db::Name::as_str)
                     .collect::<Vec<_>>()
                     .join("."),
-            );
+                None,
+            ));
         }
     }
 
     // Builtin packages: bare package name + item paths + namespaces.
     for pkg_name in baml_lsp2_actions::non_user_package_names(db) {
-        all_paths.push(pkg_name.clone());
+        all_paths.push((pkg_name.clone(), None));
         let pkg = PackageId::new(db, baml_db::Name::new(&pkg_name));
         for entry in baml_lsp2_actions::list_package_items(db, pkg) {
-            all_paths.push(entry.fqn());
+            all_paths.push((entry.fqn(), Some(entry.kind)));
         }
         let pkg_info = package_items(db, pkg);
         for ns_path in pkg_info.namespaces.keys() {
@@ -102,7 +117,7 @@ pub fn suggest_similar(db: &ProjectDatabase, name: &str, limit: usize) -> Vec<St
                     .map(baml_db::Name::as_str)
                     .collect::<Vec<_>>()
                     .join(".");
-                all_paths.push(format!("{pkg_name}.{dotted}"));
+                all_paths.push((format!("{pkg_name}.{dotted}"), None));
             }
         }
     }
@@ -111,9 +126,9 @@ pub fn suggest_similar(db: &ProjectDatabase, name: &str, limit: usize) -> Vec<St
     // get a useful "did you mean?" hint. `strsim::jaro_winkler` is case-
     // sensitive, so we lowercase both sides before scoring.
     let needle_lower = name.to_ascii_lowercase();
-    let mut scored: Vec<(f64, String)> = all_paths
+    let mut scored: Vec<(f64, String, Kind)> = all_paths
         .into_iter()
-        .map(|p| {
+        .map(|(p, kind)| {
             let p_lower = p.to_ascii_lowercase();
             // Jaro-Winkler on lowercased strings handles typos; substring
             // presence is an extra boost for cases like "Confg" → "Config".
@@ -121,9 +136,9 @@ pub fn suggest_similar(db: &ProjectDatabase, name: &str, limit: usize) -> Vec<St
             if p_lower.contains(&needle_lower) {
                 score += 0.15;
             }
-            (score, p)
+            (score, p, kind)
         })
-        .filter(|(s, _)| *s > 0.7)
+        .filter(|(s, _, _)| *s > 0.7)
         .collect();
 
     // Sort by score desc, then alphabetically for stability.
@@ -134,17 +149,32 @@ pub fn suggest_similar(db: &ProjectDatabase, name: &str, limit: usize) -> Vec<St
     });
     // Dedup adjacent duplicates after sort.
     scored.dedup_by(|a, b| a.1 == b.1);
-    scored.into_iter().take(limit).map(|(_, p)| p).collect()
+    scored
+        .into_iter()
+        .take(limit)
+        .map(|(_, p, kind)| (p, kind))
+        .collect()
 }
 
 /// Print a "Did you mean?" hint for `name` to stderr if any similar paths exist.
 fn print_did_you_mean(db: &ProjectDatabase, name: &str) {
-    let suggestions = suggest_similar(db, name, 5);
+    let suggestions = suggest_similar_kinded(db, name, 5);
     if !suggestions.is_empty() {
         eprintln!();
         eprintln!("Did you mean:");
-        for s in suggestions {
-            eprintln!("  {s}");
+        // did-you-mean goes to stderr, so gate on the stderr color flag (not the
+        // stdout one) — otherwise codes leak into a redirected stderr, or color
+        // is dropped when only stdout is redirected.
+        let colors = console::colors_enabled_stderr();
+        for (s, kind) in suggestions {
+            if colors {
+                eprintln!(
+                    "  {}",
+                    crate::describe_highlight::highlight_fqn_opt(&s, kind)
+                );
+            } else {
+                eprintln!("  {s}");
+            }
         }
     }
 }
@@ -445,12 +475,12 @@ impl DescribeArgs {
 /// Render keyword documentation to a writer.
 pub fn write_keyword(w: &mut impl std::io::Write, name: &str) -> std::io::Result<()> {
     if let Some(doc) = BAML_KEYWORDS.get(name) {
-        writeln!(w, "{name} — {}", doc.summary)?;
+        writeln!(w, "{} — {}", console::style(name).magenta(), doc.summary)?;
         if let Some(ref syntax) = doc.syntax {
             writeln!(w)?;
             writeln!(w, "Syntax:")?;
             for line in syntax.trim_end().lines() {
-                writeln!(w, "  {line}")?;
+                writeln!(w, "  {}", crate::describe_highlight::highlight_str(line))?;
             }
         }
         if let Some(ref details) = doc.details {
@@ -458,10 +488,14 @@ pub fn write_keyword(w: &mut impl std::io::Write, name: &str) -> std::io::Result
             writeln!(w, "{details}")?;
         }
     } else if let Some(doc) = TS_KEYWORDS.get(name) {
-        writeln!(w, "{name} — {}", doc.message)?;
+        writeln!(w, "{} — {}", console::style(name).magenta(), doc.message)?;
         if let Some(ref see) = doc.see {
             writeln!(w)?;
-            writeln!(w, "See: baml describe {see}")?;
+            writeln!(
+                w,
+                "See: baml describe {}",
+                crate::describe_highlight::highlight_str(see)
+            )?;
         }
     }
     Ok(())
@@ -526,17 +560,37 @@ pub fn write_description(
     // like `root.ns.Foo`).
     let kind_str = desc.kind.as_str();
     let rel_path = relative_path(&file_path, project_root);
-    let path_display = rel_path.display();
+    let colors = console::colors_enabled();
+    let hl = crate::describe_highlight::Highlighter::new(db);
     let fqn_part = desc
         .canonical_fqn
         .as_deref()
-        .map(|f| format!("  ({f})"))
+        .map(|f| {
+            if colors {
+                format!(
+                    "  ({})",
+                    crate::describe_highlight::highlight_fqn(f, desc.kind)
+                )
+            } else {
+                format!("  ({f})")
+            }
+        })
         .unwrap_or_default();
+    let name_display = if colors {
+        crate::describe_highlight::highlight_fqn(&desc.name, desc.kind)
+    } else {
+        desc.name.clone()
+    };
+    let loc = crate::describe_highlight::location(
+        &file_path,
+        &rel_path.display().to_string(),
+        &format!("{start_line}-{end_line}"),
+    );
 
     writeln!(
         w,
-        "{kind_str} {name}{fqn_part}  {path_display}:{start_line}-{end_line}",
-        name = desc.name
+        "{kind} {name_display}{fqn_part}  {loc}",
+        kind = console::style(kind_str).magenta(),
     )?;
 
     let mut lines_used = 1;
@@ -561,40 +615,48 @@ pub fn write_description(
         // body must fit at budget 5).
         writeln!(w)?;
         let available_for_body = budget.saturating_sub(lines_used);
-        let was_truncated = body_lines.len() > available_for_body;
-        let shown_body_lines;
-        if body_lines.len() <= available_for_body {
-            for line in &body_lines {
-                writeln!(w, "{line}")?;
-            }
-            shown_body_lines = body_lines.len();
-            lines_used += shown_body_lines;
-        } else if available_for_body >= 5 {
-            let truncated = truncate_body(&body_lines, available_for_body);
-            for line in &truncated {
-                writeln!(w, "{line}")?;
-            }
-            shown_body_lines = truncated.len();
-            lines_used += shown_body_lines;
+
+        // Colored TTY output renders the verbatim definition slice through the
+        // compiler's semantic tokens. Plain output (pipes, JSON, tests) keeps
+        // the existing cleaned/truncated behavior byte-for-byte.
+        if console::colors_enabled() {
+            lines_used += write_highlighted_body(w, &hl, desc, available_for_body)?;
         } else {
-            let elided_text = shape_with_elision(&desc.shape, &desc.full_body);
-            let elided_lines: Vec<&str> = elided_text.lines().collect();
-            for line in &elided_lines {
-                writeln!(w, "{line}")?;
+            let was_truncated = body_lines.len() > available_for_body;
+            let shown_body_lines;
+            if body_lines.len() <= available_for_body {
+                for line in &body_lines {
+                    writeln!(w, "{line}")?;
+                }
+                shown_body_lines = body_lines.len();
+                lines_used += shown_body_lines;
+            } else if available_for_body >= 5 {
+                let truncated = truncate_body(&body_lines, available_for_body);
+                for line in &truncated {
+                    writeln!(w, "{line}")?;
+                }
+                shown_body_lines = truncated.len();
+                lines_used += shown_body_lines;
+            } else {
+                let elided_text = shape_with_elision(&desc.shape, &desc.full_body);
+                let elided_lines: Vec<&str> = elided_text.lines().collect();
+                for line in &elided_lines {
+                    writeln!(w, "{line}")?;
+                }
+                shown_body_lines = elided_lines.len();
+                lines_used += shown_body_lines;
             }
-            shown_body_lines = elided_lines.len();
-            lines_used += shown_body_lines;
-        }
-        if was_truncated {
-            writeln!(w)?;
-            writeln!(
-                w,
-                "[INFO] Showing {shown} of {total} lines. Use --budget {needed} for full output.",
-                shown = shown_body_lines,
-                total = body_lines.len(),
-                needed = body_lines.len() + 1,
-            )?;
-            lines_used += 2;
+            if was_truncated {
+                writeln!(w)?;
+                writeln!(
+                    w,
+                    "[INFO] Showing {shown} of {total} lines. Use --budget {needed} for full output.",
+                    shown = shown_body_lines,
+                    total = body_lines.len(),
+                    needed = body_lines.len() + 1,
+                )?;
+                lines_used += 2;
+            }
         }
     }
 
@@ -631,15 +693,16 @@ pub fn write_description(
     if let Some(ref c) = desc.container {
         writeln!(w)?;
         writeln!(w, "container:")?;
-        let c_path = relative_path(&c.file.path(db), project_root);
+        let c_abs = c.file.path(db);
+        let c_path = relative_path(&c_abs, project_root);
         let c_line = line_number_at_offset(c.file.text(db), c.name_span.start().into());
-        writeln!(
+        write_kind_row(
             w,
-            "  {:<16} {:<32} {}:{}",
-            c.kind.as_str(),
-            c.name,
-            c_path.display(),
-            c_line
+            c.kind,
+            &c.name,
+            &c_abs,
+            &c_path.display().to_string(),
+            c_line,
         )?;
         remaining = remaining.saturating_sub(3);
     }
@@ -655,14 +718,15 @@ pub fn write_description(
                 elided += 1;
                 continue;
             }
-            let dep_path = relative_path(&dep.file.path(db), project_root);
+            let dep_abs = dep.file.path(db);
+            let dep_path = relative_path(&dep_abs, project_root);
             let dep_line = line_number_at_offset(dep.file.text(db), dep.name_span.start().into());
-            writeln!(
+            write_kind_row(
                 w,
-                "  {:<16} {:<32} {}:{}",
-                dep.kind.as_str(),
-                dep.name,
-                dep_path.display(),
+                dep.kind,
+                &dep.name,
+                &dep_abs,
+                &dep_path.display().to_string(),
                 dep_line,
             )?;
             remaining -= 1;
@@ -682,19 +746,79 @@ pub fn write_description(
             elided += 1;
             continue;
         }
-        let ref_path = relative_path(&r.file.path(db), project_root);
-        writeln!(
-            w,
-            "  {}:{}  {}",
-            ref_path.display(),
-            r.line_number,
-            r.line_text.trim()
-        )?;
+        let ref_abs = r.file.path(db);
+        let ref_path = relative_path(&ref_abs, project_root);
+        let preview = if colors {
+            let h = hl.enclosing_line(r.file, r.range);
+            if h.is_empty() {
+                r.line_text.trim().to_string()
+            } else {
+                h
+            }
+        } else {
+            r.line_text.trim().to_string()
+        };
+        let loc = crate::describe_highlight::location(
+            &ref_abs,
+            &ref_path.display().to_string(),
+            &r.line_number.to_string(),
+        );
+        writeln!(w, "  {}  {}", loc, preview)?;
         remaining -= 1;
     }
     write_elision_marker(w, elided)?;
 
     Ok(())
+}
+
+/// Render the definition body with ANSI highlighting (colored-output path).
+///
+/// Highlights the verbatim source slice of the item via the compiler's semantic
+/// tokens, then applies the soft line budget by line count (so an ANSI escape
+/// run is never split). Returns the number of output lines consumed.
+fn write_highlighted_body(
+    w: &mut impl std::io::Write,
+    hl: &crate::describe_highlight::Highlighter,
+    desc: &SymbolDescription,
+    available_for_body: usize,
+) -> std::io::Result<usize> {
+    let colored = hl.range(desc.file, desc.item_range);
+    let all: Vec<&str> = colored.lines().collect();
+    // `item_range` can swallow leading doc-comments/blank lines and trailing
+    // whitespace; trim blank edges so the block starts at the declaration.
+    let first = all.iter().position(|l| !l.trim().is_empty()).unwrap_or(0);
+    let last = all
+        .iter()
+        .rposition(|l| !l.trim().is_empty())
+        .map_or(first, |e| e + 1);
+    let lines = &all[first..last];
+
+    if lines.len() <= available_for_body || available_for_body < 3 {
+        for line in lines {
+            writeln!(w, "{line}")?;
+        }
+        return Ok(lines.len());
+    }
+
+    // Head + tail with a skip marker, split purely on line count.
+    let head = (available_for_body - 1) / 2;
+    let tail = (available_for_body - 1) - head;
+    for line in &lines[..head] {
+        writeln!(w, "{line}")?;
+    }
+    writeln!(w, "  [... skipped {} lines ...]", lines.len() - head - tail)?;
+    for line in &lines[lines.len() - tail..] {
+        writeln!(w, "{line}")?;
+    }
+    writeln!(w)?;
+    writeln!(
+        w,
+        "[INFO] Showing {} of {} lines. Use --budget {} for full output.",
+        head + tail + 1,
+        lines.len(),
+        lines.len() + 1,
+    )?;
+    Ok(head + tail + 3)
 }
 
 /// Write the soft-budget elision marker for `elided` hidden lines (no-op when
@@ -782,20 +906,29 @@ fn write_method_section(
             continue;
         }
         if let Some(doc) = &m.docstring {
-            writeln!(w, "  /// {doc}")?;
+            let line = format!("/// {doc}");
+            if console::colors_enabled() {
+                writeln!(w, "  {}", console::style(line).color256(244))?;
+            } else {
+                writeln!(w, "  {line}")?;
+            }
         }
         let text = m.file.text(db);
         let (start, end) =
             definition_line_range(text, m.item_range.start().into(), m.item_range.end().into());
-        let m_path = relative_path(&m.file.path(db), project_root);
-        writeln!(
-            w,
-            "  {}  {}:{}-{}",
-            m.signature,
-            m_path.display(),
-            start,
-            end
-        )?;
+        let m_abs = m.file.path(db);
+        let m_path = relative_path(&m_abs, project_root);
+        let loc = crate::describe_highlight::location(
+            &m_abs,
+            &m_path.display().to_string(),
+            &format!("{start}-{end}"),
+        );
+        let sig = if console::colors_enabled() {
+            crate::describe_highlight::highlight_str(&m.signature)
+        } else {
+            m.signature.clone()
+        };
+        writeln!(w, "  {sig}  {loc}")?;
         remaining = remaining.saturating_sub(unit_cost);
     }
     write_elision_marker(w, elided_lines)?;
@@ -813,18 +946,53 @@ pub fn write_listing(
     entries: &[baml_lsp2_actions::ListingEntry],
     project_root: &std::path::Path,
 ) -> std::io::Result<()> {
+    let colors = console::colors_enabled();
     for entry in entries {
-        let rel = relative_path(std::path::Path::new(&entry.file_path), project_root);
-        writeln!(
-            w,
-            "{:<16} {:<32} {}:{}",
-            entry.kind.as_str(),
-            entry.fqn(),
-            rel.display(),
-            entry.line,
-        )?;
+        let abs = std::path::Path::new(&entry.file_path);
+        let rel = relative_path(abs, project_root);
+        let loc = crate::describe_highlight::location(
+            abs,
+            &rel.display().to_string(),
+            &entry.line.to_string(),
+        );
+        if colors {
+            writeln!(
+                w,
+                "{} {} {}",
+                crate::describe_highlight::kind_style(entry.kind)
+                    .apply_to(format!("{:<16}", entry.kind.as_str())),
+                crate::describe_highlight::highlight_name_padded(&entry.fqn(), entry.kind, 32),
+                loc,
+            )?;
+        } else {
+            writeln!(w, "{:<16} {:<32} {}", entry.kind.as_str(), entry.fqn(), loc)?;
+        }
     }
     Ok(())
+}
+
+/// Write one indented `kind  name  location` row (dependencies / container),
+/// colored by kind on a TTY. `location` is preformatted (e.g. `path:line`).
+fn write_kind_row(
+    w: &mut impl std::io::Write,
+    kind: baml_lsp2_actions::DefinitionKind,
+    name: &str,
+    abs_path: &std::path::Path,
+    rel_display: &str,
+    line: usize,
+) -> std::io::Result<()> {
+    let loc = crate::describe_highlight::location(abs_path, rel_display, &line.to_string());
+    if console::colors_enabled() {
+        writeln!(
+            w,
+            "  {} {} {}",
+            crate::describe_highlight::kind_style(kind).apply_to(format!("{:<16}", kind.as_str())),
+            crate::describe_highlight::highlight_name_padded(name, kind, 32),
+            loc,
+        )
+    } else {
+        writeln!(w, "  {:<16} {:<32} {}", kind.as_str(), name, loc)
+    }
 }
 
 /// Convert listing entries to JSON array.

--- a/baml_language/crates/baml_cli/src/describe_highlight.rs
+++ b/baml_language/crates/baml_cli/src/describe_highlight.rs
@@ -1,0 +1,466 @@
+//! ANSI syntax highlighting (and terminal hyperlinks) for `baml describe`.
+//!
+//! Reuses the compiler's own semantic-token classifier
+//! (`baml_lsp2_actions::semantic_tokens`) instead of a separate TextMate/Sublime
+//! grammar. `describe` has already compiled the project by the time it renders,
+//! so classification is effectively free (it reads Salsa-cached queries) and can
+//! never drift from the language the way a hand-maintained grammar would.
+//!
+//! [`Highlighter`] caches the per-file token set so a single description (body +
+//! dependency/reference rows, which can touch several files) computes each file's
+//! tokens at most once.
+
+use std::{cell::RefCell, collections::HashMap, path::Path, rc::Rc};
+
+use baml_db::{
+    FileId, SourceFile,
+    baml_compiler_lexer::{TokenKind, lex_lossless},
+};
+use baml_lsp2_actions::{DefinitionKind, SemanticToken, SemanticTokenType, semantic_tokens};
+use baml_project::ProjectDatabase;
+use console::Style;
+use text_size::{TextRange, TextSize};
+
+// ── Output mode (color / hyperlinks) ───────────────────────────────────────────
+
+/// When to emit color and hyperlinks. Mirrors the conventional `--color` flag.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColorChoice {
+    /// Color on an interactive terminal; off when piped or inside an AI agent.
+    #[default]
+    Auto,
+    /// Always emit color/hyperlinks.
+    Always,
+    /// Never emit color/hyperlinks.
+    Never,
+}
+
+/// Environment variables that signal a non-interactive AI agent is capturing
+/// output, where ANSI color and hyperlinks are noise rather than UI. Sourced
+/// from each agent's docs and from maintained detection matrices
+/// (`@vercel/detect-agent`, Bun's agent checks).
+const AGENT_ENV_VARS: &[&str] = &[
+    "CLAUDECODE",      // Claude Code (code.claude.com/docs/en/env-vars)
+    "CODEX_SANDBOX",   // OpenAI Codex CLI (set in its sandbox)
+    "PI_CODING_AGENT", // Pi (earendil-works/pi)
+    "OPENCODE_CLIENT", // opencode
+    "AI_AGENT",        // @vercel/detect-agent universal var (+ custom agents)
+    "CURSOR_TRACE_ID", // Cursor agent terminal
+    "REPL_ID",         // Replit
+    "AGENT",           // generic (Codex `AGENT=codex`, Bun)
+];
+
+fn env_truthy(var: &str) -> bool {
+    std::env::var(var).is_ok_and(|v| !v.is_empty() && v != "0")
+}
+
+/// Whether output is being captured by a known AI coding agent.
+fn running_in_agent() -> bool {
+    AGENT_ENV_VARS.iter().any(|var| env_truthy(var))
+}
+
+/// Resolve color/hyperlink output once at startup, applying the decision to both
+/// stdout and stderr so the two streams agree (avoids leaking codes into a
+/// redirected stream or dropping color on a redirected sibling).
+pub fn init_color(choice: ColorChoice) {
+    match choice {
+        ColorChoice::Always => {
+            console::set_colors_enabled(true);
+            console::set_colors_enabled_stderr(true);
+        }
+        ColorChoice::Never => {
+            console::set_colors_enabled(false);
+            console::set_colors_enabled_stderr(false);
+        }
+        ColorChoice::Auto => {
+            // An explicit `CLICOLOR_FORCE` (honored by console's defaults) always
+            // wins; only suppress for agents when color was not force-requested.
+            if !env_truthy("CLICOLOR_FORCE") && running_in_agent() {
+                console::set_colors_enabled(false);
+                console::set_colors_enabled_stderr(false);
+            }
+            // Otherwise leave console's per-stream TTY / NO_COLOR / CLICOLOR defaults.
+        }
+    }
+}
+
+/// Color for each semantic token type. Loosely mirrors a typical editor theme.
+///
+/// Styling is **forced** so emission is decided by the caller per output stream
+/// (gating on `colors_enabled()` for stdout vs `colors_enabled_stderr()` for
+/// stderr), not by console's ambient stdout flag.
+fn style_for(token_type: SemanticTokenType) -> Style {
+    use SemanticTokenType as T;
+    let style = match token_type {
+        T::Keyword | T::Modifier => Style::new().magenta(),
+        T::Class | T::Struct | T::Interface | T::Enum | T::Type | T::TypeParameter => {
+            Style::new().yellow()
+        }
+        T::Function | T::Method | T::Macro => Style::new().blue().bright(),
+        T::EnumMember | T::Property => Style::new().cyan(),
+        T::Parameter => Style::new().color256(173),
+        T::Namespace => Style::new().cyan().bright(),
+        T::String | T::Regexp => Style::new().green(),
+        T::Number => Style::new().yellow().bright(),
+        T::Comment => Style::new().color256(244),
+        T::Decorator => Style::new().color256(179),
+        T::Operator => Style::new().color256(245),
+        T::Variable | T::Event => Style::new().white(),
+    };
+    style.force_styling(true)
+}
+
+/// Color for a definition kind, used to highlight listing rows (which have no
+/// source slice to tokenize). Maps each kind onto the same palette as the body.
+pub fn kind_style(kind: DefinitionKind) -> Style {
+    use DefinitionKind as K;
+    use SemanticTokenType as T;
+    style_for(match kind {
+        K::Class => T::Class,
+        K::Enum => T::Enum,
+        K::Interface => T::Interface,
+        K::TypeAlias | K::AssociatedType => T::Type,
+        K::Function | K::TemplateString => T::Function,
+        K::Method => T::Method,
+        K::Client | K::Test | K::RetryPolicy => T::Struct,
+        K::Field => T::Property,
+        K::Variant => T::EnumMember,
+        K::Parameter => T::Parameter,
+        K::Let | K::Binding => T::Variable,
+    })
+}
+
+/// Highlight a (possibly dotted) name as it would appear in source: each
+/// qualifier segment in the namespace color, the `.` separators as punctuation,
+/// and the final segment in `leaf_kind`'s color.
+pub fn highlight_fqn(name: &str, leaf_kind: DefinitionKind) -> String {
+    highlight_fqn_opt(name, Some(leaf_kind))
+}
+
+/// Like [`highlight_fqn`] but the leaf kind is optional; `None` (a namespace or
+/// package path) colors the whole path in the namespace color.
+pub fn highlight_fqn_opt(name: &str, leaf_kind: Option<DefinitionKind>) -> String {
+    let namespace = style_for(SemanticTokenType::Namespace);
+    let dot = style_for(SemanticTokenType::Operator);
+    let leaf = leaf_kind.map_or_else(|| namespace.clone(), kind_style);
+    let parts: Vec<&str> = name.split('.').collect();
+    let last = parts.len().saturating_sub(1);
+    let mut out = String::new();
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            out.push_str(&dot.apply_to('.').to_string());
+        }
+        let style = if i == last { &leaf } else { &namespace };
+        out.push_str(&style.apply_to(part).to_string());
+    }
+    out
+}
+
+/// Like [`highlight_fqn`], padded with plain trailing spaces so the *visible*
+/// text occupies `width` columns (ANSI escapes don't count toward width).
+pub fn highlight_name_padded(name: &str, leaf_kind: DefinitionKind, width: usize) -> String {
+    let pad = width.saturating_sub(name.chars().count());
+    format!("{}{}", highlight_fqn(name, leaf_kind), " ".repeat(pad))
+}
+
+// ── Lexer-based highlighting for synthesized fragments ──────────────────────────
+
+/// Primitive/builtin type names the lexer emits as plain words; colored as types.
+const PRIMITIVE_TYPES: &[&str] = &[
+    "string",
+    "int",
+    "bigint",
+    "float",
+    "bool",
+    "null",
+    "bytes",
+    "uint8array",
+    "image",
+    "audio",
+    "video",
+    "pdf",
+    "json",
+    "true",
+    "false",
+];
+
+/// The definition kind a declaration keyword introduces, so the name token that
+/// follows can be colored accordingly (`function Foo` -> `Foo` as a function).
+fn decl_keyword_kind(kind: TokenKind) -> Option<DefinitionKind> {
+    use DefinitionKind as K;
+    use TokenKind as T;
+    Some(match kind {
+        T::Class => K::Class,
+        T::Enum => K::Enum,
+        T::Interface => K::Interface,
+        T::Function => K::Function,
+        T::TemplateString => K::TemplateString,
+        T::Client => K::Client,
+        T::Test => K::Test,
+        T::RetryPolicy => K::RetryPolicy,
+        _ => return None,
+    })
+}
+
+fn is_keyword(kind: TokenKind) -> bool {
+    use TokenKind as T;
+    matches!(
+        kind,
+        T::Class
+            | T::Enum
+            | T::Interface
+            | T::Implements
+            | T::Implement
+            | T::Extends
+            | T::Requires
+            | T::Function
+            | T::Client
+            | T::Generator
+            | T::Test
+            | T::TestSet
+            | T::RetryPolicy
+            | T::TypeBuilder
+            | T::Dynamic
+            | T::Let
+            | T::If
+            | T::Else
+            | T::For
+            | T::While
+            | T::Match
+            | T::Return
+            | T::Break
+            | T::Continue
+            | T::Throw
+            | T::Throws
+            | T::Catch
+            | T::CatchAll
+            | T::Defer
+            | T::Spawn
+            | T::Await
+            | T::Watch
+            | T::In
+            | T::Is
+            | T::Instanceof
+    )
+}
+
+/// Highlight an arbitrary BAML fragment that has no source backing (synthesized
+/// signatures, keyword-doc examples).
+///
+/// Lexer-based, so it is *syntactic only*: it colors keywords, primitive types,
+/// names introduced by a declaration keyword, strings, line comments, numbers,
+/// and operators. It cannot tell a user type from a variable the way the
+/// type-aware [`Highlighter`] (used for real source ranges) can.
+pub fn highlight_str(text: &str) -> String {
+    if !console::colors_enabled() {
+        return text.to_string();
+    }
+    let toks = lex_lossless(text, FileId::new(0));
+    let mut out = String::new();
+    let mut i = 0;
+    // Set after a declaration keyword so the next name token is colored by kind.
+    let mut pending_decl: Option<DefinitionKind> = None;
+    while i < toks.len() {
+        let t = &toks[i];
+
+        // Trivia passes through and does not clear a pending declaration.
+        if matches!(t.kind, TokenKind::Whitespace | TokenKind::Newline) {
+            out.push_str(&t.text);
+            i += 1;
+            continue;
+        }
+
+        // Line comment: `//` through end of line.
+        if t.kind == TokenKind::Slash && toks.get(i + 1).map(|n| n.kind) == Some(TokenKind::Slash) {
+            let mut buf = String::new();
+            while i < toks.len()
+                && toks[i].kind != TokenKind::Newline
+                && !toks[i].text.contains('\n')
+            {
+                buf.push_str(&toks[i].text);
+                i += 1;
+            }
+            push_styled(&mut out, &buf, &style_for(SemanticTokenType::Comment));
+            pending_decl = None;
+            continue;
+        }
+
+        // Double-quoted string: consume through the closing unescaped quote.
+        if t.kind == TokenKind::Quote {
+            let mut buf = String::from(t.text.as_str());
+            let mut j = i + 1;
+            while j < toks.len() {
+                buf.push_str(&toks[j].text);
+                let closes =
+                    toks[j].kind == TokenKind::Quote && toks[j - 1].kind != TokenKind::Backslash;
+                j += 1;
+                if closes {
+                    break;
+                }
+            }
+            push_styled(&mut out, &buf, &style_for(SemanticTokenType::String));
+            i = j;
+            pending_decl = None;
+            continue;
+        }
+
+        // A single significant token.
+        let style = if is_keyword(t.kind) {
+            Some(style_for(SemanticTokenType::Keyword))
+        } else if matches!(
+            t.kind,
+            TokenKind::IntegerLiteral | TokenKind::FloatLiteral | TokenKind::BigintLiteral
+        ) {
+            Some(style_for(SemanticTokenType::Number))
+        } else if t.kind == TokenKind::Word {
+            if let Some(k) = pending_decl {
+                Some(kind_style(k))
+            } else if PRIMITIVE_TYPES.contains(&t.text.as_str()) {
+                Some(style_for(SemanticTokenType::Type))
+            } else {
+                None // bare identifier: leave at the default foreground
+            }
+        } else {
+            Some(style_for(SemanticTokenType::Operator)) // punctuation / operators
+        };
+        match style {
+            Some(s) => out.push_str(&s.apply_to(&t.text).to_string()),
+            None => out.push_str(&t.text),
+        }
+        pending_decl = decl_keyword_kind(t.kind);
+        i += 1;
+    }
+    out
+}
+
+// ── Terminal hyperlinks (OSC 8) ────────────────────────────────────────────────
+
+/// Wrap `text` in an OSC 8 terminal hyperlink to `uri`.
+fn osc8(uri: &str, text: &str) -> String {
+    format!("\x1b]8;;{uri}\x1b\\{text}\x1b]8;;\x1b\\")
+}
+
+/// Minimal `file://` URI builder. Percent-encodes the few characters most likely
+/// to break a URI in a source path; not a full RFC 3986 encoder.
+fn file_uri(path: &Path) -> String {
+    let mut s = String::from("file://");
+    for ch in path.to_string_lossy().chars() {
+        match ch {
+            ' ' => s.push_str("%20"),
+            '%' => s.push_str("%25"),
+            '#' => s.push_str("%23"),
+            '?' => s.push_str("%3F"),
+            _ => s.push(ch),
+        }
+    }
+    s
+}
+
+/// A `display:line_label` location, rendered as a clickable `file://` hyperlink
+/// on a TTY when `abs_path` is a real (absolute) file, and plain text otherwise
+/// (pipes / JSON / tests / builtin `<...>` paths). `line_label` is the suffix
+/// after the path, e.g. `"55"` or `"55-66"`.
+pub fn location(abs_path: &Path, display: &str, line_label: &str) -> String {
+    let text = format!("{display}:{line_label}");
+    if console::colors_enabled() && abs_path.is_absolute() {
+        osc8(&file_uri(abs_path), &text)
+    } else {
+        text
+    }
+}
+
+// ── Source highlighting ─────────────────────────────────────────────────────────
+
+/// Highlights source ranges using the compiler's semantic tokens, caching the
+/// token set per file so repeated lookups within one render are cheap.
+pub struct Highlighter<'db> {
+    db: &'db ProjectDatabase,
+    cache: RefCell<HashMap<SourceFile, Rc<[SemanticToken]>>>,
+}
+
+impl<'db> Highlighter<'db> {
+    pub fn new(db: &'db ProjectDatabase) -> Self {
+        Self {
+            db,
+            cache: RefCell::new(HashMap::new()),
+        }
+    }
+
+    /// Semantic tokens for `file`, computed once and cached (sorted by start).
+    fn tokens(&self, file: SourceFile) -> Rc<[SemanticToken]> {
+        if let Some(cached) = self.cache.borrow().get(&file) {
+            return Rc::clone(cached);
+        }
+        let mut toks = semantic_tokens(self.db, file);
+        toks.sort_by_key(|t| t.range.start());
+        let rc: Rc<[SemanticToken]> = toks.into();
+        self.cache.borrow_mut().insert(file, Rc::clone(&rc));
+        rc
+    }
+
+    /// Highlight the verbatim source slice `file.text()[range]`.
+    ///
+    /// Styling is re-opened on every line so no SGR run crosses a `'\n'`, which
+    /// keeps the result safe to `split('\n')` for line-budgeting by the caller.
+    pub fn range(&self, file: SourceFile, range: TextRange) -> String {
+        let text = file.text(self.db);
+        let start: usize = range.start().into();
+        let end: usize = usize::min(range.end().into(), text.len());
+        if start >= end {
+            return String::new();
+        }
+        let slice = &text[start..end];
+
+        let mut out = String::new();
+        let mut cursor = 0usize;
+        for tok in self.tokens(file).iter() {
+            let ts: usize = tok.range.start().into();
+            let te: usize = tok.range.end().into();
+            if te <= start {
+                continue;
+            }
+            if ts >= end {
+                break; // tokens are sorted by start; nothing further overlaps
+            }
+            let s = ts.max(start) - start;
+            let e = te.min(end) - start;
+            if s < cursor {
+                continue; // overlapping token; the first writer wins
+            }
+            out.push_str(&slice[cursor..s]); // gap (whitespace/punctuation) stays plain
+            push_styled(&mut out, &slice[s..e], &style_for(tok.token_type));
+            cursor = e;
+        }
+        out.push_str(&slice[cursor..]);
+        out
+    }
+
+    /// Highlight the full source line(s) enclosing `range`, trimmed of
+    /// surrounding whitespace. Used for reference previews, where only the
+    /// reference span is known but the whole line is shown.
+    pub fn enclosing_line(&self, file: SourceFile, range: TextRange) -> String {
+        let text = file.text(self.db);
+        let start: usize = range.start().into();
+        let end: usize = usize::min(range.end().into(), text.len());
+        let line_start = text[..start].rfind('\n').map_or(0, |i| i + 1);
+        let line_end = text[end..].find('\n').map_or(text.len(), |i| end + i);
+        let line_range = TextRange::new(
+            TextSize::from(line_start as u32),
+            TextSize::from(line_end as u32),
+        );
+        self.range(file, line_range).trim().to_string()
+    }
+}
+
+/// Apply `style` to `seg`, re-opening it on each line so no escape run spans a
+/// newline.
+fn push_styled(out: &mut String, seg: &str, style: &Style) {
+    for (i, line) in seg.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        if !line.is_empty() {
+            out.push_str(&style.apply_to(line).to_string());
+        }
+    }
+}

--- a/baml_language/crates/baml_cli/src/describe_highlight.rs
+++ b/baml_language/crates/baml_cli/src/describe_highlight.rs
@@ -10,7 +10,7 @@
 //! dependency/reference rows, which can touch several files) computes each file's
 //! tokens at most once.
 
-use std::{cell::RefCell, collections::HashMap, path::Path, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, fmt::Write, path::Path, rc::Rc};
 
 use baml_db::{
     FileId, SourceFile,
@@ -143,15 +143,18 @@ pub fn highlight_fqn_opt(name: &str, leaf_kind: Option<DefinitionKind>) -> Strin
     let namespace = style_for(SemanticTokenType::Namespace);
     let dot = style_for(SemanticTokenType::Operator);
     let leaf = leaf_kind.map_or_else(|| namespace.clone(), kind_style);
-    let parts: Vec<&str> = name.split('.').collect();
-    let last = parts.len().saturating_sub(1);
     let mut out = String::new();
-    for (i, part) in parts.iter().enumerate() {
-        if i > 0 {
-            out.push_str(&dot.apply_to('.').to_string());
+    let mut parts = name.split('.').peekable();
+    while let Some(part) = parts.next() {
+        let style = if parts.peek().is_none() {
+            &leaf
+        } else {
+            &namespace
+        };
+        let _ = write!(out, "{}", style.apply_to(part));
+        if parts.peek().is_some() {
+            let _ = write!(out, "{}", dot.apply_to('.'));
         }
-        let style = if i == last { &leaf } else { &namespace };
-        out.push_str(&style.apply_to(part).to_string());
     }
     out
 }
@@ -324,7 +327,9 @@ pub fn highlight_str(text: &str) -> String {
             Some(style_for(SemanticTokenType::Operator)) // punctuation / operators
         };
         match style {
-            Some(s) => out.push_str(&s.apply_to(&t.text).to_string()),
+            Some(s) => {
+                let _ = write!(out, "{}", s.apply_to(&t.text));
+            }
             None => out.push_str(&t.text),
         }
         pending_decl = decl_keyword_kind(t.kind);
@@ -460,7 +465,7 @@ fn push_styled(out: &mut String, seg: &str, style: &Style) {
             out.push('\n');
         }
         if !line.is_empty() {
-            out.push_str(&style.apply_to(line).to_string());
+            let _ = write!(out, "{}", style.apply_to(line));
         }
     }
 }

--- a/baml_language/crates/baml_cli/src/grep_command.rs
+++ b/baml_language/crates/baml_cli/src/grep_command.rs
@@ -10,7 +10,10 @@ use baml_lsp2_actions::{
 use baml_project::ProjectDatabase;
 use clap::Args;
 
-use crate::project_load::load_project_or_default;
+use crate::{
+    project_load::load_project_or_default,
+    util::{line_number_at_offset, relative_path},
+};
 
 #[derive(Args, Clone, Debug)]
 pub struct GrepArgs {
@@ -384,15 +387,6 @@ pub fn parse_kind_filter(kinds: &[String]) -> Result<Vec<DefinitionKind>> {
             ),
         })
         .collect()
-}
-
-fn relative_path(path: &std::path::Path, root: &std::path::Path) -> std::path::PathBuf {
-    path.strip_prefix(root).unwrap_or(path).to_path_buf()
-}
-
-fn line_number_at_offset(text: &str, offset: usize) -> usize {
-    let offset = offset.min(text.len());
-    text[..offset].chars().filter(|&c| c == '\n').count() + 1
 }
 
 /// Choose the appropriate body representation based on budget.

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod commands;
 pub(crate) mod describe_command;
 #[cfg(test)]
 mod describe_command_tests;
+pub(crate) mod describe_highlight;
 pub(crate) mod format;
 pub(crate) mod generate;
 pub(crate) mod grep_command;

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -15,7 +15,6 @@ pub(crate) mod commands;
 pub(crate) mod describe_command;
 #[cfg(test)]
 mod describe_command_tests;
-pub(crate) mod describe_highlight;
 pub(crate) mod format;
 pub(crate) mod generate;
 pub(crate) mod grep_command;
@@ -25,12 +24,14 @@ pub(crate) mod lsp;
 pub(crate) mod manifest;
 pub(crate) mod pack_command;
 pub(crate) mod pack_elf;
+pub(crate) mod paint;
 pub(crate) mod playground_command;
 pub(crate) mod project_load;
 pub mod reporter;
 pub(crate) mod run_command;
 pub(crate) mod test_command;
 pub(crate) mod test_filter;
+pub(crate) mod util;
 
 // TODO: These modules are disabled for now as they depend on baml_runtime
 // pub(crate) mod api_client;

--- a/baml_language/crates/baml_cli/src/paint.rs
+++ b/baml_language/crates/baml_cli/src/paint.rs
@@ -536,7 +536,9 @@ impl<'db> Highlighter<'db> {
     /// reference span is known but the whole line is shown.
     pub fn enclosing_line(&self, file: SourceFile, range: TextRange) -> String {
         let text = file.text(self.db);
-        let start: usize = range.start().into();
+        // Clamp both bounds: a stale/out-of-range `range` must not panic the
+        // `text[..start]` / `text[end..]` slices below.
+        let start: usize = usize::min(range.start().into(), text.len());
         let end: usize = usize::min(range.end().into(), text.len());
         let line_start = text[..start].rfind('\n').map_or(0, |i| i + 1);
         let line_end = text[end..].find('\n').map_or(text.len(), |i| end + i);

--- a/baml_language/crates/baml_cli/src/paint.rs
+++ b/baml_language/crates/baml_cli/src/paint.rs
@@ -1,4 +1,6 @@
-//! ANSI syntax highlighting (and terminal hyperlinks) for `baml describe`.
+//! Colored, hyperlinked terminal output: a stream-bound [`Painter`] that owns
+//! the color decision, plus the BAML syntax highlighting it renders (used by
+//! `baml describe`).
 //!
 //! Reuses the compiler's own semantic-token classifier
 //! (`baml_lsp2_actions::semantic_tokens`) instead of a separate TextMate/Sublime
@@ -112,7 +114,7 @@ fn style_for(token_type: SemanticTokenType) -> Style {
 
 /// Color for a definition kind, used to highlight listing rows (which have no
 /// source slice to tokenize). Maps each kind onto the same palette as the body.
-pub fn kind_style(kind: DefinitionKind) -> Style {
+fn kind_style(kind: DefinitionKind) -> Style {
     use DefinitionKind as K;
     use SemanticTokenType as T;
     style_for(match kind {
@@ -133,13 +135,13 @@ pub fn kind_style(kind: DefinitionKind) -> Style {
 /// Highlight a (possibly dotted) name as it would appear in source: each
 /// qualifier segment in the namespace color, the `.` separators as punctuation,
 /// and the final segment in `leaf_kind`'s color.
-pub fn highlight_fqn(name: &str, leaf_kind: DefinitionKind) -> String {
+fn highlight_fqn(name: &str, leaf_kind: DefinitionKind) -> String {
     highlight_fqn_opt(name, Some(leaf_kind))
 }
 
 /// Like [`highlight_fqn`] but the leaf kind is optional; `None` (a namespace or
 /// package path) colors the whole path in the namespace color.
-pub fn highlight_fqn_opt(name: &str, leaf_kind: Option<DefinitionKind>) -> String {
+fn highlight_fqn_opt(name: &str, leaf_kind: Option<DefinitionKind>) -> String {
     let namespace = style_for(SemanticTokenType::Namespace);
     let dot = style_for(SemanticTokenType::Operator);
     let leaf = leaf_kind.map_or_else(|| namespace.clone(), kind_style);
@@ -161,7 +163,7 @@ pub fn highlight_fqn_opt(name: &str, leaf_kind: Option<DefinitionKind>) -> Strin
 
 /// Like [`highlight_fqn`], padded with plain trailing spaces so the *visible*
 /// text occupies `width` columns (ANSI escapes don't count toward width).
-pub fn highlight_name_padded(name: &str, leaf_kind: DefinitionKind, width: usize) -> String {
+fn highlight_name_padded(name: &str, leaf_kind: DefinitionKind, width: usize) -> String {
     let pad = width.saturating_sub(name.chars().count());
     format!("{}{}", highlight_fqn(name, leaf_kind), " ".repeat(pad))
 }
@@ -254,10 +256,9 @@ fn is_keyword(kind: TokenKind) -> bool {
 /// names introduced by a declaration keyword, strings, line comments, numbers,
 /// and operators. It cannot tell a user type from a variable the way the
 /// type-aware [`Highlighter`] (used for real source ranges) can.
-pub fn highlight_str(text: &str) -> String {
-    if !console::colors_enabled() {
-        return text.to_string();
-    }
+///
+/// Always emits color; callers go through [`Painter::fragment`], which gates.
+fn highlight_str(text: &str) -> String {
     let toks = lex_lossless(text, FileId::new(0));
     let mut out = String::new();
     let mut i = 0;
@@ -361,16 +362,106 @@ fn file_uri(path: &Path) -> String {
     s
 }
 
-/// A `display:line_label` location, rendered as a clickable `file://` hyperlink
-/// on a TTY when `abs_path` is a real (absolute) file, and plain text otherwise
-/// (pipes / JSON / tests / builtin `<...>` paths). `line_label` is the suffix
-/// after the path, e.g. `"55"` or `"55-66"`.
-pub fn location(abs_path: &Path, display: &str, line_label: &str) -> String {
-    let text = format!("{display}:{line_label}");
-    if console::colors_enabled() && abs_path.is_absolute() {
-        osc8(&file_uri(abs_path), &text)
-    } else {
-        text
+// ── Painter ─────────────────────────────────────────────────────────────────────
+
+/// Owns the color decision for one output stream and produces colored-or-plain
+/// text accordingly.
+///
+/// Construct [`Painter::stdout`] / [`Painter::stderr`] so the decision matches
+/// where the text is written; call sites then never branch on color and the
+/// helpers never have to guess which stream they're feeding (which previously
+/// risked leaking codes into a redirected sibling stream).
+pub struct Painter {
+    enabled: bool,
+}
+
+impl Painter {
+    /// Painter for stdout-bound output.
+    pub fn stdout() -> Self {
+        Self {
+            enabled: console::colors_enabled(),
+        }
+    }
+
+    /// Painter for stderr-bound output.
+    pub fn stderr() -> Self {
+        Self {
+            enabled: console::colors_enabled_stderr(),
+        }
+    }
+
+    /// Whether this stream renders color. Also gates the verbatim-vs-cleaned body
+    /// rendering fork in `describe` (a behavior choice, not just a color toggle).
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// A dotted name: namespace-colored qualifiers, leaf colored by `leaf_kind`.
+    pub fn fqn(&self, name: &str, leaf_kind: DefinitionKind) -> String {
+        self.fqn_opt(name, Some(leaf_kind))
+    }
+
+    /// Like [`Painter::fqn`] but the leaf kind is optional (`None` => namespace).
+    pub fn fqn_opt(&self, name: &str, leaf_kind: Option<DefinitionKind>) -> String {
+        if self.enabled {
+            highlight_fqn_opt(name, leaf_kind)
+        } else {
+            name.to_string()
+        }
+    }
+
+    /// A name whose *visible* width is padded to `width` columns.
+    pub fn name_padded(&self, name: &str, leaf_kind: DefinitionKind, width: usize) -> String {
+        if self.enabled {
+            highlight_name_padded(name, leaf_kind, width)
+        } else {
+            format!("{name:<width$}")
+        }
+    }
+
+    /// A definition-kind label padded to `width` columns, colored by kind.
+    pub fn kind_label(&self, kind: DefinitionKind, width: usize) -> String {
+        let label = kind.as_str();
+        if self.enabled {
+            kind_style(kind)
+                .apply_to(format!("{label:<width$}"))
+                .to_string()
+        } else {
+            format!("{label:<width$}")
+        }
+    }
+
+    /// An arbitrary BAML fragment with no source backing (signatures, examples).
+    pub fn fragment(&self, text: &str) -> String {
+        if self.enabled {
+            highlight_str(text)
+        } else {
+            text.to_string()
+        }
+    }
+
+    /// `text` styled as a keyword (for keyword-doc headers).
+    pub fn keyword(&self, text: &str) -> String {
+        if self.enabled {
+            style_for(SemanticTokenType::Keyword)
+                .apply_to(text)
+                .to_string()
+        } else {
+            text.to_string()
+        }
+    }
+
+    /// A `display:line_label` location, rendered as a clickable `file://`
+    /// hyperlink when this stream is colored and `abs_path` is a real (absolute)
+    /// file. Plain `display:line_label` otherwise (pipes / JSON / tests / builtin
+    /// `<...>` paths).
+    pub fn location(&self, abs_path: &Path, display: &str, line_label: &str) -> String {
+        let text = format!("{display}:{line_label}");
+        if self.enabled && abs_path.is_absolute() {
+            osc8(&file_uri(abs_path), &text)
+        } else {
+            text
+        }
     }
 }
 

--- a/baml_language/crates/baml_cli/src/util.rs
+++ b/baml_language/crates/baml_cli/src/util.rs
@@ -3,9 +3,17 @@
 use std::path::{Path, PathBuf};
 
 /// 1-based line number at a byte `offset` within `text`.
+///
+/// Counts newline *bytes* rather than slicing the `str`, so an `offset` that
+/// lands mid-codepoint (offsets are derived from byte-level scanning) can't
+/// panic.
 pub(crate) fn line_number_at_offset(text: &str, offset: usize) -> usize {
     let offset = offset.min(text.len());
-    text[..offset].chars().filter(|&c| c == '\n').count() + 1
+    text.as_bytes()[..offset]
+        .iter()
+        .filter(|&&b| b == b'\n')
+        .count()
+        + 1
 }
 
 /// Make `path` relative to `root`, or return it unchanged if not under `root`.

--- a/baml_language/crates/baml_cli/src/util.rs
+++ b/baml_language/crates/baml_cli/src/util.rs
@@ -1,0 +1,14 @@
+//! Small formatting helpers shared across CLI subcommands.
+
+use std::path::{Path, PathBuf};
+
+/// 1-based line number at a byte `offset` within `text`.
+pub(crate) fn line_number_at_offset(text: &str, offset: usize) -> usize {
+    let offset = offset.min(text.len());
+    text[..offset].chars().filter(|&c| c == '\n').count() + 1
+}
+
+/// Make `path` relative to `root`, or return it unchanged if not under `root`.
+pub(crate) fn relative_path(path: &Path, root: &Path) -> PathBuf {
+    path.strip_prefix(root).unwrap_or(path).to_path_buf()
+}


### PR DESCRIPTION
## What

`baml describe` now syntax-highlights its output and turns `file:line`
locations into clickable terminal hyperlinks.

Highlighted everywhere an identifier/keyword/type appears: definition
bodies, headers, listing rows (`baml describe` with no arg / a package /
a namespace), dependency & container rows, reference previews, method
signatures, keyword docs, and "did you mean?" suggestions.

## How

Two-tier, so each surface gets the best available fidelity:

- **Type-aware** for anything backed by real source — reuses the
  compiler's own `semantic_tokens` (via `baml_db`). `describe` already
  compiles the project, so this reads Salsa-cached queries; there's no
  separate grammar to maintain and it can't drift from the language.
  A small per-file token cache (`Highlighter`) computes each file's
  tokens at most once per render.
- **Lexer-based fallback** (`highlight_str`) for synthesized strings that
  have no file/range (canonical method signatures, keyword-doc examples);
  kinded `highlight_fqn` colors dotted names (namespace vs leaf-by-kind),
  including the did-you-mean list.
- **OSC 8 hyperlinks** on `file:line` locations (skipped for synthetic
  `<builtin>` paths).

## Output control

- New global `--color=auto|always|never` flag.
- In `auto`, color/hyperlinks are suppressed when output is captured by a
  known AI coding agent, since ANSI is noise there. Detected via env vars
  documented per agent / from maintained matrices (`@vercel/detect-agent`,
  Bun): `CLAUDECODE`, `CODEX_SANDBOX`, `PI_CODING_AGENT`, `OPENCODE_CLIENT`,
  `AI_AGENT`, `CURSOR_TRACE_ID`, `REPL_ID`, `AGENT`.
- Precedence: `--color` flag > `CLICOLOR_FORCE`/`NO_COLOR` > agent
  detection > TTY default.
- Color is decided **per stream** (`colors_enabled` for stdout vs
  `colors_enabled_stderr` for stderr), so escape codes never leak into a
  redirected stream and color isn't dropped on a redirected sibling.

## Notes

- Piped / JSON output is byte-identical (every path gates on color
  detection).
- No new crate dependency — the lexer/semantic-token APIs are reached
  through `baml_db` per the workspace dependency rules.
- `describe`/`listing`/`suggest`/`keyword`/`commands` tests pass; verified
  the color precedence matrix with a real PTY.

## Follow-ups (not in this PR)

- `baml grep` preview modes (refs-only / text-search matches) are still
  plain.
- Optional VSCode-theme colors (24-bit) instead of the built-in palette.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global `--color` option to control colored (and hyperlink-friendly) CLI output, with consistent behavior for interactive vs captured output.
  * Upgraded descriptive command rendering with richer, colorized previews and highlighted source ranges.
  * Improved “did you mean?” suggestions with kind-aware matching and clearer, formatted output.
* **Bug Fixes**
  * Standardized path/line display and location formatting across CLI views.
  * Improved truncation and preview behavior to keep highlighted content readable and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->