### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -40,13 +40,13 @@ policy.max_delta_pct = 3.0
 # engine/compiler/sdkgen generics support, +499 KB / +3.2% vs the prior
 # 15.59 MB baseline).
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 16_580_000
+max_file_bytes = 17_052_433
 # Linux x86_64: baseline 21.51 MB file.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 22_157_698
+max_file_bytes = 22_176_914
 # Windows x86_64: baseline 18.11 MB file.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 18_654_306
+max_file_bytes = 18_657_997
 
 [artifacts.packed-program]
 kind = "pack"
@@ -54,13 +54,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 12.01 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 12_370_000
+max_file_bytes = 12_472_693
 # Linux x86_64: baseline 15.62 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 16_087_826
+max_file_bytes = 16_090_067
 # Windows x86_64: baseline 13.00 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 13_392_903
+max_file_bytes = 13_397_777
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -84,4 +84,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.06 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_177_779
+max_gzip_bytes = 4_180_730

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-22T00:00:00Z"
-git_sha = "fee661a5"
+recorded_at = "2026-06-27T09:59:43Z"
+git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
 
 [artifacts.baml-cli]
-file_bytes = 16092048
-stripped_bytes = 16092096
-gzip_bytes = 7785886
+file_bytes = 16555760
+stripped_bytes = 16555792
+gzip_bytes = 7995187
 
 [artifacts.packed-program]
-file_bytes = 11976626
-gzip_bytes = 5683257
+file_bytes = 12109410
+gzip_bytes = 5741271

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-06-27T02:31:45Z"
-git_sha = "e20a605fa65e511db766aa6f7e45ea3f89560c47"
+recorded_at = "2026-06-27T09:59:43Z"
+git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
 
 [artifacts.bridge_wasm]
-file_bytes = 14318453
-gzip_bytes = 4056096
+file_bytes = 14320322
+gzip_bytes = 4058961

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-27T03:12:21Z"
-git_sha = "87d21d939b860a3fbdf74b80e1a11dc4575c550a"
+recorded_at = "2026-06-27T09:59:43Z"
+git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
 
 [artifacts.baml-cli]
-file_bytes = 18110976
-stripped_bytes = 18110976
-gzip_bytes = 8207883
+file_bytes = 18114560
+stripped_bytes = 18114560
+gzip_bytes = 8210454
 
 [artifacts.packed-program]
-file_bytes = 13002818
-gzip_bytes = 5838256
+file_bytes = 13007550
+gzip_bytes = 5840978

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-27T02:31:45Z"
-git_sha = "e20a605fa65e511db766aa6f7e45ea3f89560c47"
+recorded_at = "2026-06-27T09:59:43Z"
+git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
 
 [artifacts.baml-cli]
-file_bytes = 21512328
-stripped_bytes = 21512320
-gzip_bytes = 9192324
+file_bytes = 21530984
+stripped_bytes = 21530976
+gzip_bytes = 9200478
 
 [artifacts.packed-program]
-file_bytes = 15619248
-gzip_bytes = 6573557
+file_bytes = 15621424
+gzip_bytes = 6576288


### PR DESCRIPTION
Adopted from CI run [`18e49eefcbac896307c61050a78fb595d7fc79f4`](https://github.com/BoundaryML/baml/actions/runs/28283848568).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 21.5 MB | 9.2 MB | **file** | 21.5 MB | +18.7 KB (+0.1%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 15.6 MB | 6.6 MB | **file** | 15.6 MB | +2.2 KB (+0.0%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 16.6 MB | 8.0 MB | **file** | 16.1 MB | +463.7 KB (+2.9%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 12.1 MB | 5.7 MB | **file** | 12.0 MB | +132.8 KB (+1.1%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 14.3 MB | 🔒 4.1 MB | **gzip** | 4.1 MB | +2.9 KB (+0.1%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 18.1 MB | 8.2 MB | **file** | 18.1 MB | +3.6 KB (+0.0%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 13.0 MB | 5.8 MB | **file** | 13.0 MB | +4.7 KB (+0.0%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release size thresholds for shipped artifacts across Linux, Windows, macOS, and WebAssembly targets.
  * Refreshed recorded artifact measurements in CI so the latest build sizes are tracked accurately.
  * Increased the allowed compressed size for the WebAssembly bridge artifact slightly to match current output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->