### PR TITLE
fix(zed): pin language server download to engine release tag

### DIFF
--- a/engine/zed/Cargo.lock
+++ b/engine/zed/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "zed_baml"
-version = "0.218.0"
+version = "0.223.0"
 dependencies = [
  "log",
  "zed_extension_api",

--- a/engine/zed/src/lib.rs
+++ b/engine/zed/src/lib.rs
@@ -23,6 +23,13 @@ const HARDCODED_EXTENSION_CONFIG: HardcodedExtensionConfig = HardcodedExtensionC
 
 const GITHUB_REPO: &str = "BoundaryML/baml";
 
+// The engine (`baml-cli`) release we download the language server from is tagged
+// with this exact version. We pin to it rather than using `latest_github_release`
+// because the repo also publishes a separate `baml-language-*` nightly line, whose
+// releases hold the GitHub "latest" pointer and would otherwise be picked up here.
+// Kept in sync with extension.toml by tools/versions/zed.cfg.
+const ENGINE_RELEASE_TAG: &str = env!("CARGO_PKG_VERSION");
+
 fn language_server_binary(
     language_server_id: &LanguageServerId,
     _worktree: &zed::Worktree,
@@ -52,13 +59,7 @@ fn language_server_binary(
                 &zed::LanguageServerInstallationStatus::CheckingForUpdate,
             );
 
-            let release = zed::latest_github_release(
-                GITHUB_REPO,
-                zed::GithubReleaseOptions {
-                    require_assets: true,
-                    pre_release: false,
-                },
-            )?;
+            let release = zed::github_release_by_tag_name(GITHUB_REPO, ENGINE_RELEASE_TAG)?;
 
             let (platform, arch) = zed::current_platform();
             let asset_name = format!(


### PR DESCRIPTION
## Problem

The Zed extension fails to start the BAML language server with:

> no asset found matching `"baml-cli-baml-language-0.12.2-nightly.20260625.d-aarch64-apple-darwin.tar.gz"`

The extension resolved the `baml-cli` binary via `latest_github_release`, which returns the newest release across the **whole** repo. But the repo publishes two independent release lines:

| Release line | Tag | Asset naming |
|---|---|---|
| Engine / `baml-cli` | `0.223.0` | `baml-cli-0.223.0-<target>.tar.gz` ✅ (what the extension wants) |
| `baml-language-*` nightlies | `baml-language-0.12.2-nightly.20260625.d` | `baml-language-…-<target>.tar.gz` |

The nightly line currently holds GitHub's "latest" pointer, so `release.version` became the nightly tag and the `baml-cli-{version}-{target}` template produced an asset name that doesn't exist.

## Fix

Pin the lookup to the engine release tag — the extension's own `CARGO_PKG_VERSION` (kept in sync with `extension.toml` via `tools/versions/zed.cfg`) — using `github_release_by_tag_name` instead of `latest_github_release`. The extension version and the language-server binary it downloads now stay locked together, and the nightly line is ignored entirely.

Also corrects a stale `Cargo.lock` version (`0.218.0` → `0.223.0`).

## Verification

`cargo check` passes clean. With the extension at `0.223.0`, the asset resolves to `baml-cli-0.223.0-aarch64-apple-darwin.tar.gz`, which exists on the engine release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Language-server downloads now use a fixed release version instead of always following the latest GitHub release.
  * This helps keep the installed engine aligned with the app version, reducing mismatches and unexpected updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->