### PR TITLE
fix(cli): centralize project loading and de-noise build progress

### DIFF
--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -16,7 +16,8 @@ pub struct CheckArgs {
 impl CheckArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
         let reporter = Reporter::new();
-        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), &reporter, false)?;
+        let (db, from, baml_files) =
+            load_project_for_build(self.from.as_deref(), &reporter, false)?;
         if baml_files.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(

--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use baml_db::baml_compiler_diagnostics::{Severity, render};
 use clap::Args;
 
-use crate::{project_load::load_project_from_reporting, reporter::Reporter};
+use crate::{project_load::load_project_for_build, reporter::Reporter};
 
 #[derive(Args, Debug)]
 pub struct CheckArgs {
@@ -16,7 +16,7 @@ pub struct CheckArgs {
 impl CheckArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
         let reporter = Reporter::new();
-        let (db, from, baml_files) = load_project_from_reporting(self.from.as_deref(), &reporter)?;
+        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), &reporter, false)?;
         if baml_files.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(
@@ -53,7 +53,8 @@ impl CheckArgs {
             return Ok(crate::ExitCode::Other);
         }
 
-        reporter.spin("Compiling", format!("{} file(s)", baml_files.len()));
+        // The bytecode build runs under the same "Checking" spinner — a
+        // separate "Compiling N file(s)" line would just repeat the count.
         if let Err(err) = db
             .get_bytecode()
             .with_context(|| format!("failed to compile BAML project at {}", from.display()))

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -17,7 +17,7 @@ use text_size::{TextRange, TextSize};
 use toml::Spanned;
 
 use crate::{
-    commands::release_version, project_load::load_project_from_reporting, reporter::Reporter,
+    commands::release_version, project_load::load_project_for_build, reporter::Reporter,
 };
 
 #[derive(Args, Clone, Debug)]
@@ -50,7 +50,7 @@ impl GenerateArgs {
             "Generating",
             format!("clients with CLI version: {}", release_version()),
         );
-        let (db, from, baml_files) = load_project_from_reporting(self.from.as_deref(), &reporter)?;
+        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), &reporter, false)?;
         if baml_files.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(
@@ -65,8 +65,10 @@ impl GenerateArgs {
 
         // Compile-time diagnostics — same shape as run/pack: render the
         // ariadne block after abandoning the spinner so the colored
-        // source-snippet output doesn't fight with the lamb.
-        reporter.spin("Checking", format!("{} file(s)", baml_files.len()));
+        // source-snippet output doesn't fight with the lamb. No "Checking"
+        // line here: the meaningful "Resolving" and "Compiling" phases below
+        // carry the progress, and a "Checking N file(s)" would just duplicate
+        // the "Compiling N file(s)" count.
         let source_files = db.get_source_files();
         let diagnostics = baml_project::collect_diagnostics(&db, project, &source_files);
         let errors: Vec<_> = diagnostics

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -16,9 +16,7 @@ use sdkgen_python_pydantic2::{NamingConvention, OutputType};
 use text_size::{TextRange, TextSize};
 use toml::Spanned;
 
-use crate::{
-    commands::release_version, project_load::load_project_for_build, reporter::Reporter,
-};
+use crate::{commands::release_version, project_load::load_project_for_build, reporter::Reporter};
 
 #[derive(Args, Clone, Debug)]
 pub struct GenerateArgs {
@@ -50,7 +48,8 @@ impl GenerateArgs {
             "Generating",
             format!("clients with CLI version: {}", release_version()),
         );
-        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), &reporter, false)?;
+        let (db, from, baml_files) =
+            load_project_for_build(self.from.as_deref(), &reporter, false)?;
         if baml_files.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(

--- a/baml_language/crates/baml_cli/src/manifest.rs
+++ b/baml_language/crates/baml_cli/src/manifest.rs
@@ -45,6 +45,16 @@ pub(crate) struct BamlToml {
     pub unknown: IndexMap<String, toml::Value>,
 }
 
+/// Top-level keys that are valid in `baml.toml` but are *not* consumed by
+/// this internal binary, so they legitimately land in [`BamlToml::unknown`].
+/// They must not be flagged as typos. Currently just `toolchain` (typically a
+/// `[toolchain]` table, e.g. `channel = "nightly"`), which the `baml` wrapper
+/// reads to pick a toolchain version *before* exec'ing this binary — by the
+/// time we parse the manifest the choice is already made, so there is nothing
+/// here to act on, only a key to not warn about. Matching is by key name, so
+/// both the `[toolchain]` table and a bare `toolchain = "…"` are covered.
+const KNOWN_UNHANDLED_TOP_LEVEL_KEYS: &[&str] = &["toolchain"];
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct Package {
     /// `[package].name`. Optional here so a missing name produces our own
@@ -138,6 +148,9 @@ pub(crate) fn package_name(
 pub(crate) fn unknown_field_warnings(manifest: &BamlToml) -> Vec<String> {
     let mut warnings = Vec::new();
     for key in manifest.unknown.keys() {
+        if KNOWN_UNHANDLED_TOP_LEVEL_KEYS.contains(&key.as_str()) {
+            continue;
+        }
         warnings.push(format!(
             "ignoring unrecognized top-level key `{key}` in baml.toml"
         ));
@@ -192,6 +205,25 @@ mod tests {
         let warns = unknown_field_warnings(&m);
         assert!(warns.iter().any(|w| w.contains("nmae")), "got: {warns:?}");
         assert!(warns.iter().any(|w| w.contains("wat")), "got: {warns:?}");
+    }
+
+    #[test]
+    fn toolchain_key_is_known_and_not_warned() {
+        // `[toolchain]` is consumed by the `baml` wrapper, not this binary, so
+        // it lands in `unknown` — but it's a legitimate key, not a typo, and
+        // must not produce a warning. This mirrors a real manifest: a
+        // `[toolchain]` table sitting alongside `[package]`. A genuine
+        // top-level typo (`nmae`, before any table header) still warns.
+        let m = parse(
+            "nmae = \"typo\"\n\n[package]\nname = \"a\"\n\n[toolchain]\nchannel = \"nightly\"\n",
+        )
+        .unwrap();
+        let warns = unknown_field_warnings(&m);
+        assert!(
+            !warns.iter().any(|w| w.contains("toolchain")),
+            "toolchain must not warn, got: {warns:?}"
+        );
+        assert!(warns.iter().any(|w| w.contains("nmae")), "got: {warns:?}");
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -41,7 +41,7 @@ use sys_native::SysOpsExt;
 use crate::{
     commands::release_version,
     project_load::{
-        load_project_from_reporting, resolve_standalone_file, validate_file_from_flags,
+        load_project_for_build, resolve_standalone_file, validate_file_from_flags,
     },
     reporter::Reporter,
 };
@@ -239,25 +239,19 @@ impl PackArgs {
     }
 
     fn load_and_compile(&self, reporter: &Reporter) -> Result<(ProjectDatabase, Program, bool)> {
-        // Per-file `Loading <path>` lines come from
-        // `load_project_from_reporting` (cargo-shaped per-unit
-        // progress) — no aggregate `Loading <project>` needed.
         let (db, needs_format_hint) = if let Some(file) = self.file.as_deref() {
-            let display = file.display().to_string();
-            reporter.spin("Loading", &display);
             self.load_standalone(file)?
         } else {
             self.load_project(reporter)?
         };
 
-        // File count is the meaningful unit here — `self.from` is
-        // usually `.` and reads as noise. Matches the `Checking N
-        // file(s)` shape that `baml run` uses.
+        // One "Compiling N file(s)" line covers diagnostics + bytecode emit;
+        // file count is the meaningful unit (`self.from` is usually `.` and
+        // reads as noise). A separate "Checking" line just repeated the count.
         let file_count = db.get_source_files().len();
-        reporter.spin("Checking", format!("{file_count} file(s)"));
+        reporter.spin("Compiling", format!("{file_count} file(s)"));
         check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
 
-        reporter.spin("Compiling", format!("{file_count} file(s)"));
         let program = baml_compiler2_emit::generate_project_bytecode(
             &db,
             &baml_compiler2_emit::CompileOptions {
@@ -270,7 +264,8 @@ impl PackArgs {
     }
 
     fn load_project(&self, reporter: &Reporter) -> Result<(ProjectDatabase, bool)> {
-        let (db, from, baml_files) = load_project_from_reporting(self.from.as_deref(), reporter)?;
+        let (db, from, baml_files) =
+            load_project_for_build(self.from.as_deref(), reporter, false)?;
         if baml_files.is_empty() {
             anyhow::bail!("No .baml files found in {}", from.display());
         }

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -40,9 +40,7 @@ use sys_native::SysOpsExt;
 
 use crate::{
     commands::release_version,
-    project_load::{
-        load_project_for_build, resolve_standalone_file, validate_file_from_flags,
-    },
+    project_load::{load_project_for_build, resolve_standalone_file, validate_file_from_flags},
     reporter::Reporter,
 };
 
@@ -264,8 +262,7 @@ impl PackArgs {
     }
 
     fn load_project(&self, reporter: &Reporter) -> Result<(ProjectDatabase, bool)> {
-        let (db, from, baml_files) =
-            load_project_for_build(self.from.as_deref(), reporter, false)?;
+        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), reporter, false)?;
         if baml_files.is_empty() {
             anyhow::bail!("No .baml files found in {}", from.display());
         }

--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -109,10 +109,11 @@ pub(crate) fn load_project_from(
 
 /// Variant of [`load_project_from`] that announces each discovered
 /// file through the [`Reporter`] as it's loaded — cargo's
-/// `   Compiling foo v0.1.0` shape but for source files. Used by
-/// `run`/`pack`/`test`/`generate` so the user sees per-file progress
-/// instead of a single `Loading <project>` line. `grep`/`describe`
-/// stay on the lenient [`load_project_or_default`].
+/// `   Compiling foo v0.1.0` shape but for source files. The per-file
+/// `Loading <path>` flood is verbose-only detail; prefer
+/// [`load_project_for_build`] in command code, which gates this behind the
+/// command's verbosity. `grep`/`describe` stay on the lenient
+/// [`load_project_or_default`].
 pub(crate) fn load_project_from_reporting(
     from: Option<&Path>,
     reporter: &Reporter,
@@ -120,6 +121,27 @@ pub(crate) fn load_project_from_reporting(
     load_project_from_inner(from, |path| {
         reporter.spin("Loading", path.display().to_string());
     })
+}
+
+/// Single front-end every build-style command (`run`/`test`/`generate`/
+/// `check`/`pack`) uses to load its project.
+///
+/// Centralizes the one decision they all share: the per-file `Loading <path>`
+/// flood is *verbose-only* detail. By default the load is silent and the
+/// caller's single aggregate `Compiling N file(s)` line is the only progress
+/// shown for the whole load → check → compile span; a redundant `Checking`
+/// line and ~one `Loading` line per source file are exactly the noise this
+/// removes. Pass the command's own `--verbose` (or `false` when it has none).
+pub(crate) fn load_project_for_build(
+    from: Option<&Path>,
+    reporter: &Reporter,
+    verbose: bool,
+) -> Result<(ProjectDatabase, PathBuf, Vec<PathBuf>)> {
+    if verbose {
+        load_project_from_reporting(from, reporter)
+    } else {
+        load_project_from(from)
+    }
 }
 
 /// Read-only/introspection loader: like [`load_project_from`] but **never

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -20,7 +20,7 @@ use sys_native::{CallId, SysOpsExt};
 
 use crate::{
     project_load::{
-        find_project_root_from, load_project_from_reporting, load_project_or_default,
+        find_project_root_from, load_project_for_build, load_project_or_default,
         resolve_standalone_file, validate_file_from_flags,
     },
     reporter::Reporter,
@@ -605,8 +605,9 @@ impl RunArgs {
         Ok((entries, lookups))
     }
 
-    /// Shared tail: spawn the runtime, run dispatch, render the
-    /// `Running` / `Finished` lines.
+    /// Shared tail: spawn the runtime and run dispatch. Compilation already
+    /// emitted the final `Compiled … in <t>` line and cleared the spinner, so
+    /// the program runs silently — its own stdout is the output that matters.
     fn dispatch_and_finish(
         &self,
         engine: BexEngine,
@@ -616,7 +617,8 @@ impl RunArgs {
         reporter: &Reporter,
     ) -> Result<crate::ExitCode> {
         self.vlog(format_args!("Calling {function_name}"));
-        reporter.status("Running", function_name);
+        // Belt-and-suspenders: the compile step already finished the spinner,
+        // but make sure nothing is left animating over the program's output.
         reporter.abandon();
 
         let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
@@ -634,10 +636,7 @@ impl RunArgs {
         self.vlog(format_args!("Completed in {:.2?}", start.elapsed()));
 
         match dispatch_result {
-            Ok(baml_exec::DispatchResult::Ok) => {
-                reporter.finish("Finished", function_name);
-                Ok(crate::ExitCode::Success)
-            }
+            Ok(baml_exec::DispatchResult::Ok) => Ok(crate::ExitCode::Success),
             Ok(baml_exec::DispatchResult::TargetError) => Ok(crate::ExitCode::TargetError),
             Ok(baml_exec::DispatchResult::Exit(code)) => {
                 std::process::exit(baml_exec::clamp_exit_code(code));
@@ -717,10 +716,11 @@ impl RunArgs {
             return self.load_and_compile_standalone(file, argv, reporter);
         }
 
-        // `load_project_from_reporting` emits one `Loading <file>`
-        // line per discovered source file (cargo-style per-unit
-        // progress) — no aggregate `Loading <project>` needed.
-        let (db, from, baml_files) = load_project_from_reporting(self.from.as_deref(), reporter)?;
+        // Per-file `Loading <file>` progress is verbose-only — by default
+        // the single `Compiling N file(s)` line below is the only progress a
+        // run shows.
+        let (db, from, baml_files) =
+            load_project_for_build(self.from.as_deref(), reporter, self.verbose)?;
         self.vlog(format_args!("Loading project from {}", from.display()));
         if baml_files.is_empty() {
             anyhow::bail!("No .baml files found in {}", from.display());
@@ -732,22 +732,25 @@ impl RunArgs {
                 .unwrap_or(false)
         });
 
-        reporter.spin("Checking", format!("{} file(s)", baml_files.len()));
-        self.check_project_diagnostics(&db, "Cannot run: compilation errors found", reporter)?;
-        // For `--list` the bytecode emit isn't preparing the program
-        // for execution — it's just there so we can call
-        // `engine.user_functions()` to enumerate signatures. Showing
-        // "Compiling" in that case is technically true but misleading
-        // ("am I about to run something?"). Use "Resolving" so the
-        // verb reflects what the user is actually waiting on.
+        // One verb covers the whole compile pipeline (diagnostics + bytecode
+        // emit); a separate "Checking" line was redundant — same file count,
+        // same wait. For `--list` nothing is executed, so "Resolving" is the
+        // honest verb (the emit only exists to enumerate signatures).
         let compile_verb = if self.list { "Resolving" } else { "Compiling" };
         reporter.spin(compile_verb, format!("{} file(s)", baml_files.len()));
+        self.check_project_diagnostics(&db, "Cannot run: compilation errors found", reporter)?;
         self.vlog(format_args!("Compiling..."));
         let engine = self.compile_to_engine(&db, argv)?;
         self.vlog(format_args!(
             "Compiled {} user function(s)",
             engine.user_functions().len()
         ));
+        // Close out compilation with its elapsed time, then let the program
+        // run silently — its output is the point, not our status lines.
+        // `--list` keeps the spinner alive for `print_list` to wrap up.
+        if !self.list {
+            reporter.finish("Compiled", format!("{} file(s)", baml_files.len()));
+        }
         Ok((db, engine, needs_format_hint))
     }
 
@@ -762,7 +765,6 @@ impl RunArgs {
         reporter: &Reporter,
     ) -> Result<(ProjectDatabase, BexEngine, bool)> {
         let display = file_path.display().to_string();
-        reporter.spin("Loading", &display);
         let canonical = resolve_standalone_file(file_path)?;
         self.vlog(format_args!(
             "Standalone mode: loading {}",
@@ -780,21 +782,23 @@ impl RunArgs {
         db.set_project_root(parent);
         db.add_or_update_file(&canonical, &content);
 
-        reporter.spin("Checking", &display);
+        // Single "Compiling" verb covers load + diagnostics + emit; see the
+        // note in `load_and_compile`. "Resolving" when --list is the target.
+        let compile_verb = if self.list { "Resolving" } else { "Compiling" };
+        reporter.spin(compile_verb, &display);
         self.check_project_diagnostics(
             &db,
             &format!("Cannot run: compilation errors in {display}"),
             reporter,
         )?;
-        // See note in `load_and_compile`: "Resolving" is the honest
-        // verb when --list is the destination, "Compiling" otherwise.
-        let compile_verb = if self.list { "Resolving" } else { "Compiling" };
-        reporter.spin(compile_verb, &display);
         let engine = self.compile_to_engine(&db, argv)?;
         self.vlog(format_args!(
             "Compiled {} function(s) from standalone file",
             engine.user_functions().len()
         ));
+        if !self.list {
+            reporter.finish("Compiled", &display);
+        }
         Ok((db, engine, needs_format_hint))
     }
 
@@ -852,11 +856,9 @@ impl RunArgs {
         // `file` containing `2 + 2`) produce the same argv.
         let engine = self.compile_to_engine(&db, self.build_argv_for_expression(expr_body))?;
 
-        // Cargo-shape `     Running …` before the program's stdout
-        // starts; then clear the spinner so the evaluated expression's
-        // output doesn't collide with a still-ticking lamb.
-        reporter.status("Running", "expression");
-        reporter.abandon();
+        // Close out compilation with its elapsed time and clear the spinner,
+        // then evaluate silently — the expression's value is the output.
+        reporter.finish("Compiled", "expression");
 
         let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
         let engine = Arc::new(engine);
@@ -887,10 +889,7 @@ impl RunArgs {
         });
 
         match result {
-            Ok(()) => {
-                reporter.finish("Finished", "expression");
-                Ok(crate::ExitCode::Success)
-            }
+            Ok(()) => Ok(crate::ExitCode::Success),
             Err(bex_engine::EngineError::Exit { code }) => {
                 std::process::exit(baml_exec::clamp_exit_code(code));
             }
@@ -1458,8 +1457,7 @@ impl RunArgs {
 // Reserved verbs & namespace helpers
 // ============================================================================
 
-pub(crate) const FORMAT_HINT: &str =
-    "Your code is unformatted — run `baml fmt` to format it. Continuing.";
+pub(crate) const FORMAT_HINT: &str = "Code is unformatted — run `baml fmt`.";
 
 pub(crate) fn source_needs_format_hint(source: &str) -> bool {
     let options = baml_fmt::FormatOptions::default();
@@ -1611,10 +1609,7 @@ mod tests {
     fn format_hint_text_matches_ticket() {
         // Pinned because the wording is user-facing copy: any change
         // here is a deliberate UX call, not a casual refactor.
-        assert_eq!(
-            FORMAT_HINT,
-            "Your code is unformatted — run `baml fmt` to format it. Continuing."
-        );
+        assert_eq!(FORMAT_HINT, "Code is unformatted — run `baml fmt`.");
     }
 
     // Tests that touch the filesystem build paths under $TMPDIR. Appending

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -747,8 +747,12 @@ impl RunArgs {
         ));
         // Close out compilation with its elapsed time, then let the program
         // run silently — its output is the point, not our status lines.
-        // `--list` keeps the spinner alive for `print_list` to wrap up.
-        if !self.list {
+        // `--list` has no program run to time, and `print_list` writes straight
+        // to stdout, so just clear the spinner to keep it from smearing over
+        // the listing.
+        if self.list {
+            reporter.abandon();
+        } else {
             reporter.finish("Compiled", format!("{} file(s)", baml_files.len()));
         }
         Ok((db, engine, needs_format_hint))
@@ -796,7 +800,11 @@ impl RunArgs {
             "Compiled {} function(s) from standalone file",
             engine.user_functions().len()
         ));
-        if !self.list {
+        // See `load_and_compile`: clear the spinner before `--list` output,
+        // otherwise finish with the elapsed-time line.
+        if self.list {
+            reporter.abandon();
+        } else {
             reporter.finish("Compiled", &display);
         }
         Ok((db, engine, needs_format_hint))

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -14,7 +14,7 @@ use clap::Args;
 use sys_native::{CallId, SysOpsExt};
 
 use crate::{
-    project_load::load_project_from_reporting, reporter::Reporter, test_filter::TestFilter,
+    project_load::load_project_for_build, reporter::Reporter, test_filter::TestFilter,
 };
 
 #[derive(Args, Clone, Debug)]
@@ -22,28 +22,35 @@ pub struct TestArgs {
     #[arg(long, help = "Project search starting point", value_name = "PATH")]
     pub from: Option<PathBuf>,
 
-    /// Only list selected tests
+    /// List the selected tests instead of running them. The
+    /// "Testset::TestName" shown on each line is a valid -i / -x selector.
     #[arg(long, default_value_t = false)]
     list: bool,
 
     #[arg(long, short = 'i')]
-    /// Specific functions or tests to include. If none provided, runs all tests.
+    /// Tests (or whole testsets) to include. If none provided, runs all tests.
+    ///
+    /// A selector is "Testset::TestName": the part before `::` is the enclosing
+    /// testset, the part after is the test. Either side may be empty or use `*`
+    /// wildcards. (For a legacy function-attached `test`, the part before `::`
+    /// is the function name instead.)
     ///
     /// Examples:
     ///
-    /// -i "FunctionName::TestName" will match the specific test
+    /// -i "MySet::my test"  one test inside testset "MySet"
     ///
-    /// -i "FunctionName::" will run all tests in the function
+    /// -i "MySet::"  every test in testset "MySet"
     ///
-    /// -i "::TestName" will run the test in any function
+    /// -i "::my test"  a test in any testset — also the form for a top-level
+    /// `test` with no enclosing testset (its testset name is empty)
     ///
-    /// -i "Get*::*Bar" will match with wildcards
+    /// -i "Get*::*Bar"  wildcards on either side
     pub include: Vec<String>,
 
     #[arg(long, short = 'x')]
-    /// Specific functions or tests to exclude. Takes precedence over --include.
+    /// Tests (or whole testsets) to exclude. Takes precedence over --include.
     ///
-    /// Uses the same syntax as --include.
+    /// Uses the same "Testset::TestName" syntax as --include.
     pub exclude: Vec<String>,
 }
 
@@ -71,7 +78,7 @@ impl TestArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
         let reporter = Reporter::new();
         // ── 1. Load project ────────────────────────────────────────────────
-        let (db, from, baml_files) = load_project_from_reporting(self.from.as_deref(), &reporter)?;
+        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), &reporter, false)?;
         if baml_files.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(
@@ -85,7 +92,9 @@ impl TestArgs {
             .ok_or_else(|| anyhow!("No project context"))?;
 
         // ── 2. Diagnostics ─────────────────────────────────────────────────
-        reporter.spin("Checking", format!("{} file(s)", baml_files.len()));
+        // One "Compiling" verb covers diagnostics + the bytecode build below;
+        // a separate "Checking" line would just repeat the file count.
+        reporter.spin("Compiling", format!("{} file(s)", baml_files.len()));
         let source_files = db.get_source_files();
         let diagnostics = baml_project::collect_diagnostics(&db, project, &source_files);
         let errors: Vec<_> = diagnostics

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -13,9 +13,7 @@ use bex_engine::{
 use clap::Args;
 use sys_native::{CallId, SysOpsExt};
 
-use crate::{
-    project_load::load_project_for_build, reporter::Reporter, test_filter::TestFilter,
-};
+use crate::{project_load::load_project_for_build, reporter::Reporter, test_filter::TestFilter};
 
 #[derive(Args, Clone, Debug)]
 pub struct TestArgs {
@@ -78,7 +76,8 @@ impl TestArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
         let reporter = Reporter::new();
         // ── 1. Load project ────────────────────────────────────────────────
-        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), &reporter, false)?;
+        let (db, from, baml_files) =
+            load_project_for_build(self.from.as_deref(), &reporter, false)?;
         if baml_files.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(
@@ -92,8 +91,9 @@ impl TestArgs {
             .ok_or_else(|| anyhow!("No project context"))?;
 
         // ── 2. Diagnostics ─────────────────────────────────────────────────
-        // One "Compiling" verb covers diagnostics + the bytecode build below;
-        // a separate "Checking" line would just repeat the file count.
+        // One "Compiling" spinner stays up for the whole diagnostics +
+        // bytecode-build span below; a separate "Checking" line (or a second
+        // "Compiling") would just repeat the file count.
         reporter.spin("Compiling", format!("{} file(s)", baml_files.len()));
         let source_files = db.get_source_files();
         let diagnostics = baml_project::collect_diagnostics(&db, project, &source_files);
@@ -127,7 +127,8 @@ impl TestArgs {
         let legacy = discover_legacy_tests(&db, project);
 
         // ── 4. Compile + engine + runtime ──────────────────────────────────
-        reporter.spin("Compiling", format!("{} file(s)", baml_files.len()));
+        // The "Compiling N file(s)" spinner from step 2 is still up — no need
+        // to re-issue it here.
         let compile_options = baml_compiler2_emit::CompileOptions {
             emit_test_cases: true,
         };


### PR DESCRIPTION
## Summary

A set of `baml_cli` UX/progress-reporting cleanups (the bugfixes that were in flight on this branch):

- **Single project-load front-end.** `run`/`test`/`generate`/`check`/`pack` now go through `load_project_for_build`, which gates the per-file `Loading <path>` flood behind the command's verbosity instead of always emitting it.
- **De-duplicated spinner verbs.** The redundant `Checking N file(s)` + `Compiling N file(s)` pair collapses into one `Compiling N file(s)` verb covering diagnostics + bytecode emit. `--list` uses the honest `Resolving` verb (nothing is executed).
- **Quieter run output.** Compilation closes with a `Compiled … in <t>` line and the program then runs silently — its own stdout is the output that matters (drops the `Running`/`Finished` status lines).
- **`[toolchain]` is not a typo.** Exempt the `toolchain` key (read by the `baml` wrapper before this binary execs) from unknown-top-level-key warnings, with a regression test.
- **Copy tweaks.** Tightened the `FORMAT_HINT` wording and clarified `baml test` `--include`/`--exclude` help to describe the `Testset::TestName` selector syntax.

## Notes

- Resolves a stale `git stash apply` conflict in `test_command.rs` by keeping this branch's `LegacyTest`/`registry` design (the stashed `DiscoveredTest`/`TestKind` design was already superseded).
- `cargo check -p baml_cli` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and manifest warning behavior only; compilation and execution logic are unchanged aside from when status lines are printed.
> 
> **Overview**
> This PR streamlines **CLI progress output** and **project loading** across build-style commands (`run`, `test`, `generate`, `check`, `pack`).
> 
> **`load_project_for_build`** is the shared entry point: per-file `Loading <path>` lines appear only when the command passes `verbose` (e.g. `baml run --verbose`); otherwise loading stays quiet and callers show one aggregate progress line.
> 
> **Spinner verbs** are de-duplicated: redundant `Checking N file(s)` plus `Compiling N file(s)` collapse into a single **`Compiling N file(s)`** (or **`Resolving`** for `baml run --list`). `check` keeps one **`Checking`** spinner through diagnostics and bytecode. `generate` drops an extra checking line before its existing Resolving/Compiling phases.
> 
> **`baml run`** ends compilation with **`Compiled … in <t>`**, then runs without **`Running`/`Finished`** status lines so program stdout is unobstructed. Expression mode follows the same pattern.
> 
> **`baml.toml`**: top-level **`toolchain`** (used by the outer `baml` wrapper) is no longer reported as an unrecognized key; real typos still warn.
> 
> Minor copy: shorter **`FORMAT_HINT`**, and clearer **`baml test`** help for `--list` and `Testset::TestName` selectors on `--include`/`--exclude`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e063ac2a584864c2334f33b2d76be93dd304b28a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved and streamlined CLI progress messaging across check, generate, pack, run, and test, with consolidated resolving/compiling status and quieter successful dispatch output.

* **Bug Fixes**
  * Manifest unknown-field warnings now ignore the recognized `toolchain` key while still warning on actual typos.
  * Several commands now use a more consistent build/compile loading flow, improving progress behavior.

* **Documentation**
  * Updated test command help/usage (`--list`, `--include`, `--exclude`) with clearer selector syntax and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->