### PR TITLE
Solve `_` inference holes in expression-context type positions

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
@@ -625,17 +625,26 @@ pub(crate) fn check_throws_wildcard(
     }
 }
 
-/// Reject — and neutralize — the `_` wildcard type where it cannot be inferred.
+/// Reject — and neutralize — the `_` wildcard type at a DECLARATION-site type
+/// position, where it cannot be inferred.
 ///
-/// `_` is an inference hole: it is only meaningful in a `let` binding annotation
-/// (filled from the initializer) or as a top-level `throws`-clause member
-/// (filled from the body's inferred throw set). In a signature, field, alias, or
-/// bound type there is nothing to infer it from. Every such occurrence is
-/// reported AND rewritten to [`TypeExprKind::Error`], so it lowers to the
-/// error-recovery `Ty::Unknown` sentinel rather than a `Ty::Infer` — which would
-/// otherwise reach type normalization, where an inference hole has no sound
-/// form (see `baml_type::normalize`). This keeps the invariant that a
-/// `Ty::Infer` only ever originates from the two hole-handling contexts.
+/// `_` is an inference hole. This firewall governs only the declaration sites it
+/// is applied to (a signature parameter/return, a field, an alias, a generic
+/// bound): there is nothing local to infer a hole from there, so every
+/// occurrence is reported AND rewritten to [`TypeExprKind::Error`]. It then
+/// lowers to the error-recovery `Ty::Unknown` sentinel rather than a `Ty::Infer`
+/// — which would otherwise reach type normalization, where an inference hole has
+/// no sound form (see `baml_type::normalize`).
+///
+/// A `Ty::Infer` therefore reaches type checking only from the positions this
+/// firewall does NOT cover, each of which fills-or-rejects the hole itself:
+///   * a `let` binding annotation (filled from the initializer),
+///   * a top-level `throws`-clause member (filled from the inferred throw set;
+///     nested `throws` holes ARE firewalled, see `check_throws_wildcard`), and
+///   * the expression-context type positions — a call turbofish, an object
+///     construction, a generic-apply value, an upcast target — handled during
+///     inference (see the expression-context `_` hole policy in
+///     `baml_compiler2_tir`'s `builder.rs`).
 ///
 /// Emits `WildcardTypeNotAllowed` for every occurrence at any depth.
 pub(crate) fn check_wildcard_type(

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3957,11 +3957,35 @@ impl<'db> LoweringContext<'db> {
         expr_id: AstExprId,
         explicit_type_args: &[AstTypeExpr],
     ) -> Vec<TyTemplate> {
-        if explicit_type_args.is_empty() {
+        // Empty (`Box { … }`) or hole-bearing (`Box<_> { … }`) type args: use the
+        // class type TIR inferred/solved for this expression rather than
+        // re-lowering the raw args — a written `_` lowers to `Ty::Infer`, which
+        // cannot cross the runtime boundary.
+        let generic_params = self.enclosing_generic_params();
+        let has_hole = explicit_type_args
+            .iter()
+            .any(|arg| self.type_arg_is_infer_hole(arg, &generic_params));
+        if explicit_type_args.is_empty() || has_hole {
             self.class_type_arg_templates(expr_id)
         } else {
             self.generic_apply_type_arg_templates(explicit_type_args)
         }
+    }
+
+    /// Whether a written type argument lowers to a type that cannot cross the
+    /// runtime boundary — a `_` wildcard (`Ty::Infer`) or an error-recovery
+    /// sentinel, at any depth. A bare frame type-arg reference (`T`) and any
+    /// concrete type return `false`.
+    fn type_arg_is_infer_hole(
+        &self,
+        type_arg: &AstTypeExpr,
+        generic_params: &[baml_base::Name],
+    ) -> bool {
+        if Self::direct_frame_type_arg_template(type_arg, generic_params).is_some() {
+            return false;
+        }
+        let tir_ty = self.lower_type_arg_to_tir(type_arg, generic_params);
+        baml_type::lower_to_runtime(&tir_ty, self.resolved_aliases).is_err()
     }
 
     /// Get the `baml_type::RuntimeTy` for a pattern binding
@@ -8987,7 +9011,20 @@ impl LoweringContext<'_> {
         if let Some(template) = Self::direct_frame_type_arg_template(type_arg, generic_params) {
             return template;
         }
+        let tir_ty = self.lower_type_arg_to_tir(type_arg, generic_params);
+        self.ty_to_template(&tir_ty, generic_params)
+    }
 
+    /// Lower a written type-argument expression to its `Tir2Ty`, resolving names
+    /// against the canonical (PPIR-merged) package items and with the enclosing
+    /// generic params in scope (so `T` becomes `Tir2Ty::TypeVar("T")`). A `_`
+    /// wildcard lowers to `Tir2Ty::Infer` — callers that may see one (explicit
+    /// type-arg lowering) must fill it before it reaches runtime conversion.
+    fn lower_type_arg_to_tir(
+        &self,
+        type_arg: &AstTypeExpr,
+        generic_params: &[baml_base::Name],
+    ) -> Tir2Ty {
         let pkg_info = file_package(self.db, self.file);
         let pkg_id = PackageId::new(self.db, pkg_info.package);
         // The canonical (PPIR-merged) package items, NOT HIR's: explicit type
@@ -8998,15 +9035,14 @@ impl LoweringContext<'_> {
         // at runtime.
         let pkg_items = baml_compiler2_ppir::package_items(self.db, pkg_id);
         let mut diags = Vec::new();
-        let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_expr_in_ns(
+        baml_compiler2_tir::lower_type_expr::lower_type_expr_in_ns(
             self.db,
             type_arg,
             pkg_items,
             &pkg_info.namespace_path,
             generic_params,
             &mut diags,
-        );
-        self.ty_to_template(&tir_ty, generic_params)
+        )
     }
 
     fn direct_frame_type_arg_template(
@@ -9145,11 +9181,21 @@ impl LoweringContext<'_> {
                 Vec::new()
             };
         if !ast_type_args.is_empty() {
-            let ast_type_args = match max_count {
+            let ast_type_args: Vec<AstTypeExpr> = match max_count {
                 Some(max_count) => ast_type_args.into_iter().take(max_count).collect(),
                 None => ast_type_args,
             };
-            return self.lower_explicit_type_args(&ast_type_args);
+            // Explicit type args may carry `_` inference holes (`race<T, _>`).
+            // TIR solved those holes and recorded the result in declared-generic
+            // order (matching the written positions) on the call plan; supply it
+            // so `lower_explicit_type_args` substitutes the solved type into each
+            // hole slot instead of re-lowering the raw `_` (which would reach
+            // runtime conversion as a `Ty::Infer` and panic).
+            let solved_type_args = self
+                .tir_call_plan(self.expr_metadata_key(call_expr_id))
+                .map(|plan| plan.type_args.clone())
+                .unwrap_or_default();
+            return self.lower_explicit_type_args(&ast_type_args, &solved_type_args);
         }
         if !include_inferred {
             return Vec::new();
@@ -9200,7 +9246,11 @@ impl LoweringContext<'_> {
     ///
     /// Returns `(type_arg_operands, ntypeargs)` — the number equals
     /// `ast_type_args.len()`.  Returns an empty vec when there are no type args.
-    fn lower_explicit_type_args(&mut self, ast_type_args: &[AstTypeExpr]) -> Vec<Operand> {
+    fn lower_explicit_type_args(
+        &mut self,
+        ast_type_args: &[AstTypeExpr],
+        solved_type_args: &[Tir2Ty],
+    ) -> Vec<Operand> {
         if ast_type_args.is_empty() {
             return vec![];
         }
@@ -9209,8 +9259,19 @@ impl LoweringContext<'_> {
         let type_ty = baml_type::RuntimeTy::type_type();
 
         let mut operands = Vec::with_capacity(ast_type_args.len());
-        for type_arg in ast_type_args {
-            let template = self.type_expr_to_template(type_arg, &generic_params);
+        for (idx, type_arg) in ast_type_args.iter().enumerate() {
+            // A `_` wildcard (or a nested one, e.g. `Box<_>`) lowers to a
+            // `Tir2Ty::Infer` that cannot cross the runtime boundary. Where TIR
+            // solved that position, swap in its solved type; otherwise lower the
+            // written type faithfully (a bare frame `T` → `TypeArgRef`, a
+            // concrete arg → itself).
+            let template = if self.type_arg_is_infer_hole(type_arg, &generic_params)
+                && let Some(solved) = solved_type_args.get(idx)
+            {
+                self.ty_to_template(solved, &generic_params)
+            } else {
+                self.type_expr_to_template(type_arg, &generic_params)
+            };
             let temp = self.builder.temp(type_ty.clone());
             self.builder
                 .assign(Place::local(temp), Rvalue::LoadType(template));

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2114,6 +2114,15 @@ impl<'db> TypeInferenceBuilder<'db> {
             resolved.push(ty);
         }
 
+        // A `_` in a bare generic instantiation *value* (`let f = id<_>`) has no
+        // argument or initializer to be solved from — unlike the call form
+        // `id<_>(x)`, which infers it. With no candidate, each hole is rejected
+        // (see the expression-context `_` hole policy on
+        // `fill_expression_type_arg_hole`).
+        for (idx, ty) in resolved.iter_mut().enumerate() {
+            *ty = self.fill_expression_type_arg_hole(ty, None, &generic_params[idx], expr_id);
+        }
+
         let bindings = crate::generics::bind_type_vars(&generic_params, &resolved);
 
         // Generic-bound enforcement: each supplied type arg must satisfy its
@@ -2418,8 +2427,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // must thread `T = string`, not `T = literal "hi"` — the runtime
                 // compares class type args invariantly, so an escaped instance
                 // carrying the literal would never match `is Box<string>`.
-                // (Explicit type args never reach here; recording is gated on
-                // `!explicit_args_used`.)
+                // (Fully-explicit type args never reach here; recording is gated
+                // on `!explicit_args_used`, except partial `_`-hole type args,
+                // which record their solved values in declared-generic order.)
                 let ty = bindings
                     .get(param)
                     .cloned()
@@ -3478,6 +3488,23 @@ impl<'db> TypeInferenceBuilder<'db> {
                     bindings.entry(name.clone()).or_insert_with(|| ty.clone());
                 }
 
+                // A `_` inside an explicit type-argument list (`race<T, _>`) is a
+                // PARTIAL annotation: the user pinned some type args and left the
+                // rest as inference holes. Pull the hole-bearing bindings out so
+                // ordinary argument inference (the `runtime_type_arg_bindings`
+                // pass below) can solve them, then fill them back — mirroring the
+                // `_`-in-`let` path (`fill_infer_holes`). Left in `bindings`, a raw
+                // `Ty::Infer` would substitute straight into the call's result
+                // type and trip the runtime-lowering boundary (an `unreachable!`).
+                let hole_type_arg_bindings: Vec<(Name, Ty)> = bindings
+                    .iter()
+                    .filter(|(_, ty)| Self::ty_has_infer_hole(ty))
+                    .map(|(name, ty)| (name.clone(), ty.clone()))
+                    .collect();
+                for (name, _) in &hole_type_arg_bindings {
+                    bindings.remove(name);
+                }
+
                 // Only explicit call-site type args suppress inference. Owner
                 // interface args seeded for default methods are already known,
                 // but method generics still need normal argument/return inference.
@@ -3794,6 +3821,18 @@ impl<'db> TypeInferenceBuilder<'db> {
                         &mut runtime_type_arg_bindings,
                     );
                 }
+
+                // Fill the `_` holes pulled out of the explicit type args above
+                // from what argument inference solved (`runtime_type_arg_bindings`
+                // ran over every argument regardless of `run_inference_phases`).
+                // See the expression-context `_` hole policy on
+                // `fill_expression_type_arg_hole`.
+                for (name, partial) in &hole_type_arg_bindings {
+                    let candidate = runtime_type_arg_bindings.get(name);
+                    let filled =
+                        self.fill_expression_type_arg_hole(partial, candidate, name, expr_id);
+                    bindings.insert(name.clone(), filled);
+                }
                 self.validate_function_generic_bounds(
                     expr_id,
                     &generic_params,
@@ -3837,6 +3876,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                         runtime_type_arg_params,
                         &runtime_type_arg_bindings,
                     );
+                    self.record_call_type_args(expr_id, type_args);
+                } else if !hole_type_arg_bindings.is_empty() && !generic_params.is_empty() {
+                    // Explicit type args carrying `_` holes (`race<T, _>`): record
+                    // the SOLVED args in the callee's declared-generic order so it
+                    // matches the written type-arg positions. MIR substitutes these
+                    // into the hole slots instead of re-lowering the raw `_`, which
+                    // would otherwise reach runtime lowering as a `Ty::Infer`.
+                    let type_args = self.runtime_call_type_args(&generic_params, &bindings);
                     self.record_call_type_args(expr_id, type_args);
                 }
 
@@ -4895,6 +4942,15 @@ impl<'db> TypeInferenceBuilder<'db> {
         for diag in diags {
             self.context.report_simple(diag, expr_id);
         }
+        // An upcast target is an explicit ascription (`c.as<Show<_>>`); a `_`
+        // there has nothing to be inferred from and must not reach the subtype
+        // check below, where an inference hole trips structural normalization.
+        // The hole is nested in the interface type (no single parameter), so it
+        // is rejected with the ascription form of the diagnostic — see the
+        // expression-context `_` hole policy on `report_uninferable_type_hole`.
+        if Self::ty_has_infer_hole(&target_ty) {
+            return self.report_uninferable_type_hole(None, expr_id);
+        }
         let valid_target = matches!(target_ty, Ty::Interface(_, _, _, _));
         if !valid_target && !matches!(target_ty, Ty::Unknown { .. } | Ty::Error { .. }) {
             self.context.report_simple(
@@ -5628,8 +5684,19 @@ impl<'db> TypeInferenceBuilder<'db> {
         let ty = self.lower_object_type_name(expr_id, type_name, obj_type_args);
         let ty = match ty {
             Ty::Class(class_name, type_args, attr) => {
-                if type_args.is_empty()
-                    && obj_type_args.is_empty()
+                // A partial `Box<_> { … }` carries `_` inference holes in its
+                // type args; fill them from the field values just like the bare
+                // `Box { … }` form (which arrives with empty `type_args`). A raw
+                // `Ty::Infer` left in the class args would reach structural
+                // normalization and panic (`normalize.rs`).
+                //
+                // This is the object-construction case of the expression-context
+                // `_` hole policy (see `fill_expression_type_arg_hole`): the fill
+                // source is the field values, and an unconstrained *phantom* param
+                // recovers to `BuiltinUnknown` rather than erroring, so it resolves
+                // holes inline below instead of routing through the shared helper.
+                let has_type_arg_hole = type_args.iter().any(Self::ty_has_infer_hole);
+                if (type_args.is_empty() || has_type_arg_hole)
                     && let Some(class_loc) = self.resolve_class_loc(&class_name)
                 {
                     let class_tree = baml_compiler2_hir::file_item_tree(
@@ -5690,19 +5757,30 @@ impl<'db> TypeInferenceBuilder<'db> {
                         let inferred_type_args: Vec<Ty> = class_data
                             .generic_params
                             .iter()
-                            .map(|param| match bindings.get(param) {
-                                Some(bound) => bound.clone(),
-                                None => {
-                                    if field_constrained_params.contains(param) {
-                                        self.context.report_simple(
-                                            TirTypeError::CannotInferTypeParameter {
-                                                name: param.clone(),
-                                            },
-                                            expr_id,
-                                        );
+                            .enumerate()
+                            .map(|(idx, param)| {
+                                // Keep an explicitly-provided non-hole arg
+                                // (`Box<int, _>` pins the first, infers the
+                                // second); only holes and the bare form infer.
+                                if let Some(explicit) = type_args.get(idx) {
+                                    if !Self::ty_has_infer_hole(explicit) {
+                                        return explicit.clone();
                                     }
-                                    Ty::BuiltinUnknown {
-                                        attr: TyAttr::default(),
+                                }
+                                match bindings.get(param) {
+                                    Some(bound) => bound.clone(),
+                                    None => {
+                                        if field_constrained_params.contains(param) {
+                                            self.context.report_simple(
+                                                TirTypeError::CannotInferTypeParameter {
+                                                    name: param.clone(),
+                                                },
+                                                expr_id,
+                                            );
+                                        }
+                                        Ty::BuiltinUnknown {
+                                            attr: TyAttr::default(),
+                                        }
                                     }
                                 }
                             })
@@ -8593,6 +8671,71 @@ impl<'db> TypeInferenceBuilder<'db> {
             };
         }
         filled
+    }
+
+    // ── Expression-context `_` hole policy ──────────────────────────────────
+    //
+    // `_` (`Ty::Infer`) is firewalled to `Ty::Error` at every DECLARATION-site
+    // type position by `check_wildcard_type` (in the AST layer), so a signature,
+    // field, alias, or bound never carries a hole into type checking. The
+    // EXPRESSION positions that admit a written type — a call turbofish
+    // (`race<T, _>`), an object construction (`Box<_> { … }`), a generic-apply
+    // value (`id<_>`), and an upcast target (`.as<Show<_>>`) — bypass that
+    // firewall, so each must fill the hole from a local source or reject it
+    // *here*, before the resulting type reaches a subtype / structural-normalize
+    // check (`normalize.rs`) or MIR runtime lowering (`runtime_ty.rs`), both of
+    // which treat a surviving `Ty::Infer` as an unreachable compiler bug.
+    //
+    // The two helpers below are that shared policy. Object construction resolves
+    // its holes inline (its source is the field values, and an unconstrained
+    // *phantom* param recovers to `BuiltinUnknown` rather than erroring), so it
+    // does not route through them, but it follows the same rule.
+
+    /// Report that a `_` hole could not be inferred and neutralize it to
+    /// `Ty::Error` (so it never reaches a subtype/normalize check). `param`
+    /// names the offending type parameter for the diagnostic; pass `None` for a
+    /// hole nested in an ascription (`.as<Show<_>>`) that has no single
+    /// parameter, matching the pattern path's `unresolved type: _`.
+    fn report_uninferable_type_hole(&mut self, param: Option<&Name>, at: ExprId) -> Ty {
+        let diagnostic = match param {
+            Some(name) => TirTypeError::CannotInferTypeParameter { name: name.clone() },
+            None => TirTypeError::UnresolvedType {
+                name: Name::new("_"),
+                suggestions: Vec::new(),
+                span: TextRange::default(),
+            },
+        };
+        self.context.report_simple(diagnostic, at);
+        Ty::Error {
+            attr: TyAttr::default(),
+        }
+    }
+
+    /// Resolve one explicitly-written type argument that may carry a `_` hole:
+    /// keep it unchanged when concrete, fill its holes from `candidate` (what
+    /// the site's local inference solved for this parameter) while preserving
+    /// every non-hole position the user wrote, or — when there is no candidate
+    /// or the fill leaves a hole / resolution failure — reject it as an
+    /// un-inferable `param` via [`Self::report_uninferable_type_hole`]. This is
+    /// the single fill-or-reject used by the call-turbofish and
+    /// generic-apply-value positions.
+    fn fill_expression_type_arg_hole(
+        &mut self,
+        partial: &Ty,
+        candidate: Option<&Ty>,
+        param: &Name,
+        at: ExprId,
+    ) -> Ty {
+        if !Self::ty_has_infer_hole(partial) {
+            return partial.clone();
+        }
+        if let Some(candidate) = candidate {
+            let filled = Self::fill_infer_holes(partial, candidate);
+            if !Self::ty_has_infer_hole(&filled) && !Self::ty_contains_resolution_failure(&filled) {
+                return filled;
+            }
+        }
+        self.report_uninferable_type_hole(Some(param), at)
     }
 
     /// Strict resolution-failure check: only the recovery placeholders

--- a/baml_language/crates/baml_tests/tests/wildcard_expression_holes.rs
+++ b/baml_language/crates/baml_tests/tests/wildcard_expression_holes.rs
@@ -1,0 +1,190 @@
+//! Regression: a `_` inference hole in an *expression-context* type position
+//! (call turbofish `race<T, _>`, object construction `Box<_> { … }`, a bare
+//! generic-apply value `id<_>`) must be solved from context or produce a clean
+//! diagnostic — never left as a raw `Ty::Infer` that reaches structural
+//! normalization or runtime lowering and panics.
+//!
+//! These positions bypass the declaration-site `_` firewall
+//! (`check_wildcard_type`), so each needs its own hole handling, mirroring the
+//! existing `_`-in-`let`/`throws` wildcard feature.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+const TIMEOUT_HELPERS: &str = r#"
+function with_timeout<T>(millis: int, f: () -> T) -> T {
+    let work = spawn { f() };
+    let timer = spawn {
+        baml.sys.sleep(baml.time.Duration.from_milliseconds(millis));
+        work.cancel();
+        throw TimeoutError { message: `Operation timed out after ${millis} milliseconds` };
+    };
+    let result = baml.future.race<T, _>([work, timer]);
+    await result
+}
+
+class TimeoutError {
+    message: string,
+
+    implements baml.ToString {
+        function to_string(self) -> string throws never {
+            return self.message;
+        }
+    }
+}
+"#;
+
+/// The exact reported repro: `race<T, _>` compiles and the fast work future
+/// wins, returning its value.
+#[tokio::test]
+async fn wildcard_turbofish_race_work_wins() {
+    let src = format!(
+        "{TIMEOUT_HELPERS}\nfunction main() -> int {{\n  with_timeout(1000, () -> {{ 42 }})\n}}\n"
+    );
+    let out = baml_test!(&src);
+    assert!(
+        matches!(out.result, Ok(BexExternalValue::Int(42))),
+        "expected 42, got {:?}",
+        out.result
+    );
+}
+
+/// The timer branch actually fires when the work outlasts the timeout: the
+/// inferred `_` error type (`TimeoutError | …`) is thrown and surfaces.
+#[tokio::test]
+async fn wildcard_turbofish_race_timer_fires() {
+    let src = format!(
+        "{TIMEOUT_HELPERS}\nfunction main() -> int {{\n  with_timeout(1, () -> {{ baml.sys.sleep(baml.time.Duration.from_milliseconds(1000)); 7 }})\n}}\n"
+    );
+    let out = baml_test!(&src);
+    assert!(
+        out.result.is_err(),
+        "expected the timeout error to surface, got {:?}",
+        out.result
+    );
+    let msg = format!("{:?}", out.result);
+    assert!(
+        msg.contains("timed out"),
+        "expected the TimeoutError message, got {msg}"
+    );
+}
+
+/// A `_` turbofish hole that argument inference cannot solve is a clean
+/// `cannot infer type parameter` diagnostic, never a runtime-lowering panic.
+#[tokio::test]
+#[should_panic(expected = "cannot infer type parameter")]
+async fn wildcard_turbofish_uninferable_is_rejected() {
+    // `pick<int, _>(5)` — `U` appears in neither an argument nor the return
+    // type, so the `_` hole has nothing to be solved from.
+    let src = r#"
+function pick<T, U>(x: T) -> T { x }
+function main() -> int {
+    pick<int, _>(5)
+}
+"#;
+    let _ = baml_test!(src);
+}
+
+// ===========================================================================
+// Object construction: `Foo<_> { … }` solves the hole from field values.
+// ===========================================================================
+
+/// `Box<_> { v: 5 }` infers `T = int` from the field value, exactly like the
+/// bare `Box { v: 5 }` form.
+#[tokio::test]
+async fn wildcard_object_ctor_infers_from_field() {
+    let src = r#"
+class Box<T> { v T }
+function main() -> int { let b = Box<_> { v: 5 }; b.v }
+"#;
+    let out = baml_test!(src);
+    assert!(
+        matches!(out.result, Ok(BexExternalValue::Int(5))),
+        "expected 5, got {:?}",
+        out.result
+    );
+}
+
+/// A partial `Pair<int, _>` pins the first arg and infers the second from a
+/// field.
+#[tokio::test]
+async fn wildcard_object_ctor_mixed_partial() {
+    let src = r#"
+class Pair<A, B> { a A  b B }
+function main() -> string { let p = Pair<int, _> { a: 1, b: "hi" }; p.b }
+"#;
+    let out = baml_test!(src);
+    assert!(
+        matches!(out.result, Ok(BexExternalValue::String(ref s)) if s == "hi"),
+        "expected \"hi\", got {:?}",
+        out.result
+    );
+}
+
+/// A nested hole (`Box<Box<_>>`) is filled structurally from the field value.
+#[tokio::test]
+async fn wildcard_object_ctor_nested_hole() {
+    let src = r#"
+class Box<T> { v T }
+function main() -> int { let b = Box<Box<_>> { v: Box<int> { v: 5 } }; b.v.v }
+"#;
+    let out = baml_test!(src);
+    assert!(
+        matches!(out.result, Ok(BexExternalValue::Int(5))),
+        "expected 5, got {:?}",
+        out.result
+    );
+}
+
+/// A phantom param (used by no field) can never be determined by construction;
+/// it is recovered silently rather than crashing.
+#[tokio::test]
+async fn wildcard_object_ctor_phantom_param_recovers() {
+    let src = r#"
+class Phantom<T> { label string }
+function main() -> string { let p = Phantom<_> { label: "hi" }; p.label }
+"#;
+    let out = baml_test!(src);
+    assert!(
+        matches!(out.result, Ok(BexExternalValue::String(ref s)) if s == "hi"),
+        "expected \"hi\", got {:?}",
+        out.result
+    );
+}
+
+// ===========================================================================
+// Generic-apply value: `id<_>` has nothing to infer from → clean diagnostic.
+// ===========================================================================
+
+/// A `_` in a bare generic instantiation value (not immediately called) cannot
+/// be inferred and is a clean diagnostic, never a normalization panic.
+#[tokio::test]
+#[should_panic(expected = "cannot infer type parameter")]
+async fn wildcard_generic_apply_value_is_rejected() {
+    let src = r#"
+function id<T>(x: T) -> T { x }
+function main() -> int { let f = id<_>; f(5) }
+"#;
+    let _ = baml_test!(src);
+}
+
+// ===========================================================================
+// Upcast target: `.as<Show<_>>` is an explicit ascription with no local source
+// for the hole → clean diagnostic (mirrors the `is Show<_>` pattern).
+// ===========================================================================
+
+/// A `_` in an interface upcast target is rejected cleanly, never a
+/// normalization panic.
+#[tokio::test]
+#[should_panic(expected = "unresolved type")]
+async fn wildcard_upcast_target_is_rejected() {
+    let src = r#"
+interface Show<T> { function show(self) -> T }
+class C {
+  v int
+  implements Show<int> { function show(self) -> int { self.v } }
+}
+function main() -> int { let c = C { v: 5 }; let s = c.as<Show<_>>; 0 }
+"#;
+    let _ = baml_test!(src);
+}


### PR DESCRIPTION
## Summary

Extends the `_` wildcard feature from #3887 (B-230/B-247) to the **expression-context** type positions. Before this, `_` was solvable in a `let` annotation and a `throws` clause, but writing it anywhere in an expression (a call turbofish, an object literal, a generic value, an upcast) either panicked the compiler or was silently un-handled.

cc @antoniosarosi, since this builds directly on your `_` inference work and changes the invariant your firewall documented.

## Root cause

Your `check_wildcard_type` firewall rewrites `_` to `Ty::Error` at every **declaration** site (params, returns, fields, aliases, bounds), which is why the doc there said "a `Ty::Infer` only ever originates from the two hole-handling contexts."

That invariant was actually already violated: there are **four expression positions that carry a written type and never pass through the firewall**, so a `_` there reached type checking as a live `Ty::Infer`:

1. call turbofish, `foo<T, _>(x)`
2. object construction, `Box<_> { ... }`
3. generic-apply value, `id<_>`
4. upcast target, `c.as<Show<_>>`

A surviving `Ty::Infer` then tripped an `unreachable!` at one of the two boundaries that deliberately refuse to guess a meaning for a hole:

- `baml_type/src/runtime_ty.rs` (MIR runtime lowering): `` `Infer` is not a valid `RuntimeTy` ``
- `baml_compiler2_tir/src/normalize.rs:566` (structural normalization): `inference hole `_` reached structural normalization`

These were latent panics, not something a user had to do anything exotic to hit.

## Approach

Same principle as your `let`/`throws` handling: fill the hole from a local source where one exists, reject it cleanly where none does. Never let a `Ty::Infer` escape the site.

| Position | Fill source | Behavior |
|---|---|---|
| Call turbofish `race<T, _>(...)` | the call arguments | **solved** |
| Object `Box<_> { v: 5 }` | the field values | **solved** |
| Generic-apply value `id<_>` | none (a bare value has nothing to infer from) | clean diagnostic |
| Upcast `c.as<Show<_>>` | none (explicit ascription) | clean diagnostic |

For the two solve sites, a hole that still cannot be resolved from its source (e.g. `pick<int, _>(5)` where `U` is in neither an argument nor the return) is reported as `cannot infer type parameter`, not accepted or panicked.

I deliberately left upcast as a **reject** rather than solving `_` from the receiver's `implements` list. That is a bigger feature and matches how `is Show<_>` already behaves. Happy to revisit if you think upcast should solve.

## Before / after

**1. Call turbofish (the original report)**

```baml
function with_timeout<T>(millis: int, f: () -> T) -> T {
    let work = spawn { f() };
    let timer = spawn {
        baml.sys.sleep(baml.time.Duration.from_milliseconds(millis));
        work.cancel();
        throw TimeoutError { message: `timed out` };
    };
    let result = baml.future.race<T, _>([work, timer]);
    await result
}
```
- Before: panic, `` `Infer` is not a valid `RuntimeTy` `` (runtime lowering).
- After: compiles and runs. `_` (the future's error type) is inferred from `[work, timer]`, while `T` stays pinned. Note the no-turbofish form `race([work, timer])` cannot type-check here (the two futures do not unify), which is exactly why the partial `<T, _>` is needed.

**2. Object construction**

```baml
class Box<T> { v T }
let b = Box<_> { v: 5 }        // was: panic (normalize.rs:566)  ->  now: T = int, runs

class Pair<A, B> { a A  b B }
let p = Pair<int, _> { a: 1, b: "hi" }   // pins A = int, infers B = string from the field
```

**3. Generic-apply value (no source, reject)**

```baml
function id<T>(x: T) -> T { x }
let f = id<_>                  // was: panic (normalize.rs:566)  ->  now: E0002 cannot infer type parameter `T`
```

**4. Upcast target (no source, reject)**

```baml
c.as<Show<_>>                  // was: panic (normalize.rs:566)  ->  now: E0002 unresolved type: _  (matches `is Show<_>`)
```

## Centralized policy (so a 5th position does not reintroduce this)

The enforcement is necessarily per-site (a hole has no sound normal form, so it must be resolved before that site's own subtype/normalize checks; the `unreachable!` is the intentional tripwire). To avoid four ad-hoc copies, the fill-or-reject rule now lives in one documented place in `builder.rs`:

- `report_uninferable_type_hole(param, at)`: the single reject-and-neutralize path. `CannotInferTypeParameter` when a parameter is named, `UnresolvedType` for a nested ascription hole.
- `fill_expression_type_arg_hole(partial, candidate, param, at)`: keep-if-concrete, else fill from the site's inferred candidate, else reject. `candidate: None` degenerates to pure reject, so the same helper serves both solve and reject sites.

Call, generic-apply, and upcast all route through these. Object keeps its own field-inference loop (it has a richer policy: an unconstrained *phantom* param recovers to `BuiltinUnknown` instead of erroring) but is documented as the field-sourced case of the same rule.

On the MIR side, the two hole detectors were merged into one (`type_arg_is_infer_hole`), which asks the actual conversion boundary (`lower_to_runtime(..).is_err()`) so it can never drift from what the runtime accepts.

I also corrected the `check_wildcard_type` doc, which claimed the two-context invariant that is no longer true.

## What "handled" means here

Every `_` position now either solves or produces a clean diagnostic. It does **not** mean every theoretically-inferable `_` is inferred (upcast is a deliberate reject). The guarantee is: no `Ty::Infer` reaches normalization or runtime lowering from a supported syntactic position.

## Files

- `baml_compiler2_tir/src/builder.rs`: policy helpers + the four sites (call, object, generic-apply, upcast).
- `baml_compiler2_mir/src/lower.rs`: substitute the TIR-solved type into hole slots for call and object type-args instead of re-lowering the raw `_`; single hole detector.
- `baml_compiler2_ast/src/lower_type_expr.rs`: corrected `check_wildcard_type` invariant docs.
- `baml_tests/tests/wildcard_expression_holes.rs`: 9 regression tests covering all four positions (solve, mixed-partial, nested, phantom, and each reject).

## Testing

New file green (9). No regressions across wildcard (17), interfaces (35 / 150), instantiation, spawn, match/typevar, json interfaces (12 / 11), and tir/mir unit (175). Clean `cargo clippy` / `cargo fmt`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `_` type holes in expression-contexts are now handled more consistently, producing clear compile-time errors instead of runtime panics.
  * Improved inference for partial/explicit generic type arguments, including mixed inferred and written holes.
  * Object construction, upcast/ascription targets, and call-site generics now resolve `_` reliably using available context.
* **Tests**
  * Added regression coverage for wildcard holes across function calls, timeouts/race-style expressions, nested constructors, and interface upcasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->