### PR TITLE
pkg-playground graph refit + LSP crash fix + docs/test updates

### DIFF
--- a/baml_language/TEST_INSTRUCTIONS.md
+++ b/baml_language/TEST_INSTRUCTIONS.md
@@ -117,3 +117,162 @@ A good place to start when given a diagnostic failure or some parser issue is to
 BEFORE you run these lsp tests with update_expect, make sure to just run without it and figure out if the new results are what you expect.
 
 Just because the existing file may say 'no diagnostics expected' doesn't mean it is correct by the way. We haven't finished implementing all diagnostics. You have to see if we added some other comments elsewhere in the file to see what we should sort of expect, or just inspect the behavior manually.
+
+---
+
+# END-TO-END TESTING (running real BAML programs)
+
+The snapshot/LSP suites above test the *compiler internals*. This section is about
+testing BAML **end-to-end as a user would**: write a `.baml` program, compile it, run it,
+and run its `test` blocks — using the real CLI. Use this when you want to know "does this
+actually *work* when someone writes it", not "what CST does the parser produce".
+
+## The binary
+
+Build and use the local dev CLI (do **not** use a `brew`-installed `baml` — you must test
+*this* checkout):
+
+```bash
+cargo build -p baml_cli           # produces target/debug/baml-cli
+BAML=/Users/aaron/projects/baml/baml_language/target/debug/baml-cli
+```
+
+It prints `warning: using the internal BAML toolchain binary directly is not recommended` on
+every invocation — that is expected; ignore/grep it out. The binary name is `baml-cli`
+(hyphen), even though the crate is `baml_cli`.
+
+## `baml describe` — the CLI **is** the stdlib documentation. Never guess.
+
+The single most important tool for end-to-end work. The stdlib is large (~50 files,
+`crates/baml_builtins2/baml_std/**.baml`); rather than guess method names, ask the binary:
+
+```bash
+$BAML describe baml                 # ← THE FULL PICTURE: every namespace, type & function
+                                    #   in the stdlib in one listing (csv, env, errors, fs,
+                                    #   http, json, math, net, time, toml, yaml, iter, …)
+$BAML describe baml.json            # drill into a namespace → its types + function signatures
+$BAML describe Array                # drill into a type → full method list + docs
+$BAML describe String --budget 200  # output is line-budgeted; raise --budget to see all methods
+$BAML describe <YourSymbol>         # also works on symbols in the loaded project
+```
+
+`describe` resolves symbols against a project. From inside a project dir it just works; from
+elsewhere pass `--from <project-dir>`. Output is capped by `--budget` (default 30) and tells
+you "… N more lines (re-run with a higher --budget)" — raise it to see everything. Anything
+you can't see, `describe` it; do not guess stdlib names or signatures.
+
+## Setting up a project
+
+```bash
+$BAML init <dir> --name <name>      # scaffolds <dir>/baml.toml + <dir>/baml_src/main.baml
+                                    # (refuses to clobber an existing baml.toml)
+$BAML new <dir>                     # like init but creates a fresh dir (errors if it exists)
+```
+
+`baml.toml` minimum is just `[package]\nname = "..."`. Source lives under `baml_src/**.baml`.
+An optional `[scripts]` table aliases `baml run` invocations (e.g. `dev = "-f main"`).
+
+## Running code
+
+```bash
+# Eval a one-off expression — fastest feedback loop, doubles as a syntax/type check.
+# Runs WITHOUT a project; great for probing stdlib behavior in isolation.
+$BAML run -e '1 + 2'                                  # → 3
+$BAML run -e 'let xs=[3,1,2]; xs.length()'            # → 3
+$BAML run -e 'baml.unstable.string(6)'                # → "6"
+
+# Run a named function in the loaded project. The runtime builds a typed clap CLI from the
+# function signature and exposes each function as a SUBCOMMAND, so the function name must be
+# REPEATED after `--`, then its args as flags:
+$BAML run main                                        # simplest for a zero-arg fn (positional target)
+$BAML run --function main -- main                     # equivalent explicit form
+$BAML run --function greet -- greet --name "Ada"      # scalar args: repeat the fn name, then --flags
+$BAML run --function total -- total --json-args '{"xs":[3,1,2]}'   # collection/class/union args: use --json-args
+# GOTCHA: bare `$BAML run --function main` (no `-- main`) prints a clap usage screen, not the result.
+# GOTCHA: `--json-args` IS a real flag and is REQUIRED for array/map/class/union params (it goes
+#         AFTER the repeated function-name subcommand).
+
+# Compile-check the whole project without running:
+$BAML check
+```
+
+`baml run` always prints a `Loading … / Checking … / Compiling …` preamble; the program's
+result is printed after. On compile errors it prints rich diagnostics with `Error code: E####`
+and exits non-zero with `Cannot run: compilation errors found`.
+
+## Tests + assertions
+
+```bash
+$BAML test --list                    # discover tests without running
+$BAML test                           # run all; prints PASS/FAIL per test, exits non-zero on failure
+$BAML test -i "<testset>::<case>"    # run a single test by id
+```
+
+- A single test needs no wrapper: `test "name" { ... }`. `testset "name" { ... }` only **groups**.
+- Assertions live in the `assert` namespace and **throw** (panic) on failure:
+  `assert.is_true(cond)`, `assert.equal(actual, expected)`, `assert.not_null(v)`,
+  `assert.contains(haystack, needle)`. A test passes iff its body runs without an uncaught throw.
+- A failing assert surfaces as `UnhandledThrow { value: Instance { class_name:
+  "baml.panics.UserPanic", … } }` with a stack trace pointing into `testing/registry.baml`.
+- LLM functions (`client:` + `prompt:`) hit the network — **do not** rely on live LLM calls in
+  e2e tests. Test the deterministic logic, and for parsing use the generated `Fn$parse(raw)`
+  companion against a canned string (or `baml.json.from_string<T>(...)`).
+
+## A known-good reference program
+
+```baml
+function sum_list(xs: int[]) -> string {
+  let total = 0;
+  for (let x in xs) {        // for-loops need `(let …)` and iterate VALUES
+    total += x;
+  }
+  return "sum=" + baml.unstable.string(total);   // no implicit int→string coercion
+}
+
+test "sums inline" {
+  assert.equal(sum_list([3, 1, 2]), "sum=6")     // inline call form
+}
+```
+
+## Language cheat-sheet (the traps that cost the most time)
+
+BAML is expression-oriented and TypeScript-ish with snake_case methods. The five things that
+bite first — everything else, `baml describe` it:
+
+1. **Class fields are `name: type,`** (trailing comma); construct with `Point { x: 1 }`.
+   Methods take an explicit `self`; static factories don't. `baml fmt` normalizes layout.
+2. **Last expression in a block is its value** (Rust-style). Early exit is `return x;` (with
+   trailing `;`). A no-value function is `-> null` with a trailing `null`.
+3. **`for (let x in xs)`** iterates values and requires `let`. `if` / `match` / blocks are
+   expressions; `match (v) { 0 => "a", _ => "b" }`.
+4. **No implicit string coercion** — `"n=" + 5` will NOT compile; use `baml.unstable.string(5)`.
+   Indexing out of bounds **panics** — use `.at(i)` / map `.get(k)` which return `T?`.
+   Closures are `(x: T) -> R { ... }`; the `=>` arrow is **match-only**. `.map`/`.filter`
+   return arrays directly (no `.collect()`). **Map keys must be `string`.**
+5. **`catch` arms are type-only and non-exhaustive**: `f(x) catch (e) { BadInput => fallback }`.
+   `throws T` is part of a function's signature; **panics are not catchable**.
+
+## Recommended workflow
+
+`baml describe baml` (full picture) → sketch the program → `baml run -e` / `baml check`
+constantly for fast feedback → `baml describe <name>` whenever you need a signature →
+`baml test` → `baml fmt baml_src/*.baml` before finishing.
+
+## Finding & reporting language bugs end-to-end
+
+When something behaves wrong, **prove it is the language, not your code**:
+
+1. Reduce to the **smallest** `.baml` (or `baml run -e` one-liner) that still shows it.
+2. Confirm the *intended* behavior via `baml describe` / the stdlib source so you're sure it's
+   a real defect and not a misuse.
+3. Record an exact repro: the minimal source, the exact command, observed vs. expected, and the
+   `E####` error code or runtime throw. Classify severity:
+   `crash` (VM/compiler panic or internal error) > `wrong-result` > `spurious-compile-error`
+   (rejects valid code) > `missing-error` (accepts invalid code) > `bad-diagnostic`.
+4. A bug that only reproduces inside one construct (e.g. only inside a `test` block, only under
+   a generic) is worth noting — the construct boundary is a strong clue to the root cause.
+
+Example of a real defect found this way: inside a `test` block, a `let`-bound local does not
+compare equal to a literal of the same value — `test "x" { let r = "x"; assert.equal(r, "x") }`
+**fails**, while the inline form `assert.equal("x", "x")` and `run -e 'let r="x"; r=="x"'` both
+**pass**. Tiny source, exact command, observed≠expected, construct-scoped → that's a good report.

--- a/baml_language/crates/baml_lsp2_actions/src/type_info.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/type_info.rs
@@ -724,6 +724,15 @@ fn body_stmt_to_pat_id(
         return None;
     };
 
+    // `stmt_id` is arena-local to the body it was created in. When the use-site's
+    // definition resolves into a *different* ExprBody than `body` (e.g. a binding
+    // declared inside a nested testset / lambda), this body's `stmts` arena may
+    // not contain that index — indexing it would panic, and a panic aborts the
+    // whole wasm runtime. Bounds-check and bail instead.
+    let raw = stmt_id.into_raw().into_u32() as usize;
+    if raw >= expr_body.stmts.len() {
+        return None;
+    }
     let stmt = &expr_body.stmts[stmt_id];
     match stmt {
         baml_compiler2_ast::Stmt::Let { pattern, .. }

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1006,9 +1006,10 @@ colors:
     light: "#ffffff"
     dark: "#0b0d0e"
 logo:
-  light: assets/favicon.ico
-  dark: assets/favicon.ico
-  height: 40
+  light: assets/boundary-black-big.svg
+  dark: assets/boundary-white.svg
+  height: 28
+  href: https://boundaryml.com
 favicon: assets/favicon.ico
 css: assets/styles.css
 layout:

--- a/typescript2/pkg-playground/src/gateway.ts
+++ b/typescript2/pkg-playground/src/gateway.ts
@@ -17,12 +17,18 @@
 import { defaultSessionStore, type SessionStore } from './session-store';
 import { BOUNDARY_PROXY_URL_KEY, getProxyEnvVarConfig } from './proxy-config';
 
-/** Provider keys seeded on first load; the proxy swaps in real keys upstream. */
+/** Provider keys seeded on first load; the proxy swaps in real keys upstream.
+ * Every key here must have a matching entry in the proxy allowlist
+ * (app-fiddleproxy/server.js) so the placeholder is replaced server-side. */
 const DEFAULT_ENV_VARS: Record<string, string> = {
   OPENAI_API_KEY: 'placeholder',
   ANTHROPIC_API_KEY: 'placeholder',
+  AI_GATEWAY_API_KEY: 'placeholder',
 };
-const DEFAULTS_SEEDED_STORAGE_KEY = 'baml-playground-defaults-seeded';
+// Bump the version suffix whenever DEFAULT_ENV_VARS gains a key, so existing
+// visitors re-seed once and pick up the new placeholder (v2 added
+// AI_GATEWAY_API_KEY). User-entered values still win — the seed merges them last.
+const DEFAULTS_SEEDED_STORAGE_KEY = 'baml-playground-defaults-seeded-v2';
 
 let store: SessionStore = defaultSessionStore;
 

--- a/typescript2/pkg-playground/src/graph/GraphView.tsx
+++ b/typescript2/pkg-playground/src/graph/GraphView.tsx
@@ -476,10 +476,18 @@ function GraphViewInner({
         setLayoutReady(true);
         if (refitAfterLayoutRef.current) {
           refitAfterLayoutRef.current = false;
-          // Wait a frame so ReactFlow has measured the re-laid nodes.
-          requestAnimationFrame(() => {
-            fitView({ padding: 0.2, minZoom: 0.3, maxZoom: 1.5, duration: 250 });
-          });
+          // Let ReactFlow commit the re-laid nodes and re-measure their rotated
+          // positions into the store before fitting — a couple of frames isn't
+          // enough (fitView then sees the pre-rotation bounds and the toggled
+          // graph looks uncentred). A short timeout matches the resize refit,
+          // which settles reliably.
+          setTimeout(() => {
+            // Match the manual "fit view" control, which calls fitView() with no
+            // options (padding 0.1, instance zoom range). Passing our own tighter
+            // padding/maxZoom here left the toggled graph more zoomed out than
+            // that button; defaults make it fit just as snugly.
+            fitView({ duration: 250 });
+          }, 150);
         }
       })
       .catch((err) => {
@@ -550,6 +558,27 @@ function GraphViewInner({
   const { setCenter, getNode, getViewport, fitView } = useReactFlow();
   const containerWidth = useStore((s) => s.width);
   const containerHeight = useStore((s) => s.height);
+
+  // Refit when ReactFlow's measured container size changes — e.g. dragging the
+  // editor/graph splitter or resizing the window. ReactFlow keeps the viewport
+  // transform across resizes, so without this the graph holds its old pan/zoom
+  // and no longer fits the new size. Skip the first measurement (the `fitView`
+  // prop handles initial paint) and debounce so we fit once the drag settles,
+  // not on every intermediate width during the gesture.
+  const didMeasureRef = useRef(false);
+  useEffect(() => {
+    if (!containerWidth || !containerHeight) return undefined;
+    if (!didMeasureRef.current) {
+      didMeasureRef.current = true;
+      return undefined;
+    }
+    const t = setTimeout(() => {
+      // Defaults (padding 0.1, instance zoom range) match the manual "fit view"
+      // control so a resize fits as snugly as that button.
+      fitView({ duration: 200 });
+    }, 120);
+    return () => clearTimeout(t);
+  }, [containerWidth, containerHeight, fitView]);
   // Auto-pan to the selected node — but the node may not be laid out yet (e.g.
   // the LOD reveal effect above surfaces it only on a later layout). So record
   // the request on selection change, then fulfill it once the node actually

--- a/typescript2/pkg-playground/src/index.ts
+++ b/typescript2/pkg-playground/src/index.ts
@@ -9,6 +9,10 @@ export { WebSocketRuntimePort } from './ports/WebSocketRuntimePort';
 export { createRunStoreClient } from './run-store-client';
 export { applyRunPatch, createExecutionStore } from './execution-store';
 export { decodeRunResultValue } from './run-store-projections';
+export { createValueBodyCache } from './value-body-cache';
+export type { ValueBodyCache } from './value-body-cache';
+export { awaitRunCompletion } from './run-await';
+export type { AwaitedRun } from './run-await';
 export type {
   RunStoreClient,
   RunSubscriptionEvent,

--- a/typescript2/pkg-playground/src/run-await.ts
+++ b/typescript2/pkg-playground/src/run-await.ts
@@ -1,0 +1,82 @@
+import type { BamlJsValue } from '@b/pkg-proto';
+import { applyRunPatch } from './execution-store';
+import { decodeRunResultValue } from './run-store-projections';
+import type { RunStoreClient, RunSubscriptionEvent } from './run-store-client';
+import type { ValueBodyCache } from './value-body-cache';
+import type { BoundaryId, Run } from './worker-protocol';
+
+const TERMINAL_RUN_STATUS = new Set<Run['status']>([
+  'succeeded',
+  'failed',
+  'cancelled',
+  'panicked',
+]);
+
+export interface AwaitedRun {
+  /** The terminal run snapshot, or null if it never reached a terminal status. */
+  run: Run | null;
+  status: Run['status'] | undefined;
+  /** Decoded result value (its `valueRef` body is fetched into the cache first),
+   *  or null when there's no value or it couldn't be decoded. */
+  value: BamlJsValue | null;
+}
+
+/**
+ * Subscribe to a run, apply its snapshot + patch stream until it reaches a
+ * terminal status (racing a timeout), then fetch the result `valueRef` body and
+ * decode it.
+ *
+ * This is the canonical "await a run to completion and read its result" flow.
+ * Both the playground's `ExecutionPanel` and the inline `BamlEditor` cells run
+ * over the same RunStore protocol, so the terminal-detection + valueRef-fetch +
+ * decode lives here rather than being reimplemented per caller — the places
+ * protocol changes (runId→boundaryId, inline-value→valueRef) silently broke a
+ * private copy of this loop are exactly what this prevents.
+ */
+export async function awaitRunCompletion(
+  client: RunStoreClient,
+  valueBodyCache: ValueBodyCache,
+  boundaryId: BoundaryId,
+  opts: { timeoutMs?: number } = {},
+): Promise<AwaitedRun> {
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const handle = client.subscribe(boundaryId);
+  const iterator = handle.events[Symbol.asyncIterator]();
+  const timeout = new Promise<'timeout'>((resolve) =>
+    setTimeout(() => resolve('timeout'), timeoutMs),
+  );
+
+  let run: Run | null = null;
+  try {
+    while (true) {
+      const next = await Promise.race([iterator.next(), timeout]);
+      if (next === 'timeout' || next.done) break;
+      const event = next.value as RunSubscriptionEvent;
+      if (event.type === 'snapshot') run = event.snapshot;
+      else if (event.type === 'patch' && run)
+        run = applyRunPatch(run, event.patch);
+      else if (event.type === 'cursorExpired')
+        run = await client.snapshot(boundaryId);
+      if (run && TERMINAL_RUN_STATUS.has(run.status)) break;
+    }
+  } finally {
+    void handle.unsubscribe();
+  }
+
+  if (!run || !TERMINAL_RUN_STATUS.has(run.status)) {
+    return { run, status: run?.status, value: null };
+  }
+
+  // Results come back as a `valueRef` into the runtime's value store; fetch the
+  // body into the cache, then decode.
+  const resultRef = run.result?.valueRef;
+  if (resultRef) {
+    try {
+      await valueBodyCache.read(run.boundaryId, resultRef);
+    } catch {
+      /* fall through — decode returns null and the caller reports a failure */
+    }
+  }
+  const value = decodeRunResultValue(run, valueBodyCache);
+  return { run, status: run.status, value };
+}

--- a/typescript2/pkg-playground/src/run-await.ts
+++ b/typescript2/pkg-playground/src/run-await.ts
@@ -42,14 +42,24 @@ export async function awaitRunCompletion(
   const timeoutMs = opts.timeoutMs ?? 30_000;
   const handle = client.subscribe(boundaryId);
   const iterator = handle.events[Symbol.asyncIterator]();
-  const timeout = new Promise<'timeout'>((resolve) =>
-    setTimeout(() => resolve('timeout'), timeoutMs),
-  );
+  let timeoutId: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timeoutId = setTimeout(() => resolve('timeout'), timeoutMs);
+  });
 
   let run: Run | null = null;
   try {
     while (true) {
-      const next = await Promise.race([iterator.next(), timeout]);
+      // Attach a catch to `iterator.next()` so a transport error that settles
+      // after the timeout has already won the race doesn't become an unhandled
+      // rejection; treat it as end-of-stream.
+      const next = await Promise.race([
+        iterator.next().catch((err) => {
+          console.error('[awaitRunCompletion] subscription error:', err);
+          return { done: true, value: undefined } as const;
+        }),
+        timeout,
+      ]);
       if (next === 'timeout' || next.done) break;
       const event = next.value as RunSubscriptionEvent;
       if (event.type === 'snapshot') run = event.snapshot;
@@ -60,6 +70,7 @@ export async function awaitRunCompletion(
       if (run && TERMINAL_RUN_STATUS.has(run.status)) break;
     }
   } finally {
+    clearTimeout(timeoutId!);
     void handle.unsubscribe();
   }
 

--- a/typescript2/pkg-playground/wasm.version
+++ b/typescript2/pkg-playground/wasm.version
@@ -1,1 +1,1 @@
-0.1.0-canary.90ffe2cae
+0.1.0-canary.082e4c486


### PR DESCRIPTION
Non-app-website changes split out from `dhilan/website-v1` so they can land on `canary` independently.

## Compiler / LSP
- **`baml_lsp2_actions/type_info.rs`** — bounds-check `stmt_id` before indexing the body's `stmts` arena. `stmt_id` is arena-local, so a definition that resolves into a *different* `ExprBody` (nested testset / lambda) could index out of range and panic — and a panic aborts the whole wasm runtime. Now it bails with `None`.

## pkg-playground
- **`GraphView.tsx`** — refit the graph when the measured container size changes (splitter drag / window resize), and center a toggled graph like the manual "fit view" control (default `fitView()` + a settle timeout).
- **`gateway.ts`** — seed an `AI_GATEWAY_API_KEY` placeholder and bump the seed storage key to `-v2` so existing visitors re-seed. (Needs a matching entry in the `app-fiddleproxy` allowlist.)
- **`index.ts`** — export `awaitRunCompletion` / `AwaitedRun` and `createValueBodyCache` / `ValueBodyCache`.
- **`run-await.ts`** — new `awaitRunCompletion` helper.
- **`wasm.version`** — version bump.

## Docs / tests
- **`fern/docs.yml`** — use the Boundary SVG logo (light/dark) with an `href` to boundaryml.com.
- **`TEST_INSTRUCTIONS.md`** — document end-to-end CLI testing (`baml describe`, `baml init`, running `test` blocks with the local dev binary).

No `app-website/` files and no `pnpm-lock.yaml` changes are included (those are website-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The LSP bounds-check prevents wasm aborts but may skip hover for some nested bindings; playground gateway seeding depends on a matching proxy allowlist entry for the new key.
> 
> **Overview**
> Fixes a **wasm LSP crash** when hover/type info resolves a `stmt_id` from a different `ExprBody` (nested testset/lambda) by bounds-checking before indexing `stmts` in `body_stmt_to_pat_id`, returning `None` instead of panicking.
> 
> **pkg-playground:** `GraphView` debounces `fitView` on container resize and after layout toggles, using default padding to match the manual fit control. `gateway.ts` seeds `AI_GATEWAY_API_KEY` and bumps the localStorage seed key to `v2`. New shared **`awaitRunCompletion`** (subscribe → terminal status → `valueRef` fetch/decode) is exported from the package; `wasm.version` is bumped.
> 
> **Docs:** `TEST_INSTRUCTIONS.md` adds end-to-end CLI testing (`baml describe`, `init`, `run`, `test`). Fern docs logo switches to Boundary SVG assets linking to boundaryml.com.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b742ae424ef4a3c44a85287ee37d36e00ea3e3c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved playground behavior with more reliable graph resizing and automatic re-fitting after layout or window size changes.
  * Added new playground utilities for waiting on run completion and caching run values.
  * Extended default playground environment seeding with an additional placeholder API key.
* **Bug Fixes**
  * Prevented a rare crash when inspecting statement information from an unexpected context.
  * Made run completion handling more robust, including better timeout and terminal result retrieval behavior.
* **Documentation**
  * Expanded end-to-end CLI testing guidance with workflows, examples, and troubleshooting.
  * Updated documentation site branding/logo and link target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->