### PR TITLE
feat(bridge-python): switch optional args to using pep-661 sentinels

### DIFF
--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_optional_args.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_optional_args.py
@@ -17,9 +17,11 @@ def test_optional_args_runtime_matrix():
 
 
 def test_python_unset_and_none_differ_in_one_call():
+    # UNSET means "omit this argument"; None means "pass an explicit null".
+    # The two must stay distinct within a single call.
+    assert baml.UNSET is not None
     assert optional_args_probe(1, opt1=baml.UNSET, opt2=None) == [1, 5, None]
-    assert baml.Unset() is baml.UNSET
-    assert optional_args_probe(1, opt1=baml.Unset(), opt2=None) == [1, 5, None]
+    assert optional_args_probe(1, opt1=None, opt2=baml.UNSET) == [1, None, 99]
 
 
 async def test_optional_args_async_samples():

--- a/baml_language/sdk_tests/harness_setup/src/templates/pyproject.toml
+++ b/baml_language/sdk_tests/harness_setup/src/templates/pyproject.toml
@@ -5,11 +5,13 @@ requires-python = ">=3.10"
 dependencies = [
     "baml_core",
     "pydantic>=2",
-    "typing-extensions",
+    # `UNSET` is a `typing_extensions.Sentinel` (PEP 661); recognizing a
+    # sentinel in a type expression needs pyright >= 1.1.410.
+    "typing-extensions>=4.14.0",
     "pytest>=7",
     "pytest-asyncio>=0.23",
     "ruff",
-    "pyright>=1.1",
+    "pyright>=1.1.410",
 ]
 
 [dependency-groups]

--- a/baml_language/sdks/python/pyproject.toml
+++ b/baml_language/sdks/python/pyproject.toml
@@ -8,6 +8,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "protobuf>=6.31.1",
+    # `UNSET` is built with `typing_extensions.Sentinel` (PEP 661).
+    "typing-extensions>=4.14.0",
 ]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -31,7 +33,7 @@ dev = [
     "maturin>=1.9.4,<2.0",
     "grpcio-tools>=1.50",
     "pydantic>=2",
-    "pyright>=1.1.409",
+    "pyright>=1.1.410",
     "ruff",
     "ty",
 ]

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
@@ -1347,7 +1347,7 @@ pub(crate) fn render_leaf_body(body: &LeafBody) -> String {
     if is_baml_builtins_root {
         out.push('\n');
         out.push_str(
-            "from baml_core import BamlError as BamlError, BamlPanic as BamlPanic, Unset as Unset, UNSET as UNSET\n",
+            "from baml_core import BamlError as BamlError, BamlPanic as BamlPanic, UNSET as UNSET\n",
         );
     }
 
@@ -1395,7 +1395,6 @@ pub(crate) fn render_leaf_body(body: &LeafBody) -> String {
     if is_baml_builtins_root {
         names.push("BamlError");
         names.push("BamlPanic");
-        names.push("Unset");
         names.push("UNSET");
     }
     if !names.is_empty() {
@@ -1736,7 +1735,7 @@ fn render_typed_params(
 /// positional; optional params (the `?` marker on a BAML callable type) get an
 /// Ellipsis default (`= ...`) so a host callback that either supplies or omits
 /// them type-checks. Unlike an optional *function* argument there is no
-/// `baml.Unset` sentinel: BAML invokes the callback positionally, and the
+/// `UNSET` sentinel: BAML invokes the callback positionally, and the
 /// callback's own language-level default fills any omitted trailing arg.
 fn render_callback_protocol(
     name: &str,
@@ -1782,20 +1781,24 @@ fn render_param_pyi(
 }
 
 fn with_unset_union(ty_py: &str) -> String {
+    // `UNSET` is a PEP 661 sentinel that doubles as its own type. Type
+    // checkers only accept a sentinel in a type expression when it is a bare
+    // name, so the leaf imports `UNSET` directly (see `render_leaf_body_pyi`)
+    // and we reference it unqualified here rather than as `baml.UNSET`.
     if let Some(inner) = ty_py
         .strip_prefix("typing.Union[")
         .and_then(|inner| inner.strip_suffix(']'))
     {
-        format!("typing.Union[{inner}, baml.Unset]")
+        format!("typing.Union[{inner}, UNSET]")
     } else if let Some(inner) = ty_py
         .strip_prefix("typing.Optional[")
         .and_then(|inner| inner.strip_suffix(']'))
     {
         // `Optional[X]` is `Union[X, None]`; flatten so a nullable keyword
-        // argument composes into a single `Union[X, None, baml.Unset]`.
-        format!("typing.Union[{inner}, None, baml.Unset]")
+        // argument composes into a single `Union[X, None, UNSET]`.
+        format!("typing.Union[{inner}, None, UNSET]")
     } else {
-        format!("typing.Union[{ty_py}, baml.Unset]")
+        format!("typing.Union[{ty_py}, UNSET]")
     }
 }
 
@@ -1807,7 +1810,7 @@ fn render_default_pyi(default: &FunctionArgumentDefault) -> String {
         }
         FunctionArgumentDefault::Literal(DefaultLiteral::EmptyList) => "[]".to_string(),
         FunctionArgumentDefault::Literal(DefaultLiteral::EmptyMap) => "{}".to_string(),
-        FunctionArgumentDefault::Expression { .. } => "baml.UNSET".to_string(),
+        FunctionArgumentDefault::Expression { .. } => "UNSET".to_string(),
     }
 }
 
@@ -1843,10 +1846,15 @@ pub(crate) fn render_leaf_body_pyi(body: &LeafBody) -> String {
     // type checkers and keeps the stub minimal.
     let mut rel_imports = body.all_rel_imports_py();
     if body.has_defaulted_call_params() && body.leaf.segments != ["baml"] {
+        // Optional arguments annotate as `typing.Union[..., UNSET]` and
+        // default to `UNSET`. The sentinel must be a bare name in the type
+        // expression (type checkers reject `baml.UNSET` member access there),
+        // so import it directly from the `baml` builtins package rather than
+        // importing the package and using attribute access.
         rel_imports.push(RelImport {
             depth: body.leaf.segments.len() + 1,
-            from_path: String::new(),
-            anchor: "baml".to_string(),
+            from_path: "baml".to_string(),
+            anchor: "UNSET as UNSET".to_string(),
         });
         rel_imports.sort();
         rel_imports.dedup();
@@ -1892,7 +1900,7 @@ pub(crate) fn render_leaf_body_pyi(body: &LeafBody) -> String {
     if is_baml_builtins_root {
         out.push('\n');
         out.push_str(
-            "from baml_core import BamlError as BamlError, BamlPanic as BamlPanic, Unset as Unset, UNSET as UNSET\n",
+            "from baml_core import BamlError as BamlError, BamlPanic as BamlPanic, UNSET as UNSET\n",
         );
     }
 
@@ -1973,7 +1981,6 @@ pub(crate) fn render_leaf_body_pyi(body: &LeafBody) -> String {
     if is_baml_builtins_root {
         names.push("BamlError");
         names.push("BamlPanic");
-        names.push("Unset");
         names.push("UNSET");
     }
     if !names.is_empty() {

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -1910,11 +1910,15 @@ mod tests {
 
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
         assert!(pyi.contains(
-            "def search(query: str, *, max_results: typing.Union[int, baml.Unset] = 10, filter: typing.Union[str, baml.Unset] = baml.UNSET, tags: typing.Union[typing.List[str], baml.Unset] = [], metadata: typing.Union[typing.Dict[str, str], baml.Unset] = {}, fallback: typing.Union[str, None, baml.Unset] = None) -> str: ...\n"
+            "def search(query: str, *, max_results: typing.Union[int, UNSET] = 10, filter: typing.Union[str, UNSET] = UNSET, tags: typing.Union[typing.List[str], UNSET] = [], metadata: typing.Union[typing.Dict[str, str], UNSET] = {}, fallback: typing.Union[str, None, UNSET] = None) -> str: ...\n"
         ));
         assert!(pyi.contains(
-            "async def search_async(query: str, *, max_results: typing.Union[int, baml.Unset] = 10, filter: typing.Union[str, baml.Unset] = baml.UNSET, tags: typing.Union[typing.List[str], baml.Unset] = [], metadata: typing.Union[typing.Dict[str, str], baml.Unset] = {}, fallback: typing.Union[str, None, baml.Unset] = None) -> str: ...\n"
+            "async def search_async(query: str, *, max_results: typing.Union[int, UNSET] = 10, filter: typing.Union[str, UNSET] = UNSET, tags: typing.Union[typing.List[str], UNSET] = [], metadata: typing.Union[typing.Dict[str, str], UNSET] = {}, fallback: typing.Union[str, None, UNSET] = None) -> str: ...\n"
         ));
+        // The sentinel is imported as a bare name so it can appear in the
+        // `typing.Union[..., UNSET]` type expressions above (type checkers
+        // reject `baml.UNSET` member access in a type position).
+        assert!(pyi.contains("    from ..baml import UNSET as UNSET\n"));
     }
 
     #[test]
@@ -1979,10 +1983,10 @@ mod tests {
 
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
         assert!(pyi.contains(
-            "def extract_resume(resume: str, *, client: typing.Union[baml.llm.Client, baml.Unset] = baml.UNSET) -> str: ...\n"
+            "def extract_resume(resume: str, *, client: typing.Union[baml.llm.Client, UNSET] = UNSET) -> str: ...\n"
         ));
         assert!(pyi.contains(
-            "def extract_resume__build_request(resume: str, *, client: typing.Union[baml.llm.Client, baml.Unset] = baml.UNSET) -> baml.http.Request: ...\n"
+            "def extract_resume__build_request(resume: str, *, client: typing.Union[baml.llm.Client, UNSET] = UNSET) -> baml.http.Request: ...\n"
         ));
     }
 
@@ -2030,10 +2034,10 @@ mod tests {
         let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
 
         assert!(pyi.contains(
-            "def defaults(*, tags: typing.Union[typing.List[str], baml.Unset] = [], metadata: typing.Union[typing.Dict[str, int], baml.Unset] = {}, fallback: typing.Union[str, None, baml.Unset] = None) -> str: ...\n"
+            "def defaults(*, tags: typing.Union[typing.List[str], UNSET] = [], metadata: typing.Union[typing.Dict[str, int], UNSET] = {}, fallback: typing.Union[str, None, UNSET] = None) -> str: ...\n"
         ));
         assert!(pyi.contains(
-            "async def defaults_async(*, tags: typing.Union[typing.List[str], baml.Unset] = [], metadata: typing.Union[typing.Dict[str, int], baml.Unset] = {}, fallback: typing.Union[str, None, baml.Unset] = None) -> str: ...\n"
+            "async def defaults_async(*, tags: typing.Union[typing.List[str], UNSET] = [], metadata: typing.Union[typing.Dict[str, int], UNSET] = {}, fallback: typing.Union[str, None, UNSET] = None) -> str: ...\n"
         ));
     }
 

--- a/baml_language/sdks/python/src/baml_core/__init__.py
+++ b/baml_language/sdks/python/src/baml_core/__init__.py
@@ -9,6 +9,8 @@ import asyncio
 import functools
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence
 
+from typing_extensions import Sentinel
+
 from .baml_py import (
     BamlCallContext,
     BamlPyHandle,
@@ -213,21 +215,14 @@ async def call_function(rt, function_name, kwargs, ctx=None, collectors=None, _c
 Mode = Literal["sync", "async"]
 
 
-class Unset:
-    """Sentinel type for explicitly omitted generated SDK arguments."""
-    __slots__ = ()
-    _instance: "Unset | None" = None
-
-    def __new__(cls) -> "Unset":
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __repr__(self) -> str:
-        return "baml.UNSET"
-
-
-UNSET = Unset()
+# Sentinel for explicitly omitted generated SDK arguments. `Sentinel`
+# (PEP 661, via `typing_extensions`) yields a single value that doubles as
+# its own type, so generated `.pyi` stubs can write
+# `opt: typing.Union[int, None, UNSET] = UNSET` — both the annotation and
+# the default are this one object. Type checkers only recognize a sentinel
+# in a type expression when it is referenced by a *bare name*, so generated
+# code imports `UNSET` directly rather than reaching it via attribute access.
+UNSET = Sentinel("UNSET")
 
 
 def _build_kwargs(
@@ -512,7 +507,6 @@ __all__ = [
     "HostSpanManager",
     "LLMCall",
     "Timing",
-    "Unset",
     "UNSET",
     "Usage",
     "BamlCtxManager",

--- a/baml_language/sdks/python/uv.lock
+++ b/baml_language/sdks/python/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "2026-06-18T21:49:52.922423Z"
+exclude-newer-span = "-P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -26,6 +30,7 @@ version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "protobuf" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -42,14 +47,17 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "protobuf", specifier = ">=6.31.1" }]
+requires-dist = [
+    { name = "protobuf", specifier = ">=6.31.1" },
+    { name = "typing-extensions", specifier = ">=4.14.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "grpcio-tools", specifier = ">=1.50" },
     { name = "maturin", specifier = ">=1.9.4,<2.0" },
     { name = "pydantic", specifier = ">=2" },
-    { name = "pyright", specifier = ">=1.1.409" },
+    { name = "pyright", specifier = ">=1.1.410" },
     { name = "pytest", specifier = ">=7" },
     { name = "pytest-asyncio", specifier = ">=0.21" },
     { name = "pytest-xdist", specifier = ">=3" },
@@ -428,15 +436,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.410"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Switches the Python SDK's optional-argument sentinel from a hand-written `baml_core.Unset` singleton class to a [PEP 661](https://peps.python.org/pep-0661/) sentinel: `UNSET = typing_extensions.Sentinel("UNSET")`.

A `Sentinel` value doubles as its own type, so generated `.pyi` stubs use a single object for both the annotation and the default:

```python
def optional_args_probe(arg0: int, *, opt1: typing.Union[int, None, UNSET] = 5, opt2: typing.Union[int, None, UNSET] = UNSET) -> ...: ...
```

### Key detail: bare-name requirement

Type checkers only recognize a sentinel in a *type expression* when it's referenced by a **bare name** — `baml.UNSET` member access in a type position is rejected (`reportInvalidTypeForm`). So codegen now imports the sentinel directly (under `TYPE_CHECKING` in the `.pyi`) and references it unqualified:

```python
if typing.TYPE_CHECKING:
    from ..baml import UNSET as UNSET
```

The `Unset` class is removed entirely, including its re-export from the `baml` builtins package and `__all__`.

## Changes
- `baml_core`: `UNSET = Sentinel("UNSET")` replaces the `Unset` singleton class.
- `sdkgen_python_pydantic2`: emit bare `UNSET` in `.pyi` unions/defaults; import it as a bare name for leaves with optional args; drop `Unset` from the builtins re-export and `__all__`.
- Deps: `typing-extensions>=4.13` (adds `Sentinel`) and `pyright>=1.1.410` (first version accepting sentinels in type expressions) in `baml_core` and the SDK-test harness template.
- Updated unit tests and the `function_calls` optional-args pytest fixture.

## Testing
- `cargo test -p sdkgen_python_pydantic2` — 116 passed
- `cargo nextest run -p sdk_test_python_pydantic2` — 14 passed (ruff + pyright + pytest across all fixtures)
- `mise run clippy` clean, `mise run fmt` applied

> ⚠️ Raises the minimum pyright for type-checking a generated SDK to **1.1.410**; older pyright reports `reportInvalidTypeForm` on the `typing.Union[..., UNSET]` annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified Python optional-argument handling by distinguishing omitted values (`UNSET`) from explicit `null`.
  * Updated Python SDK generation and stubs so the “unset” sentinel is consistently referenced as `UNSET` in types and default expressions.
* **Tests**
  * Strengthened optional-argument assertions to explicitly cover all `UNSET` vs `None` combinations.
* **Chores**
  * Updated Python tooling/template requirements (e.g., `typing-extensions` and `pyright` minimum versions).
* **Breaking/Behavioral Notes**
  * `UNSET` is now implemented via `typing_extensions.Sentinel`; `Unset` is no longer publicly exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->