### PR TITLE
feat(beps): allow public viewing and rename draft to slop

### DIFF
--- a/typescript/apps/beps/src/app/page.tsx
+++ b/typescript/apps/beps/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useUser } from "@/components/providers/user-provider";
 import { BepList } from "@/components/bep/bep-list";
 import { BepCreateModal } from "@/components/bep/bep-create-modal";
@@ -15,17 +15,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, User, Users, ChevronDown } from "lucide-react";
+import { LogOut, User, Users, ChevronDown, LogIn } from "lucide-react";
 
 export default function Home() {
   const { user, userId, isLoading, logout, hasManagementPermissions } = useUser();
   const router = useRouter();
-
-  useEffect(() => {
-    if (!isLoading && !userId) {
-      router.push("/login");
-    }
-  }, [isLoading, userId, router]);
 
   const handleLogout = () => {
     logout();
@@ -48,54 +42,59 @@ export default function Home() {
     );
   }
 
-  if (!user) {
-    return null; // Will redirect
-  }
-
   return (
     <div className="min-h-screen bg-background">
       <header className="border-b">
         <div className="max-w-[1600px] mx-auto px-4 py-4 flex items-center justify-between">
           <h1 className="text-2xl font-bold">BAML Enhancement Proposals</h1>
           <div className="flex items-center gap-4">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="gap-2">
-                  {user.avatarUrl ? (
-                    <img
-                      src={user.avatarUrl}
-                      alt={user.name}
-                      className="w-6 h-6 rounded-full"
-                    />
-                  ) : (
-                    <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
-                      <span className="text-xs text-muted-foreground font-medium">
-                        {user.name.charAt(0).toUpperCase()}
-                      </span>
-                    </div>
-                  )}
-                  <span className="text-sm">{user.name}</span>
-                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem onClick={() => router.push("/profile")}>
-                  <User className="h-4 w-4 mr-2" />
-                  Your Profile
-                </DropdownMenuItem>
-                {hasManagementPermissions && (
-                  <DropdownMenuItem onClick={() => router.push("/users")}>
-                    <Users className="h-4 w-4 mr-2" />
-                    Manage Users
+            {user ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm" className="gap-2">
+                    {user.avatarUrl ? (
+                      <img
+                        src={user.avatarUrl}
+                        alt={user.name}
+                        className="w-6 h-6 rounded-full"
+                      />
+                    ) : (
+                      <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
+                        <span className="text-xs text-muted-foreground font-medium">
+                          {user.name.charAt(0).toUpperCase()}
+                        </span>
+                      </div>
+                    )}
+                    <span className="text-sm">{user.name}</span>
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48">
+                  <DropdownMenuItem onClick={() => router.push("/profile")}>
+                    <User className="h-4 w-4 mr-2" />
+                    Your Profile
                   </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleLogout}>
-                  <LogOut className="h-4 w-4 mr-2" />
-                  Sign Out
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  {hasManagementPermissions && (
+                    <DropdownMenuItem onClick={() => router.push("/users")}>
+                      <Users className="h-4 w-4 mr-2" />
+                      Manage Users
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleLogout}>
+                    <LogOut className="h-4 w-4 mr-2" />
+                    Sign Out
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <Link href="/login">
+                <Button variant="outline" size="sm" className="gap-2">
+                  <LogIn className="h-4 w-4" />
+                  Sign In
+                </Button>
+              </Link>
+            )}
           </div>
         </div>
       </header>
@@ -104,7 +103,7 @@ export default function Home() {
           <h2 className="text-xl font-semibold">All Proposals</h2>
           <div className="flex items-center gap-2">
             <BepExportAllDialog />
-            <BepCreateModal userId={userId} />
+            {userId && <BepCreateModal userId={userId} />}
           </div>
         </div>
         <BepList />

--- a/typescript/apps/beps/src/components/bep/bep-export-all-dialog.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-export-all-dialog.tsx
@@ -56,7 +56,7 @@ const STATUS_CONFIG: Record<string, { icon: React.ReactNode; color: string; labe
   draft: {
     icon: <Circle className="h-3 w-3" />,
     color: "bg-gray-500/20 text-gray-700 dark:bg-gray-500/30 dark:text-gray-300",
-    label: "Draft",
+    label: "Slop",
   },
   superseded: {
     icon: <RefreshCw className="h-3 w-3" />,

--- a/typescript/apps/beps/src/components/bep/bep-list.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-list.tsx
@@ -24,7 +24,7 @@ type ViewMode = "list" | "kanban";
 
 const STATUS_OPTIONS: { value: BepStatus | "all"; label: string }[] = [
   { value: "all", label: "All" },
-  { value: "draft", label: "Draft" },
+  { value: "draft", label: "Slop" },
   { value: "proposed", label: "Proposed" },
   { value: "pending", label: "Pending" },
   { value: "accepted", label: "Accepted" },
@@ -34,7 +34,7 @@ const STATUS_OPTIONS: { value: BepStatus | "all"; label: string }[] = [
 ];
 
 const KANBAN_COLUMNS: { status: BepStatus; label: string; color: string }[] = [
-  { status: "draft", label: "Draft", color: "bg-slate-500" },
+  { status: "draft", label: "Slop", color: "bg-slate-500" },
   { status: "proposed", label: "Proposed", color: "bg-blue-500" },
   { status: "pending", label: "Pending", color: "bg-yellow-500" },
   { status: "accepted", label: "Accepted", color: "bg-green-500" },

--- a/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
@@ -36,7 +36,7 @@ import { AIAssistantPanel } from "@/components/ai-assistant/ai-assistant-panel";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowLeft, Check, Copy, Edit, History, Maximize2, Minimize2, Pencil } from "lucide-react";
+import { ArrowLeft, Check, Copy, Edit, History, LogIn, Maximize2, Minimize2, Pencil } from "lucide-react";
 import {
   MAIN_CONTENT_ID,
   RESERVED_PAGE_SLUGS,
@@ -182,11 +182,6 @@ const [copied, setCopied] = useState(false);
       : "skip"
   );
 
-  useEffect(() => {
-    if (!userLoading && !userId) {
-      router.push("/login");
-    }
-  }, [userLoading, userId, router]);
 
   useEffect(() => {
     if (!hasValidBepNumber) {
@@ -653,7 +648,7 @@ const [copied, setCopied] = useState(false);
     }
   };
 
-  if (userLoading || bep === undefined) {
+  if (bep === undefined) {
     return (
       <div className="min-h-screen bg-background">
         <header className="border-b">
@@ -677,9 +672,7 @@ const [copied, setCopied] = useState(false);
     );
   }
 
-  if (!user) {
-    return null;
-  }
+  const isLoggedIn = !!user;
 
   if (!hasValidBepNumber) {
     return null;
@@ -806,7 +799,7 @@ const [copied, setCopied] = useState(false);
               )}
             </Button>
             <BepExportDialog bepId={bep._id} bepNumber={bep.number} />
-            <BepImportDialog bepId={bep._id} bepNumber={bep.number} />
+            {isLoggedIn && <BepImportDialog bepId={bep._id} bepNumber={bep.number} />}
             <BepVersionSelect
               versions={bep.versions}
               currentVersionNumber={
@@ -814,7 +807,7 @@ const [copied, setCopied] = useState(false);
               }
               onVersionChange={handleVersionRouteChange}
             />
-            {!isViewingHistorical && (
+            {!isViewingHistorical && isLoggedIn && (
               <Button
                 variant={isEditMode ? "default" : "outline"}
                 size="sm"
@@ -832,6 +825,14 @@ const [copied, setCopied] = useState(false);
                   </>
                 )}
               </Button>
+            )}
+            {!isLoggedIn && (
+              <Link href="/login">
+                <Button variant="outline" size="sm" className="gap-2">
+                  <LogIn className="h-4 w-4" />
+                  Sign In
+                </Button>
+              </Link>
             )}
           </div>
         </div>
@@ -879,7 +880,7 @@ const [copied, setCopied] = useState(false);
                   )}
                 </Button>
               )}
-              {!isViewingHistorical && (
+              {!isViewingHistorical && isLoggedIn && (
                 <>
                   <BepGoodReferenceToggle
                     bepId={bep._id}
@@ -908,7 +909,7 @@ const [copied, setCopied] = useState(false);
                 bepId={bep._id}
                 versionId={currentVersionId}
                 versionNumber={latestVersionNumber ?? 1}
-                readOnly={isViewingHistorical}
+                readOnly={isViewingHistorical || !isLoggedIn}
               />
             )}
           </div>
@@ -926,9 +927,9 @@ const [copied, setCopied] = useState(false);
                 openIssueCount={isViewingHistorical ? 0 : openIssueCount}
                 decisionCount={isViewingHistorical ? 0 : bep.decisions.length}
                 hideMetaSections={isViewingHistorical}
-                isEditMode={isEditMode}
+                isEditMode={isEditMode && isLoggedIn}
                 pageStatuses={pageStatuses}
-                onAddPage={() => setShowAddPageModal(true)}
+                onAddPage={isLoggedIn ? () => setShowAddPageModal(true) : undefined}
               />
             </div>
           </aside>
@@ -1016,7 +1017,7 @@ const [copied, setCopied] = useState(false);
                               bepId={bep._id}
                               versionId={effectiveVersionId}
                               pageId={currentPageId}
-                              readOnly={isViewingHistorical}
+                              readOnly={isViewingHistorical || !isLoggedIn}
                               comments={(pageComments ?? [])
                                 .filter((c) => c.anchor)
                                 .map((c) => ({
@@ -1048,7 +1049,7 @@ const [copied, setCopied] = useState(false);
                       versionId={effectiveVersionId}
                       pageId={currentPageId}
                       viewingVersionId={viewingVersionId ?? undefined}
-                      readOnly={isViewingHistorical}
+                      readOnly={isViewingHistorical || !isLoggedIn}
                       linkContext={{
                         bepNumber,
                         isHistorical: isViewingHistorical,

--- a/typescript/apps/beps/src/components/bep/bep-status-select.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-status-select.tsx
@@ -35,7 +35,7 @@ type BepStatus =
   | "superseded";
 
 const STATUS_OPTIONS: { value: BepStatus; label: string; description: string }[] = [
-  { value: "draft", label: "Draft", description: "Work in progress" },
+  { value: "draft", label: "Slop", description: "Work in progress" },
   { value: "proposed", label: "Proposed", description: "Ready for review" },
   { value: "pending", label: "Pending", description: "Under consideration" },
   { value: "accepted", label: "Accepted", description: "Approved for implementation" },
@@ -108,8 +108,12 @@ export function BepStatusSelect({
     );
   };
 
+  const getDisplayLabel = (status: BepStatus) => {
+    return STATUS_OPTIONS.find((o) => o.value === status)?.label ?? status;
+  };
+
   if (!canEdit) {
-    return <Badge variant={currentStatus}>{currentStatus}</Badge>;
+    return <Badge variant={currentStatus}>{getDisplayLabel(currentStatus)}</Badge>;
   }
 
   return (
@@ -121,8 +125,8 @@ export function BepStatusSelect({
       >
         <SelectTrigger className="w-40">
           <SelectValue>
-            <Badge variant={currentStatus} className="capitalize">
-              {currentStatus}
+            <Badge variant={currentStatus}>
+              {getDisplayLabel(currentStatus)}
             </Badge>
           </SelectValue>
         </SelectTrigger>
@@ -130,7 +134,7 @@ export function BepStatusSelect({
           {STATUS_OPTIONS.map((option) => (
             <SelectItem key={option.value} value={option.value}>
               <div className="flex items-center gap-2">
-                <Badge variant={option.value} className="capitalize">
+                <Badge variant={option.value}>
                   {option.label}
                 </Badge>
                 <span className="text-xs text-muted-foreground">

--- a/typescript/apps/beps/src/components/bep/bep-status.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-status.tsx
@@ -9,14 +9,24 @@ type BepStatus =
   | "rejected"
   | "superseded";
 
+const STATUS_DISPLAY_LABELS: Record<BepStatus, string> = {
+  draft: "Slop",
+  proposed: "Proposed",
+  pending: "Pending",
+  accepted: "Accepted",
+  implemented: "Implemented",
+  rejected: "Rejected",
+  superseded: "Superseded",
+};
+
 interface BepStatusBadgeProps {
   status: BepStatus;
 }
 
 export function BepStatusBadge({ status }: BepStatusBadgeProps) {
   return (
-    <Badge variant={status} className="capitalize">
-      {status}
+    <Badge variant={status}>
+      {STATUS_DISPLAY_LABELS[status]}
     </Badge>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference

This PR addresses the request to make BEPs publicly viewable and rename the "draft" status to "slop" in the UI.

## Changes

### Public Viewing of BEPs
- Modified the homepage (`/`) to display the BEP list without requiring login
- Updated the BEP detail page to allow viewing content without authentication
- Added "Sign In" button in the header for non-logged-in users
- Non-logged-in users can:
  - Browse all BEPs
  - View BEP content, pages, and comments
  - Export BEPs
- Features that still require login:
  - Creating new BEPs
  - Editing BEP content
  - Importing content
  - Changing BEP status
  - Leaving comments
  - Updating user stance
  - Adding new pages
  - Toggling "good reference" status

### Status Label Rename
- Changed the display label for "draft" status to "Slop" throughout the UI
- Updated in:
  - `bep-status.tsx` - Badge display component
  - `bep-status-select.tsx` - Status dropdown selector
  - `bep-list.tsx` - Filter badges and kanban column headers
  - `bep-export-all-dialog.tsx` - Export dialog status labels
- The underlying database value remains "draft" - only the UI display text changed
- Badge colors and variant remain unchanged

## Testing

- [x] TypeScript type checking passes (`pnpm tsc --noEmit`)
- [ ] Manual testing performed

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1782667998034799?thread_ts=1782667998.034799&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-25c90d82-b301-58a6-bb18-151dbde11ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25c90d82-b301-58a6-bb18-151dbde11ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated sign-in and account controls to show a clear login button for logged-out users and account actions for signed-in users.
  * Restricted proposal creation and editing tools to signed-in users, while keeping read-only browsing available.

* **Bug Fixes**
  * Improved navigation after signing out by sending users back to the login page.
  * Standardized status labels across the app, including the updated “Slop” label for draft items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->