### PR TITLE
[codex] Remove compile progress logs from BAML CLI

### DIFF
--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -243,11 +243,9 @@ impl PackArgs {
             self.load_project(reporter)?
         };
 
-        // One "Compiling N file(s)" line covers diagnostics + bytecode emit;
-        // file count is the meaningful unit (`self.from` is usually `.` and
-        // reads as noise). A separate "Checking" line just repeated the count.
-        let file_count = db.get_source_files().len();
-        reporter.spin("Compiling", format!("{file_count} file(s)"));
+        // Keep `baml pack` quiet during compilation. Its visible progress is
+        // packaging/downloading/output-oriented; compile/count status belongs
+        // to `check` and `generate`.
         check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
 
         let program = baml_compiler2_emit::generate_project_bytecode(

--- a/baml_language/crates/baml_cli/src/reporter.rs
+++ b/baml_language/crates/baml_cli/src/reporter.rs
@@ -1,16 +1,11 @@
-//! Cargo-style status reporter for `baml run` / `baml pack`.
+//! Cargo-style status reporter.
 //!
 //! Provides a [`Reporter`] that emits cargo-shaped status lines
-//! (`   Compiling 552 files`) and an inline spinner during long phases.
-//! When stderr isn't a TTY (CI, redirected to file, piped to `less`) the
-//! spinner is suppressed and each status update prints as a plain line —
-//! `console::style` auto-strips ANSI in that case, so no raw color codes
-//! end up in logs.
+//! (`   Compiling 552 files`). `console::style` auto-strips ANSI when
+//! stderr is not a TTY, so piped output stays plain.
 //!
 //! Verb formatting matches cargo: 12-char right-aligned, bold green for
-//! normal phases. Diagnostic output is routed through [`Reporter::suspend`]
-//! so the spinner pauses cleanly during multi-line ariadne dumps instead
-//! of getting interleaved with the source-snippet output.
+//! normal phases.
 
 // Status reporting is intrinsically `print*!` to stderr — that's the
 // whole job of this module. The workspace clippy ban exists to flag
@@ -18,10 +13,10 @@
 // inside `Reporter::status` / `spin` / `finish` / `warning`.
 #![allow(clippy::print_stderr)]
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use console::{Color, Style};
-use indicatif::{HumanDuration, ProgressBar, ProgressStyle};
+use indicatif::HumanDuration;
 
 /// Brand purple `#A855F7` for the cargo-style verb. Rendered via 24-bit
 /// truecolor ANSI (`\x1b[38;2;168;85;247m`) on terminals that support it;
@@ -41,56 +36,14 @@ fn verb_style() -> Style {
 pub use baml_exec::CLAP_STYLING;
 
 /// Cargo-style status reporter.
-///
-/// Holds either a real `indicatif` spinner (when stderr is a TTY) or
-/// nothing (when not), so the same API works in both modes.
 pub struct Reporter {
-    bar: Option<ProgressBar>,
     started: Instant,
 }
 
 impl Reporter {
-    /// Construct a reporter that auto-detects whether to render an
-    /// animated spinner based on stderr being a TTY.
+    /// Construct a reporter.
     pub fn new() -> Self {
-        use std::io::IsTerminal;
-        let bar = if std::io::stderr().is_terminal() {
-            let pb = ProgressBar::new_spinner();
-            #[rustfmt::skip]
-            pb.set_style(
-                ProgressStyle::with_template("{spinner} {wide_msg}")
-                    .expect("static template")
-                    .tick_strings(&[
-                        concat!("            ", "\n",
-                                "🐑   🚧   🐑"),
-                        concat!("            ", "\n",
-                                "     🚧  🐑 "),
-                        concat!("            ", "\n",
-                                "     🚧 🐑  "),
-                        concat!("            ", "\n",
-                                "     🚧🐑   "),
-                        concat!("     🐑      ", "\n",
-                                "     🚧     "),
-                        concat!("            ", "\n",
-                                "   🐑🚧     "),
-                        concat!("            ", "\n",
-                                "  🐑 🚧     "),
-                        concat!("            ", "\n",
-                                " 🐑  🚧     "),
-                        // final / resting
-                        "",
-                    ]),
-            );
-            // ~150ms/frame -> roughly one full walk-cycle every ~2.7s.
-            // Slow enough to read the lamb's position, fast enough to
-            // feel alive.
-            pb.enable_steady_tick(Duration::from_millis(150));
-            Some(pb)
-        } else {
-            None
-        };
         Self {
-            bar,
             started: Instant::now(),
         }
     }
@@ -99,49 +52,15 @@ impl Reporter {
     /// cargo's `   Compiling foo v0.1.0` shape.
     pub fn status(&self, verb: &str, msg: impl AsRef<str>) {
         let line = format_status(verb, msg.as_ref());
-        match &self.bar {
-            Some(b) => b.println(line),
-            None => eprintln!("{line}"),
-        }
+        eprintln!("{line}");
     }
 
-    /// Mark a new phase. Persists the phase line to scrollback (cargo
-    /// behavior — each `   Verb msg` stays in history once it scrolls
-    /// past) *and* updates the lamb spinner's inline message so the
-    /// bar reflects the current phase.
-    ///
-    /// Two formats for the two destinations:
-    ///   - `bar.println` gets the cargo-padded version (12-col
-    ///     right-aligned verb) so the persistent scrollback lines look
-    ///     identical to the piped/non-TTY output.
-    ///   - `bar.set_message` gets the inline (no padding) version
-    ///     because the 🐑 spinner already provides the visual left
-    ///     margin — stacking the 12-col cargo padding on top would put
-    ///     6+ blank cells between the lamb and the verb text.
-    ///
-    /// Non-TTY: single cargo-aligned `eprintln!` (only path; nothing
-    /// to update).
+    /// Mark a new phase with a persistent cargo-style line.
     pub fn spin(&self, verb: &str, msg: impl AsRef<str>) {
-        let msg = msg.as_ref();
-        match &self.bar {
-            Some(b) => {
-                b.println(format_status(verb, msg));
-                b.set_message(format_status_inline(verb, msg));
-            }
-            None => eprintln!("{}", format_status(verb, msg)),
-        }
+        eprintln!("{}", format_status(verb, msg.as_ref()));
     }
 
-    /// Stop the spinner and print a final cargo-style "Finished" line
-    /// with elapsed wall-clock time.
-    ///
-    /// Uses `println` + `finish_and_clear` rather than
-    /// `finish_with_message` so the Finished line lands in scrollback
-    /// the same way every other phase line does — no `{spinner}`
-    /// prefix from the bar's template, which would otherwise insert
-    /// the final tick string (+ a literal template space) ahead of the
-    /// 12-col cargo padding and shift the verb one column right
-    /// versus its peers above.
+    /// Print a final cargo-style "Finished" line with elapsed wall-clock time.
     pub fn finish(&self, verb: &str, msg: impl AsRef<str>) {
         // `{:#}` is `HumanDuration`'s alternate form — the compact
         // `5s` / `2m` / `1h` shape, matching cargo's `Finished` line.
@@ -149,31 +68,15 @@ impl Reporter {
         // wordy for a one-line status.
         let elapsed = HumanDuration(self.started.elapsed());
         let line = format!("{} in {elapsed:#}", format_status(verb, msg.as_ref()));
-        match &self.bar {
-            Some(b) => {
-                b.println(line);
-                b.finish_and_clear();
-            }
-            None => eprintln!("{line}"),
-        }
+        eprintln!("{line}");
     }
 
-    /// Stop the spinner without writing a status line. Use before
-    /// printing an error so the spinner doesn't get left animating.
-    pub fn abandon(&self) {
-        if let Some(b) = &self.bar {
-            b.finish_and_clear();
-        }
-    }
+    /// Preserve the old call shape for diagnostic/error paths.
+    pub fn abandon(&self) {}
 
-    /// Run `f` with the spinner paused so multi-line output (ariadne
-    /// diagnostic blocks, panic backtraces) can render cleanly. Returns
-    /// whatever `f` returns. A no-op when no spinner is active.
+    /// Run `f` and return whatever it returns.
     pub fn suspend<R>(&self, f: impl FnOnce() -> R) -> R {
-        match &self.bar {
-            Some(b) => b.suspend(f),
-            None => f(),
-        }
+        f()
     }
 }
 
@@ -194,15 +97,6 @@ fn format_status(verb: &str, msg: &str) -> String {
     format!("{styled} {msg}")
 }
 
-/// Inline (no-padding) verb formatting for spinner messages. Used when
-/// the 🐑 spinner already provides a visual left margin, so the cargo
-/// 12-col verb pad would just stack extra blank cells between the lamb
-/// and the verb text.
-fn format_status_inline(verb: &str, msg: &str) -> String {
-    let styled = verb_style().apply_to(verb);
-    format!("{styled} {msg}")
-}
-
 /// Re-exports of the shared `error:` / `warning:` printers (defined in
 /// `baml_exec::diag_print`). Lives in this module so callers across
 /// `baml_cli` keep importing `crate::reporter::print_error` etc., while
@@ -211,28 +105,19 @@ fn format_status_inline(verb: &str, msg: &str) -> String {
 pub use baml_exec::{print_anyhow_error, print_error, print_warning};
 
 impl Reporter {
-    /// Print an error through this reporter, abandoning the spinner
-    /// first so multi-line error output doesn't interleave with ticks.
+    /// Print an error through this reporter.
     pub fn error(&self, msg: impl std::fmt::Display) {
         self.abandon();
         print_error(msg);
     }
 
-    /// Print a warning that scrolls into the buffer *above* the active
-    /// spinner. Unlike [`Reporter::error`], the spinner keeps running
-    /// after the warning — warnings are advisories, not failures.
-    /// Falls back to a plain stderr write when no spinner is active.
-    /// Mirrors the formatting of [`print_warning`].
+    /// Print a warning. Mirrors the formatting of [`print_warning`].
     pub fn warning(&self, msg: impl std::fmt::Display) {
         let line = format!(
             "{}: {msg}",
             Style::new().yellow().bold().apply_to("warning")
         );
-        match &self.bar {
-            Some(b) => b.println(line),
-            #[allow(clippy::print_stderr)]
-            None => eprintln!("{line}"),
-        }
+        eprintln!("{line}");
     }
 }
 

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -200,9 +200,6 @@ impl RunArgs {
     /// Collect diagnostics on `db` and bail with `bail_context` if any are errors.
     /// Warnings are intentionally not surfaced by `baml run`: successful
     /// execution should print only the program output.
-    ///
-    /// Diagnostic output is routed through `reporter.suspend()` to preserve
-    /// the call shape used by the rest of the CLI.
     fn check_project_diagnostics(
         &self,
         db: &ProjectDatabase,

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -182,30 +182,27 @@ pub use baml_exec::OutputFormat;
 // ============================================================================
 
 impl RunArgs {
-    /// Emit the "your code is unformatted" advisory above the active
-    /// spinner. Routed through the reporter (rather than a raw
-    /// `eprintln!`) so the message both takes the bold-yellow
-    /// `warning:` header — matching ariadne — *and* doesn't interleave
-    /// with the spinner ticks that would otherwise still be running.
+    /// Emit the "your code is unformatted" advisory. This is the one
+    /// user-facing warning `baml run` keeps on successful execution.
     fn emit_format_hint_if_needed(reporter: &Reporter, needs_format_hint: bool) {
         if needs_format_hint {
             reporter.warning(FORMAT_HINT);
         }
     }
 
-    /// Print a `[verbose]`-prefixed line when `--verbose` is set; no-op otherwise.
+    /// Keep execution silent even when legacy call sites still pass
+    /// diagnostics-oriented strings through `vlog`. `--verbose` only affects
+    /// explicit listing output, not successful program execution.
     fn vlog(&self, args: std::fmt::Arguments<'_>) {
-        if self.verbose {
-            eprintln!("[verbose] {args}");
-        }
+        let _ = args;
     }
 
     /// Collect diagnostics on `db` and bail with `bail_context` if any are errors.
-    /// Warnings are surfaced only in verbose mode.
+    /// Warnings are intentionally not surfaced by `baml run`: successful
+    /// execution should print only the program output.
     ///
-    /// When a [`Reporter`] is active, diagnostic output is routed through
-    /// `reporter.suspend()` so the multi-line ariadne block doesn't
-    /// interleave with the spinner.
+    /// Diagnostic output is routed through `reporter.suspend()` to preserve
+    /// the call shape used by the rest of the CLI.
     fn check_project_diagnostics(
         &self,
         db: &ProjectDatabase,
@@ -222,12 +219,7 @@ impl RunArgs {
             .iter()
             .filter(|d| d.severity == Severity::Error)
             .collect();
-        let warnings: Vec<_> = diagnostics
-            .iter()
-            .filter(|d| d.severity == Severity::Warning)
-            .collect();
-
-        let needs_sources = !errors.is_empty() || (self.verbose && !warnings.is_empty());
+        let needs_sources = !errors.is_empty();
         let (sources, file_paths) = if needs_sources {
             let mut sources = HashMap::new();
             let mut file_paths = HashMap::new();
@@ -240,16 +232,6 @@ impl RunArgs {
         } else {
             (HashMap::new(), HashMap::new())
         };
-
-        if self.verbose && !warnings.is_empty() {
-            let rendered = render::render_diagnostics(
-                &warnings.iter().copied().cloned().collect::<Vec<_>>(),
-                &sources,
-                &file_paths,
-                &render::RenderConfig::cli_auto(),
-            );
-            reporter.suspend(|| eprintln!("{rendered}"));
-        }
 
         if !errors.is_empty() {
             let rendered = render::render_diagnostics(
@@ -280,8 +262,7 @@ impl RunArgs {
 
     pub fn run(&self) -> Result<crate::ExitCode> {
         // Short-circuit verb-level `--help` (no target / function /
-        // expression given) before constructing the Reporter, so the
-        // spinner doesn't briefly draw a frame above the help text.
+        // expression given) before constructing the Reporter.
         if self.help
             && self.functions.is_empty()
             && self.target.is_none()
@@ -429,8 +410,7 @@ impl RunArgs {
             let parsed = Self::parse_scripts(&content);
             (toml_path, content, parsed)
         };
-        let namespaces = collect_namespaces(&engine);
-        self.validate_scripts(&engine, &scripts, &namespaces, &toml_path, &toml_content)?;
+        self.validate_scripts(&engine, &scripts, &toml_path, &toml_content)?;
 
         // Resolve to (function_name, effective_args, was_script).
         let (function_name, effective_target_args, was_script) =
@@ -605,9 +585,8 @@ impl RunArgs {
         Ok((entries, lookups))
     }
 
-    /// Shared tail: spawn the runtime and run dispatch. Compilation already
-    /// emitted the final `Compiled … in <t>` line and cleared the spinner, so
-    /// the program runs silently — its own stdout is the output that matters.
+    /// Shared tail: spawn the runtime and run dispatch. The program runs
+    /// silently — its own stdout is the output that matters.
     fn dispatch_and_finish(
         &self,
         engine: BexEngine,
@@ -617,8 +596,7 @@ impl RunArgs {
         reporter: &Reporter,
     ) -> Result<crate::ExitCode> {
         self.vlog(format_args!("Calling {function_name}"));
-        // Belt-and-suspenders: the compile step already finished the spinner,
-        // but make sure nothing is left animating over the program's output.
+        // Preserve the old cleanup call shape before program output.
         reporter.abandon();
 
         let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
@@ -719,8 +697,7 @@ impl RunArgs {
         // Per-file `Loading <file>` progress is verbose-only — by default
         // the single `Compiling N file(s)` line below is the only progress a
         // run shows.
-        let (db, from, baml_files) =
-            load_project_for_build(self.from.as_deref(), reporter, self.verbose)?;
+        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), reporter, false)?;
         self.vlog(format_args!("Loading project from {}", from.display()));
         if baml_files.is_empty() {
             anyhow::bail!("No .baml files found in {}", from.display());
@@ -732,12 +709,8 @@ impl RunArgs {
                 .unwrap_or(false)
         });
 
-        // One verb covers the whole compile pipeline (diagnostics + bytecode
-        // emit); a separate "Checking" line was redundant — same file count,
-        // same wait. For `--list` nothing is executed, so "Resolving" is the
-        // honest verb (the emit only exists to enumerate signatures).
-        let compile_verb = if self.list { "Resolving" } else { "Compiling" };
-        reporter.spin(compile_verb, format!("{} file(s)", baml_files.len()));
+        // `baml run` keeps the compile phase silent; the program's output is
+        // the point. Compile/count progress belongs to `check` and `generate`.
         self.check_project_diagnostics(&db, "Cannot run: compilation errors found", reporter)?;
         self.vlog(format_args!("Compiling..."));
         let engine = self.compile_to_engine(&db, argv)?;
@@ -745,16 +718,6 @@ impl RunArgs {
             "Compiled {} user function(s)",
             engine.user_functions().len()
         ));
-        // Close out compilation with its elapsed time, then let the program
-        // run silently — its output is the point, not our status lines.
-        // `--list` has no program run to time, and `print_list` writes straight
-        // to stdout, so just clear the spinner to keep it from smearing over
-        // the listing.
-        if self.list {
-            reporter.abandon();
-        } else {
-            reporter.finish("Compiled", format!("{} file(s)", baml_files.len()));
-        }
         Ok((db, engine, needs_format_hint))
     }
 
@@ -786,10 +749,8 @@ impl RunArgs {
         db.set_project_root(parent);
         db.add_or_update_file(&canonical, &content);
 
-        // Single "Compiling" verb covers load + diagnostics + emit; see the
-        // note in `load_and_compile`. "Resolving" when --list is the target.
-        let compile_verb = if self.list { "Resolving" } else { "Compiling" };
-        reporter.spin(compile_verb, &display);
+        // Keep standalone compilation quiet for `baml run`; diagnostics still
+        // render through the reporter when needed.
         self.check_project_diagnostics(
             &db,
             &format!("Cannot run: compilation errors in {display}"),
@@ -800,13 +761,6 @@ impl RunArgs {
             "Compiled {} function(s) from standalone file",
             engine.user_functions().len()
         ));
-        // See `load_and_compile`: clear the spinner before `--list` output,
-        // otherwise finish with the elapsed-time line.
-        if self.list {
-            reporter.abandon();
-        } else {
-            reporter.finish("Compiled", &display);
-        }
         Ok((db, engine, needs_format_hint))
     }
 
@@ -823,7 +777,6 @@ impl RunArgs {
     /// from inline / `@file` / stdin by the caller. We avoid re-reading
     /// because `-e -` reads stdin once.
     fn run_expression(&self, expr_body: &str, reporter: &Reporter) -> Result<crate::ExitCode> {
-        reporter.spin("Compiling", "expression");
         self.vlog(format_args!(
             "Expression mode: evaluating {} byte(s)",
             expr_body.len()
@@ -863,10 +816,6 @@ impl RunArgs {
         // matches the inline case: `-e '2 + 2'` and `-e @file` (with
         // `file` containing `2 + 2`) produce the same argv.
         let engine = self.compile_to_engine(&db, self.build_argv_for_expression(expr_body))?;
-
-        // Close out compilation with its elapsed time and clear the spinner,
-        // then evaluate silently — the expression's value is the output.
-        reporter.finish("Compiled", "expression");
 
         let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
         let engine = Arc::new(engine);
@@ -914,21 +863,13 @@ impl RunArgs {
 
     /// Parse `[scripts]` from raw `baml.toml` content.
     ///
-    /// Emits a styled `Warning:` on TOML parse failures so a typo in
-    /// `baml.toml` doesn't silently disable every script. A missing
-    /// `baml.toml` (empty content) is normal and stays quiet. Routed
-    /// through `print_warning` so the bold-yellow `Warning:` prefix
-    /// matches every other advisory the CLI emits.
+    /// Parse failures leave the scripts map empty so a typo in `baml.toml`
+    /// does not block direct function execution. `baml run` stays quiet on
+    /// successful execution; validation errors are surfaced separately.
     fn parse_scripts(content: &str) -> HashMap<String, Vec<String>> {
-        let trimmed = content.trim();
         let manifest = match crate::manifest::parse(content) {
             Ok(m) => m,
-            Err(e) => {
-                if !trimmed.is_empty() {
-                    crate::reporter::print_warning(format_args!(
-                        "failed to parse `baml.toml` ({e}); [scripts] entries will be ignored"
-                    ));
-                }
+            Err(_e) => {
                 return HashMap::new();
             }
         };
@@ -985,7 +926,6 @@ impl RunArgs {
         &self,
         engine: &BexEngine,
         scripts: &HashMap<String, Vec<String>>,
-        namespaces: &HashSet<String>,
         toml_path: &Path,
         toml_content: &str,
     ) -> Result<()> {
@@ -1004,16 +944,6 @@ impl RunArgs {
                     "name is a reserved verb and cannot be used as a script name",
                 ));
                 continue;
-            }
-
-            if namespaces.contains(name) {
-                let loc = Self::find_script_line(toml_content, name)
-                    .map(|l| format!("{}:{l}", toml_path.display()))
-                    .unwrap_or_else(|| toml_path.display().to_string());
-                crate::reporter::print_warning(format_args!(
-                    "{loc}: [scripts] `{name}` shadows namespace `{name}` — \
-                     the script takes precedence"
-                ));
             }
 
             match parse_script_body(tokens) {
@@ -1535,8 +1465,7 @@ fn looks_like_path(target: &str) -> bool {
 
 /// Render a clap error and return the matching CLI exit code.
 /// Help / version requests render to stdout and exit success; all other
-/// kinds go to stderr with a non-zero exit. The spinner is abandoned
-/// first so the multi-line clap block lands cleanly above the cursor.
+/// kinds go to stderr with a non-zero exit.
 fn surface_clap_error(reporter: &Reporter, err: clap::Error) -> Result<crate::ExitCode> {
     use baml_exec::clap_reexport::ErrorKind;
     let kind = err.kind();

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -91,10 +91,8 @@ impl TestArgs {
             .ok_or_else(|| anyhow!("No project context"))?;
 
         // ── 2. Diagnostics ─────────────────────────────────────────────────
-        // One "Compiling" spinner stays up for the whole diagnostics +
-        // bytecode-build span below; a separate "Checking" line (or a second
-        // "Compiling") would just repeat the file count.
-        reporter.spin("Compiling", format!("{} file(s)", baml_files.len()));
+        // Keep `baml test` quiet during the compile phase. `baml check` and
+        // `baml generate` own the compile/count progress lines.
         let source_files = db.get_source_files();
         let diagnostics = baml_project::collect_diagnostics(&db, project, &source_files);
         let errors: Vec<_> = diagnostics
@@ -127,8 +125,6 @@ impl TestArgs {
         let legacy = discover_legacy_tests(&db, project);
 
         // ── 4. Compile + engine + runtime ──────────────────────────────────
-        // The "Compiling N file(s)" spinner from step 2 is still up — no need
-        // to re-issue it here.
         let compile_options = baml_compiler2_emit::CompileOptions {
             emit_test_cases: true,
         };

--- a/baml_language/crates/baml_cli/tests/common/mod.rs
+++ b/baml_language/crates/baml_cli/tests/common/mod.rs
@@ -155,3 +155,16 @@ pub fn write_project(dir: &std::path::Path, main_source: &str) {
     std::fs::create_dir_all(&src).unwrap();
     std::fs::write(src.join("main.baml"), main_source).unwrap();
 }
+
+pub fn assert_no_compile_file_status(stderr: &str) {
+    for line in stderr.lines() {
+        assert!(
+            !(line.contains("Compiling ") && line.contains(" file(s)")),
+            "unexpected compile file-count status in stderr:\n{stderr}"
+        );
+        assert!(
+            !(line.contains("Compiled ") && line.contains(" file(s)")),
+            "unexpected compiled file-count status in stderr:\n{stderr}"
+        );
+    }
+}

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -25,6 +25,7 @@ fn run_baml_cli(built: &BuiltPaths, dir: &Path, args: &[&str]) -> Output {
         cmd.arg(arg);
     }
     cmd.current_dir(dir);
+    cmd.env("BAML_CLI_ALLOW_DIRECT", "1");
     cmd.output().expect("spawn baml-cli")
 }
 
@@ -238,6 +239,10 @@ fn generate_valid_project_returns_zero_exit_code() {
         )),
         "Expected generate output to include CLI version, got: {stderr}",
     );
+    assert!(
+        stderr.contains("Compiling 1 file(s)"),
+        "`baml generate` should keep compile progress, got: {stderr}",
+    );
 }
 
 // ============================================================================
@@ -266,6 +271,60 @@ fn run_list_compilation_error_returns_nonzero_exit_code() {
         Some(4),
         "Expected exit code 4 for compilation error",
     );
+}
+
+/// `baml run` should only emit the program output for a formatted project.
+/// Compile progress remains reserved for `baml check` and `baml generate`.
+#[test]
+fn run_valid_project_outputs_only_program_output() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(tmp.path(), "function answer() -> int {\n    42\n}\n");
+
+    let output = run_baml_cli(built, tmp.path(), &["run", "answer", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for valid run, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("42"), "Expected run result, got:\n{stdout}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.trim().is_empty(),
+        "Expected empty stderr, got:\n{stderr}"
+    );
+}
+
+/// The formatter advisory is the allowed `baml run` stderr exception.
+#[test]
+fn run_unformatted_project_keeps_format_warning() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(tmp.path(), "function answer()->int {\n42\n}\n");
+
+    let output = run_baml_cli(built, tmp.path(), &["run", "answer", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for valid run, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("42"), "Expected run result, got:\n{stdout}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Code is unformatted"),
+        "Expected format warning, got:\n{stderr}"
+    );
+    common::assert_no_compile_file_status(&stderr);
 }
 
 // ============================================================================
@@ -318,6 +377,38 @@ fn test_no_tests_returns_specific_exit_code() {
         output.status.code(),
         String::from_utf8_lossy(&output.stderr),
     );
+}
+
+/// `baml test` should not emit the compile file-count status pair.
+#[test]
+fn test_valid_project_omits_compile_file_status() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        r#"
+test "passes" {
+  assert.equal(1, 1)
+}
+"#,
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["test", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Expected exit code 0 for valid test, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("PASS"),
+        "Expected passing test output, got:\n{stdout}"
+    );
+    common::assert_no_compile_file_status(&String::from_utf8_lossy(&output.stderr));
 }
 
 /// Failing `assert.equal` should surface both operand values and keep stack

--- a/baml_language/crates/baml_cli/tests/pack_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/pack_e2e.rs
@@ -101,6 +101,38 @@ fn pack_e2e_root_main() {
     assert!(String::from_utf8_lossy(&out.stdout).contains("hi, Ada"));
 }
 
+/// `baml pack` keeps packaging progress, but should not emit the compile
+/// file-count status pair reserved for `check` and `generate`.
+#[test]
+fn pack_e2e_omits_compile_file_status() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+    common::write_project(
+        tmp.path(),
+        "function main() -> string { \"packed quietly\" }\n",
+    );
+    let out_bin = tmp.path().join("out");
+
+    let output = Command::new(&built.baml_cli)
+        .arg("pack")
+        .arg("--from")
+        .arg(tmp.path())
+        .arg("-o")
+        .arg(&out_bin)
+        .arg("main")
+        .output()
+        .expect("spawn baml-cli pack");
+
+    assert!(
+        output.status.success(),
+        "pack failed: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    common::assert_no_compile_file_status(&String::from_utf8_lossy(&output.stderr));
+}
+
 /// `--function` produces a subcommand-mode binary even with a single
 /// target. The function name becomes `argv[1]` and parameter flags
 /// follow it — a different dispatch path than the positional `pack

--- a/baml_language/crates/baml_cli/tests/pack_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/pack_e2e.rs
@@ -114,6 +114,7 @@ fn pack_e2e_omits_compile_file_status() {
     let out_bin = tmp.path().join("out");
 
     let output = Command::new(&built.baml_cli)
+        .env("BAML_CLI_ALLOW_DIRECT", "1")
         .arg("pack")
         .arg("--from")
         .arg(tmp.path())


### PR DESCRIPTION
## Summary

- Stop `baml run`, `baml test`, and `baml pack` from printing compile file-count status lines such as `Compiling N file(s)` / `Compiled N file(s)`.
- Keep `baml check` and `baml generate` compile progress intact.
- Remove the animated loading/sheep reporter implementation while preserving cargo-style status lines for commands that still use them.
- Keep the `baml run` formatting warning as the allowed stderr exception.

## Why

The compile progress/status output was leaking into commands where the user-facing result should be the command output itself. In particular, `baml run` should emit only the program output on a formatted successful run, and `baml pack` should not show compile file-count messages.

## Validation

- `cargo nextest run -p baml_cli --lib reporter::tests::format_status_pads_verb_to_column_12`
- `cargo nextest run -p baml_cli --test exit_code_e2e -E 'test(run_valid_project_outputs_only_program_output) or test(run_unformatted_project_keeps_format_warning) or test(test_valid_project_omits_compile_file_status) or test(generate_valid_project_returns_zero_exit_code)'`
- `cargo nextest run -p baml_cli --test pack_e2e -E 'test(pack_e2e_omits_compile_file_status)'`
- `cargo nextest run -p baml_cli`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and stderr-only reporting changes with preserved error paths; no auth, data, or compilation logic changes beyond quieter success paths.
> 
> **Overview**
> **Quiets CLI stderr during successful `baml run`, `baml test`, and `baml pack`** so user-facing output is the program or test results, not compile status. **`baml check` and `baml generate` still emit compile file-count lines** (e.g. `Compiling N file(s)`).
> 
> **`Reporter` no longer uses an indicatif spinner** — `spin`, `finish`, `warning`, and related paths are plain cargo-style `eprintln!` lines; `abandon` / `suspend` remain as no-ops for existing call sites.
> 
> **`baml run` changes:** drops compile/resolving/finished status during load and compile; **`--verbose` no longer prints `[verbose]` logs** on success; **diagnostic warnings are not shown** on successful runs (errors still render). **Successful runs keep only the format advisory** on unformatted sources. **`load_project_for_build` is always called with `verbose: false`**. **`parse_scripts` no longer warns on bad `baml.toml`**; **namespace shadow warnings for scripts are removed**.
> 
> **`baml pack` and `baml test`** drop their compile-phase `Compiling N file(s)` spinners.
> 
> **E2E tests** add `assert_no_compile_file_status`, **`BAML_CLI_ALLOW_DIRECT=1`** in harnesses, and cases that **`generate` still shows compile progress** while run/test/pack omit it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f36233524d9c1d5e3adad9feb9ffbc64ece21bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy compilation status output so `baml run`, `baml test`, and `baml pack` no longer emit compile file-count “Compiling/Compiled … file(s)” lines during their quiet phases.
  * Simplified CLI diagnostics so successful executions stay clean, while formatting advisories are still shown when applicable.

* **Tests**
  * Added/updated CLI e2e checks to assert where compilation status lines must appear (e.g., check/generate) and to confirm they are omitted for `run`, `test`, and `pack`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->