### PR TITLE
fix(diagnostics): narrow unresolved dotted-root span to the root segment

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -9379,11 +9379,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .iter()
                     .any(|(n, _)| n == &segments[0]);
                 if !is_dep_package && !self.locals.contains_key(&segments[0]) {
-                    self.context.report_simple(
+                    // Narrow the span to the offending root segment (`o`), not
+                    // the whole `o.value` access (B-539).
+                    self.context.report_at_segment(
                         TirTypeError::UnresolvedName {
                             name: segments[0].clone(),
                         },
                         expr_id,
+                        0,
+                        Vec::new(),
                     );
                 }
                 Ty::Unknown {

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_binding_scope.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/if_let/if_let_binding_scope.baml
@@ -43,8 +43,8 @@ function BindingDoesNotLeakIntoElse(r: Ok | Err) -> string {
 //     ╭─[ if_let_if_let_binding_scope.baml:15:3 ]
 //     │
 //  15 │   o.value
-//     │   ───┬───
-//     │      ╰───── unresolved name: o
+//     │   ┬
+//     │   ╰── unresolved name: o
 //     │
 //     │ Note: Error code: E0003
 // ────╯
@@ -52,8 +52,8 @@ function BindingDoesNotLeakIntoElse(r: Ok | Err) -> string {
 //     ╭─[ if_let_if_let_binding_scope.baml:27:3 ]
 //     │
 //  27 │   o.value
-//     │   ───┬───
-//     │      ╰───── unresolved name: o
+//     │   ┬
+//     │   ╰── unresolved name: o
 //     │
 //     │ Note: Error code: E0003
 // ────╯
@@ -61,8 +61,8 @@ function BindingDoesNotLeakIntoElse(r: Ok | Err) -> string {
 //     ╭─[ if_let_if_let_binding_scope.baml:36:5 ]
 //     │
 //  36 │     o.value
-//     │     ───┬───
-//     │        ╰───── unresolved name: o
+//     │     ┬
+//     │     ╰── unresolved name: o
 //     │
 //     │ Note: Error code: E0003
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/interface/error_default_outside_implements.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/interface/error_default_outside_implements.baml
@@ -18,8 +18,8 @@ class Plain {
 //     ╭─[ interface_error_default_outside_implements.baml:11:12 ]
 //     │
 //  11 │     return default.log("hi")
-//     │            ─────┬─────
-//     │                 ╰─────── unresolved name: default
+//     │            ───┬───
+//     │               ╰───── unresolved name: default
 //     │
 //     │ Note: Error code: E0003
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_else_no_bindings.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/let_else/let_else_else_no_bindings.baml
@@ -14,8 +14,8 @@ function ElseDoesNotSeeBinding(r: Ok | Err) -> string {
 //    ╭─[ let_else_let_else_else_no_bindings.baml:7:31 ]
 //    │
 //  7 │   let o: Ok = r else { return o.value; };
-//    │                               ───┬───
-//    │                                  ╰───── unresolved name: o
+//    │                               ┬
+//    │                               ╰── unresolved name: o
 //    │
 //    │ Note: Error code: E0003
 // ───╯

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -222,6 +222,29 @@ function f(s: Sentiment) -> string {
 }
 
 #[test]
+fn unresolved_dotted_root_span_should_narrow_to_root() {
+    // B-539 regression: when the root of a dotted access (`o.value`) is an
+    // unresolved name, the diagnostic should underline only `o`, not the whole
+    // `o.value` expression.
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        "\
+function f() -> string {
+  return o.value;
+}",
+    );
+    insta::assert_snapshot!(render_tir(&db, file), @"
+    function user.f() -> string throws never {
+      { : never
+        return o.value : unknown
+      }
+      !! 34..35: unresolved name: o
+    }
+    ");
+}
+
+#[test]
 fn unknown_field_access_uses_narrowing_diagnostic() {
     let mut db = make_db();
     let file = db.add_file(


### PR DESCRIPTION
## Summary

Fixes [B-539](https://linear.app/boundaryml2/issue/B-539/dotted-access-wrong-span-too-wide).

When the root of a dotted access (`o.value`) is an unresolved name, the `E0003` diagnostic underlined the whole `o.value` expression instead of just the offending `o`:

```
// before
return o.value
       ───┬───
          ╰───── unresolved name: o

// after
return o.value
       ┬
       ╰── unresolved name: o
```

## Change

`infer_path` reported the unresolved-root error at the whole path's `expr_id` span. Switched to the existing `report_at_segment(..., 0, ...)` helper (`DiagnosticLocation::ExprSegment` -> `path_segment_span(id, 0)`), which targets just the root token. Per-segment spans were already recorded at lowering time; this call site just wasn't using them.

```
!! 34..41: unresolved name: o   // before (covers o.value)
!! 34..35: unresolved name: o   // after  (covers o)
```

## Test

Added `unresolved_dotted_root_span_should_narrow_to_root` (mirrors the existing `unresolved_field_span_should_narrow_to_member`). Confirmed it fails on the old span (`34..41`) and passes after the fix.

Verified `compiler2_tir` + `tagged_template` modules: 361 passed, 0 failed.

## Scope

Strictly B-539. The package-path branch (`baml.events.foo`) and pattern-resolution site also report wider-than-ideal spans; those belong to the related [B-543](https://linear.app/boundaryml2/issue/B-543) "polish diagnostic spans" and are left untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unresolved-name diagnostics to underline only the root identifier (narrowed span) rather than the entire dotted expression.
  * Updated LSP diagnostic span formatting for relevant syntax scenarios to consistently surface the correct error location.

* **Tests**
  * Added a regression test to verify unresolved dotted-root spans narrow to the root identifier.
  * Refreshed expected diagnostic snapshots for existing test fixtures affected by the refined span rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->