### PR TITLE
perf(emit): skip redundant Pass-1 MIR lowering [run-perf]

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
  "baml_compiler_lexer",
  "baml_compiler_parser",
  "baml_compiler_syntax",
+ "borsh",
  "la-arena",
  "num-bigint",
  "rowan 0.16.1",

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "baml_compiler_diagnostics",
  "baml_compiler_parser",
  "baml_workspace",
+ "borsh",
  "indexmap",
  "la-arena",
  "rustc-hash 2.1.2",

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -938,6 +938,7 @@ name = "baml_db"
 version = "0.0.0-beta"
 dependencies = [
  "baml_base",
+ "baml_compiler2_ast",
  "baml_compiler2_emit",
  "baml_compiler2_hir",
  "baml_compiler2_mir",

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -716,11 +716,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "baml_builtins2_prebuilt"
+version = "0.0.0-beta"
+dependencies = [
+ "baml_db",
+ "baml_project",
+ "borsh",
+]
+
+[[package]]
 name = "baml_cli"
 version = "0.0.0-beta"
 dependencies = [
  "anyhow",
  "baml_builtins2",
+ "baml_builtins2_prebuilt",
  "baml_db",
  "baml_exec",
  "baml_fmt",
@@ -797,6 +807,7 @@ dependencies = [
  "baml_type",
  "baml_workspace",
  "bex_vm_types",
+ "borsh",
  "indexmap",
  "log",
  "rustc-hash 2.1.2",

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "baml_compiler2_ppir",
  "baml_type",
  "baml_workspace",
+ "borsh",
  "indexmap",
  "num-bigint",
  "rustc-hash 2.1.2",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -83,6 +83,7 @@ baml_lsp2_actions = { path = "crates/baml_lsp2_actions" }
 baml_lsp_server = { path = "crates/baml_lsp_server", default-features = false }
 baml_project = { path = "crates/baml_project" }
 baml_release = { path = "crates/baml_release" }
+baml_builtins2_prebuilt = { path = "crates/baml_builtins2_prebuilt" }
 baml_tests = { path = "crates/baml_tests" }
 baml_version = { path = "crates/baml_version" }
 bex_vm = { path = "crates/bex_vm" }

--- a/baml_language/crates/baml_base/src/core_types.rs
+++ b/baml_language/crates/baml_base/src/core_types.rs
@@ -205,7 +205,7 @@ pub type Name = SmolStr;
 ///
 /// `Display` joins with `.` for diagnostics and for places that key off the
 /// dotted form (the bytecode emitter's class registry, debug snapshots).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct TypePath(pub Vec<Name>);
 
 impl TypePath {

--- a/baml_language/crates/baml_builtins2_prebuilt/Cargo.toml
+++ b/baml_language/crates/baml_builtins2_prebuilt/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "baml_builtins2_prebuilt"
+version = { workspace = true }
+publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+description = "Build-time precompiled BAML stdlib emit artifact"
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true
+
+# Compiler interfaces are accessed via baml_db / baml_project (per the workspace
+# crate-dependency policy), not baml_compiler2_emit / bex_vm_types directly.
+[dependencies]
+baml_db = { workspace = true }
+borsh = { workspace = true }
+
+# build.rs compiles the stdlib once into an EmitState prefix. Nothing in the
+# normal dependency graph depends on this crate's compiler usage, so there is no
+# build-dependency cycle. Consumers (CLI/LSP) inject the deserialized artifact.
+[build-dependencies]
+baml_db = { workspace = true }
+baml_project = { workspace = true }
+borsh = { workspace = true }

--- a/baml_language/crates/baml_builtins2_prebuilt/build.rs
+++ b/baml_language/crates/baml_builtins2_prebuilt/build.rs
@@ -13,7 +13,7 @@
 use std::{collections::HashMap, path::PathBuf};
 
 fn main() {
-    use baml_db::{baml_compiler_parser, baml_compiler2_ast, baml_compiler2_hir};
+    use baml_db::{baml_compiler2_hir, baml_compiler2_tir};
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     // Rebuild the artifacts whenever the stdlib sources change.
@@ -36,36 +36,53 @@ fn main() {
     std::fs::write(out_dir.join("stdlib_prefix.bin"), &prefix_bytes)
         .expect("write prefix artifact");
 
-    // --- HIR prefix: per-file pre-lowered AST for each builtin file.
+    // --- HIR prefix: snapshot each builtin file's FileSemanticIndex. The cache
+    // is not installed at build time, so file_semantic_index builds from source
+    // here; PrecompiledFile::from_index captures it in borsh-friendly form.
     let mut hir: HashMap<String, baml_compiler2_hir::precompiled::PrecompiledFile> = HashMap::new();
     for file in baml_compiler2_hir::compiler2_all_files(&db) {
         let path = file.path(&db).to_string_lossy().to_string();
-        let tree = baml_compiler_parser::syntax_tree(&db, file);
-        let range = tree.text_range();
-        let (items, diags, env_var_refs) =
-            baml_compiler2_ast::lower_file_with_path(&tree, Some(std::path::Path::new(&path)));
-        assert!(
-            diags.is_empty(),
-            "stdlib file {path} produced CST->AST lowering diagnostics; the HIR \
-             prefix assumes the frozen stdlib lowers cleanly"
-        );
+        let index = baml_compiler2_hir::file_semantic_index(&db, file);
         hir.insert(
             path,
-            baml_compiler2_hir::precompiled::PrecompiledFile {
-                items,
-                env_var_refs,
-                range_start: range.start().into(),
-                range_end: range.end().into(),
-            },
+            baml_compiler2_hir::precompiled::PrecompiledFile::from_index(&db, index),
         );
     }
     let hir_bytes = borsh::to_vec(&hir).expect("serialize stdlib HIR prefix");
     std::fs::write(out_dir.join("stdlib_hir.bin"), &hir_bytes).expect("write HIR artifact");
 
+    // --- TIR prefix: each stdlib package's fully-resolved PackageInterface (the
+    // signature graph: class fields, enum variants, type aliases, function
+    // signatures, throw sets). Resolving these is the dominant cost of the first
+    // user-file type-check; this does it once, here, so a normal compile loads it.
+    let mut tir: HashMap<String, baml_compiler2_tir::package_interface::PackageInterface> =
+        HashMap::new();
+    let mut implements: HashMap<String, baml_compiler2_tir::interfaces::ImplementsRegistry> =
+        HashMap::new();
+    let mut seen = std::collections::HashSet::new();
+    for file in baml_compiler2_hir::compiler2_all_files(&db) {
+        let pkg_name = baml_compiler2_hir::file_package::file_package(&db, file).package;
+        if !seen.insert(pkg_name.clone()) {
+            continue;
+        }
+        let pkg_id = baml_compiler2_hir::package::PackageId::new(&db, pkg_name.clone());
+        let pi = baml_compiler2_tir::package_interface::package_interface(&db, pkg_id);
+        tir.insert(pkg_name.to_string(), pi.clone());
+        let reg = baml_compiler2_tir::interfaces::package_implements_registry(&db, pkg_id);
+        implements.insert(pkg_name.to_string(), reg.clone());
+    }
+    let tir_bytes = borsh::to_vec(&tir).expect("serialize stdlib TIR interfaces");
+    std::fs::write(out_dir.join("stdlib_tir.bin"), &tir_bytes).expect("write TIR artifact");
+    let impl_bytes = borsh::to_vec(&implements).expect("serialize stdlib implements registries");
+    std::fs::write(out_dir.join("stdlib_implements.bin"), &impl_bytes)
+        .expect("write implements artifact");
+
     println!(
-        "cargo:warning=baml_builtins2_prebuilt: EmitState prefix = {} bytes, HIR prefix = {} bytes ({} files)",
+        "cargo:warning=baml_builtins2_prebuilt: EmitState prefix = {} bytes, HIR prefix = {} bytes ({} files), TIR prefix = {} bytes ({} packages)",
         prefix_bytes.len(),
         hir_bytes.len(),
-        hir.len()
+        hir.len(),
+        tir_bytes.len(),
+        tir.len()
     );
 }

--- a/baml_language/crates/baml_builtins2_prebuilt/build.rs
+++ b/baml_language/crates/baml_builtins2_prebuilt/build.rs
@@ -1,37 +1,71 @@
-//! Compiles the embedded BAML stdlib into a `Program` once, at build time, and
-//! serializes it to `$OUT_DIR/stdlib_program.bin` for `lib.rs` to `include_bytes!`.
+//! Compiles the embedded BAML stdlib once, at build time, into two artifacts
+//! that a normal `baml` invocation loads instead of recompiling the stdlib:
+//!
+//! - `stdlib_prefix.bin`: the emit `EmitState` prefix (globals/object pool/type
+//!   tags) — lets `get_bytecode` skip re-lowering+re-emitting the stdlib.
+//! - `stdlib_hir.bin`: per-file pre-lowered AST (`PrecompiledFile`) keyed by
+//!   builtin virtual path — lets `file_semantic_index` skip lex/parse/lower for
+//!   stdlib files and re-run only the semantic-index builder.
 //!
 //! The stdlib source is frozen per compiler version (embedded in `baml_builtins2`
-//! via `include_str!`), so its compiled bytecode is identical on every run. This
-//! moves that work out of every `baml` invocation.
+//! via `include_str!`), so both artifacts are deterministic.
 
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 fn main() {
+    use baml_db::{baml_compiler_parser, baml_compiler2_ast, baml_compiler2_hir};
+
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    // Rebuild the artifact whenever the stdlib sources change.
+    // Rebuild the artifacts whenever the stdlib sources change.
     println!("cargo:rerun-if-changed={manifest_dir}/../baml_builtins2/baml_std");
     println!("cargo:rerun-if-changed=build.rs");
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
-    // No user files: `set_project_root` loads only the embedded stdlib builtins,
-    // so `precompile_stdlib` runs the core emit passes (1-4) over the stdlib only
-    // and returns the reusable `EmitState` prefix (stdlib globals, object pool,
-    // and type-tag cursors). A normal compile resumes from this instead of
-    // recompiling the stdlib. Built at `OptLevel::Two` to match `get_bytecode`.
+    // No user files: `set_project_root` loads only the embedded stdlib builtins.
     let mut db = baml_project::ProjectDatabase::new();
     db.set_project_root(std::path::Path::new("/__baml_stdlib_precompile__"));
 
+    // --- Emit prefix: core emit passes (1-4) over the stdlib, at OptLevel::Two
+    // (matching `ProjectDatabase::get_bytecode`'s default).
     let prefix = baml_db::baml_compiler2_emit::precompile_stdlib(
         &db,
         baml_db::baml_compiler2_emit::OptLevel::Two,
     );
+    let prefix_bytes = borsh::to_vec(&prefix).expect("serialize stdlib EmitState");
+    std::fs::write(out_dir.join("stdlib_prefix.bin"), &prefix_bytes)
+        .expect("write prefix artifact");
 
-    let bytes = borsh::to_vec(&prefix).expect("serialize stdlib EmitState");
-    std::fs::write(out_dir.join("stdlib_prefix.bin"), &bytes).expect("write artifact");
+    // --- HIR prefix: per-file pre-lowered AST for each builtin file.
+    let mut hir: HashMap<String, baml_compiler2_hir::precompiled::PrecompiledFile> = HashMap::new();
+    for file in baml_compiler2_hir::compiler2_all_files(&db) {
+        let path = file.path(&db).to_string_lossy().to_string();
+        let tree = baml_compiler_parser::syntax_tree(&db, file);
+        let range = tree.text_range();
+        let (items, diags, env_var_refs) =
+            baml_compiler2_ast::lower_file_with_path(&tree, Some(std::path::Path::new(&path)));
+        assert!(
+            diags.is_empty(),
+            "stdlib file {path} produced CST->AST lowering diagnostics; the HIR \
+             prefix assumes the frozen stdlib lowers cleanly"
+        );
+        hir.insert(
+            path,
+            baml_compiler2_hir::precompiled::PrecompiledFile {
+                items,
+                env_var_refs,
+                range_start: range.start().into(),
+                range_end: range.end().into(),
+            },
+        );
+    }
+    let hir_bytes = borsh::to_vec(&hir).expect("serialize stdlib HIR prefix");
+    std::fs::write(out_dir.join("stdlib_hir.bin"), &hir_bytes).expect("write HIR artifact");
+
     println!(
-        "cargo:warning=baml_builtins2_prebuilt: stdlib EmitState prefix = {} bytes",
-        bytes.len()
+        "cargo:warning=baml_builtins2_prebuilt: EmitState prefix = {} bytes, HIR prefix = {} bytes ({} files)",
+        prefix_bytes.len(),
+        hir_bytes.len(),
+        hir.len()
     );
 }

--- a/baml_language/crates/baml_builtins2_prebuilt/build.rs
+++ b/baml_language/crates/baml_builtins2_prebuilt/build.rs
@@ -1,0 +1,37 @@
+//! Compiles the embedded BAML stdlib into a `Program` once, at build time, and
+//! serializes it to `$OUT_DIR/stdlib_program.bin` for `lib.rs` to `include_bytes!`.
+//!
+//! The stdlib source is frozen per compiler version (embedded in `baml_builtins2`
+//! via `include_str!`), so its compiled bytecode is identical on every run. This
+//! moves that work out of every `baml` invocation.
+
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    // Rebuild the artifact whenever the stdlib sources change.
+    println!("cargo:rerun-if-changed={manifest_dir}/../baml_builtins2/baml_std");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+
+    // No user files: `set_project_root` loads only the embedded stdlib builtins,
+    // so `precompile_stdlib` runs the core emit passes (1-4) over the stdlib only
+    // and returns the reusable `EmitState` prefix (stdlib globals, object pool,
+    // and type-tag cursors). A normal compile resumes from this instead of
+    // recompiling the stdlib. Built at `OptLevel::Two` to match `get_bytecode`.
+    let mut db = baml_project::ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new("/__baml_stdlib_precompile__"));
+
+    let prefix = baml_db::baml_compiler2_emit::precompile_stdlib(
+        &db,
+        baml_db::baml_compiler2_emit::OptLevel::Two,
+    );
+
+    let bytes = borsh::to_vec(&prefix).expect("serialize stdlib EmitState");
+    std::fs::write(out_dir.join("stdlib_prefix.bin"), &bytes).expect("write artifact");
+    println!(
+        "cargo:warning=baml_builtins2_prebuilt: stdlib EmitState prefix = {} bytes",
+        bytes.len()
+    );
+}

--- a/baml_language/crates/baml_builtins2_prebuilt/src/lib.rs
+++ b/baml_language/crates/baml_builtins2_prebuilt/src/lib.rs
@@ -1,0 +1,23 @@
+//! Precompiled BAML stdlib emit artifact.
+//!
+//! `build.rs` runs the compiler's core emit passes (1-4) over the embedded
+//! stdlib once and serializes the resulting [`EmitState`] prefix to
+//! `$OUT_DIR/stdlib_prefix.bin`. This crate embeds those bytes and exposes a
+//! deserialize helper so a normal compile can resume from the stdlib prefix
+//! (via `generate_project_bytecode_with_prefix`) instead of recompiling the
+//! ~676-function stdlib from source on every invocation.
+
+// Compiler types are reached through baml_db's re-export (workspace policy).
+use baml_db::baml_compiler2_emit::EmitState;
+
+/// Borsh-serialized stdlib [`EmitState`] prefix, produced at build time.
+pub static STDLIB_PREFIX_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/stdlib_prefix.bin"));
+
+/// Deserialize the precompiled stdlib [`EmitState`] prefix.
+///
+/// Pass the result to `generate_project_bytecode_with_prefix` (or
+/// `ProjectDatabase::get_bytecode_with_prefix`) to skip recompiling the stdlib.
+pub fn stdlib_prefix() -> EmitState {
+    borsh::from_slice(STDLIB_PREFIX_BYTES).expect("decode precompiled stdlib EmitState")
+}

--- a/baml_language/crates/baml_builtins2_prebuilt/src/lib.rs
+++ b/baml_language/crates/baml_builtins2_prebuilt/src/lib.rs
@@ -1,18 +1,27 @@
-//! Precompiled BAML stdlib emit artifact.
+//! Precompiled BAML stdlib artifacts.
 //!
-//! `build.rs` runs the compiler's core emit passes (1-4) over the embedded
-//! stdlib once and serializes the resulting [`EmitState`] prefix to
-//! `$OUT_DIR/stdlib_prefix.bin`. This crate embeds those bytes and exposes a
-//! deserialize helper so a normal compile can resume from the stdlib prefix
-//! (via `generate_project_bytecode_with_prefix`) instead of recompiling the
-//! ~676-function stdlib from source on every invocation.
+//! `build.rs` compiles the embedded, frozen stdlib once and serializes two
+//! artifacts that a normal `baml` invocation loads instead of recompiling:
+//!
+//! - the emit [`EmitState`] prefix (`stdlib_prefix.bin`) — reused via
+//!   `generate_project_bytecode_with_prefix` to skip re-lowering/re-emitting the
+//!   stdlib's bytecode.
+//! - the per-file pre-lowered HIR (`stdlib_hir.bin`) — installed via
+//!   [`install_precompiled_hir`] so `file_semantic_index` skips lex/parse/lower
+//!   for builtin files.
+//!
+//! Compiler types are reached through `baml_db`'s re-exports (workspace policy).
 
-// Compiler types are reached through baml_db's re-export (workspace policy).
-use baml_db::baml_compiler2_emit::EmitState;
+use std::collections::HashMap;
+
+use baml_db::{baml_compiler2_emit::EmitState, baml_compiler2_hir::precompiled};
 
 /// Borsh-serialized stdlib [`EmitState`] prefix, produced at build time.
 pub static STDLIB_PREFIX_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/stdlib_prefix.bin"));
+
+/// Borsh-serialized per-file stdlib HIR prefix, produced at build time.
+pub static STDLIB_HIR_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/stdlib_hir.bin"));
 
 /// Deserialize the precompiled stdlib [`EmitState`] prefix.
 ///
@@ -20,4 +29,28 @@ pub static STDLIB_PREFIX_BYTES: &[u8] =
 /// `ProjectDatabase::get_bytecode_with_prefix`) to skip recompiling the stdlib.
 pub fn stdlib_prefix() -> EmitState {
     borsh::from_slice(STDLIB_PREFIX_BYTES).expect("decode precompiled stdlib EmitState")
+}
+
+/// Deserialize and install the precompiled stdlib HIR cache, so
+/// `file_semantic_index` skips lex/parse/lower for builtin files. Idempotent
+/// (first call wins); call once at startup. No-op safe: if not called, the
+/// compiler parses the stdlib from source as before.
+pub fn install_precompiled_hir() {
+    let map: HashMap<String, precompiled::PrecompiledFile> =
+        borsh::from_slice(STDLIB_HIR_BYTES).expect("decode precompiled stdlib HIR");
+    precompiled::set_precompiled_builtins(map);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn artifacts_load_and_lookup() {
+        // EmitState prefix round-trips.
+        let _ = super::stdlib_prefix();
+        // HIR cache installs and a known builtin path resolves.
+        super::install_precompiled_hir();
+        let pc = super::precompiled::precompiled_builtin("<builtin>/baml/string.baml")
+            .expect("string.baml precompiled");
+        assert!(!pc.items.is_empty(), "string.baml should have items");
+    }
 }

--- a/baml_language/crates/baml_builtins2_prebuilt/src/lib.rs
+++ b/baml_language/crates/baml_builtins2_prebuilt/src/lib.rs
@@ -14,7 +14,13 @@
 
 use std::collections::HashMap;
 
-use baml_db::{baml_compiler2_emit::EmitState, baml_compiler2_hir::precompiled};
+use baml_db::{
+    baml_compiler2_emit::EmitState,
+    baml_compiler2_hir::precompiled,
+    baml_compiler2_tir::{
+        interfaces::ImplementsRegistry, package_interface::PackageInterface, precompiled_tir,
+    },
+};
 
 /// Borsh-serialized stdlib [`EmitState`] prefix, produced at build time.
 pub static STDLIB_PREFIX_BYTES: &[u8] =
@@ -22,6 +28,13 @@ pub static STDLIB_PREFIX_BYTES: &[u8] =
 
 /// Borsh-serialized per-file stdlib HIR prefix, produced at build time.
 pub static STDLIB_HIR_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/stdlib_hir.bin"));
+
+/// Borsh-serialized per-package stdlib TIR `PackageInterface` prefix.
+pub static STDLIB_TIR_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/stdlib_tir.bin"));
+
+/// Borsh-serialized per-package stdlib `ImplementsRegistry` prefix.
+pub static STDLIB_IMPLEMENTS_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/stdlib_implements.bin"));
 
 /// Deserialize the precompiled stdlib [`EmitState`] prefix.
 ///
@@ -31,14 +44,28 @@ pub fn stdlib_prefix() -> EmitState {
     borsh::from_slice(STDLIB_PREFIX_BYTES).expect("decode precompiled stdlib EmitState")
 }
 
-/// Deserialize and install the precompiled stdlib HIR cache, so
-/// `file_semantic_index` skips lex/parse/lower for builtin files. Idempotent
-/// (first call wins); call once at startup. No-op safe: if not called, the
-/// compiler parses the stdlib from source as before.
-pub fn install_precompiled_hir() {
-    let map: HashMap<String, precompiled::PrecompiledFile> =
+/// Deserialize and install all precompiled stdlib caches, so a normal compile
+/// skips re-deriving the frozen stdlib:
+///
+/// - HIR: `file_semantic_index` skips lex/parse/lower + builder for builtin files.
+/// - TIR: `package_interface` and `package_implements_registry` return each
+///   stdlib package's resolved signature graph + interface-impl rules directly
+///   (the dominant cost of the first user-file type-check).
+///
+/// Idempotent (first call wins); call once at startup. No-op safe: if not called,
+/// the compiler derives the stdlib from source as before.
+pub fn install_precompiled_stdlib() {
+    let hir: HashMap<String, precompiled::PrecompiledFile> =
         borsh::from_slice(STDLIB_HIR_BYTES).expect("decode precompiled stdlib HIR");
-    precompiled::set_precompiled_builtins(map);
+    precompiled::set_precompiled_builtins(hir);
+
+    let tir: HashMap<String, PackageInterface> =
+        borsh::from_slice(STDLIB_TIR_BYTES).expect("decode precompiled stdlib TIR");
+    precompiled_tir::set_precompiled_package_interfaces(tir);
+
+    let implements: HashMap<String, ImplementsRegistry> =
+        borsh::from_slice(STDLIB_IMPLEMENTS_BYTES).expect("decode precompiled stdlib implements");
+    precompiled_tir::set_precompiled_implements_registries(implements);
 }
 
 #[cfg(test)]
@@ -47,10 +74,15 @@ mod tests {
     fn artifacts_load_and_lookup() {
         // EmitState prefix round-trips.
         let _ = super::stdlib_prefix();
-        // HIR cache installs and a known builtin path resolves.
-        super::install_precompiled_hir();
-        let pc = super::precompiled::precompiled_builtin("<builtin>/baml/string.baml")
-            .expect("string.baml precompiled");
-        assert!(!pc.items.is_empty(), "string.baml should have items");
+        // HIR + TIR caches install; a known builtin path and the baml package resolve.
+        super::install_precompiled_stdlib();
+        assert!(
+            super::precompiled::precompiled_builtin("<builtin>/baml/string.baml").is_some(),
+            "string.baml should be in the precompiled HIR cache"
+        );
+        assert!(
+            super::precompiled_tir::precompiled_package_interface("baml").is_some(),
+            "baml package should be in the precompiled TIR cache"
+        );
     }
 }

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 baml_builtins2 = { workspace = true }
+baml_builtins2_prebuilt = { workspace = true }
 baml_db = { workspace = true }
 baml_exec = { workspace = true }
 baml_fmt = { workspace = true }

--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -55,7 +55,7 @@ impl CheckArgs {
 
         reporter.spin("Compiling", format!("{} file(s)", baml_files.len()));
         if let Err(err) = db
-            .get_bytecode()
+            .get_bytecode_with_prefix(baml_builtins2_prebuilt::stdlib_prefix())
             .with_context(|| format!("failed to compile BAML project at {}", from.display()))
         {
             reporter.abandon();

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -107,6 +107,10 @@ impl From<ExitCode> for u32 {
 /// `format`, or `language-server`. `baml run` is the top-level entry for
 /// standalone execution.
 pub fn run_cli(argv: Vec<String>) -> Result<ExitCode> {
+    // Install the precompiled stdlib HIR so `file_semantic_index` skips
+    // lex/parse/lower for builtin files (paired with the bytecode prefix that
+    // `get_bytecode_with_prefix` uses). Idempotent; no-op safe.
+    baml_builtins2_prebuilt::install_precompiled_hir();
     let cli = commands::RuntimeCli::parse_from_smart(argv);
     cli.run()
 }

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -107,10 +107,10 @@ impl From<ExitCode> for u32 {
 /// `format`, or `language-server`. `baml run` is the top-level entry for
 /// standalone execution.
 pub fn run_cli(argv: Vec<String>) -> Result<ExitCode> {
-    // Install the precompiled stdlib HIR so `file_semantic_index` skips
-    // lex/parse/lower for builtin files (paired with the bytecode prefix that
-    // `get_bytecode_with_prefix` uses). Idempotent; no-op safe.
-    baml_builtins2_prebuilt::install_precompiled_hir();
+    // Install the precompiled stdlib caches (HIR + TIR signatures) so a normal
+    // compile skips re-deriving the frozen stdlib (paired with the bytecode prefix
+    // that `get_bytecode_with_prefix` uses). Idempotent; no-op safe.
+    baml_builtins2_prebuilt::install_precompiled_stdlib();
     let cli = commands::RuntimeCli::parse_from_smart(argv);
     cli.run()
 }

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -267,11 +267,13 @@ impl RunArgs {
 
     /// Compile `db` to bytecode and build a `BexEngine`.
     fn compile_to_engine(&self, db: &ProjectDatabase, argv: Vec<String>) -> Result<BexEngine> {
-        let bytecode = baml_compiler2_emit::generate_project_bytecode(
+        let bytecode = baml_compiler2_emit::generate_project_bytecode_with_prefix(
             db,
             &baml_compiler2_emit::CompileOptions {
                 emit_test_cases: false,
             },
+            baml_compiler2_emit::OptLevel::Two,
+            baml_builtins2_prebuilt::stdlib_prefix(),
         )
         .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
         BexEngine::new(bytecode, Arc::new(sys_native::SysOps::native()), argv)

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -145,8 +145,13 @@ impl TestArgs {
         let compile_options = baml_compiler2_emit::CompileOptions {
             emit_test_cases: true,
         };
-        let bytecode = baml_compiler2_emit::generate_project_bytecode(&db, &compile_options)
-            .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
+        let bytecode = baml_compiler2_emit::generate_project_bytecode_with_prefix(
+            &db,
+            &compile_options,
+            baml_compiler2_emit::OptLevel::Two,
+            baml_builtins2_prebuilt::stdlib_prefix(),
+        )
+        .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
 
         let engine = Arc::new(
             BexEngine::new(bytecode, Arc::new(sys_native::SysOps::native()), Vec::new())

--- a/baml_language/crates/baml_compiler2_ast/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_ast/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 baml_base = { workspace = true }
 baml_compiler_diagnostics = { workspace = true }
 baml_compiler_syntax = { workspace = true }
+borsh = { workspace = true }
 la-arena = { workspace = true }
 num-bigint = { workspace = true }
 rowan = { workspace = true }

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -15,17 +15,25 @@ use text_size::TextRange;
 // ── Attributes ──────────────────────────────────────────────────
 
 /// Raw attribute from CST — not yet validated.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct RawAttribute {
     pub name: Name,
     pub args: Vec<RawAttributeArg>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct RawAttributeArg {
     pub key: Option<Name>,
     pub value: String,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
@@ -36,7 +44,7 @@ pub struct RawAttributeArg {
 /// Corresponds to `TypeRef` in `baml_compiler_hir/src/type_ref.rs` but lives
 /// in the AST layer (before any name resolution). CST → `TypeExpr` conversion
 /// happens once during `lower_file` and is never repeated.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum TypeExpr {
     /// Named type path: `User`, `baml.http.Request`, `Stream<T>`
     Path {
@@ -339,7 +347,7 @@ impl std::fmt::Display for TypeExpr {
 }
 
 /// A parameter in a function type expression.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct FunctionTypeParam {
     pub name: Option<Name>,
     pub optional: bool,
@@ -348,7 +356,7 @@ pub struct FunctionTypeParam {
 
 /// Named associated type binding used inside type applications:
 /// `Iterator<Item = int>`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct AssociatedTypeBinding {
     pub name: Name,
     pub ty: Box<TypeExpr>,
@@ -356,9 +364,13 @@ pub struct AssociatedTypeBinding {
 
 /// A type expression with its source span — used in item definitions
 /// where we need both the type data and the source location.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct SpannedTypeExpr {
     pub expr: TypeExpr,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
@@ -377,16 +389,44 @@ pub type TypeAnnotId = Idx<TypeExpr>;
 
 /// Full expression body — owned arena of expressions, statements,
 /// and patterns. Modeled after `ExprBody` in `body.rs`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ExprBody {
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena"
+    )]
     pub exprs: Arena<Expr>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena"
+    )]
     pub stmts: Arena<Stmt>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena"
+    )]
     pub patterns: Arena<Pattern>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena"
+    )]
     pub match_arms: Arena<MatchArm>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena"
+    )]
     pub catch_arms: Arena<CatchArm>,
     /// Type annotations on let bindings etc.
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena"
+    )]
     pub type_annotations: Arena<TypeExpr>,
     /// Root expression of the function body.
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+    )]
     pub root_expr: Option<ExprId>,
 }
 
@@ -522,21 +562,54 @@ impl ExprBody {
 /// Parallel span storage for an `ExprBody` — maps arena IDs to source ranges.
 /// Separated so semantic queries (type checking) can ignore spans and get
 /// Salsa early-cutoff on whitespace changes.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct AstSourceMap {
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena_text_range"
+    )]
     pub expr_spans: Arena<TextRange>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena_text_range"
+    )]
     pub stmt_spans: Arena<TextRange>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena_text_range"
+    )]
     pub pattern_spans: Arena<TextRange>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena_text_range"
+    )]
     pub match_arm_spans: Arena<TextRange>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena_text_range"
+    )]
     pub type_annotation_spans: Arena<TextRange>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_arena_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_arena_text_range"
+    )]
     pub catch_arm_spans: Arena<TextRange>,
+    // Secondary diagnostic sub-spans (member-name, path-segment, and call-label
+    // refinements of a node's primary span). Skipped from borsh: they only
+    // sharpen diagnostic locations, and the precompiled artifact is built from
+    // the frozen, error-free stdlib whose nodes never originate user-facing
+    // diagnostics. Default to empty on load; primary spans (the arenas above)
+    // are preserved.
     /// For `MemberAccess` expressions, the span of just the member name (after the dot).
+    #[borsh(skip)]
     pub member_access_member_spans: HashMap<ExprId, TextRange>,
     /// For multi-segment `Path` expressions, per-segment spans.
     /// `path_segment_spans[expr_id][i]` is the `TextRange` of `segments[i]`.
+    #[borsh(skip)]
     pub path_segment_spans: HashMap<ExprId, Vec<TextRange>>,
     /// For labeled call arguments, the span of the label name keyed by
     /// `(call_expr_id, argument_expr_id)`.
+    #[borsh(skip)]
     pub call_arg_label_spans: HashMap<(ExprId, ExprId), TextRange>,
 
     /// Ids of compiler-synthesized nodes — desugarings that have no
@@ -548,8 +621,20 @@ pub struct AstSourceMap {
     /// uniform replacement for fragile structural heuristics (e.g. comparing a
     /// call's span to its callee's). Populated at the `alloc_*` chokepoints
     /// during lowering, via a scoped "synthesizing" flag.
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx_set",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx_set"
+    )]
     pub synthetic_exprs: HashSet<ExprId>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx_set",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx_set"
+    )]
     pub synthetic_stmts: HashSet<StmtId>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx_set",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx_set"
+    )]
     pub synthetic_patterns: HashSet<PatId>,
 }
 
@@ -684,7 +769,7 @@ impl Default for AstSourceMap {
 }
 
 /// Expressions — modeled after `Expr` in `body.rs`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum Expr {
     Literal(Literal),
     /// Byte string literal: `b"hello"`, `b"\x00\xFF"`.
@@ -698,14 +783,30 @@ pub enum Expr {
     /// the specialized function value (`(int) -> int`). Distinct from
     /// `Call { type_args, .. }`, which applies type args *and* invokes.
     GenericApply {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         base: ExprId,
         /// Explicit type arguments, e.g. the `<int>` in `foo<int>`. Never empty
         /// (a bare path lowers to `Path`, not `GenericApply`).
         type_args: Vec<TypeExpr>,
     },
     If {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         condition: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         then_branch: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         else_branch: Option<ExprId>,
     },
     /// `if let PATTERN = SCRUTINEE { THEN } else { ELSE }` — refutable
@@ -714,14 +815,42 @@ pub enum Expr {
     /// never after the `if let`). Unlike `Stmt::Let`, the pattern is
     /// expected to be *refutable*; an irrefutable pattern earns a warning.
     IfLet {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         pattern: PatId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         scrutinee: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         then_branch: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         else_branch: Option<ExprId>,
     },
     Match {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         scrutinee: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         scrutinee_type: Option<TypeAnnotId>,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx_vec",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx_vec"
+        )]
         arms: Vec<MatchArmId>,
     },
     /// `<expr> is <pattern>` — Rust `matches!`-style pattern test.
@@ -732,14 +861,30 @@ pub enum Expr {
     /// it just always evaluates to `false`. Treat it as a one-arm
     /// pattern-test, not as an exhaustive match.
     Is {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         scrutinee: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         pattern: PatId,
     },
     Catch {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         base: ExprId,
         clauses: Vec<CatchClause>,
     },
     Throw {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         value: ExprId,
     },
     /// BEP-034 `spawn name_expr? (with expr (, expr)*)? { body }`. The body is
@@ -748,31 +893,63 @@ pub enum Expr {
     /// surfaces in debug / stack traces.
     Spawn {
         /// Optional human-readable label for the spawn.
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         name: Option<ExprId>,
         /// BEP-034 spawn options: the `with expr (, expr)*` clause. Each entry
         /// is an arbitrary expression; in v1 TIR requires exactly one, a call
         /// to `baml.spawn.options(...)`. Empty when there is no `with` clause.
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx_vec",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx_vec"
+        )]
         with_exprs: Vec<ExprId>,
         /// Body of the spawn (`{...}`) — always an `Expr::Block` after
         /// CST lowering.
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         body: ExprId,
     },
     /// BEP-034 `await expr` — prefix form. Suspends the current thread
     /// until `expr`'s future settles, then unwraps the value or re-throws
     /// the future's error.
     Await {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         future: ExprId,
     },
     Binary {
         op: BinaryOp,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         lhs: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         rhs: ExprId,
     },
     Unary {
         op: UnaryOp,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         expr: ExprId,
     },
     Call {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         callee: ExprId,
         /// Explicit type arguments at the call site, e.g. `foo<int, string>(x)`.
         /// Empty vec when no `<...>` was written.
@@ -788,38 +965,78 @@ pub enum Expr {
         /// Explicit generic type args from syntax like `Foo<int> { ... }`.
         /// Empty when no `<...>` was written (e.g. bare `Foo { ... }`).
         type_args: Vec<TypeExpr>,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_vec_name_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_vec_name_idx"
+        )]
         fields: Vec<(Name, ExprId)>,
         spreads: Vec<SpreadField>,
     },
     Array {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx_vec",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx_vec"
+        )]
         elements: Vec<ExprId>,
     },
     Map {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_vec_idx_pair",
+            deserialize_with = "crate::borsh_helpers::deserialize_vec_idx_pair"
+        )]
         entries: Vec<(ExprId, ExprId)>,
     },
     Block {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx_vec",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx_vec"
+        )]
         stmts: Vec<StmtId>,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         tail_expr: Option<ExprId>,
     },
     // These nodes are constructed purely in the HIR layer AFTER
     // name resolution as we can't know if it's a member access
     // until we know how to resolve the path
     MemberAccess {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         base: ExprId,
         member: Name,
     },
     /// Explicit static projection/upcast: `expr.as<T>`.
     Upcast {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         base: ExprId,
         target: TypeExpr,
     },
     /// Optional member access: `obj?.member` — short-circuits to null if base is null.
     OptionalMemberAccess {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         base: ExprId,
         member: Name,
     },
     Index {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         base: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         index: ExprId,
     },
     /// Lambda expression: anonymous function in expression position.
@@ -828,11 +1045,23 @@ pub enum Expr {
     Lambda(Box<FunctionDef>),
     /// Optional index: `obj?.[expr]` — short-circuits to null if base is null.
     OptionalIndex {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         base: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         index: ExprId,
     },
     /// Optional call: `func?.(args)` — short-circuits to null if callee is null.
     OptionalCall {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         callee: ExprId,
         args: Vec<CallArg>,
     },
@@ -840,6 +1069,10 @@ pub enum Expr {
     /// Delimits the scope of null short-circuiting.
     /// If any `?.` inside encounters null, the entire `OptionalChain` evaluates to null.
     OptionalChain {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         expr: ExprId,
     },
     /// Backtick template literal site (BEP-049). Held as a first-class HIR
@@ -872,7 +1105,7 @@ pub enum Expr {
 
 /// Which BEP-049 backtick form an [`Expr::Template`] is, plus the per-form
 /// payload needed to realize it.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum TemplateTag {
     /// Untagged `` `…` `` (BEP §11): implicit per-value `.to_string()`,
     /// result type `string`.
@@ -884,7 +1117,13 @@ pub enum TemplateTag {
     /// consume it directly; the structured `segments` exist only so TIR can
     /// emit per-`${…}` strict-stringify diagnostics (BEP §11) on the original
     /// spans rather than on the synthetic `.to_string()` calls.
-    Default { elaborated: ExprId },
+    Default {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
+        elaborated: ExprId,
+    },
     /// Tagged `` tag`…` `` (BEP §10): `tag` is the tag expression — usually a
     /// bare identifier referring to a fn marked `//baml:tagged_string`. Stored
     /// as an `ExprId` so paths and future curry forms compose without grammar
@@ -899,21 +1138,46 @@ pub enum TemplateTag {
     /// hand-rolled `body` closure — except when the template is purely static
     /// (text + interp, no `${for}`/`${if}`), where MIR keeps a fixed-array
     /// fast-path off `segments` instead.
-    Custom { tag: ExprId, body: ExprId },
+    Custom {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
+        tag: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
+        body: ExprId,
+    },
 }
 
 /// One segment of an [`Expr::Template`] body. Parallel to `BacktickSegment`
 /// in the CST layer, but every sub-expression is already lowered.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum TemplateSegment {
     /// Literal text between interpolations / block tags.
     Text(std::string::String),
     /// A `${expr}` interpolation. The wrapped `ExprId` is the lowered
     /// inner expression (already a block expression per BEP §4).
-    Interp(ExprId),
+    Interp(
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
+        ExprId,
+    ),
     /// A `${for (let p in c)}...${endfor}` block (iterator form).
     For {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         binding: PatId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         collection: ExprId,
         body: Vec<TemplateSegment>,
     },
@@ -925,8 +1189,20 @@ pub enum TemplateSegment {
     /// `{ init; while cond { body } after { step } }` shape the host C-style
     /// `for` lowers to (`lower_c_style_for`).
     CStyleFor {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         init: StmtId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         cond: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         step: Option<StmtId>,
         body: Vec<TemplateSegment>,
     },
@@ -937,15 +1213,23 @@ pub enum TemplateSegment {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct TemplateIfBranch {
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub condition: ExprId,
     pub body: Vec<TemplateSegment>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct CallArg {
     pub label: Option<Name>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub expr: ExprId,
 }
 
@@ -963,14 +1247,28 @@ impl CallArg {
 }
 
 /// Statements — modeled after `Stmt` in `body.rs`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum Stmt {
-    Expr(ExprId),
+    Expr(
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
+        ExprId,
+    ),
     Let {
         /// The binding pattern. A `: T` annotation lives inside the pattern
         /// as the bind's sub-pattern slot, not as a separate field on
         /// `Stmt::Let` — see [`Pattern::Bind`].
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         pattern: PatId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         initializer: Option<ExprId>,
         is_watched: bool,
         origin: LetOrigin,
@@ -979,11 +1277,27 @@ pub enum Stmt {
         /// the pattern may be refutable, and the else expression is
         /// required to have type `Ty::Never`. Pattern bindings flow into
         /// the enclosing scope on a successful match.
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         else_branch: Option<ExprId>,
     },
     While {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         condition: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         body: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
         after: Option<StmtId>,
         origin: LoopOrigin,
     },
@@ -997,8 +1311,20 @@ pub enum Stmt {
     /// `Stmt::While`) no `after`/`origin` — those exist only for desugared
     /// C-style `for` loops.
     WhileLet {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         pattern: PatId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         scrutinee: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         body: ExprId,
     },
     /// For-in loop: `for let <binding> in <collection> { <body> }`.
@@ -1011,14 +1337,36 @@ pub enum Stmt {
     /// Desugaring to index-based iteration happens at MIR lowering time.
     For {
         /// The loop variable binding pattern (e.g. `i` in `for let i in xs`).
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         binding: PatId,
         /// The collection expression to iterate over.
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         collection: ExprId,
         /// The loop body expression.
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         body: ExprId,
     },
-    Return(Option<ExprId>),
+    Return(
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
+        Option<ExprId>,
+    ),
     Throw {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         value: ExprId,
     },
     Break,
@@ -1030,15 +1378,35 @@ pub enum Stmt {
     /// capturing values at the `defer` site). `return`/`break`/`continue` that
     /// would escape the body are rejected in TIR; `throw` is allowed.
     Defer {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         body: ExprId,
     },
     Assign {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         target: ExprId,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         value: ExprId,
     },
     AssignOp {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         target: ExprId,
         op: AssignOp,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx"
+        )]
         value: ExprId,
     },
     Missing,
@@ -1062,7 +1430,7 @@ pub enum Stmt {
 ///   `ascription` field for `[…]: T`. `:` is only valid after `let x` or
 ///   `[…]` — it is rejected on `_`, `Class { … }`, bare types, and
 ///   Or-patterns.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum Pattern {
     // ── Atoms (single-shape patterns) ────────────────────────────────────
     /// `_` — wildcard. Always irrefutable. Binds nothing. Cannot carry a
@@ -1077,7 +1445,14 @@ pub enum Pattern {
     /// Progressive widening like `let x: int: float` is naturally
     /// impossible because `Pattern::Type` doesn't itself have a sub-
     /// pattern slot.
-    Bind { name: Name, subpat: Option<PatId> },
+    Bind {
+        name: Name,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+            deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+        )]
+        subpat: Option<PatId>,
+    },
     /// `pkg.Foo { a, b: <pat>, ... }` — class destructure. `class` is the
     /// dotted path as segments (single-element vec for unqualified names).
     /// Class destructures cannot carry `: T` ascriptions.
@@ -1094,8 +1469,16 @@ pub enum Pattern {
     /// so deeper chains like `[…]: T1: T2` and exotic shapes like
     /// `[…]: let xs` are syntactically rejected at AST lowering.
     Array {
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx_vec",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx_vec"
+        )]
         prefix: Vec<PatId>,
         rest: Option<ArrayRestPat>,
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx_vec",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx_vec"
+        )]
         suffix: Vec<PatId>,
         ascription: Option<TypeExpr>,
     },
@@ -1111,22 +1494,40 @@ pub enum Pattern {
     /// `p1 | p2 | ...` — alternation. Length always `>= 2`. Every alternative
     /// must bind the same names (TIR enforces). Cannot carry a `: T`
     /// ascription.
-    Or(Vec<PatId>),
+    Or(
+        #[borsh(
+            serialize_with = "crate::borsh_helpers::serialize_idx_vec",
+            deserialize_with = "crate::borsh_helpers::deserialize_idx_vec"
+        )]
+        Vec<PatId>,
+    ),
 }
 
 /// Single field inside a class destructure pattern.
 ///
 /// Shorthand `{ f }` lowers to `FieldPat { field: f, pat: <Bind { name: f }> }`,
 /// so consumers never see the missing-pattern shape.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct FieldPat {
     pub field: Name,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub field_span: text_size::TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub pat: PatId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ArrayRestPat {
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+    )]
     pub pat: Option<PatId>,
 }
 
@@ -1210,37 +1611,75 @@ impl Pattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct MatchArm {
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub pattern: PatId,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+    )]
     pub guard: Option<ExprId>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub body: ExprId,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize,
+)]
 pub enum CatchClauseKind {
     Catch,
     CatchAll,
     CatchAllPanics,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct CatchClause {
     pub kind: CatchClauseKind,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub binding: PatId,
     /// Optional second binding for the stack trace: `catch (e, st) { ... }`
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_opt_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_opt_idx"
+    )]
     pub stack_trace_binding: Option<PatId>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx_vec",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx_vec"
+    )]
     pub arms: Vec<CatchArmId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct CatchArm {
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub pattern: PatId,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub body: ExprId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct SpreadField {
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
     pub expr: ExprId,
     pub position: usize,
 }
@@ -1248,14 +1687,14 @@ pub struct SpreadField {
 /// Re-export `baml_base::Literal` as the canonical literal type.
 pub type Literal = baml_base::Literal;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum LetOrigin {
     Source,
     Client,
     RetryPolicy,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum FunctionOrigin {
     UserDefined,
     Companion,
@@ -1265,14 +1704,14 @@ pub enum FunctionOrigin {
     AutoDerive,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum LoopOrigin {
     While,
     For,
 }
 
 /// Binary operators — matches those supported in `body.rs`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum BinaryOp {
     Add,
     Sub,
@@ -1323,7 +1762,7 @@ impl std::fmt::Display for BinaryOp {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum UnaryOp {
     Not,
     Neg,
@@ -1340,7 +1779,7 @@ impl std::fmt::Display for UnaryOp {
 }
 
 /// Compound assignment operators.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum AssignOp {
     Add,
     Sub,
@@ -1358,7 +1797,7 @@ pub enum AssignOp {
 
 /// Top-level item — the output unit of CST → AST lowering.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum Item {
     Function(FunctionDef),
     Class(ClassDef),
@@ -1373,7 +1812,7 @@ pub enum Item {
     ImplementsFor(ImplementsForDef),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum DeclarativeMeta {
     /// LLM function metadata (client name, prompt template).
     /// Present only for functions declared with `{ client ...; prompt ... }` syntax.
@@ -1382,7 +1821,7 @@ pub enum DeclarativeMeta {
     Llm(LlmBodyDef),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct FunctionDef {
     pub name: Name,
     /// Generic type parameters (e.g., `["T", "U"]`). Empty for non-generic functions.
@@ -1406,11 +1845,19 @@ pub struct FunctionDef {
     /// tags (a tag name immediately followed by a backtick literal), and
     /// their first parameter must be `body: (...) -> TaggedString`.
     pub is_tagged_template_tag: bool,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct FunctionDefaults {
     pub exprs: ExprBody,
     pub source_map: AstSourceMap,
@@ -1430,7 +1877,7 @@ impl FunctionDefaults {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum FunctionBodyDef {
     Expr(ExprBody, AstSourceMap),
     /// Body is `$rust_function` or `$rust_io_function` — Rust-bound implementation.
@@ -1438,7 +1885,7 @@ pub enum FunctionBodyDef {
 }
 
 /// What kind of builtin a function is.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum BuiltinKind {
     /// VM instruction — fast, synchronous, no I/O.
     Vm,
@@ -1454,7 +1901,7 @@ pub enum BuiltinKind {
     AwaitAny,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct LlmBodyDef {
     pub client: Option<Name>,
     pub prompt: Option<RawPrompt>,
@@ -1477,35 +1924,63 @@ pub struct LlmBodyDef {
     /// `stream_body`) and read back by `make_llm_companion`. Empty for legacy
     /// Jinja `#"..."#` prompts (their companions use the 3-arg Jinja path).
     pub companion_bodies: Vec<(std::string::String, (ExprBody, AstSourceMap))>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct RawPrompt {
     pub text: std::string::String,
     /// Interpolation locations within the template.
     pub interpolations: Vec<Interpolation>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Interpolation {
     pub content: std::string::String,
     /// Span of the full interpolation, including delimiters.
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Param {
     pub name: Name,
     pub type_expr: Option<SpannedTypeExpr>,
     pub default: Option<DefaultExprId>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct DefaultExprId(ExprId);
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize,
+)]
+pub struct DefaultExprId(
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_idx",
+        deserialize_with = "crate::borsh_helpers::deserialize_idx"
+    )]
+    ExprId,
+);
 
 impl DefaultExprId {
     pub fn new(expr: ExprId) -> Self {
@@ -1517,7 +1992,7 @@ impl DefaultExprId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ClassDef {
     pub name: Name,
     /// Generic type parameters (e.g., `["T"]` for `Array<T>`). Empty for non-generic classes.
@@ -1533,7 +2008,15 @@ pub struct ClassDef {
     pub attributes: Vec<RawAttribute>,
     /// Joined `///` doc-comment lines preceding this declaration.
     pub docstring: Option<std::string::String>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
@@ -1541,7 +2024,7 @@ pub struct ClassDef {
 ///
 /// Interfaces declare a contract over fields and methods. Classes opt in to
 /// the contract via [`ImplementsBlockDef`] inside the class body.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct InterfaceDef {
     pub name: Name,
     /// Generic type parameters (e.g., `["T"]` for `Container<T>`). Empty for non-generic interfaces.
@@ -1564,13 +2047,21 @@ pub struct InterfaceDef {
     pub default_methods: Vec<FunctionDef>,
     pub attributes: Vec<RawAttribute>,
     pub docstring: Option<std::string::String>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
 /// Method signature declared in an interface body without a body — i.e., a
 /// required method. Mirrors [`FunctionDef`] minus the body.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct MethodSigDef {
     pub name: Name,
     pub generic_params: Vec<Name>,
@@ -1582,12 +2073,20 @@ pub struct MethodSigDef {
     pub throws: Option<SpannedTypeExpr>,
     pub attributes: Vec<RawAttribute>,
     pub docstring: Option<std::string::String>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
 /// One `implements I { ... }` block inside a class body (BEP-044).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ImplementsBlockDef {
     /// The target interface, captured as a `TypeExpr` so we can accept generic
     /// parameterization like `implements Container<int>`. The path's first
@@ -1602,6 +2101,10 @@ pub struct ImplementsBlockDef {
     pub methods: Vec<FunctionDef>,
     /// True when this block came from top-level `implements I for T`.
     pub is_out_of_body: bool,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
@@ -1616,17 +2119,29 @@ impl ImplementsBlockDef {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct InterfaceFieldLinkDef {
     pub interface_field: Name,
     pub class_field: Name,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub interface_field_span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub class_field_span: TextRange,
 }
 
 /// Top-level `implements I for T { ... }` block (BEP-044).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ImplementsForDef {
     /// Generic type parameters on the implements block (e.g. `<T>` or `<T extends Named>`).
     pub generic_params: Vec<(Name, Option<TypeExpr>)>,
@@ -1640,113 +2155,209 @@ pub struct ImplementsForDef {
     pub associated_type_bindings: Vec<AssociatedTypeBindingDef>,
     /// Method definitions inside the block.
     pub methods: Vec<FunctionDef>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct AssociatedTypeDef {
     pub name: Name,
     pub bound: Option<SpannedTypeExpr>,
     pub default: Option<SpannedTypeExpr>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct AssociatedTypeBindingDef {
     pub name: Name,
     pub type_expr: Option<SpannedTypeExpr>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct FieldDef {
     pub name: Name,
     pub type_expr: Option<SpannedTypeExpr>,
     pub attributes: Vec<RawAttribute>,
     /// Joined `///` doc-comment lines preceding this declaration.
     pub docstring: Option<std::string::String>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct EnumDef {
     pub name: Name,
     pub variants: Vec<VariantDef>,
     pub attributes: Vec<RawAttribute>,
     /// Joined `///` doc-comment lines preceding this declaration.
     pub docstring: Option<std::string::String>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct VariantDef {
     pub name: Name,
     pub attributes: Vec<RawAttribute>,
     /// Joined `///` doc-comment lines preceding this declaration.
     pub docstring: Option<std::string::String>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct TypeAliasDef {
     pub name: Name,
     pub type_expr: Option<SpannedTypeExpr>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ClientDef {
     pub name: Name,
     pub config_items: Vec<ConfigItemDef>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ConfigItemDef {
     pub key: Name,
     pub value: std::string::String,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct TestDef {
     pub name: Name,
     pub config_items: Vec<ConfigItemDef>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct TemplateStringDef {
     pub name: Name,
     pub params: Vec<Param>,
     pub body: Option<RawPrompt>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct RetryPolicyDef {
     pub name: Name,
     pub config_items: Vec<ConfigItemDef>,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
 /// A top-level let binding — compiler-generated, not user syntax.
 /// Carries an optional `ExprBody` initializer that flows through TIR type-checking.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct LetDef {
     pub name: Name,
     pub initializer: Option<(ExprBody, AstSourceMap)>,
     pub origin: LetOrigin,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }

--- a/baml_language/crates/baml_compiler2_ast/src/borsh_helpers.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/borsh_helpers.rs
@@ -71,6 +71,34 @@ pub fn deserialize_vec_idx_pair<T, R: Read>(r: &mut R) -> Result<Vec<(Idx<T>, Id
     Ok(v)
 }
 
+// ── TextSize (one u32 offset) ────────────────────────────────────────────────
+
+pub fn serialize_text_size<W: Write>(size: &text_size::TextSize, w: &mut W) -> Result<(), Error> {
+    u32::from(*size).serialize(w)
+}
+
+pub fn deserialize_text_size<R: Read>(r: &mut R) -> Result<text_size::TextSize, Error> {
+    Ok(text_size::TextSize::from(u32::deserialize_reader(r)?))
+}
+
+// ── Range<T: Borsh> (e.g. Range<FileScopeId>) ────────────────────────────────
+
+pub fn serialize_range<T: BorshSerialize, W: Write>(
+    range: &std::ops::Range<T>,
+    w: &mut W,
+) -> Result<(), Error> {
+    range.start.serialize(w)?;
+    range.end.serialize(w)
+}
+
+pub fn deserialize_range<T: BorshDeserialize, R: Read>(
+    r: &mut R,
+) -> Result<std::ops::Range<T>, Error> {
+    let start = T::deserialize_reader(r)?;
+    let end = T::deserialize_reader(r)?;
+    Ok(start..end)
+}
+
 // ── TextRange (two u32 offsets) ──────────────────────────────────────────────
 
 pub fn serialize_text_range<W: Write>(range: &TextRange, w: &mut W) -> Result<(), Error> {

--- a/baml_language/crates/baml_compiler2_ast/src/borsh_helpers.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/borsh_helpers.rs
@@ -24,6 +24,53 @@ fn len_as_u32(len: usize) -> u32 {
     u32::try_from(len).expect("arena length exceeds u32::MAX")
 }
 
+// ── Vec<(Name, Idx<T>)> (object-literal fields) ──────────────────────────────
+
+pub fn serialize_vec_name_idx<T, W: Write>(
+    v: &[(baml_base::Name, Idx<T>)],
+    w: &mut W,
+) -> Result<(), Error> {
+    len_as_u32(v.len()).serialize(w)?;
+    for (name, idx) in v {
+        name.serialize(w)?;
+        serialize_idx(idx, w)?;
+    }
+    Ok(())
+}
+
+pub fn deserialize_vec_name_idx<T, R: Read>(
+    r: &mut R,
+) -> Result<Vec<(baml_base::Name, Idx<T>)>, Error> {
+    let len = u32::deserialize_reader(r)?;
+    let mut v = Vec::with_capacity(len as usize);
+    for _ in 0..len {
+        let name = baml_base::Name::deserialize_reader(r)?;
+        v.push((name, deserialize_idx(r)?));
+    }
+    Ok(v)
+}
+
+// ── Vec<(Idx<T>, Idx<T>)> (map-literal entries) ──────────────────────────────
+
+pub fn serialize_vec_idx_pair<T, W: Write>(v: &[(Idx<T>, Idx<T>)], w: &mut W) -> Result<(), Error> {
+    len_as_u32(v.len()).serialize(w)?;
+    for (a, b) in v {
+        serialize_idx(a, w)?;
+        serialize_idx(b, w)?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::type_complexity)] // mirrors the AST field type `Vec<(ExprId, ExprId)>`
+pub fn deserialize_vec_idx_pair<T, R: Read>(r: &mut R) -> Result<Vec<(Idx<T>, Idx<T>)>, Error> {
+    let len = u32::deserialize_reader(r)?;
+    let mut v = Vec::with_capacity(len as usize);
+    for _ in 0..len {
+        v.push((deserialize_idx(r)?, deserialize_idx(r)?));
+    }
+    Ok(v)
+}
+
 // ── TextRange (two u32 offsets) ──────────────────────────────────────────────
 
 pub fn serialize_text_range<W: Write>(range: &TextRange, w: &mut W) -> Result<(), Error> {
@@ -67,6 +114,49 @@ pub fn deserialize_opt_idx<T, R: Read>(r: &mut R) -> Result<Option<Idx<T>>, Erro
     } else {
         Ok(Some(deserialize_idx(r)?))
     }
+}
+
+// ── Vec<Idx<T>> ──────────────────────────────────────────────────────────────
+
+pub fn serialize_idx_vec<T, W: Write>(v: &[Idx<T>], w: &mut W) -> Result<(), Error> {
+    len_as_u32(v.len()).serialize(w)?;
+    for idx in v {
+        serialize_idx(idx, w)?;
+    }
+    Ok(())
+}
+
+pub fn deserialize_idx_vec<T, R: Read>(r: &mut R) -> Result<Vec<Idx<T>>, Error> {
+    let len = u32::deserialize_reader(r)?;
+    let mut v = Vec::with_capacity(len as usize);
+    for _ in 0..len {
+        v.push(deserialize_idx(r)?);
+    }
+    Ok(v)
+}
+
+// ── HashSet<Idx<T>> ──────────────────────────────────────────────────────────
+
+pub fn serialize_idx_set<T, W: Write>(
+    set: &std::collections::HashSet<Idx<T>>,
+    w: &mut W,
+) -> Result<(), Error> {
+    len_as_u32(set.len()).serialize(w)?;
+    for idx in set {
+        serialize_idx(idx, w)?;
+    }
+    Ok(())
+}
+
+pub fn deserialize_idx_set<T, R: Read>(
+    r: &mut R,
+) -> Result<std::collections::HashSet<Idx<T>>, Error> {
+    let len = u32::deserialize_reader(r)?;
+    let mut set = std::collections::HashSet::with_capacity(len as usize);
+    for _ in 0..len {
+        set.insert(deserialize_idx(r)?);
+    }
+    Ok(set)
 }
 
 // ── Arena<T> where T: Borsh (dense, alloc-only) ──────────────────────────────

--- a/baml_language/crates/baml_compiler2_ast/src/borsh_helpers.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/borsh_helpers.rs
@@ -1,0 +1,168 @@
+//! Borsh `serialize_with` / `deserialize_with` helpers for foreign types the
+//! BAML AST embeds but that do not implement `Borsh`: `text_size::TextRange`,
+//! `la_arena::Idx`, and `la_arena::Arena`.
+//!
+//! The precompiled-stdlib artifacts share one serialization format (borsh, as
+//! used by the compiled-bytecode prefix in `baml_builtins2_prebuilt`), so the
+//! serialized HIR/AST uses borsh too. Foreign types are handled via
+//! `#[borsh(serialize_with = "...", deserialize_with = "...")]` field
+//! attributes pointing at these helpers, since the orphan rule forbids
+//! implementing `Borsh` on them directly.
+//!
+//! `Arena` is dense and alloc-only (no removal), so iterating it yields elements
+//! in `Idx` order `0..len`; re-`alloc`ing them in that order on load reproduces
+//! the original indices, keeping every `Idx` valid across a round trip.
+
+use borsh::{
+    BorshDeserialize, BorshSerialize,
+    io::{Error, Read, Write},
+};
+use la_arena::{Arena, Idx, RawIdx};
+use text_size::TextRange;
+
+fn len_as_u32(len: usize) -> u32 {
+    u32::try_from(len).expect("arena length exceeds u32::MAX")
+}
+
+// ── TextRange (two u32 offsets) ──────────────────────────────────────────────
+
+pub fn serialize_text_range<W: Write>(range: &TextRange, w: &mut W) -> Result<(), Error> {
+    let start: u32 = range.start().into();
+    let end: u32 = range.end().into();
+    start.serialize(w)?;
+    end.serialize(w)
+}
+
+pub fn deserialize_text_range<R: Read>(r: &mut R) -> Result<TextRange, Error> {
+    let start = u32::deserialize_reader(r)?;
+    let end = u32::deserialize_reader(r)?;
+    Ok(TextRange::new(start.into(), end.into()))
+}
+
+// ── Idx<T> (a dense u32 arena index) ─────────────────────────────────────────
+
+pub fn serialize_idx<T, W: Write>(idx: &Idx<T>, w: &mut W) -> Result<(), Error> {
+    idx.into_raw().into_u32().serialize(w)
+}
+
+pub fn deserialize_idx<T, R: Read>(r: &mut R) -> Result<Idx<T>, Error> {
+    Ok(Idx::from_raw(RawIdx::from_u32(u32::deserialize_reader(r)?)))
+}
+
+// ── Option<Idx<T>> ───────────────────────────────────────────────────────────
+
+pub fn serialize_opt_idx<T, W: Write>(idx: &Option<Idx<T>>, w: &mut W) -> Result<(), Error> {
+    match idx {
+        Some(i) => {
+            1u8.serialize(w)?;
+            serialize_idx(i, w)
+        }
+        None => 0u8.serialize(w),
+    }
+}
+
+pub fn deserialize_opt_idx<T, R: Read>(r: &mut R) -> Result<Option<Idx<T>>, Error> {
+    if u8::deserialize_reader(r)? == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(deserialize_idx(r)?))
+    }
+}
+
+// ── Arena<T> where T: Borsh (dense, alloc-only) ──────────────────────────────
+
+pub fn serialize_arena<T: BorshSerialize, W: Write>(
+    arena: &Arena<T>,
+    w: &mut W,
+) -> Result<(), Error> {
+    len_as_u32(arena.len()).serialize(w)?;
+    for (_, v) in arena.iter() {
+        v.serialize(w)?;
+    }
+    Ok(())
+}
+
+pub fn deserialize_arena<T: BorshDeserialize, R: Read>(r: &mut R) -> Result<Arena<T>, Error> {
+    let len = u32::deserialize_reader(r)?;
+    let mut arena = Arena::new();
+    for _ in 0..len {
+        arena.alloc(T::deserialize_reader(r)?);
+    }
+    Ok(arena)
+}
+
+// ── Arena<TextRange> (source-map spans; TextRange isn't Borsh) ───────────────
+
+pub fn serialize_arena_text_range<W: Write>(
+    arena: &Arena<TextRange>,
+    w: &mut W,
+) -> Result<(), Error> {
+    len_as_u32(arena.len()).serialize(w)?;
+    for (_, range) in arena.iter() {
+        serialize_text_range(range, w)?;
+    }
+    Ok(())
+}
+
+pub fn deserialize_arena_text_range<R: Read>(r: &mut R) -> Result<Arena<TextRange>, Error> {
+    let len = u32::deserialize_reader(r)?;
+    let mut arena = Arena::new();
+    for _ in 0..len {
+        arena.alloc(deserialize_text_range(r)?);
+    }
+    Ok(arena)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A tiny struct mirroring how the AST annotates foreign-typed fields, to
+    // prove the helper signatures satisfy borsh's derive and round-trip.
+    #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
+    struct Sample {
+        #[borsh(
+            serialize_with = "serialize_text_range",
+            deserialize_with = "deserialize_text_range"
+        )]
+        span: TextRange,
+        #[borsh(serialize_with = "serialize_idx", deserialize_with = "deserialize_idx")]
+        idx: Idx<u32>,
+        #[borsh(
+            serialize_with = "serialize_opt_idx",
+            deserialize_with = "deserialize_opt_idx"
+        )]
+        opt_idx: Option<Idx<u32>>,
+        #[borsh(
+            serialize_with = "serialize_arena",
+            deserialize_with = "deserialize_arena"
+        )]
+        arena: Arena<u32>,
+        #[borsh(
+            serialize_with = "serialize_arena_text_range",
+            deserialize_with = "deserialize_arena_text_range"
+        )]
+        spans: Arena<TextRange>,
+    }
+
+    #[test]
+    fn foreign_types_round_trip_through_borsh() {
+        let mut arena = Arena::new();
+        let i0 = arena.alloc(10u32);
+        arena.alloc(20u32);
+        let mut spans = Arena::new();
+        spans.alloc(TextRange::new(3.into(), 7.into()));
+
+        let sample = Sample {
+            span: TextRange::new(5.into(), 11.into()),
+            idx: i0,
+            opt_idx: Some(i0),
+            arena,
+            spans,
+        };
+
+        let bytes = borsh::to_vec(&sample).unwrap();
+        let decoded: Sample = borsh::from_slice(&bytes).unwrap();
+        assert_eq!(sample, decoded);
+    }
+}

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod ast;
 pub(crate) mod auto_derive_json;
+pub mod borsh_helpers;
 pub(crate) mod companions;
 pub(crate) mod disambiguate;
 pub mod docstring;

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -22,11 +22,15 @@ use crate::{
 };
 
 /// A reference to an environment variable found in source code (`env.VAR_NAME`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct EnvVarRef {
     /// The variable name (e.g., `"OPENAI_API_KEY"`).
     pub name: String,
     /// The text range of the entire `env.VAR_NAME` expression in the source.
+    #[borsh(
+        serialize_with = "crate::borsh_helpers::serialize_text_range",
+        deserialize_with = "crate::borsh_helpers::deserialize_text_range"
+    )]
     pub range: TextRange,
 }
 

--- a/baml_language/crates/baml_compiler2_emit/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_emit/Cargo.toml
@@ -22,6 +22,7 @@ baml_compiler2_tir = { workspace = true }
 baml_type = { workspace = true }
 baml_workspace = { workspace = true }
 bex_vm_types = { workspace = true }
+borsh = { workspace = true }
 indexmap = { workspace = true }
 log = { workspace = true }
 rustc-hash = { workspace = true }

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -671,6 +671,36 @@ fn fq_to_type_name(fq: &str) -> baml_type::TypeName {
     baml_type::QualifiedTypeName::from_dotted_path(fq)
 }
 
+/// Reusable result of the expensive "core" emit passes (globals + object pool:
+/// Passes 1-4) over a set of files, plus the cursors needed to resume emission
+/// of more files on top. Serialized as the precompiled-stdlib artifact (see
+/// `baml_builtins2_prebuilt`): building it once at compile time lets a normal
+/// compile skip re-lowering and re-emitting the entire stdlib.
+///
+/// Captures state *after Pass 4 and before the trailing passes* (let/$init,
+/// template macros, recursive aliases, interface impls, test cases) — those are
+/// cheap, index-free or name-keyed, and always re-run over all files, so they
+/// are never part of the artifact (which would otherwise double-append `$init`).
+#[derive(Clone, borsh::BorshSerialize, borsh::BorshDeserialize)]
+pub struct EmitState {
+    /// Program with the block's objects and function globals appended.
+    pub program: Program,
+    /// Function/let fully-qualified name -> global slot.
+    pub globals: HashMap<String, usize>,
+    /// Next free global slot (== `program.globals.len()` at the Pass-4 boundary).
+    pub global_idx: usize,
+    /// Class fq-name -> (field name -> field index).
+    pub classes: HashMap<String, HashMap<String, usize>>,
+    /// Class fq-name -> object-pool index.
+    pub class_object_indices: HashMap<String, usize>,
+    /// Monotonic class type-tag counter (relative to `type_tags::CLASS_BASE`).
+    pub class_type_tag_counter: i64,
+    /// Enum fq-name -> (variant name -> variant index).
+    pub enum_variants: HashMap<String, HashMap<String, usize>>,
+    /// Enum fq-name -> object-pool index.
+    pub enum_object_indices: HashMap<String, usize>,
+}
+
 /// Generate bytecode for the entire project (default: `OptLevel::Two`).
 pub fn generate_project_bytecode(
     db: &dyn baml_compiler2_mir::Db,
@@ -685,23 +715,128 @@ pub fn generate_project_bytecode_with_opt(
     options: &CompileOptions,
     opt: OptLevel,
 ) -> Result<Program, LoweringError> {
-    let mut program = Program::new();
+    emit_with_prefix(db, options, opt, None)
+}
+
+/// Like [`generate_project_bytecode_with_opt`] but resumes from a precompiled
+/// stdlib [`EmitState`]: the stdlib's Passes 1-4 (its globals, object pool, and
+/// type tags) are taken from `prefix` instead of recompiled, and only user
+/// files are emitted on top. Requires `prefix` to have been produced by
+/// [`precompile_stdlib`] with the *same* compiler/stdlib (the stable-prefix
+/// invariant guarantees stdlib indices/tags match this DB's).
+pub fn generate_project_bytecode_with_prefix(
+    db: &dyn baml_compiler2_mir::Db,
+    options: &CompileOptions,
+    opt: OptLevel,
+    prefix: EmitState,
+) -> Result<Program, LoweringError> {
+    emit_with_prefix(db, options, opt, Some(prefix))
+}
+
+/// Run the core emit passes (1-4) over the stdlib (`<builtin>/`) files only and
+/// return the resulting [`EmitState`]. This is the precompiled artifact; a
+/// builtins-only database produces a stdlib-only prefix.
+pub fn precompile_stdlib(db: &dyn baml_compiler2_mir::Db, opt: OptLevel) -> EmitState {
+    let all_files = compiler2_all_files(db);
+    let (stdlib_files, user_files): (Vec<baml_base::SourceFile>, Vec<baml_base::SourceFile>) =
+        all_files
+            .iter()
+            .copied()
+            .partition(|f| f.path(db).to_string_lossy().starts_with("<builtin>/"));
+    let alias_caches = build_alias_caches(db, &all_files);
+    emit_core(db, opt, &stdlib_files, &user_files, &alias_caches, None)
+}
+
+fn emit_with_prefix(
+    db: &dyn baml_compiler2_mir::Db,
+    options: &CompileOptions,
+    opt: OptLevel,
+    prefix: Option<EmitState>,
+) -> Result<Program, LoweringError> {
     let all_files = compiler2_all_files(db);
     let alias_caches = build_alias_caches(db, &all_files);
+
+    // Stdlib (`<builtin>/`) files form a stable object/global/type-tag prefix
+    // (see `emit_core`); the trailing passes below run once over all files.
+    let (stdlib_files, user_files): (Vec<baml_base::SourceFile>, Vec<baml_base::SourceFile>) =
+        all_files
+            .iter()
+            .copied()
+            .partition(|f| f.path(db).to_string_lossy().starts_with("<builtin>/"));
+
+    let state = emit_core(db, opt, &stdlib_files, &user_files, &alias_caches, prefix);
+    emit_trailing(db, options, opt, state)
+}
+
+/// Core emit passes (1-4): global-slot assignment (Pass 1) and the object pool
+/// (Passes 2-4). Stdlib (`<builtin>/`) files are processed as a contiguous block
+/// before user files so the stdlib's globals, object indices, and class type
+/// tags form a stable prefix independent of user code. When `prefix` is `Some`,
+/// the stdlib block is taken from it and only user files are emitted on top.
+fn emit_core(
+    db: &dyn baml_compiler2_mir::Db,
+    opt: OptLevel,
+    stdlib_files: &[baml_base::SourceFile],
+    user_files: &[baml_base::SourceFile],
+    alias_caches: &HashMap<Name, ResolvedAliases>,
+    prefix: Option<EmitState>,
+) -> EmitState {
+    let skip_stdlib = prefix.is_some();
+    let (
+        mut program,
+        mut globals,
+        mut global_idx,
+        mut classes,
+        mut class_object_indices,
+        mut class_type_tag_counter,
+        mut enum_variants,
+        mut enum_object_indices,
+    ) = match prefix {
+        Some(p) => (
+            p.program,
+            p.globals,
+            p.global_idx,
+            p.classes,
+            p.class_object_indices,
+            p.class_type_tag_counter,
+            p.enum_variants,
+            p.enum_object_indices,
+        ),
+        None => (
+            Program::new(),
+            HashMap::new(),
+            0usize,
+            HashMap::new(),
+            HashMap::new(),
+            0i64,
+            HashMap::new(),
+            HashMap::new(),
+        ),
+    };
 
     // --- Pass 1: Build globals map (function name -> global index) ---
     // Functions are allocated first (slots 0..N-1), then let bindings (slots N..M-1).
     // This ensures function slots match the order they're appended to program.globals
-    // in Pass 4, and let binding slots don't interleave with function slots.
-    let mut globals: HashMap<String, usize> = HashMap::new();
-    let mut global_idx = 0usize;
+    // in Pass 4, and let binding slots don't interleave with function slots. On a
+    // resume (`skip_stdlib`), the stdlib slots are already in `globals`/`global_idx`
+    // from the prefix, so Pass 1 only assigns user slots (continuing the cursor).
+    let ordered_files: Vec<baml_base::SourceFile> = if skip_stdlib {
+        user_files.to_vec()
+    } else {
+        stdlib_files
+            .iter()
+            .chain(user_files.iter())
+            .copied()
+            .collect()
+    };
 
-    // First sub-pass: assign slots to all functions across all files.
+    // First sub-pass: assign slots to all functions across all files (stdlib
+    // first, via `ordered_files`, so stdlib function slots are `0..N_stdlib`).
     // Intrinsic functions are skipped: they are lowered to StatementKind::Intrinsic
     // at call sites and never appear as callable objects in the globals pool.
     // Including them here would create a mismatch between Pass-1 indices and the
     // actual program.globals array built in Pass 4 (which also skips intrinsics).
-    for file in &all_files {
+    for file in &ordered_files {
         let item_tree = file_item_tree(db, *file);
         for local_id in item_tree.functions.keys() {
             let func_loc = FunctionLoc::new(db, *file, *local_id);
@@ -737,7 +872,7 @@ pub fn generate_project_bytecode_with_opt(
 
     // Second sub-pass: assign slots to all let bindings across all files,
     // after all function slots have been reserved.
-    for file in &all_files {
+    for file in &ordered_files {
         let item_tree = file_item_tree(db, *file);
         for local_id in item_tree.lets.keys() {
             let let_loc = LetLoc::new(db, *file, *local_id);
@@ -753,265 +888,300 @@ pub fn generate_project_bytecode_with_opt(
     // --- Pass 2: Build classes table ---
     // Maps fully-qualified class name -> (field name -> field index).
     // Also builds class_object_indices: class fq_name -> object index in program.objects.
-    let mut classes: HashMap<String, HashMap<String, usize>> = HashMap::new();
-    let mut class_object_indices: HashMap<String, usize> = HashMap::new();
-    let mut class_type_tag_counter = 0i64;
-
-    for file in &all_files {
-        let item_tree = file_item_tree(db, *file);
-        let pkg_info = file_package(db, *file);
-        let pkg_id = PackageId::new(db, pkg_info.package.clone());
-        let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
-        let cache = &alias_caches[&pkg_info.package];
-        for class_data in item_tree.classes.values() {
-            // Build fully-qualified name: "user.MyClass" or "baml.ns.MyClass"
-            let fq_name = if pkg_info.namespace_path.is_empty() {
-                format!("{}.{}", pkg_info.package, class_data.name)
-            } else {
-                let ns: Vec<&str> = pkg_info
-                    .namespace_path
-                    .iter()
-                    .map(baml_base::Name::as_str)
-                    .collect();
-                format!("{}.{}.{}", pkg_info.package, ns.join("."), class_data.name)
-            };
-
-            let mut field_indices = HashMap::new();
-            let mut fields = Vec::new();
-            // Class-level generic params, used to resolve `T`-references in
-            // field type expressions to `TyTemplate::TypeArgRef(N)`.  When
-            // empty, `tir2_to_template` produces `TyTemplate::Concrete(...)`
-            // for every leaf and `field_template == Concrete(field_type)`.
-            let class_generic_params: Vec<baml_base::Name> = class_data.generic_params.clone();
-            // BEP-044: collect only the class's actual runtime fields.
-            // Interface fields are typed views over class storage, and the
-            // validator enforces/link-checks them before emit.
-            let merged_fields =
-                collect_class_fields_with_implements(&pkg_info.namespace_path, class_data);
-            for (idx, (name, type_expr, attrs, gen_params, ns)) in merged_fields.iter().enumerate()
-            {
-                field_indices.insert(name.clone(), idx);
-                let (field_type, field_template) = match type_expr {
-                    Some(te) => {
-                        let mut diags = Vec::new();
-                        // Pass `class_generic_params` as the binding context so
-                        // `T`-references inside `class Container<T> { item: T }`
-                        // lower to `Tir2Ty::TypeVar("T")` rather than
-                        // `Tir2Ty::Unknown`.  This is the input both to the
-                        // erased-`Ty` (TypeVar→BuiltinUnknown) used by codegen and to
-                        // the `TyTemplate` (TypeVar→TypeArgRef(N)) used by
-                        // typed runtime walking.
-                        let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_expr_in_ns(
-                            db, &te.expr, pkg_items, ns, gen_params, &mut diags,
-                        );
-                        let resolved_ty = cache.convert(&tir_ty);
-                        let template = baml_compiler2_mir::tir2_to_template(
-                            &tir_ty,
-                            cache,
-                            &class_generic_params,
-                        );
-                        (resolved_ty, template)
-                    }
-                    None => {
-                        let null_ty = baml_type::RuntimeTy::Null {
-                            attr: baml_type::TyAttr::default(),
-                        };
-                        (null_ty.clone(), baml_type::TyTemplate::Concrete(null_ty))
-                    }
-                };
-                let (field_desc, field_alias, field_skip) = extract_schema_attrs(attrs.as_slice());
-                fields.push(ClassField {
-                    name: name.clone(),
-                    field_type,
-                    field_template,
-                    description: field_desc,
-                    alias: field_alias,
-                    skip: field_skip,
-                });
-            }
-
-            let (class_desc, class_alias, _class_skip) =
-                extract_schema_attrs(&class_data.attributes);
-
-            let type_tag = bex_vm_types::type_tags::CLASS_BASE + class_type_tag_counter;
-            class_type_tag_counter += 1;
-
-            let class_obj_idx = program.add_object(Object::Class(Box::new(Class {
-                name: fq_to_type_name(&fq_name),
-                fields,
-                description: class_desc,
-                alias: class_alias,
-                type_tag,
-                ty_attr: TyAttr::default(),
-            })));
-            // Register with fully-qualified name for inter-package lookups.
-            class_object_indices.insert(fq_name.clone(), class_obj_idx);
-            classes.insert(fq_name.clone(), field_indices);
-            // MIR TypeName display for user-defined classes omits the `user.`
-            // package prefix in diagnostics/snapshots. Register the same key
-            // so emit-time type checks can do a direct display-name lookup.
-            let display_name = if pkg_info.package.as_str() == "user" {
-                if pkg_info.namespace_path.is_empty() {
-                    class_data.name.to_string()
+    // (classes / class_object_indices / class_type_tag_counter / enum_variants /
+    // enum_object_indices are declared above so they seed from / persist into the
+    // returned `EmitState`.)
+    //
+    // Passes 2-4 run once per file block (stdlib, then user). Per-block emission
+    // keeps each block's objects contiguous in the pool: all stdlib
+    // classes+enums+functions form a stable prefix, then all user objects. A
+    // single kind-grouped pass over every file would instead append all classes,
+    // then all enums, then all functions, interleaving stdlib enum/function
+    // objects *after* user classes and shifting stdlib object indices by user
+    // counts. The maps above accumulate across both calls, so the user block
+    // resolves references to stdlib classes/enums/functions.
+    let mut emit_object_block = |block_files: &[baml_base::SourceFile]| {
+        for file in block_files {
+            let item_tree = file_item_tree(db, *file);
+            let pkg_info = file_package(db, *file);
+            let pkg_id = PackageId::new(db, pkg_info.package.clone());
+            let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
+            let cache = &alias_caches[&pkg_info.package];
+            for class_data in item_tree.classes.values() {
+                // Build fully-qualified name: "user.MyClass" or "baml.ns.MyClass"
+                let fq_name = if pkg_info.namespace_path.is_empty() {
+                    format!("{}.{}", pkg_info.package, class_data.name)
                 } else {
                     let ns: Vec<&str> = pkg_info
                         .namespace_path
                         .iter()
                         .map(baml_base::Name::as_str)
                         .collect();
-                    format!("{}.{}", ns.join("."), class_data.name)
-                }
-            } else {
-                fq_name.clone()
-            };
-            class_object_indices
-                .entry(display_name.clone())
-                .or_insert(class_obj_idx);
-            // Also register with the short (unqualified) class name so that MIR aggregates,
-            // which store only the local name (e.g., "Point" not "user.Point"), can find it.
-            let short_name = class_data.name.to_string();
-            class_object_indices
-                .entry(short_name.clone())
-                .or_insert(class_obj_idx);
-            // The display- and short-name maps must agree with the emitted
-            // runtime field indices used by the Class object above. Use a
-            // closure that rebuilds the same ordering.
-            let rebuild_indices = || {
-                let merged =
+                    format!("{}.{}.{}", pkg_info.package, ns.join("."), class_data.name)
+                };
+
+                let mut field_indices = HashMap::new();
+                let mut fields = Vec::new();
+                // Class-level generic params, used to resolve `T`-references in
+                // field type expressions to `TyTemplate::TypeArgRef(N)`.  When
+                // empty, `tir2_to_template` produces `TyTemplate::Concrete(...)`
+                // for every leaf and `field_template == Concrete(field_type)`.
+                let class_generic_params: Vec<baml_base::Name> = class_data.generic_params.clone();
+                // BEP-044: collect only the class's actual runtime fields.
+                // Interface fields are typed views over class storage, and the
+                // validator enforces/link-checks them before emit.
+                let merged_fields =
                     collect_class_fields_with_implements(&pkg_info.namespace_path, class_data);
-                let mut m = HashMap::new();
-                for (idx, (name, _, _, _, _)) in merged.iter().enumerate() {
-                    m.insert(name.clone(), idx);
-                }
-                m
-            };
-            classes.entry(display_name).or_insert_with(rebuild_indices);
-            classes.entry(short_name).or_insert_with(rebuild_indices);
-        }
-    }
-
-    // --- Pass 3: Build enums table ---
-    // Maps fully-qualified enum name -> (variant name -> variant index).
-    let mut enum_variants: HashMap<String, HashMap<String, usize>> = HashMap::new();
-    let mut enum_object_indices: HashMap<String, usize> = HashMap::new();
-
-    for file in &all_files {
-        let item_tree = file_item_tree(db, *file);
-        let pkg_info = file_package(db, *file);
-        for enum_data in item_tree.enums.values() {
-            let fq_name = if pkg_info.namespace_path.is_empty() {
-                format!("{}.{}", pkg_info.package, enum_data.name)
-            } else {
-                let ns: Vec<&str> = pkg_info
-                    .namespace_path
-                    .iter()
-                    .map(baml_base::Name::as_str)
-                    .collect();
-                format!("{}.{}.{}", pkg_info.package, ns.join("."), enum_data.name)
-            };
-
-            let mut variant_map = HashMap::new();
-            let mut variants = Vec::new();
-            for (idx, variant) in enum_data.variants.iter().enumerate() {
-                let (var_desc, var_alias, var_skip) = extract_schema_attrs(&variant.attributes);
-                variant_map.insert(variant.name.to_string(), idx);
-                variants.push(EnumVariant {
-                    name: variant.name.to_string(),
-                    description: var_desc,
-                    alias: var_alias,
-                    skip: var_skip,
-                });
-            }
-
-            let (enum_desc, enum_alias, _enum_skip) = extract_schema_attrs(&enum_data.attributes);
-
-            let enum_obj_idx = program.add_object(Object::Enum(Box::new(Enum {
-                name: fq_to_type_name(&fq_name),
-                variants,
-                description: enum_desc,
-                alias: enum_alias,
-                ty_attr: TyAttr::default(),
-            })));
-            enum_object_indices.insert(fq_name.clone(), enum_obj_idx);
-            enum_variants.insert(fq_name, variant_map);
-        }
-    }
-
-    // --- Pass 4: Compile each function ---
-    for file in &all_files {
-        let line_starts = build_line_starts(file.text(db));
-        let item_tree = file_item_tree(db, *file);
-        let pkg_info_pass4 = file_package(db, *file);
-        let cache_pass4 = &alias_caches[&pkg_info_pass4.package];
-        for (local_id, func_data) in &item_tree.functions {
-            let func_loc = FunctionLoc::new(db, *file, *local_id);
-            let mir = lower_function(db, func_loc, opt);
-            let fq_name = mir.item_ref.to_string();
-
-            let mut compiled_fn = match &mir.kind {
-                MirFunctionKind::Bytecode(body) => {
-                    // Compile lambda children first, collecting their ObjectPool indices.
-                    let source_file = file.path(db).display().to_string();
-                    let empty_capture_types = Vec::new();
-                    let empty_spawn_capture_indices = HashSet::new();
-                    let lambda_info = compile_lambdas_flat(
-                        &mir.lambdas,
-                        Some(body),
-                        &empty_capture_types,
-                        &empty_spawn_capture_indices,
-                        &line_starts,
-                        &source_file,
-                        &globals,
-                        &classes,
-                        &class_object_indices,
-                        &enum_object_indices,
-                        &enum_variants,
-                        &mut program.objects,
-                        opt,
-                    );
-                    let lambda_obj_indices: Vec<usize> =
-                        lambda_info.iter().map(|(idx, _)| *idx).collect();
-                    let lambda_names_vec: Vec<String> =
-                        lambda_info.iter().map(|(_, name)| name.clone()).collect();
-                    let ctx = MirCodegenContext {
-                        globals: &globals,
-                        classes: &classes,
-                        class_object_indices: &class_object_indices,
-                        enum_object_indices: &enum_object_indices,
-                        enum_variants: &enum_variants,
-                        objects: &mut program.objects,
-                        lambda_object_indices: &lambda_obj_indices,
-                        lambda_names: &lambda_names_vec,
-                        capture_types: &empty_capture_types,
-                        spawn_capture_indices: &empty_spawn_capture_indices,
+                for (idx, (name, type_expr, attrs, gen_params, ns)) in
+                    merged_fields.iter().enumerate()
+                {
+                    field_indices.insert(name.clone(), idx);
+                    let (field_type, field_template) = match type_expr {
+                        Some(te) => {
+                            let mut diags = Vec::new();
+                            // Pass `class_generic_params` as the binding context so
+                            // `T`-references inside `class Container<T> { item: T }`
+                            // lower to `Tir2Ty::TypeVar("T")` rather than
+                            // `Tir2Ty::Unknown`.  This is the input both to the
+                            // erased-`Ty` (TypeVar→BuiltinUnknown) used by codegen and to
+                            // the `TyTemplate` (TypeVar→TypeArgRef(N)) used by
+                            // typed runtime walking.
+                            let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_expr_in_ns(
+                                db, &te.expr, pkg_items, ns, gen_params, &mut diags,
+                            );
+                            let resolved_ty = cache.convert(&tir_ty);
+                            let template = baml_compiler2_mir::tir2_to_template(
+                                &tir_ty,
+                                cache,
+                                &class_generic_params,
+                            );
+                            (resolved_ty, template)
+                        }
+                        None => {
+                            let null_ty = baml_type::RuntimeTy::Null {
+                                attr: baml_type::TyAttr::default(),
+                            };
+                            (null_ty.clone(), baml_type::TyTemplate::Concrete(null_ty))
+                        }
                     };
-                    let mut f =
-                        compile_mir_function(body, mir.arity, mir.span, &line_starts, ctx, opt);
-                    f.name.clone_from(&fq_name);
-                    f.source_file.clone_from(&source_file);
-                    f
+                    let (field_desc, field_alias, field_skip) =
+                        extract_schema_attrs(attrs.as_slice());
+                    fields.push(ClassField {
+                        name: name.clone(),
+                        field_type,
+                        field_template,
+                        description: field_desc,
+                        alias: field_alias,
+                        skip: field_skip,
+                    });
                 }
-                MirFunctionKind::Builtin(BuiltinKind::Intrinsic) => {
-                    // Intrinsic functions have no callable body — call sites use
-                    // StatementKind::Intrinsic directly. Skip compilation entirely.
-                    continue;
+
+                let (class_desc, class_alias, _class_skip) =
+                    extract_schema_attrs(&class_data.attributes);
+
+                let type_tag = bex_vm_types::type_tags::CLASS_BASE + class_type_tag_counter;
+                class_type_tag_counter += 1;
+
+                let class_obj_idx = program.add_object(Object::Class(Box::new(Class {
+                    name: fq_to_type_name(&fq_name),
+                    fields,
+                    description: class_desc,
+                    alias: class_alias,
+                    type_tag,
+                    ty_attr: TyAttr::default(),
+                })));
+                // Register with fully-qualified name for inter-package lookups.
+                class_object_indices.insert(fq_name.clone(), class_obj_idx);
+                classes.insert(fq_name.clone(), field_indices);
+                // MIR TypeName display for user-defined classes omits the `user.`
+                // package prefix in diagnostics/snapshots. Register the same key
+                // so emit-time type checks can do a direct display-name lookup.
+                let display_name = if pkg_info.package.as_str() == "user" {
+                    if pkg_info.namespace_path.is_empty() {
+                        class_data.name.to_string()
+                    } else {
+                        let ns: Vec<&str> = pkg_info
+                            .namespace_path
+                            .iter()
+                            .map(baml_base::Name::as_str)
+                            .collect();
+                        format!("{}.{}", ns.join("."), class_data.name)
+                    }
+                } else {
+                    fq_name.clone()
+                };
+                class_object_indices
+                    .entry(display_name.clone())
+                    .or_insert(class_obj_idx);
+                // Also register with the short (unqualified) class name so that MIR aggregates,
+                // which store only the local name (e.g., "Point" not "user.Point"), can find it.
+                let short_name = class_data.name.to_string();
+                class_object_indices
+                    .entry(short_name.clone())
+                    .or_insert(class_obj_idx);
+                // The display- and short-name maps must agree with the emitted
+                // runtime field indices used by the Class object above. Use a
+                // closure that rebuilds the same ordering.
+                let rebuild_indices = || {
+                    let merged =
+                        collect_class_fields_with_implements(&pkg_info.namespace_path, class_data);
+                    let mut m = HashMap::new();
+                    for (idx, (name, _, _, _, _)) in merged.iter().enumerate() {
+                        m.insert(name.clone(), idx);
+                    }
+                    m
+                };
+                classes.entry(display_name).or_insert_with(rebuild_indices);
+                classes.entry(short_name).or_insert_with(rebuild_indices);
+            }
+        }
+
+        // --- Pass 3: Build enums table ---
+        // Maps fully-qualified enum name -> (variant name -> variant index).
+        // (enum_variants / enum_object_indices are hoisted above the closure.)
+        for file in block_files {
+            let item_tree = file_item_tree(db, *file);
+            let pkg_info = file_package(db, *file);
+            for enum_data in item_tree.enums.values() {
+                let fq_name = if pkg_info.namespace_path.is_empty() {
+                    format!("{}.{}", pkg_info.package, enum_data.name)
+                } else {
+                    let ns: Vec<&str> = pkg_info
+                        .namespace_path
+                        .iter()
+                        .map(baml_base::Name::as_str)
+                        .collect();
+                    format!("{}.{}.{}", pkg_info.package, ns.join("."), enum_data.name)
+                };
+
+                let mut variant_map = HashMap::new();
+                let mut variants = Vec::new();
+                for (idx, variant) in enum_data.variants.iter().enumerate() {
+                    let (var_desc, var_alias, var_skip) = extract_schema_attrs(&variant.attributes);
+                    variant_map.insert(variant.name.to_string(), idx);
+                    variants.push(EnumVariant {
+                        name: variant.name.to_string(),
+                        description: var_desc,
+                        alias: var_alias,
+                        skip: var_skip,
+                    });
                 }
-                MirFunctionKind::Builtin(BuiltinKind::AwaitAny) => {
-                    // BEP-034 `__await_any` has no callable body — call sites
-                    // lower to a `Terminator::AwaitAny` suspend point directly.
-                    // Skip compilation entirely (like an intrinsic).
-                    continue;
-                }
-                MirFunctionKind::Builtin(BuiltinKind::Io) => {
-                    let sys_op = bex_vm_types::sys_op_for_path(&fq_name)
-                        .unwrap_or_else(|| panic!("unknown sys_op path: {fq_name}"));
-                    Function {
+
+                let (enum_desc, enum_alias, _enum_skip) =
+                    extract_schema_attrs(&enum_data.attributes);
+
+                let enum_obj_idx = program.add_object(Object::Enum(Box::new(Enum {
+                    name: fq_to_type_name(&fq_name),
+                    variants,
+                    description: enum_desc,
+                    alias: enum_alias,
+                    ty_attr: TyAttr::default(),
+                })));
+                enum_object_indices.insert(fq_name.clone(), enum_obj_idx);
+                enum_variants.insert(fq_name, variant_map);
+            }
+        }
+
+        // --- Pass 4: Compile each function ---
+        for file in block_files {
+            let line_starts = build_line_starts(file.text(db));
+            let item_tree = file_item_tree(db, *file);
+            let pkg_info_pass4 = file_package(db, *file);
+            let cache_pass4 = &alias_caches[&pkg_info_pass4.package];
+            for (local_id, func_data) in &item_tree.functions {
+                let func_loc = FunctionLoc::new(db, *file, *local_id);
+                let mir = lower_function(db, func_loc, opt);
+                let fq_name = mir.item_ref.to_string();
+
+                let mut compiled_fn = match &mir.kind {
+                    MirFunctionKind::Bytecode(body) => {
+                        // Compile lambda children first, collecting their ObjectPool indices.
+                        let source_file = file.path(db).display().to_string();
+                        let empty_capture_types = Vec::new();
+                        let empty_spawn_capture_indices = HashSet::new();
+                        let lambda_info = compile_lambdas_flat(
+                            &mir.lambdas,
+                            Some(body),
+                            &empty_capture_types,
+                            &empty_spawn_capture_indices,
+                            &line_starts,
+                            &source_file,
+                            &globals,
+                            &classes,
+                            &class_object_indices,
+                            &enum_object_indices,
+                            &enum_variants,
+                            &mut program.objects,
+                            opt,
+                        );
+                        let lambda_obj_indices: Vec<usize> =
+                            lambda_info.iter().map(|(idx, _)| *idx).collect();
+                        let lambda_names_vec: Vec<String> =
+                            lambda_info.iter().map(|(_, name)| name.clone()).collect();
+                        let ctx = MirCodegenContext {
+                            globals: &globals,
+                            classes: &classes,
+                            class_object_indices: &class_object_indices,
+                            enum_object_indices: &enum_object_indices,
+                            enum_variants: &enum_variants,
+                            objects: &mut program.objects,
+                            lambda_object_indices: &lambda_obj_indices,
+                            lambda_names: &lambda_names_vec,
+                            capture_types: &empty_capture_types,
+                            spawn_capture_indices: &empty_spawn_capture_indices,
+                        };
+                        let mut f =
+                            compile_mir_function(body, mir.arity, mir.span, &line_starts, ctx, opt);
+                        f.name.clone_from(&fq_name);
+                        f.source_file.clone_from(&source_file);
+                        f
+                    }
+                    MirFunctionKind::Builtin(BuiltinKind::Intrinsic) => {
+                        // Intrinsic functions have no callable body — call sites use
+                        // StatementKind::Intrinsic directly. Skip compilation entirely.
+                        continue;
+                    }
+                    MirFunctionKind::Builtin(BuiltinKind::AwaitAny) => {
+                        // BEP-034 `__await_any` has no callable body — call sites
+                        // lower to a `Terminator::AwaitAny` suspend point directly.
+                        // Skip compilation entirely (like an intrinsic).
+                        continue;
+                    }
+                    MirFunctionKind::Builtin(BuiltinKind::Io) => {
+                        let sys_op = bex_vm_types::sys_op_for_path(&fq_name)
+                            .unwrap_or_else(|| panic!("unknown sys_op path: {fq_name}"));
+                        Function {
+                            name: fq_name.clone(),
+                            source_file: String::new(), // builtins have no source file
+                            arity: mir.arity,
+                            real_local_count: 0,
+                            bytecode: Bytecode::default(),
+                            kind: FunctionKind::SysOp(sys_op),
+                            local_names: Vec::new(),
+                            debug_locals: Vec::new(),
+                            span: Span::fake(),
+                            return_type: baml_type::RuntimeTy::Null {
+                                attr: baml_type::TyAttr::default(),
+                            },
+                            param_names: Vec::new(),
+                            param_types: Vec::new(),
+                            param_has_default: Vec::new(),
+                            display_type_params: Vec::new(),
+                            display_param_types: Vec::new(),
+                            display_return_type: "null".to_string(),
+                            throws_type: None,
+                            origin: FunctionOrigin::Builtin,
+                            body_meta: None,
+                            function_id: 0, // assigned at engine init (interim provider)
+                        }
+                    }
+                    MirFunctionKind::Builtin(BuiltinKind::Vm) => Function {
                         name: fq_name.clone(),
                         source_file: String::new(), // builtins have no source file
                         arity: mir.arity,
                         real_local_count: 0,
                         bytecode: Bytecode::default(),
-                        kind: FunctionKind::SysOp(sys_op),
+                        kind: FunctionKind::NativeUnresolved,
                         local_names: Vec::new(),
                         debug_locals: Vec::new(),
                         span: Span::fake(),
@@ -1028,94 +1198,120 @@ pub fn generate_project_bytecode_with_opt(
                         origin: FunctionOrigin::Builtin,
                         body_meta: None,
                         function_id: 0, // assigned at engine init (interim provider)
+                    },
+                };
+
+                // Set function metadata from signature
+                let parameter_defaults =
+                    baml_compiler2_ppir::function_parameter_defaults(db, func_loc);
+                let signature_metadata = compute_function_metadata_from_item_tree(
+                    db,
+                    *file,
+                    *local_id,
+                    func_data,
+                    &parameter_defaults,
+                    cache_pass4,
+                );
+                compiled_fn.return_type = signature_metadata.return_type;
+                compiled_fn.param_names = signature_metadata.param_names;
+                compiled_fn.param_types = signature_metadata.param_types;
+                compiled_fn.param_has_default = signature_metadata.param_has_default;
+                compiled_fn.display_type_params = signature_metadata.display_type_params;
+                compiled_fn.display_param_types = signature_metadata.display_param_types;
+                compiled_fn.display_return_type = signature_metadata.display_return_type;
+
+                // Set inferred throws type from TIR throw inference
+                compiled_fn.throws_type =
+                    compute_throws_type(db, *file, &func_data.name, cache_pass4);
+                compiled_fn.origin = emitted_function_origin(&fq_name, func_data.origin);
+
+                // Set LLM-specific body_meta if this is an LLM function
+                if let Some(baml_compiler2_ast::DeclarativeMeta::Llm(llm_meta)) =
+                    &func_data.declarative_meta
+                {
+                    // NOTE (canary merge): canary removed the runtime `Function.stream_return_type`
+                    // field and its plumbing (the pre-existing streaming infra from PRs #3362/#3755).
+                    // The stream return type is now carried by the synthesized `$stream` companion's
+                    // own `return_type` (see ppir's `companion_stream_return_type`), so the old
+                    // emit-side pre-computation block was dropped. BEP-049 M5e stream-path rendering
+                    // of `ctx.output_format` should be re-verified against canary's streaming.
+                    if let Some(client) = &llm_meta.client {
+                        // New-mode (BEP-049 M5) functions have no Jinja `prompt`
+                        // text — the compiled closure renders it — but they still
+                        // need a registry entry so `get_return_type` /
+                        // `get_stream_return_type` (used by `__make_stream` and the
+                        // streaming `Context`) resolve by name. The empty template
+                        // is never read for them (their `prompt_closure` is non-null,
+                        // so the Jinja `get_jinja_template` branch is skipped).
+                        let prompt_template = llm_meta
+                            .prompt
+                            .as_ref()
+                            .map(|p| p.text.clone())
+                            .unwrap_or_default();
+                        compiled_fn.body_meta = Some(FunctionMeta::Llm {
+                            prompt_template,
+                            client: client.to_string(),
+                        });
                     }
                 }
-                MirFunctionKind::Builtin(BuiltinKind::Vm) => Function {
-                    name: fq_name.clone(),
-                    source_file: String::new(), // builtins have no source file
-                    arity: mir.arity,
-                    real_local_count: 0,
-                    bytecode: Bytecode::default(),
-                    kind: FunctionKind::NativeUnresolved,
-                    local_names: Vec::new(),
-                    debug_locals: Vec::new(),
-                    span: Span::fake(),
-                    return_type: baml_type::RuntimeTy::Null {
-                        attr: baml_type::TyAttr::default(),
-                    },
-                    param_names: Vec::new(),
-                    param_types: Vec::new(),
-                    param_has_default: Vec::new(),
-                    display_type_params: Vec::new(),
-                    display_param_types: Vec::new(),
-                    display_return_type: "null".to_string(),
-                    throws_type: None,
-                    origin: FunctionOrigin::Builtin,
-                    body_meta: None,
-                    function_id: 0, // assigned at engine init (interim provider)
-                },
-            };
 
-            // Set function metadata from signature
-            let parameter_defaults = baml_compiler2_ppir::function_parameter_defaults(db, func_loc);
-            let signature_metadata = compute_function_metadata_from_item_tree(
-                db,
-                *file,
-                *local_id,
-                func_data,
-                &parameter_defaults,
-                cache_pass4,
-            );
-            compiled_fn.return_type = signature_metadata.return_type;
-            compiled_fn.param_names = signature_metadata.param_names;
-            compiled_fn.param_types = signature_metadata.param_types;
-            compiled_fn.param_has_default = signature_metadata.param_has_default;
-            compiled_fn.display_type_params = signature_metadata.display_type_params;
-            compiled_fn.display_param_types = signature_metadata.display_param_types;
-            compiled_fn.display_return_type = signature_metadata.display_return_type;
-
-            // Set inferred throws type from TIR throw inference
-            compiled_fn.throws_type = compute_throws_type(db, *file, &func_data.name, cache_pass4);
-            compiled_fn.origin = emitted_function_origin(&fq_name, func_data.origin);
-
-            // Set LLM-specific body_meta if this is an LLM function
-            if let Some(baml_compiler2_ast::DeclarativeMeta::Llm(llm_meta)) =
-                &func_data.declarative_meta
-            {
-                // NOTE (canary merge): canary removed the runtime `Function.stream_return_type`
-                // field and its plumbing (the pre-existing streaming infra from PRs #3362/#3755).
-                // The stream return type is now carried by the synthesized `$stream` companion's
-                // own `return_type` (see ppir's `companion_stream_return_type`), so the old
-                // emit-side pre-computation block was dropped. BEP-049 M5e stream-path rendering
-                // of `ctx.output_format` should be re-verified against canary's streaming.
-                if let Some(client) = &llm_meta.client {
-                    // New-mode (BEP-049 M5) functions have no Jinja `prompt`
-                    // text — the compiled closure renders it — but they still
-                    // need a registry entry so `get_return_type` /
-                    // `get_stream_return_type` (used by `__make_stream` and the
-                    // streaming `Context`) resolve by name. The empty template
-                    // is never read for them (their `prompt_closure` is non-null,
-                    // so the Jinja `get_jinja_template` branch is skipped).
-                    let prompt_template = llm_meta
-                        .prompt
-                        .as_ref()
-                        .map(|p| p.text.clone())
-                        .unwrap_or_default();
-                    compiled_fn.body_meta = Some(FunctionMeta::Llm {
-                        prompt_template,
-                        client: client.to_string(),
-                    });
-                }
+                let fn_obj_idx = program.add_object(Object::Function(Box::new(compiled_fn)));
+                program.function_indices.insert(fq_name.clone(), fn_obj_idx);
+                program
+                    .function_global_indices
+                    .insert(fq_name, program.globals.len());
+                program.add_global(ConstValue::Object(ObjectIndex::from_raw(fn_obj_idx)));
             }
-
-            let fn_obj_idx = program.add_object(Object::Function(Box::new(compiled_fn)));
-            program.function_indices.insert(fq_name.clone(), fn_obj_idx);
-            program
-                .function_global_indices
-                .insert(fq_name, program.globals.len());
-            program.add_global(ConstValue::Object(ObjectIndex::from_raw(fn_obj_idx)));
         }
+    };
+
+    // Emit the stdlib object block first so its objects occupy a stable prefix
+    // (`0..N_stdlib`), then the user block. On a resume the stdlib block is
+    // already in the seeded state (from the prefix), so it is skipped. The
+    // closure's borrows of `program` and the index maps end at its last call
+    // (NLL), so they are free to move into `EmitState` below.
+    if !skip_stdlib {
+        emit_object_block(stdlib_files);
     }
+    emit_object_block(user_files);
+
+    EmitState {
+        program,
+        globals,
+        global_idx,
+        classes,
+        class_object_indices,
+        class_type_tag_counter,
+        enum_variants,
+        enum_object_indices,
+    }
+}
+
+/// Trailing emit passes (4.5-8): let/`$init`, `$init_test`, template-string
+/// macros, recursive type aliases, interface impls, and test cases. These are
+/// all index-free or name-keyed, so they run over every file and produce
+/// identical output whether the stdlib core was freshly emitted or restored
+/// from a prefix.
+/// `all_files` / `alias_caches` are recomputed here (both salsa-cached) so the
+/// pass bodies below are unchanged from the single-pass form.
+fn emit_trailing(
+    db: &dyn baml_compiler2_mir::Db,
+    options: &CompileOptions,
+    opt: OptLevel,
+    state: EmitState,
+) -> Result<Program, LoweringError> {
+    let all_files = compiler2_all_files(db);
+    let alias_caches = build_alias_caches(db, &all_files);
+    let EmitState {
+        mut program,
+        globals,
+        global_idx: _,
+        classes,
+        class_object_indices,
+        class_type_tag_counter: _,
+        enum_variants,
+        enum_object_indices,
+    } = state;
 
     // --- Pass 4.5: Populate let-binding global slots and synthesize $init ---
     // Collect all let bindings grouped by package.

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -14,6 +14,7 @@ pub use analysis::OptLevel;
 use baml_base::{Name, Span};
 use baml_compiler2_ast::TypeExpr;
 use baml_compiler2_hir::{
+    body::FunctionBody,
     compiler2_all_files,
     contributions::Definition,
     file_package::file_package,
@@ -26,7 +27,7 @@ use baml_compiler2_mir::{
 };
 // Use the PPIR item tree (which includes synthetic *$stream items) rather than
 // the bare HIR item tree, to stay consistent with TIR's LocalItemId indices.
-use baml_compiler2_ppir::file_item_tree;
+use baml_compiler2_ppir::{file_item_tree, function_body};
 use baml_type::{RuntimeTy, TyAttr};
 use bex_vm_types::{
     Bytecode, Class, ClassField, ConstValue, Enum, EnumVariant, Function, FunctionKind,
@@ -704,20 +705,28 @@ pub fn generate_project_bytecode_with_opt(
         let item_tree = file_item_tree(db, *file);
         for local_id in item_tree.functions.keys() {
             let func_loc = FunctionLoc::new(db, *file, *local_id);
-            let mir = lower_function(db, func_loc, opt);
-            // Skip intrinsic and await-any functions — they are never called via
-            // a Call instruction (intrinsics lower to StatementKind::Intrinsic;
+            // Pass 1 only needs each function's global-slot name and whether it
+            // is skipped; both are derivable without lowering the body. Skip
+            // intrinsic and await-any functions — they are never called via a
+            // Call instruction (intrinsics lower to StatementKind::Intrinsic;
             // `__await_any` lowers to a Terminator::AwaitAny). Pass 4 skips them
             // too, so they must be skipped here as well or the Pass-1 indices
             // desync from the program.globals array (off-by-one for everything
-            // after the skipped function).
+            // after the skipped function). The skip set is exactly the
+            // intrinsic/await-any builtins: only a `FunctionBody::Builtin` ever
+            // lowers to `MirFunctionKind::Builtin` (Expr/Missing bodies always
+            // lower to `Bytecode`), so matching the body is equivalent to
+            // matching `mir.kind` — without paying for a full `lower_function`
+            // (which is not memoized, so Pass 4 would re-do it regardless).
             if matches!(
-                mir.kind,
-                MirFunctionKind::Builtin(BuiltinKind::Intrinsic | BuiltinKind::AwaitAny)
+                function_body(db, func_loc).as_ref(),
+                FunctionBody::Builtin(BuiltinKind::Intrinsic | BuiltinKind::AwaitAny)
             ) {
                 continue;
             }
-            let fq_name = mir.item_ref.to_string();
+            // Identical to the old `mir.item_ref.to_string()`: every
+            // `lower_function` branch sets `item_ref` to this exact value.
+            let fq_name = def_to_item_ref(db, Definition::Function(func_loc)).to_string();
             globals.entry(fq_name).or_insert_with(|| {
                 let idx = global_idx;
                 global_idx += 1;

--- a/baml_language/crates/baml_compiler2_hir/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_hir/Cargo.toml
@@ -12,6 +12,7 @@ baml_compiler2_ast = { workspace = true }
 baml_compiler_diagnostics = { workspace = true }
 baml_compiler_parser = { workspace = true }
 baml_workspace = { workspace = true }
+borsh = { workspace = true }
 indexmap = { workspace = true }
 la-arena = { workspace = true }
 rustc-hash = { workspace = true }

--- a/baml_language/crates/baml_compiler2_hir/src/contributions.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/contributions.rs
@@ -15,7 +15,9 @@ use crate::loc::{
 /// Covers both namespace-level items (Class, Function, …) and intra-item
 /// members (Field, Method, Variant, Binding, Parameter). Used by
 /// `Definition<'db>::kind()` and `Hir2Diagnostic::DuplicateDefinition`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize,
+)]
 pub enum DefinitionKind {
     // Namespace-level items
     Class,

--- a/baml_language/crates/baml_compiler2_hir/src/ids.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/ids.rs
@@ -85,6 +85,15 @@ impl<T> LocalItemId<T> {
     pub const fn as_u32(self) -> u32 {
         self.packed
     }
+
+    /// Reconstruct from the packed `as_u32` value (inverse of [`Self::as_u32`]).
+    /// Used to rehydrate precompiled stdlib loc-handles.
+    pub const fn from_u32(packed: u32) -> Self {
+        Self {
+            packed,
+            _phantom: PhantomData,
+        }
+    }
 }
 
 // ── hash_name ────────────────────────────────────────────────────────────────

--- a/baml_language/crates/baml_compiler2_hir/src/ids.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/ids.rs
@@ -39,16 +39,38 @@ pub struct LetMarker;
 /// Upper 16 bits = name hash, lower 16 bits = collision index.
 /// Following rust-analyzer's approach: hash for position-independence,
 /// index for collision handling.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct LocalItemId<T> {
     /// Upper 16 bits: hash, lower 16 bits: collision index.
+    // Empty bound overrides borsh's default `T: Borsh` bound on the generated
+    // impl (`T` is a phantom marker, never serialized); only `packed` is on the
+    // wire.
+    #[borsh(bound(serialize = "", deserialize = ""))]
     packed: u32,
+    #[borsh(skip)]
     _phantom: PhantomData<T>,
 }
 
 impl<T> std::fmt::Debug for LocalItemId<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "LocalItemId({:#010x})", self.packed)
+    }
+}
+
+// Manual `Ord`/`PartialOrd` over `packed` (no `T: Ord` bound, unlike `derive`):
+// borsh serializes `HashMap` by sorting keys, so `LocalItemId` map keys must be
+// `Ord` once `ItemTree` derives Borsh.
+// Bounds mirror the derived `Eq`/`PartialEq` (which bound `T`), satisfying the
+// `Ord: Eq` / `PartialOrd: PartialEq` supertraits; the markers are all `Eq`.
+impl<T: Eq> Ord for LocalItemId<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.packed.cmp(&other.packed)
+    }
+}
+
+impl<T: PartialEq> PartialOrd for LocalItemId<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.packed.cmp(&other.packed))
     }
 }
 
@@ -81,7 +103,18 @@ pub fn hash_name(name: &baml_base::Name) -> u16 {
 // ── ItemKind ─────────────────────────────────────────────────────────────────
 
 /// Item kinds for collision tracking in the `ItemTree`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+)]
 pub enum ItemKind {
     Function,
     Class,

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree.rs
@@ -20,14 +20,14 @@ use crate::ids::{
 
 /// A span-free attribute for position-independent storage in the `ItemTree`.
 /// Derived from `ast::RawAttribute` with all `TextRange`s stripped.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Attribute {
     pub name: Name,
     pub args: Vec<AttributeArg>,
 }
 
 /// A span-free attribute argument.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct AttributeArg {
     pub key: Option<Name>,
     pub value: String,
@@ -56,7 +56,7 @@ impl From<&ast::RawAttributeArg> for AttributeArg {
 /// Full function data stored in the `ItemTree`.
 /// Params and return type are stored for signature queries.
 /// Body is stored for body queries (no CST re-parsing needed).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Function {
     pub name: Name,
     /// Generic type parameters (e.g., `["T", "U"]`).
@@ -86,26 +86,34 @@ pub struct Function {
     /// tagged-template tags without re-reading the CST.
     pub is_tagged_template_tag: bool,
     /// Full source span of the function.
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
 /// A function parameter entry in the `ItemTree`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct FunctionParam {
     pub name: Name,
     pub type_expr: Option<ast::SpannedTypeExpr>,
     pub default: Option<DefaultExprRef>,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct DefaultExprRef {
     pub function: LocalItemId<FunctionMarker>,
     pub expr: ast::DefaultExprId,
 }
 
 /// A class field stored in the `ItemTree`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ClassField {
     pub name: Name,
     pub type_expr: Option<ast::SpannedTypeExpr>,
@@ -114,7 +122,7 @@ pub struct ClassField {
     pub docstring: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Class {
     pub name: Name,
     /// Generic type parameters (e.g., `["T"]` for `Array<T>`).
@@ -140,19 +148,27 @@ pub struct Class {
     /// Joined `///` doc-comment lines preceding this declaration.
     pub docstring: Option<String>,
     /// Full source span of the class declaration.
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ImplementsBlock {
     pub target: ast::SpannedTypeExpr,
     pub field_links: Vec<InterfaceFieldLink>,
     pub associated_type_bindings: Vec<ast::AssociatedTypeBindingDef>,
     pub is_out_of_body: bool,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ImplementsFor {
     pub generic_params: Vec<Name>,
     pub generic_param_bounds: Vec<Option<ast::TypeExpr>>,
@@ -161,20 +177,36 @@ pub struct ImplementsFor {
     pub field_links: Vec<InterfaceFieldLink>,
     pub associated_type_bindings: Vec<ast::AssociatedTypeBindingDef>,
     pub methods: Vec<LocalItemId<FunctionMarker>>,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct InterfaceFieldLink {
     pub interface_field: Name,
     pub class_field: Name,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub interface_field_span: TextRange,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub class_field_span: TextRange,
 }
 
 /// An enum variant stored in the `ItemTree`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct EnumVariant {
     pub name: Name,
     /// Field-level attributes (@description, @alias, @skip, etc.).
@@ -183,7 +215,7 @@ pub struct EnumVariant {
     pub docstring: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Enum {
     pub name: Name,
     /// Variants of the enum, in declaration order.
@@ -193,11 +225,15 @@ pub struct Enum {
     /// Joined `///` doc-comment lines preceding this declaration.
     pub docstring: Option<String>,
     /// Full source span of the enum declaration.
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
 /// A required (no-body) method signature on an interface (BEP-044).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct InterfaceMethodSig {
     pub name: Name,
     /// Generic type parameters local to this method.
@@ -209,6 +245,10 @@ pub struct InterfaceMethodSig {
     pub throws: Option<ast::SpannedTypeExpr>,
     pub attributes: Vec<Attribute>,
     pub docstring: Option<String>,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
@@ -216,7 +256,7 @@ pub struct InterfaceMethodSig {
 ///
 /// Default methods are stored as full `FunctionMarker` entries in `methods`
 /// (same as `Class::methods`). Required signatures live in `required_methods`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Interface {
     pub name: Name,
     /// Generic type parameters declared on the interface.
@@ -236,19 +276,27 @@ pub struct Interface {
     pub required_methods: Vec<InterfaceMethodSig>,
     pub attributes: Vec<Attribute>,
     pub docstring: Option<String>,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct TypeAlias {
     pub name: Name,
     /// The type expression on the RHS of the alias, if present.
     pub type_expr: Option<ast::SpannedTypeExpr>,
     /// Full source span of the type alias declaration.
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Client {
     pub name: Name,
     /// Provider name (e.g., "openai", "anthropic", "fallback", "round-robin").
@@ -264,7 +312,7 @@ pub struct Client {
 /// A test argument value stored in the `ItemTree`.
 ///
 /// Floats are stored as bit patterns (via `f64::to_bits`) to allow `Eq` and `Hash`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum TestArgValue {
     Null,
     Int(i64),
@@ -289,7 +337,7 @@ impl TestArgValue {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Test {
     pub name: Name,
     /// The function(s) this test exercises.
@@ -298,7 +346,7 @@ pub struct Test {
     pub args: Vec<(Name, TestArgValue)>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct TemplateString {
     pub name: Name,
     /// Template parameters with optional type annotations and spans.
@@ -306,10 +354,14 @@ pub struct TemplateString {
     /// Template body text (Jinja template).
     pub body: Option<String>,
     /// Full source span of the template string declaration.
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct RetryPolicy {
     pub name: Name,
     /// Raw string value of `max_retries` (parsed at emit time).
@@ -324,12 +376,20 @@ pub struct RetryPolicy {
 
 /// A top-level let binding stored in the `ItemTree`.
 /// Carries the optional initializer `ExprBody` for body queries.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Let {
     pub name: Name,
     pub initializer: Option<(ast::ExprBody, ast::AstSourceMap)>,
     pub origin: ast::LetOrigin,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub span: TextRange,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub name_span: TextRange,
 }
 
@@ -341,13 +401,20 @@ pub struct Let {
 ///
 /// Follows the same body/signature source-map pattern used by
 /// `function_body` / `function_body_source_map`.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ItemTreeSourceMap {
+    // Diagnostic name-span side-tables. Skipped from borsh (like AstSourceMap's
+    // secondary spans): only used to point diagnostics at field/variant/function
+    // names, never consulted for the frozen, error-free stdlib the precompiled
+    // artifact is built from. Default to empty on load.
     /// `name_span` for each class's fields, parallel to `Class::fields`.
+    #[borsh(skip)]
     pub class_field_spans: FxHashMap<LocalItemId<ClassMarker>, Vec<TextRange>>,
     /// `name_span` for each enum's variants, parallel to `Enum::variants`.
+    #[borsh(skip)]
     pub enum_variant_spans: FxHashMap<LocalItemId<EnumMarker>, Vec<TextRange>>,
     /// `name_span` for each function.
+    #[borsh(skip)]
     pub function_name_spans: FxHashMap<LocalItemId<FunctionMarker>, TextRange>,
 }
 
@@ -358,7 +425,7 @@ pub struct ItemTreeSourceMap {
 /// Items are stored in hash maps keyed by name-based IDs.
 /// The `next_index` map tracks the next available collision index
 /// per `(ItemKind, hash)`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ItemTree {
     pub functions: FxHashMap<LocalItemId<FunctionMarker>, Function>,
     pub classes: FxHashMap<LocalItemId<ClassMarker>, Class>,

--- a/baml_language/crates/baml_compiler2_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/lib.rs
@@ -22,6 +22,7 @@ pub mod item_tree;
 pub mod loc;
 pub mod namespace;
 pub mod package;
+pub mod precompiled;
 pub mod scope;
 pub mod semantic_index;
 pub mod signature;
@@ -96,9 +97,21 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
 /// `scope_bindings`) provide Salsa early-cutoff via `Arc` equality.
 #[salsa::tracked(returns(ref), no_eq)]
 pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
+    let path = file.path(db);
+
+    // Fast path: a frozen stdlib file with precompiled AST. Skip lex/parse/lower
+    // and re-run only the builder (which re-interns `'db` handles in this DB), so
+    // the result is identical to the from-source path. Falls through to parsing
+    // when the cache is not installed.
+    if let Some(pc) = crate::precompiled::precompiled_builtin(&path.to_string_lossy()) {
+        return SemanticIndexBuilder::new(db, file)
+            .with_lowering_diagnostics(Vec::new())
+            .with_env_var_refs(pc.env_var_refs.clone())
+            .build(&pc.items, pc.file_range());
+    }
+
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
     let (items, lowering_diags, env_var_refs) =
         baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
 

--- a/baml_language/crates/baml_compiler2_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/lib.rs
@@ -99,15 +99,12 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
 pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let path = file.path(db);
 
-    // Fast path: a frozen stdlib file with precompiled AST. Skip lex/parse/lower
-    // and re-run only the builder (which re-interns `'db` handles in this DB), so
-    // the result is identical to the from-source path. Falls through to parsing
-    // when the cache is not installed.
+    // Fast path: a frozen stdlib file with a precompiled semantic index. Skip
+    // lex/parse/lower AND the builder; rehydrate the cached index, re-interning
+    // the `'db`-bound fields in this DB, so the result is identical to the
+    // from-source path. Falls through to building when the cache is not installed.
     if let Some(pc) = crate::precompiled::precompiled_builtin(&path.to_string_lossy()) {
-        return SemanticIndexBuilder::new(db, file)
-            .with_lowering_diagnostics(Vec::new())
-            .with_env_var_refs(pc.env_var_refs.clone())
-            .build(&pc.items, pc.file_range());
+        return pc.rehydrate(db, file);
     }
 
     let tree = baml_compiler_parser::syntax_tree(db, file);

--- a/baml_language/crates/baml_compiler2_hir/src/precompiled.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/precompiled.rs
@@ -1,0 +1,53 @@
+//! Precompiled per-file AST cache for the frozen stdlib.
+//!
+//! `file_semantic_index` lexes, parses, and AST-lowers a file before running the
+//! (cheaper) `SemanticIndexBuilder`. The stdlib is frozen per compiler version,
+//! so that lex/parse/lower output is deterministic. This module lets a consumer
+//! embed it (built once by `baml_builtins2_prebuilt`) and install it, so
+//! `file_semantic_index` skips straight to the builder for `<builtin>/` files.
+//!
+//! The builder re-interns all `'db`-bound handles (scope ids, symbol
+//! contributions) in the runtime database, so the resulting `FileSemanticIndex`
+//! is identical to the from-source one — only the lex/parse/lower work is saved.
+//!
+//! The cache is optional: when unset (e.g. tests, LSP), `file_semantic_index`
+//! falls back to parsing from source, so behavior is unchanged.
+
+use std::{collections::HashMap, sync::OnceLock};
+
+use baml_compiler2_ast::{EnvVarRef, Item};
+use text_size::TextRange;
+
+/// Pre-lowered AST for one stdlib file: the `(items, env_var_refs)` output of
+/// `baml_compiler2_ast::lower_file_with_path` plus the file's text range.
+///
+/// Lowering diagnostics are omitted: the frozen, error-free stdlib produces
+/// none (asserted at artifact-build time), so the builder is fed an empty set,
+/// matching the from-source path.
+#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
+pub struct PrecompiledFile {
+    pub items: Vec<Item>,
+    pub env_var_refs: Vec<EnvVarRef>,
+    pub range_start: u32,
+    pub range_end: u32,
+}
+
+impl PrecompiledFile {
+    pub fn file_range(&self) -> TextRange {
+        TextRange::new(self.range_start.into(), self.range_end.into())
+    }
+}
+
+static PRECOMPILED_BUILTINS: OnceLock<HashMap<String, PrecompiledFile>> = OnceLock::new();
+
+/// Install the precompiled stdlib AST cache (first writer wins; subsequent calls
+/// are ignored). Keyed by builtin virtual path (e.g. `<builtin>/baml/string.baml`).
+pub fn set_precompiled_builtins(map: HashMap<String, PrecompiledFile>) {
+    let _ = PRECOMPILED_BUILTINS.set(map);
+}
+
+/// Precompiled AST for a builtin file by virtual path, if the cache is installed
+/// and contains it.
+pub fn precompiled_builtin(path: &str) -> Option<&'static PrecompiledFile> {
+    PRECOMPILED_BUILTINS.get()?.get(path)
+}

--- a/baml_language/crates/baml_compiler2_hir/src/precompiled.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/precompiled.rs
@@ -1,53 +1,223 @@
-//! Precompiled per-file AST cache for the frozen stdlib.
+//! Precompiled per-file `FileSemanticIndex` cache for the frozen stdlib.
 //!
-//! `file_semantic_index` lexes, parses, and AST-lowers a file before running the
-//! (cheaper) `SemanticIndexBuilder`. The stdlib is frozen per compiler version,
-//! so that lex/parse/lower output is deterministic. This module lets a consumer
-//! embed it (built once by `baml_builtins2_prebuilt`) and install it, so
-//! `file_semantic_index` skips straight to the builder for `<builtin>/` files.
+//! Building a file's `FileSemanticIndex` runs the lexer, parser, AST lowering,
+//! and the semantic-index builder. The stdlib is frozen per compiler version, so
+//! that output is deterministic. This module lets a consumer embed it (built once
+//! by `baml_builtins2_prebuilt`) and install it, so `file_semantic_index` skips
+//! all of that for `<builtin>/` files and just rehydrates the cached index.
 //!
-//! The builder re-interns all `'db`-bound handles (scope ids, symbol
-//! contributions) in the runtime database, so the resulting `FileSemanticIndex`
-//! is identical to the from-source one — only the lex/parse/lower work is saved.
+//! The index is stored in a borsh-friendly plain form ([`PrecompiledFile`]): all
+//! arena indices are `u32`, and the two `'db`-bound fields are reconstructed on
+//! load against the runtime database -- `scope_ids` by re-interning each
+//! `FileScopeId`, and `symbol_contributions` by rebuilding each `Definition`
+//! loc-handle via `XxxLoc::new(db, file, id)`. The result is identical to the
+//! from-source `FileSemanticIndex`.
 //!
-//! The cache is optional: when unset (e.g. tests, LSP), `file_semantic_index`
-//! falls back to parsing from source, so behavior is unchanged.
+//! The cache is optional: when unset (tests, LSP), `file_semantic_index` builds
+//! from source as before, so behavior is unchanged.
 
-use std::{collections::HashMap, sync::OnceLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
 
-use baml_compiler2_ast::{EnvVarRef, Item};
+use baml_base::{Name, SourceFile};
+use baml_compiler2_ast::{EnvVarRef, ExprId};
+use la_arena::{Idx, RawIdx};
 use text_size::TextRange;
 
-/// Pre-lowered AST for one stdlib file: the `(items, env_var_refs)` output of
-/// `baml_compiler2_ast::lower_file_with_path` plus the file's text range.
-///
-/// Lowering diagnostics are omitted: the frozen, error-free stdlib produces
-/// none (asserted at artifact-build time), so the builder is fed an empty set,
-/// matching the from-source path.
+use crate::{
+    Db,
+    contributions::{Contribution, Definition, DefinitionKind, FileSymbolContributions},
+    item_tree::{ItemTree, ItemTreeSourceMap},
+    loc::{
+        ClassLoc, ClientLoc, EnumLoc, FunctionLoc, InterfaceLoc, LetLoc, RetryPolicyLoc,
+        TemplateStringLoc, TestLoc, TypeAliasLoc,
+    },
+    scope::{FileScopeId, Scope, ScopeId},
+    semantic_index::{FileSemanticIndex, PathResolution, ScopeBindings},
+};
+
+fn expr_id_to_u32(id: ExprId) -> u32 {
+    id.into_raw().into_u32()
+}
+
+fn expr_id_from_u32(raw: u32) -> ExprId {
+    Idx::from_raw(RawIdx::from_u32(raw))
+}
+
+/// A namespace-level `Definition`, flattened to `(kind, packed LocalItemId)`.
+/// `symbol_contributions` only ever holds the ten namespace-level definition
+/// kinds, so reconstruction covers exactly those.
+#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
+struct PlainContribution {
+    name: Name,
+    span_start: u32,
+    span_end: u32,
+    kind: DefinitionKind,
+    id: u32,
+}
+
+fn definition_to_plain(db: &dyn Db, def: Definition<'_>) -> (DefinitionKind, u32) {
+    let id = match def {
+        Definition::Class(l) => l.id(db).as_u32(),
+        Definition::Enum(l) => l.id(db).as_u32(),
+        Definition::Interface(l) => l.id(db).as_u32(),
+        Definition::TypeAlias(l) => l.id(db).as_u32(),
+        Definition::Function(l) => l.id(db).as_u32(),
+        Definition::TemplateString(l) => l.id(db).as_u32(),
+        Definition::Client(l) => l.id(db).as_u32(),
+        Definition::Test(l) => l.id(db).as_u32(),
+        Definition::RetryPolicy(l) => l.id(db).as_u32(),
+        Definition::Let(l) => l.id(db).as_u32(),
+    };
+    (def.kind(), id)
+}
+
+fn plain_to_definition(
+    db: &dyn Db,
+    file: SourceFile,
+    kind: DefinitionKind,
+    id: u32,
+) -> Definition<'_> {
+    use crate::ids::LocalItemId;
+    match kind {
+        DefinitionKind::Class => {
+            Definition::Class(ClassLoc::new(db, file, LocalItemId::from_u32(id)))
+        }
+        DefinitionKind::Enum => Definition::Enum(EnumLoc::new(db, file, LocalItemId::from_u32(id))),
+        DefinitionKind::Interface => {
+            Definition::Interface(InterfaceLoc::new(db, file, LocalItemId::from_u32(id)))
+        }
+        DefinitionKind::TypeAlias => {
+            Definition::TypeAlias(TypeAliasLoc::new(db, file, LocalItemId::from_u32(id)))
+        }
+        DefinitionKind::Function => {
+            Definition::Function(FunctionLoc::new(db, file, LocalItemId::from_u32(id)))
+        }
+        DefinitionKind::TemplateString => {
+            Definition::TemplateString(TemplateStringLoc::new(db, file, LocalItemId::from_u32(id)))
+        }
+        DefinitionKind::Client => {
+            Definition::Client(ClientLoc::new(db, file, LocalItemId::from_u32(id)))
+        }
+        DefinitionKind::Test => Definition::Test(TestLoc::new(db, file, LocalItemId::from_u32(id))),
+        DefinitionKind::RetryPolicy => {
+            Definition::RetryPolicy(RetryPolicyLoc::new(db, file, LocalItemId::from_u32(id)))
+        }
+        DefinitionKind::Let => Definition::Let(LetLoc::new(db, file, LocalItemId::from_u32(id))),
+        other => panic!("symbol_contributions held a non-namespace definition kind: {other:?}"),
+    }
+}
+
+/// A borsh-friendly snapshot of one file's `FileSemanticIndex`, with arena
+/// indices flattened to `u32` and the `'db` fields dropped (reconstructed on
+/// load). `item_tree_source_map` is omitted (rehydrated empty): its name-span
+/// side-tables only refine diagnostics, never consulted for the frozen stdlib.
 #[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct PrecompiledFile {
-    pub items: Vec<Item>,
-    pub env_var_refs: Vec<EnvVarRef>,
-    pub range_start: u32,
-    pub range_end: u32,
+    scopes: Vec<Scope>,
+    expr_scopes: Vec<(u32, FileScopeId)>,
+    scope_bindings: Vec<ScopeBindings>,
+    item_tree: ItemTree,
+    contributions_types: Vec<PlainContribution>,
+    contributions_values: Vec<PlainContribution>,
+    path_resolutions: Vec<(u32, PathResolution)>,
+    env_var_refs: Vec<EnvVarRef>,
 }
 
 impl PrecompiledFile {
-    pub fn file_range(&self) -> TextRange {
-        TextRange::new(self.range_start.into(), self.range_end.into())
+    /// Snapshot a freshly-built `FileSemanticIndex` (build-time only).
+    pub fn from_index(db: &dyn Db, index: &FileSemanticIndex<'_>) -> Self {
+        let conv = |list: &[(Name, Contribution<'_>)]| -> Vec<PlainContribution> {
+            list.iter()
+                .map(|(name, c)| {
+                    let (kind, id) = definition_to_plain(db, c.definition);
+                    PlainContribution {
+                        name: name.clone(),
+                        span_start: c.name_span.start().into(),
+                        span_end: c.name_span.end().into(),
+                        kind,
+                        id,
+                    }
+                })
+                .collect()
+        };
+        Self {
+            scopes: index.scopes.clone(),
+            expr_scopes: index
+                .expr_scopes
+                .iter()
+                .map(|(e, s)| (expr_id_to_u32(*e), *s))
+                .collect(),
+            scope_bindings: index.scope_bindings.clone(),
+            item_tree: (*index.item_tree).clone(),
+            contributions_types: conv(&index.symbol_contributions.types),
+            contributions_values: conv(&index.symbol_contributions.values),
+            path_resolutions: index
+                .path_resolutions
+                .iter()
+                .map(|(e, r)| (expr_id_to_u32(*e), r.clone()))
+                .collect(),
+            env_var_refs: index.env_var_refs.clone(),
+        }
+    }
+
+    /// Rebuild a `FileSemanticIndex` against the runtime `db`/`file`,
+    /// reconstructing the two `'db`-bound fields. Identical to from-source.
+    pub fn rehydrate<'db>(&self, db: &'db dyn Db, file: SourceFile) -> FileSemanticIndex<'db> {
+        #[allow(clippy::cast_possible_truncation)]
+        let scope_ids: Vec<ScopeId<'db>> = (0..self.scopes.len())
+            .map(|i| ScopeId::new(db, file, FileScopeId::new(i as u32)))
+            .collect();
+        let rebuild = |list: &[PlainContribution]| -> Vec<(Name, Contribution<'db>)> {
+            list.iter()
+                .map(|pc| {
+                    (
+                        pc.name.clone(),
+                        Contribution {
+                            name_span: TextRange::new(pc.span_start.into(), pc.span_end.into()),
+                            definition: plain_to_definition(db, file, pc.kind, pc.id),
+                        },
+                    )
+                })
+                .collect()
+        };
+        FileSemanticIndex {
+            scopes: self.scopes.clone(),
+            expr_scopes: self
+                .expr_scopes
+                .iter()
+                .map(|(u, s)| (expr_id_from_u32(*u), *s))
+                .collect(),
+            scope_bindings: self.scope_bindings.clone(),
+            scope_ids,
+            item_tree: Arc::new(self.item_tree.clone()),
+            item_tree_source_map: Arc::new(ItemTreeSourceMap::default()),
+            symbol_contributions: Arc::new(FileSymbolContributions {
+                types: rebuild(&self.contributions_types),
+                values: rebuild(&self.contributions_values),
+            }),
+            extra: None,
+            path_resolutions: self
+                .path_resolutions
+                .iter()
+                .map(|(u, r)| (expr_id_from_u32(*u), r.clone()))
+                .collect(),
+            env_var_refs: self.env_var_refs.clone(),
+        }
     }
 }
 
 static PRECOMPILED_BUILTINS: OnceLock<HashMap<String, PrecompiledFile>> = OnceLock::new();
 
-/// Install the precompiled stdlib AST cache (first writer wins; subsequent calls
-/// are ignored). Keyed by builtin virtual path (e.g. `<builtin>/baml/string.baml`).
+/// Install the precompiled stdlib semantic-index cache (first writer wins).
+/// Keyed by builtin virtual path (e.g. `<builtin>/baml/string.baml`).
 pub fn set_precompiled_builtins(map: HashMap<String, PrecompiledFile>) {
     let _ = PRECOMPILED_BUILTINS.set(map);
 }
 
-/// Precompiled AST for a builtin file by virtual path, if the cache is installed
-/// and contains it.
+/// Precompiled index for a builtin file by virtual path, if installed.
 pub fn precompiled_builtin(path: &str) -> Option<&'static PrecompiledFile> {
     PRECOMPILED_BUILTINS.get()?.get(path)
 }

--- a/baml_language/crates/baml_compiler2_hir/src/scope.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/scope.rs
@@ -11,7 +11,18 @@ use text_size::TextRange;
 
 /// Dense sequential index into the per-file scope arena.
 /// `FileScopeId(0)` is always the Project scope (outermost).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+)]
 pub struct FileScopeId(u32);
 
 impl FileScopeId {
@@ -48,7 +59,7 @@ pub struct ScopeId<'db> {
 }
 
 /// What kind of scope this is in the hierarchy.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum ScopeKind {
     /// The compilation unit — collects all packages.
     Project,
@@ -83,7 +94,7 @@ pub enum ScopeKind {
 }
 
 /// A single scope node in the per-file scope tree.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Scope {
     /// Parent scope. `None` only for the Project root scope.
     pub parent: Option<FileScopeId>,
@@ -94,9 +105,17 @@ pub struct Scope {
     /// Source range of this scope. Used by `scope_at_offset()` to find the
     /// innermost scope containing a cursor position. Structural scopes
     /// (Project, Package, Namespace) use the file's full range.
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub range: TextRange,
     /// Contiguous range of descendant scope IDs (DFS pre-order).
     /// All scopes in `descendants` are proper descendants of this scope.
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_range"
+    )]
     pub descendants: Range<FileScopeId>,
     /// True for the synthetic `ScopeKind::Lambda` scope a tagged template's
     /// body is walked in (BEP-049 `walk_template_lambda_body`). Unlike a real

--- a/baml_language/crates/baml_compiler2_hir/src/semantic_index.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/semantic_index.rs
@@ -23,7 +23,7 @@ use text_size::{TextRange, TextSize};
 /// that are not available during HIR building (would create a circular
 /// dependency: `file_semantic_index` → `package_items` → `file_semantic_index`).
 /// Full resolution (namespace vs package-item vs unknown) is done in TIR.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum PathResolution {
     /// Root segment is a local variable, parameter, or capture in the current scope.
     /// Segments[1..] are field/method accesses on the local, resolved by TIR type
@@ -44,19 +44,44 @@ use crate::{
 // ── DefinitionSite ───────────────────────────────────────────────────────────
 
 /// Where a local variable was defined (for go-to-definition).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, borsh::BorshSerialize, borsh::BorshDeserialize,
+)]
 pub enum DefinitionSite {
     /// Defined in a let statement.
-    Statement(StmtId),
+    Statement(
+        #[borsh(
+            serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_idx",
+            deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_idx"
+        )]
+        StmtId,
+    ),
     /// Defined as a function parameter (with its index).
     Parameter(usize),
     /// Defined by a pattern binding (match arm, catch arm, catch clause, etc.).
-    PatternBinding(PatId),
+    PatternBinding(
+        #[borsh(
+            serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_idx",
+            deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_idx"
+        )]
+        PatId,
+    ),
 }
 
 // ── BindingId ────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+)]
 pub enum BindingKind {
     /// A local binding row in `scope_bindings[scope].bindings`.
     Local(u32),
@@ -64,7 +89,18 @@ pub enum BindingKind {
     Parameter(usize),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+)]
 pub struct BindingId {
     pub scope: FileScopeId,
     pub kind: BindingKind,
@@ -97,12 +133,24 @@ impl BindingId {
 
 // ── ScopeBindings ────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct LocalBinding {
     pub name: Name,
     pub site: DefinitionSite,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_idx",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_idx"
+    )]
     pub pattern: PatId,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_range",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_range"
+    )]
     pub name_range: TextRange,
+    #[borsh(
+        serialize_with = "baml_compiler2_ast::borsh_helpers::serialize_text_size",
+        deserialize_with = "baml_compiler2_ast::borsh_helpers::deserialize_text_size"
+    )]
     pub visible_from: TextSize,
 }
 
@@ -111,7 +159,7 @@ pub struct LocalBinding {
 /// Lightweight version of Ty's `PlaceTable` + `UseDefMap`. BAML's simpler
 /// scoping (no reassignment, no conditional definitions) means a flat list
 /// suffices — no flow-sensitive bitsets needed.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ScopeBindings {
     /// Let-bindings in this scope, in source order.
     pub bindings: Vec<LocalBinding>,

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -2521,16 +2521,31 @@ impl<'db> LoweringContext<'db> {
         }
     }
 
-    /// Build `class_type_tags` by iterating `compiler2_all_files` in the same order as the
+    /// Build `class_type_tags` by iterating files in the same order as the
     /// emitter (`generate_project_bytecode` in `baml_compiler2_emit`). This guarantees that
     /// the integer type tags stored in Switch arms exactly match the `class.type_tag` values
     /// assigned to runtime Class objects.
+    ///
+    /// The emitter processes stdlib (`<builtin>/`) files as a contiguous block
+    /// before user files (so stdlib type tags form a stable prefix); this
+    /// iteration must use the identical builtins-first order or type-tag Switch
+    /// arms desync from runtime `class.type_tag`, making type switches miss and
+    /// throw `Unreachable`.
     fn build_class_type_tags(db: &'db dyn crate::Db) -> IndexMap<TypeName, i64> {
         let all_files = compiler2_all_files(db);
+        let (stdlib_files, user_files): (Vec<_>, Vec<_>) = all_files
+            .iter()
+            .copied()
+            .partition(|f| f.path(db).to_string_lossy().starts_with("<builtin>/"));
+        let ordered_files: Vec<_> = stdlib_files
+            .iter()
+            .chain(user_files.iter())
+            .copied()
+            .collect();
         let mut class_type_tags: IndexMap<TypeName, i64> = IndexMap::new();
         let mut class_type_tag_counter = 0i64;
 
-        for file in &all_files {
+        for file in &ordered_files {
             let item_tree = file_item_tree(db, *file);
             let pkg_info = file_package(db, *file);
 

--- a/baml_language/crates/baml_compiler2_tir/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_tir/Cargo.toml
@@ -13,6 +13,7 @@ baml_compiler2_hir = { workspace = true }
 baml_compiler2_ppir = { workspace = true }
 baml_type = { workspace = true }
 baml_workspace = { workspace = true }
+borsh = { workspace = true }
 indexmap = { workspace = true }
 num-bigint = { workspace = true }
 rustc-hash = { workspace = true }

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
@@ -53,7 +53,7 @@ struct InterfaceTypeAssocLowering<'a, 'db> {
 /// This is intentionally small: semantic matching only needs the rule's TIR
 /// types, while MIR can still recover methods from HIR by looking at the
 /// original class or out-of-body `implements for` block.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum InterfaceImplOrigin {
     InBodyClass { class_qtn: QualifiedTypeName },
     OutOfBody,
@@ -67,7 +67,7 @@ pub enum InterfaceImplOrigin {
 /// - `for_ty_pattern`: the implementor pattern, e.g. `Box<T>` or `T`.
 /// - `interface_ty`: the implemented interface, e.g. `Printable` or
 ///   `Container<T>`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct InterfaceImplRule {
     pub generic_params: Vec<Name>,
     pub generic_param_bounds: Vec<Option<Ty>>,
@@ -79,7 +79,7 @@ pub struct InterfaceImplRule {
     pub source_span: Option<Span>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct InterfaceImplInstantiation {
     pub bindings: TypeBindings,
     pub for_ty: Ty,
@@ -88,7 +88,7 @@ pub struct InterfaceImplInstantiation {
 
 /// Compatibility view for old callers while rule-based matching is being
 /// plumbed through the compiler.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct BlanketClassImpl {
     pub class_qtn: QualifiedTypeName,
     pub generic_params: Vec<Name>,
@@ -98,7 +98,7 @@ pub struct BlanketClassImpl {
     pub for_target_ty: Ty,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct InterfaceImplRuleIndex {
     /// Interface QTN -> all rules that can possibly satisfy that interface.
     pub by_interface: FxHashMap<QualifiedTypeName, Vec<usize>>,
@@ -157,7 +157,7 @@ impl InterfaceImplRuleIndex {
 }
 
 /// For every class in a package, the set of interfaces it implements directly.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ImplementsRegistry {
     /// Canonical implementation rules. New interface semantics should be
     /// expressed in terms of these rules rather than the compatibility maps
@@ -1259,6 +1259,17 @@ pub fn package_implements_registry<'db>(
     db: &'db dyn crate::Db,
     pkg_id: PackageId<'db>,
 ) -> ImplementsRegistry {
+    // Fast path: a frozen stdlib package's interface-implementation rules,
+    // resolved once at artifact-build time. `ImplementsRegistry` is pure data
+    // (Ty + names), so the cached value is returned directly. This is a second
+    // cold cost (after `package_interface`) pulled by inference over the stdlib
+    // type graph. Falls through to resolution when the cache is not installed.
+    if let Some(reg) =
+        crate::precompiled_tir::precompiled_implements_registry(pkg_id.name(db).as_str())
+    {
+        return reg.clone();
+    }
+
     let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
     let mut interface_impl_rules: Vec<InterfaceImplRule> = Vec::new();
     let mut all_class_qtns: Vec<QualifiedTypeName> = Vec::new();

--- a/baml_language/crates/baml_compiler2_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lib.rs
@@ -39,6 +39,7 @@ pub mod narrowing;
 pub mod normalize;
 pub mod package_interface;
 pub mod pattern_lowering;
+pub mod precompiled_tir;
 pub mod resolve;
 pub mod throw_inference;
 pub mod throws_analysis;

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -28,7 +28,7 @@ use crate::{
 
 /// Fully-resolved typed interface for a package.
 /// Consumers never touch dependency `ItemTree` or raw `TypeExpr`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct PackageInterface {
     /// All exported types: namespace path -> name -> `ExportedType`
     pub types: FxHashMap<Vec<Name>, FxHashMap<Name, ExportedType>>,
@@ -39,7 +39,7 @@ pub struct PackageInterface {
 }
 
 /// A type exported from a package.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub enum ExportedType {
     Class {
         qtn: QualifiedTypeName,
@@ -58,7 +58,7 @@ pub enum ExportedType {
 }
 
 /// A function exported from a package (free function or method).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ExportedFunction {
     pub name: Name,
     pub params: Vec<FunctionParamTy>,
@@ -303,6 +303,18 @@ fn lower_class_method_signature<'db>(
 
 #[salsa::tracked(returns(ref))]
 pub fn package_interface<'db>(db: &'db dyn crate::Db, pkg_id: PackageId<'db>) -> PackageInterface {
+    // Fast path: a frozen stdlib package with a precompiled interface. Its
+    // signatures are resolved once at artifact-build time; `PackageInterface` is
+    // pure data, so the cached value is returned directly (no reconstruction).
+    // This is the dominant cost of the first user-file type-check, which pulls in
+    // the stdlib type graph through this query. Falls through to resolution when
+    // the cache is not installed (tests, LSP) or for the user's own package.
+    if let Some(pi) =
+        crate::precompiled_tir::precompiled_package_interface(pkg_id.name(db).as_str())
+    {
+        return pi.clone();
+    }
+
     let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
 
     let mut types: FxHashMap<Vec<Name>, FxHashMap<Name, ExportedType>> = FxHashMap::default();

--- a/baml_language/crates/baml_compiler2_tir/src/precompiled_tir.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/precompiled_tir.rs
@@ -1,0 +1,46 @@
+//! Precompiled per-package `PackageInterface` cache for the frozen stdlib.
+//!
+//! Resolving a package's `PackageInterface` (all class fields, enum variants,
+//! type aliases, function signatures, throw sets) is the dominant cost of the
+//! first `baml check`: a trivial user file lazily pulls in the whole stdlib type
+//! graph through `package_interface(<stdlib pkg>)`. The stdlib is frozen per
+//! compiler version, so that interface is deterministic.
+//!
+//! `PackageInterface` is pure data (`Ty` + names; no `'db` lifetime, no salsa
+//! handles), so it serializes with borsh and needs *no* reconstruction on load
+//! -- unlike the HIR caches, the cached value is returned directly. This module
+//! lets a consumer embed it (built once by `baml_builtins2_prebuilt`) and
+//! install it, so `package_interface` short-circuits for stdlib packages.
+//!
+//! The cache is optional: when unset (tests, LSP), `package_interface` resolves
+//! from source as before, so behavior is unchanged.
+
+use std::{collections::HashMap, sync::OnceLock};
+
+use crate::{interfaces::ImplementsRegistry, package_interface::PackageInterface};
+
+static PRECOMPILED: OnceLock<HashMap<String, PackageInterface>> = OnceLock::new();
+static PRECOMPILED_IMPLEMENTS: OnceLock<HashMap<String, ImplementsRegistry>> = OnceLock::new();
+
+/// Install the precompiled stdlib `PackageInterface` cache (first writer wins).
+/// Keyed by package name (e.g. `baml`, `log`, `reflect`, `testing`, `assert`).
+pub fn set_precompiled_package_interfaces(map: HashMap<String, PackageInterface>) {
+    let _ = PRECOMPILED.set(map);
+}
+
+/// The precompiled interface for a stdlib package by name, if installed.
+pub fn precompiled_package_interface(name: &str) -> Option<&'static PackageInterface> {
+    PRECOMPILED.get()?.get(name)
+}
+
+/// Install the precompiled stdlib `ImplementsRegistry` cache (first writer wins).
+/// Keyed by package name. Resolving interface-implementation rules over the
+/// stdlib is a second cold cost pulled by inference; this skips it.
+pub fn set_precompiled_implements_registries(map: HashMap<String, ImplementsRegistry>) {
+    let _ = PRECOMPILED_IMPLEMENTS.set(map);
+}
+
+/// The precompiled implements registry for a stdlib package by name, if installed.
+pub fn precompiled_implements_registry(name: &str) -> Option<&'static ImplementsRegistry> {
+    PRECOMPILED_IMPLEMENTS.get()?.get(name)
+}

--- a/baml_language/crates/baml_compiler2_tir/src/throw_inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throw_inference.rs
@@ -22,7 +22,7 @@ use crate::{
 /// A throw fact is now a proper `Ty` — no more lossy string round-trips.
 pub type ThrowFact = Ty;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct FunctionThrowSets {
     pub direct: BTreeMap<Name, BTreeSet<ThrowFact>>,
     pub transitive: BTreeMap<Name, BTreeSet<ThrowFact>>,

--- a/baml_language/crates/baml_db/Cargo.toml
+++ b/baml_language/crates/baml_db/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 baml_base = { workspace = true }
+baml_compiler2_ast = { workspace = true }
 baml_compiler2_emit = { workspace = true }
 baml_compiler2_hir = { workspace = true }
 baml_compiler2_mir = { workspace = true }

--- a/baml_language/crates/baml_db/src/lib.rs
+++ b/baml_language/crates/baml_db/src/lib.rs
@@ -15,6 +15,7 @@ pub use baml_compiler_diagnostics;
 pub use baml_compiler_lexer;
 pub use baml_compiler_parser;
 pub use baml_compiler_syntax;
+pub use baml_compiler2_ast;
 pub use baml_compiler2_emit;
 pub use baml_compiler2_hir;
 pub use baml_compiler2_mir;

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -61,6 +61,15 @@ pub fn collect_compiler2_diagnostics(db: &ProjectDatabase) -> Vec<Diagnostic> {
     let source_files = baml_compiler2_hir::compiler2_all_files(db);
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     for file in &source_files {
+        // Skip per-file diagnostics for the frozen stdlib (`<builtin>/`). Its
+        // bodies are validated when the precompiled artifact is built (it must
+        // lower + emit cleanly), so re-running TIR body inference + lints over
+        // them on every user compile is wasted work -- user typechecking needs
+        // the stdlib's declared signatures, not its body diagnostics. This is the
+        // dominant stdlib cost in `check` (the parse/build is comparatively cheap).
+        if file.path(db).to_string_lossy().starts_with("<builtin>/") {
+            continue;
+        }
         diagnostics.extend(lsp2_check_file(db, *file));
     }
 

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -396,26 +396,20 @@ impl ProjectDatabase {
         })
     }
 
-    /// Get the compiled bytecode for the project using the compiler2 pipeline.
-    pub fn get_bytecode(
-        &self,
-    ) -> Result<bex_vm_types::Program, baml_compiler2_emit::LoweringError> {
-        // Bytecode generation lowers types through the runtime-conversion
-        // boundary (`ResolvedAliases::convert`), which deliberately panics on
-        // inference-only `Unknown`/`Error` types. Those are legitimate
-        // error-recovery types in a program that does not type-check, so do not
-        // attempt codegen on an error-bearing project: surface the failure as a
-        // recoverable `LoweringError`. The diagnostics themselves are reported
-        // through the normal check path. (CLI commands gate before calling
-        // `generate_project_bytecode` directly; this protects the in-process /
-        // runtime-eval callers that go through `get_bytecode`.) The error filter
-        // matches `testing::assert_no_diagnostic_errors` — user-file errors only.
+    /// Count user-file (non-builtin) compiler2 errors. Bytecode generation
+    /// lowers types through the runtime-conversion boundary
+    /// (`ResolvedAliases::convert`), which deliberately panics on inference-only
+    /// `Unknown`/`Error` types. Those are legitimate error-recovery types in a
+    /// program that does not type-check, so callers must not attempt codegen on
+    /// an error-bearing project. The filter matches
+    /// `testing::assert_no_diagnostic_errors` — user-file errors only.
+    fn compiler2_user_error_count(&self) -> usize {
         let user_file_ids: std::collections::HashSet<_> = self
             .get_source_files()
             .iter()
             .map(|f| f.file_id(self))
             .collect();
-        let error_count = crate::check::collect_compiler2_diagnostics(self)
+        crate::check::collect_compiler2_diagnostics(self)
             .iter()
             .filter(|d| matches!(d.severity, baml_compiler_diagnostics::Severity::Error))
             .filter(|d| {
@@ -423,7 +417,17 @@ impl ProjectDatabase {
                     .map(|span| user_file_ids.contains(&span.file_id))
                     .unwrap_or(false)
             })
-            .count();
+            .count()
+    }
+
+    /// Get the compiled bytecode for the project using the compiler2 pipeline.
+    ///
+    /// Surfaces an error-bearing project as a recoverable `LoweringError` rather
+    /// than attempting codegen (see [`Self::compiler2_user_error_count`]).
+    pub fn get_bytecode(
+        &self,
+    ) -> Result<bex_vm_types::Program, baml_compiler2_emit::LoweringError> {
+        let error_count = self.compiler2_user_error_count();
         if error_count > 0 {
             return Err(baml_compiler2_emit::LoweringError::ProjectHasErrors { error_count });
         }
@@ -431,6 +435,30 @@ impl ProjectDatabase {
             emit_test_cases: false,
         };
         baml_compiler2_emit::generate_project_bytecode(self, &opts)
+    }
+
+    /// Like [`Self::get_bytecode`] but resumes from a precompiled stdlib
+    /// [`baml_compiler2_emit::EmitState`] prefix (built at `OptLevel::Two`,
+    /// matching `generate_project_bytecode`'s default), skipping recompilation of
+    /// the stdlib. Callers (CLI/LSP) obtain the prefix from `baml_builtins2_prebuilt`
+    /// and inject it here — `baml_project` does not depend on that crate.
+    pub fn get_bytecode_with_prefix(
+        &self,
+        prefix: baml_compiler2_emit::EmitState,
+    ) -> Result<bex_vm_types::Program, baml_compiler2_emit::LoweringError> {
+        let error_count = self.compiler2_user_error_count();
+        if error_count > 0 {
+            return Err(baml_compiler2_emit::LoweringError::ProjectHasErrors { error_count });
+        }
+        let opts = baml_compiler2_emit::CompileOptions {
+            emit_test_cases: false,
+        };
+        baml_compiler2_emit::generate_project_bytecode_with_prefix(
+            self,
+            &opts,
+            baml_compiler2_emit::OptLevel::Two,
+            prefix,
+        )
     }
 
     /// Build a control flow graph for the given function using the compiler2 AST builder.

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -3,7 +3,7 @@ source: crates/baml_tests/tests/bytecode_format/main.rs
 ---
 function assert.contains(haystack: string, needle: string) -> null {
   51   0   load_var2 1 2          
-       1   call 181 ntypeargs=0   (baml.String.includes)
+       1   call 175 ntypeargs=0   (baml.String.includes)
        2   unary_op !             
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
@@ -13,13 +13,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   51   6   jump +3                (to 9)
 
   52   7   load_const 1           ("assertion failed: string does not contain expected substring")
-       8   call 284 ntypeargs=0   (baml.sys.panic)
+       8   call 278 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   37   0    load_var2 1 2          
-       1    call 790 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 784 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -29,11 +29,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   37   6    jump +15               (to 21)
 
   40   7    load_var 1             (actual)
-       8    call 841 ntypeargs=0   (assert.format_operand)
+       8    call 835 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   42   10   load_var 2             (expected)
-       11   call 841 ntypeargs=0   (assert.format_operand)
+       11   call 835 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   40   13   load_const 1           ("assertion failed: left = ")
@@ -43,13 +43,13 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 284 ntypeargs=0   (baml.sys.panic)
+       20   call 278 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
 function assert.format_operand(value: unknown) -> string {
   32   0   load_var 1             (value)
-       1   call 155 ntypeargs=0   (baml.String.from)
+       1   call 149 ntypeargs=0   (baml.String.from)
        2   return                 
 }
 
@@ -64,14 +64,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 284 ntypeargs=0   (baml.sys.panic)
+      7   call 278 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 790 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 784 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -80,7 +80,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 284 ntypeargs=0   (baml.sys.panic)
+       8   call 278 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -91,25 +91,25 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1524 0   
+  101   0   make_closure 1491 0   
         1   return                
 }
 
 function testing.NamedChildReport.from_json(j: baml.json.json) -> testing.NamedChildReport {
   40   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("report")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.NamedChildReport .name, .report)
        15   return                 
 }
@@ -131,11 +131,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 284 ntypeargs=0   (baml.sys.panic)
+       14   call 278 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1535 1    
+       17   make_closure 1502 1    
        18   return                 
 }
 
@@ -165,16 +165,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 284 ntypeargs=0   (baml.sys.panic)
+       22   call 278 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 284 ntypeargs=0   (baml.sys.panic)
+       26   call 278 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1549 2    
+       29   make_closure 1516 2    
        30   return                 
 }
 
@@ -189,60 +189,60 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 284 ntypeargs=0   (baml.sys.panic)
+       8    call 278 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1542 1    
+       11   make_closure 1509 1    
        12   return                 
 }
 
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
   7   0    load_var 1             (j)
       1    load_const 0           ("outcome")
-      2    call 377 ntypeargs=0   (baml.json.field)
+      2    call 371 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 372 ntypeargs=1   (baml.json.from_json)
+      6    call 366 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("duration_ms")
-      9    call 377 ntypeargs=0   (baml.json.field)
+      9    call 371 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 372 ntypeargs=1   (baml.json.from_json)
+      13   call 366 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("message")
-      16   call 377 ntypeargs=0   (baml.json.field)
+      16   call 371 ntypeargs=0   (baml.json.field)
       17   store_var 4            (_9)
       18   load_type 5            
       19   load_var 4             (_9)
-      20   call 372 ntypeargs=1   (baml.json.from_json)
+      20   call 366 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (testing.RunReport .outcome, .duration_ms, .message)
       22   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1528 0   
+  95   0   make_closure 1495 0   
        1   return                
 }
 
 function testing.SerializedTest.from_json(j: baml.json.json) -> testing.SerializedTest {
   75   0    load_var 1             (j)
        1    load_const 0           ("type")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("name")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 1            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.SerializedTest .type, .name)
        15   return                 
 }
@@ -250,25 +250,25 @@ function testing.SerializedTest.from_json(j: baml.json.json) -> testing.Serializ
 function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.SerializedTestSet {
   80   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("items")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loadingTimeMs")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
        22   return                 
 }
@@ -279,7 +279,7 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        2     store_var 3              (_3)
        3     load_type 0              
        4     load_var 3               (_3)
-       5     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 4              (_4)
        7     load_var 4               (_4)
        8     is_type 1                
@@ -323,16 +323,16 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        46    load_type 0              
        47    load_type 11             
        48    load_var 4               (_4)
-       49    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 5              (_6)
        51    jump +50                 (to 101)
        52    load_var 4               (_4)
-       53    make_bound_method 602    
+       53    make_bound_method 596    
        54    call_indirect            
        55    store_var 5              (_6)
        56    jump +45                 (to 101)
        57    load_var 4               (_4)
-       58    make_bound_method 613    
+       58    make_bound_method 607    
        59    call_indirect            
        60    store_var 5              (_6)
        61    jump +40                 (to 101)
@@ -340,39 +340,39 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        63    load_type 11             
        64    load_type 11             
        65    load_var 4               (_4)
-       66    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 5              (_6)
        68    jump +33                 (to 101)
        69    load_var 4               (_4)
-       70    make_bound_method 558    
+       70    make_bound_method 552    
        71    call_indirect            
        72    store_var 5              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 4               (_4)
-       76    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 5              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 4               (_4)
-       83    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 5              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 4               (_4)
-       89    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 5              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 4               (_4)
-       94    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 5              (_6)
        96    jump +5                  (to 101)
        97    load_var 4               (_4)
-       98    make_bound_method 588    
+       98    make_bound_method 582    
        99    call_indirect            
        100   store_var 5              (_6)
        101   load_var 5               (_6)
@@ -403,7 +403,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        2     store_var 3              (_3)
        3     load_type 0              
        4     load_var 3               (_3)
-       5     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 4              (_4)
        7     load_var 4               (_4)
        8     is_type 1                
@@ -447,16 +447,16 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        46    load_type 0              
        47    load_type 11             
        48    load_var 4               (_4)
-       49    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 5              (_6)
        51    jump +50                 (to 101)
        52    load_var 4               (_4)
-       53    make_bound_method 602    
+       53    make_bound_method 596    
        54    call_indirect            
        55    store_var 5              (_6)
        56    jump +45                 (to 101)
        57    load_var 4               (_4)
-       58    make_bound_method 613    
+       58    make_bound_method 607    
        59    call_indirect            
        60    store_var 5              (_6)
        61    jump +40                 (to 101)
@@ -464,39 +464,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        63    load_type 11             
        64    load_type 11             
        65    load_var 4               (_4)
-       66    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 5              (_6)
        68    jump +33                 (to 101)
        69    load_var 4               (_4)
-       70    make_bound_method 558    
+       70    make_bound_method 552    
        71    call_indirect            
        72    store_var 5              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 4               (_4)
-       76    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 5              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 4               (_4)
-       83    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 5              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 4               (_4)
-       89    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 5              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 4               (_4)
-       94    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 5              (_6)
        96    jump +5                  (to 101)
        97    load_var 4               (_4)
-       98    make_bound_method 588    
+       98    make_bound_method 582    
        99    call_indirect            
        100   store_var 5              (_6)
        101   load_var 5               (_6)
@@ -524,25 +524,25 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
   17   0    load_var 1             (j)
        1    load_const 0           ("prefix")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("tests")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("testsets")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        22   return                 
 }
@@ -586,7 +586,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        24    store_var 8              (_13)
        25    load_type 4              
        26    load_var 8               (_13)
-       27    call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 9              (_14)
        29    load_var 9               (_14)
        30    is_type 5                
@@ -630,16 +630,16 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        68    load_type 4              
        69    load_type 15             
        70    load_var 9               (_14)
-       71    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 10             (_16)
        73    jump +50                 (to 123)
        74    load_var 9               (_14)
-       75    make_bound_method 602    
+       75    make_bound_method 596    
        76    call_indirect            
        77    store_var 10             (_16)
        78    jump +45                 (to 123)
        79    load_var 9               (_14)
-       80    make_bound_method 613    
+       80    make_bound_method 607    
        81    call_indirect            
        82    store_var 10             (_16)
        83    jump +40                 (to 123)
@@ -647,39 +647,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        85    load_type 15             
        86    load_type 15             
        87    load_var 9               (_14)
-       88    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 10             (_16)
        90    jump +33                 (to 123)
        91    load_var 9               (_14)
-       92    make_bound_method 558    
+       92    make_bound_method 552    
        93    call_indirect            
        94    store_var 10             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 9               (_14)
-       98    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 10             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 9               (_14)
-       105   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 10             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 9               (_14)
-       111   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 10             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 9               (_14)
-       116   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 10             (_16)
        118   jump +5                  (to 123)
        119   load_var 9               (_14)
-       120   make_bound_method 588    
+       120   make_bound_method 582    
        121   call_indirect            
        122   store_var 10             (_16)
        123   load_var 10              (_16)
@@ -698,7 +698,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        135   load_var 11              (t)
        136   load_field 0             (name)
        137   load_var 7               (hash_prefix)
-       138   call 154 ntypeargs=0     (baml.String.starts_with)
+       138   call 148 ntypeargs=0     (baml.String.starts_with)
        139   pop_jump_if_false -110   (to 29)
        140   load_var 6               (count)
        141   load_const 17            (1)
@@ -722,7 +722,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        158   load_var 6               (count)
        159   load_const 17            (1)
        160   add_int                  
-       161   call 472 ntypeargs=1     (baml.unstable.string)
+       161   call 466 ntypeargs=1     (baml.unstable.string)
        162   store_var 14             (_57)
        163   load_var2 13 14          
        164   bin_op +                 
@@ -734,7 +734,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        169   load_var2 12 3           
        170   load_var 4               (runner)
        171   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       172   call 13 ntypeargs=1      (baml.Array.push)
+       172   call 7 ntypeargs=1       (baml.Array.push)
        173   pop 1                    
 
   26   174   load_const 20            (null)
@@ -773,7 +773,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        24    store_var 8              (_13)
        25    load_type 4              
        26    load_var 8               (_13)
-       27    call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 9              (_14)
        29    load_var 9               (_14)
        30    is_type 5                
@@ -817,16 +817,16 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        68    load_type 4              
        69    load_type 15             
        70    load_var 9               (_14)
-       71    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 10             (_16)
        73    jump +50                 (to 123)
        74    load_var 9               (_14)
-       75    make_bound_method 602    
+       75    make_bound_method 596    
        76    call_indirect            
        77    store_var 10             (_16)
        78    jump +45                 (to 123)
        79    load_var 9               (_14)
-       80    make_bound_method 613    
+       80    make_bound_method 607    
        81    call_indirect            
        82    store_var 10             (_16)
        83    jump +40                 (to 123)
@@ -834,39 +834,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        85    load_type 15             
        86    load_type 15             
        87    load_var 9               (_14)
-       88    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 10             (_16)
        90    jump +33                 (to 123)
        91    load_var 9               (_14)
-       92    make_bound_method 558    
+       92    make_bound_method 552    
        93    call_indirect            
        94    store_var 10             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 9               (_14)
-       98    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 10             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 9               (_14)
-       105   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 10             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 9               (_14)
-       111   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 10             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 9               (_14)
-       116   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 10             (_16)
        118   jump +5                  (to 123)
        119   load_var 9               (_14)
-       120   make_bound_method 588    
+       120   make_bound_method 582    
        121   call_indirect            
        122   store_var 10             (_16)
        123   load_var 10              (_16)
@@ -885,7 +885,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        135   load_var 11              (ts)
        136   load_field 0             (name)
        137   load_var 7               (hash_prefix)
-       138   call 154 ntypeargs=0     (baml.String.starts_with)
+       138   call 148 ntypeargs=0     (baml.String.starts_with)
        139   pop_jump_if_false -110   (to 29)
        140   load_var 6               (count)
        141   load_const 17            (1)
@@ -909,7 +909,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        158   load_var 6               (count)
        159   load_const 17            (1)
        160   add_int                  
-       161   call 472 ntypeargs=1     (baml.unstable.string)
+       161   call 466 ntypeargs=1     (baml.unstable.string)
        162   store_var 14             (_57)
        163   load_var2 13 14          
        164   bin_op +                 
@@ -921,7 +921,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        169   load_var2 12 3           
        170   load_var 4               (runner)
        171   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       172   call 13 ntypeargs=1      (baml.Array.push)
+       172   call 7 ntypeargs=1       (baml.Array.push)
        173   pop 1                    
 
   37   174   load_const 20            (null)
@@ -932,25 +932,25 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
 function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRegistration {
   5   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 377 ntypeargs=0   (baml.json.field)
+      2    call 371 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 372 ntypeargs=1   (baml.json.from_json)
+      6    call 366 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("body")
-      9    call 377 ntypeargs=0   (baml.json.field)
+      9    call 371 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 372 ntypeargs=1   (baml.json.from_json)
+      13   call 366 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("runner")
-      16   call 377 ntypeargs=0   (baml.json.field)
+      16   call 371 ntypeargs=0   (baml.json.field)
       17   store_var 4            (_9)
       18   load_type 5            
       19   load_var 4             (_9)
-      20   call 372 ntypeargs=1   (baml.json.from_json)
+      20   call 366 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (testing.TestRegistration .name, .body, .runner)
       22   return                 
 }
@@ -963,7 +963,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
 
   172   4     load_type 0              
         5     load_var 3               (_3)
-        6     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1007,16 +1007,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 602    
+        54    make_bound_method 596    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 613    
+        59    make_bound_method 607    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1024,39 +1024,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 558    
+        71    make_bound_method 552    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 588    
+        99    make_bound_method 582    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1072,23 +1072,23 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         111   pop_jump_if_false -103   (to 8)
 
   175   112   load_var2 1 6            
-        113   call 830 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        113   call 824 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
         114   pop 1                    
 
   176   115   load_var 1               (self)
-        116   call 816 ntypeargs=0     (testing.TestRegistry.serialize)
+        116   call 810 ntypeargs=0     (testing.TestRegistry.serialize)
         117   jump +123                (to 240)
 
   180   118   load_type 13             
         119   load_type 14             
         120   load_var 1               (self)
         121   load_field 1             (expansions)
-        122   call 15 ntypeargs=2      (baml.Map.keys)
+        122   call 9 ntypeargs=2       (baml.Map.keys)
         123   store_var 7              (_40)
 
   179   124   load_type 13             
         125   load_var 7               (_40)
-        126   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1132,16 +1132,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 602    
+        174   make_bound_method 596    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 613    
+        179   make_bound_method 607    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1149,39 +1149,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 558    
+        191   make_bound_method 552    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 588    
+        219   make_bound_method 582    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1200,11 +1200,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   182   233   load_var2 2 10           
         234   load_const 25            ("/")
         235   bin_op +                 
-        236   call 154 ntypeargs=0     (baml.String.starts_with)
+        236   call 148 ntypeargs=0     (baml.String.starts_with)
         237   pop_jump_if_false -109   (to 128)
 
   183   238   load_var2 11 2           
-        239   call 821 ntypeargs=0     (testing.TestRegistry.expand_set)
+        239   call 815 ntypeargs=0     (testing.TestRegistry.expand_set)
         240   return                   
 
   186   241   load_const 26            ("TestSet not found for expansion: ")
@@ -1221,14 +1221,14 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         3    load_field 1           (expansions)
         4    load_var 2             (ts)
         5    load_field 0           (name)
-        6    call 44 ntypeargs=2    (baml.Map.get)
+        6    call 38 ntypeargs=2    (baml.Map.get)
         7    store_var 3            (_3)
         8    load_var 3             (_3)
         9    is_type 2              
         10   pop_jump_if_false +2   (to 12)
         11   jump +32               (to 43)
 
-  193   12   call 281 ntypeargs=0   (baml.sys.now_ms)
+  193   12   call 275 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 4            (start)
 
   194   14   load_var 2             (ts)
@@ -1243,7 +1243,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         22   call_indirect          
         23   pop 1                  
 
-  196   24   call 281 ntypeargs=0   (baml.sys.now_ms)
+  196   24   call 275 ntypeargs=0   (baml.sys.now_ms)
         25   store_var 6            (_19)
 
   198   26   load_var 5             (sub_collector)
@@ -1262,7 +1262,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         36   load_var 2             (ts)
         37   load_field 0           (name)
         38   load_var 7             (sub_registry)
-        39   call 16 ntypeargs=2    (baml.Map.set)
+        39   call 10 ntypeargs=2    (baml.Map.set)
         40   pop 1                  
 
   203   41   load_var 7             (sub_registry)
@@ -1275,25 +1275,25 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
   90   0    load_var 1             (j)
        1    load_const 0           ("collector")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("expansions")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loading_time_ms")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
        22   return                 
 }
@@ -1309,9 +1309,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 807 ntypeargs=0   (testing.testset_children)
+        1   call 801 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 818 ntypeargs=0   (testing.run_testset)
+        3   call 812 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1323,7 +1323,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
 
   133   4     load_type 0              
         5     load_var 3               (_3)
-        6     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1367,16 +1367,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 602    
+        54    make_bound_method 596    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 613    
+        59    make_bound_method 607    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1384,39 +1384,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 558    
+        71    make_bound_method 552    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 588    
+        99    make_bound_method 582    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1435,19 +1435,19 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         113   load_field 1             (body)
         114   load_var 6               (t)
         115   load_field 2             (runner)
-        116   call 829 ntypeargs=0     (testing.run_test)
+        116   call 823 ntypeargs=0     (testing.run_test)
         117   jump +123                (to 240)
 
   140   118   load_type 13             
         119   load_type 14             
         120   load_var 1               (self)
         121   load_field 1             (expansions)
-        122   call 15 ntypeargs=2      (baml.Map.keys)
+        122   call 9 ntypeargs=2       (baml.Map.keys)
         123   store_var 7              (_40)
 
   139   124   load_type 13             
         125   load_var 7               (_40)
-        126   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1491,16 +1491,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 602    
+        174   make_bound_method 596    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 613    
+        179   make_bound_method 607    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1508,39 +1508,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 558    
+        191   make_bound_method 552    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 588    
+        219   make_bound_method 582    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1559,12 +1559,12 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
   143   233   load_var2 2 10           
         234   load_const 25            ("/")
         235   bin_op +                 
-        236   call 154 ntypeargs=0     (baml.String.starts_with)
+        236   call 148 ntypeargs=0     (baml.String.starts_with)
 
   142   237   pop_jump_if_false -109   (to 128)
 
   144   238   load_var2 11 2           
-        239   call 819 ntypeargs=0     (testing.TestRegistry.run_test)
+        239   call 813 ntypeargs=0     (testing.TestRegistry.run_test)
         240   return                   
 
   147   241   load_const 26            ("Test not found: ")
@@ -1581,7 +1581,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1625,16 +1625,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 602    
+        54    make_bound_method 596    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 613    
+        59    make_bound_method 607    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1642,39 +1642,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 558    
+        71    make_bound_method 552    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 588    
+        99    make_bound_method 582    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1690,22 +1690,22 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         111   pop_jump_if_false -103   (to 8)
 
   153   112   load_var2 1 6            
-        113   call 830 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
-        114   call 807 ntypeargs=0     (testing.testset_children)
+        113   call 824 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        114   call 801 ntypeargs=0     (testing.testset_children)
         115   load_var 6               (ts)
         116   load_field 2             (runner)
-        117   call 818 ntypeargs=0     (testing.run_testset)
+        117   call 812 ntypeargs=0     (testing.run_testset)
         118   jump +123                (to 241)
 
   156   119   load_type 13             
         120   load_type 14             
         121   load_var 1               (self)
         122   load_field 1             (expansions)
-        123   call 15 ntypeargs=2      (baml.Map.keys)
+        123   call 9 ntypeargs=2       (baml.Map.keys)
         124   store_var 7              (_42)
         125   load_type 13             
         126   load_var 7               (_42)
-        127   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         128   store_var 8              (_46)
         129   load_var 8               (_46)
         130   is_type 15               
@@ -1749,16 +1749,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         168   load_type 13             
         169   load_type 11             
         170   load_var 8               (_46)
-        171   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         172   store_var 9              (_48)
         173   jump +50                 (to 223)
         174   load_var 8               (_46)
-        175   make_bound_method 602    
+        175   make_bound_method 596    
         176   call_indirect            
         177   store_var 9              (_48)
         178   jump +45                 (to 223)
         179   load_var 8               (_46)
-        180   make_bound_method 613    
+        180   make_bound_method 607    
         181   call_indirect            
         182   store_var 9              (_48)
         183   jump +40                 (to 223)
@@ -1766,39 +1766,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         185   load_type 11             
         186   load_type 11             
         187   load_var 8               (_46)
-        188   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         189   store_var 9              (_48)
         190   jump +33                 (to 223)
         191   load_var 8               (_46)
-        192   make_bound_method 558    
+        192   make_bound_method 552    
         193   call_indirect            
         194   store_var 9              (_48)
         195   jump +28                 (to 223)
         196   load_type 13             
         197   load_var 8               (_46)
-        198   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         199   store_var 9              (_48)
         200   jump +23                 (to 223)
         201   load_type 13             
         202   load_type 11             
         203   load_type 11             
         204   load_var 8               (_46)
-        205   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         206   store_var 9              (_48)
         207   jump +16                 (to 223)
         208   load_type 13             
         209   load_type 11             
         210   load_var 8               (_46)
-        211   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         212   store_var 9              (_48)
         213   jump +10                 (to 223)
         214   load_type 13             
         215   load_var 8               (_46)
-        216   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         217   store_var 9              (_48)
         218   jump +5                  (to 223)
         219   load_var 8               (_46)
-        220   make_bound_method 588    
+        220   make_bound_method 582    
         221   call_indirect            
         222   store_var 9              (_48)
         223   load_var 9               (_48)
@@ -1817,11 +1817,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
   158   234   load_var2 2 10           
         235   load_const 25            ("/")
         236   bin_op +                 
-        237   call 154 ntypeargs=0     (baml.String.starts_with)
+        237   call 148 ntypeargs=0     (baml.String.starts_with)
         238   pop_jump_if_false -109   (to 129)
 
   159   239   load_var2 11 2           
-        240   call 825 ntypeargs=0     (testing.TestRegistry.run_testset)
+        240   call 819 ntypeargs=0     (testing.TestRegistry.run_testset)
         241   return                   
 
   162   242   load_const 26            ("TestSet not found: ")
@@ -1841,7 +1841,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         5     store_var 3              (_3)
         6     load_type 0              
         7     load_var 3               (_3)
-        8     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        8     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         9     store_var 4              (_4)
         10    load_var 4               (_4)
         11    is_type 1                
@@ -1885,16 +1885,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         49    load_type 0              
         50    load_type 11             
         51    load_var 4               (_4)
-        52    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        52    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         53    store_var 5              (_6)
         54    jump +50                 (to 104)
         55    load_var 4               (_4)
-        56    make_bound_method 602    
+        56    make_bound_method 596    
         57    call_indirect            
         58    store_var 5              (_6)
         59    jump +45                 (to 104)
         60    load_var 4               (_4)
-        61    make_bound_method 613    
+        61    make_bound_method 607    
         62    call_indirect            
         63    store_var 5              (_6)
         64    jump +40                 (to 104)
@@ -1902,39 +1902,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         66    load_type 11             
         67    load_type 11             
         68    load_var 4               (_4)
-        69    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        69    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         70    store_var 5              (_6)
         71    jump +33                 (to 104)
         72    load_var 4               (_4)
-        73    make_bound_method 558    
+        73    make_bound_method 552    
         74    call_indirect            
         75    store_var 5              (_6)
         76    jump +28                 (to 104)
         77    load_type 0              
         78    load_var 4               (_4)
-        79    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        79    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         80    store_var 5              (_6)
         81    jump +23                 (to 104)
         82    load_type 0              
         83    load_type 11             
         84    load_type 11             
         85    load_var 4               (_4)
-        86    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        86    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         87    store_var 5              (_6)
         88    jump +16                 (to 104)
         89    load_type 0              
         90    load_type 11             
         91    load_var 4               (_4)
-        92    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        92    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         93    store_var 5              (_6)
         94    jump +10                 (to 104)
         95    load_type 0              
         96    load_var 4               (_4)
-        97    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        97    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         98    store_var 5              (_6)
         99    jump +5                  (to 104)
         100   load_var 4               (_4)
-        101   make_bound_method 588    
+        101   make_bound_method 582    
         102   call_indirect            
         103   store_var 5              (_6)
         104   load_var 5               (_6)
@@ -1948,7 +1948,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
   110   110   load_var 5               (_6)
         111   load_field 0             (name)
         112   init_instance 0          (testing.SerializedTest .type, .name)
-        113   call 13 ntypeargs=0      (baml.Array.push)
+        113   call 7 ntypeargs=0       (baml.Array.push)
         114   pop 1                    
         115   jump -105                (to 10)
 
@@ -1958,7 +1958,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         119   store_var 6              (_39)
         120   load_type 14             
         121   load_var 6               (_39)
-        122   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        122   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         123   store_var 7              (_40)
         124   load_var 7               (_40)
         125   is_type 15               
@@ -2002,16 +2002,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         163   load_type 14             
         164   load_type 11             
         165   load_var 7               (_40)
-        166   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        166   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         167   store_var 8              (_42)
         168   jump +50                 (to 218)
         169   load_var 7               (_40)
-        170   make_bound_method 602    
+        170   make_bound_method 596    
         171   call_indirect            
         172   store_var 8              (_42)
         173   jump +45                 (to 218)
         174   load_var 7               (_40)
-        175   make_bound_method 613    
+        175   make_bound_method 607    
         176   call_indirect            
         177   store_var 8              (_42)
         178   jump +40                 (to 218)
@@ -2019,39 +2019,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         180   load_type 11             
         181   load_type 11             
         182   load_var 7               (_40)
-        183   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        183   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         184   store_var 8              (_42)
         185   jump +33                 (to 218)
         186   load_var 7               (_40)
-        187   make_bound_method 558    
+        187   make_bound_method 552    
         188   call_indirect            
         189   store_var 8              (_42)
         190   jump +28                 (to 218)
         191   load_type 14             
         192   load_var 7               (_40)
-        193   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        193   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         194   store_var 8              (_42)
         195   jump +23                 (to 218)
         196   load_type 14             
         197   load_type 11             
         198   load_type 11             
         199   load_var 7               (_40)
-        200   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        200   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         201   store_var 8              (_42)
         202   jump +16                 (to 218)
         203   load_type 14             
         204   load_type 11             
         205   load_var 7               (_40)
-        206   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        206   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         207   store_var 8              (_42)
         208   jump +10                 (to 218)
         209   load_type 14             
         210   load_var 7               (_40)
-        211   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        211   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         212   store_var 8              (_42)
         213   jump +5                  (to 218)
         214   load_var 7               (_40)
-        215   make_bound_method 588    
+        215   make_bound_method 582    
         216   call_indirect            
         217   store_var 8              (_42)
         218   load_var 8               (_42)
@@ -2067,7 +2067,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         227   load_field 1             (expansions)
         228   load_var 9               (ts)
         229   load_field 0             (name)
-        230   call 44 ntypeargs=2      (baml.Map.get)
+        230   call 38 ntypeargs=2      (baml.Map.get)
         231   store_var 10             (expanded)
 
   115   232   load_var 10              (expanded)
@@ -2080,7 +2080,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         238   load_var 9               (ts)
         239   load_field 0             (name)
         240   init_instance 1          (testing.SerializedTest .type, .name)
-        241   call 13 ntypeargs=0      (baml.Array.push)
+        241   call 7 ntypeargs=0       (baml.Array.push)
         242   pop 1                    
         243   jump -119                (to 124)
 
@@ -2092,7 +2092,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         248   store_var 12             (_81)
 
   119   249   load_var 11              (sub)
-        250   call 816 ntypeargs=0     (testing.TestRegistry.serialize)
+        250   call 810 ntypeargs=0     (testing.TestRegistry.serialize)
         251   store_var 13             (_82)
 
   117   252   load_var2 2 12           
@@ -2100,7 +2100,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 
   120   254   load_field 2             (loading_time_ms)
         255   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        256   call 13 ntypeargs=0      (baml.Array.push)
+        256   call 7 ntypeargs=0       (baml.Array.push)
         257   pop 1                    
         258   jump -134                (to 124)
 
@@ -2112,18 +2112,18 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
   19   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("runs")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.TestReport .outcome, .runs)
        15   return                 
 }
@@ -2131,18 +2131,18 @@ function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
 function testing.TestSetChild.from_json(j: baml.json.json) -> testing.TestSetChild {
   55   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("run")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.TestSetChild .name, .run)
        15   return                 
 }
@@ -2150,25 +2150,25 @@ function testing.TestSetChild.from_json(j: baml.json.json) -> testing.TestSetChi
 function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.TestSetRegistration {
   11   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("collector")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("runner")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestSetRegistration .name, .collector, .runner)
        22   return                 
 }
@@ -2176,46 +2176,46 @@ function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.Tes
 function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetReport {
   26   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("passed")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("failed")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 3            
        19   load_var 4             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   load_var 1             (j)
        22   load_const 5           ("total")
-       23   call 377 ntypeargs=0   (baml.json.field)
+       23   call 371 ntypeargs=0   (baml.json.field)
        24   store_var 5            (_12)
        25   load_type 3            
        26   load_var 5             (_12)
-       27   call 372 ntypeargs=1   (baml.json.from_json)
+       27   call 366 ntypeargs=1   (baml.json.from_json)
        28   load_var 1             (j)
        29   load_const 6           ("failed_names")
-       30   call 377 ntypeargs=0   (baml.json.field)
+       30   call 371 ntypeargs=0   (baml.json.field)
        31   store_var 6            (_15)
        32   load_type 7            
        33   load_var 6             (_15)
-       34   call 372 ntypeargs=1   (baml.json.from_json)
+       34   call 366 ntypeargs=1   (baml.json.from_json)
        35   load_var 1             (j)
        36   load_const 8           ("results")
-       37   call 377 ntypeargs=0   (baml.json.field)
+       37   call 371 ntypeargs=0   (baml.json.field)
        38   store_var 7            (_18)
        39   load_type 9            
        40   load_var 7             (_18)
-       41   call 372 ntypeargs=1   (baml.json.from_json)
+       41   call 366 ntypeargs=1   (baml.json.from_json)
        42   init_instance 0        (testing.TestSetReport .outcome, .passed, .failed, .total, .failed_names, .results)
        43   return                 
 }
@@ -2223,14 +2223,14 @@ function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetRe
 function testing._int_to_float(value: int) -> float {
   125   0   load_type 0            
         1   load_var 1             (value)
-        2   call 472 ntypeargs=1   (baml.unstable.string)
-        3   call 127 ntypeargs=0   (baml.Float.parse)
+        2   call 466 ntypeargs=1   (baml.unstable.string)
+        3   call 121 ntypeargs=0   (baml.Float.parse)
         4   jump +5                (to 9)
         5   load_var 2             (e)
         6   throw_if_panic         
 
   126   7   load_const 1           ("failed to convert int to float")
-        8   call 284 ntypeargs=0   (baml.sys.panic)
+        8   call 278 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
@@ -2252,7 +2252,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   253   10    load_type 2              
         11    load_var 1               (named_results)
-        12    call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        12    call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         13    store_var 7              (_7)
         14    load_var 7               (_7)
         15    is_type 3                
@@ -2296,16 +2296,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         53    load_type 2              
         54    load_type 13             
         55    load_var 7               (_7)
-        56    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        56    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         57    store_var 8              (_9)
         58    jump +50                 (to 108)
         59    load_var 7               (_7)
-        60    make_bound_method 602    
+        60    make_bound_method 596    
         61    call_indirect            
         62    store_var 8              (_9)
         63    jump +45                 (to 108)
         64    load_var 7               (_7)
-        65    make_bound_method 613    
+        65    make_bound_method 607    
         66    call_indirect            
         67    store_var 8              (_9)
         68    jump +40                 (to 108)
@@ -2313,39 +2313,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         70    load_type 13             
         71    load_type 13             
         72    load_var 7               (_7)
-        73    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        73    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         74    store_var 8              (_9)
         75    jump +33                 (to 108)
         76    load_var 7               (_7)
-        77    make_bound_method 558    
+        77    make_bound_method 552    
         78    call_indirect            
         79    store_var 8              (_9)
         80    jump +28                 (to 108)
         81    load_type 2              
         82    load_var 7               (_7)
-        83    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        83    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         84    store_var 8              (_9)
         85    jump +23                 (to 108)
         86    load_type 2              
         87    load_type 13             
         88    load_type 13             
         89    load_var 7               (_7)
-        90    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        90    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         91    store_var 8              (_9)
         92    jump +16                 (to 108)
         93    load_type 2              
         94    load_type 13             
         95    load_var 7               (_7)
-        96    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        96    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         97    store_var 8              (_9)
         98    jump +10                 (to 108)
         99    load_type 2              
         100   load_var 7               (_7)
-        101   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        101   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         102   store_var 8              (_9)
         103   jump +5                  (to 108)
         104   load_var 7               (_7)
-        105   make_bound_method 588    
+        105   make_bound_method 582    
         106   call_indirect            
         107   store_var 8              (_9)
         108   load_var 8               (_9)
@@ -2360,7 +2360,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         116   store_var 10             (result)
 
   255   117   load_var2 6 10           
-        118   call 13 ntypeargs=0      (baml.Array.push)
+        118   call 7 ntypeargs=0       (baml.Array.push)
         119   pop 1                    
 
   256   120   load_var 10              (result)
@@ -2377,7 +2377,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   260   131   load_var 11              (outcome)
         132   load_const 16            ("pass")
-        133   call 790 ntypeargs=0     (baml.ops.equals_equals)
+        133   call 784 ntypeargs=0     (baml.ops.equals_equals)
         134   pop_jump_if_false +2     (to 136)
         135   jump +142                (to 277)
 
@@ -2419,7 +2419,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
   272   163   store_var 13             (_56)
         164   load_type 18             
         165   load_var 13              (_56)
-        166   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        166   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         167   store_var 14             (_57)
         168   load_var 14              (_57)
         169   is_type 19               
@@ -2463,16 +2463,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         207   load_type 18             
         208   load_type 13             
         209   load_var 14              (_57)
-        210   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        210   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         211   store_var 15             (_59)
         212   jump +50                 (to 262)
         213   load_var 14              (_57)
-        214   make_bound_method 602    
+        214   make_bound_method 596    
         215   call_indirect            
         216   store_var 15             (_59)
         217   jump +45                 (to 262)
         218   load_var 14              (_57)
-        219   make_bound_method 613    
+        219   make_bound_method 607    
         220   call_indirect            
         221   store_var 15             (_59)
         222   jump +40                 (to 262)
@@ -2480,39 +2480,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         224   load_type 13             
         225   load_type 13             
         226   load_var 14              (_57)
-        227   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        227   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         228   store_var 15             (_59)
         229   jump +33                 (to 262)
         230   load_var 14              (_57)
-        231   make_bound_method 558    
+        231   make_bound_method 552    
         232   call_indirect            
         233   store_var 15             (_59)
         234   jump +28                 (to 262)
         235   load_type 18             
         236   load_var 14              (_57)
-        237   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        237   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         238   store_var 15             (_59)
         239   jump +23                 (to 262)
         240   load_type 18             
         241   load_type 13             
         242   load_type 13             
         243   load_var 14              (_57)
-        244   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        244   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         245   store_var 15             (_59)
         246   jump +16                 (to 262)
         247   load_type 18             
         248   load_type 13             
         249   load_var 14              (_57)
-        250   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        250   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         251   store_var 15             (_59)
         252   jump +10                 (to 262)
         253   load_type 18             
         254   load_var 14              (_57)
-        255   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        255   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         256   store_var 15             (_59)
         257   jump +5                  (to 262)
         258   load_var 14              (_57)
-        259   make_bound_method 588    
+        259   make_bound_method 582    
         260   call_indirect            
         261   store_var 15             (_59)
         262   load_var 15              (_59)
@@ -2522,13 +2522,13 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   273   266   load_var2 5 15           
 
-  272   267   call 13 ntypeargs=0      (baml.Array.push)
+  272   267   call 7 ntypeargs=0       (baml.Array.push)
         268   pop 1                    
         269   jump -101                (to 168)
 
   275   270   load_var 11              (outcome)
         271   load_const 29            ("error")
-        272   call 790 ntypeargs=0     (baml.ops.equals_equals)
+        272   call 784 ntypeargs=0     (baml.ops.equals_equals)
         273   pop_jump_if_false -259   (to 14)
 
   276   274   load_const 30            (true)
@@ -2587,7 +2587,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
 
   295   5     load_type 0             
         6     load_var 1              (children)
-        7     call 572 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
+        7     call 566 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
         8     store_var 3             (_3)
         9     load_var 3              (_3)
         10    is_type 1               
@@ -2631,16 +2631,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         48    load_type 0             
         49    load_type 11            
         50    load_var 3              (_3)
-        51    call 575 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
+        51    call 569 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
         52    store_var 4             (_5)
         53    jump +50                (to 103)
         54    load_var 3              (_3)
-        55    make_bound_method 602   
+        55    make_bound_method 596   
         56    call_indirect           
         57    store_var 4             (_5)
         58    jump +45                (to 103)
         59    load_var 3              (_3)
-        60    make_bound_method 613   
+        60    make_bound_method 607   
         61    call_indirect           
         62    store_var 4             (_5)
         63    jump +40                (to 103)
@@ -2648,39 +2648,39 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         65    load_type 11            
         66    load_type 11            
         67    load_var 3              (_3)
-        68    call 547 ntypeargs=3    (baml.iter.Filter.Iterator.next)
+        68    call 541 ntypeargs=3    (baml.iter.Filter.Iterator.next)
         69    store_var 4             (_5)
         70    jump +33                (to 103)
         71    load_var 3              (_3)
-        72    make_bound_method 558   
+        72    make_bound_method 552   
         73    call_indirect           
         74    store_var 4             (_5)
         75    jump +28                (to 103)
         76    load_type 0             
         77    load_var 3              (_3)
-        78    call 571 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
+        78    call 565 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
         79    store_var 4             (_5)
         80    jump +23                (to 103)
         81    load_type 0             
         82    load_type 11            
         83    load_type 11            
         84    load_var 3              (_3)
-        85    call 549 ntypeargs=3    (baml.iter.Chain.Iterator.next)
+        85    call 543 ntypeargs=3    (baml.iter.Chain.Iterator.next)
         86    store_var 4             (_5)
         87    jump +16                (to 103)
         88    load_type 0             
         89    load_type 11            
         90    load_var 3              (_3)
-        91    call 561 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
+        91    call 555 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
         92    store_var 4             (_5)
         93    jump +10                (to 103)
         94    load_type 0             
         95    load_var 3              (_3)
-        96    call 598 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
+        96    call 592 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
         97    store_var 4             (_5)
         98    jump +5                 (to 103)
         99    load_var 3              (_3)
-        100   make_bound_method 588   
+        100   make_bound_method 582   
         101   call_indirect           
         102   store_var 4             (_5)
         103   load_var 4              (_5)
@@ -2694,29 +2694,29 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         111   store_deref 5           
 
   296   112   load_var 5              (child)
-        113   make_closure 1512 1     
+        113   make_closure 1479 1     
         114   load_const 13           (null)
         115   load_const 13           (null)
         116   spawn                   
         117   store_var 6             (_38)
         118   load_var2 2 6           
-        119   call 13 ntypeargs=0     (baml.Array.push)
+        119   call 7 ntypeargs=0      (baml.Array.push)
         120   pop 1                   
         121   jump -112               (to 9)
 
   300   122   load_type 14            
         123   load_type 15            
         124   load_var 2              (futures)
-        125   call 625 ntypeargs=2    (baml.future.all_complete)
+        125   call 619 ntypeargs=2    (baml.future.all_complete)
         126   await                   
         127   jump +5                 (to 132)
         128   load_var 7              (e)
         129   throw_if_panic          
 
   301   130   load_const 16           ("unexpected test child failure")
-        131   call 284 ntypeargs=0    (baml.sys.panic)
+        131   call 278 ntypeargs=0    (baml.sys.panic)
 
-  303   132   call 815 ntypeargs=0    (testing.aggregate_reports)
+  303   132   call 809 ntypeargs=0    (testing.aggregate_reports)
         133   return                  
         134   unreachable             
 }
@@ -2727,7 +2727,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
 
   108   2     load_type 0              
         3     load_var 1               (children)
-        4     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        4     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         5     store_var 4              (_4)
         6     load_var 4               (_4)
         7     is_type 1                
@@ -2771,16 +2771,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         45    load_type 0              
         46    load_type 11             
         47    load_var 4               (_4)
-        48    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        48    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         49    store_var 5              (_6)
         50    jump +50                 (to 100)
         51    load_var 4               (_4)
-        52    make_bound_method 602    
+        52    make_bound_method 596    
         53    call_indirect            
         54    store_var 5              (_6)
         55    jump +45                 (to 100)
         56    load_var 4               (_4)
-        57    make_bound_method 613    
+        57    make_bound_method 607    
         58    call_indirect            
         59    store_var 5              (_6)
         60    jump +40                 (to 100)
@@ -2788,39 +2788,39 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         62    load_type 11             
         63    load_type 11             
         64    load_var 4               (_4)
-        65    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        65    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         66    store_var 5              (_6)
         67    jump +33                 (to 100)
         68    load_var 4               (_4)
-        69    make_bound_method 558    
+        69    make_bound_method 552    
         70    call_indirect            
         71    store_var 5              (_6)
         72    jump +28                 (to 100)
         73    load_type 0              
         74    load_var 4               (_4)
-        75    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        75    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         76    store_var 5              (_6)
         77    jump +23                 (to 100)
         78    load_type 0              
         79    load_type 11             
         80    load_type 11             
         81    load_var 4               (_4)
-        82    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        82    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         83    store_var 5              (_6)
         84    jump +16                 (to 100)
         85    load_type 0              
         86    load_type 11             
         87    load_var 4               (_4)
-        88    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        88    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         89    store_var 5              (_6)
         90    jump +10                 (to 100)
         91    load_type 0              
         92    load_var 4               (_4)
-        93    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        93    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         94    store_var 5              (_6)
         95    jump +5                  (to 100)
         96    load_var 4               (_4)
-        97    make_bound_method 588    
+        97    make_bound_method 582    
         98    call_indirect            
         99    store_var 5              (_6)
         100   load_var 5               (_6)
@@ -2838,7 +2838,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         110   load_field 0             (name)
         111   load_var 7               (report)
         112   init_instance 0          (testing.NamedChildReport .name, .report)
-        113   call 13 ntypeargs=0      (baml.Array.push)
+        113   call 7 ntypeargs=0       (baml.Array.push)
         114   pop 1                    
 
   111   115   load_var 7               (report)
@@ -2858,16 +2858,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         128   pop 1                    
         129   load_var 8               (outcome)
         130   load_const 14            ("pass")
-        131   call 790 ntypeargs=0     (baml.ops.equals_equals)
+        131   call 784 ntypeargs=0     (baml.ops.equals_equals)
         132   unary_op !               
         133   pop_jump_if_false -127   (to 6)
 
   116   134   load_var 3               (named_results)
-        135   call 815 ntypeargs=0     (testing.aggregate_reports)
+        135   call 809 ntypeargs=0     (testing.aggregate_reports)
         136   jump +3                  (to 139)
 
   121   137   load_var 3               (named_results)
-        138   call 815 ntypeargs=0     (testing.aggregate_reports)
+        138   call 809 ntypeargs=0     (testing.aggregate_reports)
         139   return                   
         140   unreachable              
 }
@@ -2878,7 +2878,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   308   3    load_var 1             (body)
-        4    make_closure 1521 1    
+        4    make_closure 1488 1    
         5    store_var 3            (base_run)
 
   332   6    load_var 2             (runner)
@@ -2910,7 +2910,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   344   8    load_var 1             (children)
-        9    call 827 ntypeargs=0   (testing.run_children_parallel)
+        9    call 821 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
@@ -2925,7 +2925,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   221   6    load_var2 1 2         
 
   223   7    load_var 3            (runner)
-        8    make_closure 1469 2   
+        8    make_closure 1436 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -2942,7 +2942,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   230   8    load_var2 1 2         
-        9    make_closure 1498 2   
+        9    make_closure 1465 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -2957,7 +2957,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         5     store_var 3              (_3)
         6     load_type 0              
         7     load_var 3               (_3)
-        8     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        8     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         9     store_var 4              (_4)
         10    load_var 4               (_4)
         11    is_type 1                
@@ -3001,16 +3001,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         49    load_type 0              
         50    load_type 11             
         51    load_var 4               (_4)
-        52    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        52    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         53    store_var 5              (_6)
         54    jump +50                 (to 104)
         55    load_var 4               (_4)
-        56    make_bound_method 602    
+        56    make_bound_method 596    
         57    call_indirect            
         58    store_var 5              (_6)
         59    jump +45                 (to 104)
         60    load_var 4               (_4)
-        61    make_bound_method 613    
+        61    make_bound_method 607    
         62    call_indirect            
         63    store_var 5              (_6)
         64    jump +40                 (to 104)
@@ -3018,39 +3018,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         66    load_type 11             
         67    load_type 11             
         68    load_var 4               (_4)
-        69    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        69    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         70    store_var 5              (_6)
         71    jump +33                 (to 104)
         72    load_var 4               (_4)
-        73    make_bound_method 558    
+        73    make_bound_method 552    
         74    call_indirect            
         75    store_var 5              (_6)
         76    jump +28                 (to 104)
         77    load_type 0              
         78    load_var 4               (_4)
-        79    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        79    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         80    store_var 5              (_6)
         81    jump +23                 (to 104)
         82    load_type 0              
         83    load_type 11             
         84    load_type 11             
         85    load_var 4               (_4)
-        86    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        86    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         87    store_var 5              (_6)
         88    jump +16                 (to 104)
         89    load_type 0              
         90    load_type 11             
         91    load_var 4               (_4)
-        92    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        92    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         93    store_var 5              (_6)
         94    jump +10                 (to 104)
         95    load_type 0              
         96    load_var 4               (_4)
-        97    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        97    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         98    store_var 5              (_6)
         99    jump +5                  (to 104)
         100   load_var 4               (_4)
-        101   make_bound_method 588    
+        101   make_bound_method 582    
         102   call_indirect            
         103   store_var 5              (_6)
         104   load_var 5               (_6)
@@ -3065,10 +3065,10 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         112   load_field 1             (body)
         113   load_var 6               (t)
         114   load_field 2             (runner)
-        115   call 813 ntypeargs=0     (testing.test_child)
+        115   call 807 ntypeargs=0     (testing.test_child)
         116   store_var 7              (_37)
         117   load_var2 2 7            
-        118   call 13 ntypeargs=0      (baml.Array.push)
+        118   call 7 ntypeargs=0       (baml.Array.push)
         119   pop 1                    
         120   jump -110                (to 10)
 
@@ -3078,7 +3078,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         124   store_var 8              (_41)
         125   load_type 13             
         126   load_var 8               (_41)
-        127   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         128   store_var 9              (_42)
         129   load_var 9               (_42)
         130   is_type 14               
@@ -3122,16 +3122,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         168   load_type 13             
         169   load_type 11             
         170   load_var 9               (_42)
-        171   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         172   store_var 10             (_44)
         173   jump +50                 (to 223)
         174   load_var 9               (_42)
-        175   make_bound_method 602    
+        175   make_bound_method 596    
         176   call_indirect            
         177   store_var 10             (_44)
         178   jump +45                 (to 223)
         179   load_var 9               (_42)
-        180   make_bound_method 613    
+        180   make_bound_method 607    
         181   call_indirect            
         182   store_var 10             (_44)
         183   jump +40                 (to 223)
@@ -3139,39 +3139,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         185   load_type 11             
         186   load_type 11             
         187   load_var 9               (_42)
-        188   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         189   store_var 10             (_44)
         190   jump +33                 (to 223)
         191   load_var 9               (_42)
-        192   make_bound_method 558    
+        192   make_bound_method 552    
         193   call_indirect            
         194   store_var 10             (_44)
         195   jump +28                 (to 223)
         196   load_type 13             
         197   load_var 9               (_42)
-        198   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         199   store_var 10             (_44)
         200   jump +23                 (to 223)
         201   load_type 13             
         202   load_type 11             
         203   load_type 11             
         204   load_var 9               (_42)
-        205   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         206   store_var 10             (_44)
         207   jump +16                 (to 223)
         208   load_type 13             
         209   load_type 11             
         210   load_var 9               (_42)
-        211   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         212   store_var 10             (_44)
         213   jump +10                 (to 223)
         214   load_type 13             
         215   load_var 9               (_42)
-        216   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         217   store_var 10             (_44)
         218   jump +5                  (to 223)
         219   load_var 9               (_42)
-        220   make_bound_method 588    
+        220   make_bound_method 582    
         221   call_indirect            
         222   store_var 10             (_44)
         223   load_var 10              (_44)
@@ -3181,11 +3181,11 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   215   227   load_var2 1 10           
 
-  214   228   call 822 ntypeargs=0     (testing.testset_child)
+  214   228   call 816 ntypeargs=0     (testing.testset_child)
         229   store_var 11             (_75)
 
   215   230   load_var2 2 11           
-        231   call 13 ntypeargs=0      (baml.Array.push)
+        231   call 7 ntypeargs=0       (baml.Array.push)
         232   pop 1                    
         233   jump -104                (to 129)
 
@@ -3197,18 +3197,18 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
   26   0    load_var 1             (j)
        1    load_const 0           ("code")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("message")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (user.ErrorInfo .code, .message)
        15   return                 
 }
@@ -3216,25 +3216,25 @@ function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
 function user.Report.from_json(j: baml.json.json) -> Report {
   20   0    load_var 1             (j)
        1    load_const 0           ("score")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 2            (_3)
        4    load_type 1            
        5    load_var 2             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("label")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 3            (_6)
        11   load_type 3            
        12   load_var 3             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("breakdown")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 4            (_9)
        18   load_type 5            
        19   load_var 4             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (user.Report .score, .label, .breakdown)
        22   return                 
 }
@@ -3242,53 +3242,53 @@ function user.Report.from_json(j: baml.json.json) -> Report {
 function user.User.from_json(j: baml.json.json) -> User {
   3   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 377 ntypeargs=0   (baml.json.field)
+      2    call 371 ntypeargs=0   (baml.json.field)
       3    store_var 2            (_3)
       4    load_type 1            
       5    load_var 2             (_3)
-      6    call 372 ntypeargs=1   (baml.json.from_json)
+      6    call 366 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("age")
-      9    call 377 ntypeargs=0   (baml.json.field)
+      9    call 371 ntypeargs=0   (baml.json.field)
       10   store_var 3            (_6)
       11   load_type 3            
       12   load_var 3             (_6)
-      13   call 372 ntypeargs=1   (baml.json.from_json)
+      13   call 366 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("role")
-      16   call 377 ntypeargs=0   (baml.json.field)
+      16   call 371 ntypeargs=0   (baml.json.field)
       17   store_var 4            (_9)
       18   load_type 5            
       19   load_var 4             (_9)
-      20   call 372 ntypeargs=1   (baml.json.from_json)
+      20   call 366 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (user.User .name, .age, .role)
       22   return                 
 }
 
 function user.User.promote(self: User, bonus: int) -> Report {
-  9    0    load_var 1           (self)
-       1    copy 0               
-       2    load_field 1         (age)
-       3    load_const 0         (1)
-       4    bin_op +             
-       5    store_field 1        (age)
+  9    0    load_var 1             (self)
+       1    copy 0                 
+       2    load_field 1           (age)
+       3    load_const 0           (1)
+       4    bin_op +               
+       5    store_field 1          (age)
 
-  10   6    load_var2 1 2        
-       7    call 4 ntypeargs=0   (user.score)
-       8    store_var 3          (base)
+  10   6    load_var2 1 2          
+       7    call 841 ntypeargs=0   (user.score)
+       8    store_var 3            (base)
 
-  11   9    load_var 3           (base)
-       10   load_field 0         (score)
-       11   load_var 2           (bonus)
-       12   add_int              
+  11   9    load_var 3             (base)
+       10   load_field 0           (score)
+       11   load_var 2             (bonus)
+       12   add_int                
 
-  14   13   load_var 3           (base)
-       14   load_field 1         (label)
+  14   13   load_var 3             (base)
+       14   load_field 1           (label)
 
-  15   15   load_var 3           (base)
-       16   load_field 2         (breakdown)
-       17   init_instance 0      (user.Report .score, .label, .breakdown)
-       18   return               
+  15   15   load_var 3             (base)
+       16   load_field 2           (breakdown)
+       17   init_instance 0        (user.Report .score, .label, .breakdown)
+       18   return                 
 }
 
 function user.http_status(code: int) -> string {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -3,7 +3,7 @@ source: crates/baml_tests/tests/bytecode_format/main.rs
 ---
 function assert.contains(haystack: string, needle: string) -> null {
   51   0   load_var2 1 2          
-       1   call 181 ntypeargs=0   (baml.String.includes)
+       1   call 175 ntypeargs=0   (baml.String.includes)
        2   unary_op !             
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
@@ -13,13 +13,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   51   6   jump +3                (to 9)
 
   52   7   load_const 1           ("assertion failed: string does not contain expected substring")
-       8   call 284 ntypeargs=0   (baml.sys.panic)
+       8   call 278 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   37   0    load_var2 1 2          
-       1    call 790 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 784 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -29,11 +29,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   37   6    jump +15               (to 21)
 
   40   7    load_var 1             (actual)
-       8    call 841 ntypeargs=0   (assert.format_operand)
+       8    call 835 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   42   10   load_var 2             (expected)
-       11   call 841 ntypeargs=0   (assert.format_operand)
+       11   call 835 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   40   13   load_const 1           ("assertion failed: left = ")
@@ -43,13 +43,13 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 284 ntypeargs=0   (baml.sys.panic)
+       20   call 278 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
 function assert.format_operand(value: unknown) -> string {
   32   0   load_var 1             (value)
-       1   call 155 ntypeargs=0   (baml.String.from)
+       1   call 149 ntypeargs=0   (baml.String.from)
        2   return                 
 }
 
@@ -64,14 +64,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 284 ntypeargs=0   (baml.sys.panic)
+      7   call 278 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 790 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 784 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -80,7 +80,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 284 ntypeargs=0   (baml.sys.panic)
+       8   call 278 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -91,7 +91,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1524 0   
+  101   0   make_closure 1491 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -100,18 +100,18 @@ function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport
 function testing.NamedChildReport.from_json(j: baml.json.json) -> testing.NamedChildReport {
   40   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("report")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.NamedChildReport .name, .report)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -135,11 +135,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 284 ntypeargs=0   (baml.sys.panic)
+       14   call 278 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1535 1    
+       17   make_closure 1502 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -171,16 +171,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 284 ntypeargs=0   (baml.sys.panic)
+       22   call 278 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 284 ntypeargs=0   (baml.sys.panic)
+       26   call 278 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1549 2    
+       29   make_closure 1516 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -197,11 +197,11 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 284 ntypeargs=0   (baml.sys.panic)
+       8    call 278 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1542 1    
+       11   make_closure 1509 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
@@ -210,25 +210,25 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
 function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
   7   0    load_var 1             (j)
       1    load_const 0           ("outcome")
-      2    call 377 ntypeargs=0   (baml.json.field)
+      2    call 371 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 372 ntypeargs=1   (baml.json.from_json)
+      6    call 366 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("duration_ms")
-      9    call 377 ntypeargs=0   (baml.json.field)
+      9    call 371 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 372 ntypeargs=1   (baml.json.from_json)
+      13   call 366 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("message")
-      16   call 377 ntypeargs=0   (baml.json.field)
+      16   call 371 ntypeargs=0   (baml.json.field)
       17   store_var 5            (_9)
       18   load_type 5            
       19   load_var 5             (_9)
-      20   call 372 ntypeargs=1   (baml.json.from_json)
+      20   call 366 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (testing.RunReport .outcome, .duration_ms, .message)
       22   store_var 2            (_0)
       23   load_var 2             (_0)
@@ -236,7 +236,7 @@ function testing.RunReport.from_json(j: baml.json.json) -> testing.RunReport {
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1528 0   
+  95   0   make_closure 1495 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -245,18 +245,18 @@ function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetRepo
 function testing.SerializedTest.from_json(j: baml.json.json) -> testing.SerializedTest {
   75   0    load_var 1             (j)
        1    load_const 0           ("type")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("name")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 1            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.SerializedTest .type, .name)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -266,25 +266,25 @@ function testing.SerializedTest.from_json(j: baml.json.json) -> testing.Serializ
 function testing.SerializedTestSet.from_json(j: baml.json.json) -> testing.SerializedTestSet {
   80   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("items")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loadingTimeMs")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.SerializedTestSet .name, .items, .loadingTimeMs)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -297,7 +297,7 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        2     store_var 4              (_3)
        3     load_type 0              
        4     load_var 4               (_3)
-       5     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 5              (_4)
        7     load_var 5               (_4)
        8     is_type 1                
@@ -341,16 +341,16 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        46    load_type 0              
        47    load_type 11             
        48    load_var 5               (_4)
-       49    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 6              (_6)
        51    jump +50                 (to 101)
        52    load_var 5               (_4)
-       53    make_bound_method 602    
+       53    make_bound_method 596    
        54    call_indirect            
        55    store_var 6              (_6)
        56    jump +45                 (to 101)
        57    load_var 5               (_4)
-       58    make_bound_method 613    
+       58    make_bound_method 607    
        59    call_indirect            
        60    store_var 6              (_6)
        61    jump +40                 (to 101)
@@ -358,39 +358,39 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        63    load_type 11             
        64    load_type 11             
        65    load_var 5               (_4)
-       66    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 6              (_6)
        68    jump +33                 (to 101)
        69    load_var 5               (_4)
-       70    make_bound_method 558    
+       70    make_bound_method 552    
        71    call_indirect            
        72    store_var 6              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 5               (_4)
-       76    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 6              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 5               (_4)
-       83    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 6              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 5               (_4)
-       89    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 6              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 5               (_4)
-       94    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 6              (_6)
        96    jump +5                  (to 101)
        97    load_var 5               (_4)
-       98    make_bound_method 588    
+       98    make_bound_method 582    
        99    call_indirect            
        100   store_var 6              (_6)
        101   load_var 6               (_6)
@@ -423,7 +423,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        2     store_var 4              (_3)
        3     load_type 0              
        4     load_var 4               (_3)
-       5     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 5              (_4)
        7     load_var 5               (_4)
        8     is_type 1                
@@ -467,16 +467,16 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        46    load_type 0              
        47    load_type 11             
        48    load_var 5               (_4)
-       49    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 6              (_6)
        51    jump +50                 (to 101)
        52    load_var 5               (_4)
-       53    make_bound_method 602    
+       53    make_bound_method 596    
        54    call_indirect            
        55    store_var 6              (_6)
        56    jump +45                 (to 101)
        57    load_var 5               (_4)
-       58    make_bound_method 613    
+       58    make_bound_method 607    
        59    call_indirect            
        60    store_var 6              (_6)
        61    jump +40                 (to 101)
@@ -484,39 +484,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        63    load_type 11             
        64    load_type 11             
        65    load_var 5               (_4)
-       66    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 6              (_6)
        68    jump +33                 (to 101)
        69    load_var 5               (_4)
-       70    make_bound_method 558    
+       70    make_bound_method 552    
        71    call_indirect            
        72    store_var 6              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 5               (_4)
-       76    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 6              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 5               (_4)
-       83    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 6              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 5               (_4)
-       89    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 6              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 5               (_4)
-       94    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 6              (_6)
        96    jump +5                  (to 101)
        97    load_var 5               (_4)
-       98    make_bound_method 588    
+       98    make_bound_method 582    
        99    call_indirect            
        100   store_var 6              (_6)
        101   load_var 6               (_6)
@@ -546,25 +546,25 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
 function testing.TestCollector.from_json(j: baml.json.json) -> testing.TestCollector {
   17   0    load_var 1             (j)
        1    load_const 0           ("prefix")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("tests")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("testsets")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -612,7 +612,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        24    store_var 9              (_13)
        25    load_type 4              
        26    load_var 9               (_13)
-       27    call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 10             (_14)
        29    load_var 10              (_14)
        30    is_type 5                
@@ -656,16 +656,16 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        68    load_type 4              
        69    load_type 15             
        70    load_var 10              (_14)
-       71    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 11             (_16)
        73    jump +50                 (to 123)
        74    load_var 10              (_14)
-       75    make_bound_method 602    
+       75    make_bound_method 596    
        76    call_indirect            
        77    store_var 11             (_16)
        78    jump +45                 (to 123)
        79    load_var 10              (_14)
-       80    make_bound_method 613    
+       80    make_bound_method 607    
        81    call_indirect            
        82    store_var 11             (_16)
        83    jump +40                 (to 123)
@@ -673,39 +673,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        85    load_type 15             
        86    load_type 15             
        87    load_var 10              (_14)
-       88    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 11             (_16)
        90    jump +33                 (to 123)
        91    load_var 10              (_14)
-       92    make_bound_method 558    
+       92    make_bound_method 552    
        93    call_indirect            
        94    store_var 11             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 10              (_14)
-       98    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 11             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 10              (_14)
-       105   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 11             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 10              (_14)
-       111   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 11             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 10              (_14)
-       116   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 11             (_16)
        118   jump +5                  (to 123)
        119   load_var 10              (_14)
-       120   make_bound_method 588    
+       120   make_bound_method 582    
        121   call_indirect            
        122   store_var 11             (_16)
        123   load_var 11              (_16)
@@ -724,7 +724,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        135   load_var 12              (t)
        136   load_field 0             (name)
        137   load_var 8               (hash_prefix)
-       138   call 154 ntypeargs=0     (baml.String.starts_with)
+       138   call 148 ntypeargs=0     (baml.String.starts_with)
        139   pop_jump_if_false -110   (to 29)
        140   load_var 7               (count)
        141   load_const 17            (1)
@@ -748,7 +748,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        158   load_var 7               (count)
        159   load_const 17            (1)
        160   add_int                  
-       161   call 472 ntypeargs=1     (baml.unstable.string)
+       161   call 466 ntypeargs=1     (baml.unstable.string)
        162   store_var 15             (_57)
        163   load_var2 14 15          
        164   bin_op +                 
@@ -760,7 +760,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        169   load_var2 13 3           
        170   load_var 4               (runner)
        171   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       172   call 13 ntypeargs=1      (baml.Array.push)
+       172   call 7 ntypeargs=1       (baml.Array.push)
        173   pop 1                    
 
   26   174   load_const 20            (null)
@@ -801,7 +801,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        24    store_var 9              (_13)
        25    load_type 4              
        26    load_var 9               (_13)
-       27    call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 10             (_14)
        29    load_var 10              (_14)
        30    is_type 5                
@@ -845,16 +845,16 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        68    load_type 4              
        69    load_type 15             
        70    load_var 10              (_14)
-       71    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 11             (_16)
        73    jump +50                 (to 123)
        74    load_var 10              (_14)
-       75    make_bound_method 602    
+       75    make_bound_method 596    
        76    call_indirect            
        77    store_var 11             (_16)
        78    jump +45                 (to 123)
        79    load_var 10              (_14)
-       80    make_bound_method 613    
+       80    make_bound_method 607    
        81    call_indirect            
        82    store_var 11             (_16)
        83    jump +40                 (to 123)
@@ -862,39 +862,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        85    load_type 15             
        86    load_type 15             
        87    load_var 10              (_14)
-       88    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 11             (_16)
        90    jump +33                 (to 123)
        91    load_var 10              (_14)
-       92    make_bound_method 558    
+       92    make_bound_method 552    
        93    call_indirect            
        94    store_var 11             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 10              (_14)
-       98    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 11             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 10              (_14)
-       105   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 11             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 10              (_14)
-       111   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 11             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 10              (_14)
-       116   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 11             (_16)
        118   jump +5                  (to 123)
        119   load_var 10              (_14)
-       120   make_bound_method 588    
+       120   make_bound_method 582    
        121   call_indirect            
        122   store_var 11             (_16)
        123   load_var 11              (_16)
@@ -913,7 +913,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        135   load_var 12              (ts)
        136   load_field 0             (name)
        137   load_var 8               (hash_prefix)
-       138   call 154 ntypeargs=0     (baml.String.starts_with)
+       138   call 148 ntypeargs=0     (baml.String.starts_with)
        139   pop_jump_if_false -110   (to 29)
        140   load_var 7               (count)
        141   load_const 17            (1)
@@ -937,7 +937,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        158   load_var 7               (count)
        159   load_const 17            (1)
        160   add_int                  
-       161   call 472 ntypeargs=1     (baml.unstable.string)
+       161   call 466 ntypeargs=1     (baml.unstable.string)
        162   store_var 15             (_57)
        163   load_var2 14 15          
        164   bin_op +                 
@@ -949,7 +949,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        169   load_var2 13 3           
        170   load_var 4               (runner)
        171   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       172   call 13 ntypeargs=1      (baml.Array.push)
+       172   call 7 ntypeargs=1       (baml.Array.push)
        173   pop 1                    
 
   37   174   load_const 20            (null)
@@ -962,25 +962,25 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
 function testing.TestRegistration.from_json(j: baml.json.json) -> testing.TestRegistration {
   5   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 377 ntypeargs=0   (baml.json.field)
+      2    call 371 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 372 ntypeargs=1   (baml.json.from_json)
+      6    call 366 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("body")
-      9    call 377 ntypeargs=0   (baml.json.field)
+      9    call 371 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 372 ntypeargs=1   (baml.json.from_json)
+      13   call 366 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("runner")
-      16   call 377 ntypeargs=0   (baml.json.field)
+      16   call 371 ntypeargs=0   (baml.json.field)
       17   store_var 5            (_9)
       18   load_type 5            
       19   load_var 5             (_9)
-      20   call 372 ntypeargs=1   (baml.json.from_json)
+      20   call 366 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (testing.TestRegistration .name, .body, .runner)
       22   store_var 2            (_0)
       23   load_var 2             (_0)
@@ -995,7 +995,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
 
   172   4     load_type 0              
         5     load_var 3               (_3)
-        6     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1039,16 +1039,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 602    
+        54    make_bound_method 596    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 613    
+        59    make_bound_method 607    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1056,39 +1056,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 558    
+        71    make_bound_method 552    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 588    
+        99    make_bound_method 582    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1104,23 +1104,23 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         111   pop_jump_if_false -103   (to 8)
 
   175   112   load_var2 1 6            
-        113   call 830 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        113   call 824 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
         114   pop 1                    
 
   176   115   load_var 1               (self)
-        116   call 816 ntypeargs=0     (testing.TestRegistry.serialize)
+        116   call 810 ntypeargs=0     (testing.TestRegistry.serialize)
         117   jump +123                (to 240)
 
   180   118   load_type 13             
         119   load_type 14             
         120   load_var 1               (self)
         121   load_field 1             (expansions)
-        122   call 15 ntypeargs=2      (baml.Map.keys)
+        122   call 9 ntypeargs=2       (baml.Map.keys)
         123   store_var 7              (_40)
 
   179   124   load_type 13             
         125   load_var 7               (_40)
-        126   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1164,16 +1164,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 602    
+        174   make_bound_method 596    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 613    
+        179   make_bound_method 607    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1181,39 +1181,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 558    
+        191   make_bound_method 552    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 588    
+        219   make_bound_method 582    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1232,11 +1232,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   182   233   load_var2 2 10           
         234   load_const 25            ("/")
         235   bin_op +                 
-        236   call 154 ntypeargs=0     (baml.String.starts_with)
+        236   call 148 ntypeargs=0     (baml.String.starts_with)
         237   pop_jump_if_false -109   (to 128)
 
   183   238   load_var2 11 2           
-        239   call 821 ntypeargs=0     (testing.TestRegistry.expand_set)
+        239   call 815 ntypeargs=0     (testing.TestRegistry.expand_set)
         240   return                   
 
   186   241   load_const 26            ("TestSet not found for expansion: ")
@@ -1253,14 +1253,14 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         3    load_field 1           (expansions)
         4    load_var 2             (ts)
         5    load_field 0           (name)
-        6    call 44 ntypeargs=2    (baml.Map.get)
+        6    call 38 ntypeargs=2    (baml.Map.get)
         7    store_var 3            (_3)
         8    load_var 3             (_3)
         9    is_type 2              
         10   pop_jump_if_false +2   (to 12)
         11   jump +33               (to 44)
 
-  193   12   call 281 ntypeargs=0   (baml.sys.now_ms)
+  193   12   call 275 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 5            (start)
 
   194   14   load_var 2             (ts)
@@ -1275,7 +1275,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         22   call_indirect          
         23   pop 1                  
 
-  196   24   call 281 ntypeargs=0   (baml.sys.now_ms)
+  196   24   call 275 ntypeargs=0   (baml.sys.now_ms)
         25   load_var 5             (start)
         26   sub_int                
         27   store_var 7            (elapsed)
@@ -1295,7 +1295,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         37   load_var 2             (ts)
         38   load_field 0           (name)
         39   load_var 8             (sub_registry)
-        40   call 16 ntypeargs=2    (baml.Map.set)
+        40   call 10 ntypeargs=2    (baml.Map.set)
         41   pop 1                  
 
   203   42   load_var 8             (sub_registry)
@@ -1311,25 +1311,25 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.from_json(j: baml.json.json) -> testing.TestRegistry {
   90   0    load_var 1             (j)
        1    load_const 0           ("collector")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("expansions")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("loading_time_ms")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestRegistry .collector, .expansions, .loading_time_ms)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -1349,9 +1349,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 807 ntypeargs=0   (testing.testset_children)
+        1   call 801 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 818 ntypeargs=0   (testing.run_testset)
+        3   call 812 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1363,7 +1363,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
 
   133   4     load_type 0              
         5     load_var 3               (_3)
-        6     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1407,16 +1407,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 602    
+        54    make_bound_method 596    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 613    
+        59    make_bound_method 607    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1424,39 +1424,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 558    
+        71    make_bound_method 552    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 588    
+        99    make_bound_method 582    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1475,19 +1475,19 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         113   load_field 1             (body)
         114   load_var 6               (t)
         115   load_field 2             (runner)
-        116   call 829 ntypeargs=0     (testing.run_test)
+        116   call 823 ntypeargs=0     (testing.run_test)
         117   jump +123                (to 240)
 
   140   118   load_type 13             
         119   load_type 14             
         120   load_var 1               (self)
         121   load_field 1             (expansions)
-        122   call 15 ntypeargs=2      (baml.Map.keys)
+        122   call 9 ntypeargs=2       (baml.Map.keys)
         123   store_var 7              (_40)
 
   139   124   load_type 13             
         125   load_var 7               (_40)
-        126   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1531,16 +1531,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 602    
+        174   make_bound_method 596    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 613    
+        179   make_bound_method 607    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1548,39 +1548,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 558    
+        191   make_bound_method 552    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 588    
+        219   make_bound_method 582    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1599,12 +1599,12 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
   143   233   load_var2 2 10           
         234   load_const 25            ("/")
         235   bin_op +                 
-        236   call 154 ntypeargs=0     (baml.String.starts_with)
+        236   call 148 ntypeargs=0     (baml.String.starts_with)
 
   142   237   pop_jump_if_false -109   (to 128)
 
   144   238   load_var2 11 2           
-        239   call 819 ntypeargs=0     (testing.TestRegistry.run_test)
+        239   call 813 ntypeargs=0     (testing.TestRegistry.run_test)
         240   return                   
 
   147   241   load_const 26            ("Test not found: ")
@@ -1621,7 +1621,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1665,16 +1665,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 602    
+        54    make_bound_method 596    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 613    
+        59    make_bound_method 607    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1682,39 +1682,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 558    
+        71    make_bound_method 552    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 588    
+        99    make_bound_method 582    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1730,22 +1730,22 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         111   pop_jump_if_false -103   (to 8)
 
   153   112   load_var2 1 6            
-        113   call 830 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
-        114   call 807 ntypeargs=0     (testing.testset_children)
+        113   call 824 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        114   call 801 ntypeargs=0     (testing.testset_children)
         115   load_var 6               (ts)
         116   load_field 2             (runner)
-        117   call 818 ntypeargs=0     (testing.run_testset)
+        117   call 812 ntypeargs=0     (testing.run_testset)
         118   jump +123                (to 241)
 
   156   119   load_type 13             
         120   load_type 14             
         121   load_var 1               (self)
         122   load_field 1             (expansions)
-        123   call 15 ntypeargs=2      (baml.Map.keys)
+        123   call 9 ntypeargs=2       (baml.Map.keys)
         124   store_var 7              (_42)
         125   load_type 13             
         126   load_var 7               (_42)
-        127   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         128   store_var 8              (_46)
         129   load_var 8               (_46)
         130   is_type 15               
@@ -1789,16 +1789,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         168   load_type 13             
         169   load_type 11             
         170   load_var 8               (_46)
-        171   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         172   store_var 9              (_48)
         173   jump +50                 (to 223)
         174   load_var 8               (_46)
-        175   make_bound_method 602    
+        175   make_bound_method 596    
         176   call_indirect            
         177   store_var 9              (_48)
         178   jump +45                 (to 223)
         179   load_var 8               (_46)
-        180   make_bound_method 613    
+        180   make_bound_method 607    
         181   call_indirect            
         182   store_var 9              (_48)
         183   jump +40                 (to 223)
@@ -1806,39 +1806,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         185   load_type 11             
         186   load_type 11             
         187   load_var 8               (_46)
-        188   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         189   store_var 9              (_48)
         190   jump +33                 (to 223)
         191   load_var 8               (_46)
-        192   make_bound_method 558    
+        192   make_bound_method 552    
         193   call_indirect            
         194   store_var 9              (_48)
         195   jump +28                 (to 223)
         196   load_type 13             
         197   load_var 8               (_46)
-        198   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         199   store_var 9              (_48)
         200   jump +23                 (to 223)
         201   load_type 13             
         202   load_type 11             
         203   load_type 11             
         204   load_var 8               (_46)
-        205   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         206   store_var 9              (_48)
         207   jump +16                 (to 223)
         208   load_type 13             
         209   load_type 11             
         210   load_var 8               (_46)
-        211   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         212   store_var 9              (_48)
         213   jump +10                 (to 223)
         214   load_type 13             
         215   load_var 8               (_46)
-        216   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         217   store_var 9              (_48)
         218   jump +5                  (to 223)
         219   load_var 8               (_46)
-        220   make_bound_method 588    
+        220   make_bound_method 582    
         221   call_indirect            
         222   store_var 9              (_48)
         223   load_var 9               (_48)
@@ -1857,11 +1857,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
   158   234   load_var2 2 10           
         235   load_const 25            ("/")
         236   bin_op +                 
-        237   call 154 ntypeargs=0     (baml.String.starts_with)
+        237   call 148 ntypeargs=0     (baml.String.starts_with)
         238   pop_jump_if_false -109   (to 129)
 
   159   239   load_var2 11 2           
-        240   call 825 ntypeargs=0     (testing.TestRegistry.run_testset)
+        240   call 819 ntypeargs=0     (testing.TestRegistry.run_testset)
         241   return                   
 
   162   242   load_const 26            ("TestSet not found: ")
@@ -1881,7 +1881,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         5     store_var 4              (_3)
         6     load_type 0              
         7     load_var 4               (_3)
-        8     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        8     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         9     store_var 5              (_4)
         10    load_var 5               (_4)
         11    is_type 1                
@@ -1925,16 +1925,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         49    load_type 0              
         50    load_type 11             
         51    load_var 5               (_4)
-        52    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        52    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         53    store_var 6              (_6)
         54    jump +50                 (to 104)
         55    load_var 5               (_4)
-        56    make_bound_method 602    
+        56    make_bound_method 596    
         57    call_indirect            
         58    store_var 6              (_6)
         59    jump +45                 (to 104)
         60    load_var 5               (_4)
-        61    make_bound_method 613    
+        61    make_bound_method 607    
         62    call_indirect            
         63    store_var 6              (_6)
         64    jump +40                 (to 104)
@@ -1942,39 +1942,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         66    load_type 11             
         67    load_type 11             
         68    load_var 5               (_4)
-        69    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        69    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         70    store_var 6              (_6)
         71    jump +33                 (to 104)
         72    load_var 5               (_4)
-        73    make_bound_method 558    
+        73    make_bound_method 552    
         74    call_indirect            
         75    store_var 6              (_6)
         76    jump +28                 (to 104)
         77    load_type 0              
         78    load_var 5               (_4)
-        79    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        79    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         80    store_var 6              (_6)
         81    jump +23                 (to 104)
         82    load_type 0              
         83    load_type 11             
         84    load_type 11             
         85    load_var 5               (_4)
-        86    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        86    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         87    store_var 6              (_6)
         88    jump +16                 (to 104)
         89    load_type 0              
         90    load_type 11             
         91    load_var 5               (_4)
-        92    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        92    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         93    store_var 6              (_6)
         94    jump +10                 (to 104)
         95    load_type 0              
         96    load_var 5               (_4)
-        97    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        97    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         98    store_var 6              (_6)
         99    jump +5                  (to 104)
         100   load_var 5               (_4)
-        101   make_bound_method 588    
+        101   make_bound_method 582    
         102   call_indirect            
         103   store_var 6              (_6)
         104   load_var 6               (_6)
@@ -1989,7 +1989,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         112   load_var 7               (t)
         113   load_field 0             (name)
         114   init_instance 0          (testing.SerializedTest .type, .name)
-        115   call 13 ntypeargs=0      (baml.Array.push)
+        115   call 7 ntypeargs=0       (baml.Array.push)
         116   pop 1                    
         117   jump -107                (to 10)
 
@@ -1999,7 +1999,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         121   store_var 8              (_39)
         122   load_type 14             
         123   load_var 8               (_39)
-        124   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        124   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         125   store_var 9              (_40)
         126   load_var 9               (_40)
         127   is_type 15               
@@ -2043,16 +2043,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         165   load_type 14             
         166   load_type 11             
         167   load_var 9               (_40)
-        168   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        168   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         169   store_var 10             (_42)
         170   jump +50                 (to 220)
         171   load_var 9               (_40)
-        172   make_bound_method 602    
+        172   make_bound_method 596    
         173   call_indirect            
         174   store_var 10             (_42)
         175   jump +45                 (to 220)
         176   load_var 9               (_40)
-        177   make_bound_method 613    
+        177   make_bound_method 607    
         178   call_indirect            
         179   store_var 10             (_42)
         180   jump +40                 (to 220)
@@ -2060,39 +2060,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         182   load_type 11             
         183   load_type 11             
         184   load_var 9               (_40)
-        185   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        185   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         186   store_var 10             (_42)
         187   jump +33                 (to 220)
         188   load_var 9               (_40)
-        189   make_bound_method 558    
+        189   make_bound_method 552    
         190   call_indirect            
         191   store_var 10             (_42)
         192   jump +28                 (to 220)
         193   load_type 14             
         194   load_var 9               (_40)
-        195   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        195   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         196   store_var 10             (_42)
         197   jump +23                 (to 220)
         198   load_type 14             
         199   load_type 11             
         200   load_type 11             
         201   load_var 9               (_40)
-        202   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        202   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         203   store_var 10             (_42)
         204   jump +16                 (to 220)
         205   load_type 14             
         206   load_type 11             
         207   load_var 9               (_40)
-        208   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        208   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         209   store_var 10             (_42)
         210   jump +10                 (to 220)
         211   load_type 14             
         212   load_var 9               (_40)
-        213   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        213   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         214   store_var 10             (_42)
         215   jump +5                  (to 220)
         216   load_var 9               (_40)
-        217   make_bound_method 588    
+        217   make_bound_method 582    
         218   call_indirect            
         219   store_var 10             (_42)
         220   load_var 10              (_42)
@@ -2108,7 +2108,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         229   load_field 1             (expansions)
         230   load_var 11              (ts)
         231   load_field 0             (name)
-        232   call 44 ntypeargs=2      (baml.Map.get)
+        232   call 38 ntypeargs=2      (baml.Map.get)
         233   store_var 12             (expanded)
 
   115   234   load_var 12              (expanded)
@@ -2121,7 +2121,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         240   load_var 11              (ts)
         241   load_field 0             (name)
         242   init_instance 1          (testing.SerializedTest .type, .name)
-        243   call 13 ntypeargs=0      (baml.Array.push)
+        243   call 7 ntypeargs=0       (baml.Array.push)
         244   pop 1                    
         245   jump -119                (to 126)
 
@@ -2133,7 +2133,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         250   store_var 14             (_81)
 
   119   251   load_var 13              (sub)
-        252   call 816 ntypeargs=0     (testing.TestRegistry.serialize)
+        252   call 810 ntypeargs=0     (testing.TestRegistry.serialize)
         253   store_var 15             (_82)
 
   117   254   load_var2 3 14           
@@ -2141,7 +2141,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 
   120   256   load_field 2             (loading_time_ms)
         257   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        258   call 13 ntypeargs=0      (baml.Array.push)
+        258   call 7 ntypeargs=0       (baml.Array.push)
         259   pop 1                    
         260   jump -134                (to 126)
 
@@ -2155,18 +2155,18 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
   19   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("runs")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.TestReport .outcome, .runs)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -2176,18 +2176,18 @@ function testing.TestReport.from_json(j: baml.json.json) -> testing.TestReport {
 function testing.TestSetChild.from_json(j: baml.json.json) -> testing.TestSetChild {
   55   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("run")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (testing.TestSetChild .name, .run)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -2197,25 +2197,25 @@ function testing.TestSetChild.from_json(j: baml.json.json) -> testing.TestSetChi
 function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.TestSetRegistration {
   11   0    load_var 1             (j)
        1    load_const 0           ("name")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("collector")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("runner")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (testing.TestSetRegistration .name, .collector, .runner)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -2225,46 +2225,46 @@ function testing.TestSetRegistration.from_json(j: baml.json.json) -> testing.Tes
 function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetReport {
   26   0    load_var 1             (j)
        1    load_const 0           ("outcome")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("passed")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("failed")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 3            
        19   load_var 5             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   load_var 1             (j)
        22   load_const 5           ("total")
-       23   call 377 ntypeargs=0   (baml.json.field)
+       23   call 371 ntypeargs=0   (baml.json.field)
        24   store_var 6            (_12)
        25   load_type 3            
        26   load_var 6             (_12)
-       27   call 372 ntypeargs=1   (baml.json.from_json)
+       27   call 366 ntypeargs=1   (baml.json.from_json)
        28   load_var 1             (j)
        29   load_const 6           ("failed_names")
-       30   call 377 ntypeargs=0   (baml.json.field)
+       30   call 371 ntypeargs=0   (baml.json.field)
        31   store_var 7            (_15)
        32   load_type 7            
        33   load_var 7             (_15)
-       34   call 372 ntypeargs=1   (baml.json.from_json)
+       34   call 366 ntypeargs=1   (baml.json.from_json)
        35   load_var 1             (j)
        36   load_const 8           ("results")
-       37   call 377 ntypeargs=0   (baml.json.field)
+       37   call 371 ntypeargs=0   (baml.json.field)
        38   store_var 8            (_18)
        39   load_type 9            
        40   load_var 8             (_18)
-       41   call 372 ntypeargs=1   (baml.json.from_json)
+       41   call 366 ntypeargs=1   (baml.json.from_json)
        42   init_instance 0        (testing.TestSetReport .outcome, .passed, .failed, .total, .failed_names, .results)
        43   store_var 2            (_0)
        44   load_var 2             (_0)
@@ -2274,14 +2274,14 @@ function testing.TestSetReport.from_json(j: baml.json.json) -> testing.TestSetRe
 function testing._int_to_float(value: int) -> float {
   125   0   load_type 0            
         1   load_var 1             (value)
-        2   call 472 ntypeargs=1   (baml.unstable.string)
-        3   call 127 ntypeargs=0   (baml.Float.parse)
+        2   call 466 ntypeargs=1   (baml.unstable.string)
+        3   call 121 ntypeargs=0   (baml.Float.parse)
         4   jump +5                (to 9)
         5   load_var 2             (e)
         6   throw_if_panic         
 
   126   7   load_const 1           ("failed to convert int to float")
-        8   call 284 ntypeargs=0   (baml.sys.panic)
+        8   call 278 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
@@ -2303,7 +2303,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   253   10    load_type 2              
         11    load_var 1               (named_results)
-        12    call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        12    call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         13    store_var 8              (_7)
         14    load_var 8               (_7)
         15    is_type 3                
@@ -2347,16 +2347,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         53    load_type 2              
         54    load_type 13             
         55    load_var 8               (_7)
-        56    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        56    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         57    store_var 9              (_9)
         58    jump +50                 (to 108)
         59    load_var 8               (_7)
-        60    make_bound_method 602    
+        60    make_bound_method 596    
         61    call_indirect            
         62    store_var 9              (_9)
         63    jump +45                 (to 108)
         64    load_var 8               (_7)
-        65    make_bound_method 613    
+        65    make_bound_method 607    
         66    call_indirect            
         67    store_var 9              (_9)
         68    jump +40                 (to 108)
@@ -2364,39 +2364,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         70    load_type 13             
         71    load_type 13             
         72    load_var 8               (_7)
-        73    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        73    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         74    store_var 9              (_9)
         75    jump +33                 (to 108)
         76    load_var 8               (_7)
-        77    make_bound_method 558    
+        77    make_bound_method 552    
         78    call_indirect            
         79    store_var 9              (_9)
         80    jump +28                 (to 108)
         81    load_type 2              
         82    load_var 8               (_7)
-        83    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        83    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         84    store_var 9              (_9)
         85    jump +23                 (to 108)
         86    load_type 2              
         87    load_type 13             
         88    load_type 13             
         89    load_var 8               (_7)
-        90    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        90    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         91    store_var 9              (_9)
         92    jump +16                 (to 108)
         93    load_type 2              
         94    load_type 13             
         95    load_var 8               (_7)
-        96    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        96    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         97    store_var 9              (_9)
         98    jump +10                 (to 108)
         99    load_type 2              
         100   load_var 8               (_7)
-        101   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        101   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         102   store_var 9              (_9)
         103   jump +5                  (to 108)
         104   load_var 8               (_7)
-        105   make_bound_method 588    
+        105   make_bound_method 582    
         106   call_indirect            
         107   store_var 9              (_9)
         108   load_var 9               (_9)
@@ -2411,7 +2411,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         116   store_var 11             (result)
 
   255   117   load_var2 7 11           
-        118   call 13 ntypeargs=0      (baml.Array.push)
+        118   call 7 ntypeargs=0       (baml.Array.push)
         119   pop 1                    
 
   256   120   load_var 11              (result)
@@ -2435,7 +2435,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   260   135   load_var 12              (outcome)
         136   load_const 16            ("pass")
-        137   call 790 ntypeargs=0     (baml.ops.equals_equals)
+        137   call 784 ntypeargs=0     (baml.ops.equals_equals)
         138   pop_jump_if_false +2     (to 140)
         139   jump +144                (to 283)
 
@@ -2477,7 +2477,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
   272   167   store_var 16             (_56)
         168   load_type 18             
         169   load_var 16              (_56)
-        170   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        170   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         171   store_var 17             (_57)
         172   load_var 17              (_57)
         173   is_type 19               
@@ -2521,16 +2521,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         211   load_type 18             
         212   load_type 13             
         213   load_var 17              (_57)
-        214   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        214   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         215   store_var 18             (_59)
         216   jump +50                 (to 266)
         217   load_var 17              (_57)
-        218   make_bound_method 602    
+        218   make_bound_method 596    
         219   call_indirect            
         220   store_var 18             (_59)
         221   jump +45                 (to 266)
         222   load_var 17              (_57)
-        223   make_bound_method 613    
+        223   make_bound_method 607    
         224   call_indirect            
         225   store_var 18             (_59)
         226   jump +40                 (to 266)
@@ -2538,39 +2538,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         228   load_type 13             
         229   load_type 13             
         230   load_var 17              (_57)
-        231   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        231   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         232   store_var 18             (_59)
         233   jump +33                 (to 266)
         234   load_var 17              (_57)
-        235   make_bound_method 558    
+        235   make_bound_method 552    
         236   call_indirect            
         237   store_var 18             (_59)
         238   jump +28                 (to 266)
         239   load_type 18             
         240   load_var 17              (_57)
-        241   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        241   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         242   store_var 18             (_59)
         243   jump +23                 (to 266)
         244   load_type 18             
         245   load_type 13             
         246   load_type 13             
         247   load_var 17              (_57)
-        248   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        248   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         249   store_var 18             (_59)
         250   jump +16                 (to 266)
         251   load_type 18             
         252   load_type 13             
         253   load_var 17              (_57)
-        254   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        254   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         255   store_var 18             (_59)
         256   jump +10                 (to 266)
         257   load_type 18             
         258   load_var 17              (_57)
-        259   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        259   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         260   store_var 18             (_59)
         261   jump +5                  (to 266)
         262   load_var 17              (_57)
-        263   make_bound_method 588    
+        263   make_bound_method 582    
         264   call_indirect            
         265   store_var 18             (_59)
         266   load_var 18              (_59)
@@ -2581,13 +2581,13 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         271   store_var 19             (name)
 
   273   272   load_var2 6 19           
-        273   call 13 ntypeargs=0      (baml.Array.push)
+        273   call 7 ntypeargs=0       (baml.Array.push)
         274   pop 1                    
         275   jump -103                (to 172)
 
   275   276   load_var 12              (outcome)
         277   load_const 29            ("error")
-        278   call 790 ntypeargs=0     (baml.ops.equals_equals)
+        278   call 784 ntypeargs=0     (baml.ops.equals_equals)
         279   pop_jump_if_false -265   (to 14)
 
   276   280   load_const 30            (true)
@@ -2648,7 +2648,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
 
   295   5     load_type 0             
         6     load_var 1              (children)
-        7     call 572 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
+        7     call 566 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
         8     store_var 3             (_3)
         9     load_var 3              (_3)
         10    is_type 1               
@@ -2692,16 +2692,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         48    load_type 0             
         49    load_type 11            
         50    load_var 3              (_3)
-        51    call 575 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
+        51    call 569 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
         52    store_var 4             (_5)
         53    jump +50                (to 103)
         54    load_var 3              (_3)
-        55    make_bound_method 602   
+        55    make_bound_method 596   
         56    call_indirect           
         57    store_var 4             (_5)
         58    jump +45                (to 103)
         59    load_var 3              (_3)
-        60    make_bound_method 613   
+        60    make_bound_method 607   
         61    call_indirect           
         62    store_var 4             (_5)
         63    jump +40                (to 103)
@@ -2709,39 +2709,39 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         65    load_type 11            
         66    load_type 11            
         67    load_var 3              (_3)
-        68    call 547 ntypeargs=3    (baml.iter.Filter.Iterator.next)
+        68    call 541 ntypeargs=3    (baml.iter.Filter.Iterator.next)
         69    store_var 4             (_5)
         70    jump +33                (to 103)
         71    load_var 3              (_3)
-        72    make_bound_method 558   
+        72    make_bound_method 552   
         73    call_indirect           
         74    store_var 4             (_5)
         75    jump +28                (to 103)
         76    load_type 0             
         77    load_var 3              (_3)
-        78    call 571 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
+        78    call 565 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
         79    store_var 4             (_5)
         80    jump +23                (to 103)
         81    load_type 0             
         82    load_type 11            
         83    load_type 11            
         84    load_var 3              (_3)
-        85    call 549 ntypeargs=3    (baml.iter.Chain.Iterator.next)
+        85    call 543 ntypeargs=3    (baml.iter.Chain.Iterator.next)
         86    store_var 4             (_5)
         87    jump +16                (to 103)
         88    load_type 0             
         89    load_type 11            
         90    load_var 3              (_3)
-        91    call 561 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
+        91    call 555 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
         92    store_var 4             (_5)
         93    jump +10                (to 103)
         94    load_type 0             
         95    load_var 3              (_3)
-        96    call 598 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
+        96    call 592 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
         97    store_var 4             (_5)
         98    jump +5                 (to 103)
         99    load_var 3              (_3)
-        100   make_bound_method 588   
+        100   make_bound_method 582   
         101   call_indirect           
         102   store_var 4             (_5)
         103   load_var 4              (_5)
@@ -2755,29 +2755,29 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         111   store_deref 5           
 
   296   112   load_var 5              (child)
-        113   make_closure 1512 1     
+        113   make_closure 1479 1     
         114   load_const 13           (null)
         115   load_const 13           (null)
         116   spawn                   
         117   store_var 6             (_38)
         118   load_var2 2 6           
-        119   call 13 ntypeargs=0     (baml.Array.push)
+        119   call 7 ntypeargs=0      (baml.Array.push)
         120   pop 1                   
         121   jump -112               (to 9)
 
   300   122   load_type 14            
         123   load_type 15            
         124   load_var 2              (futures)
-        125   call 625 ntypeargs=2    (baml.future.all_complete)
+        125   call 619 ntypeargs=2    (baml.future.all_complete)
         126   await                   
         127   jump +5                 (to 132)
         128   load_var 7              (e)
         129   throw_if_panic          
 
   301   130   load_const 16           ("unexpected test child failure")
-        131   call 284 ntypeargs=0    (baml.sys.panic)
+        131   call 278 ntypeargs=0    (baml.sys.panic)
 
-  303   132   call 815 ntypeargs=0    (testing.aggregate_reports)
+  303   132   call 809 ntypeargs=0    (testing.aggregate_reports)
         133   return                  
         134   unreachable             
 }
@@ -2788,7 +2788,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
 
   108   2     load_type 0              
         3     load_var 1               (children)
-        4     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        4     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         5     store_var 4              (_4)
         6     load_var 4               (_4)
         7     is_type 1                
@@ -2832,16 +2832,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         45    load_type 0              
         46    load_type 11             
         47    load_var 4               (_4)
-        48    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        48    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         49    store_var 5              (_6)
         50    jump +50                 (to 100)
         51    load_var 4               (_4)
-        52    make_bound_method 602    
+        52    make_bound_method 596    
         53    call_indirect            
         54    store_var 5              (_6)
         55    jump +45                 (to 100)
         56    load_var 4               (_4)
-        57    make_bound_method 613    
+        57    make_bound_method 607    
         58    call_indirect            
         59    store_var 5              (_6)
         60    jump +40                 (to 100)
@@ -2849,39 +2849,39 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         62    load_type 11             
         63    load_type 11             
         64    load_var 4               (_4)
-        65    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        65    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         66    store_var 5              (_6)
         67    jump +33                 (to 100)
         68    load_var 4               (_4)
-        69    make_bound_method 558    
+        69    make_bound_method 552    
         70    call_indirect            
         71    store_var 5              (_6)
         72    jump +28                 (to 100)
         73    load_type 0              
         74    load_var 4               (_4)
-        75    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        75    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         76    store_var 5              (_6)
         77    jump +23                 (to 100)
         78    load_type 0              
         79    load_type 11             
         80    load_type 11             
         81    load_var 4               (_4)
-        82    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        82    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         83    store_var 5              (_6)
         84    jump +16                 (to 100)
         85    load_type 0              
         86    load_type 11             
         87    load_var 4               (_4)
-        88    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        88    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         89    store_var 5              (_6)
         90    jump +10                 (to 100)
         91    load_type 0              
         92    load_var 4               (_4)
-        93    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        93    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         94    store_var 5              (_6)
         95    jump +5                  (to 100)
         96    load_var 4               (_4)
-        97    make_bound_method 588    
+        97    make_bound_method 582    
         98    call_indirect            
         99    store_var 5              (_6)
         100   load_var 5               (_6)
@@ -2899,7 +2899,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         110   load_field 0             (name)
         111   load_var 7               (report)
         112   init_instance 0          (testing.NamedChildReport .name, .report)
-        113   call 13 ntypeargs=0      (baml.Array.push)
+        113   call 7 ntypeargs=0       (baml.Array.push)
         114   pop 1                    
 
   111   115   load_var 7               (report)
@@ -2926,16 +2926,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         132   pop 1                    
         133   load_var 8               (outcome)
         134   load_const 14            ("pass")
-        135   call 790 ntypeargs=0     (baml.ops.equals_equals)
+        135   call 784 ntypeargs=0     (baml.ops.equals_equals)
         136   unary_op !               
         137   pop_jump_if_false -131   (to 6)
 
   116   138   load_var 3               (named_results)
-        139   call 815 ntypeargs=0     (testing.aggregate_reports)
+        139   call 809 ntypeargs=0     (testing.aggregate_reports)
         140   jump +3                  (to 143)
 
   121   141   load_var 3               (named_results)
-        142   call 815 ntypeargs=0     (testing.aggregate_reports)
+        142   call 809 ntypeargs=0     (testing.aggregate_reports)
         143   return                   
         144   unreachable              
 }
@@ -2946,7 +2946,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   308   3    load_var 1             (body)
-        4    make_closure 1521 1    
+        4    make_closure 1488 1    
         5    store_var 3            (base_run)
 
   332   6    load_var 2             (runner)
@@ -2982,7 +2982,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   344   10   load_var 1             (children)
-        11   call 827 ntypeargs=0   (testing.run_children_parallel)
+        11   call 821 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
@@ -2997,7 +2997,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   221   6    load_var2 1 2         
 
   223   7    load_var 3            (runner)
-        8    make_closure 1469 2   
+        8    make_closure 1436 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -3016,7 +3016,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   230   8    load_var2 1 2         
-        9    make_closure 1498 2   
+        9    make_closure 1465 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -3033,7 +3033,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         5     store_var 4              (_3)
         6     load_type 0              
         7     load_var 4               (_3)
-        8     call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        8     call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         9     store_var 5              (_4)
         10    load_var 5               (_4)
         11    is_type 1                
@@ -3077,16 +3077,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         49    load_type 0              
         50    load_type 11             
         51    load_var 5               (_4)
-        52    call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        52    call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         53    store_var 6              (_6)
         54    jump +50                 (to 104)
         55    load_var 5               (_4)
-        56    make_bound_method 602    
+        56    make_bound_method 596    
         57    call_indirect            
         58    store_var 6              (_6)
         59    jump +45                 (to 104)
         60    load_var 5               (_4)
-        61    make_bound_method 613    
+        61    make_bound_method 607    
         62    call_indirect            
         63    store_var 6              (_6)
         64    jump +40                 (to 104)
@@ -3094,39 +3094,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         66    load_type 11             
         67    load_type 11             
         68    load_var 5               (_4)
-        69    call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        69    call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         70    store_var 6              (_6)
         71    jump +33                 (to 104)
         72    load_var 5               (_4)
-        73    make_bound_method 558    
+        73    make_bound_method 552    
         74    call_indirect            
         75    store_var 6              (_6)
         76    jump +28                 (to 104)
         77    load_type 0              
         78    load_var 5               (_4)
-        79    call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        79    call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         80    store_var 6              (_6)
         81    jump +23                 (to 104)
         82    load_type 0              
         83    load_type 11             
         84    load_type 11             
         85    load_var 5               (_4)
-        86    call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        86    call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         87    store_var 6              (_6)
         88    jump +16                 (to 104)
         89    load_type 0              
         90    load_type 11             
         91    load_var 5               (_4)
-        92    call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        92    call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         93    store_var 6              (_6)
         94    jump +10                 (to 104)
         95    load_type 0              
         96    load_var 5               (_4)
-        97    call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        97    call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         98    store_var 6              (_6)
         99    jump +5                  (to 104)
         100   load_var 5               (_4)
-        101   make_bound_method 588    
+        101   make_bound_method 582    
         102   call_indirect            
         103   store_var 6              (_6)
         104   load_var 6               (_6)
@@ -3141,10 +3141,10 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         112   load_field 1             (body)
         113   load_var 7               (t)
         114   load_field 2             (runner)
-        115   call 813 ntypeargs=0     (testing.test_child)
+        115   call 807 ntypeargs=0     (testing.test_child)
         116   store_var 8              (_37)
         117   load_var2 3 8            
-        118   call 13 ntypeargs=0      (baml.Array.push)
+        118   call 7 ntypeargs=0       (baml.Array.push)
         119   pop 1                    
         120   jump -110                (to 10)
 
@@ -3154,7 +3154,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         124   store_var 9              (_41)
         125   load_type 13             
         126   load_var 9               (_41)
-        127   call 572 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   call 566 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         128   store_var 10             (_42)
         129   load_var 10              (_42)
         130   is_type 14               
@@ -3198,16 +3198,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         168   load_type 13             
         169   load_type 11             
         170   load_var 10              (_42)
-        171   call 575 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   call 569 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         172   store_var 11             (_44)
         173   jump +50                 (to 223)
         174   load_var 10              (_42)
-        175   make_bound_method 602    
+        175   make_bound_method 596    
         176   call_indirect            
         177   store_var 11             (_44)
         178   jump +45                 (to 223)
         179   load_var 10              (_42)
-        180   make_bound_method 613    
+        180   make_bound_method 607    
         181   call_indirect            
         182   store_var 11             (_44)
         183   jump +40                 (to 223)
@@ -3215,39 +3215,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         185   load_type 11             
         186   load_type 11             
         187   load_var 10              (_42)
-        188   call 547 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   call 541 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         189   store_var 11             (_44)
         190   jump +33                 (to 223)
         191   load_var 10              (_42)
-        192   make_bound_method 558    
+        192   make_bound_method 552    
         193   call_indirect            
         194   store_var 11             (_44)
         195   jump +28                 (to 223)
         196   load_type 13             
         197   load_var 10              (_42)
-        198   call 571 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   call 565 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         199   store_var 11             (_44)
         200   jump +23                 (to 223)
         201   load_type 13             
         202   load_type 11             
         203   load_type 11             
         204   load_var 10              (_42)
-        205   call 549 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   call 543 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         206   store_var 11             (_44)
         207   jump +16                 (to 223)
         208   load_type 13             
         209   load_type 11             
         210   load_var 10              (_42)
-        211   call 561 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   call 555 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         212   store_var 11             (_44)
         213   jump +10                 (to 223)
         214   load_type 13             
         215   load_var 10              (_42)
-        216   call 598 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   call 592 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         217   store_var 11             (_44)
         218   jump +5                  (to 223)
         219   load_var 10              (_42)
-        220   make_bound_method 588    
+        220   make_bound_method 582    
         221   call_indirect            
         222   store_var 11             (_44)
         223   load_var 11              (_44)
@@ -3258,10 +3258,10 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         228   store_var 12             (ts)
 
   215   229   load_var2 1 12           
-        230   call 822 ntypeargs=0     (testing.testset_child)
+        230   call 816 ntypeargs=0     (testing.testset_child)
         231   store_var 13             (_75)
         232   load_var2 3 13           
-        233   call 13 ntypeargs=0      (baml.Array.push)
+        233   call 7 ntypeargs=0       (baml.Array.push)
         234   pop 1                    
         235   jump -106                (to 129)
 
@@ -3275,18 +3275,18 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
   26   0    load_var 1             (j)
        1    load_const 0           ("code")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("message")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   init_instance 0        (user.ErrorInfo .code, .message)
        15   store_var 2            (_0)
        16   load_var 2             (_0)
@@ -3296,25 +3296,25 @@ function user.ErrorInfo.from_json(j: baml.json.json) -> ErrorInfo {
 function user.Report.from_json(j: baml.json.json) -> Report {
   20   0    load_var 1             (j)
        1    load_const 0           ("score")
-       2    call 377 ntypeargs=0   (baml.json.field)
+       2    call 371 ntypeargs=0   (baml.json.field)
        3    store_var 3            (_3)
        4    load_type 1            
        5    load_var 3             (_3)
-       6    call 372 ntypeargs=1   (baml.json.from_json)
+       6    call 366 ntypeargs=1   (baml.json.from_json)
        7    load_var 1             (j)
        8    load_const 2           ("label")
-       9    call 377 ntypeargs=0   (baml.json.field)
+       9    call 371 ntypeargs=0   (baml.json.field)
        10   store_var 4            (_6)
        11   load_type 3            
        12   load_var 4             (_6)
-       13   call 372 ntypeargs=1   (baml.json.from_json)
+       13   call 366 ntypeargs=1   (baml.json.from_json)
        14   load_var 1             (j)
        15   load_const 4           ("breakdown")
-       16   call 377 ntypeargs=0   (baml.json.field)
+       16   call 371 ntypeargs=0   (baml.json.field)
        17   store_var 5            (_9)
        18   load_type 5            
        19   load_var 5             (_9)
-       20   call 372 ntypeargs=1   (baml.json.from_json)
+       20   call 366 ntypeargs=1   (baml.json.from_json)
        21   init_instance 0        (user.Report .score, .label, .breakdown)
        22   store_var 2            (_0)
        23   load_var 2             (_0)
@@ -3324,25 +3324,25 @@ function user.Report.from_json(j: baml.json.json) -> Report {
 function user.User.from_json(j: baml.json.json) -> User {
   3   0    load_var 1             (j)
       1    load_const 0           ("name")
-      2    call 377 ntypeargs=0   (baml.json.field)
+      2    call 371 ntypeargs=0   (baml.json.field)
       3    store_var 3            (_3)
       4    load_type 1            
       5    load_var 3             (_3)
-      6    call 372 ntypeargs=1   (baml.json.from_json)
+      6    call 366 ntypeargs=1   (baml.json.from_json)
       7    load_var 1             (j)
       8    load_const 2           ("age")
-      9    call 377 ntypeargs=0   (baml.json.field)
+      9    call 371 ntypeargs=0   (baml.json.field)
       10   store_var 4            (_6)
       11   load_type 3            
       12   load_var 4             (_6)
-      13   call 372 ntypeargs=1   (baml.json.from_json)
+      13   call 366 ntypeargs=1   (baml.json.from_json)
       14   load_var 1             (j)
       15   load_const 4           ("role")
-      16   call 377 ntypeargs=0   (baml.json.field)
+      16   call 371 ntypeargs=0   (baml.json.field)
       17   store_var 5            (_9)
       18   load_type 5            
       19   load_var 5             (_9)
-      20   call 372 ntypeargs=1   (baml.json.from_json)
+      20   call 366 ntypeargs=1   (baml.json.from_json)
       21   init_instance 0        (user.User .name, .age, .role)
       22   store_var 2            (_0)
       23   load_var 2             (_0)
@@ -3358,7 +3358,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 4 ntypeargs=0     (user.score)
+       7    call 841 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)


### PR DESCRIPTION
## What

Bytecode emit (`generate_project_bytecode_with_opt`) lowered **every function twice**:

- **Pass 1** called `lower_function` only to read each function's global-slot name (`mir.item_ref`) and its intrinsic/await-any skip flag (`mir.kind`).
- **Pass 4** lowers again to actually emit code.

`lower_function` is not memoized, so this doubled all MIR lowering work — including the ~676-function / 8,287-line stdlib, which is embedded as source (`include_str!`) and recompiled from scratch on every invocation. For a typical project this lowering is ~the entire fixed compile cost.

## Change

Derive both of Pass 1's needs without lowering:

- **slot name** from `def_to_item_ref(Definition::Function(func_loc))` — identical to `mir.item_ref` in every `lower_function` branch (Expr / Builtin / Missing all set `item_ref` to exactly this).
- **skip set** by matching the function body directly: only a `FunctionBody::Builtin` ever lowers to `MirFunctionKind::Builtin` (Expr/Missing always lower to `Bytecode`), so `matches!(function_body(..), FunctionBody::Builtin(Intrinsic | AwaitAny))` is equivalent to the old `matches!(mir.kind, ...)`.

Pass 4 is untouched and still lowers to emit code, so the emitted `Program` is byte-identical. `function_body` is the same salsa query `lower_function` already calls first, so Pass 1 now does no redundant work.

## Results

Clean-compile wall time (`baml check`, median of 9 runs), same fat-LTO release profile before/after:

| project | baseline | this PR | |
|---|---|---|---|
| 1 function | 0.35s | 0.28s | -20% |
| 200 functions | 0.37s | 0.30s | -19% |
| 5000 functions | 1.22s | 0.93s | -24% |

The bytecode stage drops from ~0.25s to ~0.17s. Behavioral output verified identical on a recursive + loop program (result `232` before and after).

## Follow-up

The remaining fixed cost is the stdlib being recompiled from embedded source on every run; precompiling it to bytecode once is a separate, larger win tracked next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resumable bytecode compilation that reuses a precompiled standard library core, improving CLI compilation speed across check/run/test.

* **Bug Fixes**
  * Fixed bytecode emission to consistently handle intrinsic and special await-any routines.
  * Made built-in class/type tag ordering deterministic to reduce cross-run inconsistencies.

* **Other**
  * Improved error handling by consistently reporting project user-file errors before generating bytecode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->