### PR TITLE
Compiler perf: 2.9x faster cold compile (1.41s → 482ms empty project)

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -21,8 +21,9 @@ use baml_compiler2_hir::{
     package::PackageId,
 };
 use baml_compiler2_mir::{
-    BuiltinKind, Local, MirFunctionBody, MirFunctionKind, Operand, Place, ResolvedAliases, Rvalue,
-    StatementKind, Terminator, def_to_item_ref, lower_function, lower_let_body,
+    BuiltinKind, DispatchCandidateCache, Local, MirFunctionBody, MirFunctionKind, Operand, Place,
+    ResolvedAliases, Rvalue, StatementKind, Terminator, def_to_item_ref, lower_function_cached,
+    lower_let_body_cached,
 };
 // Use the PPIR item tree (which includes synthetic *$stream items) rather than
 // the bare HIR item tree, to stay consistent with TIR's LocalItemId indices.
@@ -875,6 +876,13 @@ pub fn generate_project_bytecode_with_opt(
     let mut program = Program::new();
     let all_files = compiler2_all_files(db);
     let alias_caches = build_alias_caches(db, &all_files);
+    // One dispatch-candidate cache per package, shared across every function
+    // lowered below so repeated interface-dispatch requests (the same
+    // `Iterator.next` question at every `for` loop, say) resolve once.
+    let dispatch_caches: HashMap<Name, std::rc::Rc<DispatchCandidateCache>> = alias_caches
+        .keys()
+        .map(|pkg| (pkg.clone(), std::rc::Rc::default()))
+        .collect();
 
     // --- Pass 1: Build globals map (function name -> global index) ---
     // Functions are allocated first (slots 0..N-1), then let bindings (slots N..M-1).
@@ -890,22 +898,30 @@ pub fn generate_project_bytecode_with_opt(
     // actual program.globals array built in Pass 4 (which also skips intrinsics).
     for file in &all_files {
         let item_tree = file_item_tree(db, *file);
-        for local_id in item_tree.functions.keys() {
+        for (local_id, func_data) in &item_tree.functions {
             let func_loc = FunctionLoc::new(db, *file, *local_id);
-            let mir = lower_function(db, func_loc, opt);
             // Skip intrinsic and await-any functions — they are never called via
             // a Call instruction (intrinsics lower to StatementKind::Intrinsic;
             // `__await_any` lowers to a Terminator::AwaitAny). Pass 4 skips them
             // too, so they must be skipped here as well or the Pass-1 indices
             // desync from the program.globals array (off-by-one for everything
             // after the skipped function).
+            //
+            // The kind is read straight off the item tree rather than from
+            // `lower_function(..).kind`: `lower_function` copies the item
+            // tree's `FunctionBodyDef::Builtin(kind)` into
+            // `MirFunctionKind::Builtin(kind)` verbatim, and fully MIR-lowering
+            // every function here just to inspect that one field would double
+            // the total lowering work (Pass 4 lowers every function again).
             if matches!(
-                mir.kind,
-                MirFunctionKind::Builtin(BuiltinKind::Intrinsic | BuiltinKind::AwaitAny)
+                func_data.body,
+                Some(baml_compiler2_ast::FunctionBodyDef::Builtin(
+                    BuiltinKind::Intrinsic | BuiltinKind::AwaitAny
+                ))
             ) {
                 continue;
             }
-            let fq_name = mir.item_ref.to_string();
+            let fq_name = def_to_item_ref(db, Definition::Function(func_loc)).to_string();
             globals.entry(fq_name).or_insert_with(|| {
                 let idx = global_idx;
                 global_idx += 1;
@@ -1225,7 +1241,8 @@ pub fn generate_project_bytecode_with_opt(
         let cache_pass4 = &alias_caches[&pkg_info_pass4.package];
         for (local_id, func_data) in &item_tree.functions {
             let func_loc = FunctionLoc::new(db, *file, *local_id);
-            let mir = lower_function(db, func_loc, opt);
+            let mir =
+                lower_function_cached(db, func_loc, opt, &dispatch_caches[&pkg_info_pass4.package]);
             let fq_name = mir.item_ref.to_string();
 
             let mut compiled_fn = match &mir.kind {
@@ -1461,6 +1478,7 @@ pub fn generate_project_bytecode_with_opt(
                 &enum_variants,
                 &mut program,
                 opt,
+                &dispatch_caches[pkg_name.as_str()],
             )?;
 
             let init_fq_name = if pkg_name.as_str() == "user" {
@@ -2563,6 +2581,7 @@ fn compile_init_function<'db>(
     enum_variants: &HashMap<String, HashMap<String, usize>>,
     program: &mut Program,
     opt: OptLevel,
+    dispatch_cache: &std::rc::Rc<DispatchCandidateCache>,
 ) -> Result<Function, LoweringError> {
     // Build the $init bytecode: a sequence of Call + StoreGlobal pairs.
     let mut init_instructions: Vec<Instruction> = Vec::new();
@@ -2578,7 +2597,7 @@ fn compile_init_function<'db>(
         };
 
         // Lower the let initializer through MIR → MirFunctionBody (+ any lambda children).
-        let maybe_body = lower_let_body(db, *let_loc, opt);
+        let maybe_body = lower_let_body_cached(db, *let_loc, opt, dispatch_cache);
 
         let helper_fn = match maybe_body {
             Some((mir_body, lambdas)) => {

--- a/baml_language/crates/baml_compiler2_mir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lib.rs
@@ -7,7 +7,8 @@ pub mod pretty;
 pub use baml_type::ResolvedAliases;
 pub use ir::*;
 pub use lower::{
-    def_to_item_ref, lower_function, lower_let_body, resolved_aliases_for_package, tir2_to_template,
+    DispatchCandidateCache, def_to_item_ref, lower_function, lower_function_cached, lower_let_body,
+    lower_let_body_cached, resolved_aliases_for_package, tir2_to_template,
 };
 
 /// Database trait for compiler2 MIR queries.

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1574,7 +1574,8 @@ type DispatchCacheKey = (
     Vec<(Name, Tir2Ty)>,
 );
 
-/// Shared memo for [`LoweringContext::interface_method_candidates_for`].
+/// Shared memo for `LoweringContext::interface_method_candidates_for` (a
+/// private lowering helper).
 ///
 /// Candidate resolution rescans every implementor of the requested interface
 /// (running type-pattern matching and normalization per candidate) at every

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1558,6 +1558,36 @@ struct InterfaceMethodCandidate {
     frame_seed: CalleeFrameSeed,
 }
 
+/// Key identifying one interface-dispatch candidate resolution: the requested
+/// interface, its type args and associated bindings, the method, the receiver
+/// type, and the enclosing function's generic bounds (sorted by name for a
+/// canonical order). The bounds are the *only* per-function input the
+/// resolution consults — everything else it reads is the Salsa db or
+/// package-level `PackageLoweringData` — so two functions issuing the same
+/// request with the same bounds always resolve identical candidates.
+type DispatchCacheKey = (
+    TypeName,
+    Vec<Tir2Ty>,
+    Vec<(Name, Tir2Ty)>,
+    Name,
+    Option<Tir2Ty>,
+    Vec<(Name, Tir2Ty)>,
+);
+
+/// Shared memo for [`LoweringContext::interface_method_candidates_for`].
+///
+/// Candidate resolution rescans every implementor of the requested interface
+/// (running type-pattern matching and normalization per candidate) at every
+/// dispatch site. The same requests recur constantly across call sites *and*
+/// functions — every `for` loop in a package asks the same `Iterator.next`
+/// question — so the emit driver shares one cache per package across all the
+/// functions it lowers ([`lower_function_cached`]); one-off callers get a
+/// fresh cache via [`lower_function`].
+#[derive(Default)]
+pub struct DispatchCandidateCache {
+    map: std::cell::RefCell<FxHashMap<DispatchCacheKey, Vec<InterfaceMethodCandidate>>>,
+}
+
 /// Strategy for seeding a dispatched method's `frame.type_args`.
 #[derive(Clone)]
 enum CalleeFrameSeed {
@@ -1660,43 +1690,25 @@ struct LoweringContext<'db> {
     catch_rethrow_locals: Vec<Local>,
     exit_block: BlockId,
 
-    // Eagerly aggregated type maps from all scopes in the function.
-    // Keyed by metadata namespace plus arena ID to avoid collisions between
-    // function bodies, lambda bodies, and parameter-default arenas.
-    expr_types: FxHashMap<ExprMetadataKey, Tir2Ty>,
-    pat_types: FxHashMap<PatMetadataKey, Tir2Ty>,
-    // Member resolutions from TIR.
-    resolutions: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::MemberResolution<'db>>,
-    // Match expressions that TIR determined are exhaustive
-    exhaustive_matches: rustc_hash::FxHashSet<ExprMetadataKey>,
-    // TIR-inferred root segment type for each multi-segment Path expression.
-    // Used by lower_multi_segment_path_as_field_chain to get the correct root
-    // type even when the MIR local was declared with a coarser type (e.g.
-    // catch variables declared as BuiltinUnknown).
-    path_root_types: FxHashMap<ExprMetadataKey, Tir2Ty>,
-    // TIR-inferred type of every prefix `segments[..=seg_idx]` for multi-segment
-    // local-rooted Path expressions. Used by the Phase-8 method-call prepend to
-    // read the receiver-prefix type (`segments[..segments.len() - 1]`) so that
-    // class-level type args are threaded correctly through depth ≥ 3 paths
-    // like `holder.box.describe()`.
-    path_segment_types: FxHashMap<(MetadataScope, AstExprId, usize), Tir2Ty>,
-    // Per-segment member resolutions for multi-segment local-rooted Path expressions.
-    // Set by TIR's infer_local_rooted_path; indexed by (scope, Path ExprId).
-    // path_member_resolutions[(scope, expr_id)][i] is the resolution for segments[i+1].
-    path_member_resolutions:
-        FxHashMap<ExprMetadataKey, Vec<baml_compiler2_tir::inference::MemberResolution<'db>>>,
-    // Full-arity argument binding plans from TIR.
-    call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan>,
-    /// TIR-recorded generic instantiation per call whose callee declares type
-    /// params (declared De Bruijn order). Lowered to `LoadType` operands when
-    /// the call site writes no explicit `<...>`, so inferred-generic calls
-    /// populate the callee's `frame.type_args` just like explicit ones.
-    // Function-value adapters from TIR checked coercions.
-    function_coercions: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::FunctionCoercion>,
+    // Per-scope TIR inference results for the function's own scope and every
+    // descendant scope (blocks, lambdas, parameter defaults), borrowed
+    // straight from the Salsa-cached `infer_scope_types` values. Lookups go
+    // through the `tir_*` accessors below, which dispatch on `MetadataScope`
+    // (Body → body tables, ParameterDefault → default tables of the same
+    // scope). The map covers *exactly* the scopes the old merged copies
+    // covered — scopes outside it answer `None`, and at least one caller
+    // (`try_lower_to_string_fallback`) keys behavior on that absence.
+    scope_inference:
+        FxHashMap<FileScopeId, &'db baml_compiler2_tir::inference::ScopeInference<'db>>,
     // Function generic bounds, lowered in TIR space. MIR uses these to keep
     // bounded type variables ABI-erased while still lowering bound-member
     // access through the interface dispatch machinery.
     generic_param_bounds: FxHashMap<Name, Tir2Ty>,
+
+    // Package-shared memo for interface-dispatch candidate resolution. Shared
+    // across every function the emit driver lowers in one package (fresh and
+    // private when constructed via the uncached entry points).
+    dispatch_cache: std::rc::Rc<DispatchCandidateCache>,
 
     // TIR types of the in-scope lambda parameters, by name. TIR does not record
     // `path_segment_types` for a lambda-parameter receiver (`(a: T) -> a.m()`),
@@ -2081,8 +2093,7 @@ impl<'db> LoweringContext<'db> {
         let saved_locals = self.locals.clone();
         let watched_depth = self.watched_locals_stack.len();
         let coll_tir_ty = self
-            .expr_types
-            .get(&self.expr_metadata_key(collection))
+            .tir_expr_type(self.expr_metadata_key(collection))
             .cloned();
 
         let coll_ty = self.expr_ty(collection);
@@ -2566,6 +2577,7 @@ impl<'db> LoweringContext<'db> {
         expr_body: AstExprBody,
         source_map: Option<AstSourceMap>,
         opt: crate::OptLevel,
+        dispatch_cache: std::rc::Rc<DispatchCandidateCache>,
     ) -> Self {
         let file = func_loc.file(db);
 
@@ -2598,147 +2610,23 @@ impl<'db> LoweringContext<'db> {
             })
             .unwrap_or_else(|| index.scope_at_offset(func_span.start(), Some(&func_data.name)));
 
-        // --- Eagerly aggregate expr_types, pat_types, resolutions, exhaustive_matches, path_root_types, and path_member_resolutions from all scopes ---
-        let mut expr_types: FxHashMap<ExprMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut pat_types: FxHashMap<PatMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut resolutions: FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
-        > = FxHashMap::default();
-        let mut exhaustive_matches: rustc_hash::FxHashSet<ExprMetadataKey> =
-            rustc_hash::FxHashSet::default();
-        let mut path_root_types: FxHashMap<ExprMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut path_segment_types: FxHashMap<(MetadataScope, AstExprId, usize), Tir2Ty> =
-            FxHashMap::default();
-        let mut path_member_resolutions: FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        > = FxHashMap::default();
-        let mut call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan> =
-            FxHashMap::default();
-        let mut function_coercions: FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        > = FxHashMap::default();
-
-        let merge_scope = |fsi: FileScopeId,
-                           expr_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           pat_types: &mut FxHashMap<PatMetadataKey, Tir2Ty>,
-                           resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
-        >,
-                           exhaustive_matches: &mut rustc_hash::FxHashSet<ExprMetadataKey>,
-                           path_root_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           path_segment_types: &mut FxHashMap<
-            (MetadataScope, AstExprId, usize),
-            Tir2Ty,
-        >,
-                           path_member_resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        >,
-                           call_plans: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::CallPlan,
-        >,
-                           function_coercions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        >| {
-            let scope_id = index.scope_ids[fsi.index() as usize];
-            let inference = infer_scope_types(db, scope_id);
-            let body_scope = MetadataScope::Body(fsi);
-            for (&expr_id, ty) in inference.iter_expressions() {
-                expr_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_bindings() {
-                pat_types.insert((body_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_resolutions() {
-                resolutions.insert((body_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_exhaustive_matches() {
-                exhaustive_matches.insert((body_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_path_root_types() {
-                path_root_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_path_segment_types() {
-                path_segment_types.insert((body_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_path_member_resolutions() {
-                path_member_resolutions.insert((body_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_call_plans() {
-                call_plans.insert((body_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_function_coercions() {
-                function_coercions.insert((body_scope, expr_id), coercion.clone());
-            }
-
-            let default_scope = MetadataScope::ParameterDefault(fsi);
-            for (&expr_id, ty) in inference.iter_default_expressions() {
-                expr_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_default_bindings() {
-                pat_types.insert((default_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_default_resolutions() {
-                resolutions.insert((default_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_default_exhaustive_matches() {
-                exhaustive_matches.insert((default_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_default_path_root_types() {
-                path_root_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_default_path_segment_types() {
-                path_segment_types.insert((default_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_default_path_member_resolutions() {
-                path_member_resolutions
-                    .insert((default_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_default_call_plans() {
-                call_plans.insert((default_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_default_function_coercions() {
-                function_coercions.insert((default_scope, expr_id), coercion.clone());
-            }
-        };
-
-        // Include the function scope itself
-        merge_scope(
-            func_scope_id,
-            &mut expr_types,
-            &mut pat_types,
-            &mut resolutions,
-            &mut exhaustive_matches,
-            &mut path_root_types,
-            &mut path_segment_types,
-            &mut path_member_resolutions,
-            &mut call_plans,
-            &mut function_coercions,
-        );
-
-        // Include all descendant scopes (blocks, lambdas, etc.)
+        // --- Collect per-scope TIR inference views (func + all descendants) ---
+        // Borrows the Salsa-cached `infer_scope_types` results instead of
+        // deep-copying every table into merged per-function maps (the old
+        // scheme cloned the whole inference output of every function on each
+        // construction). Lookups dispatch through the `tir_*` accessors.
         let func_scope = &index.scopes[func_scope_id.index() as usize];
         let desc_start = func_scope.descendants.start.index();
         let desc_end = func_scope.descendants.end.index();
-        for raw_idx in desc_start..desc_end {
-            merge_scope(
-                FileScopeId::new(raw_idx),
-                &mut expr_types,
-                &mut pat_types,
-                &mut resolutions,
-                &mut exhaustive_matches,
-                &mut path_root_types,
-                &mut path_segment_types,
-                &mut path_member_resolutions,
-                &mut call_plans,
-                &mut function_coercions,
-            );
+        let mut scope_inference: FxHashMap<
+            FileScopeId,
+            &'db baml_compiler2_tir::inference::ScopeInference<'db>,
+        > = FxHashMap::default();
+        for fsi in
+            std::iter::once(func_scope_id).chain((desc_start..desc_end).map(FileScopeId::new))
+        {
+            let scope_id = index.scope_ids[fsi.index() as usize];
+            scope_inference.insert(fsi, infer_scope_types(db, scope_id));
         }
 
         // --- Build class_fields / enum_variants from PackageItems ---
@@ -2895,16 +2783,9 @@ impl<'db> LoweringContext<'db> {
             catch_context: None,
             catch_rethrow_locals: Vec::new(),
             exit_block: BlockId(0), // placeholder; overwritten in lower_function_body
-            expr_types,
-            pat_types,
-            resolutions,
-            exhaustive_matches,
-            path_root_types,
-            path_segment_types,
-            path_member_resolutions,
-            call_plans,
-            function_coercions,
+            scope_inference,
             generic_param_bounds,
+            dispatch_cache,
             lambda_param_tir_types: FxHashMap::default(),
             current_scope: func_scope_id,
             current_metadata_scope: MetadataScope::Body(func_scope_id),
@@ -2944,6 +2825,7 @@ impl<'db> LoweringContext<'db> {
         expr_body: AstExprBody,
         source_map: Option<AstSourceMap>,
         opt: crate::OptLevel,
+        dispatch_cache: std::rc::Rc<DispatchCandidateCache>,
     ) -> Self {
         let file = let_loc.file(db);
 
@@ -2956,147 +2838,22 @@ impl<'db> LoweringContext<'db> {
         let index = file_semantic_index(db, file);
         let let_scope_id: FileScopeId = index.scope_at_offset(let_span.start(), Some(&let_name));
 
-        // --- Eagerly aggregate expr_types, pat_types, resolutions, path_root_types, path_member_resolutions from let scope ---
-        let mut expr_types: FxHashMap<ExprMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut pat_types: FxHashMap<PatMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut resolutions: FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
+        // --- Collect per-scope TIR inference views (let + all descendants) ---
+        // Borrows the Salsa-cached `infer_scope_types` results instead of
+        // deep-copying every table into merged per-function maps (the old
+        // scheme cloned the whole inference output of every let initializer on each
+        // construction). Lookups dispatch through the `tir_*` accessors.
+        let let_owner_scope = &index.scopes[let_scope_id.index() as usize];
+        let desc_start = let_owner_scope.descendants.start.index();
+        let desc_end = let_owner_scope.descendants.end.index();
+        let mut scope_inference: FxHashMap<
+            FileScopeId,
+            &'db baml_compiler2_tir::inference::ScopeInference<'db>,
         > = FxHashMap::default();
-        let mut exhaustive_matches: rustc_hash::FxHashSet<ExprMetadataKey> =
-            rustc_hash::FxHashSet::default();
-        let mut path_root_types: FxHashMap<ExprMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut path_segment_types: FxHashMap<(MetadataScope, AstExprId, usize), Tir2Ty> =
-            FxHashMap::default();
-        let mut path_member_resolutions: FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        > = FxHashMap::default();
-        let mut call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan> =
-            FxHashMap::default();
-        let mut function_coercions: FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        > = FxHashMap::default();
-
-        let merge_scope = |fsi: FileScopeId,
-                           expr_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           pat_types: &mut FxHashMap<PatMetadataKey, Tir2Ty>,
-                           resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
-        >,
-                           exhaustive_matches: &mut rustc_hash::FxHashSet<ExprMetadataKey>,
-                           path_root_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           path_segment_types: &mut FxHashMap<
-            (MetadataScope, AstExprId, usize),
-            Tir2Ty,
-        >,
-                           path_member_resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        >,
-                           call_plans: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::CallPlan,
-        >,
-                           function_coercions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        >| {
+        for fsi in std::iter::once(let_scope_id).chain((desc_start..desc_end).map(FileScopeId::new))
+        {
             let scope_id = index.scope_ids[fsi.index() as usize];
-            let inference = infer_scope_types(db, scope_id);
-            let body_scope = MetadataScope::Body(fsi);
-            for (&expr_id, ty) in inference.iter_expressions() {
-                expr_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_bindings() {
-                pat_types.insert((body_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_resolutions() {
-                resolutions.insert((body_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_exhaustive_matches() {
-                exhaustive_matches.insert((body_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_path_root_types() {
-                path_root_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_path_segment_types() {
-                path_segment_types.insert((body_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_path_member_resolutions() {
-                path_member_resolutions.insert((body_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_call_plans() {
-                call_plans.insert((body_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_function_coercions() {
-                function_coercions.insert((body_scope, expr_id), coercion.clone());
-            }
-
-            let default_scope = MetadataScope::ParameterDefault(fsi);
-            for (&expr_id, ty) in inference.iter_default_expressions() {
-                expr_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_default_bindings() {
-                pat_types.insert((default_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_default_resolutions() {
-                resolutions.insert((default_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_default_exhaustive_matches() {
-                exhaustive_matches.insert((default_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_default_path_root_types() {
-                path_root_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_default_path_segment_types() {
-                path_segment_types.insert((default_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_default_path_member_resolutions() {
-                path_member_resolutions
-                    .insert((default_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_default_call_plans() {
-                call_plans.insert((default_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_default_function_coercions() {
-                function_coercions.insert((default_scope, expr_id), coercion.clone());
-            }
-        };
-
-        // Include the let scope itself
-        merge_scope(
-            let_scope_id,
-            &mut expr_types,
-            &mut pat_types,
-            &mut resolutions,
-            &mut exhaustive_matches,
-            &mut path_root_types,
-            &mut path_segment_types,
-            &mut path_member_resolutions,
-            &mut call_plans,
-            &mut function_coercions,
-        );
-
-        // Include all descendant scopes (blocks, closures within the initializer)
-        let let_scope = &index.scopes[let_scope_id.index() as usize];
-        let desc_start = let_scope.descendants.start.index();
-        let desc_end = let_scope.descendants.end.index();
-        for raw_idx in desc_start..desc_end {
-            merge_scope(
-                FileScopeId::new(raw_idx),
-                &mut expr_types,
-                &mut pat_types,
-                &mut resolutions,
-                &mut exhaustive_matches,
-                &mut path_root_types,
-                &mut path_segment_types,
-                &mut path_member_resolutions,
-                &mut call_plans,
-                &mut function_coercions,
-            );
+            scope_inference.insert(fsi, infer_scope_types(db, scope_id));
         }
 
         // --- Build class_fields / enum_variants from PackageItems ---
@@ -3119,16 +2876,9 @@ impl<'db> LoweringContext<'db> {
             catch_context: None,
             catch_rethrow_locals: Vec::new(),
             exit_block: BlockId(0), // placeholder; overwritten in lower_let_body_inner
-            expr_types,
-            pat_types,
-            resolutions,
-            exhaustive_matches,
-            path_root_types,
-            path_segment_types,
-            path_member_resolutions,
-            call_plans,
-            function_coercions,
+            scope_inference,
             generic_param_bounds: FxHashMap::default(),
+            dispatch_cache,
             lambda_param_tir_types: FxHashMap::default(),
             current_scope: let_scope_id,
             current_metadata_scope: MetadataScope::Body(let_scope_id),
@@ -3407,6 +3157,127 @@ impl<'db> LoweringContext<'db> {
         (self.current_metadata_scope, pat_id)
     }
 
+    // --- TIR inference views ---
+    //
+    // Point lookups into the Salsa-cached per-scope `ScopeInference` values
+    // collected at construction, replacing the merged per-function copies the
+    // context used to materialize. `MetadataScope::Body` reads the scope's
+    // body tables; `MetadataScope::ParameterDefault` reads the same scope's
+    // default-parameter tables — exactly the pairing the old merge encoded in
+    // its composite keys. Scopes outside this function answer `None`, matching
+    // the old maps' coverage (some callers key behavior on that absence).
+
+    /// The inference view for `fsi`, when it belongs to this function.
+    fn inference_for(
+        &self,
+        fsi: FileScopeId,
+    ) -> Option<&'db baml_compiler2_tir::inference::ScopeInference<'db>> {
+        self.scope_inference.get(&fsi).copied()
+    }
+
+    fn tir_expr_type(&self, key: ExprMetadataKey) -> Option<&'db Tir2Ty> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.expression_type(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .expression_type(key.1),
+        }
+    }
+
+    fn tir_pat_type(&self, key: PatMetadataKey) -> Option<&'db Tir2Ty> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.binding_type(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .binding_type(key.1),
+        }
+    }
+
+    fn tir_resolution(
+        &self,
+        key: ExprMetadataKey,
+    ) -> Option<&'db baml_compiler2_tir::inference::MemberResolution<'db>> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.resolution(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .resolution(key.1),
+        }
+    }
+
+    fn tir_is_exhaustive_match(&self, key: ExprMetadataKey) -> bool {
+        match key.0 {
+            MetadataScope::Body(fsi) => self
+                .inference_for(fsi)
+                .is_some_and(|inf| inf.is_exhaustive_match(key.1)),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)
+                .is_some_and(|inf| inf.parameter_defaults().is_exhaustive_match(key.1)),
+        }
+    }
+
+    fn tir_path_root_type(&self, key: ExprMetadataKey) -> Option<&'db Tir2Ty> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.path_root_type(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .path_root_type(key.1),
+        }
+    }
+
+    fn tir_path_segment_type(&self, key: (MetadataScope, AstExprId, usize)) -> Option<&'db Tir2Ty> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.path_segment_type(key.1, key.2),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .path_segment_type(key.1, key.2),
+        }
+    }
+
+    fn tir_path_member_resolutions(
+        &self,
+        key: ExprMetadataKey,
+    ) -> Option<&'db [baml_compiler2_tir::inference::MemberResolution<'db>]> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.path_member_resolution(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .path_member_resolution(key.1),
+        }
+    }
+
+    fn tir_call_plan(
+        &self,
+        key: ExprMetadataKey,
+    ) -> Option<&'db baml_compiler2_tir::inference::CallPlan> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.call_plan(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .call_plan(key.1),
+        }
+    }
+
+    fn tir_function_coercion(
+        &self,
+        key: ExprMetadataKey,
+    ) -> Option<&'db baml_compiler2_tir::inference::FunctionCoercion> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.function_coercion(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .function_coercion(key.1),
+        }
+    }
+
     fn convert_tir_ty_for_runtime(&self, ty: &Tir2Ty) -> RuntimeTy {
         // Resolve associated-type projections against the bounds the compiler
         // knows statically; anything still symbolic — a `TypeVar` or a
@@ -3583,8 +3454,7 @@ impl<'db> LoweringContext<'db> {
     fn interface_dispatch_target_for_expr(&self, expr_id: AstExprId) -> Option<InterfaceTypeView> {
         self.source_param_interface_view_for_expr(expr_id)
             .or_else(|| {
-                self.expr_types
-                    .get(&self.expr_metadata_key(expr_id))
+                self.tir_expr_type(self.expr_metadata_key(expr_id))
                     .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
             })
             .or_else(|| {
@@ -3718,13 +3588,11 @@ impl<'db> LoweringContext<'db> {
     fn dispatch_receiver_static_tir_ty(&self, expr_id: AstExprId) -> Option<Tir2Ty> {
         if let AstExpr::Upcast { base, .. } = &self.body.exprs[expr_id] {
             return self
-                .expr_types
-                .get(&self.expr_metadata_key(*base))
+                .tir_expr_type(self.expr_metadata_key(*base))
                 .cloned()
                 .or_else(|| self.dispatch_receiver_static_tir_ty(*base));
         }
-        self.expr_types
-            .get(&self.expr_metadata_key(expr_id))
+        self.tir_expr_type(self.expr_metadata_key(expr_id))
             .cloned()
             .or_else(|| self.self_typevar_for_expr(expr_id))
     }
@@ -4028,8 +3896,7 @@ impl<'db> LoweringContext<'db> {
     }
 
     fn expr_ty(&self, expr_id: AstExprId) -> RuntimeTy {
-        self.expr_types
-            .get(&self.expr_metadata_key(expr_id))
+        self.tir_expr_type(self.expr_metadata_key(expr_id))
             .map(|ty| self.convert_tir_ty_for_runtime(ty))
             .unwrap_or(RuntimeTy::Void {
                 attr: TyAttr::default(),
@@ -4042,7 +3909,7 @@ impl<'db> LoweringContext<'db> {
     /// Returns `vec![]` for non-generic (or unresolved) classes.
     fn class_type_arg_templates(&self, expr_id: AstExprId) -> Vec<TyTemplate> {
         let generic_params = self.enclosing_generic_params();
-        match self.expr_types.get(&self.expr_metadata_key(expr_id)) {
+        match self.tir_expr_type(self.expr_metadata_key(expr_id)) {
             Some(Tir2Ty::Class(_, type_args, _)) if !type_args.is_empty() => type_args
                 .iter()
                 .map(|t| self.ty_to_template(t, &generic_params))
@@ -4058,7 +3925,7 @@ impl<'db> LoweringContext<'db> {
     /// recovery).
     fn array_element_template(&self, expr_id: AstExprId) -> TyTemplate {
         let generic_params = self.enclosing_generic_params();
-        match self.expr_types.get(&self.expr_metadata_key(expr_id)) {
+        match self.tir_expr_type(self.expr_metadata_key(expr_id)) {
             Some(Tir2Ty::List(elem, _) | Tir2Ty::EvolvingList(elem, _)) => {
                 self.ty_to_template(elem, &generic_params)
             }
@@ -4072,7 +3939,7 @@ impl<'db> LoweringContext<'db> {
     /// recovery); map keys are always strings.
     fn map_kv_templates(&self, expr_id: AstExprId) -> (TyTemplate, TyTemplate) {
         let generic_params = self.enclosing_generic_params();
-        match self.expr_types.get(&self.expr_metadata_key(expr_id)) {
+        match self.tir_expr_type(self.expr_metadata_key(expr_id)) {
             Some(Tir2Ty::Map { key, value, .. } | Tir2Ty::EvolvingMap(key, value, _)) => (
                 self.ty_to_template(key, &generic_params),
                 self.ty_to_template(value, &generic_params),
@@ -4098,8 +3965,7 @@ impl<'db> LoweringContext<'db> {
 
     /// Get the `baml_type::RuntimeTy` for a pattern binding
     fn pat_ty(&self, pat_id: AstPatId) -> RuntimeTy {
-        self.pat_types
-            .get(&self.pat_metadata_key(pat_id))
+        self.tir_pat_type(self.pat_metadata_key(pat_id))
             .map(|ty| self.convert_tir_ty_for_runtime(ty))
             .unwrap_or(RuntimeTy::Void {
                 attr: TyAttr::default(),
@@ -4116,8 +3982,7 @@ impl<'db> LoweringContext<'db> {
     /// Get the TIR-inferred root segment type for a multi-segment Path expression.
     /// Returns `None` if no root type was recorded (e.g. single-segment paths).
     fn path_root_ty(&self, expr_id: AstExprId) -> Option<RuntimeTy> {
-        self.path_root_types
-            .get(&self.expr_metadata_key(expr_id))
+        self.tir_path_root_type(self.expr_metadata_key(expr_id))
             .map(|ty| self.convert_tir_ty_for_runtime(ty))
     }
 
@@ -4125,8 +3990,7 @@ impl<'db> LoweringContext<'db> {
     /// local-rooted Path expression. Returns `None` if not recorded.
     #[allow(dead_code)]
     fn path_segment_ty(&self, expr_id: AstExprId, seg_idx: usize) -> Option<RuntimeTy> {
-        self.path_segment_types
-            .get(&(self.current_metadata_scope, expr_id, seg_idx))
+        self.tir_path_segment_type((self.current_metadata_scope, expr_id, seg_idx))
             .map(|ty| self.convert_tir_ty_for_runtime(ty))
     }
 
@@ -4920,8 +4784,7 @@ impl LoweringContext<'_> {
         // the bare last segment (`prompt`) in the user's scope would miss it.
         // Fall back to bare-name resolution for unqualified, in-file tags.
         let tag_func_loc = self
-            .resolutions
-            .get(&self.expr_metadata_key(tag))
+            .tir_resolution(self.expr_metadata_key(tag))
             .and_then(|r| match r {
                 MemberResolution::Free { func_loc }
                 | MemberResolution::UnboundMethod { func_loc, .. }
@@ -5579,8 +5442,7 @@ impl LoweringContext<'_> {
 
     fn lower_expr(&mut self, expr_id: AstExprId, dest: Place) {
         if let Some(coercion) = self
-            .function_coercions
-            .get(&self.expr_metadata_key(expr_id))
+            .tir_function_coercion(self.expr_metadata_key(expr_id))
             .cloned()
         {
             self.lower_optional_function_adapter(expr_id, &coercion, dest);
@@ -6055,9 +5917,8 @@ impl<'db> LoweringContext<'db> {
             // This takes priority over the flat resolutions map since infer_local_rooted_path
             // moves resolutions from the flat map into path_member_resolutions.
             if let Some(member_resolutions) = self
-                .path_member_resolutions
-                .get(&self.expr_metadata_key(expr_id))
-                .cloned()
+                .tir_path_member_resolutions(self.expr_metadata_key(expr_id))
+                .map(<[_]>::to_vec)
             {
                 use baml_compiler2_tir::inference::MemberResolution;
                 // The last resolution corresponds to the final segment of the path.
@@ -6135,8 +5996,7 @@ impl<'db> LoweringContext<'db> {
             // Check flat resolutions (set by infer_multi_segment_path for package-rooted paths
             // like baml.fs.open, baml.env.get, etc.).
             if let Some(resolution) = self
-                .resolutions
-                .get(&self.expr_metadata_key(expr_id))
+                .tir_resolution(self.expr_metadata_key(expr_id))
                 .cloned()
             {
                 use baml_compiler2_tir::inference::MemberResolution;
@@ -6221,8 +6081,7 @@ impl<'db> LoweringContext<'db> {
                     segments.len() - 2
                 };
                 let recv_tir_ty = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, expr_id, recv_seg_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, expr_id, recv_seg_idx))
                     .cloned();
                 if let Some((iface_tn, iface_type_args, iface_assoc)) = recv_tir_ty
                     .as_ref()
@@ -6262,8 +6121,7 @@ impl<'db> LoweringContext<'db> {
             }
             // Check for enum variant (e.g. Status.Active lowered to Path(["Status","Active"]))
             if let Some(Tir2Ty::EnumVariant(qtn, variant, _)) = self
-                .expr_types
-                .get(&self.expr_metadata_key(expr_id))
+                .tir_expr_type(self.expr_metadata_key(expr_id))
                 .cloned()
                 .as_ref()
             {
@@ -6355,8 +6213,8 @@ impl<'db> LoweringContext<'db> {
             }
             ResolvedName::Unknown => {
                 if self
-                    .expr_types
-                    .contains_key(&self.expr_metadata_key(expr_id))
+                    .tir_expr_type(self.expr_metadata_key(expr_id))
+                    .is_some()
                 {
                     // If TIR recorded a type for this expr, it was handled as a
                     // package path intermediate (e.g. `baml` in
@@ -6532,8 +6390,7 @@ impl<'db> LoweringContext<'db> {
             // (`(Dog | Named).name`): dispatch the field read on the runtime
             // class across all members' implementors.
             if let Some(members) = self
-                .path_segment_types
-                .get(&(self.current_metadata_scope, expr_id, seg_idx - 1))
+                .tir_path_segment_type((self.current_metadata_scope, expr_id, seg_idx - 1))
                 .and_then(Self::tir_union_members)
                 && self.lower_union_iface_field_access(base_local, &members, seg, &target_place)
             {
@@ -6638,8 +6495,7 @@ impl<'db> LoweringContext<'db> {
         let item = def_to_item_ref(self.db, def);
         // Check if this expression's type is EnumVariant
         if let Some(Tir2Ty::EnumVariant(_qtn, variant, _)) = self
-            .expr_types
-            .get(&self.expr_metadata_key(expr_id))
+            .tir_expr_type(self.expr_metadata_key(expr_id))
             .cloned()
             .as_ref()
         {
@@ -7251,11 +7107,7 @@ impl LoweringContext<'_> {
 
 impl<'db> LoweringContext<'db> {
     fn lower_call_arg_operands(&mut self, expr_id: AstExprId, args: &[AstExprId]) -> Vec<Operand> {
-        let Some(plan) = self
-            .call_plans
-            .get(&self.expr_metadata_key(expr_id))
-            .cloned()
-        else {
+        let Some(plan) = self.tir_call_plan(self.expr_metadata_key(expr_id)).cloned() else {
             // No call plan: lower each arg in order (the type checker would
             // have already flagged any mismatch).
             return args.iter().map(|&a| self.lower_to_operand(a)).collect();
@@ -7365,8 +7217,7 @@ impl<'db> LoweringContext<'db> {
         // A nullable receiver types the missing member as `Unknown | null`, so test
         // the non-null part (matches the TIR fallback gate).
         let callee_untyped = self
-            .expr_types
-            .get(&self.expr_metadata_key(callee))
+            .tir_expr_type(self.expr_metadata_key(callee))
             .is_none_or(|t| {
                 matches!(
                     baml_compiler2_tir::narrowing::remove_null(t),
@@ -7379,10 +7230,7 @@ impl<'db> LoweringContext<'db> {
         let (recv_op, recv_tir_ty): (Operand, Option<Tir2Ty>) = match &callee_expr {
             AstExpr::MemberAccess { base, .. } => {
                 let base_id = *base;
-                let ty = self
-                    .expr_types
-                    .get(&self.expr_metadata_key(base_id))
-                    .cloned();
+                let ty = self.tir_expr_type(self.expr_metadata_key(base_id)).cloned();
                 (self.lower_to_operand(base_id), ty)
             }
             AstExpr::Path(segments) => {
@@ -7404,8 +7252,7 @@ impl<'db> LoweringContext<'db> {
                     }
                 } else {
                     let recv_ty = self
-                        .path_segment_types
-                        .get(&(
+                        .tir_path_segment_type((
                             self.current_metadata_scope,
                             callee,
                             receiver_segments.len() - 1,
@@ -7425,8 +7272,7 @@ impl<'db> LoweringContext<'db> {
                 };
                 let prefix_idx = segments.len() - 2;
                 let ty = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, callee, prefix_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                     .cloned();
                 (recv_op, ty)
             }
@@ -7518,8 +7364,7 @@ impl<'db> LoweringContext<'db> {
         }
         // Fires only when TIR left the callee untyped (no real `to_json` method).
         let callee_untyped = self
-            .expr_types
-            .get(&self.expr_metadata_key(callee))
+            .tir_expr_type(self.expr_metadata_key(callee))
             .is_none_or(|t| {
                 matches!(
                     baml_compiler2_tir::narrowing::remove_null(t),
@@ -7532,10 +7377,7 @@ impl<'db> LoweringContext<'db> {
         let (recv_op, recv_tir_ty): (Operand, Option<Tir2Ty>) = match &callee_expr {
             AstExpr::MemberAccess { base, .. } => {
                 let base_id = *base;
-                let ty = self
-                    .expr_types
-                    .get(&self.expr_metadata_key(base_id))
-                    .cloned();
+                let ty = self.tir_expr_type(self.expr_metadata_key(base_id)).cloned();
                 (self.lower_to_operand(base_id), ty)
             }
             AstExpr::Path(segments) => {
@@ -7552,8 +7394,7 @@ impl<'db> LoweringContext<'db> {
                     }
                 } else {
                     let recv_ty = self
-                        .path_segment_types
-                        .get(&(
+                        .tir_path_segment_type((
                             self.current_metadata_scope,
                             callee,
                             receiver_segments.len() - 1,
@@ -7573,8 +7414,7 @@ impl<'db> LoweringContext<'db> {
                 };
                 let prefix_idx = segments.len() - 2;
                 let ty = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, callee, prefix_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                     .cloned();
                 (recv_op, ty)
             }
@@ -7676,8 +7516,7 @@ impl<'db> LoweringContext<'db> {
             return false;
         }
         let callee_untyped = self
-            .expr_types
-            .get(&self.expr_metadata_key(callee))
+            .tir_expr_type(self.expr_metadata_key(callee))
             .is_none_or(|t| {
                 matches!(
                     baml_compiler2_tir::narrowing::remove_null(t),
@@ -7692,10 +7531,8 @@ impl<'db> LoweringContext<'db> {
         // type arg so `baml.json.to<T>` binds `T` under monomorphization; an
         // out-of-scope typevar / unknown safely drops to ntypeargs=0 (the shim
         // resolves on the runtime value when no static type is supplied).
-        let recv_tir_ty: Option<Tir2Ty> = self
-            .expr_types
-            .get(&self.expr_metadata_key(expr_id))
-            .cloned();
+        let recv_tir_ty: Option<Tir2Ty> =
+            self.tir_expr_type(self.expr_metadata_key(expr_id)).cloned();
         let caller_generic_params = self.enclosing_generic_params();
         let type_arg_ops: Vec<Operand> = match &recv_tir_ty {
             Some(t)
@@ -7912,8 +7749,7 @@ impl<'db> LoweringContext<'db> {
                 let prefix_idx = segments.len() - 2;
                 let recv_seg_idx = if segments.len() == 2 { 0 } else { prefix_idx };
                 let recv_tir_ty = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, callee, recv_seg_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, callee, recv_seg_idx))
                     .cloned()
                     .or_else(|| {
                         if segments.len() == 2
@@ -8065,8 +7901,7 @@ impl<'db> LoweringContext<'db> {
                 // `match`/`if` whose arms are different classes). Same receiver
                 // type slot, same field-chain lowering.
                 else if let Some(members) = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, callee, prefix_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                     .and_then(Self::tir_union_members)
                 {
                     let receiver_segments = &segments[..segments.len() - 1];
@@ -8136,8 +7971,7 @@ impl<'db> LoweringContext<'db> {
             &callee_expr
         {
             if self
-                .resolutions
-                .get(&self.expr_metadata_key(callee))
+                .tir_resolution(self.expr_metadata_key(callee))
                 .is_some_and(|r| {
                     use baml_compiler2_tir::inference::MemberResolution;
                     matches!(
@@ -8160,8 +7994,7 @@ impl<'db> LoweringContext<'db> {
                                 .is_some()
                     }
                     _ => self
-                        .expr_types
-                        .get(&self.expr_metadata_key(*base))
+                        .tir_expr_type(self.expr_metadata_key(*base))
                         .map(|ty| !matches!(ty, Tir2Ty::Unknown { .. }))
                         .unwrap_or(false),
                 };
@@ -8170,8 +8003,7 @@ impl<'db> LoweringContext<'db> {
                 // and must not get the class reference prepended as an argument.
                 let method_takes_self = {
                     use baml_compiler2_tir::inference::MemberResolution;
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .is_some_and(|r| match r {
                             MemberResolution::BoundMethod { func_loc, .. }
                             | MemberResolution::UnboundMethod { func_loc, .. }
@@ -8193,10 +8025,8 @@ impl<'db> LoweringContext<'db> {
                     let receiver_op = self.lower_to_operand(*base);
                     receiver_base_for_class_type_args = Some(*base);
                     let callee_op = {
-                        let resolution = self
-                            .resolutions
-                            .get(&self.expr_metadata_key(callee))
-                            .cloned();
+                        let resolution =
+                            self.tir_resolution(self.expr_metadata_key(callee)).cloned();
                         match resolution
                             .as_ref()
                             .and_then(|r| resolution_to_item_ref(self.db, r))
@@ -8216,10 +8046,8 @@ impl<'db> LoweringContext<'db> {
                     // MakeBoundMethod (which would try to load the base type as a
                     // runtime value).
                     let callee_op = {
-                        let resolution = self
-                            .resolutions
-                            .get(&self.expr_metadata_key(callee))
-                            .cloned();
+                        let resolution =
+                            self.tir_resolution(self.expr_metadata_key(callee)).cloned();
                         match resolution
                             .as_ref()
                             .and_then(|r| resolution_to_item_ref(self.db, r))
@@ -8241,8 +8069,7 @@ impl<'db> LoweringContext<'db> {
             // [Field{profile}, Field{items}, Method{slice}] — last() is Method).
             let is_local_method = segments.len() >= 2
                 && self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .is_some_and(|r| {
                         use baml_compiler2_tir::inference::MemberResolution;
@@ -8257,8 +8084,7 @@ impl<'db> LoweringContext<'db> {
             let is_pkg_method = !is_local_method
                 && segments.len() >= 2
                 && self
-                    .resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_resolution(self.expr_metadata_key(callee))
                     .is_some_and(|r| {
                         use baml_compiler2_tir::inference::MemberResolution;
                         matches!(
@@ -8278,8 +8104,7 @@ impl<'db> LoweringContext<'db> {
                 // (not MakeBoundMethod) since the receiver is passed explicitly as self.
                 let receiver_segments = &segments[..segments.len() - 1];
                 let method_resolution = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .cloned();
                 let callee_op = match method_resolution
@@ -8330,8 +8155,7 @@ impl<'db> LoweringContext<'db> {
                     };
                     let prefix_idx = segments.len() - 2;
                     receiver_path_tir_ty = self
-                        .path_segment_types
-                        .get(&(self.current_metadata_scope, callee, prefix_idx))
+                        .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                         .cloned();
                     let mut all_args = vec![receiver_op];
                     all_args.extend(self.lower_call_arg_operands(expr_id, args));
@@ -8341,10 +8165,7 @@ impl<'db> LoweringContext<'db> {
                 // Package-path method call (via flat resolutions): same treatment.
                 // For immediate calls, emit the callee as a plain function constant
                 // (not MakeBoundMethod) since the receiver is passed explicitly as self.
-                let flat_resolution = self
-                    .resolutions
-                    .get(&self.expr_metadata_key(callee))
-                    .cloned();
+                let flat_resolution = self.tir_resolution(self.expr_metadata_key(callee)).cloned();
                 let callee_op = match flat_resolution
                     .as_ref()
                     .and_then(|r| resolution_to_item_ref(self.db, r))
@@ -8362,8 +8183,7 @@ impl<'db> LoweringContext<'db> {
                 if let Some(receiver_op) = receiver_op {
                     let prefix_idx = segments.len() - 2;
                     receiver_path_tir_ty = self
-                        .path_segment_types
-                        .get(&(self.current_metadata_scope, callee, prefix_idx))
+                        .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                         .cloned();
                     let mut all_args = vec![receiver_op];
                     all_args.extend(self.lower_call_arg_operands(expr_id, args));
@@ -8465,8 +8285,7 @@ impl<'db> LoweringContext<'db> {
         //      from `path_root_types[callee_expr_id]` (TIR records root segment type there).
         let receiver_tir_ty: Option<Tir2Ty> =
             if let Some(recv_base_id) = receiver_base_for_class_type_args {
-                self.expr_types
-                    .get(&self.expr_metadata_key(recv_base_id))
+                self.tir_expr_type(self.expr_metadata_key(recv_base_id))
                     .cloned()
             } else {
                 receiver_path_tir_ty
@@ -8666,11 +8485,10 @@ impl<'db> LoweringContext<'db> {
         use baml_compiler2_tir::inference::MemberResolution;
         let key = self.expr_metadata_key(callee);
         matches!(
-            self.resolutions.get(&key),
+            self.tir_resolution(key),
             Some(MemberResolution::BoundMethod { .. })
         ) || matches!(
-            self.path_member_resolutions
-                .get(&key)
+            self.tir_path_member_resolutions(key)
                 .and_then(|resolutions| resolutions.last()),
             Some(MemberResolution::BoundMethod { .. })
         )
@@ -8705,8 +8523,7 @@ impl<'db> LoweringContext<'db> {
                 // The last resolution in path_member_resolutions is the final-segment resolution.
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -8720,8 +8537,7 @@ impl<'db> LoweringContext<'db> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -8746,7 +8562,7 @@ impl<'db> LoweringContext<'db> {
         // ── NEW: MemberAccess callee (e.g. f.read, sock.recv) ──────────────────
         if let AstExpr::MemberAccess { .. } = &self.body.exprs[callee] {
             use baml_compiler2_tir::inference::MemberResolution;
-            if let Some(resolution) = self.resolutions.get(&self.expr_metadata_key(callee)) {
+            if let Some(resolution) = self.tir_resolution(self.expr_metadata_key(callee)) {
                 let func_loc = match resolution {
                     MemberResolution::BoundMethod { func_loc, .. }
                     | MemberResolution::UnboundMethod { func_loc, .. }
@@ -8800,8 +8616,7 @@ impl<'db> LoweringContext<'db> {
                 // The last resolution in path_member_resolutions is the final-segment resolution.
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -8815,8 +8630,7 @@ impl<'db> LoweringContext<'db> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -8841,7 +8655,7 @@ impl<'db> LoweringContext<'db> {
         // ── NEW: MemberAccess callee (e.g. f.read, sock.recv) ──────────────────
         if let AstExpr::MemberAccess { .. } = &self.body.exprs[callee] {
             use baml_compiler2_tir::inference::MemberResolution;
-            if let Some(resolution) = self.resolutions.get(&self.expr_metadata_key(callee)) {
+            if let Some(resolution) = self.tir_resolution(self.expr_metadata_key(callee)) {
                 let func_loc = match resolution {
                     MemberResolution::BoundMethod { func_loc, .. }
                     | MemberResolution::UnboundMethod { func_loc, .. }
@@ -8890,8 +8704,7 @@ impl<'db> LoweringContext<'db> {
                 // The last resolution in path_member_resolutions is the final-segment resolution.
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -8905,8 +8718,7 @@ impl<'db> LoweringContext<'db> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -8931,7 +8743,7 @@ impl<'db> LoweringContext<'db> {
         // ── NEW: MemberAccess callee (e.g. f.read, sock.recv) ──────────────────
         if let AstExpr::MemberAccess { .. } = &self.body.exprs[callee] {
             use baml_compiler2_tir::inference::MemberResolution;
-            if let Some(resolution) = self.resolutions.get(&self.expr_metadata_key(callee)) {
+            if let Some(resolution) = self.tir_resolution(self.expr_metadata_key(callee)) {
                 let func_loc = match resolution {
                     MemberResolution::BoundMethod { func_loc, .. }
                     | MemberResolution::UnboundMethod { func_loc, .. }
@@ -9001,8 +8813,7 @@ impl<'db> LoweringContext<'db> {
             } else {
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -9016,8 +8827,7 @@ impl<'db> LoweringContext<'db> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -9100,8 +8910,7 @@ impl LoweringContext<'_> {
             } else {
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -9115,8 +8924,7 @@ impl LoweringContext<'_> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -9347,8 +9155,7 @@ impl LoweringContext<'_> {
         }
 
         let mut inferred_type_args = self
-            .call_plans
-            .get(&self.expr_metadata_key(call_expr_id))
+            .tir_call_plan(self.expr_metadata_key(call_expr_id))
             .map(|plan| plan.type_args.clone())
             .unwrap_or_default();
         let caller_generic_params = self.enclosing_generic_params();
@@ -9476,8 +9283,7 @@ impl LoweringContext<'_> {
         let key = self.expr_metadata_key(base);
         // Multi-segment paths: static methods, qualified free fns (e.g. baml.json.from_string).
         if let Some(item) = self
-            .path_member_resolutions
-            .get(&key)
+            .tir_path_member_resolutions(key)
             .and_then(|rs| rs.last())
             .filter(|r| is_fn(r))
             .and_then(|r| resolution_to_item_ref(self.db, r))
@@ -9486,8 +9292,7 @@ impl LoweringContext<'_> {
         }
         // Flat / package resolutions.
         if let Some(item) = self
-            .resolutions
-            .get(&key)
+            .tir_resolution(key)
             .filter(|r| is_fn(r))
             .and_then(|r| resolution_to_item_ref(self.db, r))
         {
@@ -9920,8 +9725,7 @@ impl<'db> LoweringContext<'db> {
         // (unbound) or MakeBoundMethod (bound). Field and Variant resolutions fall through to the
         // existing lowering paths below.
         if let Some(resolution) = self
-            .resolutions
-            .get(&self.expr_metadata_key(expr_id))
+            .tir_resolution(self.expr_metadata_key(expr_id))
             .cloned()
         {
             use baml_compiler2_tir::inference::MemberResolution;
@@ -9969,8 +9773,7 @@ impl<'db> LoweringContext<'db> {
         // without evaluating the receiver expression twice.
         if let Some((iface_tn, iface_type_args, iface_assoc)) =
             self.interface_dispatch_target_for_expr(base).or_else(|| {
-                self.expr_types
-                    .get(&self.expr_metadata_key(base))
+                self.tir_expr_type(self.expr_metadata_key(base))
                     .and_then(|ty| self.registry_dispatch_target_for_concrete(ty, field))
             })
         {
@@ -9994,8 +9797,7 @@ impl<'db> LoweringContext<'db> {
 
         // Check if TIR resolved this to an enum variant (e.g. baml.HttpMethod.Get via package path)
         if let Some(Tir2Ty::EnumVariant(qtn, variant, _)) = self
-            .expr_types
-            .get(&self.expr_metadata_key(expr_id))
+            .tir_expr_type(self.expr_metadata_key(expr_id))
             .cloned()
             .as_ref()
         {
@@ -10021,11 +9823,9 @@ impl<'db> LoweringContext<'db> {
         // concrete type, this is a real field access whose field type happens to be
         // Unknown (unresolved type annotation). In that case, fall through to emit
         // the field projection.
-        if let Some(Tir2Ty::Unknown { .. }) = self.expr_types.get(&self.expr_metadata_key(expr_id))
-        {
+        if let Some(Tir2Ty::Unknown { .. }) = self.tir_expr_type(self.expr_metadata_key(expr_id)) {
             let base_is_also_unknown = self
-                .expr_types
-                .get(&self.expr_metadata_key(base))
+                .tir_expr_type(self.expr_metadata_key(base))
                 .map(|ty| matches!(ty, Tir2Ty::Unknown { .. }))
                 .unwrap_or(true);
             if base_is_also_unknown {
@@ -10087,8 +9887,7 @@ impl<'db> LoweringContext<'db> {
                     &dest,
                 )
                 || self
-                    .expr_types
-                    .get(&self.expr_metadata_key(base))
+                    .tir_expr_type(self.expr_metadata_key(base))
                     .and_then(Self::tir_union_members)
                     .is_some_and(|members| {
                         self.lower_union_iface_field_access(base_local, &members, field, &dest)
@@ -10156,16 +9955,14 @@ impl<'db> LoweringContext<'db> {
         current_ty: &RuntimeTy,
     ) -> Option<InterfaceTypeView> {
         if let Some(target) = self
-            .path_segment_types
-            .get(&(self.current_metadata_scope, expr_id, prefix_idx))
+            .tir_path_segment_type((self.current_metadata_scope, expr_id, prefix_idx))
             .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
         {
             return Some(target);
         }
         if prefix_idx == 0
             && let Some(target) = self
-                .path_root_types
-                .get(&self.expr_metadata_key(expr_id))
+                .tir_path_root_type(self.expr_metadata_key(expr_id))
                 .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
         {
             return Some(target);
@@ -10189,10 +9986,9 @@ impl<'db> LoweringContext<'db> {
         current_ty: &RuntimeTy,
     ) -> Option<(TypeName, Vec<RuntimeTy>)> {
         let tir_prefix_ty = if prefix_idx == 0 {
-            self.path_root_types.get(&self.expr_metadata_key(expr_id))
+            self.tir_path_root_type(self.expr_metadata_key(expr_id))
         } else {
-            self.path_segment_types
-                .get(&(self.current_metadata_scope, expr_id, prefix_idx))
+            self.tir_path_segment_type((self.current_metadata_scope, expr_id, prefix_idx))
         };
         if let Some(target) = tir_prefix_ty.and_then(|ty| self.class_dispatch_target_for_tir_ty(ty))
         {
@@ -10396,8 +10192,7 @@ impl<'db> LoweringContext<'db> {
         dest: &Place,
     ) -> bool {
         let dispatch_target = self.interface_dispatch_target_for_expr(base).or_else(|| {
-            self.expr_types
-                .get(&self.expr_metadata_key(base))
+            self.tir_expr_type(self.expr_metadata_key(base))
                 .and_then(|ty| self.registry_dispatch_target_for_concrete(ty, method))
         });
         let Some((iface_tn, iface_type_args, iface_assoc)) = dispatch_target else {
@@ -10594,8 +10389,7 @@ impl<'db> LoweringContext<'db> {
         }
         let recv_ty_idx = receiver_segments.len() - 1;
         let recv_ty = self
-            .path_segment_types
-            .get(&(self.current_metadata_scope, callee, recv_ty_idx))
+            .tir_path_segment_type((self.current_metadata_scope, callee, recv_ty_idx))
             .cloned()
             .map(|t| self.convert_tir_ty_for_runtime(&t))
             .unwrap_or_else(|| RuntimeTy::BuiltinUnknown {
@@ -10639,8 +10433,7 @@ impl<'db> LoweringContext<'db> {
         dest: &Place,
     ) -> bool {
         let Some(members) = self
-            .expr_types
-            .get(&self.expr_metadata_key(base))
+            .tir_expr_type(self.expr_metadata_key(base))
             .and_then(Self::tir_union_members)
         else {
             return false;
@@ -10679,8 +10472,7 @@ impl<'db> LoweringContext<'db> {
         dest: &Place,
     ) -> bool {
         let Some(members) = self
-            .expr_types
-            .get(&self.expr_metadata_key(base))
+            .tir_expr_type(self.expr_metadata_key(base))
             .and_then(Self::tir_union_members)
         else {
             return false;
@@ -10955,7 +10747,52 @@ impl<'db> LoweringContext<'db> {
     /// implementor's method (or the interface default it inherits) plus every
     /// out-of-body / primitive type implementor. Shared by the single-interface
     /// receiver path and the union-receiver path.
+    ///
+    /// Memoized in the package-shared [`DispatchCandidateCache`]: resolution
+    /// only reads the Salsa db, package-level `PackageLoweringData`, and
+    /// `self.generic_param_bounds` (all captured by the cache key), so a
+    /// repeated request — the same dispatch appearing at another call site or
+    /// in another function — returns the previously resolved candidates.
     fn interface_method_candidates_for(
+        &self,
+        iface_tn: &TypeName,
+        iface_type_args: &[Tir2Ty],
+        iface_assoc: &[(Name, Tir2Ty)],
+        method: &Name,
+        recv_tir_ty: Option<&Tir2Ty>,
+    ) -> Vec<InterfaceMethodCandidate> {
+        let mut bounds: Vec<(Name, Tir2Ty)> = self
+            .generic_param_bounds
+            .iter()
+            .map(|(name, ty)| (name.clone(), ty.clone()))
+            .collect();
+        bounds.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let key: DispatchCacheKey = (
+            iface_tn.clone(),
+            iface_type_args.to_vec(),
+            iface_assoc.to_vec(),
+            method.clone(),
+            recv_tir_ty.cloned(),
+            bounds,
+        );
+        if let Some(hit) = self.dispatch_cache.map.borrow().get(&key) {
+            return hit.clone();
+        }
+        let resolved = self.interface_method_candidates_uncached(
+            iface_tn,
+            iface_type_args,
+            iface_assoc,
+            method,
+            recv_tir_ty,
+        );
+        self.dispatch_cache
+            .map
+            .borrow_mut()
+            .insert(key, resolved.clone());
+        resolved
+    }
+
+    fn interface_method_candidates_uncached(
         &self,
         iface_tn: &TypeName,
         iface_type_args: &[Tir2Ty],
@@ -13359,8 +13196,7 @@ impl LoweringContext<'_> {
                 body,
             } => {
                 let coll_tir_ty = self
-                    .expr_types
-                    .get(&self.expr_metadata_key(collection))
+                    .tir_expr_type(self.expr_metadata_key(collection))
                     .cloned();
                 let iterable_view = coll_tir_ty
                     .as_ref()
@@ -13828,9 +13664,7 @@ impl LoweringContext<'_> {
         arm_ids: &[baml_compiler2_ast::MatchArmId],
         dest: Place,
     ) {
-        let is_exhaustive = self
-            .exhaustive_matches
-            .contains(&self.expr_metadata_key(expr_id));
+        let is_exhaustive = self.tir_is_exhaustive_match(self.expr_metadata_key(expr_id));
 
         // If scrutinee is a simple variable reference, reuse the local directly
         // instead of copying into a temp (matches MIR1 behavior).
@@ -13973,12 +13807,12 @@ impl LoweringContext<'_> {
                         kind: AstTypeExprKind::Path { .. },
                         ..
                     }) if matches!(
-                        this.pat_types.get(&this.pat_metadata_key(atom_id)),
+                        this.tir_pat_type(this.pat_metadata_key(atom_id)),
                         Some(Tir2Ty::EnumVariant(_, _, _))
                     ) =>
                     {
                         let Some(Tir2Ty::EnumVariant(qtn, variant, _)) =
-                            this.pat_types.get(&this.pat_metadata_key(atom_id))
+                            this.tir_pat_type(this.pat_metadata_key(atom_id))
                         else {
                             unreachable!("guarded by matches! above");
                         };
@@ -14799,7 +14633,7 @@ impl LoweringContext<'_> {
     }
 
     fn class_pattern_type_name(&self, pat_id: AstPatId) -> Option<TypeName> {
-        let tir_ty = self.pat_types.get(&self.pat_metadata_key(pat_id))?;
+        let tir_ty = self.tir_pat_type(self.pat_metadata_key(pat_id))?;
         match self.resolved_aliases.convert(tir_ty) {
             RuntimeTy::Class(tn, _, _) => Some(tn),
             _ => None,
@@ -14807,7 +14641,7 @@ impl LoweringContext<'_> {
     }
 
     fn class_pattern_field_ty(&self, pat_id: AstPatId, field: &Name) -> Option<RuntimeTy> {
-        let tir_ty = self.pat_types.get(&self.pat_metadata_key(pat_id))?;
+        let tir_ty = self.tir_pat_type(self.pat_metadata_key(pat_id))?;
         let Tir2Ty::Class(qtn, type_args, _) = tir_ty else {
             return None;
         };
@@ -14828,7 +14662,7 @@ impl LoweringContext<'_> {
         // positional field layout. Branch on the raw TIR type so interface
         // patterns project through field-view dispatch instead of class slots.
         if matches!(
-            self.pat_types.get(&self.pat_metadata_key(class_pat_id)),
+            self.tir_pat_type(self.pat_metadata_key(class_pat_id)),
             Some(Tir2Ty::Interface(..))
         ) {
             return self.project_interface_pattern_field(
@@ -14879,8 +14713,7 @@ impl LoweringContext<'_> {
         field: &Name,
     ) -> Option<Local> {
         let tir_ty = self
-            .pat_types
-            .get(&self.pat_metadata_key(class_pat_id))?
+            .tir_pat_type(self.pat_metadata_key(class_pat_id))?
             .clone();
         let (iface_tn, iface_args, iface_assoc) =
             self.interface_dispatch_target_for_tir_ty(&tir_ty)?;
@@ -15075,8 +14908,7 @@ impl LoweringContext<'_> {
         {
             let after_ascription = self.builder.create_block();
             if let Some(tir_ty) = self
-                .pat_types
-                .get(&self.pat_metadata_key(pat_id))
+                .tir_pat_type(self.pat_metadata_key(pat_id))
                 .filter(|ty| !matches!(ty, Tir2Ty::Never { .. }))
                 .cloned()
             {
@@ -15142,12 +14974,12 @@ impl LoweringContext<'_> {
                 }
                 AstTypeExprKind::Path { .. }
                     if matches!(
-                        self.pat_types.get(&self.pat_metadata_key(pat_id)),
+                        self.tir_pat_type(self.pat_metadata_key(pat_id)),
                         Some(Tir2Ty::EnumVariant(_, _, _))
                     ) =>
                 {
                     let Some(Tir2Ty::EnumVariant(qtn, variant, _)) =
-                        self.pat_types.get(&self.pat_metadata_key(pat_id))
+                        self.tir_pat_type(self.pat_metadata_key(pat_id))
                     else {
                         unreachable!("guarded by matches! above");
                     };
@@ -15175,8 +15007,7 @@ impl LoweringContext<'_> {
                     // the subpattern, so fall back to lowering the annotation
                     // itself with the enclosing generic params in scope.
                     let pat_tir_ty = self
-                        .pat_types
-                        .get(&self.pat_metadata_key(pat_id))
+                        .tir_pat_type(self.pat_metadata_key(pat_id))
                         .cloned()
                         .unwrap_or_else(|| self.lower_type_annotation_tir(ty_expr));
                     // A generic-interface pattern (`Slot<int>`) needs the
@@ -15252,7 +15083,7 @@ impl LoweringContext<'_> {
                     self.builder.create_block()
                 };
 
-                if let Some(tir_ty) = self.pat_types.get(&self.pat_metadata_key(pat_id)).cloned() {
+                if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)).cloned() {
                     self.emit_is_tir_type_branch(scrutinee, &tir_ty, class_success, failure);
                 } else if class_success == success {
                     self.builder.goto(success);
@@ -15293,7 +15124,7 @@ impl LoweringContext<'_> {
             } => {
                 let array_success = self.builder.create_block();
 
-                if let Some(tir_ty) = self.pat_types.get(&self.pat_metadata_key(pat_id)).cloned() {
+                if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)).cloned() {
                     self.emit_is_tir_type_branch(scrutinee, &tir_ty, array_success, failure);
                 } else {
                     self.builder.goto(array_success);
@@ -15448,8 +15279,7 @@ impl LoweringContext<'_> {
                 let ty = if let Some(narrow) = &narrow {
                     self.resolve_type_annotation(narrow)
                 } else {
-                    self.pat_types
-                        .get(&self.pat_metadata_key(pat_id))
+                    self.tir_pat_type(self.pat_metadata_key(pat_id))
                         .map(|ty| self.resolved_aliases.convert(ty))
                         .unwrap_or_else(|| self.builder.local_ty(scrutinee))
                 };
@@ -15732,8 +15562,7 @@ impl LoweringContext<'_> {
         // match-chain runtime test — which filters implementors by the specific
         // instantiation — is used instead.
         if self
-            .pat_types
-            .get(&self.pat_metadata_key(pat_id))
+            .tir_pat_type(self.pat_metadata_key(pat_id))
             .is_some_and(Self::tir_ty_needs_interface_shape_test)
         {
             return None;
@@ -15755,7 +15584,7 @@ impl LoweringContext<'_> {
             _ => None,
         };
         if let Some(ty_expr) = ascription_ty {
-            if let Some(tir_ty) = self.pat_types.get(&self.pat_metadata_key(pat_id)) {
+            if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)) {
                 let resolved = self.resolved_aliases.convert(tir_ty);
                 if let Some(tags) = self.ty_to_type_tags(&resolved) {
                     return Some(tags);
@@ -15767,12 +15596,12 @@ impl LoweringContext<'_> {
         match pat {
             AstPattern::Wildcard => None,
             AstPattern::Bind { .. } => {
-                let tir_ty = self.pat_types.get(&self.pat_metadata_key(pat_id))?;
+                let tir_ty = self.tir_pat_type(self.pat_metadata_key(pat_id))?;
                 let resolved = self.resolved_aliases.convert(tir_ty);
                 self.ty_to_type_tags(&resolved)
             }
             AstPattern::Type(_) => {
-                if let Some(tir_ty) = self.pat_types.get(&self.pat_metadata_key(pat_id)) {
+                if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)) {
                     let resolved = self.resolved_aliases.convert(tir_ty);
                     if let Some(tags) = self.ty_to_type_tags(&resolved) {
                         return Some(tags);
@@ -16161,13 +15990,31 @@ pub fn lower_let_body<'db>(
     let_loc: LetLoc<'db>,
     opt: crate::OptLevel,
 ) -> Option<(MirFunctionBody, Vec<MirFunction>)> {
+    lower_let_body_cached(db, let_loc, opt, &std::rc::Rc::default())
+}
+
+/// [`lower_let_body`] with a caller-supplied [`DispatchCandidateCache`], so a
+/// driver lowering many items in one package (the emit crate) shares dispatch
+/// resolutions across all of them.
+pub fn lower_let_body_cached<'db>(
+    db: &'db dyn crate::Db,
+    let_loc: LetLoc<'db>,
+    opt: crate::OptLevel,
+    dispatch_cache: &std::rc::Rc<DispatchCandidateCache>,
+) -> Option<(MirFunctionBody, Vec<MirFunction>)> {
     let body = let_body(db, let_loc);
     let source_map = let_body_source_map(db, let_loc);
 
     match body.as_ref() {
         LetBody::Expr(expr_body) => {
-            let mut ctx =
-                LoweringContext::new_for_let(db, let_loc, expr_body.clone(), source_map, opt);
+            let mut ctx = LoweringContext::new_for_let(
+                db,
+                let_loc,
+                expr_body.clone(),
+                source_map,
+                opt,
+                std::rc::Rc::clone(dispatch_cache),
+            );
             let mir_body = ctx.lower_let_body_inner();
             let lambdas = std::mem::take(&mut ctx.pending_lambdas);
             Some((mir_body, lambdas))
@@ -16181,6 +16028,18 @@ pub fn lower_function<'db>(
     func_loc: FunctionLoc<'db>,
     opt: crate::OptLevel,
 ) -> MirFunction {
+    lower_function_cached(db, func_loc, opt, &std::rc::Rc::default())
+}
+
+/// [`lower_function`] with a caller-supplied [`DispatchCandidateCache`], so a
+/// driver lowering many functions in one package (the emit crate) shares
+/// dispatch resolutions across all of them.
+pub fn lower_function_cached<'db>(
+    db: &'db dyn crate::Db,
+    func_loc: FunctionLoc<'db>,
+    opt: crate::OptLevel,
+    dispatch_cache: &std::rc::Rc<DispatchCandidateCache>,
+) -> MirFunction {
     let body = baml_compiler2_ppir::function_body(db, func_loc);
     let source_map = baml_compiler2_ppir::function_body_source_map(db, func_loc);
     let item_ref = def_to_item_ref(
@@ -16192,7 +16051,14 @@ pub fn lower_function<'db>(
 
     match body.as_ref() {
         FunctionBody::Expr(expr_body) => {
-            let mut ctx = LoweringContext::new(db, func_loc, expr_body.clone(), source_map, opt);
+            let mut ctx = LoweringContext::new(
+                db,
+                func_loc,
+                expr_body.clone(),
+                source_map,
+                opt,
+                std::rc::Rc::clone(dispatch_cache),
+            );
             let mut mir = ctx.lower_function_body();
             mir.item_ref = item_ref;
             mir

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -743,6 +743,59 @@ impl DefaultParameterInference<'_> {
     }
 }
 
+/// Point lookups into the default-parameter tables, mirroring the
+/// [`ScopeInference`] accessors of the same names. Consumed by MIR lowering,
+/// which reads inference facts through per-scope views rather than
+/// materializing merged copies.
+impl<'db> DefaultParameterInference<'db> {
+    /// Look up the type of a default-parameter expression.
+    pub fn expression_type(&self, expr_id: ExprId) -> Option<&Ty> {
+        self.expressions.get(&expr_id)
+    }
+
+    /// Look up the binding type for a default-parameter pattern.
+    pub fn binding_type(&self, pat_id: PatId) -> Option<&Ty> {
+        self.pattern_types.get(&pat_id)
+    }
+
+    /// Look up the member resolution for a default-parameter expression.
+    pub fn resolution(&self, expr_id: ExprId) -> Option<&MemberResolution<'db>> {
+        self.resolutions.get(&expr_id)
+    }
+
+    /// Check whether a default-parameter match expression is exhaustive.
+    pub fn is_exhaustive_match(&self, expr_id: ExprId) -> bool {
+        self.exhaustive_matches.contains(&expr_id)
+    }
+
+    /// Look up the root segment type for a default-parameter path expression.
+    pub fn path_root_type(&self, expr_id: ExprId) -> Option<&Ty> {
+        self.path_root_types.get(&expr_id)
+    }
+
+    /// Look up the type of `segments[..=seg_idx]` for a default-parameter path.
+    pub fn path_segment_type(&self, expr_id: ExprId, seg_idx: usize) -> Option<&Ty> {
+        self.path_segment_types.get(&(expr_id, seg_idx))
+    }
+
+    /// Look up per-segment member resolutions for a default-parameter path.
+    pub fn path_member_resolution(&self, expr_id: ExprId) -> Option<&[MemberResolution<'db>]> {
+        self.path_member_resolutions
+            .get(&expr_id)
+            .map(Vec::as_slice)
+    }
+
+    /// Look up the argument binding plan for a default-parameter call.
+    pub fn call_plan(&self, expr_id: ExprId) -> Option<&CallPlan> {
+        self.call_plans.get(&expr_id)
+    }
+
+    /// Look up the function adapter for a default-parameter checked coercion.
+    pub fn function_coercion(&self, expr_id: ExprId) -> Option<&FunctionCoercion> {
+        self.function_coercions.get(&expr_id)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallPlan {
     pub bindings: Vec<ParamBinding>,
@@ -887,9 +940,20 @@ impl<'db> ScopeInference<'db> {
         self.call_type_instantiations.iter()
     }
 
+    /// Look up the function adapter required by a checked coercion.
+    pub fn function_coercion(&self, expr_id: ExprId) -> Option<&FunctionCoercion> {
+        self.function_coercions.get(&expr_id)
+    }
+
     /// Iterate over all function adapters required by checked coercions.
     pub fn iter_function_coercions(&self) -> impl Iterator<Item = (&ExprId, &FunctionCoercion)> {
         self.function_coercions.iter()
+    }
+
+    /// The default-parameter inference tables for this scope, for point
+    /// lookups via [`DefaultParameterInference`]'s accessors.
+    pub fn parameter_defaults(&self) -> &DefaultParameterInference<'db> {
+        &self.parameter_defaults
     }
 
     /// Iterate over all default-parameter expression types for this scope.

--- a/baml_language/crates/baml_compiler2_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/normalize.rs
@@ -16,6 +16,13 @@ use crate::ty::{FunctionParamMode, LiteralValue, MediaKind, QualifiedTypeName, T
 
 /// Check if `sub` is a subtype of `sup`, resolving type aliases.
 pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, aliases: &HashMap<QualifiedTypeName, Ty>) -> bool {
+    // Fast path: `normalize` is a pure function of `(ty, aliases)`, so
+    // structurally identical types always normalize identically, and
+    // `StructuralTy::is_subtype_of` is reflexive. Skips the alias-graph
+    // walk + double normalization for the common `T <: T` query.
+    if sub == sup {
+        return true;
+    }
     let recursive = find_recursive_aliases(aliases);
     let sub_norm = normalize(sub, aliases, &recursive);
     let sup_norm = normalize(sup, aliases, &recursive);
@@ -33,20 +40,33 @@ pub fn is_same_normalized_type(
     rhs: &Ty,
     aliases: &HashMap<QualifiedTypeName, Ty>,
 ) -> bool {
+    // Fast path: `normalize` is a pure function of `(ty, aliases)`, so
+    // structurally identical types always normalize (and canonicalize)
+    // identically. Skips the alias-graph walk + double normalization for
+    // the very common identical-spelling case.
+    if lhs == rhs {
+        return true;
+    }
     let recursive = find_recursive_aliases(aliases);
     normalize(lhs, aliases, &recursive).canonicalize()
         == normalize(rhs, aliases, &recursive).canonicalize()
 }
 
 /// Find all recursive type aliases via DFS.
+///
+/// A single memoized DFS over the whole alias graph: `state` maps each alias
+/// to `None` while it is on the DFS stack and to `Some(reaches_cycle)` once
+/// fully explored, so every alias body is walked at most once — O(nodes +
+/// edges) total rather than a fresh DFS per alias. ("Reaches a cycle" is a
+/// property of the alias alone, independent of which root the DFS entered
+/// from, so memoizing it across roots is sound.)
 pub fn find_recursive_aliases(
     aliases: &HashMap<QualifiedTypeName, Ty>,
 ) -> HashSet<QualifiedTypeName> {
+    let mut state = HashMap::new();
     let mut recursive = HashSet::new();
     for name in aliases.keys() {
-        let mut visited = HashSet::new();
-        let mut stack = HashSet::new();
-        if has_cycle(name, aliases, &mut visited, &mut stack) {
+        if has_cycle(name, aliases, &mut state) {
             recursive.insert(name.clone());
         }
     }
@@ -690,64 +710,56 @@ fn normalize_impl(
 // CYCLE DETECTION
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Does expanding `name` ever reach a cycle in the alias graph?
+///
+/// `state` is the shared memo for [`find_recursive_aliases`]: `None` marks an
+/// alias currently on the DFS stack (so hitting it again is a back-edge, i.e.
+/// a real cycle), `Some(result)` a fully explored alias.
 fn has_cycle(
     name: &QualifiedTypeName,
     aliases: &HashMap<QualifiedTypeName, Ty>,
-    visited: &mut HashSet<QualifiedTypeName>,
-    stack: &mut HashSet<QualifiedTypeName>,
+    state: &mut HashMap<QualifiedTypeName, Option<bool>>,
 ) -> bool {
-    if stack.contains(name) {
-        return true;
+    match state.get(name) {
+        // On the current DFS stack — a back-edge, i.e. a real cycle.
+        Some(None) => return true,
+        // Fully explored on an earlier visit.
+        Some(&Some(result)) => return result,
+        None => {}
     }
-    if visited.contains(name) {
-        return false;
-    }
-    visited.insert(name.clone());
-    stack.insert(name.clone());
+    state.insert(name.clone(), None);
     let result = aliases
         .get(name)
-        .is_some_and(|ty| ty_has_cycle(ty, aliases, visited, stack));
-    stack.remove(name);
+        .is_some_and(|ty| ty_has_cycle(ty, aliases, state));
+    state.insert(name.clone(), Some(result));
     result
 }
 
 fn ty_has_cycle(
     ty: &Ty,
     aliases: &HashMap<QualifiedTypeName, Ty>,
-    visited: &mut HashSet<QualifiedTypeName>,
-    stack: &mut HashSet<QualifiedTypeName>,
+    state: &mut HashMap<QualifiedTypeName, Option<bool>>,
 ) -> bool {
     match ty {
-        Ty::TypeAlias(qn, _) if aliases.contains_key(qn) => has_cycle(qn, aliases, visited, stack),
-        Ty::List(inner, _) | Ty::EvolvingList(inner, _) => {
-            ty_has_cycle(inner, aliases, visited, stack)
-        }
+        Ty::TypeAlias(qn, _) if aliases.contains_key(qn) => has_cycle(qn, aliases, state),
+        Ty::List(inner, _) | Ty::EvolvingList(inner, _) => ty_has_cycle(inner, aliases, state),
         Ty::Map { key, value, .. } | Ty::EvolvingMap(key, value, _) => {
-            ty_has_cycle(key, aliases, visited, stack)
-                || ty_has_cycle(value, aliases, visited, stack)
+            ty_has_cycle(key, aliases, state) || ty_has_cycle(value, aliases, state)
         }
-        Ty::Union(types, _) => types
-            .iter()
-            .any(|t| ty_has_cycle(t, aliases, visited, stack)),
-        Ty::Class(_, type_args, _) => type_args
-            .iter()
-            .any(|t| ty_has_cycle(t, aliases, visited, stack)),
+        Ty::Union(types, _) => types.iter().any(|t| ty_has_cycle(t, aliases, state)),
+        Ty::Class(_, type_args, _) => type_args.iter().any(|t| ty_has_cycle(t, aliases, state)),
         Ty::Interface(_, type_args, associated_bindings, _) => {
-            type_args
-                .iter()
-                .any(|t| ty_has_cycle(t, aliases, visited, stack))
+            type_args.iter().any(|t| ty_has_cycle(t, aliases, state))
                 || associated_bindings
                     .iter()
-                    .any(|(_, ty)| ty_has_cycle(ty, aliases, visited, stack))
+                    .any(|(_, ty)| ty_has_cycle(ty, aliases, state))
         }
         Ty::AssociatedTypeProjection {
             base, interface, ..
         } => {
-            ty_has_cycle(base, aliases, visited, stack)
+            ty_has_cycle(base, aliases, state)
                 || interface.as_ref().is_some_and(|interface| {
-                    interface
-                        .tys()
-                        .any(|t| ty_has_cycle(t, aliases, visited, stack))
+                    interface.tys().any(|t| ty_has_cycle(t, aliases, state))
                 })
         }
         Ty::Function {
@@ -758,9 +770,9 @@ fn ty_has_cycle(
         } => {
             params
                 .iter()
-                .any(|param| ty_has_cycle(&param.ty, aliases, visited, stack))
-                || ty_has_cycle(ret, aliases, visited, stack)
-                || ty_has_cycle(throws, aliases, visited, stack)
+                .any(|param| ty_has_cycle(&param.ty, aliases, state))
+                || ty_has_cycle(ret, aliases, state)
+                || ty_has_cycle(throws, aliases, state)
         }
         _ => false,
     }


### PR DESCRIPTION
## Results

`cargo bench --bench compiler_benchmark -- compile_empty_project` (median, 100 samples). The "empty" project compiles the entire builtin stdlib (55 files, ~9k LOC, 199 classes, 33 interfaces), so this benchmark measures the fixed cost every cold compile pays.

| Change | Median | Step Δ |
|---|---|---|
| Baseline (canary) | 1410 ms | — |
| 1. Normalize fast paths + memoized alias DFS | 1175 ms | −17% |
| 2. Kill double MIR lowering | 805 ms | −31% |
| 3. Package-shared dispatch cache | 664 ms | −17% |
| 4. Inference views instead of metadata copies | **482 ms** | −27% |

**Net: −66%, 2.9× faster.** The wins compound because they attack the same hot path from four angles: the interface-dispatch machinery inside MIR lowering, which the profile showed dominating compile time (samply @2kHz, symbolicated; see per-fix numbers below).

## The four changes

### 1. `tir/normalize.rs`: stop redoing alias-graph analysis per type comparison
- `is_same_normalized_type` / `is_subtype_of` get a `lhs == rhs` fast path. Sound because `normalize` is a pure function of `(ty, aliases)` and `StructuralTy::is_subtype_of` is explicitly reflexive — equal inputs always produced `true` through the slow path.
- `find_recursive_aliases` was a fresh DFS (with fresh HashSets) *per alias, per call*: O(A·(A+E)). It is now a single memoized tri-color DFS over the whole graph: O(A+E). Same semantics ("reaches a cycle" is a per-node property, root-independent, so memoizing across roots is sound).

Why it wins: these functions sit at the innermost level of `match_ty_pattern`, called per recursion level per dispatch candidate. They were 49%/40% inclusive of compile time.

### 2. `emit/lib.rs` Pass 1: don't lower every function twice
Pass 1 called `lower_function` on **every function in the project** solely to check "is this an intrinsic?" for global-slot assignment; Pass 4 then lowered everything again to emit bytecode (`lower_function` is not a Salsa query, so nothing deduped the two). Pass 1 now reads the same fact off the item tree (`FunctionBodyDef::Builtin(kind)` — the exact field `lower_function` copies verbatim into `MirFunctionKind`) and gets the fq name from `def_to_item_ref`. Full MIR lowering now runs exactly once per function.

Why it wins: MIR lowering was 61% inclusive of compile time, and half of it was the duplicate.

### 3. `mir/lower.rs`: memoize interface-dispatch candidate resolution per package
`interface_method_candidates_for` rescans every implementor of an interface — running type-pattern matching and normalization per candidate — at **every call site**. The same questions recur constantly (every `for` loop asks the same `Iterator.next` question). New `DispatchCandidateCache` (`Rc<RefCell<FxHashMap>>`), one per package, shared across all functions the emit driver lowers via new `lower_function_cached` / `lower_let_body_cached` entry points (existing `lower_function` / `lower_let_body` signatures unchanged — they use a private fresh cache).

Correctness: a transitive audit of the 17-method resolution family showed its only inputs are the Salsa db, package-level `PackageLoweringData`, the request args, and the function's `generic_param_bounds` — so the cache key is (interface, type args, assoc bindings, method, receiver ty, sorted bounds), scoped per package.

Why it wins: candidate resolution + dispatch-switch emission were 33%/36% inclusive; they drop to ~8%/9% after this change.

### 4. `mir/lower.rs` + `tir/inference.rs`: read TIR inference through views, not copies
`LoweringContext::new` (and `new_for_let`) eagerly **deep-copied all nine TIR inference tables** — expr types, pattern types, resolutions, call plans, path types, coercions, exhaustive-match marks — out of the Salsa-cached per-scope `ScopeInference` values into fresh per-function merged maps, re-keying every entry. Per compile, the whole project's inference output was cloned, re-hashed, and dropped. That was ~17% of compile time in pure memory churn, and it's a materialized-view anti-pattern: the source data is already resident, immutable, and `'db`-stable behind `returns(ref)`.

The context now holds `scope_inference: FxHashMap<FileScopeId, &'db ScopeInference<'db>>` (function scope + descendants — exactly the range the old merge covered, so absence semantics are preserved for the callers that key behavior on a missing entry) and reads through `tir_*` point accessors that dispatch `MetadataScope::Body` → body tables, `::ParameterDefault` → default tables. `tir/inference.rs` gains the missing point accessors (`function_coercion`, `parameter_defaults()`, and point lookups on `DefaultParameterInference`). All 94 read sites converted; the nine maps were verified strictly read-only after construction before the change.

Architecturally this also makes `LoweringContext` construction cheap and mostly pure — a prerequisite for eventually making `lower_function` itself a tracked query (LSP incrementality) without dragging a copy layer along.

## What's deliberately NOT in this PR
Follow-ups identified by the post-change profile (remaining 482ms ≈ salsa machinery 32%, normalize cluster ~36%, TIR inference ~23%, SipHash string-hashing leaf 20%):
- thread the precomputed `ResolvedAliases.recursive` set through `is_same_normalized_type` (it's still recomputed on the non-equal path),
- cache `registry_dispatch_target_for_concrete_receiver` (uncached sibling of change 3),
- salsa-track `resolved_aliases_for_package`,
- type interning to kill string hashing.

## Validation
- Changes 1–3: full `baml_tests` integration suite green (2,600+ tests incl. all bytecode/MIR snapshots).
- Change 4: mir/emit/tir unit tests green; relying on CI for the full suite run.
- Behavior-preservation arguments per change are documented in code comments at each site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter compilation pipeline now reuses inference and dispatch results across closely related lowering steps.

* **Performance**
  * Reduced repeated type-analysis and dispatch-candidate resolution during compilation for faster builds.
  * Added quicker type comparisons and more efficient recursive type-alias cycle detection.

* **Bug Fixes**
  * Preserved correct global ordering when handling built-in functions during compilation.
  * Improved robustness of type resolution, call planning, and coercions for more consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->