### PR TITLE
Let panics bypass the declared throws contract when unwinding to the host (B-613)

### DIFF
--- a/baml_language/crates/baml_tests/tests/exceptions.rs
+++ b/baml_language/crates/baml_tests/tests/exceptions.rs
@@ -249,3 +249,137 @@ function main() -> int {
     );
     assert_eq!(output.result.unwrap(), BexExternalValue::Int(1));
 }
+
+// ============================================================================
+// §N+3 — Regression (B-613): a panic escaping to the host must bypass the
+// outer function's declared `throws` contract.
+// ============================================================================
+
+/// Assert that an uncaught throw surfaced from `main` is a clean panic
+/// `Instance` of `expected_class` (not wrapped in a union and not a leaked
+/// engine error).
+fn assert_clean_panic(output: &baml_tests::engine::TestOutput, expected_class: &str) {
+    let Err(bex_engine::EngineError::UnhandledThrow { value, .. }) = &output.result else {
+        panic!("expected UnhandledThrow, got: {:?}", output.result);
+    };
+    let BexExternalValue::Instance { class_name, .. } = value.as_ref() else {
+        panic!("expected panic Instance, got: {value:?}");
+    };
+    assert_eq!(class_name, expected_class);
+}
+
+/// The canonical B-613 repro: a `StackOverflow` panic unwinds out of a function
+/// whose `throws` clause is a 2+-member union. Before the fix the engine
+/// re-typed the escaping panic against the declared union (via
+/// `find_matching_member`, which never matches a `baml.panics.*` value) and
+/// leaked an internal `EngineError::TypeMismatch` naming `QualifiedTypeName` /
+/// `TyAttr`. It must instead surface the clean `baml.panics.StackOverflow`.
+#[tokio::test]
+async fn union_throws_panic_escapes_as_clean_panic() {
+    let output = baml_test!(
+        r#"
+function boom(n: int) -> int throws baml.errors.ParseError | baml.errors.InvalidArgument {
+  boom(n + 1)
+}
+
+function main() -> int {
+  boom(0)
+}
+"#
+    );
+    assert_clean_panic(&output, "baml.panics.StackOverflow");
+}
+
+/// Parity: a panic escaping to the host surfaces identically regardless of the
+/// outer function's `throws` shape — no-throws, single-member, 2-member union,
+/// and 3-member union all yield the same clean `baml.panics.DivisionByZero`.
+/// Uses a `DivisionByZero` panic (deterministic and cheap) rather than
+/// recursion. Before the fix only the 2+-member union shapes leaked; this
+/// documents that the asymmetry is gone.
+#[tokio::test]
+async fn panic_escapes_all_throws_shapes_identically() {
+    const NO_THROWS: &str = r#"
+function boom() -> int {
+  1 / 0
+}
+function main() -> int { boom() }
+"#;
+    const SINGLE: &str = r#"
+function boom() -> int throws baml.errors.ParseError {
+  1 / 0
+}
+function main() -> int { boom() }
+"#;
+    const UNION2: &str = r#"
+function boom() -> int throws baml.errors.ParseError | baml.errors.InvalidArgument {
+  1 / 0
+}
+function main() -> int { boom() }
+"#;
+    const UNION3: &str = r#"
+function boom() -> int throws baml.errors.ParseError | baml.errors.InvalidArgument | baml.errors.Io {
+  1 / 0
+}
+function main() -> int { boom() }
+"#;
+
+    for source in [NO_THROWS, SINGLE, UNION2, UNION3] {
+        let output = baml_test!(source);
+        assert_clean_panic(&output, "baml.panics.DivisionByZero");
+    }
+}
+
+/// A `baml.panics.Exit { code }` escaping a 2-member union `throws` must still
+/// funnel through the clean process-exit path (`extract_exit_code`) rather than
+/// tripping the union re-typing — the panic bypass routes it through
+/// `vm_value_to_owned`, so Exit is recognized and surfaces as
+/// `EngineError::Exit { code }`.
+#[tokio::test]
+async fn exit_panic_escapes_union_throws_as_clean_exit() {
+    let output = baml_test!(
+        r#"
+function boom() -> int throws baml.errors.ParseError | baml.errors.InvalidArgument {
+  baml.sys.exit(3)
+}
+
+function main() -> int {
+  boom()
+}
+"#
+    );
+    let Err(bex_engine::EngineError::Exit { code }) = output.result else {
+        panic!("expected Exit, got: {:?}", output.result);
+    };
+    assert_eq!(code, 3);
+}
+
+/// Guard against over-bypassing: a *genuine* in-contract error (a real
+/// `baml.errors.ParseError` thrown and left uncaught) escaping a 2-member union
+/// `throws` must still get its proper union-metadata wrapping — the panic
+/// bypass only fires for `baml.panics.*` values, not for declared throws.
+#[tokio::test]
+async fn genuine_in_contract_throw_still_wrapped_through_union() {
+    let output = baml_test!(
+        r#"
+function boom() -> int throws baml.errors.ParseError | baml.errors.InvalidArgument {
+  throw baml.errors.ParseError { message: "bad json" }
+}
+
+function main() -> int {
+  boom()
+}
+"#
+    );
+    let Err(bex_engine::EngineError::UnhandledThrow { value, .. }) = &output.result else {
+        panic!("expected UnhandledThrow, got: {:?}", output.result);
+    };
+    // Genuine in-contract throws are wrapped with union metadata for the wire;
+    // panics are not. Confirm the wrapping is preserved.
+    let BexExternalValue::Union { value: inner, .. } = value.as_ref() else {
+        panic!("expected union-wrapped in-contract throw, got: {value:?}");
+    };
+    let BexExternalValue::Instance { class_name, .. } = inner.as_ref() else {
+        panic!("expected Instance inside union, got: {inner:?}");
+    };
+    assert_eq!(class_name, "baml.errors.ParseError");
+}

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3539,10 +3539,22 @@ impl BexEngine {
             let _ = trace;
             return Ok(ThreadOutcome::SettledChild(ChildSettleKind::Errored));
         }
-        let external = if let Some(ty) = throws_type {
-            self.convert_vm_value_to_external_with_type(value, ty, thread.proof())?
-        } else {
-            self.vm_value_to_owned(thread.proof(), value)
+        // A panic escaping all in-BAML catches to the host is an
+        // engine-level failure mode, not a value the function opted into
+        // via `throws` — so it must bypass the declared-throws re-typing and
+        // route through `vm_value_to_owned` (the same branch used when there
+        // is no `throws` clause). Re-typing it against a 2+-member throws
+        // union would call `find_matching_member`, which never matches a
+        // `baml.panics.*` instance and would surface an internal
+        // `TypeMismatch` leak instead of the clean panic. This mirrors the
+        // panic bypass in [`enforce_host_throw_contract`].
+        let value_is_panic = value_runtime_baml_ty(value, thread.proof())
+            .is_some_and(|rt| matches!(&rt, RuntimeTy::Class(name, _, _) if name.is_panic_type()));
+        let external = match throws_type {
+            Some(ty) if !value_is_panic => {
+                self.convert_vm_value_to_external_with_type(value, ty, thread.proof())?
+            }
+            _ => self.vm_value_to_owned(thread.proof(), value),
         };
         // `baml.panics.Exit { code }` escaping all handlers is the clean-
         // termination path — surface as Exit so the host maps it to a


### PR DESCRIPTION
## Summary

A panic (e.g. `baml.panics.StackOverflow`) that unwinds out of a function whose `throws` clause is a 2+-member union was mis-typed and leaked compiler internals to the host instead of surfacing as a clean panic.

```baml
function boom(n: int) -> int throws baml.errors.ParseError | baml.errors.InvalidArgument {
    boom(n + 1)
}
function main() -> int { boom(0) }
```

Running `main` printed:

```
error: Type mismatch: Value of type 'instance' does not match any member of union [Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "InvalidArgument" }, [], TyAttr { sap_parse_without_null: Unset, ... }), Class(QualifiedTypeName { ... name: "ParseError" ... })]
```

The bug only reproduced with a 2+-member throws union; single-member and no-throws functions already surfaced the clean `baml.panics.StackOverflow`. That asymmetry was the key.

## Root cause

`route_unhandled_vm_throw` (`crates/bex_engine/src/lib.rs`) re-types a throw escaping to the host against the outer function's declared `throws`. For a union declared type this eventually calls `find_matching_member`, which never matches a `baml.panics.*` instance (a panic is never a member of a user throws union) and returns an `EngineError::TypeMismatch` whose `{:?}` on the member `Vec<RuntimeTy>` leaks `QualifiedTypeName` / `TyAttr` internals.

A single-member throws (`RuntimeTy::Class`, not `Union`) skips member-matching, and no-throws takes the `vm_value_to_owned` branch — both already produce the clean panic, which is why only the union shape leaked.

The engine already has this exact precedent: `enforce_host_throw_contract` (lib.rs ~906-913) bypasses the throws contract for panic-class values because "panics are an engine-level failure mode, not something the user opts into via `throws`." That guard only covered the host-callable `E` contract, not the outer-function throws re-typing in `route_unhandled_vm_throw`.

## Fix

In `route_unhandled_vm_throw`, detect whether the escaping value is a panic (reusing the already-proven `value_runtime_baml_ty` + `is_panic_type` predicate used by `enforce_host_throw_contract`) and, if so, route it through `vm_value_to_owned` — the same branch used when there is no `throws` clause — instead of re-typing it against the declared throws. Genuine (in-contract) thrown errors are untouched and still get their union-metadata wrapping. `baml.panics.Exit` still funnels through `extract_exit_code`, preserving the clean process-exit path.

## Tests added (`crates/baml_tests/tests/exceptions.rs`)

- `union_throws_panic_escapes_as_clean_panic` — the canonical repro: a `StackOverflow` unwinding through a 2-member union throws now surfaces a clean `baml.panics.StackOverflow` (fails with `TypeMismatch` before the fix).
- `panic_escapes_all_throws_shapes_identically` — parity across no-throws, single-member, 2-member, and 3-member union throws, all surfacing the same clean `baml.panics.DivisionByZero`.
- `exit_panic_escapes_union_throws_as_clean_exit` — `baml.sys.exit(3)` through a union throws still surfaces `EngineError::Exit { code: 3 }`.
- `genuine_in_contract_throw_still_wrapped_through_union` — guards against over-bypass: a real `baml.errors.ParseError` thrown+uncaught through the union is still union-metadata-wrapped.

## Before / after (`baml-cli run --file ...`)

| shape | before | after |
| --- | --- | --- |
| 2-member union | `error: Type mismatch: ... QualifiedTypeName ... TyAttr ...` | `uncaught throw: Instance { class_name: "baml.panics.StackOverflow", ... }` |
| 3-member union | same leak | clean `baml.panics.StackOverflow` |
| single-member | clean (unchanged) | clean (unchanged) |
| no-throws | clean (unchanged) | clean (unchanged) |
| genuine ParseError through union | `Union { value: Instance { ParseError }, metadata: ... }` (unchanged) | unchanged |

## Snapshots

None changed — the fix only affects an engine-runtime error path that is not snapshot-captured.

https://linear.app/boundaryml2/issue/B-613


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how uncaught panics are reported so they now surface cleanly instead of being wrapped in confusing type-mismatch errors.
  * Panics such as stack overflow, division by zero, and exit conditions now follow the expected host-visible error path.
  * Regular in-scope errors still preserve their original error details and union metadata when uncaught.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->