### PR TITLE
Add float.to_fixed() with JavaScript toFixed parity

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "internal-baml-core",
  "internal-baml-diagnostics",
  "internal-baml-parser-database",
+ "ryu-js",
  "tokio",
 ]
 
@@ -2603,7 +2604,7 @@ dependencies = [
  "filetime",
  "indexmap 2.9.0",
  "internal-baml-core",
- "pathdiff 0.1.0",
+ "pathdiff 0.2.3",
  "serde_json",
  "sugar_path",
  "walkdir",
@@ -6621,6 +6622,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "same-file"

--- a/engine/baml-compiler/src/codegen.rs
+++ b/engine/baml-compiler/src/codegen.rs
@@ -1305,6 +1305,11 @@ impl<'g> HirCompiler<'g> {
                         format!("baml.String.{method}")
                     }
 
+                    Some(TypeIR::Primitive(TypeValue::Float, _))
+                    | Some(TypeIR::Primitive(TypeValue::Int, _)) => {
+                        format!("baml.Float.{method}")
+                    }
+
                     Some(TypeIR::Primitive(TypeValue::Media(media_type), _)) => {
                         let subtype = match media_type {
                             BamlMediaType::Image => "baml.media.image",

--- a/engine/baml-compiler/src/thir/interpret.rs
+++ b/engine/baml-compiler/src/thir/interpret.rs
@@ -2989,6 +2989,30 @@ fn evaluate_method_call(
             let result = s.replacen(search.as_str(), replacement.as_str(), 1);
             Ok(BamlValueWithMeta::String(result, meta.clone()))
         }
+        "to_fixed" => {
+            let value = match receiver {
+                BamlValueWithMeta::Float(v, _) => *v,
+                BamlValueWithMeta::Int(v, _) => *v as f64,
+                _ => bail!(
+                    "to_fixed() method only available on floats and ints at {:?}",
+                    meta.0
+                ),
+            };
+
+            if args.len() > 1 {
+                bail!("to_fixed() method takes at most 1 argument at {:?}", meta.0);
+            }
+
+            let digits = match args.first() {
+                Some(BamlValueWithMeta::Int(v, _)) => *v,
+                Some(_) => bail!("to_fixed() digits argument must be an int at {:?}", meta.0),
+                None => 0,
+            };
+
+            let formatted = baml_vm::native::number_to_fixed(value, digits)
+                .map_err(|msg| anyhow::anyhow!("{msg} at {:?}", meta.0))?;
+            Ok(BamlValueWithMeta::String(formatted, meta.clone()))
+        }
         _ => bail!(
             "unknown method '{}' at {:?}, should have been caught during typechecking",
             method_name,

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -166,6 +166,9 @@ pub fn typecheck_returning_context<'a>(
                 vec![TypeIR::string(), TypeIR::string(), TypeIR::string()],
                 TypeIR::string(),
             ),
+            "baml.Float.to_fixed" => {
+                TypeIR::arrow(vec![TypeIR::float(), TypeIR::int()], TypeIR::string())
+            }
             "baml.media.image.from_url" => TypeIR::arrow(vec![TypeIR::string()], TypeIR::image()),
             "baml.media.audio.from_url" => TypeIR::arrow(vec![TypeIR::string()], TypeIR::audio()),
             "baml.media.video.from_url" => TypeIR::arrow(vec![TypeIR::string()], TypeIR::video()),
@@ -1971,6 +1974,28 @@ pub fn typecheck_expression(
                     }
                 },
 
+                Some(TypeIR::Primitive(TypeValue::Float, _)) => match method.as_str() {
+                    "to_fixed" => Some("baml.Float.to_fixed".to_string()),
+                    _ => {
+                        diagnostics.push_error(DatamodelError::new_validation_error(
+                            &format!("Method `{method}` is not available on type `float`"),
+                            span.clone(),
+                        ));
+                        None
+                    }
+                },
+
+                Some(TypeIR::Primitive(TypeValue::Int, _)) => match method.as_str() {
+                    "to_fixed" => Some("baml.Float.to_fixed".to_string()),
+                    _ => {
+                        diagnostics.push_error(DatamodelError::new_validation_error(
+                            &format!("Method `{method}` is not available on type `int`"),
+                            span.clone(),
+                        ));
+                        None
+                    }
+                },
+
                 Some(TypeIR::Primitive(TypeValue::Media(media_type), _)) => {
                     let subtype = match media_type {
                         BamlMediaType::Image => "baml.media.image",
@@ -2113,7 +2138,7 @@ pub fn typecheck_expression(
 
             let mut generic_return_type_inferred = None;
 
-            let typed_args: Vec<_> = if is_known_function {
+            let mut typed_args: Vec<_> = if is_known_function {
                 // Only validate arguments for known functions. Skip the first argument since that's going to be
                 // our method receiver.
                 args.iter()
@@ -2226,6 +2251,14 @@ pub fn typecheck_expression(
                     .collect()
             };
 
+            // to_fixed(digits?) defaults to digits=0 when omitted.
+            if full_name == "baml.Float.to_fixed" && typed_args.is_empty() {
+                typed_args.push(thir::Expr::Value(BamlValueWithMeta::Int(
+                    0,
+                    (span.clone(), Some(TypeIR::int())),
+                )));
+            }
+
             // image.from_url is not a "method", it's an associated function (kind of).
             let is_function_call_on_namespace = matches!(
                 &typed_receiver,
@@ -2236,9 +2269,9 @@ pub fn typecheck_expression(
             );
 
             let passed_number_of_args = if is_function_call_on_namespace {
-                args.len()
+                typed_args.len()
             } else {
-                args.len() + 1 // self
+                typed_args.len() + 1 // self
             };
 
             // Check argument count only for known functions

--- a/engine/baml-compiler/tests/builtins.rs
+++ b/engine/baml-compiler/tests/builtins.rs
@@ -113,3 +113,49 @@ fn fetch_as_with_request_param() -> anyhow::Result<()> {
         )],
     })
 }
+
+#[test]
+fn float_to_fixed_with_digits() -> anyhow::Result<()> {
+    assert_compiles(Program {
+        source: r#"
+            function main() -> string {
+                let n = 3.14159;
+                n.to_fixed(2)
+            }
+        "#,
+        expected: vec![(
+            "main",
+            vec![
+                Instruction::LoadConst(Value::Float(3.14159)),
+                Instruction::LoadGlobal(Value::function("baml.Float.to_fixed")),
+                Instruction::LoadVar("n".to_string()),
+                Instruction::LoadConst(Value::Int(2)),
+                Instruction::Call(2),
+                Instruction::Return,
+            ],
+        )],
+    })
+}
+
+#[test]
+fn float_to_fixed_defaults_digits_to_zero() -> anyhow::Result<()> {
+    assert_compiles(Program {
+        source: r#"
+            function main() -> string {
+                let n = 3.14159;
+                n.to_fixed()
+            }
+        "#,
+        expected: vec![(
+            "main",
+            vec![
+                Instruction::LoadConst(Value::Float(3.14159)),
+                Instruction::LoadGlobal(Value::function("baml.Float.to_fixed")),
+                Instruction::LoadVar("n".to_string()),
+                Instruction::LoadConst(Value::Int(0)),
+                Instruction::Call(2),
+                Instruction::Return,
+            ],
+        )],
+    })
+}

--- a/engine/baml-lib/baml/tests/bytecode_files/array_access.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/array_access.baml
@@ -75,6 +75,8 @@ function ArrayAccessWithVariable(arr: float[], idx: int) -> float {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/assert.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/assert.baml
@@ -62,6 +62,8 @@ function assertNotOk() -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/fiddle_demo2.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/fiddle_demo2.baml
@@ -155,6 +155,8 @@ test default {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/function_calls.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/function_calls.baml
@@ -83,6 +83,8 @@ function Nested(x: int) -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/literal_values.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/literal_values.baml
@@ -76,6 +76,8 @@ function ReturnArray() -> int[] {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/llm_functions.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/llm_functions.baml
@@ -67,6 +67,8 @@ function AnalyzeSentiment(text: string) -> Sentiment {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/loops/break.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/loops/break.baml
@@ -120,6 +120,8 @@ function Nested() -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/loops/c_for.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/loops/c_for.baml
@@ -160,6 +160,8 @@ function Nothing() -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/loops/continue.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/loops/continue.baml
@@ -123,6 +123,8 @@ function ContinueNested() -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/loops/for.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/loops/for.baml
@@ -254,6 +254,8 @@ function NestedFor(as: int[], bs: int[]) -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/loops/while_loops.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/loops/while_loops.baml
@@ -157,6 +157,8 @@ function WhileWithScopes() -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/maps.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/maps.baml
@@ -169,6 +169,8 @@ function Len() -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/mut_variables.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/mut_variables.baml
@@ -59,6 +59,8 @@ function MutableInArg(x: int) -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/return_statement.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/return_statement.baml
@@ -130,6 +130,8 @@ function WithStack(x: int) -> int {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-lib/baml/tests/bytecode_files/simple_function.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/simple_function.baml
@@ -38,6 +38,8 @@ function GetName(person: string) -> string {
 //
 // Function: baml.String.replace
 //
+// Function: baml.Float.to_fixed
+//
 // Function: baml.media.image.from_url
 //
 // Function: baml.media.audio.from_url

--- a/engine/baml-vm/Cargo.toml
+++ b/engine/baml-vm/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { workspace = true }
 baml-types = { path = "../baml-lib/baml-types" }
 internal-baml-diagnostics = { path = "../baml-lib/diagnostics" }
 baml-viz-events = { path = "../baml-viz-events" }
+ryu-js = "1.0.2"
 
 [lints.clippy]
 new_without_default = "allow"

--- a/engine/baml-vm/src/native.rs
+++ b/engine/baml-vm/src/native.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 
 use baml_types::{BamlMap, BamlMedia, BamlMediaContent, BamlMediaType};
+use ryu_js::Buffer;
 
 use crate::{
     errors::{InternalError, RuntimeError, VmError},
@@ -14,6 +15,18 @@ use crate::{
 };
 
 type NativeFunctionResult = Result<Value, VmError>;
+
+/// Formats a number using JavaScript's `Number.prototype.toFixed()` semantics.
+pub fn number_to_fixed(value: f64, digits: i64) -> Result<String, String> {
+    if !(0..=100).contains(&digits) {
+        return Err(format!(
+            "to_fixed: digits must be in [0, 100], got {digits}"
+        ));
+    }
+
+    let mut buffer = Buffer::new();
+    Ok(buffer.format_to_fixed(value, digits as u8).to_string())
+}
 
 /// String length.
 pub fn string_len(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
@@ -341,6 +354,32 @@ pub fn string_replace(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
     Ok(vm.alloc_string(result))
 }
 
+/// Number.prototype.toFixed compatibility for float/int values.
+pub fn float_to_fixed(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
+    let value = match args[0] {
+        Value::Float(float) => float,
+        Value::Int(int) => int as f64,
+        _ => {
+            return Err(VmError::RuntimeError(RuntimeError::Other(
+                "to_fixed() method only available on numbers".to_string(),
+            )));
+        }
+    };
+
+    let digits = match args[1] {
+        Value::Int(int) => int,
+        _ => {
+            return Err(VmError::RuntimeError(RuntimeError::Other(
+                "to_fixed() digits argument must be an int".to_string(),
+            )));
+        }
+    };
+
+    let formatted = number_to_fixed(value, digits)
+        .map_err(|msg| VmError::RuntimeError(RuntimeError::Other(msg)))?;
+    Ok(vm.alloc_string(formatted))
+}
+
 pub fn deep_copy_object(vm: &mut Vm, args: &[Value]) -> NativeFunctionResult {
     // Arity is already checked by the VM.
     let mut copied_objects = HashMap::new();
@@ -607,6 +646,7 @@ pub fn functions() -> BamlMap<String, (NativeFunction, usize)> {
         ("baml.String.split", (string_split, 2)),
         ("baml.String.substring", (string_substring, 3)),
         ("baml.String.replace", (string_replace, 3)),
+        ("baml.Float.to_fixed", (float_to_fixed, 2)),
         // Media
         ("baml.media.image.from_url", (image_from_url, 1)),
         ("baml.media.audio.from_url", (audio_from_url, 1)),
@@ -647,4 +687,84 @@ pub fn functions() -> BamlMap<String, (NativeFunction, usize)> {
         fns.iter()
             .map(|(name, (func, arity))| (name.to_string(), (*func, *arity))),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::number_to_fixed;
+
+    #[test]
+    fn number_to_fixed_matches_js_reference_cases() {
+        let cases = [
+            (3.14159, 2, "3.14"),
+            (3.14159, 5, "3.14159"),
+            (3.14159, 0, "3"),
+            (3.7, 0, "4"),
+            (3.2, 0, "3"),
+            (0.9, 0, "1"),
+            (0.5, 0, "1"),
+            (0.4, 0, "0"),
+            (1.5, 3, "1.500"),
+            (5.0, 4, "5.0000"),
+            (42.1, 5, "42.10000"),
+            (0.000123, 6, "0.000123"),
+            (1234.5678, 2, "1234.57"),
+            (-3.14, 1, "-3.1"),
+            (-1.5, 0, "-2"),
+            (-0.4, 0, "-0"),
+            (-100.5, 0, "-101"),
+            (-0.0, 2, "0.00"),
+            (-999.999, 2, "-1000.00"),
+            (1.005, 2, "1.00"),
+            (1.255, 2, "1.25"),
+            (1.355, 2, "1.35"),
+            (1.045, 2, "1.04"),
+            (1.105, 2, "1.10"),
+            (1e21, 2, "1e+21"),
+            (1.5e21, 0, "1.5e+21"),
+            (-2e25, 3, "-2e+25"),
+            (1e100, 0, "1e+100"),
+            (9.99e20, 2, "999000000000000000000.00"),
+        ];
+
+        for (value, digits, expected) in cases {
+            assert_eq!(
+                number_to_fixed(value, digits).unwrap(),
+                expected,
+                "value={value}, digits={digits}"
+            );
+        }
+    }
+
+    #[test]
+    fn number_to_fixed_handles_special_values() {
+        assert_eq!(number_to_fixed(f64::NAN, 2).unwrap(), "NaN");
+        assert_eq!(number_to_fixed(f64::INFINITY, 2).unwrap(), "Infinity");
+        assert_eq!(number_to_fixed(f64::NEG_INFINITY, 2).unwrap(), "-Infinity");
+    }
+
+    #[test]
+    fn number_to_fixed_validates_digit_range() {
+        assert_eq!(
+            number_to_fixed(3.14, -1).unwrap_err(),
+            "to_fixed: digits must be in [0, 100], got -1"
+        );
+        assert_eq!(
+            number_to_fixed(3.14, 101).unwrap_err(),
+            "to_fixed: digits must be in [0, 100], got 101"
+        );
+        assert_eq!(
+            number_to_fixed(3.14, 200).unwrap_err(),
+            "to_fixed: digits must be in [0, 100], got 200"
+        );
+    }
+
+    #[test]
+    fn number_to_fixed_accepts_boundary_digit_values() {
+        assert_eq!(number_to_fixed(3.14, 0).unwrap(), "3");
+
+        let output = number_to_fixed(3.14, 100).unwrap();
+        let (_, fractional) = output.split_once('.').expect("should contain decimal part");
+        assert_eq!(fractional.len(), 100);
+    }
 }

--- a/engine/baml-vm/tests/conformance.rs
+++ b/engine/baml-vm/tests/conformance.rs
@@ -379,3 +379,63 @@ async fn update_through_reference_conformance() -> Result<()> {
 
     suite.assert_cases(&cases).await
 }
+
+#[tokio::test]
+async fn to_fixed_conformance() -> Result<()> {
+    let project = InMemoryBamlProject::new().with_file(
+        "main.baml",
+        r#"
+        function ToFixed(value: float, digits: int) -> string {
+            value.to_fixed(digits)
+        }
+
+        function ToFixedDefault(value: float) -> string {
+            value.to_fixed()
+        }
+
+        function ToFixedInt(value: int, digits: int) -> string {
+            value.to_fixed(digits)
+        }
+    "#,
+    );
+
+    let suite = ConformanceSuite::new(project)?;
+    let cases = vec![
+        ExpressionCase::new(
+            "ToFixed",
+            bm(vec![
+                ("value", BamlValue::Float(3.14159)),
+                ("digits", BamlValue::Int(2)),
+            ]),
+        )
+        .with_expected(BamlValue::String("3.14".to_string())),
+        ExpressionCase::new(
+            "ToFixed",
+            bm(vec![
+                ("value", BamlValue::Float(1.005)),
+                ("digits", BamlValue::Int(2)),
+            ]),
+        )
+        .with_expected(BamlValue::String("1.00".to_string())),
+        ExpressionCase::new(
+            "ToFixed",
+            bm(vec![
+                ("value", BamlValue::Float(1e21)),
+                ("digits", BamlValue::Int(2)),
+            ]),
+        )
+        .with_expected(BamlValue::String("1e+21".to_string())),
+        ExpressionCase::new("ToFixedDefault", bm(vec![("value", BamlValue::Float(3.7))]))
+            .with_expected(BamlValue::String("4".to_string())),
+        ExpressionCase::new(
+            "ToFixedInt",
+            bm(vec![
+                ("value", BamlValue::Int(5)),
+                ("digits", BamlValue::Int(2)),
+            ]),
+        )
+        .with_expected(BamlValue::String("5.00".to_string())),
+    ];
+
+    suite.assert_cases(&cases).await
+}

--- a/engine/baml-vm/tests/floats.rs
+++ b/engine/baml-vm/tests/floats.rs
@@ -1,0 +1,213 @@
+//! VM tests for float/int `to_fixed` behavior.
+
+use baml_vm::RuntimeError;
+
+mod common;
+use common::{
+    assert_vm_executes, assert_vm_fails, ExecState, FailingProgram, Program, Value as TestValue,
+};
+
+use crate::common::Object;
+
+#[test]
+fn to_fixed_rounding_and_padding() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            function main() -> string[] {
+                [
+                    (3.14159).to_fixed(2),
+                    (3.14159).to_fixed(5),
+                    (3.14159).to_fixed(0),
+                    (3.14159).to_fixed(),
+                    (3.7).to_fixed(0),
+                    (3.2).to_fixed(0),
+                    (0.9).to_fixed(0),
+                    (0.5).to_fixed(0),
+                    (0.4).to_fixed(0),
+                    (1.5).to_fixed(3),
+                    (5.0).to_fixed(4),
+                    (42.1).to_fixed(5),
+                    (0.0).to_fixed(2),
+                    (100.0).to_fixed(3),
+                    (0.000123).to_fixed(6),
+                    (1234.5678).to_fixed(2),
+                    (3.14159265358979).to_fixed(10)
+                ]
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(TestValue::Object(Object::Array(vec![
+            TestValue::string("3.14"),
+            TestValue::string("3.14159"),
+            TestValue::string("3"),
+            TestValue::string("3"),
+            TestValue::string("4"),
+            TestValue::string("3"),
+            TestValue::string("1"),
+            TestValue::string("1"),
+            TestValue::string("0"),
+            TestValue::string("1.500"),
+            TestValue::string("5.0000"),
+            TestValue::string("42.10000"),
+            TestValue::string("0.00"),
+            TestValue::string("100.000"),
+            TestValue::string("0.000123"),
+            TestValue::string("1234.57"),
+            TestValue::string("3.1415926536"),
+        ]))),
+    })
+}
+
+#[test]
+fn to_fixed_negative_and_ieee754_artifacts() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            function main() -> string[] {
+                let minus_3_14 = 0.0 - 3.14;
+                let minus_1_5 = 0.0 - 1.5;
+                let minus_0_4 = 0.0 - 0.4;
+                let minus_100_5 = 0.0 - 100.5;
+                let minus_0_0 = 0.0 - 0.0;
+                let minus_999_999 = 0.0 - 999.999;
+                [
+                    minus_3_14.to_fixed(1),
+                    minus_1_5.to_fixed(0),
+                    minus_0_4.to_fixed(0),
+                    minus_100_5.to_fixed(0),
+                    minus_0_0.to_fixed(2),
+                    minus_999_999.to_fixed(2),
+                    (1.005).to_fixed(2),
+                    (1.255).to_fixed(2),
+                    (1.355).to_fixed(2),
+                    (1.045).to_fixed(2),
+                    (1.105).to_fixed(2)
+                ]
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(TestValue::Object(Object::Array(vec![
+            TestValue::string("-3.1"),
+            TestValue::string("-2"),
+            TestValue::string("-0"),
+            TestValue::string("-101"),
+            TestValue::string("0.00"),
+            TestValue::string("-1000.00"),
+            TestValue::string("1.00"),
+            TestValue::string("1.25"),
+            TestValue::string("1.35"),
+            TestValue::string("1.04"),
+            TestValue::string("1.10"),
+        ]))),
+    })
+}
+
+#[test]
+fn to_fixed_large_number_fallback() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            function main() -> string[] {
+                let negative_large = 0.0 - 20000000000000000000000000.0;
+                [
+                    (1000000000000000000000.0).to_fixed(2),
+                    (1500000000000000000000.0).to_fixed(0),
+                    negative_large.to_fixed(3),
+                    (999000000000000000000.0).to_fixed(2)
+                ]
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(TestValue::Object(Object::Array(vec![
+            TestValue::string("1e+21"),
+            TestValue::string("1.5e+21"),
+            TestValue::string("-2e+25"),
+            TestValue::string("999000000000000000000.00"),
+        ]))),
+    })
+}
+
+#[test]
+fn to_fixed_int_coercion_and_string_context() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            function main() -> string[] {
+                [
+                    (5).to_fixed(2),
+                    (0).to_fixed(3),
+                    (42).to_fixed(0),
+                    "Price: $" + (9.9).to_fixed(2),
+                    "Tax: " + (8.5).to_fixed(1) + "%",
+                    "Rating: " + (4).to_fixed(1) + " / 5.0"
+                ]
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(TestValue::Object(Object::Array(vec![
+            TestValue::string("5.00"),
+            TestValue::string("0.000"),
+            TestValue::string("42"),
+            TestValue::string("Price: $9.90"),
+            TestValue::string("Tax: 8.5%"),
+            TestValue::string("Rating: 4.0 / 5.0"),
+        ]))),
+    })
+}
+
+#[test]
+fn to_fixed_digit_boundaries() -> anyhow::Result<()> {
+    let expected_100 = baml_vm::native::number_to_fixed(3.14, 100).unwrap();
+    assert_vm_executes(Program {
+        source: r#"
+            function main() -> string {
+                (3.14).to_fixed(100)
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(TestValue::string(&expected_100)),
+    })?;
+
+    assert_vm_executes(Program {
+        source: r#"
+            function main() -> string {
+                (3.14).to_fixed(0)
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(TestValue::string("3")),
+    })
+}
+
+#[test]
+fn to_fixed_validates_digit_range() -> anyhow::Result<()> {
+    assert_vm_fails(FailingProgram {
+        source: r#"
+            function main() -> string {
+                (3.14).to_fixed(-1)
+            }
+        "#,
+        function: "main",
+        expected: RuntimeError::Other("to_fixed: digits must be in [0, 100], got -1".to_string())
+            .into(),
+    })?;
+
+    assert_vm_fails(FailingProgram {
+        source: r#"
+            function main() -> string {
+                (3.14).to_fixed(101)
+            }
+        "#,
+        function: "main",
+        expected: RuntimeError::Other("to_fixed: digits must be in [0, 100], got 101".to_string())
+            .into(),
+    })?;
+
+    assert_vm_fails(FailingProgram {
+        source: r#"
+            function main() -> string {
+                (3.14).to_fixed(200)
+            }
+        "#,
+        function: "main",
+        expected: RuntimeError::Other("to_fixed: digits must be in [0, 100], got 200".to_string())
+            .into(),
+    })
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

Implemented `float.to_fixed(digits?: int) -> string` with JavaScript `Number.prototype.toFixed()` parity across the BAML compiler + VM stack.

### What changed
- Added native `baml.Float.to_fixed` runtime support in `baml-vm`.
- Added shared formatter helper `number_to_fixed` backed by `ryu-js` (ECMAScript-compatible `toFixed`).
- Enforced digits range validation `[0, 100]` with runtime errors:
  - `to_fixed: digits must be in [0, 100], got <N>`
- Added method support on both `float` and `int` receivers (int coerces to float semantics).
- Added default argument behavior (`to_fixed()` => digits `0`) during typechecking.
- Updated codegen method dispatch to route numeric receivers to `baml.Float.*` builtins.
- Added compiler bytecode tests for explicit and default-digit calls.
- Added VM/native tests covering:
  - rounding/padding/default behavior
  - negative values / negative zero behavior as in JS engine
  - IEEE 754 artifact cases (e.g. `1.005 -> "1.00"`)
  - large-number fallback formatting
  - boundary digits `0` and `100`
  - out-of-range runtime errors
- Added runtime-vs-interpreter conformance tests for `to_fixed` behavior.

## Testing
Please describe how you tested these changes

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in [environment]

### Commands run
- `cargo fmt -- --config imports_granularity="Crate" --config group_imports="StdExternalCrate"`
- `cargo test --lib` *(fails in existing unrelated `generators-go` lib tests in this environment)*
- `cargo test -p baml-vm --lib`
- `cargo test -p baml-vm --test floats`
- `cargo test -p baml-vm --test conformance`
- `cargo test -p baml-compiler --test builtins`
- `cargo test -p baml-compiler --lib`
- `node -e '...toFixed(...)'` spot checks for IEEE artifact and edge-case parity

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

Requested review:
- @coderabbitai review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c25094e6-4150-4649-8708-86d3663db8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c25094e6-4150-4649-8708-86d3663db8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for formatting numbers with a fixed number of decimal places.
  * This works for both whole numbers and decimals, with a default of 0 digits when omitted.
* **Bug Fixes**
  * Improved handling of numeric method calls so they no longer fail on supported number types.
  * Added validation for digit limits to prevent invalid formatting requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->