### PR TITLE
Surface unhandled errors from never-awaited spawns at end of run (B-612)

### DIFF
--- a/baml_language/crates/baml_tests/baml_src/ns_spawn_throws/spawn_throws.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_spawn_throws/spawn_throws.baml
@@ -46,3 +46,19 @@ function await_rethrows_caught_by_user_catch_fn() -> int {
 test "await_rethrows_caught_by_user_catch" {
     assert.is_true(baml.deep_equals(await_rethrows_caught_by_user_catch_fn(), 99))
 }
+
+// B-612 regression lock: an erroring child whose error IS observed (awaited and
+// caught) must NOT be re-surfaced by the end-of-run drain. The `sleep` lets the
+// child throw and enqueue its error on the parent's fire-and-forget queue BEFORE
+// the await, so the await path consumes the deferred error; the drain that runs
+// when this function's root completes must then find nothing (the stash entry is
+// gone) and return the caught value cleanly rather than double-surfacing.
+function caught_after_sleep_not_double_surfaced_fn() -> int {
+    let f = spawn { boom_io_x() };
+    baml.sys.sleep(baml.time.Duration.from_milliseconds(30n));
+    (await f) catch (e) { baml.errors.Io => 99 }
+}
+
+test "caught_after_sleep_not_double_surfaced" {
+    assert.is_true(baml.deep_equals(caught_after_sleep_not_double_surfaced_fn(), 99))
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
@@ -14,6 +14,12 @@ function spawn_throws.$init_test_ns_spawn_throws_spawn_throws(registry: testing.
     load_const null
     call testing.TestCollector.register_test
     pop 1
+    load_var registry
+    load_const "caught_after_sleep_not_double_surfaced"
+    make_closure .<lambda($init_test_ns_spawn_throws_spawn_throws, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
     load_const null
     return
 }
@@ -64,4 +70,33 @@ function spawn_throws.boom_io_x() -> int {
     load_const "x"
     init_instance baml.errors.Io .message
     throw
+}
+
+function spawn_throws.caught_after_sleep_not_double_surfaced_fn() -> int {
+    make_closure .<lambda(caught_after_sleep_not_double_surfaced_fn, 0)>, 0
+    load_const null
+    load_const null
+    spawn
+    store_var _3
+    load_const 30n
+    call baml.time.Duration.from_milliseconds
+    sys_op baml.sys.sleep
+    pop 1
+    load_var _3
+    await
+    jump L2
+    load_var e
+    is_type baml.errors.Io
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const 99
+
+  L2:
+    return
 }

--- a/baml_language/crates/baml_tests/tests/spawn_semantics.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_semantics.rs
@@ -74,7 +74,7 @@ async fn never_awaited_spawn_error_surfaces_at_completion() {
         r#"
         function main() -> string {
             let f = spawn { throw baml.errors.Io { message: "boom" } };
-            baml.sys.sleep(baml.time.Duration.from_milliseconds(30n));
+            baml.sys.sleep(baml.time.Duration.from_milliseconds(250n));
             "done"
         }
         "#,
@@ -100,7 +100,7 @@ async fn never_awaited_detached_spawn_error_surfaces_at_completion() {
             let f = spawn with baml.spawn.options(detach = true) {
                 throw baml.errors.Io { message: "boom" }
             };
-            baml.sys.sleep(baml.time.Duration.from_milliseconds(30n));
+            baml.sys.sleep(baml.time.Duration.from_milliseconds(250n));
             "done"
         }
         "#,
@@ -123,7 +123,7 @@ async fn never_awaited_successful_spawn_returns_cleanly() {
         r#"
         function main() -> string {
             let f = spawn { 42 };
-            baml.sys.sleep(baml.time.Duration.from_milliseconds(30n));
+            baml.sys.sleep(baml.time.Duration.from_milliseconds(250n));
             "done"
         }
         "#,

--- a/baml_language/crates/baml_tests/tests/spawn_semantics.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_semantics.rs
@@ -1,11 +1,15 @@
 //! BEP-034: spawn/await semantic invariants beyond the basic round-trip.
 //!
-//! Only `parent_throw_cancels_running_children` remains here — it asserts on
-//! wall-clock timing, which is not expressible in a BAML test block.
+//! `parent_throw_cancels_running_children` asserts on wall-clock timing, which
+//! is not expressible in a BAML test block. The `never_awaited_*` tests below
+//! exercise the end-of-run drain (B-612): a fire-and-forget child that throws
+//! must surface its error when the root finalizes, and a successful one must
+//! not false-surface.
 
 use std::time::{Duration, Instant};
 
 use baml_tests::engine::{IndexMap, OptLevel, compile_source_with_opt, run_compiled};
+use bex_engine::BexExternalValue;
 
 /// BEP-034: "Parent throws still cascade-cancel children." When the
 /// parent function throws an unhandled error, the parent thread's
@@ -53,4 +57,84 @@ async fn parent_throw_cancels_running_children() {
         "parent-throw call took {}ms (expected <5s — cascade missing?)",
         elapsed.as_millis(),
     );
+}
+
+/// B-612: a fire-and-forget child that throws must surface its error at the
+/// root's end-of-run drain, not be silently swallowed.
+///
+/// A default `spawn` whose spawner never `await`s it parks its unhandled error
+/// on the root thread's `pending_child_errors` queue. That queue used to be
+/// drained ONLY at `Await` opcodes, so a root that completes normally dropped
+/// the parked error and exited 0. The `sleep` guarantees the child has thrown
+/// (and enqueued) before the root reaches `Complete`, so the drain must find
+/// it and surface it as an unhandled `baml.errors.Io`.
+#[tokio::test]
+async fn never_awaited_spawn_error_surfaces_at_completion() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn { throw baml.errors.Io { message: "boom" } };
+            baml.sys.sleep(baml.time.Duration.from_milliseconds(30n));
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let err = output
+        .result
+        .expect_err("never-awaited spawn throw must surface at completion");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("baml.errors.Io"), "got {msg}");
+}
+
+/// B-612: same as above but with `detach = true`, which per the documented
+/// `spawn`/`detach` contract "routes its unhandled errors to the root task
+/// instead of the spawner". A detached child's error lands on the root queue,
+/// so the end-of-run drain must surface it too.
+#[tokio::test]
+async fn never_awaited_detached_spawn_error_surfaces_at_completion() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn with baml.spawn.options(detach = true) {
+                throw baml.errors.Io { message: "boom" }
+            };
+            baml.sys.sleep(baml.time.Duration.from_milliseconds(30n));
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let err = output
+        .result
+        .expect_err("never-awaited detached spawn throw must surface at completion");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("baml.errors.Io"), "got {msg}");
+}
+
+/// B-612 negative guard: the end-of-run drain must not false-surface. A
+/// never-awaited child that completes *successfully* enqueues nothing, so the
+/// root must return its value cleanly.
+#[tokio::test]
+async fn never_awaited_successful_spawn_returns_cleanly() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn { 42 };
+            baml.sys.sleep(baml.time.Duration.from_milliseconds(30n));
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let value = output
+        .result
+        .expect("successful never-awaited spawn must return cleanly");
+    let BexExternalValue::String(s) = value else {
+        panic!("expected String, got {value:?}");
+    };
+    assert_eq!(s.to_string(), "done");
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -4229,6 +4229,38 @@ impl BexEngine {
                         return Err(cancelled_unhandled_throw());
                     }
 
+                    // End-of-run drain: the root task is finalizing without
+                    // ever having awaited. Fire-and-forget child errors
+                    // (default spawns whose spawner never awaited, and
+                    // `detach = true` spawns that route their unhandled
+                    // errors to the root task) are parked on this thread's
+                    // `pending_child_errors` queue, which is otherwise drained
+                    // ONLY at `Await` opcodes. Without this, a root that
+                    // completes normally drops the parked error at teardown
+                    // and exits 0, silently swallowing the throw and violating
+                    // the documented `spawn`/`detach` routing contract.
+                    //
+                    // Surface the first still-unobserved child error as an
+                    // `UnhandledThrow` — the exact variant `await f` produces,
+                    // which the host maps to a diagnostic + exit 1.
+                    // `drain_one_pending_child_error` skips errors an awaiter
+                    // already consumed (via the `deferred_errors` stash), so a
+                    // root that DID await (and possibly `catch`) its children
+                    // does not re-surface a handled error. The value is used
+                    // synchronously while the heap permit is still held (same
+                    // safety envelope as the `Await`-arm drain above), so
+                    // there is no GC-rooting concern. This branch is only
+                    // reached on the root path: children settle their future
+                    // and return early above, so `thread` here never settles a
+                    // future.
+                    if let Some(value) = self.drain_one_pending_child_error(&mut thread).await? {
+                        let external = self.vm_value_to_owned(thread.proof(), value);
+                        return Err(EngineError::UnhandledThrow {
+                            value: Box::new(external),
+                            trace: Vec::new(),
+                        });
+                    }
+
                     if let Some(capture) = root_capture.as_ref() {
                         self.capture_root_value(&thread, capture, CaptureKind::RootOutput, value);
                     }


### PR DESCRIPTION
## Bug (B-612)

An unhandled `throw` in a never-awaited `spawn` was silently dropped (exit 0), violating the documented `spawn`/`detach` routing contract.

Repro:
```
baml-cli run -e 'let f = spawn { throw baml.errors.Io { message: "boom" } }; baml.sys.sleep(baml.time.Duration.from_milliseconds(30)); "done"'
```
Before the fix this printed `"done"` and exited `0` with no diagnostic — the same for `spawn with baml.spawn.options(detach = true) { ... }`. Only `await f` surfaced the error (exit 1).

## Root cause

`crates/bex_engine/src/lib.rs`

A spawned child that throws with no in-VM handler is routed through `route_unhandled_vm_throw` -> `settle_child_errored`, which parks the error in the `deferred_errors` stash and pushes `(future_id, ptr)` onto the parent's `pending_child_errors` queue. For both default and `detach = true` spawns off the root, that queue is the root thread's own queue.

That queue was drained in **only one place**: the `VmExecState::Await` arm (`drain_one_pending_child_error`, self-described as "the ONLY drain point"). When the root task finishes without ever awaiting, it hits the `VmExecState::Complete(value)` root branch, builds the return value, and returns `ThreadOutcome::RootValue` **without ever draining** `pending_child_errors`. The parked error was left in the queue and dropped at teardown — clean exit 0.

## Fix

Add an end-of-run drain at the root `VmExecState::Complete` branch (after the child `settles_future` early-return and the `cancelled` early-return, before building the return value). It drains the root thread's `pending_child_errors` and converts the first still-unobserved child error into `EngineError::UnhandledThrow` — the exact variant `await f` produces, which the host already maps to a diagnostic + exit 1.

This reuses the existing `drain_one_pending_child_error` helper, which skips errors an awaiter already consumed (via the `deferred_errors` stash), so a root that DID await (and possibly `catch`) its children does not re-surface a handled error. The value is used synchronously while the heap permit is still held (same safety envelope as the existing `Await`-arm drain), so there is no GC-rooting concern. The branch is reached only on the root path (children settle their future and return early above). No VM/lowering/stdlib changes.

## Tests

- `crates/baml_tests/tests/spawn_semantics.rs` (new Rust engine tests):
  - `never_awaited_spawn_error_surfaces_at_completion` — default spawn throw surfaces as `baml.errors.Io`.
  - `never_awaited_detached_spawn_error_surfaces_at_completion` — `detach = true` variant (documents the "route to root task" contract).
  - `never_awaited_successful_spawn_returns_cleanly` — negative guard: a successful never-awaited spawn still returns cleanly (no false-surface).
- `crates/baml_tests/baml_src/ns_spawn_throws/spawn_throws.baml` (new e2e `test` block):
  - `caught_after_sleep_not_double_surfaced` — an erroring child that IS awaited+caught (after a `sleep` that guarantees the child enqueued its error before the await) must NOT be re-surfaced by the end-of-run drain. Regenerated `snapshots/baml_src/spawn_throws.snap` accordingly (only that namespace's bytecode snapshot shifts — the new test function).

## Before / after

| Case | Before | After |
|------|--------|-------|
| never-awaited default (`sleep 30ms`) | exit 0, `"done"`, no diagnostic | exit 1, `uncaught throw: ... baml.errors.Io` |
| never-awaited `detach = true` (`sleep 30ms`) | exit 0, `"done"`, no diagnostic | exit 1, `uncaught throw: ... baml.errors.Io` |
| `await f` | exit 1 | exit 1 (unchanged) |
| `(await f) catch (e) { baml.errors.Io => "caught" }` | exit 0, `"caught"` | exit 0, `"caught"` (unchanged — not double-surfaced) |
| never-awaited successful `spawn { 42 }` | exit 0, `"done"` | exit 0, `"done"` (unchanged) |

## Scope limitation

This deterministically covers the reported repro because the `sleep(30ms)` guarantees the child has thrown and enqueued its error before the root reaches `Complete`. It does **not** cover a truly racing case with no sleep (`let f = spawn { throw ... }; "done"`), where the child's tokio task may not have run by the time the root completes — that still exits 0. Closing that gap requires structured "wait for outstanding spawns at end of run" (join the live child tasks), a larger design change. Recommend filing the join-at-shutdown behavior separately.

## Test status (local)

- `cargo nextest run -p bex_engine -p bex_vm` — 565 passed, 0 failed.
- `cargo test -p baml_tests --test spawn_semantics` — 4 passed (3 new + existing `parent_throw_cancels_running_children`).
- `ns_spawn_throws` e2e (`baml-cli test -i`) — 3 passed, incl. the new `caught_after_sleep_not_double_surfaced` and existing `await_uncaught_bubbles_to_host` / `await_rethrows_caught_by_user_catch`.

https://linear.app/boundaryml2/issue/B-612


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved end-of-run handling for background (fire-and-forget) child task errors so unobserved failures are surfaced instead of dropped.

* **Bug Fixes**
  * Prevented duplicate error reporting when an error is thrown by a spawned child and later caught after a short delay.
  * Ensured spawned child errors are correctly reported at run completion for both awaited-later and never-awaited/detached scenarios.

* **Tests**
  * Added regression coverage for spawn/await end-of-run draining semantics, including “never awaited” and delayed catch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->