### PR TITLE
feat(stdlib): add String.code_point_at and String.to_code_points

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/string.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/string.baml
@@ -239,6 +239,31 @@ class String {
     $rust_function
   }
 
+  /// Returns the **Unicode code point** of the character at the given codepoint
+  /// index, as an `int`.
+  ///
+  /// This is the numeric counterpart of `char_at`, which returns the character
+  /// as a one-character string. Negative indices count from the end: `-1` is the last
+  /// character. Raises `IndexOutOfBounds` when the index is out of range after
+  /// counting from the end, mirroring `char_at` and array subscripting.
+  ///
+  /// The returned value is always in `[0, 0x10FFFF]`, so it round-trips through
+  /// `string.from_code_points([cp])`.
+  ///
+  /// # Examples
+  /// ```
+  /// "A".code_point_at(0)        // 65
+  /// "é".code_point_at(0)        // 233
+  /// "🐑".code_point_at(0)       // 128017
+  /// "hello".code_point_at(-1)   // 111 ("o")
+  /// "😀hello".code_point_at(1)  // 104 ("h", not a UTF-16 unit)
+  /// "hi".code_point_at(99)      // raises IndexOutOfBounds
+  /// ```
+  //baml:fallible
+  function code_point_at(self, index: int) -> int throws never {
+    $rust_function
+  }
+
   /// Returns a new string that repeats `self` the given number of times.
   /// Negative counts are treated as 0.
   ///
@@ -497,6 +522,28 @@ class String {
   /// string.from_utf8(b"\xFF")              // throws — 0xFF is invalid UTF-8
   /// ```
   function from_utf8(utf8: uint8array) -> string throws root.errors.InvalidArgument {
+    $rust_function
+  }
+
+  /// Returns the string's Unicode code points as an array of `int`s.
+  ///
+  /// This is the exact inverse of `string.from_code_points`: for any string
+  /// `s`, `string.from_code_points(s.to_code_points())` equals `s`. The result
+  /// has one element per character (`self.length()` elements), each in
+  /// `[0, 0x10FFFF]`. Never throws.
+  ///
+  /// Use this for char → integer mappings (checksums, base-N encoding, hashing,
+  /// character classification) instead of indexing into a literal alphabet
+  /// string.
+  ///
+  /// # Examples
+  /// ```
+  /// "hi".to_code_points()    // [104, 105]
+  /// "é".to_code_points()     // [233]
+  /// "🐑".to_code_points()    // [128017]
+  /// "".to_code_points()      // []
+  /// ```
+  function to_code_points(self) -> int[] throws never {
     $rust_function
   }
 

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
@@ -2,7 +2,7 @@
 source: crates/baml_cli/src/describe_command_tests.rs
 expression: "describe_via_dispatch(&db, \"string\")"
 ---
-class String  (string)  <builtin>/baml/string.baml:5-521
+class String  (string)  <builtin>/baml/string.baml:5-568
 
 /// A UTF-8 encoded string.
 ///
@@ -33,7 +33,7 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 57 more lines (re-run with a higher --budget)
+  … 60 more lines (re-run with a higher --budget)
 
 static_methods:
   … 6 more lines (re-run with a higher --budget)

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
@@ -2,7 +2,7 @@
 source: crates/baml_cli/src/describe_command_tests.rs
 expression: output
 ---
-class String  (string)  <builtin>/baml/string.baml:5-521
+class String  (string)  <builtin>/baml/string.baml:5-568
 
 /// A UTF-8 encoded string.
 ///
@@ -33,7 +33,7 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 57 more lines (re-run with a higher --budget)
+  … 60 more lines (re-run with a higher --budget)
 
 static_methods:
   … 6 more lines (re-run with a higher --budget)

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
@@ -2,7 +2,7 @@
 source: crates/baml_cli/src/describe_command_tests.rs
 expression: output
 ---
-class String  (string)  <builtin>/baml/string.baml:5-521
+class String  (string)  <builtin>/baml/string.baml:5-568
 
 /// A UTF-8 encoded string.
 ///
@@ -33,7 +33,7 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 57 more lines (re-run with a higher --budget)
+  … 60 more lines (re-run with a higher --budget)
 
 static_methods:
   … 6 more lines (re-run with a higher --budget)

--- a/baml_language/crates/baml_lsp2_actions/src/snapshots/baml_lsp2_actions__describe_tests__describe_builtin_string_with_compiler2_visible_files.snap
+++ b/baml_language/crates/baml_lsp2_actions/src/snapshots/baml_lsp2_actions__describe_tests__describe_builtin_string_with_compiler2_visible_files.snap
@@ -44,6 +44,7 @@ methods:
   /// Returns the **character index** of the first occurrence of `search`, or
   function index_of(self, search: string) -> int | null
   function char_at(self, index: int) -> string
+  function code_point_at(self, index: int) -> int
   /// Returns a new string that repeats `self` the given number of times.
   function repeat(self, count: int) -> string
   /// Returns true if the string contains the given `substring`.
@@ -88,6 +89,8 @@ methods:
   function is_ascii_hex(self) -> bool
   /// Returns the string encoded as a `uint8array` of UTF-8 bytes.
   function to_utf8(self) -> uint8array
+  /// Returns the string's Unicode code points as an array of `int`s.
+  function to_code_points(self) -> int[]
 static_methods:
   /// Renders any value as a human-readable string.
   function from(value: T) -> string

--- a/baml_language/crates/baml_tests/baml_src/ns_strings/strings.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_strings/strings.baml
@@ -23,6 +23,10 @@ function strings_char_at(index: int) -> string {
     "hello".char_at(index)
 }
 
+function strings_code_point_at(index: int) -> int {
+    "hello".code_point_at(index)
+}
+
 function strings_from_utf8_invalid() -> string {
     string.from_utf8(b"\xFF")
 }
@@ -247,6 +251,68 @@ test "string_char_at_past_start_panics" {
     }
 }
 
+// ─── code_point_at ─────────────────────────────────────────────────────────────
+
+// code_point_at is the numeric counterpart of char_at: same codepoint indexing,
+// but returns the code point's value instead of a one-character string.
+test "string_code_point_at_ascii" {
+    assert.is_true("A".code_point_at(0) == 65)
+}
+
+test "string_code_point_at_multibyte" {
+    // "héllo" = h é l l o; index 1 is é (U+00E9 = 233).
+    assert.is_true("héllo".code_point_at(1) == 233)
+}
+
+test "string_code_point_at_emoji" {
+    // A single emoji is one codepoint, not a pair of UTF-16 units.
+    assert.is_true("🐑hello".code_point_at(0) == 128017)
+}
+
+test "string_code_point_at_after_emoji" {
+    assert.is_true("😀hello".code_point_at(1) == 104)
+}
+
+// Negative indices count from the end: -1 is the last character.
+test "string_code_point_at_negative_counts_from_end" {
+    assert.is_true("hello".code_point_at(-1) == 111);
+    assert.is_true("héllo".code_point_at(-4) == 233)
+}
+
+// Every code_point_at value round-trips through from_code_points.
+test "string_code_point_at_round_trips_through_from_code_points" {
+    assert.is_true(baml.deep_equals(string.from_code_points([("é").code_point_at(0)]), "é"))
+}
+
+// code_point_at at or past the end raises IndexOutOfBounds ("hello" has length 5).
+test "string_code_point_at_at_length_panics" {
+    {
+        strings_code_point_at(5);
+        baml.sys.panic("expected code_point_at to throw")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
+test "string_code_point_at_past_end_panics" {
+    {
+        strings_code_point_at(99);
+        baml.sys.panic("expected code_point_at to throw")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
+// Past the start (normalizes before index 0) also raises IndexOutOfBounds.
+test "string_code_point_at_past_start_panics" {
+    {
+        strings_code_point_at(-6);
+        baml.sys.panic("expected code_point_at to throw")
+    } catch (e) {
+        baml.panics.IndexOutOfBounds => null
+    }
+}
+
 // index_of returns codepoint index.
 test "string_index_of_returns_codepoint_index" {
     assert.is_true(baml.deep_equals("héllo".index_of("l"), 2))
@@ -376,6 +442,33 @@ test "string_from_utf8_invalid_throws" {
 
 test "string_from_utf8_empty" {
     assert.is_true(baml.deep_equals(string.from_utf8(b""), ""))
+}
+
+// ─── to_code_points ───────────────────────────────────────────────────────────
+
+// to_code_points is the exact inverse of from_code_points: one int per character.
+test "string_to_code_points_ascii" {
+    assert.is_true(baml.deep_equals("hi".to_code_points(), [104, 105]))
+}
+
+test "string_to_code_points_multibyte" {
+    // "héllo" = h é l l o; é is U+00E9 = 233.
+    assert.is_true(baml.deep_equals("héllo".to_code_points(), [104, 233, 108, 108, 111]))
+}
+
+test "string_to_code_points_emoji" {
+    // A single emoji decodes to one codepoint, not a UTF-16 surrogate pair.
+    assert.is_true(baml.deep_equals("🐑".to_code_points(), [128017]))
+}
+
+test "string_to_code_points_empty" {
+    assert.is_true(baml.deep_equals("".to_code_points(), []))
+}
+
+// from_code_points ∘ to_code_points is the identity over arbitrary text.
+test "string_to_code_points_round_trips" {
+    let s = "Hëllo 🐑 World";
+    assert.is_true(baml.deep_equals(string.from_code_points(s.to_code_points()), s))
 }
 
 // ─── from_code_points ─────────────────────────────────────────────────────────

--- a/baml_language/crates/baml_tests/snapshots/baml_src/strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/strings.snap
@@ -225,710 +225,794 @@ function strings.$init_test_ns_strings_strings(registry: testing.TestCollector) 
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_index_of_returns_codepoint_index"
+    load_const "string_code_point_at_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 37)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_index_of_after_emoji"
+    load_const "string_code_point_at_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 38)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_index_of_absent_is_null"
+    load_const "string_code_point_at_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 39)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat"
+    load_const "string_code_point_at_after_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 40)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat_zero"
+    load_const "string_code_point_at_negative_counts_from_end"
     make_closure .<lambda($init_test_ns_strings_strings, 41)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_repeat_negative"
+    load_const "string_code_point_at_round_trips_through_from_code_points"
     make_closure .<lambda($init_test_ns_strings_strings, 42)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_ascii"
+    load_const "string_code_point_at_at_length_panics"
     make_closure .<lambda($init_test_ns_strings_strings, 43)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_multibyte"
+    load_const "string_code_point_at_past_end_panics"
     make_closure .<lambda($init_test_ns_strings_strings, 44)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_emoji"
+    load_const "string_code_point_at_past_start_panics"
     make_closure .<lambda($init_test_ns_strings_strings, 45)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_char_count_empty"
+    load_const "string_index_of_returns_codepoint_index"
     make_closure .<lambda($init_test_ns_strings_strings, 46)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_removes_leading_only"
+    load_const "string_index_of_after_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 47)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_end_removes_trailing_only"
+    load_const "string_index_of_absent_is_null"
     make_closure .<lambda($init_test_ns_strings_strings, 48)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_handles_newlines_and_tabs"
+    load_const "string_repeat"
     make_closure .<lambda($init_test_ns_strings_strings, 49)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_end_no_whitespace_unchanged"
+    load_const "string_repeat_zero"
     make_closure .<lambda($init_test_ns_strings_strings, 50)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_trim_start_empty"
+    load_const "string_repeat_negative"
     make_closure .<lambda($init_test_ns_strings_strings, 51)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_lf"
+    load_const "string_char_count_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 52)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_crlf"
+    load_const "string_char_count_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 53)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_trailing_newline_no_empty"
+    load_const "string_char_count_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 54)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_empty_string"
+    load_const "string_char_count_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 55)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_lines_just_newline"
+    load_const "string_trim_start_removes_leading_only"
     make_closure .<lambda($init_test_ns_strings_strings, 56)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_ascii"
+    load_const "string_trim_end_removes_trailing_only"
     make_closure .<lambda($init_test_ns_strings_strings, 57)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_multibyte"
+    load_const "string_trim_start_handles_newlines_and_tabs"
     make_closure .<lambda($init_test_ns_strings_strings, 58)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_to_utf8_empty"
+    load_const "string_trim_end_no_whitespace_unchanged"
     make_closure .<lambda($init_test_ns_strings_strings, 59)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_ascii_round_trip"
+    load_const "string_trim_start_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 60)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_multibyte_round_trip"
+    load_const "string_lines_lf"
     make_closure .<lambda($init_test_ns_strings_strings, 61)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_invalid_throws"
+    load_const "string_lines_crlf"
     make_closure .<lambda($init_test_ns_strings_strings, 62)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_utf8_empty"
+    load_const "string_lines_trailing_newline_no_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 63)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_ascii"
+    load_const "string_lines_empty_string"
     make_closure .<lambda($init_test_ns_strings_strings, 64)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_multibyte"
+    load_const "string_lines_just_newline"
     make_closure .<lambda($init_test_ns_strings_strings, 65)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_emoji"
+    load_const "string_to_utf8_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 66)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_empty"
+    load_const "string_to_utf8_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 67)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_negative_throws"
+    load_const "string_to_utf8_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 68)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_surrogate_throws"
+    load_const "string_from_utf8_ascii_round_trip"
     make_closure .<lambda($init_test_ns_strings_strings, 69)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_from_code_points_too_large_throws"
+    load_const "string_from_utf8_multibyte_round_trip"
     make_closure .<lambda($init_test_ns_strings_strings, 70)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_ascii_digits"
+    load_const "string_from_utf8_invalid_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 71)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_unicode_roman"
+    load_const "string_from_utf8_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 72)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_mixed_false"
+    load_const "string_to_code_points_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 73)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_letters_false"
+    load_const "string_to_code_points_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 74)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_numeric_empty_true"
+    load_const "string_to_code_points_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 75)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_ascii"
+    load_const "string_to_code_points_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 76)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_accented"
+    load_const "string_to_code_points_round_trips"
     make_closure .<lambda($init_test_ns_strings_strings, 77)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_cjk"
+    load_const "string_from_code_points_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 78)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_with_digit_false"
+    load_const "string_from_code_points_multibyte"
     make_closure .<lambda($init_test_ns_strings_strings, 79)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_with_space_false"
+    load_const "string_from_code_points_emoji"
     make_closure .<lambda($init_test_ns_strings_strings, 80)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphabetic_empty_true"
+    load_const "string_from_code_points_empty"
     make_closure .<lambda($init_test_ns_strings_strings, 81)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_letters_and_digits"
+    load_const "string_from_code_points_negative_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 82)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_accented_with_digit"
+    load_const "string_from_code_points_surrogate_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 83)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_with_space_false"
+    load_const "string_from_code_points_too_large_throws"
     make_closure .<lambda($init_test_ns_strings_strings, 84)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_with_punct_false"
+    load_const "string_is_numeric_ascii_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 85)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_alphanumeric_empty_true"
+    load_const "string_is_numeric_unicode_roman"
     make_closure .<lambda($init_test_ns_strings_strings, 86)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_all_upper"
+    load_const "string_is_numeric_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 87)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_mixed_false"
+    load_const "string_is_numeric_letters_false"
     make_closure .<lambda($init_test_ns_strings_strings, 88)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_digit_false"
+    load_const "string_is_numeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 89)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_uppercase_empty_true"
+    load_const "string_is_alphabetic_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 90)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_all_lower"
+    load_const "string_is_alphabetic_accented"
     make_closure .<lambda($init_test_ns_strings_strings, 91)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_mixed_false"
+    load_const "string_is_alphabetic_cjk"
     make_closure .<lambda($init_test_ns_strings_strings, 92)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_accented_lower"
+    load_const "string_is_alphabetic_with_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 93)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_lowercase_empty_true"
+    load_const "string_is_alphabetic_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 94)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_spaces"
+    load_const "string_is_alphabetic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 95)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_mixed_ws"
+    load_const "string_is_alphanumeric_letters_and_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 96)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_unicode_nbsp"
+    load_const "string_is_alphanumeric_accented_with_digit"
     make_closure .<lambda($init_test_ns_strings_strings, 97)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_with_letter_false"
+    load_const "string_is_alphanumeric_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 98)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_whitespace_empty_true"
+    load_const "string_is_alphanumeric_with_punct_false"
     make_closure .<lambda($init_test_ns_strings_strings, 99)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_newline_tab"
+    load_const "string_is_alphanumeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 100)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_letter_false"
+    load_const "string_is_uppercase_all_upper"
     make_closure .<lambda($init_test_ns_strings_strings, 101)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_control_empty_true"
+    load_const "string_is_uppercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 102)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_letters"
+    load_const "string_is_uppercase_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 103)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_accented"
+    load_const "string_is_uppercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 104)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_with_space_false"
+    load_const "string_is_lowercase_all_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 105)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_with_newline_false"
+    load_const "string_is_lowercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 106)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_graphic_empty_true"
+    load_const "string_is_lowercase_accented_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 107)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_pure_ascii"
+    load_const "string_is_lowercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 108)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_with_accent_false"
+    load_const "string_is_whitespace_spaces"
     make_closure .<lambda($init_test_ns_strings_strings, 109)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_with_emoji_false"
+    load_const "string_is_whitespace_mixed_ws"
     make_closure .<lambda($init_test_ns_strings_strings, 110)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_chars"
+    load_const "string_is_whitespace_unicode_nbsp"
     make_closure .<lambda($init_test_ns_strings_strings, 111)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_empty_true"
+    load_const "string_is_whitespace_with_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 112)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_digits"
+    load_const "string_is_whitespace_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 113)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_unicode_numeral_false"
+    load_const "string_is_control_newline_tab"
     make_closure .<lambda($init_test_ns_strings_strings, 114)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_letter_false"
+    load_const "string_is_control_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 115)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_numeric_empty_true"
+    load_const "string_is_control_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 116)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_letters"
+    load_const "string_is_graphic_letters"
     make_closure .<lambda($init_test_ns_strings_strings, 117)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_accented_false"
+    load_const "string_is_graphic_accented"
     make_closure .<lambda($init_test_ns_strings_strings, 118)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_with_digit_false"
+    load_const "string_is_graphic_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 119)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphabetic_empty_true"
+    load_const "string_is_graphic_with_newline_false"
     make_closure .<lambda($init_test_ns_strings_strings, 120)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_basic"
+    load_const "string_is_graphic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 121)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_accented_false"
+    load_const "string_is_ascii_pure_ascii"
     make_closure .<lambda($init_test_ns_strings_strings, 122)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_with_space_false"
+    load_const "string_is_ascii_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 123)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_alphanumeric_empty_true"
+    load_const "string_is_ascii_with_emoji_false"
     make_closure .<lambda($init_test_ns_strings_strings, 124)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_pure_upper"
+    load_const "string_is_ascii_control_chars"
     make_closure .<lambda($init_test_ns_strings_strings, 125)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_mixed_false"
+    load_const "string_is_ascii_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 126)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_with_accent_false"
+    load_const "string_is_ascii_numeric_digits"
     make_closure .<lambda($init_test_ns_strings_strings, 127)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_uppercase_empty_true"
+    load_const "string_is_ascii_numeric_unicode_numeral_false"
     make_closure .<lambda($init_test_ns_strings_strings, 128)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_pure_lower"
+    load_const "string_is_ascii_numeric_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 129)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_mixed_false"
+    load_const "string_is_ascii_numeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 130)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_with_accent_false"
+    load_const "string_is_ascii_alphabetic_letters"
     make_closure .<lambda($init_test_ns_strings_strings, 131)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_lowercase_empty_true"
+    load_const "string_is_ascii_alphabetic_accented_false"
     make_closure .<lambda($init_test_ns_strings_strings, 132)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_basic"
+    load_const "string_is_ascii_alphabetic_with_digit_false"
     make_closure .<lambda($init_test_ns_strings_strings, 133)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_form_feed"
+    load_const "string_is_ascii_alphabetic_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 134)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_nbsp_false"
+    load_const "string_is_ascii_alphanumeric_basic"
     make_closure .<lambda($init_test_ns_strings_strings, 135)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_letter_false"
+    load_const "string_is_ascii_alphanumeric_accented_false"
     make_closure .<lambda($init_test_ns_strings_strings, 136)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_whitespace_empty_true"
+    load_const "string_is_ascii_alphanumeric_with_space_false"
     make_closure .<lambda($init_test_ns_strings_strings, 137)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_low_range"
+    load_const "string_is_ascii_alphanumeric_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 138)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_del"
+    load_const "string_is_ascii_uppercase_pure_upper"
     make_closure .<lambda($init_test_ns_strings_strings, 139)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_letter_false"
+    load_const "string_is_ascii_uppercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 140)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_control_empty_true"
+    load_const "string_is_ascii_uppercase_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 141)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_letters"
+    load_const "string_is_ascii_uppercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 142)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_punctuation"
+    load_const "string_is_ascii_lowercase_pure_lower"
     make_closure .<lambda($init_test_ns_strings_strings, 143)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_space_false"
+    load_const "string_is_ascii_lowercase_mixed_false"
     make_closure .<lambda($init_test_ns_strings_strings, 144)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_control_false"
+    load_const "string_is_ascii_lowercase_with_accent_false"
     make_closure .<lambda($init_test_ns_strings_strings, 145)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_accented_false"
+    load_const "string_is_ascii_lowercase_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 146)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_graphic_empty_true"
+    load_const "string_is_ascii_whitespace_basic"
     make_closure .<lambda($init_test_ns_strings_strings, 147)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_lower"
+    load_const "string_is_ascii_whitespace_form_feed"
     make_closure .<lambda($init_test_ns_strings_strings, 148)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_upper"
+    load_const "string_is_ascii_whitespace_nbsp_false"
     make_closure .<lambda($init_test_ns_strings_strings, 149)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_mixed_case_with_digits"
+    load_const "string_is_ascii_whitespace_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 150)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_g_false"
+    load_const "string_is_ascii_whitespace_empty_true"
     make_closure .<lambda($init_test_ns_strings_strings, 151)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_x_prefix_false"
+    load_const "string_is_ascii_control_low_range"
     make_closure .<lambda($init_test_ns_strings_strings, 152)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_is_ascii_hex_empty_true"
+    load_const "string_is_ascii_control_del"
     make_closure .<lambda($init_test_ns_strings_strings, 153)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "string_replace"
+    load_const "string_is_ascii_control_letter_false"
     make_closure .<lambda($init_test_ns_strings_strings, 154)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_control_empty_true"
+    make_closure .<lambda($init_test_ns_strings_strings, 155)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_graphic_letters"
+    make_closure .<lambda($init_test_ns_strings_strings, 156)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_graphic_punctuation"
+    make_closure .<lambda($init_test_ns_strings_strings, 157)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_graphic_space_false"
+    make_closure .<lambda($init_test_ns_strings_strings, 158)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_graphic_control_false"
+    make_closure .<lambda($init_test_ns_strings_strings, 159)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_graphic_accented_false"
+    make_closure .<lambda($init_test_ns_strings_strings, 160)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_graphic_empty_true"
+    make_closure .<lambda($init_test_ns_strings_strings, 161)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_hex_lower"
+    make_closure .<lambda($init_test_ns_strings_strings, 162)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_hex_upper"
+    make_closure .<lambda($init_test_ns_strings_strings, 163)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_hex_mixed_case_with_digits"
+    make_closure .<lambda($init_test_ns_strings_strings, 164)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_hex_g_false"
+    make_closure .<lambda($init_test_ns_strings_strings, 165)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_hex_x_prefix_false"
+    make_closure .<lambda($init_test_ns_strings_strings, 166)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_is_ascii_hex_empty_true"
+    make_closure .<lambda($init_test_ns_strings_strings, 167)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "string_replace"
+    make_closure .<lambda($init_test_ns_strings_strings, 168)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -940,6 +1024,13 @@ function strings.strings_char_at(index: int) -> string {
     load_const "hello"
     load_var index
     call baml.String.char_at
+    return
+}
+
+function strings.strings_code_point_at(index: int) -> int {
+    load_const "hello"
+    load_var index
+    call baml.String.code_point_at
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1687,6 +1687,7 @@ function baml.byte_length(self: ?) -> int  [builtin]
 function baml.char_at(self: ?, index: int) -> string  [builtin]
 function baml.char_count(self: ?) -> int  [builtin]
 function baml.chars(self: ?) -> string[]  [builtin]
+function baml.code_point_at(self: ?, index: int) -> int  [builtin]
 function baml.ends_with(self: ?, suffix: string) -> bool  [builtin]
 function baml.from(value: T) -> string  [expr] {
   {  } root._to_string_shim(value)
@@ -1722,6 +1723,7 @@ function baml.replace_all(self: ?, search: string, replacement: string) -> strin
 function baml.split(self: ?, delimiter: string) -> string[]  [builtin]
 function baml.starts_with(self: ?, prefix: string) -> bool  [builtin]
 function baml.substring(self: ?, start: int, end: int) -> string  [builtin]
+function baml.to_code_points(self: ?) -> int[]  [builtin]
 function baml.to_lower_case(self: ?) -> string  [builtin]
 function baml.to_upper_case(self: ?) -> string  [builtin]
 function baml.to_utf8(self: ?) -> uint8array  [builtin]

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -14564,6 +14564,8 @@ fn baml.String.char_count = builtin(vm)
 
 fn baml.String.chars = builtin(vm)
 
+fn baml.String.code_point_at = builtin(vm)
+
 fn baml.String.ends_with = builtin(vm)
 
 fn baml.String.from(value: T) -> string {
@@ -14643,6 +14645,8 @@ fn baml.String.split = builtin(vm)
 fn baml.String.starts_with = builtin(vm)
 
 fn baml.String.substring = builtin(vm)
+
+fn baml.String.to_code_points = builtin(vm)
 
 fn baml.String.to_lower_case = builtin(vm)
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -1417,6 +1417,9 @@ function baml.String.char_count(self: baml.String) -> int {
 function baml.String.chars(self: baml.String) -> string[] {
 }
 
+function baml.String.code_point_at(self: baml.String, index: int) -> int {
+}
+
 function baml.String.ends_with(self: baml.String, suffix: string) -> bool {
 }
 
@@ -1518,6 +1521,9 @@ function baml.String.starts_with(self: baml.String, prefix: string) -> bool {
 }
 
 function baml.String.substring(self: baml.String, start: int, end: int) -> string {
+}
+
+function baml.String.to_code_points(self: baml.String) -> int[] {
 }
 
 function baml.String.to_lower_case(self: baml.String) -> string {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -13,7 +13,7 @@ namespace baml:
   class Map<K, V> { methods: [length, has, keys, values, set, get, delete, get_or_insert, clear] }
   class Null { methods: [] }
   type Sortable
-  class String { methods: [from, length, char_count, byte_length, to_lower_case, to_upper_case, trim, trim_start, trim_end, includes, starts_with, ends_with, split, chars, lines, substring, replace, index_of, char_at, repeat, matches, replace_all, is_numeric, is_alphabetic, is_alphanumeric, is_uppercase, is_lowercase, is_whitespace, is_control, is_graphic, is_ascii, is_ascii_numeric, is_ascii_alphabetic, is_ascii_alphanumeric, is_ascii_uppercase, is_ascii_lowercase, is_ascii_whitespace, is_ascii_control, is_ascii_graphic, is_ascii_hex, to_utf8, from_utf8, from_code_points] }
+  class String { methods: [from, length, char_count, byte_length, to_lower_case, to_upper_case, trim, trim_start, trim_end, includes, starts_with, ends_with, split, chars, lines, substring, replace, index_of, char_at, code_point_at, repeat, matches, replace_all, is_numeric, is_alphabetic, is_alphanumeric, is_uppercase, is_lowercase, is_whitespace, is_control, is_graphic, is_ascii, is_ascii_numeric, is_ascii_alphabetic, is_ascii_alphanumeric, is_ascii_uppercase, is_ascii_lowercase, is_ascii_whitespace, is_ascii_control, is_ascii_graphic, is_ascii_hex, to_utf8, from_utf8, to_code_points, from_code_points] }
   class TaggedString { methods: [] }
   type ToJson
   type ToString

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 739 ntypeargs=0   (assert.format_operand)
+       26   call 741 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 739 ntypeargs=0   (assert.format_operand)
+       29   call 741 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 739 ntypeargs=0   (assert.format_operand)
+       32   call 741 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 739 ntypeargs=0   (assert.format_operand)
+       35   call 741 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -63,17 +63,17 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        49   bin_op +               
        50   load_var 8             (_22)
        51   bin_op +               
-       52   call 235 ntypeargs=0   (baml.sys.panic)
+       52   call 237 ntypeargs=0   (baml.sys.panic)
        53   jump +3                (to 56)
 
   78   54   load_const 6           ("assertion failed: epsilon must be a non-negative number")
-       55   call 235 ntypeargs=0   (baml.sys.panic)
+       55   call 237 ntypeargs=0   (baml.sys.panic)
        56   return                 
 }
 
 function assert.contains(haystack: string, needle: string) -> null {
   100   0   load_var2 1 2          
-        1   call 172 ntypeargs=0   (baml.String.includes)
+        1   call 174 ntypeargs=0   (baml.String.includes)
         2   unary_op !             
         3   pop_jump_if_false +2   (to 5)
         4   jump +3                (to 7)
@@ -83,13 +83,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   100   6   jump +3                (to 9)
 
   101   7   load_const 1           ("assertion failed: string does not contain expected substring")
-        8   call 235 ntypeargs=0   (baml.sys.panic)
+        8   call 237 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 676 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 678 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 739 ntypeargs=0   (assert.format_operand)
+       8    call 741 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 739 ntypeargs=0   (assert.format_operand)
+       11   call 741 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -113,7 +113,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 235 ntypeargs=0   (baml.sys.panic)
+       20   call 237 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
@@ -134,14 +134,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 235 ntypeargs=0   (baml.sys.panic)
+      7   call 237 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 676 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 678 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -150,7 +150,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 235 ntypeargs=0   (baml.sys.panic)
+       8   call 237 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -170,7 +170,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1267 0   
+  101   0   make_closure 1269 0   
         1   return                
 }
 
@@ -191,11 +191,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 235 ntypeargs=0   (baml.sys.panic)
+       14   call 237 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1278 1    
+       17   make_closure 1280 1    
        18   return                 
 }
 
@@ -225,16 +225,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 235 ntypeargs=0   (baml.sys.panic)
+       22   call 237 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 235 ntypeargs=0   (baml.sys.panic)
+       26   call 237 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1292 2    
+       29   make_closure 1294 2    
        30   return                 
 }
 
@@ -249,16 +249,16 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 235 ntypeargs=0   (baml.sys.panic)
+       8    call 237 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1285 1    
+       11   make_closure 1287 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1271 0   
+  95   0   make_closure 1273 0   
        1   return                
 }
 
@@ -268,7 +268,7 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        2     store_var 3              (_3)
        3     load_type 0              
        4     load_var 3               (_3)
-       5     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 4              (_4)
        7     load_var 4               (_4)
        8     is_type 1                
@@ -312,16 +312,16 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        46    load_type 0              
        47    load_type 11             
        48    load_var 4               (_4)
-       49    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 5              (_6)
        51    jump +50                 (to 101)
        52    load_var 4               (_4)
-       53    make_bound_method 496    
+       53    make_bound_method 498    
        54    call_indirect            
        55    store_var 5              (_6)
        56    jump +45                 (to 101)
        57    load_var 4               (_4)
-       58    make_bound_method 505    
+       58    make_bound_method 507    
        59    call_indirect            
        60    store_var 5              (_6)
        61    jump +40                 (to 101)
@@ -329,39 +329,39 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        63    load_type 11             
        64    load_type 11             
        65    load_var 4               (_4)
-       66    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 5              (_6)
        68    jump +33                 (to 101)
        69    load_var 4               (_4)
-       70    make_bound_method 457    
+       70    make_bound_method 459    
        71    call_indirect            
        72    store_var 5              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 4               (_4)
-       76    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 5              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 4               (_4)
-       83    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 5              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 4               (_4)
-       89    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 5              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 4               (_4)
-       94    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 5              (_6)
        96    jump +5                  (to 101)
        97    load_var 4               (_4)
-       98    make_bound_method 484    
+       98    make_bound_method 486    
        99    call_indirect            
        100   store_var 5              (_6)
        101   load_var 5               (_6)
@@ -392,7 +392,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        2     store_var 3              (_3)
        3     load_type 0              
        4     load_var 3               (_3)
-       5     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 4              (_4)
        7     load_var 4               (_4)
        8     is_type 1                
@@ -436,16 +436,16 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        46    load_type 0              
        47    load_type 11             
        48    load_var 4               (_4)
-       49    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 5              (_6)
        51    jump +50                 (to 101)
        52    load_var 4               (_4)
-       53    make_bound_method 496    
+       53    make_bound_method 498    
        54    call_indirect            
        55    store_var 5              (_6)
        56    jump +45                 (to 101)
        57    load_var 4               (_4)
-       58    make_bound_method 505    
+       58    make_bound_method 507    
        59    call_indirect            
        60    store_var 5              (_6)
        61    jump +40                 (to 101)
@@ -453,39 +453,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        63    load_type 11             
        64    load_type 11             
        65    load_var 4               (_4)
-       66    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 5              (_6)
        68    jump +33                 (to 101)
        69    load_var 4               (_4)
-       70    make_bound_method 457    
+       70    make_bound_method 459    
        71    call_indirect            
        72    store_var 5              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 4               (_4)
-       76    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 5              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 4               (_4)
-       83    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 5              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 4               (_4)
-       89    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 5              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 4               (_4)
-       94    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 5              (_6)
        96    jump +5                  (to 101)
        97    load_var 4               (_4)
-       98    make_bound_method 484    
+       98    make_bound_method 486    
        99    call_indirect            
        100   store_var 5              (_6)
        101   load_var 5               (_6)
@@ -551,7 +551,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        24    store_var 8              (_13)
        25    load_type 4              
        26    load_var 8               (_13)
-       27    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 9              (_14)
        29    load_var 9               (_14)
        30    is_type 5                
@@ -595,16 +595,16 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        68    load_type 4              
        69    load_type 15             
        70    load_var 9               (_14)
-       71    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 10             (_16)
        73    jump +50                 (to 123)
        74    load_var 9               (_14)
-       75    make_bound_method 496    
+       75    make_bound_method 498    
        76    call_indirect            
        77    store_var 10             (_16)
        78    jump +45                 (to 123)
        79    load_var 9               (_14)
-       80    make_bound_method 505    
+       80    make_bound_method 507    
        81    call_indirect            
        82    store_var 10             (_16)
        83    jump +40                 (to 123)
@@ -612,39 +612,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        85    load_type 15             
        86    load_type 15             
        87    load_var 9               (_14)
-       88    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 10             (_16)
        90    jump +33                 (to 123)
        91    load_var 9               (_14)
-       92    make_bound_method 457    
+       92    make_bound_method 459    
        93    call_indirect            
        94    store_var 10             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 9               (_14)
-       98    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 10             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 9               (_14)
-       105   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 10             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 9               (_14)
-       111   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 10             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 9               (_14)
-       116   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 10             (_16)
        118   jump +5                  (to 123)
        119   load_var 9               (_14)
-       120   make_bound_method 484    
+       120   make_bound_method 486    
        121   call_indirect            
        122   store_var 10             (_16)
        123   load_var 10              (_16)
@@ -738,7 +738,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        24    store_var 8              (_13)
        25    load_type 4              
        26    load_var 8               (_13)
-       27    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 9              (_14)
        29    load_var 9               (_14)
        30    is_type 5                
@@ -782,16 +782,16 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        68    load_type 4              
        69    load_type 15             
        70    load_var 9               (_14)
-       71    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 10             (_16)
        73    jump +50                 (to 123)
        74    load_var 9               (_14)
-       75    make_bound_method 496    
+       75    make_bound_method 498    
        76    call_indirect            
        77    store_var 10             (_16)
        78    jump +45                 (to 123)
        79    load_var 9               (_14)
-       80    make_bound_method 505    
+       80    make_bound_method 507    
        81    call_indirect            
        82    store_var 10             (_16)
        83    jump +40                 (to 123)
@@ -799,39 +799,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        85    load_type 15             
        86    load_type 15             
        87    load_var 9               (_14)
-       88    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 10             (_16)
        90    jump +33                 (to 123)
        91    load_var 9               (_14)
-       92    make_bound_method 457    
+       92    make_bound_method 459    
        93    call_indirect            
        94    store_var 10             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 9               (_14)
-       98    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 10             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 9               (_14)
-       105   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 10             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 9               (_14)
-       111   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 10             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 9               (_14)
-       116   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 10             (_16)
        118   jump +5                  (to 123)
        119   load_var 9               (_14)
-       120   make_bound_method 484    
+       120   make_bound_method 486    
        121   call_indirect            
        122   store_var 10             (_16)
        123   load_var 10              (_16)
@@ -901,7 +901,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -945,16 +945,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 496    
+        54    make_bound_method 498    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 505    
+        59    make_bound_method 507    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -962,39 +962,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 457    
+        71    make_bound_method 459    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 484    
+        99    make_bound_method 486    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1010,11 +1010,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         111   pop_jump_if_false -103   (to 8)
 
   198   112   load_var2 1 6            
-        113   call 716 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        113   call 718 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
         114   pop 1                    
 
   199   115   load_var 1               (self)
-        116   call 699 ntypeargs=0     (testing.TestRegistry.serialize)
+        116   call 701 ntypeargs=0     (testing.TestRegistry.serialize)
         117   jump +123                (to 240)
 
   203   118   load_type 13             
@@ -1025,7 +1025,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         123   store_var 7              (_40)
         124   load_type 13             
         125   load_var 7               (_40)
-        126   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1069,16 +1069,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 496    
+        174   make_bound_method 498    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 505    
+        179   make_bound_method 507    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1086,39 +1086,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 457    
+        191   make_bound_method 459    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 484    
+        219   make_bound_method 486    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1141,7 +1141,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         237   pop_jump_if_false -109   (to 128)
 
   206   238   load_var2 11 2           
-        239   call 704 ntypeargs=0     (testing.TestRegistry.expand_set)
+        239   call 706 ntypeargs=0     (testing.TestRegistry.expand_set)
         240   return                   
 
   209   241   load_const 26            ("TestSet not found for expansion: ")
@@ -1165,7 +1165,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +36               (to 47)
 
-  216   12   call 240 ntypeargs=0   (baml.sys.now_ms)
+  216   12   call 242 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 4            (start)
 
   217   14   load_var 2             (ts)
@@ -1182,7 +1182,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         24   call_indirect          
         25   pop 1                  
 
-  219   26   call 240 ntypeargs=0   (baml.sys.now_ms)
+  219   26   call 242 ntypeargs=0   (baml.sys.now_ms)
         27   store_var 6            (_19)
 
   221   28   load_var 5             (sub_collector)
@@ -1216,7 +1216,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 698 ntypeargs=0   (testing.select_names)
+        2   call 700 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -1233,9 +1233,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 714 ntypeargs=0   (testing.testset_children)
+        1   call 716 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 692 ntypeargs=0   (testing.run_testset)
+        3   call 694 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1255,24 +1255,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   12   load_var2 1 2          
         13   load_var 3             (exclude)
-        14   call 698 ntypeargs=0   (testing.select_names)
+        14   call 700 ntypeargs=0   (testing.select_names)
         15   store_var 4            (_9)
         16   load_var2 1 4          
-        17   call 689 ntypeargs=0   (testing.TestRegistry.run_selected)
+        17   call 691 ntypeargs=0   (testing.TestRegistry.run_selected)
         18   jump +3                (to 21)
 
   180   19   load_var 1             (self)
-        20   call 711 ntypeargs=0   (testing.TestRegistry.run_all)
+        20   call 713 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   21   call 727 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   21   call 729 ntypeargs=0   (testing.flatten_with_tolerated)
         22   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 695 ntypeargs=0   (testing.testset_children_selected)
+        1   call 697 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 692 ntypeargs=0   (testing.run_testset)
+        3   call 694 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1283,7 +1283,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1327,16 +1327,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 496    
+        54    make_bound_method 498    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 505    
+        59    make_bound_method 507    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1344,39 +1344,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 457    
+        71    make_bound_method 459    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 484    
+        99    make_bound_method 486    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1395,7 +1395,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         113   load_field 1             (body)
         114   load_var 6               (t)
         115   load_field 2             (runner)
-        116   call 726 ntypeargs=0     (testing.run_test)
+        116   call 728 ntypeargs=0     (testing.run_test)
         117   jump +123                (to 240)
 
   140   118   load_type 13             
@@ -1406,7 +1406,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         123   store_var 7              (_40)
         124   load_type 13             
         125   load_var 7               (_40)
-        126   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1450,16 +1450,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 496    
+        174   make_bound_method 498    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 505    
+        179   make_bound_method 507    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1467,39 +1467,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 457    
+        191   make_bound_method 459    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 484    
+        219   make_bound_method 486    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1522,7 +1522,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         237   pop_jump_if_false -109   (to 128)
 
   144   238   load_var2 11 2           
-        239   call 703 ntypeargs=0     (testing.TestRegistry.run_test)
+        239   call 705 ntypeargs=0     (testing.TestRegistry.run_test)
         240   return                   
 
   147   241   load_const 26            ("Test not found: ")
@@ -1539,7 +1539,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1583,16 +1583,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 496    
+        54    make_bound_method 498    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 505    
+        59    make_bound_method 507    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1600,39 +1600,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 457    
+        71    make_bound_method 459    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 484    
+        99    make_bound_method 486    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1648,11 +1648,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         111   pop_jump_if_false -103   (to 8)
 
   153   112   load_var2 1 6            
-        113   call 716 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
-        114   call 714 ntypeargs=0     (testing.testset_children)
+        113   call 718 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        114   call 716 ntypeargs=0     (testing.testset_children)
         115   load_var 6               (ts)
         116   load_field 2             (runner)
-        117   call 692 ntypeargs=0     (testing.run_testset)
+        117   call 694 ntypeargs=0     (testing.run_testset)
         118   jump +123                (to 241)
 
   156   119   load_type 13             
@@ -1663,7 +1663,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         124   store_var 7              (_42)
         125   load_type 13             
         126   load_var 7               (_42)
-        127   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         128   store_var 8              (_46)
         129   load_var 8               (_46)
         130   is_type 15               
@@ -1707,16 +1707,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         168   load_type 13             
         169   load_type 11             
         170   load_var 8               (_46)
-        171   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         172   store_var 9              (_48)
         173   jump +50                 (to 223)
         174   load_var 8               (_46)
-        175   make_bound_method 496    
+        175   make_bound_method 498    
         176   call_indirect            
         177   store_var 9              (_48)
         178   jump +45                 (to 223)
         179   load_var 8               (_46)
-        180   make_bound_method 505    
+        180   make_bound_method 507    
         181   call_indirect            
         182   store_var 9              (_48)
         183   jump +40                 (to 223)
@@ -1724,39 +1724,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         185   load_type 11             
         186   load_type 11             
         187   load_var 8               (_46)
-        188   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         189   store_var 9              (_48)
         190   jump +33                 (to 223)
         191   load_var 8               (_46)
-        192   make_bound_method 457    
+        192   make_bound_method 459    
         193   call_indirect            
         194   store_var 9              (_48)
         195   jump +28                 (to 223)
         196   load_type 13             
         197   load_var 8               (_46)
-        198   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         199   store_var 9              (_48)
         200   jump +23                 (to 223)
         201   load_type 13             
         202   load_type 11             
         203   load_type 11             
         204   load_var 8               (_46)
-        205   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         206   store_var 9              (_48)
         207   jump +16                 (to 223)
         208   load_type 13             
         209   load_type 11             
         210   load_var 8               (_46)
-        211   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         212   store_var 9              (_48)
         213   jump +10                 (to 223)
         214   load_type 13             
         215   load_var 8               (_46)
-        216   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         217   store_var 9              (_48)
         218   jump +5                  (to 223)
         219   load_var 8               (_46)
-        220   make_bound_method 484    
+        220   make_bound_method 486    
         221   call_indirect            
         222   store_var 9              (_48)
         223   load_var 9               (_48)
@@ -1779,7 +1779,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         238   pop_jump_if_false -109   (to 129)
 
   159   239   load_var2 11 2           
-        240   call 707 ntypeargs=0     (testing.TestRegistry.run_testset)
+        240   call 709 ntypeargs=0     (testing.TestRegistry.run_testset)
         241   return                   
 
   162   242   load_const 26            ("TestSet not found: ")
@@ -1800,7 +1800,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         6     store_var 3              (_3)
         7     load_type 1              
         8     load_var 3               (_3)
-        9     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 4              (_4)
         11    load_var 4               (_4)
         12    is_type 2                
@@ -1844,16 +1844,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         50    load_type 1              
         51    load_type 12             
         52    load_var 4               (_4)
-        53    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 5              (_6)
         55    jump +50                 (to 105)
         56    load_var 4               (_4)
-        57    make_bound_method 496    
+        57    make_bound_method 498    
         58    call_indirect            
         59    store_var 5              (_6)
         60    jump +45                 (to 105)
         61    load_var 4               (_4)
-        62    make_bound_method 505    
+        62    make_bound_method 507    
         63    call_indirect            
         64    store_var 5              (_6)
         65    jump +40                 (to 105)
@@ -1861,39 +1861,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         67    load_type 12             
         68    load_type 12             
         69    load_var 4               (_4)
-        70    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 5              (_6)
         72    jump +33                 (to 105)
         73    load_var 4               (_4)
-        74    make_bound_method 457    
+        74    make_bound_method 459    
         75    call_indirect            
         76    store_var 5              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 4               (_4)
-        80    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 5              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 4               (_4)
-        87    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 5              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 4               (_4)
-        93    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 5              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 4               (_4)
-        98    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 5              (_6)
         100   jump +5                  (to 105)
         101   load_var 4               (_4)
-        102   make_bound_method 484    
+        102   make_bound_method 486    
         103   call_indirect            
         104   store_var 5              (_6)
         105   load_var 5               (_6)
@@ -1917,7 +1917,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         120   store_var 6              (_39)
         121   load_type 15             
         122   load_var 6               (_39)
-        123   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        123   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         124   store_var 7              (_40)
         125   load_var 7               (_40)
         126   is_type 16               
@@ -1961,16 +1961,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         164   load_type 15             
         165   load_type 12             
         166   load_var 7               (_40)
-        167   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        167   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         168   store_var 8              (_42)
         169   jump +50                 (to 219)
         170   load_var 7               (_40)
-        171   make_bound_method 496    
+        171   make_bound_method 498    
         172   call_indirect            
         173   store_var 8              (_42)
         174   jump +45                 (to 219)
         175   load_var 7               (_40)
-        176   make_bound_method 505    
+        176   make_bound_method 507    
         177   call_indirect            
         178   store_var 8              (_42)
         179   jump +40                 (to 219)
@@ -1978,39 +1978,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         181   load_type 12             
         182   load_type 12             
         183   load_var 7               (_40)
-        184   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        184   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         185   store_var 8              (_42)
         186   jump +33                 (to 219)
         187   load_var 7               (_40)
-        188   make_bound_method 457    
+        188   make_bound_method 459    
         189   call_indirect            
         190   store_var 8              (_42)
         191   jump +28                 (to 219)
         192   load_type 15             
         193   load_var 7               (_40)
-        194   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        194   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         195   store_var 8              (_42)
         196   jump +23                 (to 219)
         197   load_type 15             
         198   load_type 12             
         199   load_type 12             
         200   load_var 7               (_40)
-        201   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        201   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         202   store_var 8              (_42)
         203   jump +16                 (to 219)
         204   load_type 15             
         205   load_type 12             
         206   load_var 7               (_40)
-        207   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        207   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         208   store_var 8              (_42)
         209   jump +10                 (to 219)
         210   load_type 15             
         211   load_var 7               (_40)
-        212   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        212   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         213   store_var 8              (_42)
         214   jump +5                  (to 219)
         215   load_var 7               (_40)
-        216   make_bound_method 484    
+        216   make_bound_method 486    
         217   call_indirect            
         218   store_var 8              (_42)
         219   load_var 8               (_42)
@@ -2051,7 +2051,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         249   store_var 12             (_81)
 
   119   250   load_var 11              (sub)
-        251   call 699 ntypeargs=0     (testing.TestRegistry.serialize)
+        251   call 701 ntypeargs=0     (testing.TestRegistry.serialize)
         252   store_var 13             (_82)
 
   117   253   load_var2 2 12           
@@ -2071,7 +2071,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 function testing._has_selected_descendant(prefix: string, names: string[]) -> bool {
   311   0     load_type 0              
         1     load_var 2               (names)
-        2     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 3              (_4)
         4     load_var 3               (_4)
         5     is_type 1                
@@ -2115,16 +2115,16 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         43    load_type 0              
         44    load_type 11             
         45    load_var 3               (_4)
-        46    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 4              (_6)
         48    jump +50                 (to 98)
         49    load_var 3               (_4)
-        50    make_bound_method 496    
+        50    make_bound_method 498    
         51    call_indirect            
         52    store_var 4              (_6)
         53    jump +45                 (to 98)
         54    load_var 3               (_4)
-        55    make_bound_method 505    
+        55    make_bound_method 507    
         56    call_indirect            
         57    store_var 4              (_6)
         58    jump +40                 (to 98)
@@ -2132,39 +2132,39 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         60    load_type 11             
         61    load_type 11             
         62    load_var 3               (_4)
-        63    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 4              (_6)
         65    jump +33                 (to 98)
         66    load_var 3               (_4)
-        67    make_bound_method 457    
+        67    make_bound_method 459    
         68    call_indirect            
         69    store_var 4              (_6)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 3               (_4)
-        73    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 4              (_6)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 3               (_4)
-        80    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 4              (_6)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 3               (_4)
-        86    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 4              (_6)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 3               (_4)
-        91    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 4              (_6)
         93    jump +5                  (to 98)
         94    load_var 3               (_4)
-        95    make_bound_method 484    
+        95    make_bound_method 486    
         96    call_indirect            
         97    store_var 4              (_6)
         98    load_var 4               (_6)
@@ -2197,14 +2197,14 @@ function testing._int_to_float(value: int) -> float {
         6   throw_if_panic         
 
   126   7   load_const 1           ("failed to convert int to float")
-        8   call 235 ntypeargs=0   (baml.sys.panic)
+        8   call 237 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function testing._name_selected(name: string, names: string[]) -> bool {
   299   0     load_type 0              
         1     load_var 2               (names)
-        2     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 3              (_3)
         4     load_var 3               (_3)
         5     is_type 1                
@@ -2248,16 +2248,16 @@ function testing._name_selected(name: string, names: string[]) -> bool {
         43    load_type 0              
         44    load_type 11             
         45    load_var 3               (_3)
-        46    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 4              (_5)
         48    jump +50                 (to 98)
         49    load_var 3               (_3)
-        50    make_bound_method 496    
+        50    make_bound_method 498    
         51    call_indirect            
         52    store_var 4              (_5)
         53    jump +45                 (to 98)
         54    load_var 3               (_3)
-        55    make_bound_method 505    
+        55    make_bound_method 507    
         56    call_indirect            
         57    store_var 4              (_5)
         58    jump +40                 (to 98)
@@ -2265,39 +2265,39 @@ function testing._name_selected(name: string, names: string[]) -> bool {
         60    load_type 11             
         61    load_type 11             
         62    load_var 3               (_3)
-        63    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 4              (_5)
         65    jump +33                 (to 98)
         66    load_var 3               (_3)
-        67    make_bound_method 457    
+        67    make_bound_method 459    
         68    call_indirect            
         69    store_var 4              (_5)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 3               (_3)
-        73    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 4              (_5)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 3               (_3)
-        80    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 4              (_5)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 3               (_3)
-        86    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 4              (_5)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 3               (_3)
-        91    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 4              (_5)
         93    jump +5                  (to 98)
         94    load_var 3               (_3)
-        95    make_bound_method 484    
+        95    make_bound_method 486    
         96    call_indirect            
         97    store_var 4              (_5)
         98    load_var 4               (_5)
@@ -2336,7 +2336,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   327   12    load_type 4              
         13    load_var 1               (named_results)
-        14    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        14    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         15    store_var 7              (_7)
         16    load_var 7               (_7)
         17    is_type 5                
@@ -2380,16 +2380,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         55    load_type 4              
         56    load_type 15             
         57    load_var 7               (_7)
-        58    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        58    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         59    store_var 8              (_9)
         60    jump +50                 (to 110)
         61    load_var 7               (_7)
-        62    make_bound_method 496    
+        62    make_bound_method 498    
         63    call_indirect            
         64    store_var 8              (_9)
         65    jump +45                 (to 110)
         66    load_var 7               (_7)
-        67    make_bound_method 505    
+        67    make_bound_method 507    
         68    call_indirect            
         69    store_var 8              (_9)
         70    jump +40                 (to 110)
@@ -2397,39 +2397,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         72    load_type 15             
         73    load_type 15             
         74    load_var 7               (_7)
-        75    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        75    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         76    store_var 8              (_9)
         77    jump +33                 (to 110)
         78    load_var 7               (_7)
-        79    make_bound_method 457    
+        79    make_bound_method 459    
         80    call_indirect            
         81    store_var 8              (_9)
         82    jump +28                 (to 110)
         83    load_type 4              
         84    load_var 7               (_7)
-        85    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        85    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         86    store_var 8              (_9)
         87    jump +23                 (to 110)
         88    load_type 4              
         89    load_type 15             
         90    load_type 15             
         91    load_var 7               (_7)
-        92    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        92    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         93    store_var 8              (_9)
         94    jump +16                 (to 110)
         95    load_type 4              
         96    load_type 15             
         97    load_var 7               (_7)
-        98    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        98    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         99    store_var 8              (_9)
         100   jump +10                 (to 110)
         101   load_type 4              
         102   load_var 7               (_7)
-        103   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        103   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         104   store_var 8              (_9)
         105   jump +5                  (to 110)
         106   load_var 7               (_7)
-        107   make_bound_method 484    
+        107   make_bound_method 486    
         108   call_indirect            
         109   store_var 8              (_9)
         110   load_var 8               (_9)
@@ -2461,7 +2461,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   334   133   load_var 11              (outcome)
         134   load_const 18            ("pass")
-        135   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        135   call 678 ntypeargs=0     (baml.ops.equals_equals)
         136   pop_jump_if_false +2     (to 138)
         137   jump +144                (to 281)
 
@@ -2505,7 +2505,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
   346   167   store_var 13             (_56)
         168   load_type 2              
         169   load_var 13              (_56)
-        170   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        170   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         171   store_var 14             (_57)
         172   load_var 14              (_57)
         173   is_type 20               
@@ -2549,16 +2549,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         211   load_type 2              
         212   load_type 15             
         213   load_var 14              (_57)
-        214   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        214   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         215   store_var 15             (_59)
         216   jump +50                 (to 266)
         217   load_var 14              (_57)
-        218   make_bound_method 496    
+        218   make_bound_method 498    
         219   call_indirect            
         220   store_var 15             (_59)
         221   jump +45                 (to 266)
         222   load_var 14              (_57)
-        223   make_bound_method 505    
+        223   make_bound_method 507    
         224   call_indirect            
         225   store_var 15             (_59)
         226   jump +40                 (to 266)
@@ -2566,39 +2566,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         228   load_type 15             
         229   load_type 15             
         230   load_var 14              (_57)
-        231   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        231   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         232   store_var 15             (_59)
         233   jump +33                 (to 266)
         234   load_var 14              (_57)
-        235   make_bound_method 457    
+        235   make_bound_method 459    
         236   call_indirect            
         237   store_var 15             (_59)
         238   jump +28                 (to 266)
         239   load_type 2              
         240   load_var 14              (_57)
-        241   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        241   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         242   store_var 15             (_59)
         243   jump +23                 (to 266)
         244   load_type 2              
         245   load_type 15             
         246   load_type 15             
         247   load_var 14              (_57)
-        248   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        248   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         249   store_var 15             (_59)
         250   jump +16                 (to 266)
         251   load_type 2              
         252   load_type 15             
         253   load_var 14              (_57)
-        254   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        254   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         255   store_var 15             (_59)
         256   jump +10                 (to 266)
         257   load_type 2              
         258   load_var 14              (_57)
-        259   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        259   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         260   store_var 15             (_59)
         261   jump +5                  (to 266)
         262   load_var 14              (_57)
-        263   make_bound_method 484    
+        263   make_bound_method 486    
         264   call_indirect            
         265   store_var 15             (_59)
         266   load_var 15              (_59)
@@ -2614,7 +2614,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   349   274   load_var 11              (outcome)
         275   load_const 30            ("error")
-        276   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        276   call 678 ntypeargs=0     (baml.ops.equals_equals)
         277   pop_jump_if_false -261   (to 16)
 
   350   278   load_const 31            (true)
@@ -2666,7 +2666,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: string, test_name: string) -> bool {
   525   0     load_type 0              
         1     load_var 1               (pats)
-        2     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 4              (_4)
         4     load_var 4               (_4)
         5     is_type 1                
@@ -2710,16 +2710,16 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
         43    load_type 0              
         44    load_type 11             
         45    load_var 4               (_4)
-        46    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 5              (_6)
         48    jump +50                 (to 98)
         49    load_var 4               (_4)
-        50    make_bound_method 496    
+        50    make_bound_method 498    
         51    call_indirect            
         52    store_var 5              (_6)
         53    jump +45                 (to 98)
         54    load_var 4               (_4)
-        55    make_bound_method 505    
+        55    make_bound_method 507    
         56    call_indirect            
         57    store_var 5              (_6)
         58    jump +40                 (to 98)
@@ -2727,39 +2727,39 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
         60    load_type 11             
         61    load_type 11             
         62    load_var 4               (_4)
-        63    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 5              (_6)
         65    jump +33                 (to 98)
         66    load_var 4               (_4)
-        67    make_bound_method 457    
+        67    make_bound_method 459    
         68    call_indirect            
         69    store_var 5              (_6)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 4               (_4)
-        73    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 5              (_6)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 4               (_4)
-        80    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 5              (_6)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 4               (_4)
-        86    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 5              (_6)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 4               (_4)
-        91    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 5              (_6)
         93    jump +5                  (to 98)
         94    load_var 4               (_4)
-        95    make_bound_method 484    
+        95    make_bound_method 486    
         96    call_indirect            
         97    store_var 5              (_6)
         98    load_var 5               (_6)
@@ -2771,13 +2771,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   104   load_field 0             (func_pat)
         105   load_var 2               (function_name)
-        106   call 712 ntypeargs=0     (testing.filter_match)
+        106   call 714 ntypeargs=0     (testing.filter_match)
         107   jump_if_false +6         (to 113)
         108   pop 1                    
         109   load_var 6               (p)
         110   load_field 1             (test_pat)
         111   load_var 3               (test_name)
-        112   call 712 ntypeargs=0     (testing.filter_match)
+        112   call 714 ntypeargs=0     (testing.filter_match)
         113   pop_jump_if_false -109   (to 4)
 
   527   114   load_const 13            (true)
@@ -2791,7 +2791,7 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 function testing.collect_leaf_messages(results: (testing.TestReport | testing.TestSetReport)[], out: string[]) -> void {
   661   0     load_type 0              
         1     load_var 1               (results)
-        2     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 3              (_3)
         4     load_var 3               (_3)
         5     is_type 1                
@@ -2835,16 +2835,16 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         43    load_type 0              
         44    load_type 11             
         45    load_var 3               (_3)
-        46    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 4              (_5)
         48    jump +50                 (to 98)
         49    load_var 3               (_3)
-        50    make_bound_method 496    
+        50    make_bound_method 498    
         51    call_indirect            
         52    store_var 4              (_5)
         53    jump +45                 (to 98)
         54    load_var 3               (_3)
-        55    make_bound_method 505    
+        55    make_bound_method 507    
         56    call_indirect            
         57    store_var 4              (_5)
         58    jump +40                 (to 98)
@@ -2852,39 +2852,39 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         60    load_type 11             
         61    load_type 11             
         62    load_var 3               (_3)
-        63    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 4              (_5)
         65    jump +33                 (to 98)
         66    load_var 3               (_3)
-        67    make_bound_method 457    
+        67    make_bound_method 459    
         68    call_indirect            
         69    store_var 4              (_5)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 3               (_3)
-        73    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 4              (_5)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 3               (_3)
-        80    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 4              (_5)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 3               (_3)
-        86    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 4              (_5)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 3               (_3)
-        91    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 4              (_5)
         93    jump +5                  (to 98)
         94    load_var 3               (_3)
-        95    make_bound_method 484    
+        95    make_bound_method 486    
         96    call_indirect            
         97    store_var 4              (_5)
         98    load_var 4               (_5)
@@ -2900,7 +2900,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         107   load_var 5               (r)
         108   load_field 5             (results)
         109   load_var 2               (out)
-        110   call 705 ntypeargs=0     (testing.collect_leaf_messages)
+        110   call 707 ntypeargs=0     (testing.collect_leaf_messages)
         111   pop 1                    
         112   jump -108                (to 4)
         113   load_var 5               (r)
@@ -2909,7 +2909,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   664   116   load_type 14             
         117   load_var 6               (_37)
-        118   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        118   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         119   store_var 7              (_38)
         120   load_var 7               (_38)
         121   is_type 15               
@@ -2953,16 +2953,16 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         159   load_type 14             
         160   load_type 11             
         161   load_var 7               (_38)
-        162   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        162   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         163   store_var 8              (_40)
         164   jump +50                 (to 214)
         165   load_var 7               (_38)
-        166   make_bound_method 496    
+        166   make_bound_method 498    
         167   call_indirect            
         168   store_var 8              (_40)
         169   jump +45                 (to 214)
         170   load_var 7               (_38)
-        171   make_bound_method 505    
+        171   make_bound_method 507    
         172   call_indirect            
         173   store_var 8              (_40)
         174   jump +40                 (to 214)
@@ -2970,39 +2970,39 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         176   load_type 11             
         177   load_type 11             
         178   load_var 7               (_38)
-        179   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        179   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         180   store_var 8              (_40)
         181   jump +33                 (to 214)
         182   load_var 7               (_38)
-        183   make_bound_method 457    
+        183   make_bound_method 459    
         184   call_indirect            
         185   store_var 8              (_40)
         186   jump +28                 (to 214)
         187   load_type 14             
         188   load_var 7               (_38)
-        189   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        189   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         190   store_var 8              (_40)
         191   jump +23                 (to 214)
         192   load_type 14             
         193   load_type 11             
         194   load_type 11             
         195   load_var 7               (_38)
-        196   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        196   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         197   store_var 8              (_40)
         198   jump +16                 (to 214)
         199   load_type 14             
         200   load_type 11             
         201   load_var 7               (_38)
-        202   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        202   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         203   store_var 8              (_40)
         204   jump +10                 (to 214)
         205   load_type 14             
         206   load_var 7               (_38)
-        207   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        207   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         208   store_var 8              (_40)
         209   jump +5                  (to 214)
         210   load_var 7               (_38)
-        211   make_bound_method 484    
+        211   make_bound_method 486    
         212   call_indirect            
         213   store_var 8              (_40)
         214   load_var 8               (_40)
@@ -3014,7 +3014,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   665   220   load_field 0             (outcome)
         221   load_const 25            ("pass")
-        222   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        222   call 678 ntypeargs=0     (baml.ops.equals_equals)
         223   unary_op !               
         224   pop_jump_if_false -104   (to 120)
 
@@ -3046,7 +3046,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         6     store_var 3              (_3)
         7     load_type 1              
         8     load_var 3               (_3)
-        9     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 4              (_4)
         11    load_var 4               (_4)
         12    is_type 2                
@@ -3090,16 +3090,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         50    load_type 1              
         51    load_type 12             
         52    load_var 4               (_4)
-        53    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 5              (_6)
         55    jump +50                 (to 105)
         56    load_var 4               (_4)
-        57    make_bound_method 496    
+        57    make_bound_method 498    
         58    call_indirect            
         59    store_var 5              (_6)
         60    jump +45                 (to 105)
         61    load_var 4               (_4)
-        62    make_bound_method 505    
+        62    make_bound_method 507    
         63    call_indirect            
         64    store_var 5              (_6)
         65    jump +40                 (to 105)
@@ -3107,39 +3107,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         67    load_type 12             
         68    load_type 12             
         69    load_var 4               (_4)
-        70    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 5              (_6)
         72    jump +33                 (to 105)
         73    load_var 4               (_4)
-        74    make_bound_method 457    
+        74    make_bound_method 459    
         75    call_indirect            
         76    store_var 5              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 4               (_4)
-        80    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 5              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 4               (_4)
-        87    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 5              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 4               (_4)
-        93    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 5              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 4               (_4)
-        98    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 5              (_6)
         100   jump +5                  (to 105)
         101   load_var 4               (_4)
-        102   make_bound_method 484    
+        102   make_bound_method 486    
         103   call_indirect            
         104   store_var 5              (_6)
         105   load_var 5               (_6)
@@ -3160,7 +3160,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         117   store_var 6              (_38)
         118   load_type 14             
         119   load_var 6               (_38)
-        120   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        120   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         121   store_var 7              (_39)
         122   load_var 7               (_39)
         123   is_type 15               
@@ -3204,16 +3204,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         161   load_type 14             
         162   load_type 12             
         163   load_var 7               (_39)
-        164   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        164   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         165   store_var 8              (_41)
         166   jump +50                 (to 216)
         167   load_var 7               (_39)
-        168   make_bound_method 496    
+        168   make_bound_method 498    
         169   call_indirect            
         170   store_var 8              (_41)
         171   jump +45                 (to 216)
         172   load_var 7               (_39)
-        173   make_bound_method 505    
+        173   make_bound_method 507    
         174   call_indirect            
         175   store_var 8              (_41)
         176   jump +40                 (to 216)
@@ -3221,39 +3221,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         178   load_type 12             
         179   load_type 12             
         180   load_var 7               (_39)
-        181   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        181   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         182   store_var 8              (_41)
         183   jump +33                 (to 216)
         184   load_var 7               (_39)
-        185   make_bound_method 457    
+        185   make_bound_method 459    
         186   call_indirect            
         187   store_var 8              (_41)
         188   jump +28                 (to 216)
         189   load_type 14             
         190   load_var 7               (_39)
-        191   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        191   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         192   store_var 8              (_41)
         193   jump +23                 (to 216)
         194   load_type 14             
         195   load_type 12             
         196   load_type 12             
         197   load_var 7               (_39)
-        198   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        198   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         199   store_var 8              (_41)
         200   jump +16                 (to 216)
         201   load_type 14             
         202   load_type 12             
         203   load_var 7               (_39)
-        204   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        204   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         205   store_var 8              (_41)
         206   jump +10                 (to 216)
         207   load_type 14             
         208   load_var 7               (_39)
-        209   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        209   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         210   store_var 8              (_41)
         211   jump +5                  (to 216)
         212   load_var 7               (_39)
-        213   make_bound_method 484    
+        213   make_bound_method 486    
         214   call_indirect            
         215   store_var 8              (_41)
         216   load_var 8               (_41)
@@ -3263,12 +3263,12 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   567   220   load_var2 1 8            
 
-  566   221   call 717 ntypeargs=0     (testing.collect_subtree_names)
+  566   221   call 719 ntypeargs=0     (testing.collect_subtree_names)
         222   store_var 9              (_71)
 
   567   223   load_type 0              
         224   load_var 9               (_71)
-        225   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        225   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         226   store_var 10             (_73)
         227   load_var 10              (_73)
         228   is_type 25               
@@ -3312,16 +3312,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         266   load_type 0              
         267   load_type 12             
         268   load_var 10              (_73)
-        269   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        269   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         270   store_var 11             (_75)
         271   jump +50                 (to 321)
         272   load_var 10              (_73)
-        273   make_bound_method 496    
+        273   make_bound_method 498    
         274   call_indirect            
         275   store_var 11             (_75)
         276   jump +45                 (to 321)
         277   load_var 10              (_73)
-        278   make_bound_method 505    
+        278   make_bound_method 507    
         279   call_indirect            
         280   store_var 11             (_75)
         281   jump +40                 (to 321)
@@ -3329,39 +3329,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         283   load_type 12             
         284   load_type 12             
         285   load_var 10              (_73)
-        286   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        286   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         287   store_var 11             (_75)
         288   jump +33                 (to 321)
         289   load_var 10              (_73)
-        290   make_bound_method 457    
+        290   make_bound_method 459    
         291   call_indirect            
         292   store_var 11             (_75)
         293   jump +28                 (to 321)
         294   load_type 0              
         295   load_var 10              (_73)
-        296   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        296   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         297   store_var 11             (_75)
         298   jump +23                 (to 321)
         299   load_type 0              
         300   load_type 12             
         301   load_type 12             
         302   load_var 10              (_73)
-        303   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        303   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         304   store_var 11             (_75)
         305   jump +16                 (to 321)
         306   load_type 0              
         307   load_type 12             
         308   load_var 10              (_73)
-        309   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        309   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         310   store_var 11             (_75)
         311   jump +10                 (to 321)
         312   load_type 0              
         313   load_var 10              (_73)
-        314   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        314   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         315   store_var 11             (_75)
         316   jump +5                  (to 321)
         317   load_var 10              (_73)
-        318   make_bound_method 484    
+        318   make_bound_method 486    
         319   call_indirect            
         320   store_var 11             (_75)
         321   load_var 11              (_75)
@@ -3382,8 +3382,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 716 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 700 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 718 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 702 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +19               (to 22)
         4    load_var 3             (e)
         5    type_tag               
@@ -3424,7 +3424,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   602   8     load_type 1              
         9     load_var 1               (results)
-        10    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        10    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         11    store_var 7              (_7)
         12    load_var 7               (_7)
         13    is_type 2                
@@ -3468,16 +3468,16 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         51    load_type 1              
         52    load_type 12             
         53    load_var 7               (_7)
-        54    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        54    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         55    store_var 8              (_9)
         56    jump +50                 (to 106)
         57    load_var 7               (_7)
-        58    make_bound_method 496    
+        58    make_bound_method 498    
         59    call_indirect            
         60    store_var 8              (_9)
         61    jump +45                 (to 106)
         62    load_var 7               (_7)
-        63    make_bound_method 505    
+        63    make_bound_method 507    
         64    call_indirect            
         65    store_var 8              (_9)
         66    jump +40                 (to 106)
@@ -3485,39 +3485,39 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         68    load_type 12             
         69    load_type 12             
         70    load_var 7               (_7)
-        71    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        71    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         72    store_var 8              (_9)
         73    jump +33                 (to 106)
         74    load_var 7               (_7)
-        75    make_bound_method 457    
+        75    make_bound_method 459    
         76    call_indirect            
         77    store_var 8              (_9)
         78    jump +28                 (to 106)
         79    load_type 1              
         80    load_var 7               (_7)
-        81    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        81    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         82    store_var 8              (_9)
         83    jump +23                 (to 106)
         84    load_type 1              
         85    load_type 12             
         86    load_type 12             
         87    load_var 7               (_7)
-        88    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        88    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         89    store_var 8              (_9)
         90    jump +16                 (to 106)
         91    load_type 1              
         92    load_type 12             
         93    load_var 7               (_7)
-        94    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        94    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         95    store_var 8              (_9)
         96    jump +10                 (to 106)
         97    load_type 1              
         98    load_var 7               (_7)
-        99    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        99    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         100   store_var 8              (_9)
         101   jump +5                  (to 106)
         102   load_var 7               (_7)
-        103   make_bound_method 484    
+        103   make_bound_method 486    
         104   call_indirect            
         105   store_var 8              (_9)
         106   load_var 8               (_9)
@@ -3541,7 +3541,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         122   load_var 11              (tsr)
         123   load_field 0             (outcome)
         124   load_const 15            ("pass")
-        125   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        125   call 678 ntypeargs=0     (baml.ops.equals_equals)
         126   store_var 12             (ft)
 
   615   127   load_var 11              (tsr)
@@ -3583,14 +3583,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   157   load_var 11              (tsr)
         158   load_field 5             (results)
         159   load_var 12              (ft)
-        160   call 702 ntypeargs=0     (testing.count_leaves)
+        160   call 704 ntypeargs=0     (testing.count_leaves)
         161   store_var 10             (delta)
         162   jump +30                 (to 192)
 
   603   163   load_var 9               (r)
         164   load_field 0             (outcome)
         165   load_const 16            ("pass")
-        166   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        166   call 678 ntypeargs=0     (baml.ops.equals_equals)
 
   605   167   pop_jump_if_false +2     (to 169)
         168   jump +18                 (to 186)
@@ -3679,7 +3679,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 710 ntypeargs=0   (testing.glob_match)
+        6   call 712 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -3690,7 +3690,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   637   0    load_var 1             (report)
         1    load_field 0           (outcome)
         2    load_const 0           ("pass")
-        3    call 676 ntypeargs=0   (baml.ops.equals_equals)
+        3    call 678 ntypeargs=0   (baml.ops.equals_equals)
         4    store_var 2            (top_tolerated)
 
   638   5    load_var 1             (report)
@@ -3732,7 +3732,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   35   load_var 1             (report)
         36   load_field 5           (results)
         37   load_var 2             (top_tolerated)
-        38   call 702 ntypeargs=0   (testing.count_leaves)
+        38   call 704 ntypeargs=0   (testing.count_leaves)
         39   store_var 3            (counts)
 
   645   40   load_type 2            
@@ -3742,7 +3742,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   43   load_var 1             (report)
         44   load_field 5           (results)
         45   load_var 4             (messages)
-        46   call 705 ntypeargs=0   (testing.collect_leaf_messages)
+        46   call 707 ntypeargs=0   (testing.collect_leaf_messages)
         47   pop 1                  
 
   648   48   load_var 1             (report)
@@ -3853,7 +3853,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
         66   load_var 8              (end_limit)
         67   call 156 ntypeargs=0    (baml.String.substring)
         68   load_var 13             (part)
-        69   call 165 ntypeargs=0    (baml.String.index_of)
+        69   call 166 ntypeargs=0    (baml.String.index_of)
         70   store_var 14            (_38)
         71   load_var 14             (_38)
         72   is_type 2               
@@ -3896,14 +3896,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 722 ntypeargs=0   (testing.split_top)
+        1    call 724 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 724 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 726 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +15               (to 24)
 
@@ -3918,7 +3918,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         17   load_field 0           (head)
         18   load_var 4             (split)
         19   load_field 1           (tail)
-        20   call 724 ntypeargs=0   (testing.any_pattern_matches)
+        20   call 726 ntypeargs=0   (testing.any_pattern_matches)
         21   jump +4                (to 25)
 
   541   22   load_const 1           (true)
@@ -3935,7 +3935,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
 
   475   3     load_type 1              
         4     load_var 1               (raw)
-        5     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        5     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 3              (_3)
         7     load_var 3               (_3)
         8     is_type 2                
@@ -3979,16 +3979,16 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         46    load_type 1              
         47    load_type 12             
         48    load_var 3               (_3)
-        49    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        49    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         50    store_var 4              (_5)
         51    jump +50                 (to 101)
         52    load_var 3               (_3)
-        53    make_bound_method 496    
+        53    make_bound_method 498    
         54    call_indirect            
         55    store_var 4              (_5)
         56    jump +45                 (to 101)
         57    load_var 3               (_3)
-        58    make_bound_method 505    
+        58    make_bound_method 507    
         59    call_indirect            
         60    store_var 4              (_5)
         61    jump +40                 (to 101)
@@ -3996,39 +3996,39 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         63    load_type 12             
         64    load_type 12             
         65    load_var 3               (_3)
-        66    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        66    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         67    store_var 4              (_5)
         68    jump +33                 (to 101)
         69    load_var 3               (_3)
-        70    make_bound_method 457    
+        70    make_bound_method 459    
         71    call_indirect            
         72    store_var 4              (_5)
         73    jump +28                 (to 101)
         74    load_type 1              
         75    load_var 3               (_3)
-        76    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        76    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         77    store_var 4              (_5)
         78    jump +23                 (to 101)
         79    load_type 1              
         80    load_type 12             
         81    load_type 12             
         82    load_var 3               (_3)
-        83    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        83    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         84    store_var 4              (_5)
         85    jump +16                 (to 101)
         86    load_type 1              
         87    load_type 12             
         88    load_var 3               (_3)
-        89    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        89    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         90    store_var 4              (_5)
         91    jump +10                 (to 101)
         92    load_type 1              
         93    load_var 3               (_3)
-        94    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        94    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         95    store_var 4              (_5)
         96    jump +5                  (to 101)
         97    load_var 3               (_3)
-        98    make_bound_method 484    
+        98    make_bound_method 486    
         99    call_indirect            
         100   store_var 4              (_5)
         101   load_var 4               (_5)
@@ -4040,7 +4040,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
 
   476   107   load_var 5               (s)
         108   load_const 14            ("::")
-        109   call 165 ntypeargs=0     (baml.String.index_of)
+        109   call 166 ntypeargs=0     (baml.String.index_of)
         110   store_var 6              (_36)
         111   load_var 6               (_36)
         112   is_type 15               
@@ -4101,7 +4101,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
 
   369   6     load_type 1             
         7     load_var 1              (children)
-        8     call 469 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
+        8     call 471 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
         9     store_var 3             (_3)
         10    load_var 3              (_3)
         11    is_type 2               
@@ -4145,16 +4145,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         49    load_type 1             
         50    load_type 12            
         51    load_var 3              (_3)
-        52    call 472 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
+        52    call 474 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
         53    store_var 4             (_5)
         54    jump +50                (to 104)
         55    load_var 3              (_3)
-        56    make_bound_method 496   
+        56    make_bound_method 498   
         57    call_indirect           
         58    store_var 4             (_5)
         59    jump +45                (to 104)
         60    load_var 3              (_3)
-        61    make_bound_method 505   
+        61    make_bound_method 507   
         62    call_indirect           
         63    store_var 4             (_5)
         64    jump +40                (to 104)
@@ -4162,39 +4162,39 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         66    load_type 12            
         67    load_type 12            
         68    load_var 3              (_3)
-        69    call 448 ntypeargs=3    (baml.iter.Filter.Iterator.next)
+        69    call 450 ntypeargs=3    (baml.iter.Filter.Iterator.next)
         70    store_var 4             (_5)
         71    jump +33                (to 104)
         72    load_var 3              (_3)
-        73    make_bound_method 457   
+        73    make_bound_method 459   
         74    call_indirect           
         75    store_var 4             (_5)
         76    jump +28                (to 104)
         77    load_type 1             
         78    load_var 3              (_3)
-        79    call 468 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
+        79    call 470 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
         80    store_var 4             (_5)
         81    jump +23                (to 104)
         82    load_type 1             
         83    load_type 12            
         84    load_type 12            
         85    load_var 3              (_3)
-        86    call 450 ntypeargs=3    (baml.iter.Chain.Iterator.next)
+        86    call 452 ntypeargs=3    (baml.iter.Chain.Iterator.next)
         87    store_var 4             (_5)
         88    jump +16                (to 104)
         89    load_type 1             
         90    load_type 12            
         91    load_var 3              (_3)
-        92    call 460 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
+        92    call 462 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
         93    store_var 4             (_5)
         94    jump +10                (to 104)
         95    load_type 1             
         96    load_var 3              (_3)
-        97    call 492 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
+        97    call 494 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
         98    store_var 4             (_5)
         99    jump +5                 (to 104)
         100   load_var 3              (_3)
-        101   make_bound_method 484   
+        101   make_bound_method 486   
         102   call_indirect           
         103   store_var 4             (_5)
         104   load_var 4              (_5)
@@ -4208,7 +4208,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         112   store_deref 5           
 
   370   113   load_var 5              (child)
-        114   make_closure 1225 1     
+        114   make_closure 1227 1     
         115   load_const 14           (null)
         116   load_const 14           (null)
         117   spawn                   
@@ -4221,16 +4221,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   374   123   load_type 15            
         124   load_type 16            
         125   load_var 2              (futures)
-        126   call 515 ntypeargs=2    (baml.future.all_complete)
+        126   call 517 ntypeargs=2    (baml.future.all_complete)
         127   await                   
         128   jump +5                 (to 133)
         129   load_var 7              (e)
         130   throw_if_panic          
 
   375   131   load_const 17           ("unexpected test child failure")
-        132   call 235 ntypeargs=0    (baml.sys.panic)
+        132   call 237 ntypeargs=0    (baml.sys.panic)
 
-  377   133   call 696 ntypeargs=0    (testing.aggregate_reports)
+  377   133   call 698 ntypeargs=0    (testing.aggregate_reports)
         134   return                  
         135   unreachable             
 }
@@ -4242,7 +4242,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
 
   108   3     load_type 1              
         4     load_var 1               (children)
-        5     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        5     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 4              (_4)
         7     load_var 4               (_4)
         8     is_type 2                
@@ -4286,16 +4286,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         46    load_type 1              
         47    load_type 12             
         48    load_var 4               (_4)
-        49    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        49    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         50    store_var 5              (_6)
         51    jump +50                 (to 101)
         52    load_var 4               (_4)
-        53    make_bound_method 496    
+        53    make_bound_method 498    
         54    call_indirect            
         55    store_var 5              (_6)
         56    jump +45                 (to 101)
         57    load_var 4               (_4)
-        58    make_bound_method 505    
+        58    make_bound_method 507    
         59    call_indirect            
         60    store_var 5              (_6)
         61    jump +40                 (to 101)
@@ -4303,39 +4303,39 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         63    load_type 12             
         64    load_type 12             
         65    load_var 4               (_4)
-        66    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        66    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         67    store_var 5              (_6)
         68    jump +33                 (to 101)
         69    load_var 4               (_4)
-        70    make_bound_method 457    
+        70    make_bound_method 459    
         71    call_indirect            
         72    store_var 5              (_6)
         73    jump +28                 (to 101)
         74    load_type 1              
         75    load_var 4               (_4)
-        76    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        76    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         77    store_var 5              (_6)
         78    jump +23                 (to 101)
         79    load_type 1              
         80    load_type 12             
         81    load_type 12             
         82    load_var 4               (_4)
-        83    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        83    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         84    store_var 5              (_6)
         85    jump +16                 (to 101)
         86    load_type 1              
         87    load_type 12             
         88    load_var 4               (_4)
-        89    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        89    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         90    store_var 5              (_6)
         91    jump +10                 (to 101)
         92    load_type 1              
         93    load_var 4               (_4)
-        94    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        94    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         95    store_var 5              (_6)
         96    jump +5                  (to 101)
         97    load_var 4               (_4)
-        98    make_bound_method 484    
+        98    make_bound_method 486    
         99    call_indirect            
         100   store_var 5              (_6)
         101   load_var 5               (_6)
@@ -4373,16 +4373,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         129   pop 1                    
         130   load_var 8               (outcome)
         131   load_const 15            ("pass")
-        132   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        132   call 678 ntypeargs=0     (baml.ops.equals_equals)
         133   unary_op !               
         134   pop_jump_if_false -127   (to 7)
 
   116   135   load_var 3               (named_results)
-        136   call 696 ntypeargs=0     (testing.aggregate_reports)
+        136   call 698 ntypeargs=0     (testing.aggregate_reports)
         137   jump +3                  (to 140)
 
   121   138   load_var 3               (named_results)
-        139   call 696 ntypeargs=0     (testing.aggregate_reports)
+        139   call 698 ntypeargs=0     (testing.aggregate_reports)
         140   return                   
         141   unreachable              
 }
@@ -4393,7 +4393,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1261 1    
+        4    make_closure 1263 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -4425,17 +4425,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   418   8    load_var 1             (children)
-        9    call 709 ntypeargs=0   (testing.run_children_parallel)
+        9    call 711 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0     load_var 2               (include)
-        1     call 697 ntypeargs=0     (testing.parse_filter_patterns)
+        1     call 699 ntypeargs=0     (testing.parse_filter_patterns)
         2     store_var 4              (inc)
 
   550   3     load_var 3               (exclude)
-        4     call 697 ntypeargs=0     (testing.parse_filter_patterns)
+        4     call 699 ntypeargs=0     (testing.parse_filter_patterns)
         5     store_var 5              (exc)
 
   551   6     load_type 0              
@@ -4443,11 +4443,11 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8     store_var 6              (out)
 
   552   9     load_var 1               (registry)
-        10    call 700 ntypeargs=0     (testing.collect_leaf_names)
+        10    call 702 ntypeargs=0     (testing.collect_leaf_names)
         11    store_var 7              (_7)
         12    load_type 0              
         13    load_var 7               (_7)
-        14    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        14    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         15    store_var 8              (_8)
         16    load_var 8               (_8)
         17    is_type 1                
@@ -4491,16 +4491,16 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         55    load_type 0              
         56    load_type 11             
         57    load_var 8               (_8)
-        58    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        58    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         59    store_var 9              (_10)
         60    jump +50                 (to 110)
         61    load_var 8               (_8)
-        62    make_bound_method 496    
+        62    make_bound_method 498    
         63    call_indirect            
         64    store_var 9              (_10)
         65    jump +45                 (to 110)
         66    load_var 8               (_8)
-        67    make_bound_method 505    
+        67    make_bound_method 507    
         68    call_indirect            
         69    store_var 9              (_10)
         70    jump +40                 (to 110)
@@ -4508,39 +4508,39 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         72    load_type 11             
         73    load_type 11             
         74    load_var 8               (_8)
-        75    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        75    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         76    store_var 9              (_10)
         77    jump +33                 (to 110)
         78    load_var 8               (_8)
-        79    make_bound_method 457    
+        79    make_bound_method 459    
         80    call_indirect            
         81    store_var 9              (_10)
         82    jump +28                 (to 110)
         83    load_type 0              
         84    load_var 8               (_8)
-        85    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        85    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         86    store_var 9              (_10)
         87    jump +23                 (to 110)
         88    load_type 0              
         89    load_type 11             
         90    load_type 11             
         91    load_var 8               (_8)
-        92    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        92    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         93    store_var 9              (_10)
         94    jump +16                 (to 110)
         95    load_type 0              
         96    load_type 11             
         97    load_var 8               (_8)
-        98    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        98    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         99    store_var 9              (_10)
         100   jump +10                 (to 110)
         101   load_type 0              
         102   load_var 8               (_8)
-        103   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        103   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         104   store_var 9              (_10)
         105   jump +5                  (to 110)
         106   load_var 8               (_8)
-        107   make_bound_method 484    
+        107   make_bound_method 486    
         108   call_indirect            
         109   store_var 9              (_10)
         110   load_var 9               (_10)
@@ -4551,7 +4551,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         115   store_var_load_var 10    (name)
 
   553   116   load_var2 4 5            
-        117   call 725 ntypeargs=0     (testing.leaf_selected)
+        117   call 727 ntypeargs=0     (testing.leaf_selected)
         118   pop_jump_if_false -102   (to 16)
 
   554   119   load_var2 6 10           
@@ -4567,7 +4567,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
 function testing.split_top(path: string) -> testing.NameSplit {
   463   0    load_var 1             (path)
         1    load_const 0           ("/")
-        2    call 165 ntypeargs=0   (baml.String.index_of)
+        2    call 166 ntypeargs=0   (baml.String.index_of)
         3    store_var 2            (_2)
         4    load_var 2             (_2)
         5    is_type 1              
@@ -4609,7 +4609,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1238 2   
+        8    make_closure 1240 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -4626,7 +4626,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1252 2   
+        9    make_closure 1254 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -4647,7 +4647,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1265 3   
+        13   make_closure 1267 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -4663,7 +4663,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         6     store_var 3              (_3)
         7     load_type 1              
         8     load_var 3               (_3)
-        9     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 4              (_4)
         11    load_var 4               (_4)
         12    is_type 2                
@@ -4707,16 +4707,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         50    load_type 1              
         51    load_type 12             
         52    load_var 4               (_4)
-        53    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 5              (_6)
         55    jump +50                 (to 105)
         56    load_var 4               (_4)
-        57    make_bound_method 496    
+        57    make_bound_method 498    
         58    call_indirect            
         59    store_var 5              (_6)
         60    jump +45                 (to 105)
         61    load_var 4               (_4)
-        62    make_bound_method 505    
+        62    make_bound_method 507    
         63    call_indirect            
         64    store_var 5              (_6)
         65    jump +40                 (to 105)
@@ -4724,39 +4724,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         67    load_type 12             
         68    load_type 12             
         69    load_var 4               (_4)
-        70    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 5              (_6)
         72    jump +33                 (to 105)
         73    load_var 4               (_4)
-        74    make_bound_method 457    
+        74    make_bound_method 459    
         75    call_indirect            
         76    store_var 5              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 4               (_4)
-        80    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 5              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 4               (_4)
-        87    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 5              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 4               (_4)
-        93    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 5              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 4               (_4)
-        98    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 5              (_6)
         100   jump +5                  (to 105)
         101   load_var 4               (_4)
-        102   make_bound_method 484    
+        102   make_bound_method 486    
         103   call_indirect            
         104   store_var 5              (_6)
         105   load_var 5               (_6)
@@ -4771,7 +4771,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         113   load_field 1             (body)
         114   load_var 6               (t)
         115   load_field 2             (runner)
-        116   call 715 ntypeargs=0     (testing.test_child)
+        116   call 717 ntypeargs=0     (testing.test_child)
         117   store_var 7              (_37)
         118   load_var2 2 7            
         119   call 9 ntypeargs=0       (baml.Array.push)
@@ -4784,7 +4784,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         125   store_var 8              (_41)
         126   load_type 14             
         127   load_var 8               (_41)
-        128   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        128   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         129   store_var 9              (_42)
         130   load_var 9               (_42)
         131   is_type 15               
@@ -4828,16 +4828,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         169   load_type 14             
         170   load_type 12             
         171   load_var 9               (_42)
-        172   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        172   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         173   store_var 10             (_44)
         174   jump +50                 (to 224)
         175   load_var 9               (_42)
-        176   make_bound_method 496    
+        176   make_bound_method 498    
         177   call_indirect            
         178   store_var 10             (_44)
         179   jump +45                 (to 224)
         180   load_var 9               (_42)
-        181   make_bound_method 505    
+        181   make_bound_method 507    
         182   call_indirect            
         183   store_var 10             (_44)
         184   jump +40                 (to 224)
@@ -4845,39 +4845,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         186   load_type 12             
         187   load_type 12             
         188   load_var 9               (_42)
-        189   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        189   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         190   store_var 10             (_44)
         191   jump +33                 (to 224)
         192   load_var 9               (_42)
-        193   make_bound_method 457    
+        193   make_bound_method 459    
         194   call_indirect            
         195   store_var 10             (_44)
         196   jump +28                 (to 224)
         197   load_type 14             
         198   load_var 9               (_42)
-        199   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        199   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         200   store_var 10             (_44)
         201   jump +23                 (to 224)
         202   load_type 14             
         203   load_type 12             
         204   load_type 12             
         205   load_var 9               (_42)
-        206   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        206   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         207   store_var 10             (_44)
         208   jump +16                 (to 224)
         209   load_type 14             
         210   load_type 12             
         211   load_var 9               (_42)
-        212   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        212   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         213   store_var 10             (_44)
         214   jump +10                 (to 224)
         215   load_type 14             
         216   load_var 9               (_42)
-        217   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        217   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         218   store_var 10             (_44)
         219   jump +5                  (to 224)
         220   load_var 9               (_42)
-        221   make_bound_method 484    
+        221   make_bound_method 486    
         222   call_indirect            
         223   store_var 10             (_44)
         224   load_var 10              (_44)
@@ -4887,7 +4887,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   238   228   load_var2 1 10           
 
-  237   229   call 723 ntypeargs=0     (testing.testset_child)
+  237   229   call 725 ntypeargs=0     (testing.testset_child)
         230   store_var 11             (_75)
 
   238   231   load_var2 2 11           
@@ -4911,7 +4911,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         6     store_var 4              (_4)
         7     load_type 1              
         8     load_var 4               (_4)
-        9     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 5              (_5)
         11    load_var 5               (_5)
         12    is_type 2                
@@ -4955,16 +4955,16 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         50    load_type 1              
         51    load_type 12             
         52    load_var 5               (_5)
-        53    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 6              (_7)
         55    jump +50                 (to 105)
         56    load_var 5               (_5)
-        57    make_bound_method 496    
+        57    make_bound_method 498    
         58    call_indirect            
         59    store_var 6              (_7)
         60    jump +45                 (to 105)
         61    load_var 5               (_5)
-        62    make_bound_method 505    
+        62    make_bound_method 507    
         63    call_indirect            
         64    store_var 6              (_7)
         65    jump +40                 (to 105)
@@ -4972,39 +4972,39 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         67    load_type 12             
         68    load_type 12             
         69    load_var 5               (_5)
-        70    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 6              (_7)
         72    jump +33                 (to 105)
         73    load_var 5               (_5)
-        74    make_bound_method 457    
+        74    make_bound_method 459    
         75    call_indirect            
         76    store_var 6              (_7)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 5               (_5)
-        80    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 6              (_7)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 5               (_5)
-        87    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 6              (_7)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 5               (_5)
-        93    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 6              (_7)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 5               (_5)
-        98    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 6              (_7)
         100   jump +5                  (to 105)
         101   load_var 5               (_5)
-        102   make_bound_method 484    
+        102   make_bound_method 486    
         103   call_indirect            
         104   store_var 6              (_7)
         105   load_var 6               (_7)
@@ -5016,7 +5016,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   111   load_field 0             (name)
         112   load_var 2               (names)
-        113   call 719 ntypeargs=0     (testing._name_selected)
+        113   call 721 ntypeargs=0     (testing._name_selected)
         114   pop_jump_if_false -103   (to 11)
 
   247   115   load_var 7               (t)
@@ -5025,7 +5025,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         118   load_field 1             (body)
         119   load_var 7               (t)
         120   load_field 2             (runner)
-        121   call 715 ntypeargs=0     (testing.test_child)
+        121   call 717 ntypeargs=0     (testing.test_child)
         122   store_var 8              (_40)
         123   load_var2 3 8            
         124   call 9 ntypeargs=0       (baml.Array.push)
@@ -5038,7 +5038,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         130   store_var 9              (_44)
         131   load_type 14             
         132   load_var 9               (_44)
-        133   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        133   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         134   store_var 10             (_45)
         135   load_var 10              (_45)
         136   is_type 15               
@@ -5082,16 +5082,16 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         174   load_type 14             
         175   load_type 12             
         176   load_var 10              (_45)
-        177   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        177   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         178   store_var 11             (_47)
         179   jump +50                 (to 229)
         180   load_var 10              (_45)
-        181   make_bound_method 496    
+        181   make_bound_method 498    
         182   call_indirect            
         183   store_var 11             (_47)
         184   jump +45                 (to 229)
         185   load_var 10              (_45)
-        186   make_bound_method 505    
+        186   make_bound_method 507    
         187   call_indirect            
         188   store_var 11             (_47)
         189   jump +40                 (to 229)
@@ -5099,39 +5099,39 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         191   load_type 12             
         192   load_type 12             
         193   load_var 10              (_45)
-        194   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        194   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         195   store_var 11             (_47)
         196   jump +33                 (to 229)
         197   load_var 10              (_45)
-        198   make_bound_method 457    
+        198   make_bound_method 459    
         199   call_indirect            
         200   store_var 11             (_47)
         201   jump +28                 (to 229)
         202   load_type 14             
         203   load_var 10              (_45)
-        204   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        204   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         205   store_var 11             (_47)
         206   jump +23                 (to 229)
         207   load_type 14             
         208   load_type 12             
         209   load_type 12             
         210   load_var 10              (_45)
-        211   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        211   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         212   store_var 11             (_47)
         213   jump +16                 (to 229)
         214   load_type 14             
         215   load_type 12             
         216   load_var 10              (_45)
-        217   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        217   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         218   store_var 11             (_47)
         219   jump +10                 (to 229)
         220   load_type 14             
         221   load_var 10              (_45)
-        222   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        222   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         223   store_var 11             (_47)
         224   jump +5                  (to 229)
         225   load_var 10              (_45)
-        226   make_bound_method 484    
+        226   make_bound_method 486    
         227   call_indirect            
         228   store_var 11             (_47)
         229   load_var 11              (_47)
@@ -5143,12 +5143,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   235   load_field 0             (name)
         236   load_var 2               (names)
-        237   call 701 ntypeargs=0     (testing._has_selected_descendant)
+        237   call 703 ntypeargs=0     (testing._has_selected_descendant)
         238   pop_jump_if_false -103   (to 135)
 
   259   239   load_var2 1 12           
         240   load_var 2               (names)
-        241   call 728 ntypeargs=0     (testing.testset_child_selected)
+        241   call 730 ntypeargs=0     (testing.testset_child_selected)
         242   store_var 13             (_80)
         243   load_var2 3 13           
         244   call 9 ntypeargs=0       (baml.Array.push)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 739 ntypeargs=0   (assert.format_operand)
+       26   call 741 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 739 ntypeargs=0   (assert.format_operand)
+       29   call 741 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 739 ntypeargs=0   (assert.format_operand)
+       32   call 741 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 739 ntypeargs=0   (assert.format_operand)
+       35   call 741 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -63,17 +63,17 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        49   bin_op +               
        50   load_var 8             (_22)
        51   bin_op +               
-       52   call 235 ntypeargs=0   (baml.sys.panic)
+       52   call 237 ntypeargs=0   (baml.sys.panic)
        53   jump +3                (to 56)
 
   78   54   load_const 6           ("assertion failed: epsilon must be a non-negative number")
-       55   call 235 ntypeargs=0   (baml.sys.panic)
+       55   call 237 ntypeargs=0   (baml.sys.panic)
        56   return                 
 }
 
 function assert.contains(haystack: string, needle: string) -> null {
   100   0   load_var2 1 2          
-        1   call 172 ntypeargs=0   (baml.String.includes)
+        1   call 174 ntypeargs=0   (baml.String.includes)
         2   unary_op !             
         3   pop_jump_if_false +2   (to 5)
         4   jump +3                (to 7)
@@ -83,13 +83,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   100   6   jump +3                (to 9)
 
   101   7   load_const 1           ("assertion failed: string does not contain expected substring")
-        8   call 235 ntypeargs=0   (baml.sys.panic)
+        8   call 237 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 676 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 678 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 739 ntypeargs=0   (assert.format_operand)
+       8    call 741 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 739 ntypeargs=0   (assert.format_operand)
+       11   call 741 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -113,7 +113,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 235 ntypeargs=0   (baml.sys.panic)
+       20   call 237 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
@@ -134,14 +134,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 235 ntypeargs=0   (baml.sys.panic)
+      7   call 237 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 676 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 678 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -150,7 +150,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 235 ntypeargs=0   (baml.sys.panic)
+       8   call 237 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -170,7 +170,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1267 0   
+  101   0   make_closure 1269 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -193,11 +193,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 235 ntypeargs=0   (baml.sys.panic)
+       14   call 237 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1278 1    
+       17   make_closure 1280 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -229,16 +229,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 235 ntypeargs=0   (baml.sys.panic)
+       22   call 237 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 235 ntypeargs=0   (baml.sys.panic)
+       26   call 237 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1292 2    
+       29   make_closure 1294 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -255,18 +255,18 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 235 ntypeargs=0   (baml.sys.panic)
+       8    call 237 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1285 1    
+       11   make_closure 1287 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1271 0   
+  95   0   make_closure 1273 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -278,7 +278,7 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        2     store_var 4              (_3)
        3     load_type 0              
        4     load_var 4               (_3)
-       5     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 5              (_4)
        7     load_var 5               (_4)
        8     is_type 1                
@@ -322,16 +322,16 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        46    load_type 0              
        47    load_type 11             
        48    load_var 5               (_4)
-       49    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 6              (_6)
        51    jump +50                 (to 101)
        52    load_var 5               (_4)
-       53    make_bound_method 496    
+       53    make_bound_method 498    
        54    call_indirect            
        55    store_var 6              (_6)
        56    jump +45                 (to 101)
        57    load_var 5               (_4)
-       58    make_bound_method 505    
+       58    make_bound_method 507    
        59    call_indirect            
        60    store_var 6              (_6)
        61    jump +40                 (to 101)
@@ -339,39 +339,39 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        63    load_type 11             
        64    load_type 11             
        65    load_var 5               (_4)
-       66    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 6              (_6)
        68    jump +33                 (to 101)
        69    load_var 5               (_4)
-       70    make_bound_method 457    
+       70    make_bound_method 459    
        71    call_indirect            
        72    store_var 6              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 5               (_4)
-       76    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 6              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 5               (_4)
-       83    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 6              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 5               (_4)
-       89    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 6              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 5               (_4)
-       94    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 6              (_6)
        96    jump +5                  (to 101)
        97    load_var 5               (_4)
-       98    make_bound_method 484    
+       98    make_bound_method 486    
        99    call_indirect            
        100   store_var 6              (_6)
        101   load_var 6               (_6)
@@ -404,7 +404,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        2     store_var 4              (_3)
        3     load_type 0              
        4     load_var 4               (_3)
-       5     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 5              (_4)
        7     load_var 5               (_4)
        8     is_type 1                
@@ -448,16 +448,16 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        46    load_type 0              
        47    load_type 11             
        48    load_var 5               (_4)
-       49    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 6              (_6)
        51    jump +50                 (to 101)
        52    load_var 5               (_4)
-       53    make_bound_method 496    
+       53    make_bound_method 498    
        54    call_indirect            
        55    store_var 6              (_6)
        56    jump +45                 (to 101)
        57    load_var 5               (_4)
-       58    make_bound_method 505    
+       58    make_bound_method 507    
        59    call_indirect            
        60    store_var 6              (_6)
        61    jump +40                 (to 101)
@@ -465,39 +465,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        63    load_type 11             
        64    load_type 11             
        65    load_var 5               (_4)
-       66    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 6              (_6)
        68    jump +33                 (to 101)
        69    load_var 5               (_4)
-       70    make_bound_method 457    
+       70    make_bound_method 459    
        71    call_indirect            
        72    store_var 6              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 5               (_4)
-       76    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 6              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 5               (_4)
-       83    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 6              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 5               (_4)
-       89    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 6              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 5               (_4)
-       94    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 6              (_6)
        96    jump +5                  (to 101)
        97    load_var 5               (_4)
-       98    make_bound_method 484    
+       98    make_bound_method 486    
        99    call_indirect            
        100   store_var 6              (_6)
        101   load_var 6               (_6)
@@ -567,7 +567,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        24    store_var 9              (_13)
        25    load_type 4              
        26    load_var 9               (_13)
-       27    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 10             (_14)
        29    load_var 10              (_14)
        30    is_type 5                
@@ -611,16 +611,16 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        68    load_type 4              
        69    load_type 15             
        70    load_var 10              (_14)
-       71    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 11             (_16)
        73    jump +50                 (to 123)
        74    load_var 10              (_14)
-       75    make_bound_method 496    
+       75    make_bound_method 498    
        76    call_indirect            
        77    store_var 11             (_16)
        78    jump +45                 (to 123)
        79    load_var 10              (_14)
-       80    make_bound_method 505    
+       80    make_bound_method 507    
        81    call_indirect            
        82    store_var 11             (_16)
        83    jump +40                 (to 123)
@@ -628,39 +628,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        85    load_type 15             
        86    load_type 15             
        87    load_var 10              (_14)
-       88    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 11             (_16)
        90    jump +33                 (to 123)
        91    load_var 10              (_14)
-       92    make_bound_method 457    
+       92    make_bound_method 459    
        93    call_indirect            
        94    store_var 11             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 10              (_14)
-       98    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 11             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 10              (_14)
-       105   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 11             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 10              (_14)
-       111   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 11             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 10              (_14)
-       116   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 11             (_16)
        118   jump +5                  (to 123)
        119   load_var 10              (_14)
-       120   make_bound_method 484    
+       120   make_bound_method 486    
        121   call_indirect            
        122   store_var 11             (_16)
        123   load_var 11              (_16)
@@ -756,7 +756,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        24    store_var 9              (_13)
        25    load_type 4              
        26    load_var 9               (_13)
-       27    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 10             (_14)
        29    load_var 10              (_14)
        30    is_type 5                
@@ -800,16 +800,16 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        68    load_type 4              
        69    load_type 15             
        70    load_var 10              (_14)
-       71    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 11             (_16)
        73    jump +50                 (to 123)
        74    load_var 10              (_14)
-       75    make_bound_method 496    
+       75    make_bound_method 498    
        76    call_indirect            
        77    store_var 11             (_16)
        78    jump +45                 (to 123)
        79    load_var 10              (_14)
-       80    make_bound_method 505    
+       80    make_bound_method 507    
        81    call_indirect            
        82    store_var 11             (_16)
        83    jump +40                 (to 123)
@@ -817,39 +817,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        85    load_type 15             
        86    load_type 15             
        87    load_var 10              (_14)
-       88    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 11             (_16)
        90    jump +33                 (to 123)
        91    load_var 10              (_14)
-       92    make_bound_method 457    
+       92    make_bound_method 459    
        93    call_indirect            
        94    store_var 11             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 10              (_14)
-       98    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 11             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 10              (_14)
-       105   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 11             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 10              (_14)
-       111   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 11             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 10              (_14)
-       116   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 11             (_16)
        118   jump +5                  (to 123)
        119   load_var 10              (_14)
-       120   make_bound_method 484    
+       120   make_bound_method 486    
        121   call_indirect            
        122   store_var 11             (_16)
        123   load_var 11              (_16)
@@ -921,7 +921,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -965,16 +965,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 496    
+        54    make_bound_method 498    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 505    
+        59    make_bound_method 507    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -982,39 +982,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 457    
+        71    make_bound_method 459    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 484    
+        99    make_bound_method 486    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1030,11 +1030,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         111   pop_jump_if_false -103   (to 8)
 
   198   112   load_var2 1 6            
-        113   call 716 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        113   call 718 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
         114   pop 1                    
 
   199   115   load_var 1               (self)
-        116   call 699 ntypeargs=0     (testing.TestRegistry.serialize)
+        116   call 701 ntypeargs=0     (testing.TestRegistry.serialize)
         117   jump +123                (to 240)
 
   203   118   load_type 13             
@@ -1045,7 +1045,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         123   store_var 7              (_40)
         124   load_type 13             
         125   load_var 7               (_40)
-        126   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1089,16 +1089,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 496    
+        174   make_bound_method 498    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 505    
+        179   make_bound_method 507    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1106,39 +1106,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 457    
+        191   make_bound_method 459    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 484    
+        219   make_bound_method 486    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1161,7 +1161,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         237   pop_jump_if_false -109   (to 128)
 
   206   238   load_var2 11 2           
-        239   call 704 ntypeargs=0     (testing.TestRegistry.expand_set)
+        239   call 706 ntypeargs=0     (testing.TestRegistry.expand_set)
         240   return                   
 
   209   241   load_const 26            ("TestSet not found for expansion: ")
@@ -1185,7 +1185,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +37               (to 48)
 
-  216   12   call 240 ntypeargs=0   (baml.sys.now_ms)
+  216   12   call 242 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 5            (start)
 
   217   14   load_var 2             (ts)
@@ -1202,7 +1202,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         24   call_indirect          
         25   pop 1                  
 
-  219   26   call 240 ntypeargs=0   (baml.sys.now_ms)
+  219   26   call 242 ntypeargs=0   (baml.sys.now_ms)
         27   load_var 5             (start)
         28   sub_int                
         29   store_var 7            (elapsed)
@@ -1240,7 +1240,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 698 ntypeargs=0   (testing.select_names)
+        2   call 700 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -1259,9 +1259,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 714 ntypeargs=0   (testing.testset_children)
+        1   call 716 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 692 ntypeargs=0   (testing.run_testset)
+        3   call 694 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1281,24 +1281,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   12   load_var2 1 2          
         13   load_var 3             (exclude)
-        14   call 698 ntypeargs=0   (testing.select_names)
+        14   call 700 ntypeargs=0   (testing.select_names)
         15   store_var 4            (_9)
         16   load_var2 1 4          
-        17   call 689 ntypeargs=0   (testing.TestRegistry.run_selected)
+        17   call 691 ntypeargs=0   (testing.TestRegistry.run_selected)
         18   jump +3                (to 21)
 
   180   19   load_var 1             (self)
-        20   call 711 ntypeargs=0   (testing.TestRegistry.run_all)
+        20   call 713 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   21   call 727 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   21   call 729 ntypeargs=0   (testing.flatten_with_tolerated)
         22   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 695 ntypeargs=0   (testing.testset_children_selected)
+        1   call 697 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 692 ntypeargs=0   (testing.run_testset)
+        3   call 694 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1309,7 +1309,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1353,16 +1353,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 496    
+        54    make_bound_method 498    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 505    
+        59    make_bound_method 507    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1370,39 +1370,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 457    
+        71    make_bound_method 459    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 484    
+        99    make_bound_method 486    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1421,7 +1421,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         113   load_field 1             (body)
         114   load_var 6               (t)
         115   load_field 2             (runner)
-        116   call 726 ntypeargs=0     (testing.run_test)
+        116   call 728 ntypeargs=0     (testing.run_test)
         117   jump +123                (to 240)
 
   140   118   load_type 13             
@@ -1432,7 +1432,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         123   store_var 7              (_40)
         124   load_type 13             
         125   load_var 7               (_40)
-        126   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1476,16 +1476,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 496    
+        174   make_bound_method 498    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 505    
+        179   make_bound_method 507    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1493,39 +1493,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 457    
+        191   make_bound_method 459    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 484    
+        219   make_bound_method 486    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1548,7 +1548,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         237   pop_jump_if_false -109   (to 128)
 
   144   238   load_var2 11 2           
-        239   call 703 ntypeargs=0     (testing.TestRegistry.run_test)
+        239   call 705 ntypeargs=0     (testing.TestRegistry.run_test)
         240   return                   
 
   147   241   load_const 26            ("Test not found: ")
@@ -1565,7 +1565,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1609,16 +1609,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 496    
+        54    make_bound_method 498    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 505    
+        59    make_bound_method 507    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1626,39 +1626,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 457    
+        71    make_bound_method 459    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 484    
+        99    make_bound_method 486    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1674,11 +1674,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         111   pop_jump_if_false -103   (to 8)
 
   153   112   load_var2 1 6            
-        113   call 716 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
-        114   call 714 ntypeargs=0     (testing.testset_children)
+        113   call 718 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        114   call 716 ntypeargs=0     (testing.testset_children)
         115   load_var 6               (ts)
         116   load_field 2             (runner)
-        117   call 692 ntypeargs=0     (testing.run_testset)
+        117   call 694 ntypeargs=0     (testing.run_testset)
         118   jump +123                (to 241)
 
   156   119   load_type 13             
@@ -1689,7 +1689,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         124   store_var 7              (_42)
         125   load_type 13             
         126   load_var 7               (_42)
-        127   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         128   store_var 8              (_46)
         129   load_var 8               (_46)
         130   is_type 15               
@@ -1733,16 +1733,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         168   load_type 13             
         169   load_type 11             
         170   load_var 8               (_46)
-        171   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         172   store_var 9              (_48)
         173   jump +50                 (to 223)
         174   load_var 8               (_46)
-        175   make_bound_method 496    
+        175   make_bound_method 498    
         176   call_indirect            
         177   store_var 9              (_48)
         178   jump +45                 (to 223)
         179   load_var 8               (_46)
-        180   make_bound_method 505    
+        180   make_bound_method 507    
         181   call_indirect            
         182   store_var 9              (_48)
         183   jump +40                 (to 223)
@@ -1750,39 +1750,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         185   load_type 11             
         186   load_type 11             
         187   load_var 8               (_46)
-        188   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         189   store_var 9              (_48)
         190   jump +33                 (to 223)
         191   load_var 8               (_46)
-        192   make_bound_method 457    
+        192   make_bound_method 459    
         193   call_indirect            
         194   store_var 9              (_48)
         195   jump +28                 (to 223)
         196   load_type 13             
         197   load_var 8               (_46)
-        198   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         199   store_var 9              (_48)
         200   jump +23                 (to 223)
         201   load_type 13             
         202   load_type 11             
         203   load_type 11             
         204   load_var 8               (_46)
-        205   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         206   store_var 9              (_48)
         207   jump +16                 (to 223)
         208   load_type 13             
         209   load_type 11             
         210   load_var 8               (_46)
-        211   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         212   store_var 9              (_48)
         213   jump +10                 (to 223)
         214   load_type 13             
         215   load_var 8               (_46)
-        216   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         217   store_var 9              (_48)
         218   jump +5                  (to 223)
         219   load_var 8               (_46)
-        220   make_bound_method 484    
+        220   make_bound_method 486    
         221   call_indirect            
         222   store_var 9              (_48)
         223   load_var 9               (_48)
@@ -1805,7 +1805,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         238   pop_jump_if_false -109   (to 129)
 
   159   239   load_var2 11 2           
-        240   call 707 ntypeargs=0     (testing.TestRegistry.run_testset)
+        240   call 709 ntypeargs=0     (testing.TestRegistry.run_testset)
         241   return                   
 
   162   242   load_const 26            ("TestSet not found: ")
@@ -1826,7 +1826,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         6     store_var 4              (_3)
         7     load_type 1              
         8     load_var 4               (_3)
-        9     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 5              (_4)
         11    load_var 5               (_4)
         12    is_type 2                
@@ -1870,16 +1870,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         50    load_type 1              
         51    load_type 12             
         52    load_var 5               (_4)
-        53    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 6              (_6)
         55    jump +50                 (to 105)
         56    load_var 5               (_4)
-        57    make_bound_method 496    
+        57    make_bound_method 498    
         58    call_indirect            
         59    store_var 6              (_6)
         60    jump +45                 (to 105)
         61    load_var 5               (_4)
-        62    make_bound_method 505    
+        62    make_bound_method 507    
         63    call_indirect            
         64    store_var 6              (_6)
         65    jump +40                 (to 105)
@@ -1887,39 +1887,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         67    load_type 12             
         68    load_type 12             
         69    load_var 5               (_4)
-        70    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 6              (_6)
         72    jump +33                 (to 105)
         73    load_var 5               (_4)
-        74    make_bound_method 457    
+        74    make_bound_method 459    
         75    call_indirect            
         76    store_var 6              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 5               (_4)
-        80    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 6              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 5               (_4)
-        87    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 6              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 5               (_4)
-        93    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 6              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 5               (_4)
-        98    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 6              (_6)
         100   jump +5                  (to 105)
         101   load_var 5               (_4)
-        102   make_bound_method 484    
+        102   make_bound_method 486    
         103   call_indirect            
         104   store_var 6              (_6)
         105   load_var 6               (_6)
@@ -1944,7 +1944,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         122   store_var 8              (_39)
         123   load_type 15             
         124   load_var 8               (_39)
-        125   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        125   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         126   store_var 9              (_40)
         127   load_var 9               (_40)
         128   is_type 16               
@@ -1988,16 +1988,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         166   load_type 15             
         167   load_type 12             
         168   load_var 9               (_40)
-        169   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        169   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         170   store_var 10             (_42)
         171   jump +50                 (to 221)
         172   load_var 9               (_40)
-        173   make_bound_method 496    
+        173   make_bound_method 498    
         174   call_indirect            
         175   store_var 10             (_42)
         176   jump +45                 (to 221)
         177   load_var 9               (_40)
-        178   make_bound_method 505    
+        178   make_bound_method 507    
         179   call_indirect            
         180   store_var 10             (_42)
         181   jump +40                 (to 221)
@@ -2005,39 +2005,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         183   load_type 12             
         184   load_type 12             
         185   load_var 9               (_40)
-        186   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        186   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         187   store_var 10             (_42)
         188   jump +33                 (to 221)
         189   load_var 9               (_40)
-        190   make_bound_method 457    
+        190   make_bound_method 459    
         191   call_indirect            
         192   store_var 10             (_42)
         193   jump +28                 (to 221)
         194   load_type 15             
         195   load_var 9               (_40)
-        196   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        196   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         197   store_var 10             (_42)
         198   jump +23                 (to 221)
         199   load_type 15             
         200   load_type 12             
         201   load_type 12             
         202   load_var 9               (_40)
-        203   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        203   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         204   store_var 10             (_42)
         205   jump +16                 (to 221)
         206   load_type 15             
         207   load_type 12             
         208   load_var 9               (_40)
-        209   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        209   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         210   store_var 10             (_42)
         211   jump +10                 (to 221)
         212   load_type 15             
         213   load_var 9               (_40)
-        214   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        214   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         215   store_var 10             (_42)
         216   jump +5                  (to 221)
         217   load_var 9               (_40)
-        218   make_bound_method 484    
+        218   make_bound_method 486    
         219   call_indirect            
         220   store_var 10             (_42)
         221   load_var 10              (_42)
@@ -2078,7 +2078,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         251   store_var 14             (_81)
 
   119   252   load_var 13              (sub)
-        253   call 699 ntypeargs=0     (testing.TestRegistry.serialize)
+        253   call 701 ntypeargs=0     (testing.TestRegistry.serialize)
         254   store_var 15             (_82)
 
   117   255   load_var2 3 14           
@@ -2105,7 +2105,7 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
 
   311   4     load_type 1              
         5     load_var 2               (names)
-        6     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 2                
@@ -2149,16 +2149,16 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         47    load_type 1              
         48    load_type 12             
         49    load_var 4               (_4)
-        50    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 496    
+        54    make_bound_method 498    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 505    
+        59    make_bound_method 507    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -2166,39 +2166,39 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         64    load_type 12             
         65    load_type 12             
         66    load_var 4               (_4)
-        67    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 457    
+        71    make_bound_method 459    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 1              
         76    load_var 4               (_4)
-        77    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 1              
         81    load_type 12             
         82    load_type 12             
         83    load_var 4               (_4)
-        84    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 1              
         88    load_type 12             
         89    load_var 4               (_4)
-        90    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 1              
         94    load_var 4               (_4)
-        95    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 484    
+        99    make_bound_method 486    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -2230,14 +2230,14 @@ function testing._int_to_float(value: int) -> float {
         6   throw_if_panic         
 
   126   7   load_const 1           ("failed to convert int to float")
-        8   call 235 ntypeargs=0   (baml.sys.panic)
+        8   call 237 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function testing._name_selected(name: string, names: string[]) -> bool {
   299   0     load_type 0              
         1     load_var 2               (names)
-        2     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 3              (_3)
         4     load_var 3               (_3)
         5     is_type 1                
@@ -2281,16 +2281,16 @@ function testing._name_selected(name: string, names: string[]) -> bool {
         43    load_type 0              
         44    load_type 11             
         45    load_var 3               (_3)
-        46    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 4              (_5)
         48    jump +50                 (to 98)
         49    load_var 3               (_3)
-        50    make_bound_method 496    
+        50    make_bound_method 498    
         51    call_indirect            
         52    store_var 4              (_5)
         53    jump +45                 (to 98)
         54    load_var 3               (_3)
-        55    make_bound_method 505    
+        55    make_bound_method 507    
         56    call_indirect            
         57    store_var 4              (_5)
         58    jump +40                 (to 98)
@@ -2298,39 +2298,39 @@ function testing._name_selected(name: string, names: string[]) -> bool {
         60    load_type 11             
         61    load_type 11             
         62    load_var 3               (_3)
-        63    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 4              (_5)
         65    jump +33                 (to 98)
         66    load_var 3               (_3)
-        67    make_bound_method 457    
+        67    make_bound_method 459    
         68    call_indirect            
         69    store_var 4              (_5)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 3               (_3)
-        73    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 4              (_5)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 3               (_3)
-        80    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 4              (_5)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 3               (_3)
-        86    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 4              (_5)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 3               (_3)
-        91    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 4              (_5)
         93    jump +5                  (to 98)
         94    load_var 3               (_3)
-        95    make_bound_method 484    
+        95    make_bound_method 486    
         96    call_indirect            
         97    store_var 4              (_5)
         98    load_var 4               (_5)
@@ -2372,7 +2372,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   327   12    load_type 4              
         13    load_var 1               (named_results)
-        14    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        14    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         15    store_var 8              (_7)
         16    load_var 8               (_7)
         17    is_type 5                
@@ -2416,16 +2416,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         55    load_type 4              
         56    load_type 15             
         57    load_var 8               (_7)
-        58    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        58    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         59    store_var 9              (_9)
         60    jump +50                 (to 110)
         61    load_var 8               (_7)
-        62    make_bound_method 496    
+        62    make_bound_method 498    
         63    call_indirect            
         64    store_var 9              (_9)
         65    jump +45                 (to 110)
         66    load_var 8               (_7)
-        67    make_bound_method 505    
+        67    make_bound_method 507    
         68    call_indirect            
         69    store_var 9              (_9)
         70    jump +40                 (to 110)
@@ -2433,39 +2433,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         72    load_type 15             
         73    load_type 15             
         74    load_var 8               (_7)
-        75    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        75    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         76    store_var 9              (_9)
         77    jump +33                 (to 110)
         78    load_var 8               (_7)
-        79    make_bound_method 457    
+        79    make_bound_method 459    
         80    call_indirect            
         81    store_var 9              (_9)
         82    jump +28                 (to 110)
         83    load_type 4              
         84    load_var 8               (_7)
-        85    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        85    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         86    store_var 9              (_9)
         87    jump +23                 (to 110)
         88    load_type 4              
         89    load_type 15             
         90    load_type 15             
         91    load_var 8               (_7)
-        92    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        92    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         93    store_var 9              (_9)
         94    jump +16                 (to 110)
         95    load_type 4              
         96    load_type 15             
         97    load_var 8               (_7)
-        98    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        98    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         99    store_var 9              (_9)
         100   jump +10                 (to 110)
         101   load_type 4              
         102   load_var 8               (_7)
-        103   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        103   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         104   store_var 9              (_9)
         105   jump +5                  (to 110)
         106   load_var 8               (_7)
-        107   make_bound_method 484    
+        107   make_bound_method 486    
         108   call_indirect            
         109   store_var 9              (_9)
         110   load_var 9               (_9)
@@ -2504,7 +2504,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   334   137   load_var 12              (outcome)
         138   load_const 18            ("pass")
-        139   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        139   call 678 ntypeargs=0     (baml.ops.equals_equals)
         140   pop_jump_if_false +2     (to 142)
         141   jump +146                (to 287)
 
@@ -2548,7 +2548,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
   346   171   store_var 16             (_56)
         172   load_type 2              
         173   load_var 16              (_56)
-        174   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        174   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         175   store_var 17             (_57)
         176   load_var 17              (_57)
         177   is_type 20               
@@ -2592,16 +2592,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         215   load_type 2              
         216   load_type 15             
         217   load_var 17              (_57)
-        218   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        218   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         219   store_var 18             (_59)
         220   jump +50                 (to 270)
         221   load_var 17              (_57)
-        222   make_bound_method 496    
+        222   make_bound_method 498    
         223   call_indirect            
         224   store_var 18             (_59)
         225   jump +45                 (to 270)
         226   load_var 17              (_57)
-        227   make_bound_method 505    
+        227   make_bound_method 507    
         228   call_indirect            
         229   store_var 18             (_59)
         230   jump +40                 (to 270)
@@ -2609,39 +2609,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         232   load_type 15             
         233   load_type 15             
         234   load_var 17              (_57)
-        235   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        235   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         236   store_var 18             (_59)
         237   jump +33                 (to 270)
         238   load_var 17              (_57)
-        239   make_bound_method 457    
+        239   make_bound_method 459    
         240   call_indirect            
         241   store_var 18             (_59)
         242   jump +28                 (to 270)
         243   load_type 2              
         244   load_var 17              (_57)
-        245   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        245   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         246   store_var 18             (_59)
         247   jump +23                 (to 270)
         248   load_type 2              
         249   load_type 15             
         250   load_type 15             
         251   load_var 17              (_57)
-        252   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        252   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         253   store_var 18             (_59)
         254   jump +16                 (to 270)
         255   load_type 2              
         256   load_type 15             
         257   load_var 17              (_57)
-        258   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        258   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         259   store_var 18             (_59)
         260   jump +10                 (to 270)
         261   load_type 2              
         262   load_var 17              (_57)
-        263   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        263   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         264   store_var 18             (_59)
         265   jump +5                  (to 270)
         266   load_var 17              (_57)
-        267   make_bound_method 484    
+        267   make_bound_method 486    
         268   call_indirect            
         269   store_var 18             (_59)
         270   load_var 18              (_59)
@@ -2658,7 +2658,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   349   280   load_var 12              (outcome)
         281   load_const 30            ("error")
-        282   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        282   call 678 ntypeargs=0     (baml.ops.equals_equals)
         283   pop_jump_if_false -267   (to 16)
 
   350   284   load_const 31            (true)
@@ -2712,7 +2712,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: string, test_name: string) -> bool {
   525   0     load_type 0              
         1     load_var 1               (pats)
-        2     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 4              (_4)
         4     load_var 4               (_4)
         5     is_type 1                
@@ -2756,16 +2756,16 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
         43    load_type 0              
         44    load_type 11             
         45    load_var 4               (_4)
-        46    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 5              (_6)
         48    jump +50                 (to 98)
         49    load_var 4               (_4)
-        50    make_bound_method 496    
+        50    make_bound_method 498    
         51    call_indirect            
         52    store_var 5              (_6)
         53    jump +45                 (to 98)
         54    load_var 4               (_4)
-        55    make_bound_method 505    
+        55    make_bound_method 507    
         56    call_indirect            
         57    store_var 5              (_6)
         58    jump +40                 (to 98)
@@ -2773,39 +2773,39 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
         60    load_type 11             
         61    load_type 11             
         62    load_var 4               (_4)
-        63    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 5              (_6)
         65    jump +33                 (to 98)
         66    load_var 4               (_4)
-        67    make_bound_method 457    
+        67    make_bound_method 459    
         68    call_indirect            
         69    store_var 5              (_6)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 4               (_4)
-        73    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 5              (_6)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 4               (_4)
-        80    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 5              (_6)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 4               (_4)
-        86    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 5              (_6)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 4               (_4)
-        91    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 5              (_6)
         93    jump +5                  (to 98)
         94    load_var 4               (_4)
-        95    make_bound_method 484    
+        95    make_bound_method 486    
         96    call_indirect            
         97    store_var 5              (_6)
         98    load_var 5               (_6)
@@ -2817,13 +2817,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   104   load_field 0             (func_pat)
         105   load_var 2               (function_name)
-        106   call 712 ntypeargs=0     (testing.filter_match)
+        106   call 714 ntypeargs=0     (testing.filter_match)
         107   jump_if_false +6         (to 113)
         108   pop 1                    
         109   load_var 6               (p)
         110   load_field 1             (test_pat)
         111   load_var 3               (test_name)
-        112   call 712 ntypeargs=0     (testing.filter_match)
+        112   call 714 ntypeargs=0     (testing.filter_match)
         113   pop_jump_if_false -109   (to 4)
 
   527   114   load_const 13            (true)
@@ -2837,7 +2837,7 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 function testing.collect_leaf_messages(results: (testing.TestReport | testing.TestSetReport)[], out: string[]) -> void {
   661   0     load_type 0              
         1     load_var 1               (results)
-        2     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 4              (_3)
         4     load_var 4               (_3)
         5     is_type 1                
@@ -2881,16 +2881,16 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         43    load_type 0              
         44    load_type 11             
         45    load_var 4               (_3)
-        46    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 5              (_5)
         48    jump +50                 (to 98)
         49    load_var 4               (_3)
-        50    make_bound_method 496    
+        50    make_bound_method 498    
         51    call_indirect            
         52    store_var 5              (_5)
         53    jump +45                 (to 98)
         54    load_var 4               (_3)
-        55    make_bound_method 505    
+        55    make_bound_method 507    
         56    call_indirect            
         57    store_var 5              (_5)
         58    jump +40                 (to 98)
@@ -2898,39 +2898,39 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         60    load_type 11             
         61    load_type 11             
         62    load_var 4               (_3)
-        63    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 5              (_5)
         65    jump +33                 (to 98)
         66    load_var 4               (_3)
-        67    make_bound_method 457    
+        67    make_bound_method 459    
         68    call_indirect            
         69    store_var 5              (_5)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 4               (_3)
-        73    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 5              (_5)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 4               (_3)
-        80    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 5              (_5)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 4               (_3)
-        86    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 5              (_5)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 4               (_3)
-        91    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 5              (_5)
         93    jump +5                  (to 98)
         94    load_var 4               (_3)
-        95    make_bound_method 484    
+        95    make_bound_method 486    
         96    call_indirect            
         97    store_var 5              (_5)
         98    load_var 5               (_5)
@@ -2948,7 +2948,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   673   109   load_field 5             (results)
         110   load_var 2               (out)
-        111   call 705 ntypeargs=0     (testing.collect_leaf_messages)
+        111   call 707 ntypeargs=0     (testing.collect_leaf_messages)
         112   pop 1                    
         113   jump -109                (to 4)
 
@@ -2960,7 +2960,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         118   store_var 8              (_37)
         119   load_type 14             
         120   load_var 8               (_37)
-        121   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        121   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         122   store_var 9              (_38)
         123   load_var 9               (_38)
         124   is_type 15               
@@ -3004,16 +3004,16 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         162   load_type 14             
         163   load_type 11             
         164   load_var 9               (_38)
-        165   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        165   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         166   store_var 10             (_40)
         167   jump +50                 (to 217)
         168   load_var 9               (_38)
-        169   make_bound_method 496    
+        169   make_bound_method 498    
         170   call_indirect            
         171   store_var 10             (_40)
         172   jump +45                 (to 217)
         173   load_var 9               (_38)
-        174   make_bound_method 505    
+        174   make_bound_method 507    
         175   call_indirect            
         176   store_var 10             (_40)
         177   jump +40                 (to 217)
@@ -3021,39 +3021,39 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         179   load_type 11             
         180   load_type 11             
         181   load_var 9               (_38)
-        182   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        182   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         183   store_var 10             (_40)
         184   jump +33                 (to 217)
         185   load_var 9               (_38)
-        186   make_bound_method 457    
+        186   make_bound_method 459    
         187   call_indirect            
         188   store_var 10             (_40)
         189   jump +28                 (to 217)
         190   load_type 14             
         191   load_var 9               (_38)
-        192   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        192   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         193   store_var 10             (_40)
         194   jump +23                 (to 217)
         195   load_type 14             
         196   load_type 11             
         197   load_type 11             
         198   load_var 9               (_38)
-        199   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        199   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         200   store_var 10             (_40)
         201   jump +16                 (to 217)
         202   load_type 14             
         203   load_type 11             
         204   load_var 9               (_38)
-        205   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        205   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         206   store_var 10             (_40)
         207   jump +10                 (to 217)
         208   load_type 14             
         209   load_var 9               (_38)
-        210   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        210   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         211   store_var 10             (_40)
         212   jump +5                  (to 217)
         213   load_var 9               (_38)
-        214   make_bound_method 484    
+        214   make_bound_method 486    
         215   call_indirect            
         216   store_var 10             (_40)
         217   load_var 10              (_40)
@@ -3065,7 +3065,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   665   223   load_field 0             (outcome)
         224   load_const 25            ("pass")
-        225   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        225   call 678 ntypeargs=0     (baml.ops.equals_equals)
         226   unary_op !               
         227   pop_jump_if_false -104   (to 123)
 
@@ -3100,7 +3100,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         6     store_var 4              (_3)
         7     load_type 1              
         8     load_var 4               (_3)
-        9     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 5              (_4)
         11    load_var 5               (_4)
         12    is_type 2                
@@ -3144,16 +3144,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         50    load_type 1              
         51    load_type 12             
         52    load_var 5               (_4)
-        53    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 6              (_6)
         55    jump +50                 (to 105)
         56    load_var 5               (_4)
-        57    make_bound_method 496    
+        57    make_bound_method 498    
         58    call_indirect            
         59    store_var 6              (_6)
         60    jump +45                 (to 105)
         61    load_var 5               (_4)
-        62    make_bound_method 505    
+        62    make_bound_method 507    
         63    call_indirect            
         64    store_var 6              (_6)
         65    jump +40                 (to 105)
@@ -3161,39 +3161,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         67    load_type 12             
         68    load_type 12             
         69    load_var 5               (_4)
-        70    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 6              (_6)
         72    jump +33                 (to 105)
         73    load_var 5               (_4)
-        74    make_bound_method 457    
+        74    make_bound_method 459    
         75    call_indirect            
         76    store_var 6              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 5               (_4)
-        80    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 6              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 5               (_4)
-        87    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 6              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 5               (_4)
-        93    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 6              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 5               (_4)
-        98    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 6              (_6)
         100   jump +5                  (to 105)
         101   load_var 5               (_4)
-        102   make_bound_method 484    
+        102   make_bound_method 486    
         103   call_indirect            
         104   store_var 6              (_6)
         105   load_var 6               (_6)
@@ -3215,7 +3215,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         119   store_var 8              (_38)
         120   load_type 14             
         121   load_var 8               (_38)
-        122   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        122   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         123   store_var 9              (_39)
         124   load_var 9               (_39)
         125   is_type 15               
@@ -3259,16 +3259,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         163   load_type 14             
         164   load_type 12             
         165   load_var 9               (_39)
-        166   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        166   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         167   store_var 10             (_41)
         168   jump +50                 (to 218)
         169   load_var 9               (_39)
-        170   make_bound_method 496    
+        170   make_bound_method 498    
         171   call_indirect            
         172   store_var 10             (_41)
         173   jump +45                 (to 218)
         174   load_var 9               (_39)
-        175   make_bound_method 505    
+        175   make_bound_method 507    
         176   call_indirect            
         177   store_var 10             (_41)
         178   jump +40                 (to 218)
@@ -3276,39 +3276,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         180   load_type 12             
         181   load_type 12             
         182   load_var 9               (_39)
-        183   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        183   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         184   store_var 10             (_41)
         185   jump +33                 (to 218)
         186   load_var 9               (_39)
-        187   make_bound_method 457    
+        187   make_bound_method 459    
         188   call_indirect            
         189   store_var 10             (_41)
         190   jump +28                 (to 218)
         191   load_type 14             
         192   load_var 9               (_39)
-        193   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        193   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         194   store_var 10             (_41)
         195   jump +23                 (to 218)
         196   load_type 14             
         197   load_type 12             
         198   load_type 12             
         199   load_var 9               (_39)
-        200   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        200   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         201   store_var 10             (_41)
         202   jump +16                 (to 218)
         203   load_type 14             
         204   load_type 12             
         205   load_var 9               (_39)
-        206   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        206   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         207   store_var 10             (_41)
         208   jump +10                 (to 218)
         209   load_type 14             
         210   load_var 9               (_39)
-        211   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        211   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         212   store_var 10             (_41)
         213   jump +5                  (to 218)
         214   load_var 9               (_39)
-        215   make_bound_method 484    
+        215   make_bound_method 486    
         216   call_indirect            
         217   store_var 10             (_41)
         218   load_var 10              (_41)
@@ -3319,11 +3319,11 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         223   store_var 11             (ts)
 
   567   224   load_var2 1 11           
-        225   call 717 ntypeargs=0     (testing.collect_subtree_names)
+        225   call 719 ntypeargs=0     (testing.collect_subtree_names)
         226   store_var 12             (_71)
         227   load_type 0              
         228   load_var 12              (_71)
-        229   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        229   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         230   store_var 13             (_73)
         231   load_var 13              (_73)
         232   is_type 25               
@@ -3367,16 +3367,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         270   load_type 0              
         271   load_type 12             
         272   load_var 13              (_73)
-        273   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        273   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         274   store_var 14             (_75)
         275   jump +50                 (to 325)
         276   load_var 13              (_73)
-        277   make_bound_method 496    
+        277   make_bound_method 498    
         278   call_indirect            
         279   store_var 14             (_75)
         280   jump +45                 (to 325)
         281   load_var 13              (_73)
-        282   make_bound_method 505    
+        282   make_bound_method 507    
         283   call_indirect            
         284   store_var 14             (_75)
         285   jump +40                 (to 325)
@@ -3384,39 +3384,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         287   load_type 12             
         288   load_type 12             
         289   load_var 13              (_73)
-        290   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        290   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         291   store_var 14             (_75)
         292   jump +33                 (to 325)
         293   load_var 13              (_73)
-        294   make_bound_method 457    
+        294   make_bound_method 459    
         295   call_indirect            
         296   store_var 14             (_75)
         297   jump +28                 (to 325)
         298   load_type 0              
         299   load_var 13              (_73)
-        300   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        300   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         301   store_var 14             (_75)
         302   jump +23                 (to 325)
         303   load_type 0              
         304   load_type 12             
         305   load_type 12             
         306   load_var 13              (_73)
-        307   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        307   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         308   store_var 14             (_75)
         309   jump +16                 (to 325)
         310   load_type 0              
         311   load_type 12             
         312   load_var 13              (_73)
-        313   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        313   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         314   store_var 14             (_75)
         315   jump +10                 (to 325)
         316   load_type 0              
         317   load_var 13              (_73)
-        318   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        318   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         319   store_var 14             (_75)
         320   jump +5                  (to 325)
         321   load_var 13              (_73)
-        322   make_bound_method 484    
+        322   make_bound_method 486    
         323   call_indirect            
         324   store_var 14             (_75)
         325   load_var 14              (_75)
@@ -3440,8 +3440,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 716 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 700 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 718 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 702 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +19               (to 22)
         4    load_var 3             (e)
         5    type_tag               
@@ -3482,7 +3482,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   602   8     load_type 1              
         9     load_var 1               (results)
-        10    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        10    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         11    store_var 7              (_7)
         12    load_var 7               (_7)
         13    is_type 2                
@@ -3526,16 +3526,16 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         51    load_type 1              
         52    load_type 12             
         53    load_var 7               (_7)
-        54    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        54    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         55    store_var 8              (_9)
         56    jump +50                 (to 106)
         57    load_var 7               (_7)
-        58    make_bound_method 496    
+        58    make_bound_method 498    
         59    call_indirect            
         60    store_var 8              (_9)
         61    jump +45                 (to 106)
         62    load_var 7               (_7)
-        63    make_bound_method 505    
+        63    make_bound_method 507    
         64    call_indirect            
         65    store_var 8              (_9)
         66    jump +40                 (to 106)
@@ -3543,39 +3543,39 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         68    load_type 12             
         69    load_type 12             
         70    load_var 7               (_7)
-        71    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        71    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         72    store_var 8              (_9)
         73    jump +33                 (to 106)
         74    load_var 7               (_7)
-        75    make_bound_method 457    
+        75    make_bound_method 459    
         76    call_indirect            
         77    store_var 8              (_9)
         78    jump +28                 (to 106)
         79    load_type 1              
         80    load_var 7               (_7)
-        81    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        81    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         82    store_var 8              (_9)
         83    jump +23                 (to 106)
         84    load_type 1              
         85    load_type 12             
         86    load_type 12             
         87    load_var 7               (_7)
-        88    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        88    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         89    store_var 8              (_9)
         90    jump +16                 (to 106)
         91    load_type 1              
         92    load_type 12             
         93    load_var 7               (_7)
-        94    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        94    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         95    store_var 8              (_9)
         96    jump +10                 (to 106)
         97    load_type 1              
         98    load_var 7               (_7)
-        99    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        99    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         100   store_var 8              (_9)
         101   jump +5                  (to 106)
         102   load_var 7               (_7)
-        103   make_bound_method 484    
+        103   make_bound_method 486    
         104   call_indirect            
         105   store_var 8              (_9)
         106   load_var 8               (_9)
@@ -3599,7 +3599,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         122   load_var 12              (tsr)
         123   load_field 0             (outcome)
         124   load_const 15            ("pass")
-        125   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        125   call 678 ntypeargs=0     (baml.ops.equals_equals)
         126   store_var 13             (ft)
 
   615   127   load_var 12              (tsr)
@@ -3641,7 +3641,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   157   load_var 12              (tsr)
         158   load_field 5             (results)
         159   load_var 13              (ft)
-        160   call 702 ntypeargs=0     (testing.count_leaves)
+        160   call 704 ntypeargs=0     (testing.count_leaves)
         161   store_var 10             (delta)
         162   jump +31                 (to 193)
 
@@ -3650,7 +3650,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   605   165   load_field 0             (outcome)
         166   load_const 16            ("pass")
-        167   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        167   call 678 ntypeargs=0     (baml.ops.equals_equals)
         168   pop_jump_if_false +2     (to 170)
         169   jump +18                 (to 187)
 
@@ -3740,7 +3740,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 710 ntypeargs=0   (testing.glob_match)
+        6   call 712 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -3751,7 +3751,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   637   0    load_var 1             (report)
         1    load_field 0           (outcome)
         2    load_const 0           ("pass")
-        3    call 676 ntypeargs=0   (baml.ops.equals_equals)
+        3    call 678 ntypeargs=0   (baml.ops.equals_equals)
         4    store_var 2            (top_tolerated)
 
   638   5    load_var 1             (report)
@@ -3793,7 +3793,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   35   load_var 1             (report)
         36   load_field 5           (results)
         37   load_var 2             (top_tolerated)
-        38   call 702 ntypeargs=0   (testing.count_leaves)
+        38   call 704 ntypeargs=0   (testing.count_leaves)
         39   store_var 3            (counts)
 
   645   40   load_type 2            
@@ -3803,7 +3803,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   43   load_var 1             (report)
         44   load_field 5           (results)
         45   load_var 4             (messages)
-        46   call 705 ntypeargs=0   (testing.collect_leaf_messages)
+        46   call 707 ntypeargs=0   (testing.collect_leaf_messages)
         47   pop 1                  
 
   648   48   load_var 1             (report)
@@ -3914,7 +3914,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
         66    load_var 8              (end_limit)
         67    call 156 ntypeargs=0    (baml.String.substring)
         68    load_var 13             (part)
-        69    call 165 ntypeargs=0    (baml.String.index_of)
+        69    call 166 ntypeargs=0    (baml.String.index_of)
         70    store_var 14            (_38)
         71    load_var 14             (_38)
         72    is_type 2               
@@ -3958,14 +3958,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 722 ntypeargs=0   (testing.split_top)
+        1    call 724 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 724 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 726 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +15               (to 24)
 
@@ -3980,7 +3980,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         17   load_field 0           (head)
         18   load_var 4             (split)
         19   load_field 1           (tail)
-        20   call 724 ntypeargs=0   (testing.any_pattern_matches)
+        20   call 726 ntypeargs=0   (testing.any_pattern_matches)
         21   jump +4                (to 25)
 
   541   22   load_const 1           (true)
@@ -3997,7 +3997,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
 
   475   3     load_type 1              
         4     load_var 1               (raw)
-        5     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        5     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 4              (_3)
         7     load_var 4               (_3)
         8     is_type 2                
@@ -4041,16 +4041,16 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         46    load_type 1              
         47    load_type 12             
         48    load_var 4               (_3)
-        49    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        49    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         50    store_var 5              (_5)
         51    jump +50                 (to 101)
         52    load_var 4               (_3)
-        53    make_bound_method 496    
+        53    make_bound_method 498    
         54    call_indirect            
         55    store_var 5              (_5)
         56    jump +45                 (to 101)
         57    load_var 4               (_3)
-        58    make_bound_method 505    
+        58    make_bound_method 507    
         59    call_indirect            
         60    store_var 5              (_5)
         61    jump +40                 (to 101)
@@ -4058,39 +4058,39 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         63    load_type 12             
         64    load_type 12             
         65    load_var 4               (_3)
-        66    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        66    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         67    store_var 5              (_5)
         68    jump +33                 (to 101)
         69    load_var 4               (_3)
-        70    make_bound_method 457    
+        70    make_bound_method 459    
         71    call_indirect            
         72    store_var 5              (_5)
         73    jump +28                 (to 101)
         74    load_type 1              
         75    load_var 4               (_3)
-        76    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        76    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         77    store_var 5              (_5)
         78    jump +23                 (to 101)
         79    load_type 1              
         80    load_type 12             
         81    load_type 12             
         82    load_var 4               (_3)
-        83    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        83    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         84    store_var 5              (_5)
         85    jump +16                 (to 101)
         86    load_type 1              
         87    load_type 12             
         88    load_var 4               (_3)
-        89    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        89    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         90    store_var 5              (_5)
         91    jump +10                 (to 101)
         92    load_type 1              
         93    load_var 4               (_3)
-        94    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        94    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         95    store_var 5              (_5)
         96    jump +5                  (to 101)
         97    load_var 4               (_3)
-        98    make_bound_method 484    
+        98    make_bound_method 486    
         99    call_indirect            
         100   store_var 5              (_5)
         101   load_var 5               (_5)
@@ -4102,7 +4102,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
 
   476   107   load_var 6               (s)
         108   load_const 14            ("::")
-        109   call 165 ntypeargs=0     (baml.String.index_of)
+        109   call 166 ntypeargs=0     (baml.String.index_of)
         110   store_var 7              (_36)
         111   load_var 7               (_36)
         112   is_type 15               
@@ -4165,7 +4165,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
 
   369   6     load_type 1             
         7     load_var 1              (children)
-        8     call 469 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
+        8     call 471 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
         9     store_var 3             (_3)
         10    load_var 3              (_3)
         11    is_type 2               
@@ -4209,16 +4209,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         49    load_type 1             
         50    load_type 12            
         51    load_var 3              (_3)
-        52    call 472 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
+        52    call 474 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
         53    store_var 4             (_5)
         54    jump +50                (to 104)
         55    load_var 3              (_3)
-        56    make_bound_method 496   
+        56    make_bound_method 498   
         57    call_indirect           
         58    store_var 4             (_5)
         59    jump +45                (to 104)
         60    load_var 3              (_3)
-        61    make_bound_method 505   
+        61    make_bound_method 507   
         62    call_indirect           
         63    store_var 4             (_5)
         64    jump +40                (to 104)
@@ -4226,39 +4226,39 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         66    load_type 12            
         67    load_type 12            
         68    load_var 3              (_3)
-        69    call 448 ntypeargs=3    (baml.iter.Filter.Iterator.next)
+        69    call 450 ntypeargs=3    (baml.iter.Filter.Iterator.next)
         70    store_var 4             (_5)
         71    jump +33                (to 104)
         72    load_var 3              (_3)
-        73    make_bound_method 457   
+        73    make_bound_method 459   
         74    call_indirect           
         75    store_var 4             (_5)
         76    jump +28                (to 104)
         77    load_type 1             
         78    load_var 3              (_3)
-        79    call 468 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
+        79    call 470 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
         80    store_var 4             (_5)
         81    jump +23                (to 104)
         82    load_type 1             
         83    load_type 12            
         84    load_type 12            
         85    load_var 3              (_3)
-        86    call 450 ntypeargs=3    (baml.iter.Chain.Iterator.next)
+        86    call 452 ntypeargs=3    (baml.iter.Chain.Iterator.next)
         87    store_var 4             (_5)
         88    jump +16                (to 104)
         89    load_type 1             
         90    load_type 12            
         91    load_var 3              (_3)
-        92    call 460 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
+        92    call 462 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
         93    store_var 4             (_5)
         94    jump +10                (to 104)
         95    load_type 1             
         96    load_var 3              (_3)
-        97    call 492 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
+        97    call 494 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
         98    store_var 4             (_5)
         99    jump +5                 (to 104)
         100   load_var 3              (_3)
-        101   make_bound_method 484   
+        101   make_bound_method 486   
         102   call_indirect           
         103   store_var 4             (_5)
         104   load_var 4              (_5)
@@ -4272,7 +4272,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         112   store_deref 5           
 
   370   113   load_var 5              (child)
-        114   make_closure 1225 1     
+        114   make_closure 1227 1     
         115   load_const 14           (null)
         116   load_const 14           (null)
         117   spawn                   
@@ -4285,16 +4285,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   374   123   load_type 15            
         124   load_type 16            
         125   load_var 2              (futures)
-        126   call 515 ntypeargs=2    (baml.future.all_complete)
+        126   call 517 ntypeargs=2    (baml.future.all_complete)
         127   await                   
         128   jump +5                 (to 133)
         129   load_var 7              (e)
         130   throw_if_panic          
 
   375   131   load_const 17           ("unexpected test child failure")
-        132   call 235 ntypeargs=0    (baml.sys.panic)
+        132   call 237 ntypeargs=0    (baml.sys.panic)
 
-  377   133   call 696 ntypeargs=0    (testing.aggregate_reports)
+  377   133   call 698 ntypeargs=0    (testing.aggregate_reports)
         134   return                  
         135   unreachable             
 }
@@ -4306,7 +4306,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
 
   108   3     load_type 1              
         4     load_var 1               (children)
-        5     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        5     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 4              (_4)
         7     load_var 4               (_4)
         8     is_type 2                
@@ -4350,16 +4350,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         46    load_type 1              
         47    load_type 12             
         48    load_var 4               (_4)
-        49    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        49    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         50    store_var 5              (_6)
         51    jump +50                 (to 101)
         52    load_var 4               (_4)
-        53    make_bound_method 496    
+        53    make_bound_method 498    
         54    call_indirect            
         55    store_var 5              (_6)
         56    jump +45                 (to 101)
         57    load_var 4               (_4)
-        58    make_bound_method 505    
+        58    make_bound_method 507    
         59    call_indirect            
         60    store_var 5              (_6)
         61    jump +40                 (to 101)
@@ -4367,39 +4367,39 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         63    load_type 12             
         64    load_type 12             
         65    load_var 4               (_4)
-        66    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        66    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         67    store_var 5              (_6)
         68    jump +33                 (to 101)
         69    load_var 4               (_4)
-        70    make_bound_method 457    
+        70    make_bound_method 459    
         71    call_indirect            
         72    store_var 5              (_6)
         73    jump +28                 (to 101)
         74    load_type 1              
         75    load_var 4               (_4)
-        76    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        76    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         77    store_var 5              (_6)
         78    jump +23                 (to 101)
         79    load_type 1              
         80    load_type 12             
         81    load_type 12             
         82    load_var 4               (_4)
-        83    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        83    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         84    store_var 5              (_6)
         85    jump +16                 (to 101)
         86    load_type 1              
         87    load_type 12             
         88    load_var 4               (_4)
-        89    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        89    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         90    store_var 5              (_6)
         91    jump +10                 (to 101)
         92    load_type 1              
         93    load_var 4               (_4)
-        94    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        94    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         95    store_var 5              (_6)
         96    jump +5                  (to 101)
         97    load_var 4               (_4)
-        98    make_bound_method 484    
+        98    make_bound_method 486    
         99    call_indirect            
         100   store_var 5              (_6)
         101   load_var 5               (_6)
@@ -4444,16 +4444,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         133   pop 1                    
         134   load_var 8               (outcome)
         135   load_const 15            ("pass")
-        136   call 676 ntypeargs=0     (baml.ops.equals_equals)
+        136   call 678 ntypeargs=0     (baml.ops.equals_equals)
         137   unary_op !               
         138   pop_jump_if_false -131   (to 7)
 
   116   139   load_var 3               (named_results)
-        140   call 696 ntypeargs=0     (testing.aggregate_reports)
+        140   call 698 ntypeargs=0     (testing.aggregate_reports)
         141   jump +3                  (to 144)
 
   121   142   load_var 3               (named_results)
-        143   call 696 ntypeargs=0     (testing.aggregate_reports)
+        143   call 698 ntypeargs=0     (testing.aggregate_reports)
         144   return                   
         145   unreachable              
 }
@@ -4464,7 +4464,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1261 1    
+        4    make_closure 1263 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -4500,17 +4500,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   418   10   load_var 1             (children)
-        11   call 709 ntypeargs=0   (testing.run_children_parallel)
+        11   call 711 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0     load_var 2               (include)
-        1     call 697 ntypeargs=0     (testing.parse_filter_patterns)
+        1     call 699 ntypeargs=0     (testing.parse_filter_patterns)
         2     store_var 5              (inc)
 
   550   3     load_var 3               (exclude)
-        4     call 697 ntypeargs=0     (testing.parse_filter_patterns)
+        4     call 699 ntypeargs=0     (testing.parse_filter_patterns)
         5     store_var 6              (exc)
 
   551   6     load_type 0              
@@ -4518,11 +4518,11 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8     store_var 7              (out)
 
   552   9     load_var 1               (registry)
-        10    call 700 ntypeargs=0     (testing.collect_leaf_names)
+        10    call 702 ntypeargs=0     (testing.collect_leaf_names)
         11    store_var 8              (_7)
         12    load_type 0              
         13    load_var 8               (_7)
-        14    call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        14    call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         15    store_var 9              (_8)
         16    load_var 9               (_8)
         17    is_type 1                
@@ -4566,16 +4566,16 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         55    load_type 0              
         56    load_type 11             
         57    load_var 9               (_8)
-        58    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        58    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         59    store_var 10             (_10)
         60    jump +50                 (to 110)
         61    load_var 9               (_8)
-        62    make_bound_method 496    
+        62    make_bound_method 498    
         63    call_indirect            
         64    store_var 10             (_10)
         65    jump +45                 (to 110)
         66    load_var 9               (_8)
-        67    make_bound_method 505    
+        67    make_bound_method 507    
         68    call_indirect            
         69    store_var 10             (_10)
         70    jump +40                 (to 110)
@@ -4583,39 +4583,39 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         72    load_type 11             
         73    load_type 11             
         74    load_var 9               (_8)
-        75    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        75    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         76    store_var 10             (_10)
         77    jump +33                 (to 110)
         78    load_var 9               (_8)
-        79    make_bound_method 457    
+        79    make_bound_method 459    
         80    call_indirect            
         81    store_var 10             (_10)
         82    jump +28                 (to 110)
         83    load_type 0              
         84    load_var 9               (_8)
-        85    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        85    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         86    store_var 10             (_10)
         87    jump +23                 (to 110)
         88    load_type 0              
         89    load_type 11             
         90    load_type 11             
         91    load_var 9               (_8)
-        92    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        92    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         93    store_var 10             (_10)
         94    jump +16                 (to 110)
         95    load_type 0              
         96    load_type 11             
         97    load_var 9               (_8)
-        98    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        98    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         99    store_var 10             (_10)
         100   jump +10                 (to 110)
         101   load_type 0              
         102   load_var 9               (_8)
-        103   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        103   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         104   store_var 10             (_10)
         105   jump +5                  (to 110)
         106   load_var 9               (_8)
-        107   make_bound_method 484    
+        107   make_bound_method 486    
         108   call_indirect            
         109   store_var 10             (_10)
         110   load_var 10              (_10)
@@ -4626,7 +4626,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         115   store_var_load_var 11    (name)
 
   553   116   load_var2 5 6            
-        117   call 725 ntypeargs=0     (testing.leaf_selected)
+        117   call 727 ntypeargs=0     (testing.leaf_selected)
         118   pop_jump_if_false -102   (to 16)
 
   554   119   load_var2 7 11           
@@ -4644,7 +4644,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
 function testing.split_top(path: string) -> testing.NameSplit {
   463   0    load_var 1             (path)
         1    load_const 0           ("/")
-        2    call 165 ntypeargs=0   (baml.String.index_of)
+        2    call 166 ntypeargs=0   (baml.String.index_of)
         3    store_var 2            (_2)
         4    load_var 2             (_2)
         5    is_type 1              
@@ -4686,7 +4686,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1238 2   
+        8    make_closure 1240 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -4705,7 +4705,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1252 2   
+        9    make_closure 1254 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -4728,7 +4728,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1265 3   
+        13   make_closure 1267 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -4746,7 +4746,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         6     store_var 4              (_3)
         7     load_type 1              
         8     load_var 4               (_3)
-        9     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 5              (_4)
         11    load_var 5               (_4)
         12    is_type 2                
@@ -4790,16 +4790,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         50    load_type 1              
         51    load_type 12             
         52    load_var 5               (_4)
-        53    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 6              (_6)
         55    jump +50                 (to 105)
         56    load_var 5               (_4)
-        57    make_bound_method 496    
+        57    make_bound_method 498    
         58    call_indirect            
         59    store_var 6              (_6)
         60    jump +45                 (to 105)
         61    load_var 5               (_4)
-        62    make_bound_method 505    
+        62    make_bound_method 507    
         63    call_indirect            
         64    store_var 6              (_6)
         65    jump +40                 (to 105)
@@ -4807,39 +4807,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         67    load_type 12             
         68    load_type 12             
         69    load_var 5               (_4)
-        70    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 6              (_6)
         72    jump +33                 (to 105)
         73    load_var 5               (_4)
-        74    make_bound_method 457    
+        74    make_bound_method 459    
         75    call_indirect            
         76    store_var 6              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 5               (_4)
-        80    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 6              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 5               (_4)
-        87    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 6              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 5               (_4)
-        93    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 6              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 5               (_4)
-        98    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 6              (_6)
         100   jump +5                  (to 105)
         101   load_var 5               (_4)
-        102   make_bound_method 484    
+        102   make_bound_method 486    
         103   call_indirect            
         104   store_var 6              (_6)
         105   load_var 6               (_6)
@@ -4854,7 +4854,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         113   load_field 1             (body)
         114   load_var 7               (t)
         115   load_field 2             (runner)
-        116   call 715 ntypeargs=0     (testing.test_child)
+        116   call 717 ntypeargs=0     (testing.test_child)
         117   store_var 8              (_37)
         118   load_var2 3 8            
         119   call 9 ntypeargs=0       (baml.Array.push)
@@ -4867,7 +4867,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         125   store_var 9              (_41)
         126   load_type 14             
         127   load_var 9               (_41)
-        128   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        128   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         129   store_var 10             (_42)
         130   load_var 10              (_42)
         131   is_type 15               
@@ -4911,16 +4911,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         169   load_type 14             
         170   load_type 12             
         171   load_var 10              (_42)
-        172   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        172   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         173   store_var 11             (_44)
         174   jump +50                 (to 224)
         175   load_var 10              (_42)
-        176   make_bound_method 496    
+        176   make_bound_method 498    
         177   call_indirect            
         178   store_var 11             (_44)
         179   jump +45                 (to 224)
         180   load_var 10              (_42)
-        181   make_bound_method 505    
+        181   make_bound_method 507    
         182   call_indirect            
         183   store_var 11             (_44)
         184   jump +40                 (to 224)
@@ -4928,39 +4928,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         186   load_type 12             
         187   load_type 12             
         188   load_var 10              (_42)
-        189   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        189   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         190   store_var 11             (_44)
         191   jump +33                 (to 224)
         192   load_var 10              (_42)
-        193   make_bound_method 457    
+        193   make_bound_method 459    
         194   call_indirect            
         195   store_var 11             (_44)
         196   jump +28                 (to 224)
         197   load_type 14             
         198   load_var 10              (_42)
-        199   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        199   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         200   store_var 11             (_44)
         201   jump +23                 (to 224)
         202   load_type 14             
         203   load_type 12             
         204   load_type 12             
         205   load_var 10              (_42)
-        206   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        206   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         207   store_var 11             (_44)
         208   jump +16                 (to 224)
         209   load_type 14             
         210   load_type 12             
         211   load_var 10              (_42)
-        212   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        212   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         213   store_var 11             (_44)
         214   jump +10                 (to 224)
         215   load_type 14             
         216   load_var 10              (_42)
-        217   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        217   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         218   store_var 11             (_44)
         219   jump +5                  (to 224)
         220   load_var 10              (_42)
-        221   make_bound_method 484    
+        221   make_bound_method 486    
         222   call_indirect            
         223   store_var 11             (_44)
         224   load_var 11              (_44)
@@ -4971,7 +4971,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         229   store_var 12             (ts)
 
   238   230   load_var2 1 12           
-        231   call 723 ntypeargs=0     (testing.testset_child)
+        231   call 725 ntypeargs=0     (testing.testset_child)
         232   store_var 13             (_75)
         233   load_var2 3 13           
         234   call 9 ntypeargs=0       (baml.Array.push)
@@ -4996,7 +4996,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         6     store_var 5              (_4)
         7     load_type 1              
         8     load_var 5               (_4)
-        9     call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 6              (_5)
         11    load_var 6               (_5)
         12    is_type 2                
@@ -5040,16 +5040,16 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         50    load_type 1              
         51    load_type 12             
         52    load_var 6               (_5)
-        53    call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 7              (_7)
         55    jump +50                 (to 105)
         56    load_var 6               (_5)
-        57    make_bound_method 496    
+        57    make_bound_method 498    
         58    call_indirect            
         59    store_var 7              (_7)
         60    jump +45                 (to 105)
         61    load_var 6               (_5)
-        62    make_bound_method 505    
+        62    make_bound_method 507    
         63    call_indirect            
         64    store_var 7              (_7)
         65    jump +40                 (to 105)
@@ -5057,39 +5057,39 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         67    load_type 12             
         68    load_type 12             
         69    load_var 6               (_5)
-        70    call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 7              (_7)
         72    jump +33                 (to 105)
         73    load_var 6               (_5)
-        74    make_bound_method 457    
+        74    make_bound_method 459    
         75    call_indirect            
         76    store_var 7              (_7)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 6               (_5)
-        80    call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 7              (_7)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 6               (_5)
-        87    call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 7              (_7)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 6               (_5)
-        93    call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 7              (_7)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 6               (_5)
-        98    call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 7              (_7)
         100   jump +5                  (to 105)
         101   load_var 6               (_5)
-        102   make_bound_method 484    
+        102   make_bound_method 486    
         103   call_indirect            
         104   store_var 7              (_7)
         105   load_var 7               (_7)
@@ -5101,7 +5101,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   111   load_field 0             (name)
         112   load_var 2               (names)
-        113   call 719 ntypeargs=0     (testing._name_selected)
+        113   call 721 ntypeargs=0     (testing._name_selected)
         114   pop_jump_if_false -103   (to 11)
 
   247   115   load_var 8               (t)
@@ -5110,7 +5110,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         118   load_field 1             (body)
         119   load_var 8               (t)
         120   load_field 2             (runner)
-        121   call 715 ntypeargs=0     (testing.test_child)
+        121   call 717 ntypeargs=0     (testing.test_child)
         122   store_var 9              (_40)
         123   load_var2 4 9            
         124   call 9 ntypeargs=0       (baml.Array.push)
@@ -5123,7 +5123,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         130   store_var 10             (_44)
         131   load_type 14             
         132   load_var 10              (_44)
-        133   call 469 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        133   call 471 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         134   store_var 11             (_45)
         135   load_var 11              (_45)
         136   is_type 15               
@@ -5167,16 +5167,16 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         174   load_type 14             
         175   load_type 12             
         176   load_var 11              (_45)
-        177   call 472 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        177   call 474 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         178   store_var 12             (_47)
         179   jump +50                 (to 229)
         180   load_var 11              (_45)
-        181   make_bound_method 496    
+        181   make_bound_method 498    
         182   call_indirect            
         183   store_var 12             (_47)
         184   jump +45                 (to 229)
         185   load_var 11              (_45)
-        186   make_bound_method 505    
+        186   make_bound_method 507    
         187   call_indirect            
         188   store_var 12             (_47)
         189   jump +40                 (to 229)
@@ -5184,39 +5184,39 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         191   load_type 12             
         192   load_type 12             
         193   load_var 11              (_45)
-        194   call 448 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        194   call 450 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         195   store_var 12             (_47)
         196   jump +33                 (to 229)
         197   load_var 11              (_45)
-        198   make_bound_method 457    
+        198   make_bound_method 459    
         199   call_indirect            
         200   store_var 12             (_47)
         201   jump +28                 (to 229)
         202   load_type 14             
         203   load_var 11              (_45)
-        204   call 468 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        204   call 470 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         205   store_var 12             (_47)
         206   jump +23                 (to 229)
         207   load_type 14             
         208   load_type 12             
         209   load_type 12             
         210   load_var 11              (_45)
-        211   call 450 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        211   call 452 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         212   store_var 12             (_47)
         213   jump +16                 (to 229)
         214   load_type 14             
         215   load_type 12             
         216   load_var 11              (_45)
-        217   call 460 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        217   call 462 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         218   store_var 12             (_47)
         219   jump +10                 (to 229)
         220   load_type 14             
         221   load_var 11              (_45)
-        222   call 492 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        222   call 494 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         223   store_var 12             (_47)
         224   jump +5                  (to 229)
         225   load_var 11              (_45)
-        226   make_bound_method 484    
+        226   make_bound_method 486    
         227   call_indirect            
         228   store_var 12             (_47)
         229   load_var 12              (_47)
@@ -5228,12 +5228,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   235   load_field 0             (name)
         236   load_var 2               (names)
-        237   call 701 ntypeargs=0     (testing._has_selected_descendant)
+        237   call 703 ntypeargs=0     (testing._has_selected_descendant)
         238   pop_jump_if_false -103   (to 135)
 
   259   239   load_var2 1 13           
         240   load_var 2               (names)
-        241   call 728 ntypeargs=0     (testing.testset_child_selected)
+        241   call 730 ntypeargs=0     (testing.testset_child_selected)
         242   store_var 14             (_80)
         243   load_var2 4 14           
         244   call 9 ntypeargs=0       (baml.Array.push)

--- a/baml_language/crates/bex_vm/src/package_baml/string.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/string.rs
@@ -145,6 +145,19 @@ impl BamlClassString for PackageBamlImpl {
             .ok_or_else(|| VmPanic::IndexOutOfBounds { index, length: len }.into())
     }
 
+    fn code_point_at(string: &BexStr, index: i64) -> Result<i64, VmRustFnError> {
+        // The numeric counterpart of `char_at`: same codepoint-indexing and
+        // bounds rules (negative counts from the end, out-of-range raises
+        // `IndexOutOfBounds`), but yields the code point's value rather than a
+        // one-character string. A `char` is always in `[0, 0x10FFFF]`, so the
+        // widening to `i64` is lossless.
+        let len = string.char_count();
+        resolve_index(index, len)
+            .and_then(|i| string.as_str().chars().nth(i))
+            .map(|c| i64::from(u32::from(c)))
+            .ok_or_else(|| VmPanic::IndexOutOfBounds { index, length: len }.into())
+    }
+
     fn repeat(string: &BexStr, count: i64) -> BexStr {
         let count = usize::try_from(count.max(0)).unwrap_or(0);
         string.repeat(count)
@@ -261,6 +274,16 @@ impl BamlClassString for PackageBamlImpl {
             }
             .into()
         })
+    }
+
+    fn to_code_points(string: &BexStr) -> Vec<Value> {
+        // The exact inverse of `from_code_points`: one `int` per character. Each
+        // `char` is in `[0, 0x10FFFF]`, so `Value::int` is always in range.
+        string
+            .as_str()
+            .chars()
+            .map(|c| Value::int(i64::from(u32::from(c))))
+            .collect()
     }
 
     fn from_code_points(unicode: &[Value]) -> Result<BexStr, VmRustFnError> {


### PR DESCRIPTION
## What

Adds two `String` methods to the BAML stdlib, closing the asymmetry where `from_code_points(int[]) -> string` (encode) shipped with no decode direction:

- **`code_point_at(index: int) -> int`** — the numeric counterpart of `char_at`. Same codepoint indexing and bounds rules (negative indices count from the end; out-of-range raises `IndexOutOfBounds`), but returns the code point's value instead of a one-character string. Mirrors JS `charCodeAt` / Python `ord`.
- **`to_code_points() -> int[]`** — the exact inverse of `from_code_points`: `from_code_points(s.to_code_points()) == s`.

Closes **B-238**.

## Why

Before this, mapping a character to its integer code point required a workaround:

```baml
let alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
let val = alphabet.index_of(s.char_at(i));  // -1 for chars not in alphabet
```

which silently returns `-1` for unexpected characters, only handles the listed alphabet, can't handle arbitrary Unicode, and is O(n) per character. Every mainstream language ships both directions (`ord`/`chr`, `charCodeAt`/`fromCharCode`); BAML only had the encode half.

## Reproduction (before)

```
$ baml check   # function f() -> int { "A".code_point_at(0) }
error: type `"A"` has no member `code_point_at`   (E0007)
```

## Implementation

- `baml_std/baml/string.baml`: declarations + docs. `code_point_at` is `//baml:fallible` (raises `IndexOutOfBounds`); `to_code_points` is infallible. The `BamlClassString` trait is regenerated automatically from these declarations.
- `bex_vm/.../package_baml/string.rs`: runtime impls. `code_point_at` reuses the same `resolve_index` path as `char_at`; the `char -> i64` widening is lossless. `to_code_points` returns one `int` per character (each in `[0, 0x10FFFF]`, always within `Value::int` range).

## Tests

14 new `test` blocks in `ns_strings/strings.baml` covering ASCII, multibyte, emoji/astral-plane, negative-from-end, at-length / past-end / past-start `IndexOutOfBounds`, empty string, and round-trips with `from_code_points`.

## Verification

- Full `baml_src` suite: **1963 passed**.
- `bex_vm` clippy clean; `cargo fmt` clean.
- All affected insta snapshots regenerated (stdlib HIR/MIR/codegen, describe, package items, bytecode) and re-run without `--accept` to confirm consistency. The bytecode index shifts are the expected uniform `+2` from adding two stdlib functions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Unicode-aware string APIs for retrieving a character’s code point by index and converting an entire string into a list of code points.
  * Supports negative indexing from the end and handles multi-byte characters, including emoji.
* **Tests**
  * Added coverage for ASCII, multi-byte, emoji, empty strings, negative indexes, out-of-bounds behavior, and round-trip conversion with code points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->