### PR TITLE
[codex] Fix B-544: return null for missing String.index_of

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/string.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/string.baml
@@ -194,16 +194,16 @@ class String {
   }
 
   /// Returns the **character index** of the first occurrence of `search`, or
-  /// `-1` if not found.
+  /// `null` if not found.
   ///
   /// # Examples
   /// ```
   /// "hello world".index_of("world")  // 6
   /// "héllo".index_of("l")            // 2
   /// "😀hello".index_of("h")          // 1
-  /// "abc".index_of("z")              // -1
+  /// "abc".index_of("z")              // null
   /// ```
-  function index_of(self, search: string) -> int throws never {
+  function index_of(self, search: string) -> int? throws never {
     $rust_function
   }
 

--- a/baml_language/crates/baml_builtins2/baml_std/testing/registry.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/testing/registry.baml
@@ -460,11 +460,10 @@ class NameSplit {
 
 // Split a slash path at the first '/'. "suite/x/y" -> ("suite", "x/y").
 function split_top(path: string) -> NameSplit {
-  let idx = path.index_of("/")
-  if (idx < 0) {
-    NameSplit { head: "", tail: path }
-  } else {
+  if let idx: int = path.index_of("/") {
     NameSplit { head: path.substring(0, idx), tail: path.substring(idx + 1, path.length()) }
+  } else {
+    NameSplit { head: "", tail: path }
   }
 }
 
@@ -474,12 +473,11 @@ function split_top(path: string) -> NameSplit {
 function parse_filter_patterns(raw: string[]) -> FilterPat[] {
   let out: FilterPat[] = []
   for (let s in raw) {
-    let idx = s.index_of("::")
-    if (idx < 0) {
+    if let idx: int = s.index_of("::") {
+      out.push(FilterPat { func_pat: s.substring(0, idx), test_pat: s.substring(idx + 2, s.length()) })
+    } else {
       out.push(FilterPat { func_pat: s, test_pat: "" })
       out.push(FilterPat { func_pat: "", test_pat: s })
-    } else {
-      out.push(FilterPat { func_pat: s.substring(0, idx), test_pat: s.substring(idx + 2, s.length()) })
     }
   }
   out
@@ -504,9 +502,11 @@ function glob_match(subject: string, pattern: string) -> bool {
   for (let i = 1; i < n - 1; i += 1) {
     let part = parts[i]
     if (part != "") {
-      let idx = subject.substring(pos, end_limit).index_of(part)
-      if (idx < 0) { return false }
-      pos = pos + idx + part.length()
+      if let idx: int = subject.substring(pos, end_limit).index_of(part) {
+        pos = pos + idx + part.length()
+      } else {
+        return false
+      }
     }
   }
   true

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_testing_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_testing_package_listing.snap
@@ -25,8 +25,8 @@ function         testing.expansion_error_report   <builtin>/testing/registry.bam
 class            testing.FilterPat                <builtin>/testing/registry.baml:450
 class            testing.NameSplit                <builtin>/testing/registry.baml:456
 function         testing.split_top                <builtin>/testing/registry.baml:462
-function         testing.parse_filter_patterns    <builtin>/testing/registry.baml:474
-function         testing.glob_match               <builtin>/testing/registry.baml:490
+function         testing.parse_filter_patterns    <builtin>/testing/registry.baml:473
+function         testing.glob_match               <builtin>/testing/registry.baml:488
 function         testing.filter_match             <builtin>/testing/registry.baml:516
 function         testing.any_pattern_matches      <builtin>/testing/registry.baml:524
 function         testing.leaf_selected            <builtin>/testing/registry.baml:535

--- a/baml_language/crates/baml_lsp2_actions/src/snapshots/baml_lsp2_actions__describe_tests__describe_builtin_string_with_compiler2_visible_files.snap
+++ b/baml_language/crates/baml_lsp2_actions/src/snapshots/baml_lsp2_actions__describe_tests__describe_builtin_string_with_compiler2_visible_files.snap
@@ -40,7 +40,7 @@ methods:
   /// Replaces the first occurrence of `search` with `replacement`.
   function replace(self, search: string, replacement: string) -> string
   /// Returns the **character index** of the first occurrence of `search`, or
-  function index_of(self, search: string) -> int
+  function index_of(self, search: string) -> int | null
   function char_at(self, index: int) -> string
   /// Returns a new string that repeats `self` the given number of times.
   function repeat(self, count: int) -> string

--- a/baml_language/crates/baml_tests/baml_src/ns_strings/strings.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_strings/strings.baml
@@ -256,6 +256,10 @@ test "string_index_of_after_emoji" {
     assert.is_true(baml.deep_equals("😀hello".index_of("h"), 1))
 }
 
+test "string_index_of_absent_is_null" {
+    assert.is_true(baml.deep_equals("abc".index_of("z"), null))
+}
+
 // ─── repeat ──────────────────────────────────────────────────────────────────
 
 test "string_repeat" {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/strings.snap
@@ -237,692 +237,698 @@ function strings.$init_test_ns_strings_strings(registry: testing.TestCollector) 
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat"
+    load_const "string_index_of_absent_is_null"
     make_closure .<lambda($init_test_ns_strings_strings, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat_zero"
+    load_const "string_repeat"
     make_closure .<lambda($init_test_ns_strings_strings, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat_negative"
+    load_const "string_repeat_zero"
     make_closure .<lambda($init_test_ns_strings_strings, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_ascii"
+    load_const "string_repeat_negative"
     make_closure .<lambda($init_test_ns_strings_strings, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_multibyte"
+    load_const "string_char_count_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_emoji"
+    load_const "string_char_count_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_empty"
+    load_const "string_char_count_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_removes_leading_only"
+    load_const "string_char_count_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_end_removes_trailing_only"
+    load_const "string_trim_start_removes_leading_only"
     make_closure .<lambda($init_test_ns_strings_strings, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_handles_newlines_and_tabs"
+    load_const "string_trim_end_removes_trailing_only"
     make_closure .<lambda($init_test_ns_strings_strings, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_end_no_whitespace_unchanged"
+    load_const "string_trim_start_handles_newlines_and_tabs"
     make_closure .<lambda($init_test_ns_strings_strings, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_empty"
+    load_const "string_trim_end_no_whitespace_unchanged"
     make_closure .<lambda($init_test_ns_strings_strings, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_lf"
+    load_const "string_trim_start_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_crlf"
+    load_const "string_lines_lf"
     make_closure .<lambda($init_test_ns_strings_strings, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_trailing_newline_no_empty"
+    load_const "string_lines_crlf"
     make_closure .<lambda($init_test_ns_strings_strings, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_empty_string"
+    load_const "string_lines_trailing_newline_no_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_just_newline"
+    load_const "string_lines_empty_string"
     make_closure .<lambda($init_test_ns_strings_strings, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_ascii"
+    load_const "string_lines_just_newline"
     make_closure .<lambda($init_test_ns_strings_strings, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_multibyte"
+    load_const "string_to_utf8_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_empty"
+    load_const "string_to_utf8_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_ascii_round_trip"
+    load_const "string_to_utf8_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_multibyte_round_trip"
+    load_const "string_from_utf8_ascii_round_trip"
     make_closure .<lambda($init_test_ns_strings_strings, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_invalid_throws"
+    load_const "string_from_utf8_multibyte_round_trip"
     make_closure .<lambda($init_test_ns_strings_strings, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_empty"
+    load_const "string_from_utf8_invalid_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_ascii"
+    load_const "string_from_utf8_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_multibyte"
+    load_const "string_from_code_points_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_emoji"
+    load_const "string_from_code_points_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_empty"
+    load_const "string_from_code_points_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_negative_throws"
+    load_const "string_from_code_points_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_surrogate_throws"
+    load_const "string_from_code_points_negative_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_too_large_throws"
+    load_const "string_from_code_points_surrogate_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_ascii_digits"
+    load_const "string_from_code_points_too_large_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_unicode_roman"
+    load_const "string_is_numeric_ascii_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_mixed_false"
+    load_const "string_is_numeric_unicode_roman"
     make_closure .<lambda($init_test_ns_strings_strings, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_letters_false"
+    load_const "string_is_numeric_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_empty_true"
+    load_const "string_is_numeric_letters_false"
     make_closure .<lambda($init_test_ns_strings_strings, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_ascii"
+    load_const "string_is_numeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_accented"
+    load_const "string_is_alphabetic_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_cjk"
+    load_const "string_is_alphabetic_accented"
     make_closure .<lambda($init_test_ns_strings_strings, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_with_digit_false"
+    load_const "string_is_alphabetic_cjk"
     make_closure .<lambda($init_test_ns_strings_strings, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_with_space_false"
+    load_const "string_is_alphabetic_with_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_empty_true"
+    load_const "string_is_alphabetic_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_letters_and_digits"
+    load_const "string_is_alphabetic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_accented_with_digit"
+    load_const "string_is_alphanumeric_letters_and_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_with_space_false"
+    load_const "string_is_alphanumeric_accented_with_digit"
     make_closure .<lambda($init_test_ns_strings_strings, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_with_punct_false"
+    load_const "string_is_alphanumeric_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_empty_true"
+    load_const "string_is_alphanumeric_with_punct_false"
     make_closure .<lambda($init_test_ns_strings_strings, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_all_upper"
+    load_const "string_is_alphanumeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_mixed_false"
+    load_const "string_is_uppercase_all_upper"
     make_closure .<lambda($init_test_ns_strings_strings, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_digit_false"
+    load_const "string_is_uppercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_empty_true"
+    load_const "string_is_uppercase_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_all_lower"
+    load_const "string_is_uppercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_mixed_false"
+    load_const "string_is_lowercase_all_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_accented_lower"
+    load_const "string_is_lowercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_empty_true"
+    load_const "string_is_lowercase_accented_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_spaces"
+    load_const "string_is_lowercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_mixed_ws"
+    load_const "string_is_whitespace_spaces"
     make_closure .<lambda($init_test_ns_strings_strings, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_unicode_nbsp"
+    load_const "string_is_whitespace_mixed_ws"
     make_closure .<lambda($init_test_ns_strings_strings, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_with_letter_false"
+    load_const "string_is_whitespace_unicode_nbsp"
     make_closure .<lambda($init_test_ns_strings_strings, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_empty_true"
+    load_const "string_is_whitespace_with_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 98)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_newline_tab"
+    load_const "string_is_whitespace_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_letter_false"
+    load_const "string_is_control_newline_tab"
     make_closure .<lambda($init_test_ns_strings_strings, 100)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_empty_true"
+    load_const "string_is_control_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_letters"
+    load_const "string_is_control_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 102)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_accented"
+    load_const "string_is_graphic_letters"
     make_closure .<lambda($init_test_ns_strings_strings, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_with_space_false"
+    load_const "string_is_graphic_accented"
     make_closure .<lambda($init_test_ns_strings_strings, 104)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_with_newline_false"
+    load_const "string_is_graphic_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_empty_true"
+    load_const "string_is_graphic_with_newline_false"
     make_closure .<lambda($init_test_ns_strings_strings, 106)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_pure_ascii"
+    load_const "string_is_graphic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_with_accent_false"
+    load_const "string_is_ascii_pure_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 108)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_with_emoji_false"
+    load_const "string_is_ascii_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_chars"
+    load_const "string_is_ascii_with_emoji_false"
     make_closure .<lambda($init_test_ns_strings_strings, 110)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_empty_true"
+    load_const "string_is_ascii_control_chars"
     make_closure .<lambda($init_test_ns_strings_strings, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_digits"
+    load_const "string_is_ascii_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 112)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_unicode_numeral_false"
+    load_const "string_is_ascii_numeric_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 113)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_letter_false"
+    load_const "string_is_ascii_numeric_unicode_numeral_false"
     make_closure .<lambda($init_test_ns_strings_strings, 114)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_empty_true"
+    load_const "string_is_ascii_numeric_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 115)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_letters"
+    load_const "string_is_ascii_numeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 116)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_accented_false"
+    load_const "string_is_ascii_alphabetic_letters"
     make_closure .<lambda($init_test_ns_strings_strings, 117)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_with_digit_false"
+    load_const "string_is_ascii_alphabetic_accented_false"
     make_closure .<lambda($init_test_ns_strings_strings, 118)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_empty_true"
+    load_const "string_is_ascii_alphabetic_with_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 119)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_basic"
+    load_const "string_is_ascii_alphabetic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 120)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_accented_false"
+    load_const "string_is_ascii_alphanumeric_basic"
     make_closure .<lambda($init_test_ns_strings_strings, 121)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_with_space_false"
+    load_const "string_is_ascii_alphanumeric_accented_false"
     make_closure .<lambda($init_test_ns_strings_strings, 122)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_empty_true"
+    load_const "string_is_ascii_alphanumeric_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 123)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_pure_upper"
+    load_const "string_is_ascii_alphanumeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 124)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_mixed_false"
+    load_const "string_is_ascii_uppercase_pure_upper"
     make_closure .<lambda($init_test_ns_strings_strings, 125)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_with_accent_false"
+    load_const "string_is_ascii_uppercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 126)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_empty_true"
+    load_const "string_is_ascii_uppercase_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 127)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_pure_lower"
+    load_const "string_is_ascii_uppercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 128)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_mixed_false"
+    load_const "string_is_ascii_lowercase_pure_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 129)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_with_accent_false"
+    load_const "string_is_ascii_lowercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 130)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_empty_true"
+    load_const "string_is_ascii_lowercase_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 131)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_basic"
+    load_const "string_is_ascii_lowercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 132)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_form_feed"
+    load_const "string_is_ascii_whitespace_basic"
     make_closure .<lambda($init_test_ns_strings_strings, 133)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_nbsp_false"
+    load_const "string_is_ascii_whitespace_form_feed"
     make_closure .<lambda($init_test_ns_strings_strings, 134)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_letter_false"
+    load_const "string_is_ascii_whitespace_nbsp_false"
     make_closure .<lambda($init_test_ns_strings_strings, 135)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_empty_true"
+    load_const "string_is_ascii_whitespace_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 136)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_low_range"
+    load_const "string_is_ascii_whitespace_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 137)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_del"
+    load_const "string_is_ascii_control_low_range"
     make_closure .<lambda($init_test_ns_strings_strings, 138)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_letter_false"
+    load_const "string_is_ascii_control_del"
     make_closure .<lambda($init_test_ns_strings_strings, 139)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_empty_true"
+    load_const "string_is_ascii_control_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 140)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_letters"
+    load_const "string_is_ascii_control_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 141)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_punctuation"
+    load_const "string_is_ascii_graphic_letters"
     make_closure .<lambda($init_test_ns_strings_strings, 142)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_space_false"
+    load_const "string_is_ascii_graphic_punctuation"
     make_closure .<lambda($init_test_ns_strings_strings, 143)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_control_false"
+    load_const "string_is_ascii_graphic_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 144)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_accented_false"
+    load_const "string_is_ascii_graphic_control_false"
     make_closure .<lambda($init_test_ns_strings_strings, 145)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_empty_true"
+    load_const "string_is_ascii_graphic_accented_false"
     make_closure .<lambda($init_test_ns_strings_strings, 146)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_lower"
+    load_const "string_is_ascii_graphic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 147)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_upper"
+    load_const "string_is_ascii_hex_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 148)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_mixed_case_with_digits"
+    load_const "string_is_ascii_hex_upper"
     make_closure .<lambda($init_test_ns_strings_strings, 149)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_g_false"
+    load_const "string_is_ascii_hex_mixed_case_with_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 150)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_x_prefix_false"
+    load_const "string_is_ascii_hex_g_false"
     make_closure .<lambda($init_test_ns_strings_strings, 151)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_empty_true"
+    load_const "string_is_ascii_hex_x_prefix_false"
     make_closure .<lambda($init_test_ns_strings_strings, 152)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_replace"
+    load_const "string_is_ascii_hex_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 153)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_replace"
+    make_closure .<lambda($init_test_ns_strings_strings, 154)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1690,7 +1690,7 @@ function baml.from(value: T) -> string  [expr] {
 function baml.from_code_points(unicode: int[]) -> string  [builtin]
 function baml.from_utf8(utf8: uint8array) -> string  [builtin]
 function baml.includes(self: ?, search: string) -> bool  [builtin]
-function baml.index_of(self: ?, search: string) -> int  [builtin]
+function baml.index_of(self: ?, search: string) -> int?  [builtin]
 function baml.is_alphabetic(self: ?) -> bool  [builtin]
 function baml.is_alphanumeric(self: ?) -> bool  [builtin]
 function baml.is_ascii(self: ?) -> bool  [builtin]

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -1433,7 +1433,7 @@ function baml.String.from_utf8(utf8: uint8array) -> string {
 function baml.String.includes(self: baml.String, search: string) -> bool {
 }
 
-function baml.String.index_of(self: baml.String, search: string) -> int {
+function baml.String.index_of(self: baml.String, search: string) -> int | null {
 }
 
 function baml.String.is_alphabetic(self: baml.String) -> bool {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____03_hir.snap
@@ -99,7 +99,7 @@ function testing.flatten_with_tolerated(report: TestSetReport) -> FlatTestReport
   { let top_tolerated = report.outcome Eq "pass"; let counts = if (report.results.length() Gt 0) {  } root.count_leaves(report.results, top_tolerated) else if (top_tolerated) {  } testing.LeafCounts { passed: report.passed, failed: 0, tolerated: report.failed, total: report.total } else {  } testing.LeafCounts { passed: report.passed, failed: report.failed, tolerated: 0, total: report.total }; let messages: string[] = []; root.collect_leaf_messages(report.results, messages) } FlatTestReport { outcome: report.outcome, passed: counts.passed, failed: counts.failed, tolerated: counts.tolerated, total: counts.total, failed_names: report.failed_names, messages: messages }
 }
 function testing.glob_match(subject: string, pattern: string) -> bool  [expr] {
-  { let parts = pattern.split("*"); let n = parts.length(); if (n Eq 1) { return subject Eq pattern }; let first = parts[0]; let last = parts[n Sub 1]; if (Not subject.starts_with(first)) { return false }; if (Not subject.ends_with(last)) { return false }; let start = first.length(); let end_limit = subject.length() Sub last.length(); if (start Gt end_limit) { return false }; let pos = start; { let i = 1; while i Lt n Sub 1 { let part = parts[i] } if (part Ne "") { let idx = subject.substring(pos, end_limit).index_of(part); if (idx Lt 0) { return false }; pos = pos Add idx Add part.length() } } } true
+  { let parts = pattern.split("*"); let n = parts.length(); if (n Eq 1) { return subject Eq pattern }; let first = parts[0]; let last = parts[n Sub 1]; if (Not subject.starts_with(first)) { return false }; if (Not subject.ends_with(last)) { return false }; let start = first.length(); let end_limit = subject.length() Sub last.length(); if (start Gt end_limit) { return false }; let pos = start; { let i = 1; while i Lt n Sub 1 { let part = parts[i] } if (part Ne "") {  } if let idx: int = subject.substring(pos, end_limit).index_of(part) { pos = pos Add idx Add part.length() } else { return false } } } true
 }
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool  [expr] {
   { let split = root.split_top(name); if (root.any_pattern_matches(exclude, split.head, split.tail)) { return false }; if (include.length() Eq 0) { return true } } root.any_pattern_matches(include, split.head, split.tail)
@@ -114,7 +114,7 @@ function testing.new(prefix: string) -> testing.TestCollector  [expr] {
   {  } testing.TestCollector { prefix: prefix, tests: [], testsets: [] }
 }
 function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[]  [expr] {
-  { let out: testing.FilterPat[] = []; for s in raw { let idx = s.index_of("::") } if (idx Lt 0) { out.push(testing.FilterPat { func_pat: s, test_pat: "" }) } out.push(testing.FilterPat { func_pat: "", test_pat: s }) else {  } out.push(testing.FilterPat { func_pat: s.substring(0, idx), test_pat: s.substring(idx Add 2, s.length()) }) } out
+  { let out: testing.FilterPat[] = []; for s in raw {  } if let idx: int = s.index_of("::") {  } out.push(testing.FilterPat { func_pat: s.substring(0, idx), test_pat: s.substring(idx Add 2, s.length()) }) else { out.push(testing.FilterPat { func_pat: s, test_pat: "" }) } out.push(testing.FilterPat { func_pat: "", test_pat: s }) } out
 }
 function testing.register_test(self: ?, name: string, body: TestBody, runner: TestRunner?) -> void  [expr] {
   { let full_name = if (self.prefix Eq "") {  } name else {  } self.prefix Add "/" Add name; let count = 0; let hash_prefix = full_name Add "#"; for t in self.tests {  } if (t.name Eq full_name Or t.name.starts_with(hash_prefix)) { count Add= 1 } else {  } null; let final_name = if (count Gt 0) {  } full_name Add "#" Add string.from(count Add 1) else {  } full_name; let _ = self.tests.push(testing.TestRegistration { name: final_name, body: body, runner: runner }) }
@@ -153,7 +153,7 @@ function testing.serialize(self: ?) -> testing.SerializedTestDef[]  [expr] {
   { let items: testing.SerializedTestDef[] = []; for t in self.collector.tests {  } items.push(testing.SerializedTest { type: "test", name: t.name }); for ts in self.collector.testsets { let expanded = self.expansions.get(ts.name) } match (expanded) { sub: testing.TestRegistry => {  } items.push(testing.SerializedTestSet { name: ts.name, items: sub.serialize(), loadingTimeMs: sub.loading_time_ms }), null => {  } items.push(testing.SerializedTest { type: "lazyTestSet", name: ts.name }) }; return items }
 }
 function testing.split_top(path: string) -> testing.NameSplit  [expr] {
-  { let idx = path.index_of("/") } if (idx Lt 0) {  } testing.NameSplit { head: "", tail: path } else {  } testing.NameSplit { head: path.substring(0, idx), tail: path.substring(idx Add 1, path.length()) }
+  {  } if let idx: int = path.index_of("/") {  } testing.NameSplit { head: path.substring(0, idx), tail: path.substring(idx Add 1, path.length()) } else {  } testing.NameSplit { head: "", tail: path }
 }
 function testing.test_child(name: string, body: TestBody, runner: TestRunner?) -> TestSetChild  [expr] {
   {  } TestSetChild { name: name, run: () -> ChildReport { {  } root.run_test(body, runner) } }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
@@ -3411,13 +3411,13 @@ fn testing.glob_match(subject: string, pattern: string) -> bool {
     let _35: int
     let _36: bool
     let _37: string
-    let _38: int // idx
+    let _38: int | null
     let _39: string
     let _40: int
     let _41: int
     let _42: string
     let _43: bool
-    let _44: int
+    let _44: int // idx
     let _45: int
     let _46: int
     let _47: int
@@ -3510,7 +3510,7 @@ fn testing.glob_match(subject: string, pattern: string) -> bool {
         _33 = copy _34[_35];
         _37 = copy _33;
         _36 = copy _37 != const "";
-        branch copy _36 -> [bb15, bb20];
+        branch copy _36 -> [bb15, bb21];
     }
 
     bb15: {
@@ -3525,31 +3525,31 @@ fn testing.glob_match(subject: string, pattern: string) -> bool {
     }
 
     bb17: {
-        _44 = copy _38;
-        _43 = copy _44 < const 0_i64;
-        branch copy _43 -> [bb21, bb18];
+        _43 = is_type(copy _38, int);
+        branch copy _43 -> [bb19, bb18];
     }
 
     bb18: {
-        _46 = copy _27;
-        _47 = copy _38;
-        _45 = copy _46 + copy _47;
-        _48 = call const fn baml.String.length(copy _33) -> [bb19];
+        _0 = const false;
+        goto -> bb26;
     }
 
     bb19: {
-        _27 = copy _45 + copy _48;
-        goto -> bb20;
+        _44 = copy _38;
+        _46 = copy _27;
+        _47 = copy _44;
+        _45 = copy _46 + copy _47;
+        _48 = call const fn baml.String.length(copy _33) -> [bb20];
     }
 
     bb20: {
-        _28 = copy _28 + const 1_i64;
-        goto -> bb12;
+        _27 = copy _45 + copy _48;
+        goto -> bb21;
     }
 
     bb21: {
-        _0 = const false;
-        goto -> bb26;
+        _28 = copy _28 + const 1_i64;
+        goto -> bb12;
     }
 
     bb22: {
@@ -3727,21 +3727,21 @@ fn testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
     let _33: string
     let _34: string // s
     let _35: void
-    let _36: int // idx
+    let _36: int | null
     let _37: bool
-    let _38: int
-    let _39: int
-    let _40: testing.FilterPat
-    let _41: string
-    let _42: testing.FilterPat
-    let _43: string
-    let _44: testing.FilterPat
-    let _45: string
+    let _38: int // idx
+    let _39: testing.FilterPat
+    let _40: string
+    let _41: int
+    let _42: string
+    let _43: int
+    let _44: int
+    let _45: int
     let _46: int
-    let _47: string
-    let _48: int
-    let _49: int
-    let _50: int
+    let _47: testing.FilterPat
+    let _48: string
+    let _49: testing.FilterPat
+    let _50: string
 
     bb0: {
         _2 = []: testing.FilterPat[];
@@ -3876,41 +3876,41 @@ fn testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
     }
 
     bb25: {
-        _38 = copy _36;
-        _37 = copy _38 < const 0_i64;
-        branch copy _37 -> [bb30, bb26];
+        _37 = is_type(copy _36, int);
+        branch copy _37 -> [bb28, bb26];
     }
 
     bb26: {
-        _46 = copy _36;
-        _45 = call const fn baml.String.substring(copy _34, const 0_i64, copy _46) -> [bb27];
+        _48 = copy _34;
+        _47 = testing.FilterPat { copy _48, const "" };
+        _46 = call const fn baml.Array.push(copy _2, copy _47) -> [bb27];
     }
 
     bb27: {
-        _49 = copy _36;
-        _48 = copy _49 + const 2_i64;
-        _50 = call const fn baml.String.length(copy _34) -> [bb28];
+        _50 = copy _34;
+        _49 = testing.FilterPat { const "", copy _50 };
+        _35 = call const fn baml.Array.push(copy _2, copy _49) -> [bb2];
     }
 
     bb28: {
-        _47 = call const fn baml.String.substring(copy _34, copy _48, copy _50) -> [bb29];
+        _38 = copy _36;
+        _41 = copy _38;
+        _40 = call const fn baml.String.substring(copy _34, const 0_i64, copy _41) -> [bb29];
     }
 
     bb29: {
-        _44 = testing.FilterPat { copy _45, copy _47 };
-        _35 = call const fn baml.Array.push(copy _2, copy _44) -> [bb2];
+        _44 = copy _38;
+        _43 = copy _44 + const 2_i64;
+        _45 = call const fn baml.String.length(copy _34) -> [bb30];
     }
 
     bb30: {
-        _41 = copy _34;
-        _40 = testing.FilterPat { copy _41, const "" };
-        _39 = call const fn baml.Array.push(copy _2, copy _40) -> [bb31];
+        _42 = call const fn baml.String.substring(copy _34, copy _43, copy _45) -> [bb31];
     }
 
     bb31: {
-        _43 = copy _34;
-        _42 = testing.FilterPat { const "", copy _43 };
-        _35 = call const fn baml.Array.push(copy _2, copy _42) -> [bb2];
+        _39 = testing.FilterPat { copy _40, copy _42 };
+        _35 = call const fn baml.Array.push(copy _2, copy _39) -> [bb2];
     }
 
     bb32: {
@@ -6374,9 +6374,9 @@ fn testing.split_top(path: string) -> testing.NameSplit {
     // Locals:
     let _0: testing.NameSplit // _0 // return
     let _1: string // path // param
-    let _2: int // idx
+    let _2: int | null
     let _3: bool
-    let _4: int
+    let _4: int // idx
     let _5: string
     let _6: int
     let _7: string
@@ -6389,33 +6389,33 @@ fn testing.split_top(path: string) -> testing.NameSplit {
     }
 
     bb1: {
-        _4 = copy _2;
-        _3 = copy _4 < const 0_i64;
-        branch copy _3 -> [bb6, bb2];
+        _3 = is_type(copy _2, int);
+        branch copy _3 -> [bb3, bb2];
     }
 
     bb2: {
-        _6 = copy _2;
-        _5 = call const fn baml.String.substring(copy _1, const 0_i64, copy _6) -> [bb3];
-    }
-
-    bb3: {
-        _9 = copy _2;
-        _8 = copy _9 + const 1_i64;
-        _10 = call const fn baml.String.length(copy _1) -> [bb4];
-    }
-
-    bb4: {
-        _7 = call const fn baml.String.substring(copy _1, copy _8, copy _10) -> [bb5];
-    }
-
-    bb5: {
-        _0 = testing.NameSplit { copy _5, copy _7 };
+        _0 = testing.NameSplit { const "", copy _1 };
         goto -> bb7;
     }
 
+    bb3: {
+        _4 = copy _2;
+        _6 = copy _4;
+        _5 = call const fn baml.String.substring(copy _1, const 0_i64, copy _6) -> [bb4];
+    }
+
+    bb4: {
+        _9 = copy _4;
+        _8 = copy _9 + const 1_i64;
+        _10 = call const fn baml.String.length(copy _1) -> [bb5];
+    }
+
+    bb5: {
+        _7 = call const fn baml.String.substring(copy _1, copy _8, copy _10) -> [bb6];
+    }
+
     bb6: {
-        _0 = testing.NameSplit { const "", copy _1 };
+        _0 = testing.NameSplit { copy _5, copy _7 };
         goto -> bb7;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_tir.snap
@@ -504,15 +504,7 @@ class testing.NameSplit {
 }
 function testing.split_top(path: string) -> testing.NameSplit throws never {
   { : testing.NameSplit
-    let idx = path.index_of("/") : int
-    if (idx < 0 : bool) : testing.NameSplit
-      { : testing.NameSplit
-        NameSplit { head: "", tail: path } : testing.NameSplit
-      }
-    else
-      { : testing.NameSplit
-        NameSplit { head: path.substring(0, idx), tail: path.substring(idx + 1, path.length()) } : testing.NameSplit
-      }
+    if let <pat> = path.index_of("/") { 0 stmts + tail } else { 0 stmts + tail } : testing.NameSplit
   }
 }
 function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] throws never {
@@ -520,16 +512,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] thr
     let out: FilterPat[] = [] : testing.FilterPat[]
     for s in raw
       { : int
-        let idx = s.index_of("::") : int
-        if (idx < 0 : bool) : int
-          { : int
-            out.push(FilterPat { func_pat: s, test_pat: "" }) : int
-            out.push(FilterPat { func_pat: "", test_pat: s }) : int
-          }
-        else
-          { : int
-            out.push(FilterPat { func_pat: s.substring(0, idx), test_pat: s.substring(idx + 2, s.length()) }) : int
-          }
+        if let <pat> = s.index_of("::") { 0 stmts + tail } else { 1 stmts + tail } : int
       }
     out : testing.FilterPat[]
   }
@@ -566,12 +549,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool throws nev
           let part = parts[i] : string
           if (part != "" : bool) : void
             { : void
-              let idx = subject.substring(pos, end_limit).index_of(part) : int
-              if (idx < 0 : bool) : void
-                { : never
-                  return false : false
-                }
-              pos = pos + idx + part.length() : int
+              if let <pat> = subject.substring(pos, end_limit).index_of(part) { 1 stmts } else { 1 stmts } : void
             }
         }
     }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
@@ -4699,20 +4699,23 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
     store_var_load_var part
     load_const ""
     cmp_op !=
-    pop_jump_if_false L8
+    pop_jump_if_false L9
     load_var2 1 11
     load_var end_limit
     call baml.String.substring
     load_var part
     call baml.String.index_of
-    store_var idx
-    load_var idx
-    load_const 0
-    cmp_int_op <
+    store_var _38
+    load_var _38
+    is_type int
     pop_jump_if_false L7
-    jump L9
+    jump L8
 
   L7:
+    load_const false
+    jump L14
+
+  L8:
     load_var2 11 14
     add_int
     store_var _45
@@ -4722,16 +4725,12 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
     add_int
     store_var pos
 
-  L8:
+  L9:
     load_var i
     load_const 1
     add_int
     store_var i
     jump L4
-
-  L9:
-    load_const false
-    jump L14
 
   L10:
     load_const false
@@ -4945,36 +4944,13 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
     load_var s
     load_const "::"
     call baml.String.index_of
-    store_var idx
-    load_var idx
-    load_const 0
-    cmp_int_op <
+    store_var _36
+    load_var _36
+    is_type int
     pop_jump_if_false L21
     jump L22
 
   L21:
-    load_var s
-    load_const 0
-    load_var idx
-    call baml.String.substring
-    store_var _45
-    load_var s
-    call baml.String.length
-    store_var _50
-    load_var2 5 6
-    load_const 2
-    add_int
-    load_var _50
-    call baml.String.substring
-    store_var _47
-    load_var2 2 7
-    load_var _47
-    init_instance testing.FilterPat .func_pat, .test_pat
-    call baml.Array.push
-    pop 1
-    jump L0
-
-  L22:
     load_var2 2 5
     load_const ""
     init_instance testing.FilterPat .func_pat, .test_pat
@@ -4983,6 +4959,30 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
     load_var out
     load_const ""
     load_var s
+    init_instance testing.FilterPat .func_pat, .test_pat
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L22:
+    load_var _36
+    store_var idx
+    load_var s
+    load_const 0
+    load_var idx
+    call baml.String.substring
+    store_var _40
+    load_var s
+    call baml.String.length
+    store_var _45
+    load_var2 5 7
+    load_const 2
+    add_int
+    load_var _45
+    call baml.String.substring
+    store_var _42
+    load_var2 2 8
+    load_var _42
     init_instance testing.FilterPat .func_pat, .test_pat
     call baml.Array.push
     pop 1
@@ -5610,14 +5610,21 @@ function testing.split_top(path: string) -> testing.NameSplit {
     load_var path
     load_const "/"
     call baml.String.index_of
-    store_var idx
-    load_var idx
-    load_const 0
-    cmp_int_op <
+    store_var _2
+    load_var _2
+    is_type int
     pop_jump_if_false L0
     jump L1
 
   L0:
+    load_const ""
+    load_var path
+    init_instance testing.NameSplit .head, .tail
+    jump L2
+
+  L1:
+    load_var _2
+    store_var idx
     load_var path
     load_const 0
     load_var idx
@@ -5625,17 +5632,11 @@ function testing.split_top(path: string) -> testing.NameSplit {
     load_var path
     call baml.String.length
     store_var _10
-    load_var2 1 2
+    load_var2 1 3
     load_const 1
     add_int
     load_var _10
     call baml.String.substring
-    init_instance testing.NameSplit .head, .tail
-    jump L2
-
-  L1:
-    load_const ""
-    load_var path
     init_instance testing.NameSplit .head, .tail
 
   L2:

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -3695,49 +3695,49 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
 }
 
 function testing.glob_match(subject: string, pattern: string) -> bool {
-  491   0    load_var 2              (pattern)
+  489   0    load_var 2              (pattern)
         1    load_const 0            ("*")
         2    call 137 ntypeargs=0    (baml.String.split)
         3    store_var 3             (parts)
 
-  492   4    load_var 3              (parts)
+  490   4    load_var 3              (parts)
         5    container_len           
         6    store_var 4             (n)
 
-  493   7    load_var 4              (n)
+  491   7    load_var 4              (n)
         8    load_const 1            (1)
         9    cmp_int_op ==           
         10   pop_jump_if_false +2    (to 12)
-        11   jump +86                (to 97)
+        11   jump +85                (to 96)
 
-  496   12   load_var 3              (parts)
+  494   12   load_var 3              (parts)
         13   load_const 2            (0)
         14   load_array_element      
         15   store_var 5             (first)
 
-  497   16   load_var2 3 4           
+  495   16   load_var2 3 4           
         17   load_const 1            (1)
         18   sub_int                 
         19   load_array_element      
         20   store_var 6             (last)
 
-  498   21   load_var2 1 5           
+  496   21   load_var2 1 5           
         22   call 145 ntypeargs=0    (baml.String.starts_with)
         23   unary_op !              
         24   pop_jump_if_false +2    (to 26)
-        25   jump +70                (to 95)
+        25   jump +69                (to 94)
 
-  499   26   load_var2 1 6           
+  497   26   load_var2 1 6           
         27   call 133 ntypeargs=0    (baml.String.ends_with)
         28   unary_op !              
         29   pop_jump_if_false +2    (to 31)
-        30   jump +63                (to 93)
+        30   jump +62                (to 92)
 
-  500   31   load_var 5              (first)
+  498   31   load_var 5              (first)
         32   call 152 ntypeargs=0    (baml.String.length)
         33   store_var 7             (start)
 
-  501   34   load_var 1              (subject)
+  499   34   load_var 1              (subject)
         35   call 152 ntypeargs=0    (baml.String.length)
         36   store_var 9             (_22)
         37   load_var 6              (last)
@@ -3747,15 +3747,15 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
         41   sub_int                 
         42   store_var 8             (end_limit)
 
-  502   43   load_var2 7 8           
+  500   43   load_var2 7 8           
         44   cmp_int_op >            
         45   pop_jump_if_false +2    (to 47)
-        46   jump +45                (to 91)
+        46   jump +44                (to 90)
 
-  503   47   load_var 7              (start)
+  501   47   load_var 7              (start)
         48   store_var 11            (pos)
 
-  504   49   load_const 1            (1)
+  502   49   load_const 1            (1)
         50   store_var 12            (i)
         51   load_var2 12 4          
         52   load_const 1            (1)
@@ -3765,59 +3765,59 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
         56   jump +3                 (to 59)
 
   512   57   load_const 3            (true)
-        58   jump +41                (to 99)
+        58   jump +40                (to 98)
 
-  505   59   load_var2 3 12          
+  503   59   load_var2 3 12          
         60   load_array_element      
         61   store_var_load_var 13   (part)
 
-  506   62   load_const 4            ("")
+  504   62   load_const 4            ("")
         63   cmp_op !=               
-        64   pop_jump_if_false +20   (to 84)
+        64   pop_jump_if_false +21   (to 85)
 
-  507   65   load_var2 1 11          
+  505   65   load_var2 1 11          
         66   load_var 8              (end_limit)
         67   call 155 ntypeargs=0    (baml.String.substring)
         68   load_var 13             (part)
         69   call 164 ntypeargs=0    (baml.String.index_of)
-        70   store_var 14            (idx)
+        70   store_var 14            (_38)
+        71   load_var 14             (_38)
+        72   is_type 2               
+        73   pop_jump_if_false +2    (to 75)
+        74   jump +3                 (to 77)
 
-  508   71   load_var 14             (idx)
-        72   load_const 2            (0)
-        73   cmp_int_op <            
-        74   pop_jump_if_false +2    (to 76)
-        75   jump +14                (to 89)
+  508   75   load_const 5            (false)
+        76   jump +22                (to 98)
 
-  509   76   load_var2 11 14         
-        77   add_int                 
-        78   store_var 15            (_45)
-        79   load_var 13             (part)
-        80   call 152 ntypeargs=0    (baml.String.length)
-        81   load_var 15             (_45)
-        82   add_int                 
-        83   store_var 11            (pos)
+  506   77   load_var2 11 14         
 
-  504   84   load_var 12             (i)
-        85   load_const 1            (1)
-        86   add_int                 
-        87   store_var 12            (i)
-        88   jump -37                (to 51)
+  505   78   add_int                 
+        79   store_var 15            (_45)
 
-  508   89   load_const 5            (false)
-        90   jump +9                 (to 99)
+  506   80   load_var 13             (part)
+        81   call 152 ntypeargs=0    (baml.String.length)
+        82   load_var 15             (_45)
+        83   add_int                 
+        84   store_var 11            (pos)
 
-  502   91   load_const 5            (false)
-        92   jump +7                 (to 99)
+  502   85   load_var 12             (i)
+        86   load_const 1            (1)
+        87   add_int                 
+        88   store_var 12            (i)
+        89   jump -38                (to 51)
 
-  499   93   load_const 5            (false)
-        94   jump +5                 (to 99)
+  500   90   load_const 5            (false)
+        91   jump +7                 (to 98)
 
-  498   95   load_const 5            (false)
-        96   jump +3                 (to 99)
+  497   92   load_const 5            (false)
+        93   jump +5                 (to 98)
 
-  494   97   load_var2 1 2           
-        98   cmp_op ==               
-        99   return                  
+  496   94   load_const 5            (false)
+        95   jump +3                 (to 98)
+
+  492   96   load_var2 1 2           
+        97   cmp_op ==               
+        98   return                  
 }
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
@@ -3855,11 +3855,11 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
 }
 
 function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
-  475   0     load_type 0              
+  474   0     load_type 0              
         1     alloc_array 0            
         2     store_var 2              (out)
 
-  476   3     load_type 1              
+  475   3     load_type 1              
         4     load_var 1               (raw)
         5     call 468 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 3              (_3)
@@ -3901,7 +3901,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         42    jump +10                 (to 52)
         43    load_var 3               (_3)
         44    is_type 11               
-        45    pop_jump_if_false +105   (to 150)
+        45    pop_jump_if_false +106   (to 151)
         46    load_type 1              
         47    load_type 12             
         48    load_var 3               (_3)
@@ -3960,59 +3960,60 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         101   load_var 4               (_5)
         102   is_type 13               
         103   pop_jump_if_false +2     (to 105)
-        104   jump +44                 (to 148)
+        104   jump +45                 (to 149)
         105   load_var 4               (_5)
         106   store_var 5              (s)
 
-  477   107   load_var 5               (s)
+  476   107   load_var 5               (s)
         108   load_const 14            ("::")
         109   call 164 ntypeargs=0     (baml.String.index_of)
-        110   store_var 6              (idx)
+        110   store_var 6              (_36)
+        111   load_var 6               (_36)
+        112   is_type 15               
+        113   pop_jump_if_false +2     (to 115)
+        114   jump +13                 (to 127)
 
-  478   111   load_var 6               (idx)
-        112   load_const 15            (0)
-        113   cmp_int_op <             
-        114   pop_jump_if_false +2     (to 116)
-        115   jump +21                 (to 136)
+  479   115   load_var2 2 5            
+        116   load_const 16            ("")
+        117   init_instance 0          (testing.FilterPat .func_pat, .test_pat)
+        118   call 9 ntypeargs=0       (baml.Array.push)
+        119   pop 1                    
 
-  482   116   load_var 5               (s)
-        117   load_const 15            (0)
-        118   load_var 6               (idx)
-        119   call 155 ntypeargs=0     (baml.String.substring)
-        120   store_var 7              (_45)
-        121   load_var 5               (s)
-        122   call 152 ntypeargs=0     (baml.String.length)
-        123   store_var 9              (_50)
-        124   load_var2 5 6            
-        125   load_const 16            (2)
-        126   add_int                  
-        127   load_var 9               (_50)
-        128   call 155 ntypeargs=0     (baml.String.substring)
-        129   store_var 8              (_47)
-        130   load_var2 2 7            
-        131   load_var 8               (_47)
-        132   init_instance 0          (testing.FilterPat .func_pat, .test_pat)
-        133   call 9 ntypeargs=0       (baml.Array.push)
-        134   pop 1                    
-        135   jump -128                (to 7)
+  480   120   load_var 2               (out)
+        121   load_const 17            ("")
+        122   load_var 5               (s)
+        123   init_instance 1          (testing.FilterPat .func_pat, .test_pat)
+        124   call 9 ntypeargs=0       (baml.Array.push)
+        125   pop 1                    
+        126   jump -119                (to 7)
 
-  479   136   load_var2 2 5            
-        137   load_const 17            ("")
-        138   init_instance 1          (testing.FilterPat .func_pat, .test_pat)
-        139   call 9 ntypeargs=0       (baml.Array.push)
-        140   pop 1                    
+  476   127   load_var 6               (_36)
+        128   store_var 7              (idx)
 
-  480   141   load_var 2               (out)
-        142   load_const 18            ("")
-        143   load_var 5               (s)
-        144   init_instance 2          (testing.FilterPat .func_pat, .test_pat)
-        145   call 9 ntypeargs=0       (baml.Array.push)
-        146   pop 1                    
-        147   jump -140                (to 7)
+  477   129   load_var 5               (s)
+        130   load_const 15            (0)
+        131   load_var 7               (idx)
+        132   call 155 ntypeargs=0     (baml.String.substring)
+        133   store_var 8              (_40)
+        134   load_var 5               (s)
+        135   call 152 ntypeargs=0     (baml.String.length)
+        136   store_var 10             (_45)
+        137   load_var2 5 7            
+        138   load_const 18            (2)
+        139   add_int                  
+        140   load_var 10              (_45)
+        141   call 155 ntypeargs=0     (baml.String.substring)
+        142   store_var 9              (_42)
+        143   load_var2 2 8            
+        144   load_var 9               (_42)
+        145   init_instance 2          (testing.FilterPat .func_pat, .test_pat)
+        146   call 9 ntypeargs=0       (baml.Array.push)
+        147   pop 1                    
+        148   jump -141                (to 7)
 
-  485   148   load_var 2               (out)
-        149   return                   
-        150   unreachable              
+  483   149   load_var 2               (out)
+        150   return                   
+        151   unreachable              
 }
 
 function testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.TestSetReport {
@@ -4493,34 +4494,34 @@ function testing.split_top(path: string) -> testing.NameSplit {
   463   0    load_var 1             (path)
         1    load_const 0           ("/")
         2    call 164 ntypeargs=0   (baml.String.index_of)
-        3    store_var 2            (idx)
+        3    store_var 2            (_2)
+        4    load_var 2             (_2)
+        5    is_type 1              
+        6    pop_jump_if_false +2   (to 8)
+        7    jump +5                (to 12)
 
-  464   4    load_var 2             (idx)
-        5    load_const 1           (0)
-        6    cmp_int_op <           
-        7    pop_jump_if_false +2   (to 9)
-        8    jump +15               (to 23)
+  466   8    load_const 2           ("")
+        9    load_var 1             (path)
+        10   init_instance 0        (testing.NameSplit .head, .tail)
 
-  467   9    load_var 1             (path)
-        10   load_const 1           (0)
-        11   load_var 2             (idx)
-        12   call 155 ntypeargs=0   (baml.String.substring)
-        13   load_var 1             (path)
-        14   call 152 ntypeargs=0   (baml.String.length)
-        15   store_var 3            (_10)
-        16   load_var2 1 2          
-        17   load_const 2           (1)
-        18   add_int                
-        19   load_var 3             (_10)
-        20   call 155 ntypeargs=0   (baml.String.substring)
-        21   init_instance 0        (testing.NameSplit .head, .tail)
+  463   11   jump +16               (to 27)
+        12   load_var 2             (_2)
+        13   store_var 3            (idx)
 
-  464   22   jump +4                (to 26)
-
-  465   23   load_const 3           ("")
-        24   load_var 1             (path)
-        25   init_instance 1        (testing.NameSplit .head, .tail)
-        26   return                 
+  464   14   load_var 1             (path)
+        15   load_const 1           (0)
+        16   load_var 3             (idx)
+        17   call 155 ntypeargs=0   (baml.String.substring)
+        18   load_var 1             (path)
+        19   call 152 ntypeargs=0   (baml.String.length)
+        20   store_var 4            (_10)
+        21   load_var2 1 3          
+        22   load_const 3           (1)
+        23   add_int                
+        24   load_var 4             (_10)
+        25   call 155 ntypeargs=0   (baml.String.substring)
+        26   init_instance 1        (testing.NameSplit .head, .tail)
+        27   return                 
 }
 
 function testing.test_child(name: string, body: () -> void throws unknown, runner: ((() -> testing.TestReport throws never) -> (() -> testing.TestReport throws never) throws never) | null) -> testing.TestSetChild {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -3756,129 +3756,130 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
 }
 
 function testing.glob_match(subject: string, pattern: string) -> bool {
-  491   0    load_var 2              (pattern)
-        1    load_const 0            ("*")
-        2    call 137 ntypeargs=0    (baml.String.split)
-        3    store_var 3             (parts)
+  489   0     load_var 2              (pattern)
+        1     load_const 0            ("*")
+        2     call 137 ntypeargs=0    (baml.String.split)
+        3     store_var 3             (parts)
 
-  492   4    load_var 3              (parts)
-        5    container_len           
-        6    store_var 4             (n)
+  490   4     load_var 3              (parts)
+        5     container_len           
+        6     store_var 4             (n)
 
-  493   7    load_var 4              (n)
-        8    load_const 1            (1)
-        9    cmp_int_op ==           
-        10   pop_jump_if_false +2    (to 12)
-        11   jump +86                (to 97)
+  491   7     load_var 4              (n)
+        8     load_const 1            (1)
+        9     cmp_int_op ==           
+        10    pop_jump_if_false +2    (to 12)
+        11    jump +87                (to 98)
 
-  496   12   load_var 3              (parts)
-        13   load_const 2            (0)
-        14   load_array_element      
-        15   store_var 5             (first)
+  494   12    load_var 3              (parts)
+        13    load_const 2            (0)
+        14    load_array_element      
+        15    store_var 5             (first)
 
-  497   16   load_var2 3 4           
-        17   load_const 1            (1)
-        18   sub_int                 
-        19   load_array_element      
-        20   store_var 6             (last)
+  495   16    load_var2 3 4           
+        17    load_const 1            (1)
+        18    sub_int                 
+        19    load_array_element      
+        20    store_var 6             (last)
 
-  498   21   load_var2 1 5           
-        22   call 145 ntypeargs=0    (baml.String.starts_with)
-        23   unary_op !              
-        24   pop_jump_if_false +2    (to 26)
-        25   jump +70                (to 95)
+  496   21    load_var2 1 5           
+        22    call 145 ntypeargs=0    (baml.String.starts_with)
+        23    unary_op !              
+        24    pop_jump_if_false +2    (to 26)
+        25    jump +71                (to 96)
 
-  499   26   load_var2 1 6           
-        27   call 133 ntypeargs=0    (baml.String.ends_with)
-        28   unary_op !              
-        29   pop_jump_if_false +2    (to 31)
-        30   jump +63                (to 93)
+  497   26    load_var2 1 6           
+        27    call 133 ntypeargs=0    (baml.String.ends_with)
+        28    unary_op !              
+        29    pop_jump_if_false +2    (to 31)
+        30    jump +64                (to 94)
 
-  500   31   load_var 5              (first)
-        32   call 152 ntypeargs=0    (baml.String.length)
-        33   store_var 7             (start)
+  498   31    load_var 5              (first)
+        32    call 152 ntypeargs=0    (baml.String.length)
+        33    store_var 7             (start)
 
-  501   34   load_var 1              (subject)
-        35   call 152 ntypeargs=0    (baml.String.length)
-        36   store_var 9             (_22)
-        37   load_var 6              (last)
-        38   call 152 ntypeargs=0    (baml.String.length)
-        39   store_var 10            (_23)
-        40   load_var2 9 10          
-        41   sub_int                 
-        42   store_var 8             (end_limit)
+  499   34    load_var 1              (subject)
+        35    call 152 ntypeargs=0    (baml.String.length)
+        36    store_var 9             (_22)
+        37    load_var 6              (last)
+        38    call 152 ntypeargs=0    (baml.String.length)
+        39    store_var 10            (_23)
+        40    load_var2 9 10          
+        41    sub_int                 
+        42    store_var 8             (end_limit)
 
-  502   43   load_var2 7 8           
-        44   cmp_int_op >            
-        45   pop_jump_if_false +2    (to 47)
-        46   jump +45                (to 91)
+  500   43    load_var2 7 8           
+        44    cmp_int_op >            
+        45    pop_jump_if_false +2    (to 47)
+        46    jump +46                (to 92)
 
-  503   47   load_var 7              (start)
-        48   store_var 11            (pos)
+  501   47    load_var 7              (start)
+        48    store_var 11            (pos)
 
-  504   49   load_const 1            (1)
-        50   store_var 12            (i)
-        51   load_var2 12 4          
-        52   load_const 1            (1)
-        53   sub_int                 
-        54   cmp_int_op <            
-        55   pop_jump_if_false +2    (to 57)
-        56   jump +3                 (to 59)
+  502   49    load_const 1            (1)
+        50    store_var 12            (i)
+        51    load_var2 12 4          
+        52    load_const 1            (1)
+        53    sub_int                 
+        54    cmp_int_op <            
+        55    pop_jump_if_false +2    (to 57)
+        56    jump +3                 (to 59)
 
-  512   57   load_const 3            (true)
-        58   jump +41                (to 99)
+  512   57    load_const 3            (true)
+        58    jump +42                (to 100)
 
-  505   59   load_var2 3 12          
-        60   load_array_element      
-        61   store_var_load_var 13   (part)
+  503   59    load_var2 3 12          
+        60    load_array_element      
+        61    store_var_load_var 13   (part)
 
-  506   62   load_const 4            ("")
-        63   cmp_op !=               
-        64   pop_jump_if_false +20   (to 84)
+  504   62    load_const 4            ("")
+        63    cmp_op !=               
+        64    pop_jump_if_false +23   (to 87)
 
-  507   65   load_var2 1 11          
-        66   load_var 8              (end_limit)
-        67   call 155 ntypeargs=0    (baml.String.substring)
-        68   load_var 13             (part)
-        69   call 164 ntypeargs=0    (baml.String.index_of)
-        70   store_var 14            (idx)
+  505   65    load_var2 1 11          
+        66    load_var 8              (end_limit)
+        67    call 155 ntypeargs=0    (baml.String.substring)
+        68    load_var 13             (part)
+        69    call 164 ntypeargs=0    (baml.String.index_of)
+        70    store_var 14            (_38)
+        71    load_var 14             (_38)
+        72    is_type 2               
+        73    pop_jump_if_false +2    (to 75)
+        74    jump +3                 (to 77)
 
-  508   71   load_var 14             (idx)
-        72   load_const 2            (0)
-        73   cmp_int_op <            
-        74   pop_jump_if_false +2    (to 76)
-        75   jump +14                (to 89)
+  508   75    load_const 5            (false)
+        76    jump +24                (to 100)
 
-  509   76   load_var2 11 14         
-        77   add_int                 
-        78   store_var 15            (_45)
-        79   load_var 13             (part)
-        80   call 152 ntypeargs=0    (baml.String.length)
-        81   load_var 15             (_45)
-        82   add_int                 
-        83   store_var 11            (pos)
+  505   77    load_var 14             (_38)
+        78    store_var 15            (idx)
 
-  504   84   load_var 12             (i)
-        85   load_const 1            (1)
-        86   add_int                 
-        87   store_var 12            (i)
-        88   jump -37                (to 51)
+  506   79    load_var2 11 15         
+        80    add_int                 
+        81    store_var 16            (_45)
+        82    load_var 13             (part)
+        83    call 152 ntypeargs=0    (baml.String.length)
+        84    load_var 16             (_45)
+        85    add_int                 
+        86    store_var 11            (pos)
 
-  508   89   load_const 5            (false)
-        90   jump +9                 (to 99)
+  502   87    load_var 12             (i)
+        88    load_const 1            (1)
+        89    add_int                 
+        90    store_var 12            (i)
+        91    jump -40                (to 51)
 
-  502   91   load_const 5            (false)
-        92   jump +7                 (to 99)
+  500   92    load_const 5            (false)
+        93    jump +7                 (to 100)
 
-  499   93   load_const 5            (false)
-        94   jump +5                 (to 99)
+  497   94    load_const 5            (false)
+        95    jump +5                 (to 100)
 
-  498   95   load_const 5            (false)
-        96   jump +3                 (to 99)
+  496   96    load_const 5            (false)
+        97    jump +3                 (to 100)
 
-  494   97   load_var2 1 2           
-        98   cmp_op ==               
-        99   return                  
+  492   98    load_var2 1 2           
+        99    cmp_op ==               
+        100   return                  
 }
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
@@ -3916,11 +3917,11 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
 }
 
 function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
-  475   0     load_type 0              
+  474   0     load_type 0              
         1     alloc_array 0            
         2     store_var 3              (out)
 
-  476   3     load_type 1              
+  475   3     load_type 1              
         4     load_var 1               (raw)
         5     call 468 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 4              (_3)
@@ -3962,7 +3963,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         42    jump +10                 (to 52)
         43    load_var 4               (_3)
         44    is_type 11               
-        45    pop_jump_if_false +107   (to 152)
+        45    pop_jump_if_false +108   (to 153)
         46    load_type 1              
         47    load_type 12             
         48    load_var 4               (_3)
@@ -4021,61 +4022,62 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         101   load_var 5               (_5)
         102   is_type 13               
         103   pop_jump_if_false +2     (to 105)
-        104   jump +44                 (to 148)
+        104   jump +45                 (to 149)
         105   load_var 5               (_5)
         106   store_var 6              (s)
 
-  477   107   load_var 6               (s)
+  476   107   load_var 6               (s)
         108   load_const 14            ("::")
         109   call 164 ntypeargs=0     (baml.String.index_of)
-        110   store_var 7              (idx)
+        110   store_var 7              (_36)
+        111   load_var 7               (_36)
+        112   is_type 15               
+        113   pop_jump_if_false +2     (to 115)
+        114   jump +13                 (to 127)
 
-  478   111   load_var 7               (idx)
-        112   load_const 15            (0)
-        113   cmp_int_op <             
-        114   pop_jump_if_false +2     (to 116)
-        115   jump +21                 (to 136)
+  479   115   load_var2 3 6            
+        116   load_const 16            ("")
+        117   init_instance 0          (testing.FilterPat .func_pat, .test_pat)
+        118   call 9 ntypeargs=0       (baml.Array.push)
+        119   pop 1                    
 
-  482   116   load_var 6               (s)
-        117   load_const 15            (0)
-        118   load_var 7               (idx)
-        119   call 155 ntypeargs=0     (baml.String.substring)
-        120   store_var 8              (_45)
-        121   load_var 6               (s)
-        122   call 152 ntypeargs=0     (baml.String.length)
-        123   store_var 10             (_50)
-        124   load_var2 6 7            
-        125   load_const 16            (2)
-        126   add_int                  
-        127   load_var 10              (_50)
-        128   call 155 ntypeargs=0     (baml.String.substring)
-        129   store_var 9              (_47)
-        130   load_var2 3 8            
-        131   load_var 9               (_47)
-        132   init_instance 0          (testing.FilterPat .func_pat, .test_pat)
-        133   call 9 ntypeargs=0       (baml.Array.push)
-        134   pop 1                    
-        135   jump -128                (to 7)
+  480   120   load_var 3               (out)
+        121   load_const 17            ("")
+        122   load_var 6               (s)
+        123   init_instance 1          (testing.FilterPat .func_pat, .test_pat)
+        124   call 9 ntypeargs=0       (baml.Array.push)
+        125   pop 1                    
+        126   jump -119                (to 7)
 
-  479   136   load_var2 3 6            
-        137   load_const 17            ("")
-        138   init_instance 1          (testing.FilterPat .func_pat, .test_pat)
-        139   call 9 ntypeargs=0       (baml.Array.push)
-        140   pop 1                    
+  476   127   load_var 7               (_36)
+        128   store_var 8              (idx)
 
-  480   141   load_var 3               (out)
-        142   load_const 18            ("")
-        143   load_var 6               (s)
-        144   init_instance 2          (testing.FilterPat .func_pat, .test_pat)
-        145   call 9 ntypeargs=0       (baml.Array.push)
-        146   pop 1                    
-        147   jump -140                (to 7)
+  477   129   load_var 6               (s)
+        130   load_const 15            (0)
+        131   load_var 8               (idx)
+        132   call 155 ntypeargs=0     (baml.String.substring)
+        133   store_var 9              (_40)
+        134   load_var 6               (s)
+        135   call 152 ntypeargs=0     (baml.String.length)
+        136   store_var 11             (_45)
+        137   load_var2 6 8            
+        138   load_const 18            (2)
+        139   add_int                  
+        140   load_var 11              (_45)
+        141   call 155 ntypeargs=0     (baml.String.substring)
+        142   store_var 10             (_42)
+        143   load_var2 3 9            
+        144   load_var 10              (_42)
+        145   init_instance 2          (testing.FilterPat .func_pat, .test_pat)
+        146   call 9 ntypeargs=0       (baml.Array.push)
+        147   pop 1                    
+        148   jump -141                (to 7)
 
-  485   148   load_var 3               (out)
-        149   store_var 2              (_0)
-        150   load_var 2               (_0)
-        151   return                   
-        152   unreachable              
+  483   149   load_var 3               (out)
+        150   store_var 2              (_0)
+        151   load_var 2               (_0)
+        152   return                   
+        153   unreachable              
 }
 
 function testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.TestSetReport {
@@ -4569,34 +4571,34 @@ function testing.split_top(path: string) -> testing.NameSplit {
   463   0    load_var 1             (path)
         1    load_const 0           ("/")
         2    call 164 ntypeargs=0   (baml.String.index_of)
-        3    store_var 2            (idx)
+        3    store_var 2            (_2)
+        4    load_var 2             (_2)
+        5    is_type 1              
+        6    pop_jump_if_false +2   (to 8)
+        7    jump +5                (to 12)
 
-  464   4    load_var 2             (idx)
-        5    load_const 1           (0)
-        6    cmp_int_op <           
-        7    pop_jump_if_false +2   (to 9)
-        8    jump +15               (to 23)
+  466   8    load_const 2           ("")
+        9    load_var 1             (path)
+        10   init_instance 0        (testing.NameSplit .head, .tail)
 
-  467   9    load_var 1             (path)
-        10   load_const 1           (0)
-        11   load_var 2             (idx)
-        12   call 155 ntypeargs=0   (baml.String.substring)
-        13   load_var 1             (path)
-        14   call 152 ntypeargs=0   (baml.String.length)
-        15   store_var 3            (_10)
-        16   load_var2 1 2          
-        17   load_const 2           (1)
-        18   add_int                
-        19   load_var 3             (_10)
-        20   call 155 ntypeargs=0   (baml.String.substring)
-        21   init_instance 0        (testing.NameSplit .head, .tail)
+  463   11   jump +16               (to 27)
+        12   load_var 2             (_2)
+        13   store_var 3            (idx)
 
-  464   22   jump +4                (to 26)
-
-  465   23   load_const 3           ("")
-        24   load_var 1             (path)
-        25   init_instance 1        (testing.NameSplit .head, .tail)
-        26   return                 
+  464   14   load_var 1             (path)
+        15   load_const 1           (0)
+        16   load_var 3             (idx)
+        17   call 155 ntypeargs=0   (baml.String.substring)
+        18   load_var 1             (path)
+        19   call 152 ntypeargs=0   (baml.String.length)
+        20   store_var 4            (_10)
+        21   load_var2 1 3          
+        22   load_const 3           (1)
+        23   add_int                
+        24   load_var 4             (_10)
+        25   call 155 ntypeargs=0   (baml.String.substring)
+        26   init_instance 1        (testing.NameSplit .head, .tail)
+        27   return                 
 }
 
 function testing.test_child(name: string, body: () -> void throws unknown, runner: ((() -> testing.TestReport throws never) -> (() -> testing.TestReport throws never) throws never) | null) -> testing.TestSetChild {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -4792,20 +4792,23 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
     store_var_load_var part
     load_const ""
     cmp_op !=
-    pop_jump_if_false L8
+    pop_jump_if_false L9
     load_var2 1 11
     load_var end_limit
     call baml.String.substring
     load_var part
     call baml.String.index_of
-    store_var idx
-    load_var idx
-    load_const 0
-    cmp_int_op <
+    store_var _38
+    load_var _38
+    is_type int
     pop_jump_if_false L7
-    jump L9
+    jump L8
 
   L7:
+    load_const false
+    jump L14
+
+  L8:
     load_var2 11 14
     add_int
     store_var _45
@@ -4815,16 +4818,12 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
     add_int
     store_var pos
 
-  L8:
+  L9:
     load_var i
     load_const 1
     add_int
     store_var i
     jump L4
-
-  L9:
-    load_const false
-    jump L14
 
   L10:
     load_const false
@@ -5038,36 +5037,13 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
     load_var s
     load_const "::"
     call baml.String.index_of
-    store_var idx
-    load_var idx
-    load_const 0
-    cmp_int_op <
+    store_var _36
+    load_var _36
+    is_type int
     pop_jump_if_false L21
     jump L22
 
   L21:
-    load_var s
-    load_const 0
-    load_var idx
-    call baml.String.substring
-    store_var _45
-    load_var s
-    call baml.String.length
-    store_var _50
-    load_var2 5 6
-    load_const 2
-    add_int
-    load_var _50
-    call baml.String.substring
-    store_var _47
-    load_var2 2 7
-    load_var _47
-    init_instance testing.FilterPat .func_pat, .test_pat
-    call baml.Array.push
-    pop 1
-    jump L0
-
-  L22:
     load_var2 2 5
     load_const ""
     init_instance testing.FilterPat .func_pat, .test_pat
@@ -5076,6 +5052,30 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
     load_var out
     load_const ""
     load_var s
+    init_instance testing.FilterPat .func_pat, .test_pat
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L22:
+    load_var _36
+    store_var idx
+    load_var s
+    load_const 0
+    load_var idx
+    call baml.String.substring
+    store_var _40
+    load_var s
+    call baml.String.length
+    store_var _45
+    load_var2 5 7
+    load_const 2
+    add_int
+    load_var _45
+    call baml.String.substring
+    store_var _42
+    load_var2 2 8
+    load_var _42
     init_instance testing.FilterPat .func_pat, .test_pat
     call baml.Array.push
     pop 1
@@ -5703,14 +5703,21 @@ function testing.split_top(path: string) -> testing.NameSplit {
     load_var path
     load_const "/"
     call baml.String.index_of
-    store_var idx
-    load_var idx
-    load_const 0
-    cmp_int_op <
+    store_var _2
+    load_var _2
+    is_type int
     pop_jump_if_false L0
     jump L1
 
   L0:
+    load_const ""
+    load_var path
+    init_instance testing.NameSplit .head, .tail
+    jump L2
+
+  L1:
+    load_var _2
+    store_var idx
     load_var path
     load_const 0
     load_var idx
@@ -5718,17 +5725,11 @@ function testing.split_top(path: string) -> testing.NameSplit {
     load_var path
     call baml.String.length
     store_var _10
-    load_var2 1 2
+    load_var2 1 3
     load_const 1
     add_int
     load_var _10
     call baml.String.substring
-    init_instance testing.NameSplit .head, .tail
-    jump L2
-
-  L1:
-    load_const ""
-    load_var path
     init_instance testing.NameSplit .head, .tail
 
   L2:

--- a/baml_language/crates/bex_vm/src/package_baml/string.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/string.rs
@@ -116,10 +116,8 @@ impl BamlClassString for PackageBamlImpl {
     }
 
     #[allow(clippy::cast_possible_wrap)]
-    fn index_of(string: &BexStr, search: &BexStr) -> i64 {
-        string
-            .char_index_of(search.as_str())
-            .map_or(-1, |i| i as i64)
+    fn index_of(string: &BexStr, search: &BexStr) -> Option<i64> {
+        string.char_index_of(search.as_str()).map(|i| i as i64)
     }
 
     fn char_at(string: &BexStr, index: i64) -> Result<BexStr, VmRustFnError> {


### PR DESCRIPTION
## Summary

- Change `String.index_of` to return `int | null` instead of `int`.
- Return `null` from the VM intrinsic when the search string is absent.
- Update testing stdlib helpers and snapshots for nullable `index_of` semantics.
- Add a BAML source regression for `"abc".index_of("z") == null`.

## Validation

- `cargo nextest run -p baml_tests baml_test`
- `cargo nextest run -p baml_tests compiles::__baml_std__`
- `cargo nextest run -p baml_tests compiles::__testing_std__`
- `cargo nextest run -p baml_lsp2_actions describe_tests::describe_builtin_string_with_compiler2_visible_files`
- `cargo nextest run -p baml_tests bytecode`
- `cargo fmt --all --check`
- `SKIP=no-commit-to-branch prek run --all-files --show-diff-on-failure --hook-stage manual`

Fixes B-544.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking change to a core stdlib method; impact is limited because in-repo callers were migrated and coverage was added, but external BAML code comparing to `-1` would need updates.
> 
> **Overview**
> **`String.index_of`** now returns **`int | null`** instead of **`int`**, and returns **`null`** when the substring is missing (replacing the old **`-1`** sentinel). The builtin signature, docs, LSP describe output, and the VM intrinsic in `bex_vm` were updated to match.
> 
> Builtin **testing** helpers that depended on **`index_of`** (`split_top`, `parse_filter_patterns`, `glob_match`) were rewritten from **`idx < 0`** checks to **`if let idx: int = …index_of(…)`**, with compiler/MIR/bytecode snapshots refreshed accordingly.
> 
> A BAML regression test asserts **`"abc".index_of("z")`** equals **`null`**; remaining changes are snapshot churn from that test and line shifts in registry listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ff54aeeaf561358f34259bbaaed45e3be2d4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `String.index_of` now returns `null` when a substring is not found, instead of `-1`.
  * String search behavior is now consistent across the language and runtime.

* **Tests**
  * Added coverage for the “not found” case to verify `index_of` returns `null`.

* **Refactor**
  * Updated related string-matching logic to use the new nullable result style while preserving existing matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->