### PR TITLE
fix(zed): pin the playground version to the zed extension version

### DIFF
--- a/engine/zed/Cargo.lock
+++ b/engine/zed/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "zed_baml"
-version = "0.218.0"
+version = "0.223.0"
 dependencies = [
  "log",
  "zed_extension_api",

--- a/engine/zed/src/lib.rs
+++ b/engine/zed/src/lib.rs
@@ -23,6 +23,22 @@ const HARDCODED_EXTENSION_CONFIG: HardcodedExtensionConfig = HardcodedExtensionC
 
 const GITHUB_REPO: &str = "BoundaryML/baml";
 
+/// The extension version, kept in sync with `extension.toml`. The `engine/`
+/// release pipeline tags each release as `X.Y.Z` and publishes the matching
+/// `baml-cli-X.Y.Z-<target>` assets, so the extension fetches the GitHub
+/// release whose tag equals its own version via `github_release_by_tag_name`
+/// (which hits `/releases/tags/<tag>` directly).
+///
+/// We deliberately do NOT use `latest_github_release` here. This repo carries
+/// two release streams: `engine/` (`X.Y.Z` tags, our `baml-cli-*` assets) and
+/// `baml_language/` (`baml-language-*` tags, published frequently and NOT as
+/// pre-releases). `latest_github_release` only inspects the first page of
+/// `/releases` (the 30 most-recent) and has no asset-name filter, so the
+/// high-cadence `baml-language-*` releases bury our latest `engine/` release and
+/// it returns a tag with no `baml-cli-*` asset. Pinning to our own version sticks
+/// to the `engine/` stream regardless of what the other pipeline publishes.
+const EXTENSION_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 fn language_server_binary(
     language_server_id: &LanguageServerId,
     _worktree: &zed::Worktree,
@@ -52,13 +68,7 @@ fn language_server_binary(
                 &zed::LanguageServerInstallationStatus::CheckingForUpdate,
             );
 
-            let release = zed::latest_github_release(
-                GITHUB_REPO,
-                zed::GithubReleaseOptions {
-                    require_assets: true,
-                    pre_release: false,
-                },
-            )?;
+            let release = zed::github_release_by_tag_name(GITHUB_REPO, EXTENSION_VERSION)?;
 
             let (platform, arch) = zed::current_platform();
             let asset_name = format!(
@@ -77,7 +87,7 @@ fn language_server_binary(
                     zed::Os::Mac | zed::Os::Linux => ".tar.gz",
                     zed::Os::Windows => ".zip",
                 },
-                version = release.version,
+                version = EXTENSION_VERSION,
             );
 
             let asset = release
@@ -86,7 +96,7 @@ fn language_server_binary(
                 .find(|asset| asset.name == asset_name)
                 .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
-            let version_dir = format!("baml-cli-{}", release.version);
+            let version_dir = format!("baml-cli-{}", EXTENSION_VERSION);
             let binary_path = format!(
                 "{version_dir}/baml-cli{}",
                 match platform {


### PR DESCRIPTION
Previously we let this float so that users would receive the latest playground version without having to upgrade their Zed extension, but now that we have two release pipelines going in the monorepo, Zed users have been broken by the floating release.

Original report in #3848, see:

> Installing the BAML Zed extension fails with:

> no asset found matching "baml-cli-baml-language-0.12.2-nightly.20260625.e-aarch64-apple-darwin.tar.gz"

> engine/zed/src/lib.rs formatted the asset name as baml-cli-{release.version}-{target} from latest_github_release("BoundaryML/baml"). The auto-published baml-language toolchain releases are not flagged as GitHub pre-releases, so /releases/latest now returns a baml-language-* tag. The extension then builds baml-cli- + baml-language-<version> + -<target>, a doubled-up name that no release asset matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The extension now fetches the release that matches its own version, helping ensure users get the correct update package.
  * Improved version handling so downloaded assets and local versioned files stay aligned with the installed extension version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->