### PR TITLE
feat: make init set up more explicit generator blocks

### DIFF
--- a/baml_language/crates/baml_cli/src/init_command.rs
+++ b/baml_language/crates/baml_cli/src/init_command.rs
@@ -164,16 +164,37 @@ fn validate_project_name(name: &str) -> Result<()> {
 
 fn render_baml_toml(name: &str) -> String {
     format!(
-        "[package]\n\
-         name = \"{name}\"\n\
-         \n\
-         # [scripts]\n\
-         # dev = \"-f main\"\n\
-         \n\
-         # [generator.my_client]\n\
-         # output_type = \"python/pydantic\"\n\
-         # output_dir = \"../python\"\n\
-         # naming_convention = \"preserve-case\"\n",
+        r#"[package]
+name = "{name}"
+
+# [scripts]
+# dev = "-f main"
+
+# Uncomment this to generate the Python SDK.
+#
+# Note: you also need to install the BAML runtime bridge for Python:
+#   uv add baml_core
+#   pip install baml_core
+#   conda install -c conda-forge baml_core
+#
+# [generator.python_client]
+# output_type = "python/pydantic"
+# output_dir = "./baml_python"
+# naming_convention = "preserve-case"
+
+# Uncomment this to generate the Node SDK.
+#
+# Note: you also need to install the BAML runtime bridge for Node.js:
+#   npm install @boundaryml/baml-core-node
+#   pnpm add @boundaryml/baml-core-node
+#   yarn add @boundaryml/baml-core-node
+#   bun add @boundaryml/baml-core-node
+#
+# [generator.node_client]
+# output_type = "typescript/node"
+# output_dir = "./baml_ts"
+# naming_convention = "preserve-case"
+"#,
     )
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the default `baml.toml` starter content shown during project initialization with clearer guidance for generating Python and Node SDKs.
  * Revised the scaffold’s commented configuration and setup notes, replacing the previous generator example with more extensive, generator-specific guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->