### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -40,13 +40,13 @@ policy.max_delta_pct = 3.0
 # engine/compiler/sdkgen generics support, +499 KB / +3.2% vs the prior
 # 15.59 MB baseline).
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 17_052_433
+max_file_bytes = 17_343_882
 # Linux x86_64: baseline 21.51 MB file.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 22_176_914
+max_file_bytes = 22_543_899
 # Windows x86_64: baseline 18.11 MB file.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 18_657_997
+max_file_bytes = 18_938_025
 
 [artifacts.packed-program]
 kind = "pack"
@@ -54,13 +54,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 12.01 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 12_472_693
+max_file_bytes = 12_559_114
 # Linux x86_64: baseline 15.62 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 16_090_067
+max_file_bytes = 16_232_916
 # Windows x86_64: baseline 13.00 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 13_397_777
+max_file_bytes = 13_464_690
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -84,4 +84,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.06 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_180_730
+max_gzip_bytes = 4_255_304

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-27T09:59:43Z"
-git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
+recorded_at = "2026-07-13T10:28:21Z"
+git_sha = "50301c7841fcd75b1d0efa5b92d41c6f53ba2503"
 
 [artifacts.baml-cli]
-file_bytes = 16555760
-stripped_bytes = 16555792
-gzip_bytes = 7995187
+file_bytes = 16838720
+stripped_bytes = 16838768
+gzip_bytes = 8131248
 
 [artifacts.packed-program]
-file_bytes = 12109410
-gzip_bytes = 5741271
+file_bytes = 12193314
+gzip_bytes = 5859726

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-06-27T09:59:43Z"
-git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
+recorded_at = "2026-07-13T10:28:21Z"
+git_sha = "50301c7841fcd75b1d0efa5b92d41c6f53ba2503"
 
 [artifacts.bridge_wasm]
-file_bytes = 14320322
-gzip_bytes = 4058961
+file_bytes = 14571966
+gzip_bytes = 4131363

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-27T09:59:43Z"
-git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
+recorded_at = "2026-07-13T10:28:21Z"
+git_sha = "50301c7841fcd75b1d0efa5b92d41c6f53ba2503"
 
 [artifacts.baml-cli]
-file_bytes = 18114560
-stripped_bytes = 18114560
-gzip_bytes = 8210454
+file_bytes = 18386432
+stripped_bytes = 18386432
+gzip_bytes = 8341261
 
 [artifacts.packed-program]
-file_bytes = 13007550
-gzip_bytes = 5840978
+file_bytes = 13072514
+gzip_bytes = 5951652

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-27T09:59:43Z"
-git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
+recorded_at = "2026-07-13T10:28:21Z"
+git_sha = "50301c7841fcd75b1d0efa5b92d41c6f53ba2503"
 
 [artifacts.baml-cli]
-file_bytes = 21530984
-stripped_bytes = 21530976
-gzip_bytes = 9200478
+file_bytes = 21887280
+stripped_bytes = 21887272
+gzip_bytes = 9357697
 
 [artifacts.packed-program]
-file_bytes = 15621424
-gzip_bytes = 6576288
+file_bytes = 15760112
+gzip_bytes = 6696068


### PR DESCRIPTION
Adopted from CI run [`50301c7841fcd75b1d0efa5b92d41c6f53ba2503`](https://github.com/BoundaryML/baml/actions/runs/29225240685).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 21.9 MB | 9.4 MB | **file** | 21.5 MB | +356.3 KB (+1.7%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 15.8 MB | 6.7 MB | **file** | 15.6 MB | +138.7 KB (+0.9%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 16.8 MB | 8.1 MB | **file** | 16.6 MB | +283.0 KB (+1.7%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 12.2 MB | 5.9 MB | **file** | 12.1 MB | +83.9 KB (+0.7%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 14.6 MB | 🔒 4.1 MB | **gzip** | 4.1 MB | +72.4 KB (+1.8%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 18.4 MB | 8.3 MB | **file** | 18.1 MB | +271.9 KB (+1.5%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 13.1 MB | 6.0 MB | **file** | 13.0 MB | +65.0 KB (+0.5%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*
