### PR TITLE
Migrate Zed extension to baml-language toolchain

### DIFF
--- a/engine/zed/Cargo.lock
+++ b/engine/zed/Cargo.lock
@@ -474,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +546,47 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "topological-sort"
@@ -613,6 +663,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -746,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "zed_baml"
-version = "0.218.0"
+version = "0.224.0"
 dependencies = [
- "log",
+ "toml",
  "zed_extension_api",
 ]
 

--- a/engine/zed/Cargo.toml
+++ b/engine/zed/Cargo.toml
@@ -3,7 +3,7 @@ name = "zed_baml"
 edition = "2024"
 # Both Cargo.toml and extension.toml's version strings
 # are consumed by the Zed extension publishing logic
-version = "0.223.0"
+version = "0.224.0"
 description = "BAML language support for Zed"
 
 [lib]
@@ -18,7 +18,7 @@ debug = []
 
 [dependencies]
 zed_extension_api = "0.7.0"
-log = "0.4"
+toml = "0.8"
 
 [workspace]
 # Empty workspace table to make this package standalone

--- a/engine/zed/extension.toml
+++ b/engine/zed/extension.toml
@@ -3,7 +3,7 @@ name = "Baml"
 description = "Baml support."
 # Both Cargo.toml and extension.toml's version strings
 # are consumed by the Zed extension publishing logic
-version = "0.223.0"
+version = "0.224.0"
 schema_version = 1
 authors = ["Boundary <contact@boundaryml.com>"]
 repository = "https://github.com/BoundaryML/zed-baml"

--- a/engine/zed/src/lib.rs
+++ b/engine/zed/src/lib.rs
@@ -1,136 +1,14 @@
 use std::fs;
 
-use zed_extension_api::{self as zed, LanguageServerId, Result};
-
-#[derive(Debug)]
-enum BamlExtensionLspSource {
-    #[allow(dead_code)]
-    LocalBuild,
-    GithubRelease,
-}
-
-#[derive(Debug)]
-struct HardcodedExtensionConfig {
-    lsp_source: BamlExtensionLspSource,
-}
-
-const HARDCODED_EXTENSION_CONFIG: HardcodedExtensionConfig = HardcodedExtensionConfig {
-    // uncomment this to use the local build
-    // THIS MUST BE COMMENTED OUT WHEN MERGING
-    // lsp_source: BamlExtensionLspSource::LocalBuild,
-    lsp_source: BamlExtensionLspSource::GithubRelease,
+use zed_extension_api::{
+    self as zed, LanguageServerId, Result,
+    http_client::{HttpMethod, HttpRequest, RedirectPolicy},
+    settings::LspSettings,
 };
 
-const GITHUB_REPO: &str = "BoundaryML/baml";
-
-fn language_server_binary(
-    language_server_id: &LanguageServerId,
-    _worktree: &zed::Worktree,
-) -> Result<zed::Command> {
-    log::info!(
-        "Retrieving language server binary with settings: {:?}",
-        HARDCODED_EXTENSION_CONFIG
-    );
-    // let binary_settings = LspSettings::for_worktree("baml", worktree)
-    //     .ok()
-    //     .and_then(|lsp_settings| lsp_settings.binary);
-    // let binary_args = binary_settings
-    //     .as_ref()
-    //     .and_then(|binary_settings| binary_settings.arguments.clone());
-
-    // if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
-    //     return Ok(BamlBinary {
-    //         path,
-    //         args: binary_args,
-    //     });
-    // }
-
-    match HARDCODED_EXTENSION_CONFIG.lsp_source {
-        BamlExtensionLspSource::GithubRelease => {
-            zed::set_language_server_installation_status(
-                language_server_id,
-                &zed::LanguageServerInstallationStatus::CheckingForUpdate,
-            );
-
-            let release = zed::latest_github_release(
-                GITHUB_REPO,
-                zed::GithubReleaseOptions {
-                    require_assets: true,
-                    pre_release: false,
-                },
-            )?;
-
-            let (platform, arch) = zed::current_platform();
-            let asset_name = format!(
-                "baml-cli-{version}-{arch}-{os}{extension}",
-                os = match platform {
-                    zed::Os::Mac => "apple-darwin",
-                    zed::Os::Linux => "unknown-linux-gnu",
-                    zed::Os::Windows => "pc-windows-msvc",
-                },
-                arch = match arch {
-                    zed::Architecture::Aarch64 => "aarch64",
-                    zed::Architecture::X86 => "unsupported",
-                    zed::Architecture::X8664 => "x86_64",
-                },
-                extension = match platform {
-                    zed::Os::Mac | zed::Os::Linux => ".tar.gz",
-                    zed::Os::Windows => ".zip",
-                },
-                version = release.version,
-            );
-
-            let asset = release
-                .assets
-                .iter()
-                .find(|asset| asset.name == asset_name)
-                .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
-
-            let version_dir = format!("baml-cli-{}", release.version);
-            let binary_path = format!(
-                "{version_dir}/baml-cli{}",
-                match platform {
-                    zed::Os::Mac | zed::Os::Linux => "",
-                    zed::Os::Windows => ".exe",
-                },
-            );
-
-            if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
-                zed::set_language_server_installation_status(
-                    language_server_id,
-                    &zed::LanguageServerInstallationStatus::Downloading,
-                );
-
-                zed::download_file(
-                    &asset.download_url,
-                    &version_dir,
-                    match platform {
-                        zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
-                        zed::Os::Windows => zed::DownloadedFileType::Zip,
-                    },
-                )
-                .map_err(|e| format!("failed to download file: {e}"))?;
-
-                let entries = fs::read_dir(".")
-                    .map_err(|e| format!("failed to list working directory {e}"))?;
-                for entry in entries {
-                    let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
-                    if entry.file_name().to_str() != Some(&version_dir) {
-                        fs::remove_dir_all(entry.path()).ok();
-                    }
-                }
-            }
-
-            Ok(zed::Command::new(binary_path).arg("lsp"))
-        }
-        BamlExtensionLspSource::LocalBuild => Ok(zed::Command::new(format!(
-            "{}/../target/debug/language-server-hot-reload",
-            env!("CARGO_MANIFEST_DIR")
-        ))
-        .arg("lsp")
-        .env("VSCODE_DEBUG_MODE", "true")),
-    }
-}
+const MANIFEST_BASE_URL: &str = "https://pkg.boundaryml.com/manifest/v1";
+const DEFAULT_CHANNEL: &str = "canary";
+const LANGUAGE_SERVER_ID: &str = "baml-language-server";
 
 struct BamlExtension {}
 
@@ -141,10 +19,16 @@ impl zed::Extension for BamlExtension {
 
     fn language_server_command(
         &mut self,
-        language_server_id: &zed::LanguageServerId,
+        language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        language_server_binary(language_server_id, worktree)
+        if let Some(command) = configured_command(worktree) {
+            return Ok(command);
+        }
+        if let Some(baml) = worktree.which("baml") {
+            return Ok(zed::Command::new(baml).arg("lsp").envs(worktree.shell_env()));
+        }
+        downloaded_command(language_server_id, worktree)
     }
 
     fn language_server_initialization_options(
@@ -152,20 +36,158 @@ impl zed::Extension for BamlExtension {
         _language_server_id: &LanguageServerId,
         _worktree: &zed::Worktree,
     ) -> Result<Option<zed::serde_json::Value>> {
-        Ok(Some(zed::serde_json::json!({
-            "settings": {
-                "featureFlags": [],
-                "generateCodeOnSave": "always",
-                "lspMethodsToForwardToWebview": [
-                    "runtime_updated",
-                    // This allows us to update the currently shown fn/test in the webview when the
-                    // user changes their cursor position in Zed.
-                    // We use this instead of an "update_cursor" method because Zed doesn't have support
-                    // for custom cursor update listeners.
-                    "textDocument/codeAction"
-                ]
-            }
-        })))
+        Ok(None)
+    }
+}
+
+/// Honour an explicit `lsp.baml-language-server.binary` override from Zed settings.
+fn configured_command(worktree: &zed::Worktree) -> Option<zed::Command> {
+    let binary = LspSettings::for_worktree(LANGUAGE_SERVER_ID, worktree)
+        .ok()?
+        .binary?;
+    let path = binary.path?;
+    let arguments = binary.arguments.unwrap_or_else(|| vec!["lsp".to_string()]);
+    let mut command = zed::Command::new(path)
+        .args(arguments)
+        .envs(worktree.shell_env());
+    if let Some(env) = binary.env {
+        command = command.envs(env);
+    }
+    Some(command)
+}
+
+enum Selector {
+    Channel(String),
+    Version(String),
+}
+
+/// Last resort when no `baml` wrapper is installed: fetch a toolchain ourselves.
+fn downloaded_command(
+    language_server_id: &LanguageServerId,
+    worktree: &zed::Worktree,
+) -> Result<zed::Command> {
+    zed::set_language_server_installation_status(
+        language_server_id,
+        &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+    );
+
+    let target = host_target()?;
+    let manifest = fetch_manifest(&manifest_url(&resolve_selector(worktree)))?;
+    let version = manifest
+        .get("version")
+        .and_then(zed::serde_json::Value::as_str)
+        .ok_or_else(|| "BAML manifest is missing a version".to_string())?;
+    let url = manifest
+        .get("artifacts")
+        .and_then(|artifacts| artifacts.get(target.as_str()))
+        .and_then(|artifact| artifact.get("url"))
+        .and_then(zed::serde_json::Value::as_str)
+        .ok_or_else(|| format!("BAML manifest has no artifact for {target}"))?;
+
+    let (platform, _) = zed::current_platform();
+    let exe = if platform == zed::Os::Windows { ".exe" } else { "" };
+    let version_dir = format!("baml-language-{version}");
+    let binary_path = format!("{version_dir}/bin/baml-cli{exe}");
+
+    if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::Downloading,
+        );
+        let file_type = match platform {
+            zed::Os::Windows => zed::DownloadedFileType::Zip,
+            _ => zed::DownloadedFileType::GzipTar,
+        };
+        zed::download_file(url, &version_dir, file_type)
+            .map_err(|err| format!("failed to download BAML toolchain {version}: {err}"))?;
+        remove_other_entries(&version_dir);
+    }
+
+    Ok(zed::Command::new(binary_path)
+        .arg("lsp")
+        .envs(worktree.shell_env()))
+}
+
+/// Mirror the wrapper's resolution (BAML_VERSION, then baml.toml) so a downloaded toolchain honours a pin.
+fn resolve_selector(worktree: &zed::Worktree) -> Selector {
+    if let Some(value) = env_value(worktree, "BAML_VERSION") {
+        return classify(value);
+    }
+    if let Some(selector) = project_selector(worktree) {
+        return selector;
+    }
+    Selector::Channel(DEFAULT_CHANNEL.to_string())
+}
+
+fn classify(selector: String) -> Selector {
+    if selector == "canary" || selector == "nightly" {
+        Selector::Channel(selector)
+    } else {
+        Selector::Version(selector)
+    }
+}
+
+fn env_value(worktree: &zed::Worktree, key: &str) -> Option<String> {
+    worktree
+        .shell_env()
+        .into_iter()
+        .find(|(name, _)| name.as_str() == key)
+        .map(|(_, value)| value)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn project_selector(worktree: &zed::Worktree) -> Option<Selector> {
+    let text = worktree.read_text_file("baml.toml").ok()?;
+    let value: toml::Value = toml::from_str(&text).ok()?;
+    let toolchain = value.get("toolchain")?;
+    if let Some(version) = toolchain.get("version").and_then(toml::Value::as_str) {
+        return Some(Selector::Version(version.to_string()));
+    }
+    let channel = toolchain.get("channel").and_then(toml::Value::as_str)?;
+    Some(classify(channel.to_string()))
+}
+
+fn manifest_url(selector: &Selector) -> String {
+    match selector {
+        Selector::Channel(channel) => format!("{MANIFEST_BASE_URL}/{channel}.json"),
+        Selector::Version(version) => format!("{MANIFEST_BASE_URL}/version/{version}.json"),
+    }
+}
+
+fn fetch_manifest(url: &str) -> Result<zed::serde_json::Value> {
+    let request = HttpRequest::builder()
+        .method(HttpMethod::Get)
+        .url(url)
+        .redirect_policy(RedirectPolicy::FollowAll)
+        .build()?;
+    let response = zed::http_client::fetch(&request)?;
+    zed::serde_json::from_slice(&response.body)
+        .map_err(|err| format!("failed to parse BAML manifest from {url}: {err}"))
+}
+
+fn host_target() -> Result<String> {
+    let (platform, arch) = zed::current_platform();
+    let os = match platform {
+        zed::Os::Mac => "apple-darwin",
+        zed::Os::Linux => "unknown-linux-gnu",
+        zed::Os::Windows => "pc-windows-msvc",
+    };
+    let arch = match arch {
+        zed::Architecture::Aarch64 => "aarch64",
+        zed::Architecture::X8664 => "x86_64",
+        zed::Architecture::X86 => return Err("BAML has no 32-bit x86 toolchain".to_string()),
+    };
+    Ok(format!("{arch}-{os}"))
+}
+
+fn remove_other_entries(keep: &str) {
+    let Ok(entries) = fs::read_dir(".") else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry.file_name().to_str() != Some(keep) {
+            fs::remove_dir_all(entry.path()).ok();
+        }
     }
 }
 


### PR DESCRIPTION
## Migrate the Zed extension to the baml-language toolchain

### Problem

Installing the BAML Zed extension fails with:

```
no asset found matching "baml-cli-baml-language-0.12.2-nightly.20260625.e-aarch64-apple-darwin.tar.gz"
```

`engine/zed/src/lib.rs` formatted the asset name as `baml-cli-{release.version}-{target}` from `latest_github_release("BoundaryML/baml")`. The auto-published `baml-language` toolchain releases are **not** flagged as GitHub pre-releases, so `/releases/latest` now returns a `baml-language-*` tag. The extension then builds `baml-cli-` + `baml-language-<version>` + `-<target>`, a doubled-up name that no release asset matches.

### Fix

Replace the bespoke GitHub-release download with the same thin-client model the VSCode extension uses, as a layered resolver in `language_server_command`:

1. **Explicit override** — `lsp.baml-language-server.binary.path` (+ `arguments`).
2. **`baml` wrapper on PATH** — `worktree.which("baml")`, run `baml lsp`. The wrapper resolves the project's pinned toolchain, so the LSP always matches `baml generate`.
3. **Managed download fallback** — fetch `pkg.boundaryml.com/manifest/v1/{channel}.json`, read `version` + `artifacts[<target>].url`, `download_file` the toolchain archive, run `bin/baml-cli lsp`. Pin-aware: honours `BAML_VERSION` / `baml.toml [toolchain] version`, otherwise the `canary` channel head.

`language_server_initialization_options` drops to `None` — the new server ignores initialization options (`bex_project` `on_request_initialize` only reads workspace roots). The unused `log` dependency is swapped for `toml`; version bumped `0.223.0` → `0.224.0`.

### Validation

- Builds to `wasm32-wasip2`.
- Canary toolchain `0.12.1`: `baml-cli check` against an existing `baml_src` project exits 0; `baml-cli lsp` completes an `initialize` handshake and advertises hover/completion/semantic-tokens.

### Notes

- The `[features] debug` block in `Cargo.toml` predates this change and is no longer wired to anything (the old `LocalBuild` source is gone). Left untouched to keep this PR focused; happy to remove it separately.
- The download fallback can match an exact `baml.toml` version pin, but not a `channel =` pin (the wrapper resolves channels against machine-local state an editor can't see). Installing the `baml` wrapper — path 2 — is the way to guarantee an exact channel-pin match.
