### PR TITLE
bump BAML language canary to 0.13.0

### DIFF
--- a/baml_language/crates/baml_version/src/lib.rs
+++ b/baml_language/crates/baml_version/src/lib.rs
@@ -1,6 +1,6 @@
 //! Stamped BAML language product version.
 
-pub const CANONICAL_VERSION: &str = "0.12.1";
-pub const PYPI_VERSION: &str = "0.12.1";
+pub const CANONICAL_VERSION: &str = "0.13.0";
+pub const PYPI_VERSION: &str = "0.13.0";
 pub const CHANNEL: &str = "canary";
-pub const STABLE_VERSION: &str = "0.12.1";
+pub const STABLE_VERSION: &str = "0.13.0";

--- a/baml_language/release.toml
+++ b/baml_language/release.toml
@@ -1,2 +1,2 @@
 [release]
-canary_version = "0.12.1"
+canary_version = "0.13.0"

--- a/baml_language/sdks/nodejs/bridge_nodejs/dist/native.js
+++ b/baml_language/sdks/nodejs/bridge_nodejs/dist/native.js
@@ -88,8 +88,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-android-arm64')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -104,8 +104,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-android-arm-eabi')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -125,8 +125,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-win32-x64-gnu')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -141,8 +141,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-win32-x64-msvc')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -158,8 +158,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-win32-ia32-msvc')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -174,8 +174,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-win32-arm64-msvc')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -193,8 +193,8 @@ function requireNative() {
     try {
       const binding = require('@boundaryml/baml-core-node-darwin-universal')
       const bindingPackageVersion = require('@boundaryml/baml-core-node-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -209,8 +209,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-darwin-x64')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -225,8 +225,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-darwin-arm64')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -245,8 +245,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-freebsd-x64')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -261,8 +261,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-freebsd-arm64')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -282,8 +282,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-x64-musl')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -298,8 +298,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-x64-gnu')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -316,8 +316,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-arm64-musl')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -332,8 +332,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-arm64-gnu')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -350,8 +350,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-arm-musleabihf')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -366,8 +366,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -384,8 +384,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-loong64-musl')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -400,8 +400,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-loong64-gnu')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -418,8 +418,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-riscv64-musl')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -434,8 +434,8 @@ function requireNative() {
         try {
           const binding = require('@boundaryml/baml-core-node-linux-riscv64-gnu')
           const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -451,8 +451,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-linux-ppc64-gnu')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -467,8 +467,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-linux-s390x-gnu')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -487,8 +487,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-openharmony-arm64')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -503,8 +503,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-openharmony-x64')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -519,8 +519,8 @@ function requireNative() {
       try {
         const binding = require('@boundaryml/baml-core-node-openharmony-arm')
         const bindingPackageVersion = require('@boundaryml/baml-core-node-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.12.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/baml_language/sdks/nodejs/bridge_nodejs/package.json
+++ b/baml_language/sdks/nodejs/bridge_nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaryml/baml-core-node",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/baml_language/sdks/python/pyproject.toml
+++ b/baml_language/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baml_core"
-version = "0.12.1"
+version = "0.13.0"
 description = "BAML python bindings (new system, bex_engine)"
 authors = [{ "name" = "Boundary", "email" = "contact@boundaryml.com" }]
 license = "Apache-2.0"

--- a/baml_language/sdks/python/src/baml_core/__init__.py
+++ b/baml_language/sdks/python/src/baml_core/__init__.py
@@ -53,7 +53,7 @@ from .typemap import (
 # Flush buffered trace events on process exit so nothing is lost.
 atexit.register(flush_events)
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 
 
 # ---------------------------------------------------------------------------

--- a/typescript2/app-vscode-ext/package.json
+++ b/typescript2/app-vscode-ext/package.json
@@ -2,7 +2,7 @@
   "name": "baml-language",
   "displayName": "BAML",
   "description": "BAML language support — syntax highlighting, hover, completions, diagnostics, go-to-definition",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "publisher": "Boundary",
   "private": true,
   "type": "commonjs",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the product and distribution version to **0.13.0** across the core release, Python package, Node.js package, and VS Code extension.
  * Updated the published canary release setting to match the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->