### PR TITLE
Compiler perf: thread ResolvedAliases through type comparisons (482ms → 281ms)

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -2036,7 +2036,7 @@ fn compute_function_metadata_from_item_tree(
     let raw_bound_resolver =
         baml_compiler2_tir::associated_projection::AssociatedProjectionResolver::new(
             db,
-            &cache.aliases,
+            cache,
             &raw_generic_param_bounds,
         );
     let generic_param_bounds: HashMap<Name, baml_compiler2_tir::ty::Ty> = raw_generic_param_bounds
@@ -2048,7 +2048,7 @@ fn compute_function_metadata_from_item_tree(
         let tir_ty = lower_tir_type(te);
         baml_compiler2_tir::associated_projection::AssociatedProjectionResolver::new(
             db,
-            &cache.aliases,
+            cache,
             &generic_param_bounds,
         )
         .resolve_deep(&tir_ty)

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -21,8 +21,9 @@ use baml_compiler2_hir::{
     package::PackageId,
 };
 use baml_compiler2_mir::{
-    BuiltinKind, Local, MirFunctionBody, MirFunctionKind, Operand, Place, ResolvedAliases, Rvalue,
-    StatementKind, Terminator, def_to_item_ref, lower_function, lower_let_body,
+    BuiltinKind, DispatchCandidateCache, Local, MirFunctionBody, MirFunctionKind, Operand, Place,
+    ResolvedAliases, Rvalue, StatementKind, Terminator, def_to_item_ref, lower_function_cached,
+    lower_let_body_cached,
 };
 // Use the PPIR item tree (which includes synthetic *$stream items) rather than
 // the bare HIR item tree, to stay consistent with TIR's LocalItemId indices.
@@ -875,6 +876,13 @@ pub fn generate_project_bytecode_with_opt(
     let mut program = Program::new();
     let all_files = compiler2_all_files(db);
     let alias_caches = build_alias_caches(db, &all_files);
+    // One dispatch-candidate cache per package, shared across every function
+    // lowered below so repeated interface-dispatch requests (the same
+    // `Iterator.next` question at every `for` loop, say) resolve once.
+    let dispatch_caches: HashMap<Name, std::rc::Rc<DispatchCandidateCache>> = alias_caches
+        .keys()
+        .map(|pkg| (pkg.clone(), std::rc::Rc::default()))
+        .collect();
 
     // --- Pass 1: Build globals map (function name -> global index) ---
     // Functions are allocated first (slots 0..N-1), then let bindings (slots N..M-1).
@@ -890,22 +898,30 @@ pub fn generate_project_bytecode_with_opt(
     // actual program.globals array built in Pass 4 (which also skips intrinsics).
     for file in &all_files {
         let item_tree = file_item_tree(db, *file);
-        for local_id in item_tree.functions.keys() {
+        for (local_id, func_data) in &item_tree.functions {
             let func_loc = FunctionLoc::new(db, *file, *local_id);
-            let mir = lower_function(db, func_loc, opt);
             // Skip intrinsic and await-any functions — they are never called via
             // a Call instruction (intrinsics lower to StatementKind::Intrinsic;
             // `__await_any` lowers to a Terminator::AwaitAny). Pass 4 skips them
             // too, so they must be skipped here as well or the Pass-1 indices
             // desync from the program.globals array (off-by-one for everything
             // after the skipped function).
+            //
+            // The kind is read straight off the item tree rather than from
+            // `lower_function(..).kind`: `lower_function` copies the item
+            // tree's `FunctionBodyDef::Builtin(kind)` into
+            // `MirFunctionKind::Builtin(kind)` verbatim, and fully MIR-lowering
+            // every function here just to inspect that one field would double
+            // the total lowering work (Pass 4 lowers every function again).
             if matches!(
-                mir.kind,
-                MirFunctionKind::Builtin(BuiltinKind::Intrinsic | BuiltinKind::AwaitAny)
+                func_data.body,
+                Some(baml_compiler2_ast::FunctionBodyDef::Builtin(
+                    BuiltinKind::Intrinsic | BuiltinKind::AwaitAny
+                ))
             ) {
                 continue;
             }
-            let fq_name = mir.item_ref.to_string();
+            let fq_name = def_to_item_ref(db, Definition::Function(func_loc)).to_string();
             globals.entry(fq_name).or_insert_with(|| {
                 let idx = global_idx;
                 global_idx += 1;
@@ -1225,7 +1241,8 @@ pub fn generate_project_bytecode_with_opt(
         let cache_pass4 = &alias_caches[&pkg_info_pass4.package];
         for (local_id, func_data) in &item_tree.functions {
             let func_loc = FunctionLoc::new(db, *file, *local_id);
-            let mir = lower_function(db, func_loc, opt);
+            let mir =
+                lower_function_cached(db, func_loc, opt, &dispatch_caches[&pkg_info_pass4.package]);
             let fq_name = mir.item_ref.to_string();
 
             let mut compiled_fn = match &mir.kind {
@@ -1461,6 +1478,7 @@ pub fn generate_project_bytecode_with_opt(
                 &enum_variants,
                 &mut program,
                 opt,
+                &dispatch_caches[pkg_name.as_str()],
             )?;
 
             let init_fq_name = if pkg_name.as_str() == "user" {
@@ -2563,6 +2581,7 @@ fn compile_init_function<'db>(
     enum_variants: &HashMap<String, HashMap<String, usize>>,
     program: &mut Program,
     opt: OptLevel,
+    dispatch_cache: &std::rc::Rc<DispatchCandidateCache>,
 ) -> Result<Function, LoweringError> {
     // Build the $init bytecode: a sequence of Call + StoreGlobal pairs.
     let mut init_instructions: Vec<Instruction> = Vec::new();
@@ -2578,7 +2597,7 @@ fn compile_init_function<'db>(
         };
 
         // Lower the let initializer through MIR → MirFunctionBody (+ any lambda children).
-        let maybe_body = lower_let_body(db, *let_loc, opt);
+        let maybe_body = lower_let_body_cached(db, *let_loc, opt, dispatch_cache);
 
         let helper_fn = match maybe_body {
             Some((mir_body, lambdas)) => {

--- a/baml_language/crates/baml_compiler2_mir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lib.rs
@@ -7,7 +7,8 @@ pub mod pretty;
 pub use baml_type::ResolvedAliases;
 pub use ir::*;
 pub use lower::{
-    def_to_item_ref, lower_function, lower_let_body, resolved_aliases_for_package, tir2_to_template,
+    DispatchCandidateCache, def_to_item_ref, lower_function, lower_function_cached, lower_let_body,
+    lower_let_body_cached, resolved_aliases_for_package, tir2_to_template,
 };
 
 /// Database trait for compiler2 MIR queries.

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1574,7 +1574,8 @@ type DispatchCacheKey = (
     Vec<(Name, Tir2Ty)>,
 );
 
-/// Shared memo for [`LoweringContext::interface_method_candidates_for`].
+/// Shared memo for `LoweringContext::interface_method_candidates_for` (a
+/// private lowering helper).
 ///
 /// Candidate resolution rescans every implementor of the requested interface
 /// (running type-pattern matching and normalization per candidate) at every

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1558,6 +1558,36 @@ struct InterfaceMethodCandidate {
     frame_seed: CalleeFrameSeed,
 }
 
+/// Key identifying one interface-dispatch candidate resolution: the requested
+/// interface, its type args and associated bindings, the method, the receiver
+/// type, and the enclosing function's generic bounds (sorted by name for a
+/// canonical order). The bounds are the *only* per-function input the
+/// resolution consults — everything else it reads is the Salsa db or
+/// package-level `PackageLoweringData` — so two functions issuing the same
+/// request with the same bounds always resolve identical candidates.
+type DispatchCacheKey = (
+    TypeName,
+    Vec<Tir2Ty>,
+    Vec<(Name, Tir2Ty)>,
+    Name,
+    Option<Tir2Ty>,
+    Vec<(Name, Tir2Ty)>,
+);
+
+/// Shared memo for [`LoweringContext::interface_method_candidates_for`].
+///
+/// Candidate resolution rescans every implementor of the requested interface
+/// (running type-pattern matching and normalization per candidate) at every
+/// dispatch site. The same requests recur constantly across call sites *and*
+/// functions — every `for` loop in a package asks the same `Iterator.next`
+/// question — so the emit driver shares one cache per package across all the
+/// functions it lowers ([`lower_function_cached`]); one-off callers get a
+/// fresh cache via [`lower_function`].
+#[derive(Default)]
+pub struct DispatchCandidateCache {
+    map: std::cell::RefCell<FxHashMap<DispatchCacheKey, Vec<InterfaceMethodCandidate>>>,
+}
+
 /// Strategy for seeding a dispatched method's `frame.type_args`.
 #[derive(Clone)]
 enum CalleeFrameSeed {
@@ -1660,43 +1690,25 @@ struct LoweringContext<'db> {
     catch_rethrow_locals: Vec<Local>,
     exit_block: BlockId,
 
-    // Eagerly aggregated type maps from all scopes in the function.
-    // Keyed by metadata namespace plus arena ID to avoid collisions between
-    // function bodies, lambda bodies, and parameter-default arenas.
-    expr_types: FxHashMap<ExprMetadataKey, Tir2Ty>,
-    pat_types: FxHashMap<PatMetadataKey, Tir2Ty>,
-    // Member resolutions from TIR.
-    resolutions: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::MemberResolution<'db>>,
-    // Match expressions that TIR determined are exhaustive
-    exhaustive_matches: rustc_hash::FxHashSet<ExprMetadataKey>,
-    // TIR-inferred root segment type for each multi-segment Path expression.
-    // Used by lower_multi_segment_path_as_field_chain to get the correct root
-    // type even when the MIR local was declared with a coarser type (e.g.
-    // catch variables declared as BuiltinUnknown).
-    path_root_types: FxHashMap<ExprMetadataKey, Tir2Ty>,
-    // TIR-inferred type of every prefix `segments[..=seg_idx]` for multi-segment
-    // local-rooted Path expressions. Used by the Phase-8 method-call prepend to
-    // read the receiver-prefix type (`segments[..segments.len() - 1]`) so that
-    // class-level type args are threaded correctly through depth ≥ 3 paths
-    // like `holder.box.describe()`.
-    path_segment_types: FxHashMap<(MetadataScope, AstExprId, usize), Tir2Ty>,
-    // Per-segment member resolutions for multi-segment local-rooted Path expressions.
-    // Set by TIR's infer_local_rooted_path; indexed by (scope, Path ExprId).
-    // path_member_resolutions[(scope, expr_id)][i] is the resolution for segments[i+1].
-    path_member_resolutions:
-        FxHashMap<ExprMetadataKey, Vec<baml_compiler2_tir::inference::MemberResolution<'db>>>,
-    // Full-arity argument binding plans from TIR.
-    call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan>,
-    /// TIR-recorded generic instantiation per call whose callee declares type
-    /// params (declared De Bruijn order). Lowered to `LoadType` operands when
-    /// the call site writes no explicit `<...>`, so inferred-generic calls
-    /// populate the callee's `frame.type_args` just like explicit ones.
-    // Function-value adapters from TIR checked coercions.
-    function_coercions: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::FunctionCoercion>,
+    // Per-scope TIR inference results for the function's own scope and every
+    // descendant scope (blocks, lambdas, parameter defaults), borrowed
+    // straight from the Salsa-cached `infer_scope_types` values. Lookups go
+    // through the `tir_*` accessors below, which dispatch on `MetadataScope`
+    // (Body → body tables, ParameterDefault → default tables of the same
+    // scope). The map covers *exactly* the scopes the old merged copies
+    // covered — scopes outside it answer `None`, and at least one caller
+    // (`try_lower_to_string_fallback`) keys behavior on that absence.
+    scope_inference:
+        FxHashMap<FileScopeId, &'db baml_compiler2_tir::inference::ScopeInference<'db>>,
     // Function generic bounds, lowered in TIR space. MIR uses these to keep
     // bounded type variables ABI-erased while still lowering bound-member
     // access through the interface dispatch machinery.
     generic_param_bounds: FxHashMap<Name, Tir2Ty>,
+
+    // Package-shared memo for interface-dispatch candidate resolution. Shared
+    // across every function the emit driver lowers in one package (fresh and
+    // private when constructed via the uncached entry points).
+    dispatch_cache: std::rc::Rc<DispatchCandidateCache>,
 
     // TIR types of the in-scope lambda parameters, by name. TIR does not record
     // `path_segment_types` for a lambda-parameter receiver (`(a: T) -> a.m()`),
@@ -2081,8 +2093,7 @@ impl<'db> LoweringContext<'db> {
         let saved_locals = self.locals.clone();
         let watched_depth = self.watched_locals_stack.len();
         let coll_tir_ty = self
-            .expr_types
-            .get(&self.expr_metadata_key(collection))
+            .tir_expr_type(self.expr_metadata_key(collection))
             .cloned();
 
         let coll_ty = self.expr_ty(collection);
@@ -2566,6 +2577,7 @@ impl<'db> LoweringContext<'db> {
         expr_body: AstExprBody,
         source_map: Option<AstSourceMap>,
         opt: crate::OptLevel,
+        dispatch_cache: std::rc::Rc<DispatchCandidateCache>,
     ) -> Self {
         let file = func_loc.file(db);
 
@@ -2598,147 +2610,23 @@ impl<'db> LoweringContext<'db> {
             })
             .unwrap_or_else(|| index.scope_at_offset(func_span.start(), Some(&func_data.name)));
 
-        // --- Eagerly aggregate expr_types, pat_types, resolutions, exhaustive_matches, path_root_types, and path_member_resolutions from all scopes ---
-        let mut expr_types: FxHashMap<ExprMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut pat_types: FxHashMap<PatMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut resolutions: FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
-        > = FxHashMap::default();
-        let mut exhaustive_matches: rustc_hash::FxHashSet<ExprMetadataKey> =
-            rustc_hash::FxHashSet::default();
-        let mut path_root_types: FxHashMap<ExprMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut path_segment_types: FxHashMap<(MetadataScope, AstExprId, usize), Tir2Ty> =
-            FxHashMap::default();
-        let mut path_member_resolutions: FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        > = FxHashMap::default();
-        let mut call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan> =
-            FxHashMap::default();
-        let mut function_coercions: FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        > = FxHashMap::default();
-
-        let merge_scope = |fsi: FileScopeId,
-                           expr_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           pat_types: &mut FxHashMap<PatMetadataKey, Tir2Ty>,
-                           resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
-        >,
-                           exhaustive_matches: &mut rustc_hash::FxHashSet<ExprMetadataKey>,
-                           path_root_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           path_segment_types: &mut FxHashMap<
-            (MetadataScope, AstExprId, usize),
-            Tir2Ty,
-        >,
-                           path_member_resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        >,
-                           call_plans: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::CallPlan,
-        >,
-                           function_coercions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        >| {
-            let scope_id = index.scope_ids[fsi.index() as usize];
-            let inference = infer_scope_types(db, scope_id);
-            let body_scope = MetadataScope::Body(fsi);
-            for (&expr_id, ty) in inference.iter_expressions() {
-                expr_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_bindings() {
-                pat_types.insert((body_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_resolutions() {
-                resolutions.insert((body_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_exhaustive_matches() {
-                exhaustive_matches.insert((body_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_path_root_types() {
-                path_root_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_path_segment_types() {
-                path_segment_types.insert((body_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_path_member_resolutions() {
-                path_member_resolutions.insert((body_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_call_plans() {
-                call_plans.insert((body_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_function_coercions() {
-                function_coercions.insert((body_scope, expr_id), coercion.clone());
-            }
-
-            let default_scope = MetadataScope::ParameterDefault(fsi);
-            for (&expr_id, ty) in inference.iter_default_expressions() {
-                expr_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_default_bindings() {
-                pat_types.insert((default_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_default_resolutions() {
-                resolutions.insert((default_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_default_exhaustive_matches() {
-                exhaustive_matches.insert((default_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_default_path_root_types() {
-                path_root_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_default_path_segment_types() {
-                path_segment_types.insert((default_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_default_path_member_resolutions() {
-                path_member_resolutions
-                    .insert((default_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_default_call_plans() {
-                call_plans.insert((default_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_default_function_coercions() {
-                function_coercions.insert((default_scope, expr_id), coercion.clone());
-            }
-        };
-
-        // Include the function scope itself
-        merge_scope(
-            func_scope_id,
-            &mut expr_types,
-            &mut pat_types,
-            &mut resolutions,
-            &mut exhaustive_matches,
-            &mut path_root_types,
-            &mut path_segment_types,
-            &mut path_member_resolutions,
-            &mut call_plans,
-            &mut function_coercions,
-        );
-
-        // Include all descendant scopes (blocks, lambdas, etc.)
+        // --- Collect per-scope TIR inference views (func + all descendants) ---
+        // Borrows the Salsa-cached `infer_scope_types` results instead of
+        // deep-copying every table into merged per-function maps (the old
+        // scheme cloned the whole inference output of every function on each
+        // construction). Lookups dispatch through the `tir_*` accessors.
         let func_scope = &index.scopes[func_scope_id.index() as usize];
         let desc_start = func_scope.descendants.start.index();
         let desc_end = func_scope.descendants.end.index();
-        for raw_idx in desc_start..desc_end {
-            merge_scope(
-                FileScopeId::new(raw_idx),
-                &mut expr_types,
-                &mut pat_types,
-                &mut resolutions,
-                &mut exhaustive_matches,
-                &mut path_root_types,
-                &mut path_segment_types,
-                &mut path_member_resolutions,
-                &mut call_plans,
-                &mut function_coercions,
-            );
+        let mut scope_inference: FxHashMap<
+            FileScopeId,
+            &'db baml_compiler2_tir::inference::ScopeInference<'db>,
+        > = FxHashMap::default();
+        for fsi in
+            std::iter::once(func_scope_id).chain((desc_start..desc_end).map(FileScopeId::new))
+        {
+            let scope_id = index.scope_ids[fsi.index() as usize];
+            scope_inference.insert(fsi, infer_scope_types(db, scope_id));
         }
 
         // --- Build class_fields / enum_variants from PackageItems ---
@@ -2895,16 +2783,9 @@ impl<'db> LoweringContext<'db> {
             catch_context: None,
             catch_rethrow_locals: Vec::new(),
             exit_block: BlockId(0), // placeholder; overwritten in lower_function_body
-            expr_types,
-            pat_types,
-            resolutions,
-            exhaustive_matches,
-            path_root_types,
-            path_segment_types,
-            path_member_resolutions,
-            call_plans,
-            function_coercions,
+            scope_inference,
             generic_param_bounds,
+            dispatch_cache,
             lambda_param_tir_types: FxHashMap::default(),
             current_scope: func_scope_id,
             current_metadata_scope: MetadataScope::Body(func_scope_id),
@@ -2944,6 +2825,7 @@ impl<'db> LoweringContext<'db> {
         expr_body: AstExprBody,
         source_map: Option<AstSourceMap>,
         opt: crate::OptLevel,
+        dispatch_cache: std::rc::Rc<DispatchCandidateCache>,
     ) -> Self {
         let file = let_loc.file(db);
 
@@ -2956,147 +2838,22 @@ impl<'db> LoweringContext<'db> {
         let index = file_semantic_index(db, file);
         let let_scope_id: FileScopeId = index.scope_at_offset(let_span.start(), Some(&let_name));
 
-        // --- Eagerly aggregate expr_types, pat_types, resolutions, path_root_types, path_member_resolutions from let scope ---
-        let mut expr_types: FxHashMap<ExprMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut pat_types: FxHashMap<PatMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut resolutions: FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
+        // --- Collect per-scope TIR inference views (let + all descendants) ---
+        // Borrows the Salsa-cached `infer_scope_types` results instead of
+        // deep-copying every table into merged per-function maps (the old
+        // scheme cloned the whole inference output of every let initializer on each
+        // construction). Lookups dispatch through the `tir_*` accessors.
+        let let_owner_scope = &index.scopes[let_scope_id.index() as usize];
+        let desc_start = let_owner_scope.descendants.start.index();
+        let desc_end = let_owner_scope.descendants.end.index();
+        let mut scope_inference: FxHashMap<
+            FileScopeId,
+            &'db baml_compiler2_tir::inference::ScopeInference<'db>,
         > = FxHashMap::default();
-        let mut exhaustive_matches: rustc_hash::FxHashSet<ExprMetadataKey> =
-            rustc_hash::FxHashSet::default();
-        let mut path_root_types: FxHashMap<ExprMetadataKey, Tir2Ty> = FxHashMap::default();
-        let mut path_segment_types: FxHashMap<(MetadataScope, AstExprId, usize), Tir2Ty> =
-            FxHashMap::default();
-        let mut path_member_resolutions: FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        > = FxHashMap::default();
-        let mut call_plans: FxHashMap<ExprMetadataKey, baml_compiler2_tir::inference::CallPlan> =
-            FxHashMap::default();
-        let mut function_coercions: FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        > = FxHashMap::default();
-
-        let merge_scope = |fsi: FileScopeId,
-                           expr_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           pat_types: &mut FxHashMap<PatMetadataKey, Tir2Ty>,
-                           resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::MemberResolution<'db>,
-        >,
-                           exhaustive_matches: &mut rustc_hash::FxHashSet<ExprMetadataKey>,
-                           path_root_types: &mut FxHashMap<ExprMetadataKey, Tir2Ty>,
-                           path_segment_types: &mut FxHashMap<
-            (MetadataScope, AstExprId, usize),
-            Tir2Ty,
-        >,
-                           path_member_resolutions: &mut FxHashMap<
-            ExprMetadataKey,
-            Vec<baml_compiler2_tir::inference::MemberResolution<'db>>,
-        >,
-                           call_plans: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::CallPlan,
-        >,
-                           function_coercions: &mut FxHashMap<
-            ExprMetadataKey,
-            baml_compiler2_tir::inference::FunctionCoercion,
-        >| {
+        for fsi in std::iter::once(let_scope_id).chain((desc_start..desc_end).map(FileScopeId::new))
+        {
             let scope_id = index.scope_ids[fsi.index() as usize];
-            let inference = infer_scope_types(db, scope_id);
-            let body_scope = MetadataScope::Body(fsi);
-            for (&expr_id, ty) in inference.iter_expressions() {
-                expr_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_bindings() {
-                pat_types.insert((body_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_resolutions() {
-                resolutions.insert((body_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_exhaustive_matches() {
-                exhaustive_matches.insert((body_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_path_root_types() {
-                path_root_types.insert((body_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_path_segment_types() {
-                path_segment_types.insert((body_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_path_member_resolutions() {
-                path_member_resolutions.insert((body_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_call_plans() {
-                call_plans.insert((body_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_function_coercions() {
-                function_coercions.insert((body_scope, expr_id), coercion.clone());
-            }
-
-            let default_scope = MetadataScope::ParameterDefault(fsi);
-            for (&expr_id, ty) in inference.iter_default_expressions() {
-                expr_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&pat_id, ty) in inference.iter_default_bindings() {
-                pat_types.insert((default_scope, pat_id), ty.clone());
-            }
-            for (&expr_id, res) in inference.iter_default_resolutions() {
-                resolutions.insert((default_scope, expr_id), res.clone());
-            }
-            for &expr_id in inference.iter_default_exhaustive_matches() {
-                exhaustive_matches.insert((default_scope, expr_id));
-            }
-            for (&expr_id, ty) in inference.iter_default_path_root_types() {
-                path_root_types.insert((default_scope, expr_id), ty.clone());
-            }
-            for (&(expr_id, seg_idx), ty) in inference.iter_default_path_segment_types() {
-                path_segment_types.insert((default_scope, expr_id, seg_idx), ty.clone());
-            }
-            for (&expr_id, member_resolutions) in inference.iter_default_path_member_resolutions() {
-                path_member_resolutions
-                    .insert((default_scope, expr_id), member_resolutions.clone());
-            }
-            for (&expr_id, plan) in inference.iter_default_call_plans() {
-                call_plans.insert((default_scope, expr_id), plan.clone());
-            }
-            for (&expr_id, coercion) in inference.iter_default_function_coercions() {
-                function_coercions.insert((default_scope, expr_id), coercion.clone());
-            }
-        };
-
-        // Include the let scope itself
-        merge_scope(
-            let_scope_id,
-            &mut expr_types,
-            &mut pat_types,
-            &mut resolutions,
-            &mut exhaustive_matches,
-            &mut path_root_types,
-            &mut path_segment_types,
-            &mut path_member_resolutions,
-            &mut call_plans,
-            &mut function_coercions,
-        );
-
-        // Include all descendant scopes (blocks, closures within the initializer)
-        let let_scope = &index.scopes[let_scope_id.index() as usize];
-        let desc_start = let_scope.descendants.start.index();
-        let desc_end = let_scope.descendants.end.index();
-        for raw_idx in desc_start..desc_end {
-            merge_scope(
-                FileScopeId::new(raw_idx),
-                &mut expr_types,
-                &mut pat_types,
-                &mut resolutions,
-                &mut exhaustive_matches,
-                &mut path_root_types,
-                &mut path_segment_types,
-                &mut path_member_resolutions,
-                &mut call_plans,
-                &mut function_coercions,
-            );
+            scope_inference.insert(fsi, infer_scope_types(db, scope_id));
         }
 
         // --- Build class_fields / enum_variants from PackageItems ---
@@ -3119,16 +2876,9 @@ impl<'db> LoweringContext<'db> {
             catch_context: None,
             catch_rethrow_locals: Vec::new(),
             exit_block: BlockId(0), // placeholder; overwritten in lower_let_body_inner
-            expr_types,
-            pat_types,
-            resolutions,
-            exhaustive_matches,
-            path_root_types,
-            path_segment_types,
-            path_member_resolutions,
-            call_plans,
-            function_coercions,
+            scope_inference,
             generic_param_bounds: FxHashMap::default(),
+            dispatch_cache,
             lambda_param_tir_types: FxHashMap::default(),
             current_scope: let_scope_id,
             current_metadata_scope: MetadataScope::Body(let_scope_id),
@@ -3407,6 +3157,127 @@ impl<'db> LoweringContext<'db> {
         (self.current_metadata_scope, pat_id)
     }
 
+    // --- TIR inference views ---
+    //
+    // Point lookups into the Salsa-cached per-scope `ScopeInference` values
+    // collected at construction, replacing the merged per-function copies the
+    // context used to materialize. `MetadataScope::Body` reads the scope's
+    // body tables; `MetadataScope::ParameterDefault` reads the same scope's
+    // default-parameter tables — exactly the pairing the old merge encoded in
+    // its composite keys. Scopes outside this function answer `None`, matching
+    // the old maps' coverage (some callers key behavior on that absence).
+
+    /// The inference view for `fsi`, when it belongs to this function.
+    fn inference_for(
+        &self,
+        fsi: FileScopeId,
+    ) -> Option<&'db baml_compiler2_tir::inference::ScopeInference<'db>> {
+        self.scope_inference.get(&fsi).copied()
+    }
+
+    fn tir_expr_type(&self, key: ExprMetadataKey) -> Option<&'db Tir2Ty> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.expression_type(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .expression_type(key.1),
+        }
+    }
+
+    fn tir_pat_type(&self, key: PatMetadataKey) -> Option<&'db Tir2Ty> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.binding_type(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .binding_type(key.1),
+        }
+    }
+
+    fn tir_resolution(
+        &self,
+        key: ExprMetadataKey,
+    ) -> Option<&'db baml_compiler2_tir::inference::MemberResolution<'db>> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.resolution(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .resolution(key.1),
+        }
+    }
+
+    fn tir_is_exhaustive_match(&self, key: ExprMetadataKey) -> bool {
+        match key.0 {
+            MetadataScope::Body(fsi) => self
+                .inference_for(fsi)
+                .is_some_and(|inf| inf.is_exhaustive_match(key.1)),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)
+                .is_some_and(|inf| inf.parameter_defaults().is_exhaustive_match(key.1)),
+        }
+    }
+
+    fn tir_path_root_type(&self, key: ExprMetadataKey) -> Option<&'db Tir2Ty> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.path_root_type(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .path_root_type(key.1),
+        }
+    }
+
+    fn tir_path_segment_type(&self, key: (MetadataScope, AstExprId, usize)) -> Option<&'db Tir2Ty> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.path_segment_type(key.1, key.2),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .path_segment_type(key.1, key.2),
+        }
+    }
+
+    fn tir_path_member_resolutions(
+        &self,
+        key: ExprMetadataKey,
+    ) -> Option<&'db [baml_compiler2_tir::inference::MemberResolution<'db>]> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.path_member_resolution(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .path_member_resolution(key.1),
+        }
+    }
+
+    fn tir_call_plan(
+        &self,
+        key: ExprMetadataKey,
+    ) -> Option<&'db baml_compiler2_tir::inference::CallPlan> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.call_plan(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .call_plan(key.1),
+        }
+    }
+
+    fn tir_function_coercion(
+        &self,
+        key: ExprMetadataKey,
+    ) -> Option<&'db baml_compiler2_tir::inference::FunctionCoercion> {
+        match key.0 {
+            MetadataScope::Body(fsi) => self.inference_for(fsi)?.function_coercion(key.1),
+            MetadataScope::ParameterDefault(fsi) => self
+                .inference_for(fsi)?
+                .parameter_defaults()
+                .function_coercion(key.1),
+        }
+    }
+
     fn convert_tir_ty_for_runtime(&self, ty: &Tir2Ty) -> RuntimeTy {
         // Resolve associated-type projections against the bounds the compiler
         // knows statically; anything still symbolic — a `TypeVar` or a
@@ -3583,8 +3454,7 @@ impl<'db> LoweringContext<'db> {
     fn interface_dispatch_target_for_expr(&self, expr_id: AstExprId) -> Option<InterfaceTypeView> {
         self.source_param_interface_view_for_expr(expr_id)
             .or_else(|| {
-                self.expr_types
-                    .get(&self.expr_metadata_key(expr_id))
+                self.tir_expr_type(self.expr_metadata_key(expr_id))
                     .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
             })
             .or_else(|| {
@@ -3718,13 +3588,11 @@ impl<'db> LoweringContext<'db> {
     fn dispatch_receiver_static_tir_ty(&self, expr_id: AstExprId) -> Option<Tir2Ty> {
         if let AstExpr::Upcast { base, .. } = &self.body.exprs[expr_id] {
             return self
-                .expr_types
-                .get(&self.expr_metadata_key(*base))
+                .tir_expr_type(self.expr_metadata_key(*base))
                 .cloned()
                 .or_else(|| self.dispatch_receiver_static_tir_ty(*base));
         }
-        self.expr_types
-            .get(&self.expr_metadata_key(expr_id))
+        self.tir_expr_type(self.expr_metadata_key(expr_id))
             .cloned()
             .or_else(|| self.self_typevar_for_expr(expr_id))
     }
@@ -4028,8 +3896,7 @@ impl<'db> LoweringContext<'db> {
     }
 
     fn expr_ty(&self, expr_id: AstExprId) -> RuntimeTy {
-        self.expr_types
-            .get(&self.expr_metadata_key(expr_id))
+        self.tir_expr_type(self.expr_metadata_key(expr_id))
             .map(|ty| self.convert_tir_ty_for_runtime(ty))
             .unwrap_or(RuntimeTy::Void {
                 attr: TyAttr::default(),
@@ -4042,7 +3909,7 @@ impl<'db> LoweringContext<'db> {
     /// Returns `vec![]` for non-generic (or unresolved) classes.
     fn class_type_arg_templates(&self, expr_id: AstExprId) -> Vec<TyTemplate> {
         let generic_params = self.enclosing_generic_params();
-        match self.expr_types.get(&self.expr_metadata_key(expr_id)) {
+        match self.tir_expr_type(self.expr_metadata_key(expr_id)) {
             Some(Tir2Ty::Class(_, type_args, _)) if !type_args.is_empty() => type_args
                 .iter()
                 .map(|t| self.ty_to_template(t, &generic_params))
@@ -4058,7 +3925,7 @@ impl<'db> LoweringContext<'db> {
     /// recovery).
     fn array_element_template(&self, expr_id: AstExprId) -> TyTemplate {
         let generic_params = self.enclosing_generic_params();
-        match self.expr_types.get(&self.expr_metadata_key(expr_id)) {
+        match self.tir_expr_type(self.expr_metadata_key(expr_id)) {
             Some(Tir2Ty::List(elem, _) | Tir2Ty::EvolvingList(elem, _)) => {
                 self.ty_to_template(elem, &generic_params)
             }
@@ -4072,7 +3939,7 @@ impl<'db> LoweringContext<'db> {
     /// recovery); map keys are always strings.
     fn map_kv_templates(&self, expr_id: AstExprId) -> (TyTemplate, TyTemplate) {
         let generic_params = self.enclosing_generic_params();
-        match self.expr_types.get(&self.expr_metadata_key(expr_id)) {
+        match self.tir_expr_type(self.expr_metadata_key(expr_id)) {
             Some(Tir2Ty::Map { key, value, .. } | Tir2Ty::EvolvingMap(key, value, _)) => (
                 self.ty_to_template(key, &generic_params),
                 self.ty_to_template(value, &generic_params),
@@ -4098,8 +3965,7 @@ impl<'db> LoweringContext<'db> {
 
     /// Get the `baml_type::RuntimeTy` for a pattern binding
     fn pat_ty(&self, pat_id: AstPatId) -> RuntimeTy {
-        self.pat_types
-            .get(&self.pat_metadata_key(pat_id))
+        self.tir_pat_type(self.pat_metadata_key(pat_id))
             .map(|ty| self.convert_tir_ty_for_runtime(ty))
             .unwrap_or(RuntimeTy::Void {
                 attr: TyAttr::default(),
@@ -4116,8 +3982,7 @@ impl<'db> LoweringContext<'db> {
     /// Get the TIR-inferred root segment type for a multi-segment Path expression.
     /// Returns `None` if no root type was recorded (e.g. single-segment paths).
     fn path_root_ty(&self, expr_id: AstExprId) -> Option<RuntimeTy> {
-        self.path_root_types
-            .get(&self.expr_metadata_key(expr_id))
+        self.tir_path_root_type(self.expr_metadata_key(expr_id))
             .map(|ty| self.convert_tir_ty_for_runtime(ty))
     }
 
@@ -4125,8 +3990,7 @@ impl<'db> LoweringContext<'db> {
     /// local-rooted Path expression. Returns `None` if not recorded.
     #[allow(dead_code)]
     fn path_segment_ty(&self, expr_id: AstExprId, seg_idx: usize) -> Option<RuntimeTy> {
-        self.path_segment_types
-            .get(&(self.current_metadata_scope, expr_id, seg_idx))
+        self.tir_path_segment_type((self.current_metadata_scope, expr_id, seg_idx))
             .map(|ty| self.convert_tir_ty_for_runtime(ty))
     }
 
@@ -4920,8 +4784,7 @@ impl LoweringContext<'_> {
         // the bare last segment (`prompt`) in the user's scope would miss it.
         // Fall back to bare-name resolution for unqualified, in-file tags.
         let tag_func_loc = self
-            .resolutions
-            .get(&self.expr_metadata_key(tag))
+            .tir_resolution(self.expr_metadata_key(tag))
             .and_then(|r| match r {
                 MemberResolution::Free { func_loc }
                 | MemberResolution::UnboundMethod { func_loc, .. }
@@ -5579,8 +5442,7 @@ impl LoweringContext<'_> {
 
     fn lower_expr(&mut self, expr_id: AstExprId, dest: Place) {
         if let Some(coercion) = self
-            .function_coercions
-            .get(&self.expr_metadata_key(expr_id))
+            .tir_function_coercion(self.expr_metadata_key(expr_id))
             .cloned()
         {
             self.lower_optional_function_adapter(expr_id, &coercion, dest);
@@ -6055,9 +5917,8 @@ impl<'db> LoweringContext<'db> {
             // This takes priority over the flat resolutions map since infer_local_rooted_path
             // moves resolutions from the flat map into path_member_resolutions.
             if let Some(member_resolutions) = self
-                .path_member_resolutions
-                .get(&self.expr_metadata_key(expr_id))
-                .cloned()
+                .tir_path_member_resolutions(self.expr_metadata_key(expr_id))
+                .map(<[_]>::to_vec)
             {
                 use baml_compiler2_tir::inference::MemberResolution;
                 // The last resolution corresponds to the final segment of the path.
@@ -6135,8 +5996,7 @@ impl<'db> LoweringContext<'db> {
             // Check flat resolutions (set by infer_multi_segment_path for package-rooted paths
             // like baml.fs.open, baml.env.get, etc.).
             if let Some(resolution) = self
-                .resolutions
-                .get(&self.expr_metadata_key(expr_id))
+                .tir_resolution(self.expr_metadata_key(expr_id))
                 .cloned()
             {
                 use baml_compiler2_tir::inference::MemberResolution;
@@ -6221,8 +6081,7 @@ impl<'db> LoweringContext<'db> {
                     segments.len() - 2
                 };
                 let recv_tir_ty = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, expr_id, recv_seg_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, expr_id, recv_seg_idx))
                     .cloned();
                 if let Some((iface_tn, iface_type_args, iface_assoc)) = recv_tir_ty
                     .as_ref()
@@ -6262,8 +6121,7 @@ impl<'db> LoweringContext<'db> {
             }
             // Check for enum variant (e.g. Status.Active lowered to Path(["Status","Active"]))
             if let Some(Tir2Ty::EnumVariant(qtn, variant, _)) = self
-                .expr_types
-                .get(&self.expr_metadata_key(expr_id))
+                .tir_expr_type(self.expr_metadata_key(expr_id))
                 .cloned()
                 .as_ref()
             {
@@ -6355,8 +6213,8 @@ impl<'db> LoweringContext<'db> {
             }
             ResolvedName::Unknown => {
                 if self
-                    .expr_types
-                    .contains_key(&self.expr_metadata_key(expr_id))
+                    .tir_expr_type(self.expr_metadata_key(expr_id))
+                    .is_some()
                 {
                     // If TIR recorded a type for this expr, it was handled as a
                     // package path intermediate (e.g. `baml` in
@@ -6532,8 +6390,7 @@ impl<'db> LoweringContext<'db> {
             // (`(Dog | Named).name`): dispatch the field read on the runtime
             // class across all members' implementors.
             if let Some(members) = self
-                .path_segment_types
-                .get(&(self.current_metadata_scope, expr_id, seg_idx - 1))
+                .tir_path_segment_type((self.current_metadata_scope, expr_id, seg_idx - 1))
                 .and_then(Self::tir_union_members)
                 && self.lower_union_iface_field_access(base_local, &members, seg, &target_place)
             {
@@ -6638,8 +6495,7 @@ impl<'db> LoweringContext<'db> {
         let item = def_to_item_ref(self.db, def);
         // Check if this expression's type is EnumVariant
         if let Some(Tir2Ty::EnumVariant(_qtn, variant, _)) = self
-            .expr_types
-            .get(&self.expr_metadata_key(expr_id))
+            .tir_expr_type(self.expr_metadata_key(expr_id))
             .cloned()
             .as_ref()
         {
@@ -7251,11 +7107,7 @@ impl LoweringContext<'_> {
 
 impl<'db> LoweringContext<'db> {
     fn lower_call_arg_operands(&mut self, expr_id: AstExprId, args: &[AstExprId]) -> Vec<Operand> {
-        let Some(plan) = self
-            .call_plans
-            .get(&self.expr_metadata_key(expr_id))
-            .cloned()
-        else {
+        let Some(plan) = self.tir_call_plan(self.expr_metadata_key(expr_id)).cloned() else {
             // No call plan: lower each arg in order (the type checker would
             // have already flagged any mismatch).
             return args.iter().map(|&a| self.lower_to_operand(a)).collect();
@@ -7365,8 +7217,7 @@ impl<'db> LoweringContext<'db> {
         // A nullable receiver types the missing member as `Unknown | null`, so test
         // the non-null part (matches the TIR fallback gate).
         let callee_untyped = self
-            .expr_types
-            .get(&self.expr_metadata_key(callee))
+            .tir_expr_type(self.expr_metadata_key(callee))
             .is_none_or(|t| {
                 matches!(
                     baml_compiler2_tir::narrowing::remove_null(t),
@@ -7379,10 +7230,7 @@ impl<'db> LoweringContext<'db> {
         let (recv_op, recv_tir_ty): (Operand, Option<Tir2Ty>) = match &callee_expr {
             AstExpr::MemberAccess { base, .. } => {
                 let base_id = *base;
-                let ty = self
-                    .expr_types
-                    .get(&self.expr_metadata_key(base_id))
-                    .cloned();
+                let ty = self.tir_expr_type(self.expr_metadata_key(base_id)).cloned();
                 (self.lower_to_operand(base_id), ty)
             }
             AstExpr::Path(segments) => {
@@ -7404,8 +7252,7 @@ impl<'db> LoweringContext<'db> {
                     }
                 } else {
                     let recv_ty = self
-                        .path_segment_types
-                        .get(&(
+                        .tir_path_segment_type((
                             self.current_metadata_scope,
                             callee,
                             receiver_segments.len() - 1,
@@ -7425,8 +7272,7 @@ impl<'db> LoweringContext<'db> {
                 };
                 let prefix_idx = segments.len() - 2;
                 let ty = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, callee, prefix_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                     .cloned();
                 (recv_op, ty)
             }
@@ -7518,8 +7364,7 @@ impl<'db> LoweringContext<'db> {
         }
         // Fires only when TIR left the callee untyped (no real `to_json` method).
         let callee_untyped = self
-            .expr_types
-            .get(&self.expr_metadata_key(callee))
+            .tir_expr_type(self.expr_metadata_key(callee))
             .is_none_or(|t| {
                 matches!(
                     baml_compiler2_tir::narrowing::remove_null(t),
@@ -7532,10 +7377,7 @@ impl<'db> LoweringContext<'db> {
         let (recv_op, recv_tir_ty): (Operand, Option<Tir2Ty>) = match &callee_expr {
             AstExpr::MemberAccess { base, .. } => {
                 let base_id = *base;
-                let ty = self
-                    .expr_types
-                    .get(&self.expr_metadata_key(base_id))
-                    .cloned();
+                let ty = self.tir_expr_type(self.expr_metadata_key(base_id)).cloned();
                 (self.lower_to_operand(base_id), ty)
             }
             AstExpr::Path(segments) => {
@@ -7552,8 +7394,7 @@ impl<'db> LoweringContext<'db> {
                     }
                 } else {
                     let recv_ty = self
-                        .path_segment_types
-                        .get(&(
+                        .tir_path_segment_type((
                             self.current_metadata_scope,
                             callee,
                             receiver_segments.len() - 1,
@@ -7573,8 +7414,7 @@ impl<'db> LoweringContext<'db> {
                 };
                 let prefix_idx = segments.len() - 2;
                 let ty = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, callee, prefix_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                     .cloned();
                 (recv_op, ty)
             }
@@ -7676,8 +7516,7 @@ impl<'db> LoweringContext<'db> {
             return false;
         }
         let callee_untyped = self
-            .expr_types
-            .get(&self.expr_metadata_key(callee))
+            .tir_expr_type(self.expr_metadata_key(callee))
             .is_none_or(|t| {
                 matches!(
                     baml_compiler2_tir::narrowing::remove_null(t),
@@ -7692,10 +7531,8 @@ impl<'db> LoweringContext<'db> {
         // type arg so `baml.json.to<T>` binds `T` under monomorphization; an
         // out-of-scope typevar / unknown safely drops to ntypeargs=0 (the shim
         // resolves on the runtime value when no static type is supplied).
-        let recv_tir_ty: Option<Tir2Ty> = self
-            .expr_types
-            .get(&self.expr_metadata_key(expr_id))
-            .cloned();
+        let recv_tir_ty: Option<Tir2Ty> =
+            self.tir_expr_type(self.expr_metadata_key(expr_id)).cloned();
         let caller_generic_params = self.enclosing_generic_params();
         let type_arg_ops: Vec<Operand> = match &recv_tir_ty {
             Some(t)
@@ -7912,8 +7749,7 @@ impl<'db> LoweringContext<'db> {
                 let prefix_idx = segments.len() - 2;
                 let recv_seg_idx = if segments.len() == 2 { 0 } else { prefix_idx };
                 let recv_tir_ty = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, callee, recv_seg_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, callee, recv_seg_idx))
                     .cloned()
                     .or_else(|| {
                         if segments.len() == 2
@@ -8065,8 +7901,7 @@ impl<'db> LoweringContext<'db> {
                 // `match`/`if` whose arms are different classes). Same receiver
                 // type slot, same field-chain lowering.
                 else if let Some(members) = self
-                    .path_segment_types
-                    .get(&(self.current_metadata_scope, callee, prefix_idx))
+                    .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                     .and_then(Self::tir_union_members)
                 {
                     let receiver_segments = &segments[..segments.len() - 1];
@@ -8136,8 +7971,7 @@ impl<'db> LoweringContext<'db> {
             &callee_expr
         {
             if self
-                .resolutions
-                .get(&self.expr_metadata_key(callee))
+                .tir_resolution(self.expr_metadata_key(callee))
                 .is_some_and(|r| {
                     use baml_compiler2_tir::inference::MemberResolution;
                     matches!(
@@ -8160,8 +7994,7 @@ impl<'db> LoweringContext<'db> {
                                 .is_some()
                     }
                     _ => self
-                        .expr_types
-                        .get(&self.expr_metadata_key(*base))
+                        .tir_expr_type(self.expr_metadata_key(*base))
                         .map(|ty| !matches!(ty, Tir2Ty::Unknown { .. }))
                         .unwrap_or(false),
                 };
@@ -8170,8 +8003,7 @@ impl<'db> LoweringContext<'db> {
                 // and must not get the class reference prepended as an argument.
                 let method_takes_self = {
                     use baml_compiler2_tir::inference::MemberResolution;
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .is_some_and(|r| match r {
                             MemberResolution::BoundMethod { func_loc, .. }
                             | MemberResolution::UnboundMethod { func_loc, .. }
@@ -8193,10 +8025,8 @@ impl<'db> LoweringContext<'db> {
                     let receiver_op = self.lower_to_operand(*base);
                     receiver_base_for_class_type_args = Some(*base);
                     let callee_op = {
-                        let resolution = self
-                            .resolutions
-                            .get(&self.expr_metadata_key(callee))
-                            .cloned();
+                        let resolution =
+                            self.tir_resolution(self.expr_metadata_key(callee)).cloned();
                         match resolution
                             .as_ref()
                             .and_then(|r| resolution_to_item_ref(self.db, r))
@@ -8216,10 +8046,8 @@ impl<'db> LoweringContext<'db> {
                     // MakeBoundMethod (which would try to load the base type as a
                     // runtime value).
                     let callee_op = {
-                        let resolution = self
-                            .resolutions
-                            .get(&self.expr_metadata_key(callee))
-                            .cloned();
+                        let resolution =
+                            self.tir_resolution(self.expr_metadata_key(callee)).cloned();
                         match resolution
                             .as_ref()
                             .and_then(|r| resolution_to_item_ref(self.db, r))
@@ -8241,8 +8069,7 @@ impl<'db> LoweringContext<'db> {
             // [Field{profile}, Field{items}, Method{slice}] — last() is Method).
             let is_local_method = segments.len() >= 2
                 && self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .is_some_and(|r| {
                         use baml_compiler2_tir::inference::MemberResolution;
@@ -8257,8 +8084,7 @@ impl<'db> LoweringContext<'db> {
             let is_pkg_method = !is_local_method
                 && segments.len() >= 2
                 && self
-                    .resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_resolution(self.expr_metadata_key(callee))
                     .is_some_and(|r| {
                         use baml_compiler2_tir::inference::MemberResolution;
                         matches!(
@@ -8278,8 +8104,7 @@ impl<'db> LoweringContext<'db> {
                 // (not MakeBoundMethod) since the receiver is passed explicitly as self.
                 let receiver_segments = &segments[..segments.len() - 1];
                 let method_resolution = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .cloned();
                 let callee_op = match method_resolution
@@ -8330,8 +8155,7 @@ impl<'db> LoweringContext<'db> {
                     };
                     let prefix_idx = segments.len() - 2;
                     receiver_path_tir_ty = self
-                        .path_segment_types
-                        .get(&(self.current_metadata_scope, callee, prefix_idx))
+                        .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                         .cloned();
                     let mut all_args = vec![receiver_op];
                     all_args.extend(self.lower_call_arg_operands(expr_id, args));
@@ -8341,10 +8165,7 @@ impl<'db> LoweringContext<'db> {
                 // Package-path method call (via flat resolutions): same treatment.
                 // For immediate calls, emit the callee as a plain function constant
                 // (not MakeBoundMethod) since the receiver is passed explicitly as self.
-                let flat_resolution = self
-                    .resolutions
-                    .get(&self.expr_metadata_key(callee))
-                    .cloned();
+                let flat_resolution = self.tir_resolution(self.expr_metadata_key(callee)).cloned();
                 let callee_op = match flat_resolution
                     .as_ref()
                     .and_then(|r| resolution_to_item_ref(self.db, r))
@@ -8362,8 +8183,7 @@ impl<'db> LoweringContext<'db> {
                 if let Some(receiver_op) = receiver_op {
                     let prefix_idx = segments.len() - 2;
                     receiver_path_tir_ty = self
-                        .path_segment_types
-                        .get(&(self.current_metadata_scope, callee, prefix_idx))
+                        .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
                         .cloned();
                     let mut all_args = vec![receiver_op];
                     all_args.extend(self.lower_call_arg_operands(expr_id, args));
@@ -8465,8 +8285,7 @@ impl<'db> LoweringContext<'db> {
         //      from `path_root_types[callee_expr_id]` (TIR records root segment type there).
         let receiver_tir_ty: Option<Tir2Ty> =
             if let Some(recv_base_id) = receiver_base_for_class_type_args {
-                self.expr_types
-                    .get(&self.expr_metadata_key(recv_base_id))
+                self.tir_expr_type(self.expr_metadata_key(recv_base_id))
                     .cloned()
             } else {
                 receiver_path_tir_ty
@@ -8666,11 +8485,10 @@ impl<'db> LoweringContext<'db> {
         use baml_compiler2_tir::inference::MemberResolution;
         let key = self.expr_metadata_key(callee);
         matches!(
-            self.resolutions.get(&key),
+            self.tir_resolution(key),
             Some(MemberResolution::BoundMethod { .. })
         ) || matches!(
-            self.path_member_resolutions
-                .get(&key)
+            self.tir_path_member_resolutions(key)
                 .and_then(|resolutions| resolutions.last()),
             Some(MemberResolution::BoundMethod { .. })
         )
@@ -8705,8 +8523,7 @@ impl<'db> LoweringContext<'db> {
                 // The last resolution in path_member_resolutions is the final-segment resolution.
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -8720,8 +8537,7 @@ impl<'db> LoweringContext<'db> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -8746,7 +8562,7 @@ impl<'db> LoweringContext<'db> {
         // ── NEW: MemberAccess callee (e.g. f.read, sock.recv) ──────────────────
         if let AstExpr::MemberAccess { .. } = &self.body.exprs[callee] {
             use baml_compiler2_tir::inference::MemberResolution;
-            if let Some(resolution) = self.resolutions.get(&self.expr_metadata_key(callee)) {
+            if let Some(resolution) = self.tir_resolution(self.expr_metadata_key(callee)) {
                 let func_loc = match resolution {
                     MemberResolution::BoundMethod { func_loc, .. }
                     | MemberResolution::UnboundMethod { func_loc, .. }
@@ -8800,8 +8616,7 @@ impl<'db> LoweringContext<'db> {
                 // The last resolution in path_member_resolutions is the final-segment resolution.
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -8815,8 +8630,7 @@ impl<'db> LoweringContext<'db> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -8841,7 +8655,7 @@ impl<'db> LoweringContext<'db> {
         // ── NEW: MemberAccess callee (e.g. f.read, sock.recv) ──────────────────
         if let AstExpr::MemberAccess { .. } = &self.body.exprs[callee] {
             use baml_compiler2_tir::inference::MemberResolution;
-            if let Some(resolution) = self.resolutions.get(&self.expr_metadata_key(callee)) {
+            if let Some(resolution) = self.tir_resolution(self.expr_metadata_key(callee)) {
                 let func_loc = match resolution {
                     MemberResolution::BoundMethod { func_loc, .. }
                     | MemberResolution::UnboundMethod { func_loc, .. }
@@ -8890,8 +8704,7 @@ impl<'db> LoweringContext<'db> {
                 // The last resolution in path_member_resolutions is the final-segment resolution.
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -8905,8 +8718,7 @@ impl<'db> LoweringContext<'db> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -8931,7 +8743,7 @@ impl<'db> LoweringContext<'db> {
         // ── NEW: MemberAccess callee (e.g. f.read, sock.recv) ──────────────────
         if let AstExpr::MemberAccess { .. } = &self.body.exprs[callee] {
             use baml_compiler2_tir::inference::MemberResolution;
-            if let Some(resolution) = self.resolutions.get(&self.expr_metadata_key(callee)) {
+            if let Some(resolution) = self.tir_resolution(self.expr_metadata_key(callee)) {
                 let func_loc = match resolution {
                     MemberResolution::BoundMethod { func_loc, .. }
                     | MemberResolution::UnboundMethod { func_loc, .. }
@@ -9001,8 +8813,7 @@ impl<'db> LoweringContext<'db> {
             } else {
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -9016,8 +8827,7 @@ impl<'db> LoweringContext<'db> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -9100,8 +8910,7 @@ impl LoweringContext<'_> {
             } else {
                 use baml_compiler2_tir::inference::MemberResolution;
                 let from_pmr = self
-                    .path_member_resolutions
-                    .get(&self.expr_metadata_key(callee))
+                    .tir_path_member_resolutions(self.expr_metadata_key(callee))
                     .and_then(|resolutions| resolutions.last())
                     .and_then(|res| match res {
                         MemberResolution::Free { func_loc } => Some(*func_loc),
@@ -9115,8 +8924,7 @@ impl LoweringContext<'_> {
                 if from_pmr.is_some() {
                     from_pmr
                 } else {
-                    self.resolutions
-                        .get(&self.expr_metadata_key(callee))
+                    self.tir_resolution(self.expr_metadata_key(callee))
                         .and_then(|res| match res {
                             MemberResolution::Free { func_loc } => Some(*func_loc),
                             MemberResolution::BoundMethod { func_loc, .. }
@@ -9347,8 +9155,7 @@ impl LoweringContext<'_> {
         }
 
         let mut inferred_type_args = self
-            .call_plans
-            .get(&self.expr_metadata_key(call_expr_id))
+            .tir_call_plan(self.expr_metadata_key(call_expr_id))
             .map(|plan| plan.type_args.clone())
             .unwrap_or_default();
         let caller_generic_params = self.enclosing_generic_params();
@@ -9476,8 +9283,7 @@ impl LoweringContext<'_> {
         let key = self.expr_metadata_key(base);
         // Multi-segment paths: static methods, qualified free fns (e.g. baml.json.from_string).
         if let Some(item) = self
-            .path_member_resolutions
-            .get(&key)
+            .tir_path_member_resolutions(key)
             .and_then(|rs| rs.last())
             .filter(|r| is_fn(r))
             .and_then(|r| resolution_to_item_ref(self.db, r))
@@ -9486,8 +9292,7 @@ impl LoweringContext<'_> {
         }
         // Flat / package resolutions.
         if let Some(item) = self
-            .resolutions
-            .get(&key)
+            .tir_resolution(key)
             .filter(|r| is_fn(r))
             .and_then(|r| resolution_to_item_ref(self.db, r))
         {
@@ -9920,8 +9725,7 @@ impl<'db> LoweringContext<'db> {
         // (unbound) or MakeBoundMethod (bound). Field and Variant resolutions fall through to the
         // existing lowering paths below.
         if let Some(resolution) = self
-            .resolutions
-            .get(&self.expr_metadata_key(expr_id))
+            .tir_resolution(self.expr_metadata_key(expr_id))
             .cloned()
         {
             use baml_compiler2_tir::inference::MemberResolution;
@@ -9969,8 +9773,7 @@ impl<'db> LoweringContext<'db> {
         // without evaluating the receiver expression twice.
         if let Some((iface_tn, iface_type_args, iface_assoc)) =
             self.interface_dispatch_target_for_expr(base).or_else(|| {
-                self.expr_types
-                    .get(&self.expr_metadata_key(base))
+                self.tir_expr_type(self.expr_metadata_key(base))
                     .and_then(|ty| self.registry_dispatch_target_for_concrete(ty, field))
             })
         {
@@ -9994,8 +9797,7 @@ impl<'db> LoweringContext<'db> {
 
         // Check if TIR resolved this to an enum variant (e.g. baml.HttpMethod.Get via package path)
         if let Some(Tir2Ty::EnumVariant(qtn, variant, _)) = self
-            .expr_types
-            .get(&self.expr_metadata_key(expr_id))
+            .tir_expr_type(self.expr_metadata_key(expr_id))
             .cloned()
             .as_ref()
         {
@@ -10021,11 +9823,9 @@ impl<'db> LoweringContext<'db> {
         // concrete type, this is a real field access whose field type happens to be
         // Unknown (unresolved type annotation). In that case, fall through to emit
         // the field projection.
-        if let Some(Tir2Ty::Unknown { .. }) = self.expr_types.get(&self.expr_metadata_key(expr_id))
-        {
+        if let Some(Tir2Ty::Unknown { .. }) = self.tir_expr_type(self.expr_metadata_key(expr_id)) {
             let base_is_also_unknown = self
-                .expr_types
-                .get(&self.expr_metadata_key(base))
+                .tir_expr_type(self.expr_metadata_key(base))
                 .map(|ty| matches!(ty, Tir2Ty::Unknown { .. }))
                 .unwrap_or(true);
             if base_is_also_unknown {
@@ -10087,8 +9887,7 @@ impl<'db> LoweringContext<'db> {
                     &dest,
                 )
                 || self
-                    .expr_types
-                    .get(&self.expr_metadata_key(base))
+                    .tir_expr_type(self.expr_metadata_key(base))
                     .and_then(Self::tir_union_members)
                     .is_some_and(|members| {
                         self.lower_union_iface_field_access(base_local, &members, field, &dest)
@@ -10156,16 +9955,14 @@ impl<'db> LoweringContext<'db> {
         current_ty: &RuntimeTy,
     ) -> Option<InterfaceTypeView> {
         if let Some(target) = self
-            .path_segment_types
-            .get(&(self.current_metadata_scope, expr_id, prefix_idx))
+            .tir_path_segment_type((self.current_metadata_scope, expr_id, prefix_idx))
             .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
         {
             return Some(target);
         }
         if prefix_idx == 0
             && let Some(target) = self
-                .path_root_types
-                .get(&self.expr_metadata_key(expr_id))
+                .tir_path_root_type(self.expr_metadata_key(expr_id))
                 .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
         {
             return Some(target);
@@ -10189,10 +9986,9 @@ impl<'db> LoweringContext<'db> {
         current_ty: &RuntimeTy,
     ) -> Option<(TypeName, Vec<RuntimeTy>)> {
         let tir_prefix_ty = if prefix_idx == 0 {
-            self.path_root_types.get(&self.expr_metadata_key(expr_id))
+            self.tir_path_root_type(self.expr_metadata_key(expr_id))
         } else {
-            self.path_segment_types
-                .get(&(self.current_metadata_scope, expr_id, prefix_idx))
+            self.tir_path_segment_type((self.current_metadata_scope, expr_id, prefix_idx))
         };
         if let Some(target) = tir_prefix_ty.and_then(|ty| self.class_dispatch_target_for_tir_ty(ty))
         {
@@ -10396,8 +10192,7 @@ impl<'db> LoweringContext<'db> {
         dest: &Place,
     ) -> bool {
         let dispatch_target = self.interface_dispatch_target_for_expr(base).or_else(|| {
-            self.expr_types
-                .get(&self.expr_metadata_key(base))
+            self.tir_expr_type(self.expr_metadata_key(base))
                 .and_then(|ty| self.registry_dispatch_target_for_concrete(ty, method))
         });
         let Some((iface_tn, iface_type_args, iface_assoc)) = dispatch_target else {
@@ -10594,8 +10389,7 @@ impl<'db> LoweringContext<'db> {
         }
         let recv_ty_idx = receiver_segments.len() - 1;
         let recv_ty = self
-            .path_segment_types
-            .get(&(self.current_metadata_scope, callee, recv_ty_idx))
+            .tir_path_segment_type((self.current_metadata_scope, callee, recv_ty_idx))
             .cloned()
             .map(|t| self.convert_tir_ty_for_runtime(&t))
             .unwrap_or_else(|| RuntimeTy::BuiltinUnknown {
@@ -10639,8 +10433,7 @@ impl<'db> LoweringContext<'db> {
         dest: &Place,
     ) -> bool {
         let Some(members) = self
-            .expr_types
-            .get(&self.expr_metadata_key(base))
+            .tir_expr_type(self.expr_metadata_key(base))
             .and_then(Self::tir_union_members)
         else {
             return false;
@@ -10679,8 +10472,7 @@ impl<'db> LoweringContext<'db> {
         dest: &Place,
     ) -> bool {
         let Some(members) = self
-            .expr_types
-            .get(&self.expr_metadata_key(base))
+            .tir_expr_type(self.expr_metadata_key(base))
             .and_then(Self::tir_union_members)
         else {
             return false;
@@ -10955,7 +10747,52 @@ impl<'db> LoweringContext<'db> {
     /// implementor's method (or the interface default it inherits) plus every
     /// out-of-body / primitive type implementor. Shared by the single-interface
     /// receiver path and the union-receiver path.
+    ///
+    /// Memoized in the package-shared [`DispatchCandidateCache`]: resolution
+    /// only reads the Salsa db, package-level `PackageLoweringData`, and
+    /// `self.generic_param_bounds` (all captured by the cache key), so a
+    /// repeated request — the same dispatch appearing at another call site or
+    /// in another function — returns the previously resolved candidates.
     fn interface_method_candidates_for(
+        &self,
+        iface_tn: &TypeName,
+        iface_type_args: &[Tir2Ty],
+        iface_assoc: &[(Name, Tir2Ty)],
+        method: &Name,
+        recv_tir_ty: Option<&Tir2Ty>,
+    ) -> Vec<InterfaceMethodCandidate> {
+        let mut bounds: Vec<(Name, Tir2Ty)> = self
+            .generic_param_bounds
+            .iter()
+            .map(|(name, ty)| (name.clone(), ty.clone()))
+            .collect();
+        bounds.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let key: DispatchCacheKey = (
+            iface_tn.clone(),
+            iface_type_args.to_vec(),
+            iface_assoc.to_vec(),
+            method.clone(),
+            recv_tir_ty.cloned(),
+            bounds,
+        );
+        if let Some(hit) = self.dispatch_cache.map.borrow().get(&key) {
+            return hit.clone();
+        }
+        let resolved = self.interface_method_candidates_uncached(
+            iface_tn,
+            iface_type_args,
+            iface_assoc,
+            method,
+            recv_tir_ty,
+        );
+        self.dispatch_cache
+            .map
+            .borrow_mut()
+            .insert(key, resolved.clone());
+        resolved
+    }
+
+    fn interface_method_candidates_uncached(
         &self,
         iface_tn: &TypeName,
         iface_type_args: &[Tir2Ty],
@@ -13359,8 +13196,7 @@ impl LoweringContext<'_> {
                 body,
             } => {
                 let coll_tir_ty = self
-                    .expr_types
-                    .get(&self.expr_metadata_key(collection))
+                    .tir_expr_type(self.expr_metadata_key(collection))
                     .cloned();
                 let iterable_view = coll_tir_ty
                     .as_ref()
@@ -13828,9 +13664,7 @@ impl LoweringContext<'_> {
         arm_ids: &[baml_compiler2_ast::MatchArmId],
         dest: Place,
     ) {
-        let is_exhaustive = self
-            .exhaustive_matches
-            .contains(&self.expr_metadata_key(expr_id));
+        let is_exhaustive = self.tir_is_exhaustive_match(self.expr_metadata_key(expr_id));
 
         // If scrutinee is a simple variable reference, reuse the local directly
         // instead of copying into a temp (matches MIR1 behavior).
@@ -13973,12 +13807,12 @@ impl LoweringContext<'_> {
                         kind: AstTypeExprKind::Path { .. },
                         ..
                     }) if matches!(
-                        this.pat_types.get(&this.pat_metadata_key(atom_id)),
+                        this.tir_pat_type(this.pat_metadata_key(atom_id)),
                         Some(Tir2Ty::EnumVariant(_, _, _))
                     ) =>
                     {
                         let Some(Tir2Ty::EnumVariant(qtn, variant, _)) =
-                            this.pat_types.get(&this.pat_metadata_key(atom_id))
+                            this.tir_pat_type(this.pat_metadata_key(atom_id))
                         else {
                             unreachable!("guarded by matches! above");
                         };
@@ -14799,7 +14633,7 @@ impl LoweringContext<'_> {
     }
 
     fn class_pattern_type_name(&self, pat_id: AstPatId) -> Option<TypeName> {
-        let tir_ty = self.pat_types.get(&self.pat_metadata_key(pat_id))?;
+        let tir_ty = self.tir_pat_type(self.pat_metadata_key(pat_id))?;
         match self.resolved_aliases.convert(tir_ty) {
             RuntimeTy::Class(tn, _, _) => Some(tn),
             _ => None,
@@ -14807,7 +14641,7 @@ impl LoweringContext<'_> {
     }
 
     fn class_pattern_field_ty(&self, pat_id: AstPatId, field: &Name) -> Option<RuntimeTy> {
-        let tir_ty = self.pat_types.get(&self.pat_metadata_key(pat_id))?;
+        let tir_ty = self.tir_pat_type(self.pat_metadata_key(pat_id))?;
         let Tir2Ty::Class(qtn, type_args, _) = tir_ty else {
             return None;
         };
@@ -14828,7 +14662,7 @@ impl LoweringContext<'_> {
         // positional field layout. Branch on the raw TIR type so interface
         // patterns project through field-view dispatch instead of class slots.
         if matches!(
-            self.pat_types.get(&self.pat_metadata_key(class_pat_id)),
+            self.tir_pat_type(self.pat_metadata_key(class_pat_id)),
             Some(Tir2Ty::Interface(..))
         ) {
             return self.project_interface_pattern_field(
@@ -14879,8 +14713,7 @@ impl LoweringContext<'_> {
         field: &Name,
     ) -> Option<Local> {
         let tir_ty = self
-            .pat_types
-            .get(&self.pat_metadata_key(class_pat_id))?
+            .tir_pat_type(self.pat_metadata_key(class_pat_id))?
             .clone();
         let (iface_tn, iface_args, iface_assoc) =
             self.interface_dispatch_target_for_tir_ty(&tir_ty)?;
@@ -15075,8 +14908,7 @@ impl LoweringContext<'_> {
         {
             let after_ascription = self.builder.create_block();
             if let Some(tir_ty) = self
-                .pat_types
-                .get(&self.pat_metadata_key(pat_id))
+                .tir_pat_type(self.pat_metadata_key(pat_id))
                 .filter(|ty| !matches!(ty, Tir2Ty::Never { .. }))
                 .cloned()
             {
@@ -15142,12 +14974,12 @@ impl LoweringContext<'_> {
                 }
                 AstTypeExprKind::Path { .. }
                     if matches!(
-                        self.pat_types.get(&self.pat_metadata_key(pat_id)),
+                        self.tir_pat_type(self.pat_metadata_key(pat_id)),
                         Some(Tir2Ty::EnumVariant(_, _, _))
                     ) =>
                 {
                     let Some(Tir2Ty::EnumVariant(qtn, variant, _)) =
-                        self.pat_types.get(&self.pat_metadata_key(pat_id))
+                        self.tir_pat_type(self.pat_metadata_key(pat_id))
                     else {
                         unreachable!("guarded by matches! above");
                     };
@@ -15175,8 +15007,7 @@ impl LoweringContext<'_> {
                     // the subpattern, so fall back to lowering the annotation
                     // itself with the enclosing generic params in scope.
                     let pat_tir_ty = self
-                        .pat_types
-                        .get(&self.pat_metadata_key(pat_id))
+                        .tir_pat_type(self.pat_metadata_key(pat_id))
                         .cloned()
                         .unwrap_or_else(|| self.lower_type_annotation_tir(ty_expr));
                     // A generic-interface pattern (`Slot<int>`) needs the
@@ -15252,7 +15083,7 @@ impl LoweringContext<'_> {
                     self.builder.create_block()
                 };
 
-                if let Some(tir_ty) = self.pat_types.get(&self.pat_metadata_key(pat_id)).cloned() {
+                if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)).cloned() {
                     self.emit_is_tir_type_branch(scrutinee, &tir_ty, class_success, failure);
                 } else if class_success == success {
                     self.builder.goto(success);
@@ -15293,7 +15124,7 @@ impl LoweringContext<'_> {
             } => {
                 let array_success = self.builder.create_block();
 
-                if let Some(tir_ty) = self.pat_types.get(&self.pat_metadata_key(pat_id)).cloned() {
+                if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)).cloned() {
                     self.emit_is_tir_type_branch(scrutinee, &tir_ty, array_success, failure);
                 } else {
                     self.builder.goto(array_success);
@@ -15448,8 +15279,7 @@ impl LoweringContext<'_> {
                 let ty = if let Some(narrow) = &narrow {
                     self.resolve_type_annotation(narrow)
                 } else {
-                    self.pat_types
-                        .get(&self.pat_metadata_key(pat_id))
+                    self.tir_pat_type(self.pat_metadata_key(pat_id))
                         .map(|ty| self.resolved_aliases.convert(ty))
                         .unwrap_or_else(|| self.builder.local_ty(scrutinee))
                 };
@@ -15732,8 +15562,7 @@ impl LoweringContext<'_> {
         // match-chain runtime test — which filters implementors by the specific
         // instantiation — is used instead.
         if self
-            .pat_types
-            .get(&self.pat_metadata_key(pat_id))
+            .tir_pat_type(self.pat_metadata_key(pat_id))
             .is_some_and(Self::tir_ty_needs_interface_shape_test)
         {
             return None;
@@ -15755,7 +15584,7 @@ impl LoweringContext<'_> {
             _ => None,
         };
         if let Some(ty_expr) = ascription_ty {
-            if let Some(tir_ty) = self.pat_types.get(&self.pat_metadata_key(pat_id)) {
+            if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)) {
                 let resolved = self.resolved_aliases.convert(tir_ty);
                 if let Some(tags) = self.ty_to_type_tags(&resolved) {
                     return Some(tags);
@@ -15767,12 +15596,12 @@ impl LoweringContext<'_> {
         match pat {
             AstPattern::Wildcard => None,
             AstPattern::Bind { .. } => {
-                let tir_ty = self.pat_types.get(&self.pat_metadata_key(pat_id))?;
+                let tir_ty = self.tir_pat_type(self.pat_metadata_key(pat_id))?;
                 let resolved = self.resolved_aliases.convert(tir_ty);
                 self.ty_to_type_tags(&resolved)
             }
             AstPattern::Type(_) => {
-                if let Some(tir_ty) = self.pat_types.get(&self.pat_metadata_key(pat_id)) {
+                if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)) {
                     let resolved = self.resolved_aliases.convert(tir_ty);
                     if let Some(tags) = self.ty_to_type_tags(&resolved) {
                         return Some(tags);
@@ -16161,13 +15990,31 @@ pub fn lower_let_body<'db>(
     let_loc: LetLoc<'db>,
     opt: crate::OptLevel,
 ) -> Option<(MirFunctionBody, Vec<MirFunction>)> {
+    lower_let_body_cached(db, let_loc, opt, &std::rc::Rc::default())
+}
+
+/// [`lower_let_body`] with a caller-supplied [`DispatchCandidateCache`], so a
+/// driver lowering many items in one package (the emit crate) shares dispatch
+/// resolutions across all of them.
+pub fn lower_let_body_cached<'db>(
+    db: &'db dyn crate::Db,
+    let_loc: LetLoc<'db>,
+    opt: crate::OptLevel,
+    dispatch_cache: &std::rc::Rc<DispatchCandidateCache>,
+) -> Option<(MirFunctionBody, Vec<MirFunction>)> {
     let body = let_body(db, let_loc);
     let source_map = let_body_source_map(db, let_loc);
 
     match body.as_ref() {
         LetBody::Expr(expr_body) => {
-            let mut ctx =
-                LoweringContext::new_for_let(db, let_loc, expr_body.clone(), source_map, opt);
+            let mut ctx = LoweringContext::new_for_let(
+                db,
+                let_loc,
+                expr_body.clone(),
+                source_map,
+                opt,
+                std::rc::Rc::clone(dispatch_cache),
+            );
             let mir_body = ctx.lower_let_body_inner();
             let lambdas = std::mem::take(&mut ctx.pending_lambdas);
             Some((mir_body, lambdas))
@@ -16181,6 +16028,18 @@ pub fn lower_function<'db>(
     func_loc: FunctionLoc<'db>,
     opt: crate::OptLevel,
 ) -> MirFunction {
+    lower_function_cached(db, func_loc, opt, &std::rc::Rc::default())
+}
+
+/// [`lower_function`] with a caller-supplied [`DispatchCandidateCache`], so a
+/// driver lowering many functions in one package (the emit crate) shares
+/// dispatch resolutions across all of them.
+pub fn lower_function_cached<'db>(
+    db: &'db dyn crate::Db,
+    func_loc: FunctionLoc<'db>,
+    opt: crate::OptLevel,
+    dispatch_cache: &std::rc::Rc<DispatchCandidateCache>,
+) -> MirFunction {
     let body = baml_compiler2_ppir::function_body(db, func_loc);
     let source_map = baml_compiler2_ppir::function_body_source_map(db, func_loc);
     let item_ref = def_to_item_ref(
@@ -16192,7 +16051,14 @@ pub fn lower_function<'db>(
 
     match body.as_ref() {
         FunctionBody::Expr(expr_body) => {
-            let mut ctx = LoweringContext::new(db, func_loc, expr_body.clone(), source_map, opt);
+            let mut ctx = LoweringContext::new(
+                db,
+                func_loc,
+                expr_body.clone(),
+                source_map,
+                opt,
+                std::rc::Rc::clone(dispatch_cache),
+            );
             let mut mir = ctx.lower_function_body();
             mir.item_ref = item_ref;
             mir

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -86,7 +86,7 @@ pub fn resolved_aliases_for_package(
 fn interface_tir_type_args_match_preserving_typevars(
     impl_iface_args: &[Tir2Ty],
     iface_type_args: &[Tir2Ty],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &ResolvedAliases,
 ) -> bool {
     impl_iface_args.len() == iface_type_args.len()
         && impl_iface_args
@@ -108,7 +108,7 @@ fn interface_tir_type_args_match_preserving_typevars(
 fn tir_type_satisfies_dispatch_request(
     actual: &Tir2Ty,
     requested: &Tir2Ty,
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &ResolvedAliases,
 ) -> bool {
     if baml_compiler2_tir::normalize::is_same_normalized_type(actual, requested, aliases) {
         return true;
@@ -366,7 +366,7 @@ fn bind_interface_class_type_arg(
     name: &Name,
     actual: &Tir2Ty,
     bindings: &mut FxHashMap<Name, Tir2Ty>,
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &ResolvedAliases,
 ) -> bool {
     match bindings.get(name) {
         Some(existing) => {
@@ -383,7 +383,7 @@ fn infer_interface_class_bindings(
     formal: &Tir2Ty,
     actual: &Tir2Ty,
     class_params: &[Name],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut FxHashMap<Name, Tir2Ty>,
     // Associated-type bindings tolerate an unpinnable typevar union
     // (`Error = E | E2` vs a normalized request) by leaving the params
@@ -614,7 +614,7 @@ fn interface_class_guard_for_args(
     requested_iface_args: &[Tir2Ty],
     requested_iface_assoc: &[(Name, Tir2Ty)],
     class_params: &[Name],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &ResolvedAliases,
 ) -> Option<InterfaceClassGuard> {
     // An *uninstantiated* request (no type args) matches any implementor
     // instantiation — e.g. `self: Container` inside a generic interface's
@@ -818,7 +818,7 @@ fn type_satisfies_bound(
     db: &dyn crate::Db,
     actual: &Tir2Ty,
     bound: &Tir2Ty,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &ResolvedAliases,
     default_pkg: &baml_base::Name,
     depth: u32,
 ) -> bool {
@@ -1587,6 +1587,16 @@ type DispatchCacheKey = (
 #[derive(Default)]
 pub struct DispatchCandidateCache {
     map: std::cell::RefCell<FxHashMap<DispatchCacheKey, Vec<InterfaceMethodCandidate>>>,
+    /// Memo for [`LoweringContext::registry_dispatch_target_for_concrete`]:
+    /// `(receiver type, method name)` → the interface view that dispatches it,
+    /// if any. Resolution scans every impl rule of every package (running
+    /// `match_ty_pattern` per rule), and the *negative* answer — "no interface
+    /// dispatches this method" — is both the common case and the most
+    /// expensive (the scan never short-circuits), so misses are cached too.
+    /// The resolution reads only the Salsa db and package-level data (the
+    /// current file contributes nothing but its package, which is this
+    /// cache's own dimension), so no per-function state is in the key.
+    registry_targets: std::cell::RefCell<FxHashMap<(Tir2Ty, Name), Option<InterfaceTypeView>>>,
 }
 
 /// Strategy for seeding a dispatched method's `frame.type_args`.
@@ -1930,7 +1940,7 @@ impl<'db> LoweringContext<'db> {
                     &rule.for_ty_pattern,
                     actual_ty,
                     &rule.generic_params,
-                    &self.resolved_aliases.aliases,
+                    self.resolved_aliases,
                 ) else {
                     continue;
                 };
@@ -1939,13 +1949,13 @@ impl<'db> LoweringContext<'db> {
                 if !registry.type_implements_interface_via_rule(
                     actual_ty,
                     &iface_ty,
-                    &self.resolved_aliases.aliases,
+                    self.resolved_aliases,
                     |actual, bound| {
                         type_satisfies_bound(
                             self.db,
                             actual,
                             bound,
-                            &self.resolved_aliases.aliases,
+                            self.resolved_aliases,
                             &default_pkg,
                             BLANKET_BOUND_DEPTH,
                         )
@@ -2064,7 +2074,7 @@ impl<'db> LoweringContext<'db> {
                 let resolver =
                     baml_compiler2_tir::associated_projection::AssociatedProjectionResolver::new(
                         self.db,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                         &self.generic_param_bounds,
                     );
                 let resolved = resolver.resolve_deep(ty);
@@ -2454,13 +2464,13 @@ impl<'db> LoweringContext<'db> {
                             if !registry.type_implements_interface_via_rule(
                                 &actual,
                                 &bound_ty,
-                                &resolved_aliases.aliases,
+                                resolved_aliases,
                                 |nested_actual, nested_bound| {
                                     type_satisfies_bound(
                                         db,
                                         nested_actual,
                                         nested_bound,
-                                        &resolved_aliases.aliases,
+                                        resolved_aliases,
                                         &pkg_info.package,
                                         BLANKET_BOUND_DEPTH,
                                     )
@@ -3289,7 +3299,7 @@ impl<'db> LoweringContext<'db> {
         let resolved =
             baml_compiler2_tir::associated_projection::AssociatedProjectionResolver::new(
                 self.db,
-                &self.resolved_aliases.aliases,
+                self.resolved_aliases,
                 &self.generic_param_bounds,
             )
             .resolve_deep(ty);
@@ -3437,7 +3447,7 @@ impl<'db> LoweringContext<'db> {
                 let resolver =
                     baml_compiler2_tir::associated_projection::AssociatedProjectionResolver::new(
                         self.db,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                         &self.generic_param_bounds,
                     );
                 let resolved = resolver.resolve_deep(ty);
@@ -3652,7 +3662,7 @@ impl<'db> LoweringContext<'db> {
                 let resolver =
                     baml_compiler2_tir::associated_projection::AssociatedProjectionResolver::new(
                         self.db,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                         &self.generic_param_bounds,
                     );
                 let resolved = resolver.resolve_deep(ty);
@@ -3674,7 +3684,28 @@ impl<'db> LoweringContext<'db> {
     /// switch. Returns the interface view. TIR has already rejected the
     /// ambiguous (>1 interface) case with E0121, so the first declaring match
     /// is unambiguous for a compiling program.
+    ///
+    /// Memoized in the package-shared [`DispatchCandidateCache`] — see the
+    /// `registry_targets` field for why (the rule scan is expensive and its
+    /// negative answer is the common case).
     fn registry_dispatch_target_for_concrete(
+        &self,
+        recv_ty: &Tir2Ty,
+        method: &Name,
+    ) -> Option<InterfaceTypeView> {
+        let key = (recv_ty.clone(), method.clone());
+        if let Some(hit) = self.dispatch_cache.registry_targets.borrow().get(&key) {
+            return hit.clone();
+        }
+        let resolved = self.registry_dispatch_target_for_concrete_uncached(recv_ty, method);
+        self.dispatch_cache
+            .registry_targets
+            .borrow_mut()
+            .insert(key, resolved.clone());
+        resolved
+    }
+
+    fn registry_dispatch_target_for_concrete_uncached(
         &self,
         recv_ty: &Tir2Ty,
         method: &Name,
@@ -3711,7 +3742,7 @@ impl<'db> LoweringContext<'db> {
                     &rule.for_ty_pattern,
                     recv_ty,
                     &rule.generic_params,
-                    &self.resolved_aliases.aliases,
+                    self.resolved_aliases,
                 ) else {
                     continue;
                 };
@@ -3789,7 +3820,7 @@ impl<'db> LoweringContext<'db> {
             pkg_id,
             ty,
             iface,
-            &self.resolved_aliases.aliases,
+            self.resolved_aliases,
         )?;
         Some(ResolvedImplBlock {
             ctx: self,
@@ -11604,7 +11635,7 @@ impl<'db> LoweringContext<'db> {
                         &rule.for_ty_pattern,
                         &candidate_class_ty,
                         &rule.generic_params,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                     );
                     let candidate_ty =
                         if matches!(rule.for_ty_pattern, baml_compiler2_tir::ty::Ty::TypeVar(..))
@@ -11637,13 +11668,13 @@ impl<'db> LoweringContext<'db> {
                                 &rule,
                                 &requested_iface_ty,
                                 Some(candidate_ty),
-                                &self.resolved_aliases.aliases,
+                                self.resolved_aliases,
                                 |actual, bound| {
                                     type_satisfies_bound(
                                         self.db,
                                         actual,
                                         bound,
-                                        &self.resolved_aliases.aliases,
+                                        self.resolved_aliases,
                                         &file_pkg_info.package,
                                         BLANKET_BOUND_DEPTH,
                                     )
@@ -11655,13 +11686,13 @@ impl<'db> LoweringContext<'db> {
                                 &rule,
                                 &requested_iface_ty,
                                 None,
-                                &self.resolved_aliases.aliases,
+                                self.resolved_aliases,
                                 |actual, bound| {
                                     type_satisfies_bound(
                                         self.db,
                                         actual,
                                         bound,
-                                        &self.resolved_aliases.aliases,
+                                        self.resolved_aliases,
                                         &file_pkg_info.package,
                                         BLANKET_BOUND_DEPTH,
                                     )
@@ -11841,7 +11872,7 @@ impl<'db> LoweringContext<'db> {
         interface_tir_type_args_match_preserving_typevars(
             impl_iface_args,
             iface_type_args,
-            &self.resolved_aliases.aliases,
+            self.resolved_aliases,
         )
     }
 
@@ -11858,7 +11889,7 @@ impl<'db> LoweringContext<'db> {
                     tir_type_satisfies_dispatch_request(
                         impl_ty,
                         requested_ty,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                     ) || self.tir_types_equivalent(impl_ty, requested_ty)
                 })
         })
@@ -11994,7 +12025,7 @@ impl<'db> LoweringContext<'db> {
     fn tir_types_equivalent(&self, a: &Tir2Ty, b: &Tir2Ty) -> bool {
         let resolver = baml_compiler2_tir::associated_projection::AssociatedProjectionResolver::new(
             self.db,
-            &self.resolved_aliases.aliases,
+            self.resolved_aliases,
             &(),
         );
         let resolved_a = resolver.resolve_deep(a);
@@ -12116,7 +12147,7 @@ impl<'db> LoweringContext<'db> {
                     if !baml_compiler2_tir::normalize::is_same_normalized_type(
                         &target_ty_tir,
                         impl_ty_tir,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                     ) {
                         continue;
                     }
@@ -12126,7 +12157,7 @@ impl<'db> LoweringContext<'db> {
                         &target_ty_tir,
                         impl_ty_tir,
                         &imp.generic_params,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                     ) else {
                         continue;
                     };
@@ -12186,13 +12217,13 @@ impl<'db> LoweringContext<'db> {
                             &rule,
                             &requested_iface_ty,
                             None,
-                            &self.resolved_aliases.aliases,
+                            self.resolved_aliases,
                             |actual, bound| {
                                 type_satisfies_bound(
                                     self.db,
                                     actual,
                                     bound,
-                                    &self.resolved_aliases.aliases,
+                                    self.resolved_aliases,
                                     &pkg_info.package,
                                     BLANKET_BOUND_DEPTH,
                                 )
@@ -12207,13 +12238,13 @@ impl<'db> LoweringContext<'db> {
                                 &rule,
                                 &dispatch_iface_ty,
                                 None,
-                                &self.resolved_aliases.aliases,
+                                self.resolved_aliases,
                                 |actual, bound| {
                                     type_satisfies_bound(
                                         self.db,
                                         actual,
                                         bound,
-                                        &self.resolved_aliases.aliases,
+                                        self.resolved_aliases,
                                         &pkg_info.package,
                                         BLANKET_BOUND_DEPTH,
                                     )
@@ -12370,7 +12401,7 @@ impl<'db> LoweringContext<'db> {
                     requested_args,
                     requested_assoc,
                     class_params,
-                    &self.resolved_aliases.aliases,
+                    self.resolved_aliases,
                 ) else {
                     continue;
                 };
@@ -12610,7 +12641,7 @@ impl<'db> LoweringContext<'db> {
                             requested_args,
                             requested_assoc,
                             &class_data.generic_params,
-                            &self.resolved_aliases.aliases,
+                            self.resolved_aliases,
                         ) else {
                             continue;
                         };
@@ -12689,7 +12720,7 @@ impl<'db> LoweringContext<'db> {
                         requested_args,
                         requested_assoc,
                         &class_data.generic_params,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                     ) else {
                         continue;
                     };
@@ -16155,7 +16186,7 @@ mod tests {
 
     #[test]
     fn interface_tir_type_args_match_preserves_type_var_identity() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
 
         assert!(interface_tir_type_args_match_preserving_typevars(
             &[type_var("L"), type_var("R")],
@@ -16171,7 +16202,7 @@ mod tests {
 
     #[test]
     fn interface_class_guard_checks_assoc_when_request_omits_generic_args() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let impl_args = vec![primitive(&PrimitiveType::String)];
         let requested_args = Vec::new();
         let requested_assoc = vec![(Name::new("Value"), primitive(&PrimitiveType::Int))];

--- a/baml_language/crates/baml_compiler2_tir/src/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/associated_projection.rs
@@ -47,7 +47,7 @@ impl TypeVarBounds for () {
 pub struct AssociatedProjectionResolver<'a, 'db, B: TypeVarBounds + ?Sized> {
     db: &'db dyn crate::Db,
     res_ctx: Option<&'db PackageResolutionContext<'db>>,
-    aliases: &'a HashMap<QualifiedTypeName, Ty>,
+    aliases: &'a crate::normalize::ResolvedAliases,
     generic_param_bounds: &'a B,
 }
 
@@ -58,7 +58,7 @@ impl<'a, 'db, B: TypeVarBounds + ?Sized> AssociatedProjectionResolver<'a, 'db, B
     /// emission where the package access check has already happened upstream.
     pub fn new(
         db: &'db dyn crate::Db,
-        aliases: &'a HashMap<QualifiedTypeName, Ty>,
+        aliases: &'a crate::normalize::ResolvedAliases,
         generic_param_bounds: &'a B,
     ) -> Self {
         Self {
@@ -74,7 +74,7 @@ impl<'a, 'db, B: TypeVarBounds + ?Sized> AssociatedProjectionResolver<'a, 'db, B
     pub fn with_resolution_context(
         db: &'db dyn crate::Db,
         res_ctx: &'db PackageResolutionContext<'db>,
-        aliases: &'a HashMap<QualifiedTypeName, Ty>,
+        aliases: &'a crate::normalize::ResolvedAliases,
         generic_param_bounds: &'a B,
     ) -> Self {
         Self {
@@ -1094,7 +1094,7 @@ impl<'a, 'db, B: TypeVarBounds + ?Sized> AssociatedProjectionResolver<'a, 'db, B
         let mut ty = ty;
         for _ in 0..64 {
             match &ty {
-                Ty::TypeAlias(qtn, _) => match self.aliases.get(qtn) {
+                Ty::TypeAlias(qtn, _) => match self.aliases.aliases.get(qtn) {
                     Some(expanded) => ty = expanded.clone(),
                     None => break,
                 },

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -516,7 +516,7 @@ struct NormalizeCtx<'a, 'db>(&'a TypeInferenceBuilder<'db>);
 
 impl baml_type::normalize::TypeContext for NormalizeCtx<'_, '_> {
     fn alias_def(&self, name: &crate::ty::QualifiedTypeName) -> Option<Ty> {
-        self.0.aliases.get(name).cloned()
+        self.0.aliases.aliases.get(name).cloned()
     }
 
     fn implements_interface(&self, concrete: &Ty, interface: &baml_type::Interface) -> bool {
@@ -649,9 +649,10 @@ pub struct TypeInferenceBuilder<'db> {
     scope: ScopeId<'db>,
     /// Declared return type for the function (used to check return statements).
     declared_return_ty: Option<Ty>,
-    /// Resolved type alias map: alias qualified name → expanded Ty.
-    /// Used by the normalizer for structural subtype checking.
-    aliases: HashMap<crate::ty::QualifiedTypeName, Ty>,
+    /// Resolved type-alias environment (alias map + precomputed recursive
+    /// set), built once per scope so per-comparison normalization never
+    /// re-derives the recursive-alias analysis.
+    aliases: crate::normalize::ResolvedAliases,
     /// Namespace path for the file being analyzed (e.g. `["env"]` for `baml/env.baml`).
     ns_context: Vec<Name>,
     /// BEP-044: when this body is the override of an interface method
@@ -972,7 +973,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             package_id,
             scope,
             declared_return_ty: None,
-            aliases,
+            aliases: crate::normalize::resolved_aliases_from_map(aliases),
             ns_context,
             implements_block_interface: None,
             generic_param_bounds: rustc_hash::FxHashMap::default(),
@@ -1283,7 +1284,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn expand_alias_chains(&self, ty: Ty) -> Ty {
-        crate::inference::expand_alias_chains(ty, &self.aliases)
+        crate::inference::expand_alias_chains(ty, &self.aliases.aliases)
     }
 
     /// Pattern-matrix-internal normalization of a scrutinee type.
@@ -8845,7 +8846,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         match ty {
             Ty::Class(qtn, _, _) => qtn.is_panic_type().then(|| ty.clone()),
             Ty::TypeAlias(qtn, _) => {
-                if let Some(expanded) = self.aliases.get(qtn) {
+                if let Some(expanded) = self.aliases.aliases.get(qtn) {
                     self.ty_panic_subset(expanded)
                 } else if qtn.is_panic_type() {
                     Some(ty.clone())
@@ -12365,7 +12366,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 attr: TyAttr::default(),
             }),
             Ty::TypeAlias(qtn, _) => {
-                if let Some(expanded) = self.aliases.get(qtn) {
+                if let Some(expanded) = self.aliases.aliases.get(qtn) {
                     let expanded = expanded.clone();
                     self.try_resolve_member_on_ty(&expanded, member)
                 } else {

--- a/baml_language/crates/baml_compiler2_tir/src/callable.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/callable.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
 use baml_base::Name;
 use baml_compiler2_ast::ExprBody;
@@ -205,7 +205,7 @@ struct CallableThrowsAnalysis<'a, 'db> {
     pkg_id: PackageId<'db>,
     ns_context: &'a [Name],
     inference: &'a ScopeInference<'db>,
-    aliases: &'a HashMap<crate::ty::QualifiedTypeName, Ty>,
+    aliases: &'a crate::normalize::ResolvedAliases,
 }
 
 impl ThrowsAnalysisContext for CallableThrowsAnalysis<'_, '_> {
@@ -287,7 +287,7 @@ fn callee_uses_method_call_convention(
 
 pub(crate) fn instantiated_callee_throws(
     inference: &ScopeInference<'_>,
-    aliases: &HashMap<crate::ty::QualifiedTypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     callee_expr_id: baml_compiler2_ast::ExprId,
     args: &[baml_compiler2_ast::ExprId],
     unwrap_optional_callee: bool,
@@ -303,7 +303,7 @@ pub(crate) fn instantiated_callee_throws(
     // parameter) must be resolved to its underlying `Ty::Function` before its
     // `throws` can be read; otherwise the match below falls through and the
     // caller fabricates an `Unknown` throw fact.
-    let typed_callee = crate::inference::expand_alias_chains(typed_callee, aliases);
+    let typed_callee = crate::inference::expand_alias_chains(typed_callee, &aliases.aliases);
 
     let uses_method_convention = callee_uses_method_call_convention(inference, callee_expr_id);
 
@@ -405,7 +405,9 @@ pub fn callable_throws<'db>(db: &'db dyn crate::Db, function: FunctionLoc<'db>) 
             };
             let inference = infer_scope_types(db, scope_id);
             let res_ctx = package_resolution_context(db, pkg_id);
-            let aliases = crate::inference::package_alias_map(db, res_ctx);
+            let aliases = crate::normalize::resolved_aliases_from_map(
+                crate::inference::package_alias_map(db, res_ctx),
+            );
             crate::throws_analysis::collect_escaping_throws(
                 &CallableThrowsAnalysis {
                     db,

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -743,6 +743,59 @@ impl DefaultParameterInference<'_> {
     }
 }
 
+/// Point lookups into the default-parameter tables, mirroring the
+/// [`ScopeInference`] accessors of the same names. Consumed by MIR lowering,
+/// which reads inference facts through per-scope views rather than
+/// materializing merged copies.
+impl<'db> DefaultParameterInference<'db> {
+    /// Look up the type of a default-parameter expression.
+    pub fn expression_type(&self, expr_id: ExprId) -> Option<&Ty> {
+        self.expressions.get(&expr_id)
+    }
+
+    /// Look up the binding type for a default-parameter pattern.
+    pub fn binding_type(&self, pat_id: PatId) -> Option<&Ty> {
+        self.pattern_types.get(&pat_id)
+    }
+
+    /// Look up the member resolution for a default-parameter expression.
+    pub fn resolution(&self, expr_id: ExprId) -> Option<&MemberResolution<'db>> {
+        self.resolutions.get(&expr_id)
+    }
+
+    /// Check whether a default-parameter match expression is exhaustive.
+    pub fn is_exhaustive_match(&self, expr_id: ExprId) -> bool {
+        self.exhaustive_matches.contains(&expr_id)
+    }
+
+    /// Look up the root segment type for a default-parameter path expression.
+    pub fn path_root_type(&self, expr_id: ExprId) -> Option<&Ty> {
+        self.path_root_types.get(&expr_id)
+    }
+
+    /// Look up the type of `segments[..=seg_idx]` for a default-parameter path.
+    pub fn path_segment_type(&self, expr_id: ExprId, seg_idx: usize) -> Option<&Ty> {
+        self.path_segment_types.get(&(expr_id, seg_idx))
+    }
+
+    /// Look up per-segment member resolutions for a default-parameter path.
+    pub fn path_member_resolution(&self, expr_id: ExprId) -> Option<&[MemberResolution<'db>]> {
+        self.path_member_resolutions
+            .get(&expr_id)
+            .map(Vec::as_slice)
+    }
+
+    /// Look up the argument binding plan for a default-parameter call.
+    pub fn call_plan(&self, expr_id: ExprId) -> Option<&CallPlan> {
+        self.call_plans.get(&expr_id)
+    }
+
+    /// Look up the function adapter for a default-parameter checked coercion.
+    pub fn function_coercion(&self, expr_id: ExprId) -> Option<&FunctionCoercion> {
+        self.function_coercions.get(&expr_id)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallPlan {
     pub bindings: Vec<ParamBinding>,
@@ -887,9 +940,20 @@ impl<'db> ScopeInference<'db> {
         self.call_type_instantiations.iter()
     }
 
+    /// Look up the function adapter required by a checked coercion.
+    pub fn function_coercion(&self, expr_id: ExprId) -> Option<&FunctionCoercion> {
+        self.function_coercions.get(&expr_id)
+    }
+
     /// Iterate over all function adapters required by checked coercions.
     pub fn iter_function_coercions(&self) -> impl Iterator<Item = (&ExprId, &FunctionCoercion)> {
         self.function_coercions.iter()
+    }
+
+    /// The default-parameter inference tables for this scope, for point
+    /// lookups via [`DefaultParameterInference`]'s accessors.
+    pub fn parameter_defaults(&self) -> &DefaultParameterInference<'db> {
+        &self.parameter_defaults
     }
 
     /// Iterate over all default-parameter expression types for this scope.

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
@@ -223,7 +223,7 @@ impl ImplementsRegistry {
     }
 
     pub fn type_implements(&self, ty: &Ty, iface_qtn: &QualifiedTypeName) -> bool {
-        let aliases = std::collections::HashMap::default();
+        let aliases = crate::normalize::ResolvedAliases::default();
         self.type_implements_qtn_via_rule(ty, iface_qtn, &aliases, |actual, bound| {
             self.compatibility_subtype(actual, bound)
         })
@@ -241,7 +241,7 @@ impl ImplementsRegistry {
         &self,
         actual_ty: &Ty,
         iface_qtn: &QualifiedTypeName,
-        aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+        aliases: &normalize::ResolvedAliases,
         mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
     ) -> bool {
         self.interface_impl_rule_index
@@ -282,7 +282,7 @@ impl ImplementsRegistry {
         if let Ty::Interface(iface_qtn, iface_args, associated_bindings, _) = bound
             && !matches!(actual, Ty::Interface(..))
         {
-            let aliases = std::collections::HashMap::default();
+            let aliases = crate::normalize::ResolvedAliases::default();
             let requested_iface_ty = Ty::Interface(
                 iface_qtn.clone(),
                 iface_args.clone(),
@@ -297,7 +297,7 @@ impl ImplementsRegistry {
             );
         }
 
-        normalize::is_subtype_of(actual, bound, &std::collections::HashMap::default())
+        normalize::is_subtype_of(actual, bound, &crate::normalize::ResolvedAliases::default())
     }
 
     /// True iff `class_qtn<class_type_args>` nominally implements `iface_qtn`
@@ -324,7 +324,7 @@ impl ImplementsRegistry {
         rule: &InterfaceImplRule,
         actual_ty: &Ty,
         requested_iface_ty: &Ty,
-        aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+        aliases: &normalize::ResolvedAliases,
         mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
     ) -> Option<InterfaceImplInstantiation> {
         let mut bindings = TypeBindings::default();
@@ -377,7 +377,7 @@ impl ImplementsRegistry {
         &self,
         actual_ty: &Ty,
         requested_iface_ty: &Ty,
-        aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+        aliases: &normalize::ResolvedAliases,
         mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
     ) -> Option<(Name, Ty, Ty)> {
         for rule in &self.interface_impl_rules {
@@ -441,7 +441,7 @@ impl ImplementsRegistry {
         &self,
         actual_ty: &Ty,
         requested_iface_ty: &Ty,
-        aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+        aliases: &normalize::ResolvedAliases,
         mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
     ) -> bool {
         let Some(iface_qtn) = interface_qtn(requested_iface_ty) else {
@@ -539,7 +539,7 @@ impl ImplementsRegistry {
         indices: &[usize],
         actual_ty: &Ty,
         requested_iface_ty: &Ty,
-        aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+        aliases: &normalize::ResolvedAliases,
         is_subtype: &mut impl FnMut(&Ty, &Ty) -> bool,
     ) -> bool {
         indices.iter().any(|idx| {
@@ -563,7 +563,7 @@ impl ImplementsRegistry {
         rule: &InterfaceImplRule,
         requested_iface_ty: &Ty,
         candidate_ty: Option<&Ty>,
-        aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+        aliases: &normalize::ResolvedAliases,
         mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
     ) -> Option<InterfaceImplInstantiation> {
         let mut bindings = TypeBindings::default();
@@ -858,7 +858,7 @@ fn all_rule_generic_params_bound(rule: &InterfaceImplRule, bindings: &TypeBindin
 fn interface_ty_satisfies_request(
     actual: &Ty,
     requested: &Ty,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &normalize::ResolvedAliases,
     is_subtype: &mut impl FnMut(&Ty, &Ty) -> bool,
 ) -> bool {
     let (
@@ -896,7 +896,7 @@ fn interface_ty_satisfies_request(
 fn types_equivalent_for_rule_match(
     actual: &Ty,
     requested: &Ty,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &normalize::ResolvedAliases,
     is_subtype: &mut impl FnMut(&Ty, &Ty) -> bool,
 ) -> bool {
     if normalize::is_same_normalized_type(actual, requested, aliases) {
@@ -953,7 +953,7 @@ pub fn match_ty_pattern(
     pattern: &Ty,
     concrete: &Ty,
     generic_params: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &normalize::ResolvedAliases,
 ) -> Option<TypeBindings> {
     let mut bindings = TypeBindings::default();
     match_ty_pattern_into(pattern, concrete, generic_params, aliases, &mut bindings)?;
@@ -969,7 +969,7 @@ pub fn match_ty_pattern(
 pub fn match_ty_patterns(
     pairs: &[(&Ty, &Ty)],
     generic_params: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &normalize::ResolvedAliases,
 ) -> Option<TypeBindings> {
     let mut bindings = TypeBindings::default();
     for (pattern, concrete) in pairs {
@@ -982,7 +982,7 @@ fn match_ty_pattern_into(
     pattern: &Ty,
     concrete: &Ty,
     generic_params: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Option<()> {
     if let Ty::TypeVar(name, _) = pattern
@@ -1083,7 +1083,7 @@ fn match_union_members(
     pattern_members: &[Ty],
     concrete_members: &[Ty],
     generic_params: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Option<()> {
     let Some((pattern_head, pattern_tail)) = pattern_members.split_first() else {
@@ -1131,7 +1131,7 @@ fn bind_type_var(
     name: &Name,
     concrete: &Ty,
     bindings: &mut TypeBindings,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &normalize::ResolvedAliases,
 ) -> Option<()> {
     match bindings.get(name) {
         Some(existing) if normalize::is_same_normalized_type(existing, concrete, aliases) => {
@@ -1815,7 +1815,7 @@ mod tests {
                 &pattern,
                 &good,
                 &params,
-                &std::collections::HashMap::default()
+                &crate::normalize::ResolvedAliases::default()
             )
             .is_some()
         );
@@ -1824,7 +1824,7 @@ mod tests {
                 &pattern,
                 &bad,
                 &params,
-                &std::collections::HashMap::default()
+                &crate::normalize::ResolvedAliases::default()
             )
             .is_none()
         );
@@ -1846,7 +1846,7 @@ mod tests {
             &pattern,
             &actual,
             &params,
-            &std::collections::HashMap::default(),
+            &crate::normalize::ResolvedAliases::default(),
         )
         .expect("nested list arg should bind T");
         assert_eq!(bindings.get(&Name::new("T")), Some(&int()));
@@ -1947,7 +1947,7 @@ mod tests {
                 &pattern,
                 &same_short_name,
                 &[],
-                &std::collections::HashMap::default()
+                &crate::normalize::ResolvedAliases::default()
             )
             .is_none(),
             "same short name in different namespaces must not match"
@@ -1964,7 +1964,7 @@ mod tests {
             &pattern,
             &actual,
             &params,
-            &std::collections::HashMap::default(),
+            &crate::normalize::ResolvedAliases::default(),
         )
         .expect("union members should be matched by type, not position");
         assert_eq!(bindings.get(&Name::new("T")), Some(&int()));
@@ -1999,7 +1999,7 @@ mod tests {
                     &rule,
                     &actual,
                     &requested,
-                    &std::collections::HashMap::default(),
+                    &crate::normalize::ResolvedAliases::default(),
                     |_, _| true,
                 )
                 .is_none()
@@ -2037,19 +2037,19 @@ mod tests {
                     &rule,
                     &actual,
                     &requested,
-                    &std::collections::HashMap::default(),
+                    &crate::normalize::ResolvedAliases::default(),
                     |lhs, rhs| {
                         matches!(lhs, Ty::AssociatedTypeProjection { member, .. } if member.as_str() == "Item")
                             && normalize::is_same_normalized_type(
                                 rhs,
                                 &string(),
-                                &std::collections::HashMap::default(),
+                                &crate::normalize::ResolvedAliases::default(),
                             )
                             || matches!(rhs, Ty::AssociatedTypeProjection { member, .. } if member.as_str() == "Item")
                                 && normalize::is_same_normalized_type(
                                     lhs,
                                     &string(),
-                                    &std::collections::HashMap::default(),
+                                    &crate::normalize::ResolvedAliases::default(),
                                 )
                     },
                 )

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -132,6 +132,10 @@ pub fn package_coherence_diagnostics<'db>(
             aliases.entry(qtn).or_insert(ty);
         }
     }
+    // Full alias environment (map + recursive set), computed once per registry
+    // build; every comparison below reuses it instead of re-deriving the
+    // recursive-alias analysis per call.
+    let aliases = crate::normalize::resolved_aliases_from_map(aliases);
 
     let dep_rules: Vec<&InterfaceImplRule> = deps
         .iter()
@@ -186,13 +190,13 @@ pub fn package_coherence_diagnostics<'db>(
 /// resolved — aliases nested under a constructor are handled by `is_same_normalized_type`.
 /// Mirrors `expand_type_alias` in the diagnostics layer so the coherence valid-subject
 /// gate sees through the same aliases the E0138 concreteness gate does.
-fn expand_alias_head(ty: &Ty, aliases: &std::collections::HashMap<TypeName, Ty>) -> Ty {
+fn expand_alias_head(ty: &Ty, aliases: &crate::normalize::ResolvedAliases) -> Ty {
     let mut current = ty.clone();
     for _ in 0..64 {
         let Ty::TypeAlias(qtn, _) = &current else {
             break;
         };
-        match aliases.get(qtn) {
+        match aliases.aliases.get(qtn) {
             Some(next) => current = next.clone(),
             None => break,
         }
@@ -209,7 +213,7 @@ pub fn impls_conflict<'db>(
     pkg_id: PackageId<'db>,
     a: &InterfaceImplRule,
     b: &InterfaceImplRule,
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
 ) -> Overlap {
     let (Some(a_qtn), Some(b_qtn)) = (
         interface_qtn(&a.interface_ty),
@@ -269,7 +273,7 @@ fn impls_overlap<'db>(
     pkg_id: PackageId<'db>,
     a: &InterfaceImplRule,
     b: &InterfaceImplRule,
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
 ) -> Overlap {
     let enum_variants = |qtn: &TypeName| enum_variant_names(db, qtn);
     let (a_for, a_args) = renamed_subject(a, 'a', &enum_variants);
@@ -675,7 +679,7 @@ fn unify_into(
     x: &Ty,
     y: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Overlap {
     unify_into_at(x, y, vars, aliases, bindings, 0)
@@ -689,7 +693,7 @@ fn unify_into_at(
     x: &Ty,
     y: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -871,7 +875,7 @@ fn unify_all(
     xs: &[Ty],
     ys: &[Ty],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -895,7 +899,7 @@ fn unify_associated_bindings(
     xb: &[(Name, Ty)],
     yb: &[(Name, Ty)],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -941,7 +945,7 @@ fn unify_union_members_at(
     xs: &[Ty],
     ys: &[Ty],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -999,7 +1003,7 @@ fn unify_union_members(
     xs: &[Ty],
     ys: &[Ty],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Overlap {
     unify_union_members_at(xs, ys, vars, aliases, bindings, 0)
@@ -1011,7 +1015,7 @@ fn try_union_set_equality(
     xs: &[Ty],
     ys: &[Ty],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
 ) -> Option<Overlap> {
     let has_var = |members: &[Ty]| members.iter().any(|m| contains_bound_typevar(m, vars));
     if has_var(xs) || has_var(ys) {
@@ -1042,11 +1046,7 @@ fn is_bare_var(m: &Ty, vars: &[Name]) -> bool {
 /// Whether two ground unions denote the same set of types (order-insensitive).
 /// Members are de-duplicated, so equal cardinality plus "every member of `xs`
 /// has an equal member in `ys`" implies a bijection.
-fn unions_set_equal(
-    xs: &[Ty],
-    ys: &[Ty],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
-) -> bool {
+fn unions_set_equal(xs: &[Ty], ys: &[Ty], aliases: &crate::normalize::ResolvedAliases) -> bool {
     xs.len() == ys.len()
         && xs.iter().all(|x| {
             ys.iter()
@@ -1072,7 +1072,7 @@ fn cover_at(
     member: &Ty,
     candidate: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -1093,7 +1093,7 @@ fn cover(
     member: &Ty,
     candidate: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Overlap {
     cover_at(member, candidate, vars, aliases, bindings, 0)
@@ -1145,7 +1145,7 @@ fn needs_conservative_membership(a: &Ty, b: &Ty) -> bool {
 fn cover_search(
     obligations: &[(Ty, Vec<Ty>)],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
     budget: &mut usize,
     depth: usize,
@@ -1236,7 +1236,7 @@ fn bind_unify_var(
     n: &Name,
     t: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -1399,7 +1399,13 @@ mod tests {
         let xs = vec![Ty::int(), Ty::type_var("T")];
         let ys = vec![Ty::string(), Ty::type_var("V")];
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1414,7 +1420,13 @@ mod tests {
         let xs = vec![Ty::int(), Ty::type_var("T")];
         let ys = vec![Ty::int(), Ty::string(), Ty::class("Foo")];
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1429,7 +1441,13 @@ mod tests {
         let xs = vec![Ty::int(), Ty::type_var("T")];
         let ys = vec![Ty::string(), Ty::class("Foo")];
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::No
         );
     }
@@ -1445,7 +1463,13 @@ mod tests {
         let xs = vec![Ty::class("A1"), Ty::class("A2"), Ty::type_var("T")];
         let ys: Vec<Ty> = (1..=9).map(|i| Ty::class(&format!("A{i}"))).collect();
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1468,7 +1492,13 @@ mod tests {
             .map(|i| Ty::list(Ty::class(&format!("A{i}"))))
             .collect();
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1489,7 +1519,13 @@ mod tests {
         ];
         let ys = vec![Ty::list(Ty::class("A1")), Ty::list(Ty::class("A2"))];
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1514,7 +1550,13 @@ mod tests {
             ys.push(pair(Ty::class(&format!("R{i}")), a2()));
         }
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Unknown
         );
     }
@@ -1529,7 +1571,13 @@ mod tests {
         let xs = vec![int_literal(1), Ty::type_var("T")];
         let ys = vec![Ty::int(), Ty::string()];
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1544,7 +1592,13 @@ mod tests {
         let xs = vec![Ty::int(), Ty::type_var("T")];
         let ys = vec![int_literal(1), Ty::string()];
         assert_eq!(
-            unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings),
+            unify_union_members(
+                &xs,
+                &ys,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::No
         );
     }
@@ -1559,7 +1613,13 @@ mod tests {
         let a = interface_with_assoc("I", vec![("Item", Ty::int())]);
         let b = interface_with_assoc("I", vec![("Item", Ty::string())]);
         assert_eq!(
-            unify_into(&a, &b, &[], &aliases, &mut bindings),
+            unify_into(
+                &a,
+                &b,
+                &[],
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::No
         );
     }
@@ -1573,7 +1633,13 @@ mod tests {
         let a = interface_with_assoc("I", vec![("Item", Ty::int())]);
         let b = interface_with_assoc("I", vec![("Item", Ty::type_var("T"))]);
         assert_eq!(
-            unify_into(&a, &b, &vars, &aliases, &mut bindings),
+            unify_into(
+                &a,
+                &b,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
         assert_eq!(bindings.get(&Name::new("T")), Some(&Ty::int()));
@@ -1605,7 +1671,7 @@ mod tests {
                 &Ty::TypeAlias(r, TyAttr::default()),
                 &Ty::TypeAlias(s, TyAttr::default()),
                 &[],
-                &aliases,
+                &crate::normalize::resolved_aliases_from_map(aliases.clone()),
                 &mut bindings,
             ),
             Overlap::Unknown,
@@ -1620,7 +1686,16 @@ mod tests {
         let mut bindings = TypeBindings::default();
         let a = interface_with_assoc("I", vec![("Item", Ty::int())]);
         let b = interface_with_assoc("I", vec![("Item", Ty::string())]);
-        assert_eq!(cover(&a, &b, &[], &aliases, &mut bindings), Overlap::No);
+        assert_eq!(
+            cover(
+                &a,
+                &b,
+                &[],
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
+            Overlap::No
+        );
     }
 
     #[test]
@@ -1632,7 +1707,16 @@ mod tests {
         let mut bindings = TypeBindings::default();
         let a = Ty::class("A");
         let b = interface("I", vec![]);
-        assert_eq!(cover(&a, &b, &[], &aliases, &mut bindings), Overlap::Yes);
+        assert_eq!(
+            cover(
+                &a,
+                &b,
+                &[],
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
+            Overlap::Yes
+        );
     }
 
     #[test]
@@ -1720,7 +1804,13 @@ mod tests {
         let mut bindings = TypeBindings::default();
         let u = Ty::union(vec![enum_variant("Cmp", "Less"), Ty::type_var("T")]);
         assert_eq!(
-            unify_into(&u, &enum_ty("Cmp"), &vars, &aliases, &mut bindings),
+            unify_into(
+                &u,
+                &enum_ty("Cmp"),
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1736,7 +1826,13 @@ mod tests {
             enum_variant("Cmp", "Equal"),
         ]);
         assert_eq!(
-            unify_into(&u, &enum_ty("Cmp"), &[], &aliases, &mut bindings),
+            unify_into(
+                &u,
+                &enum_ty("Cmp"),
+                &[],
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::No
         );
     }
@@ -1753,7 +1849,13 @@ mod tests {
         let c = || Ty::class("C");
         let u = Ty::union(vec![c(), Ty::type_var("T")]);
         assert_eq!(
-            unify_into(&u, &c(), &vars, &aliases, &mut bindings),
+            unify_into(
+                &u,
+                &c(),
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1767,7 +1869,13 @@ mod tests {
         let mut bindings = TypeBindings::default();
         let u = Ty::union(vec![int_literal(1), Ty::type_var("T")]);
         assert_eq!(
-            unify_into(&u, &Ty::int(), &vars, &aliases, &mut bindings),
+            unify_into(
+                &u,
+                &Ty::int(),
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::Yes
         );
     }
@@ -1783,7 +1891,13 @@ mod tests {
         let u = Ty::union(vec![Ty::class("D"), Ty::type_var("T")]);
         let c = Ty::class("C");
         assert_eq!(
-            unify_into(&u, &c, &vars, &aliases, &mut bindings),
+            unify_into(
+                &u,
+                &c,
+                &vars,
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::No
         );
     }
@@ -1801,7 +1915,7 @@ mod tests {
                 &Ty::type_var("T"),
                 &Ty::unknown(),
                 &vars,
-                &aliases,
+                &crate::normalize::resolved_aliases_from_map(aliases),
                 &mut bindings
             ),
             Overlap::Yes
@@ -1816,7 +1930,13 @@ mod tests {
         let aliases = std::collections::HashMap::default();
         let mut bindings = TypeBindings::default();
         assert_eq!(
-            unify_into(&Ty::unknown(), &Ty::int(), &[], &aliases, &mut bindings),
+            unify_into(
+                &Ty::unknown(),
+                &Ty::int(),
+                &[],
+                &crate::normalize::resolved_aliases_from_map(aliases),
+                &mut bindings
+            ),
             Overlap::No
         );
     }
@@ -1839,7 +1959,13 @@ mod tests {
                 pair(a.clone(), a)
             })
             .collect();
-        unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings)
+        unify_union_members(
+            &xs,
+            &ys,
+            &vars,
+            &crate::normalize::resolved_aliases_from_map(aliases),
+            &mut bindings,
+        )
     }
 
     #[test]
@@ -1897,7 +2023,13 @@ mod tests {
         xs.push(Ty::type_var("ABSORB"));
         let mut vars: Vec<Name> = (0..num_vars).map(|i| Name::new(format!("V{i}"))).collect();
         vars.push(Name::new("ABSORB"));
-        unify_union_members(&xs, &ys, &vars, &aliases, &mut bindings)
+        unify_union_members(
+            &xs,
+            &ys,
+            &vars,
+            &crate::normalize::resolved_aliases_from_map(aliases),
+            &mut bindings,
+        )
     }
 
     // All 2^n exclusion clauses over the first `n` vars ⇒ unsatisfiable.

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use baml_base::{Name, Span, TyAttr};
 use baml_compiler2_hir::{contributions::Definition, package::PackageId};
 use baml_type::{QualifiedTypeName, Ty};
@@ -598,7 +596,7 @@ pub fn get_implements_block<'db>(
     pkg_id: PackageId<'db>,
     concrete_ty: &Ty,
     requested_iface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
 ) -> Option<ResolvedImpl<'db>> {
     get_implements_block_within_depth(
         db,
@@ -618,7 +616,7 @@ fn get_implements_block_within_depth<'db>(
     pkg_id: PackageId<'db>,
     concrete_ty: &Ty,
     requested_iface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     depth: u32,
 ) -> Option<ResolvedImpl<'db>> {
     debug_assert!(
@@ -770,7 +768,7 @@ pub fn implements_interface(
     db: &dyn crate::Db,
     concrete: &Ty,
     interface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     is_subtype: impl FnMut(&Ty, &Ty) -> bool,
 ) -> bool {
     // Orphan rule: the impl lives in the implementor type's package (for a class) or
@@ -802,7 +800,7 @@ pub fn type_implements_interface<'db>(
     pkg_id: PackageId<'db>,
     concrete: &Ty,
     interface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &crate::normalize::ResolvedAliases,
     is_subtype: impl FnMut(&Ty, &Ty) -> bool,
 ) -> bool {
     crate::interfaces::package_implements_registry(db, pkg_id).type_implements_interface_via_rule(

--- a/baml_language/crates/baml_compiler2_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/normalize.rs
@@ -7,6 +7,7 @@
 use std::collections::{HashMap, HashSet};
 
 use baml_base::Name;
+pub use baml_type::ResolvedAliases;
 
 use crate::ty::{FunctionParamMode, LiteralValue, MediaKind, QualifiedTypeName, Ty};
 
@@ -14,18 +15,27 @@ use crate::ty::{FunctionParamMode, LiteralValue, MediaKind, QualifiedTypeName, T
 // PUBLIC API
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Build a [`ResolvedAliases`] environment from a bare alias map, computing
+/// its recursive-alias set once. This is the only sanctioned constructor on
+/// the compiler side: every comparison entry point below takes the full
+/// environment, so the O(aliases + edges) cycle analysis is paid once per
+/// environment instead of once per type comparison.
+pub fn resolved_aliases_from_map(aliases: HashMap<QualifiedTypeName, Ty>) -> ResolvedAliases {
+    let recursive = find_recursive_aliases(&aliases);
+    ResolvedAliases { aliases, recursive }
+}
+
 /// Check if `sub` is a subtype of `sup`, resolving type aliases.
-pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, aliases: &HashMap<QualifiedTypeName, Ty>) -> bool {
-    // Fast path: `normalize` is a pure function of `(ty, aliases)`, so
+pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, env: &ResolvedAliases) -> bool {
+    // Fast path: `normalize` is a pure function of `(ty, env)`, so
     // structurally identical types always normalize identically, and
-    // `StructuralTy::is_subtype_of` is reflexive. Skips the alias-graph
-    // walk + double normalization for the common `T <: T` query.
+    // `StructuralTy::is_subtype_of` is reflexive. Skips the double
+    // normalization for the common `T <: T` query.
     if sub == sup {
         return true;
     }
-    let recursive = find_recursive_aliases(aliases);
-    let sub_norm = normalize(sub, aliases, &recursive);
-    let sup_norm = normalize(sup, aliases, &recursive);
+    let sub_norm = normalize(sub, &env.aliases, &env.recursive);
+    let sup_norm = normalize(sup, &env.aliases, &env.recursive);
     sub_norm.is_subtype_of(&sup_norm, &mut HashSet::new())
 }
 
@@ -35,21 +45,16 @@ pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, aliases: &HashMap<QualifiedTypeN
 /// This is not an assignability/subtyping check. Use it for invariant positions
 /// where two type spellings may differ but still denote the same type, such as
 /// interface field implementations.
-pub fn is_same_normalized_type(
-    lhs: &Ty,
-    rhs: &Ty,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
-) -> bool {
-    // Fast path: `normalize` is a pure function of `(ty, aliases)`, so
+pub fn is_same_normalized_type(lhs: &Ty, rhs: &Ty, env: &ResolvedAliases) -> bool {
+    // Fast path: `normalize` is a pure function of `(ty, env)`, so
     // structurally identical types always normalize (and canonicalize)
-    // identically. Skips the alias-graph walk + double normalization for
-    // the very common identical-spelling case.
+    // identically. Skips the double normalization for the very common
+    // identical-spelling case.
     if lhs == rhs {
         return true;
     }
-    let recursive = find_recursive_aliases(aliases);
-    normalize(lhs, aliases, &recursive).canonicalize()
-        == normalize(rhs, aliases, &recursive).canonicalize()
+    normalize(lhs, &env.aliases, &env.recursive).canonicalize()
+        == normalize(rhs, &env.aliases, &env.recursive).canonicalize()
 }
 
 /// Find all recursive type aliases via DFS.
@@ -1307,7 +1312,11 @@ mod tests {
         let lhs = Ty::Union(vec![int.clone(), string.clone()], TyAttr::default());
         let rhs = Ty::Union(vec![string, int], TyAttr::default());
 
-        assert!(is_same_normalized_type(&lhs, &rhs, &aliases));
+        assert!(is_same_normalized_type(
+            &lhs,
+            &rhs,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -1321,7 +1330,11 @@ mod tests {
         };
         let union = Ty::Union(vec![int.clone(), string], TyAttr::default());
 
-        assert!(!is_same_normalized_type(&int, &union, &aliases));
+        assert!(!is_same_normalized_type(
+            &int,
+            &union,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -1356,7 +1369,7 @@ mod tests {
         assert!(is_same_normalized_type(
             &type_alias("IntOrString"),
             &direct,
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
     }
 
@@ -1386,7 +1399,11 @@ mod tests {
             attr: TyAttr::default(),
         };
 
-        assert!(is_same_normalized_type(&lhs, &rhs, &aliases));
+        assert!(is_same_normalized_type(
+            &lhs,
+            &rhs,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -1424,7 +1441,11 @@ mod tests {
             attr: TyAttr::default(),
         };
 
-        assert!(is_same_normalized_type(&lhs, &rhs, &aliases));
+        assert!(is_same_normalized_type(
+            &lhs,
+            &rhs,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -1442,14 +1463,14 @@ mod tests {
             &Ty::Int {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(is_subtype_of(
             &Ty::Int {
                 attr: TyAttr::default()
             },
             &type_alias("MyInt"),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
     }
 
@@ -1469,12 +1490,12 @@ mod tests {
             &Ty::Int {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(is_subtype_of(
             &type_alias("AnotherInt"),
             &type_alias("MyInt"),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
     }
 
@@ -1501,21 +1522,21 @@ mod tests {
                 attr: TyAttr::default()
             },
             &type_alias("IntOrString"),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(is_subtype_of(
             &Ty::String {
                 attr: TyAttr::default()
             },
             &type_alias("IntOrString"),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &Ty::Bool {
                 attr: TyAttr::default()
             },
             &type_alias("IntOrString"),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
     }
 
@@ -1564,7 +1585,7 @@ mod tests {
             &Ty::Int {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(is_subtype_of(
             &Ty::Never {
@@ -1573,14 +1594,14 @@ mod tests {
             &Ty::String {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(is_subtype_of(
             &Ty::Never {
                 attr: TyAttr::default()
             },
             &Ty::Class(qn("Foo"), vec![], TyAttr::default()),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(is_subtype_of(
             &Ty::Never {
@@ -1589,7 +1610,7 @@ mod tests {
             &Ty::optional(Ty::Int {
                 attr: TyAttr::default()
             }),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -1606,7 +1627,7 @@ mod tests {
             &Ty::Float {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &Ty::Float {
@@ -1615,7 +1636,7 @@ mod tests {
             &Ty::Int {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -1633,7 +1654,7 @@ mod tests {
             &Ty::Bigint {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -1646,7 +1667,7 @@ mod tests {
             &Ty::Int {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // `Literal(Int) <: Float` was removed (lossy past 2^53). The
         // widening, if needed, must be explicit.
@@ -1655,21 +1676,21 @@ mod tests {
             &Ty::Int {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &Ty::Literal(LiteralValue::Int(42), Freshness::Regular, TyAttr::default()),
             &Ty::Bigint {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &Ty::Literal(LiteralValue::Int(42), Freshness::Regular, TyAttr::default()),
             &Ty::Float {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(is_subtype_of(
             &Ty::Literal(
@@ -1680,20 +1701,20 @@ mod tests {
             &Ty::String {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &Ty::Literal(LiteralValue::Int(42), Freshness::Fresh, TyAttr::default()),
             &Ty::String {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // Freshness is ignored for subtyping: Fresh(1) <: Regular(1)
         assert!(is_subtype_of(
             &Ty::Literal(LiteralValue::Int(42), Freshness::Fresh, TyAttr::default()),
             &Ty::Literal(LiteralValue::Int(42), Freshness::Regular, TyAttr::default()),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -1703,12 +1724,12 @@ mod tests {
         assert!(is_subtype_of(
             &Ty::EnumVariant(qn("Color"), Name::new("Red"), TyAttr::default()),
             &Ty::Enum(qn("Color"), TyAttr::default()),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &Ty::EnumVariant(qn("Color"), Name::new("Red"), TyAttr::default()),
             &Ty::Enum(qn("Shape"), TyAttr::default()),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -1749,12 +1770,12 @@ mod tests {
         assert!(is_subtype_of(
             &returns_literal_string,
             &returns_string,
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &returns_string,
             &returns_literal_string,
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
 
         let returns_variant = Ty::Function {
@@ -1777,8 +1798,16 @@ mod tests {
             }),
             attr: TyAttr::default(),
         };
-        assert!(is_subtype_of(&returns_variant, &returns_enum, &aliases));
-        assert!(!is_subtype_of(&returns_enum, &returns_variant, &aliases));
+        assert!(is_subtype_of(
+            &returns_variant,
+            &returns_enum,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
+        assert!(!is_subtype_of(
+            &returns_enum,
+            &returns_variant,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
 
         // `fn() -> int` is NOT usable as `fn() -> bigint`: there is no site to
         // insert the `int → bigint` coercion on the returned value.
@@ -1802,8 +1831,16 @@ mod tests {
             }),
             attr: TyAttr::default(),
         };
-        assert!(!is_subtype_of(&returns_int, &returns_bigint, &aliases));
-        assert!(!is_subtype_of(&returns_bigint, &returns_int, &aliases));
+        assert!(!is_subtype_of(
+            &returns_int,
+            &returns_bigint,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
+        assert!(!is_subtype_of(
+            &returns_bigint,
+            &returns_int,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -1843,12 +1880,12 @@ mod tests {
         assert!(is_subtype_of(
             &accepts_string,
             &accepts_literal_string,
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &accepts_literal_string,
             &accepts_string,
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
 
         let accepts_enum = Ty::Function {
@@ -1875,8 +1912,16 @@ mod tests {
             }),
             attr: TyAttr::default(),
         };
-        assert!(is_subtype_of(&accepts_enum, &accepts_variant, &aliases));
-        assert!(!is_subtype_of(&accepts_variant, &accepts_enum, &aliases));
+        assert!(is_subtype_of(
+            &accepts_enum,
+            &accepts_variant,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
+        assert!(!is_subtype_of(
+            &accepts_variant,
+            &accepts_enum,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
 
         // `fn(bigint)` is NOT usable as `fn(int)`: the caller's `int` argument
         // has no site at which to widen before reaching the `bigint` callee.
@@ -1904,8 +1949,16 @@ mod tests {
             }),
             attr: TyAttr::default(),
         };
-        assert!(!is_subtype_of(&accepts_bigint, &accepts_int, &aliases));
-        assert!(!is_subtype_of(&accepts_int, &accepts_bigint, &aliases));
+        assert!(!is_subtype_of(
+            &accepts_bigint,
+            &accepts_int,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
+        assert!(!is_subtype_of(
+            &accepts_int,
+            &accepts_bigint,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -1939,8 +1992,16 @@ mod tests {
             )),
             attr: TyAttr::default(),
         };
-        assert!(is_subtype_of(&f1, &f2, &aliases));
-        assert!(!is_subtype_of(&f2, &f1, &aliases));
+        assert!(is_subtype_of(
+            &f1,
+            &f2,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
+        assert!(!is_subtype_of(
+            &f2,
+            &f1,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -1996,12 +2057,12 @@ mod tests {
         assert!(is_subtype_of(
             &with_two_optionals,
             &with_one_optional,
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         assert!(!is_subtype_of(
             &with_one_optional,
             &with_two_optionals,
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2061,8 +2122,16 @@ mod tests {
             attr: TyAttr::default(),
         };
 
-        assert!(is_subtype_of(&f1, &f2, &aliases));
-        assert!(is_subtype_of(&f2, &f1, &aliases));
+        assert!(is_subtype_of(
+            &f1,
+            &f2,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
+        assert!(is_subtype_of(
+            &f2,
+            &f1,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -2099,8 +2168,16 @@ mod tests {
             attr: TyAttr::default(),
         };
 
-        assert!(!is_subtype_of(&optional, &required, &aliases));
-        assert!(!is_subtype_of(&required, &optional, &aliases));
+        assert!(!is_subtype_of(
+            &optional,
+            &required,
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
+        ));
+        assert!(!is_subtype_of(
+            &required,
+            &optional,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -2114,7 +2191,7 @@ mod tests {
             &Ty::optional(Ty::Int {
                 attr: TyAttr::default()
             }),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // null <: int?
         assert!(is_subtype_of(
@@ -2124,7 +2201,7 @@ mod tests {
             &Ty::optional(Ty::Int {
                 attr: TyAttr::default()
             }),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // string NOT <: int?
         assert!(!is_subtype_of(
@@ -2134,7 +2211,7 @@ mod tests {
             &Ty::optional(Ty::Int {
                 attr: TyAttr::default()
             }),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2157,7 +2234,7 @@ mod tests {
                 }),
                 TyAttr::default()
             ),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // List(int) <: EvolvingList(int)
         assert!(is_subtype_of(
@@ -2173,7 +2250,7 @@ mod tests {
                 }),
                 TyAttr::default()
             ),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2196,7 +2273,7 @@ mod tests {
                 }),
                 TyAttr::default()
             ),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // EvolvingList(string) NOT <: List(int) — unrelated primitives.
         assert!(!is_subtype_of(
@@ -2212,7 +2289,7 @@ mod tests {
                 }),
                 TyAttr::default()
             ),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // Free widenings inside the container survive coercion-free
         // recursion: a literal int element widens to its base type.
@@ -2231,7 +2308,7 @@ mod tests {
                 }),
                 TyAttr::default()
             ),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2252,7 +2329,7 @@ mod tests {
                 }),
                 TyAttr::default()
             ),
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2279,7 +2356,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2306,7 +2383,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // map<never, never> <: map<string, int>
         assert!(is_subtype_of(
@@ -2328,7 +2405,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2359,7 +2436,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // map<"name", "World"> <: map<string, string>
         assert!(is_subtype_of(
@@ -2385,7 +2462,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2414,7 +2491,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2443,7 +2520,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2472,7 +2549,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // map<string, string> NOT <: map<int, string> — incompatible key types
         assert!(!is_subtype_of(
@@ -2494,7 +2571,7 @@ mod tests {
                 }),
                 attr: TyAttr::default(),
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 
@@ -2632,7 +2709,11 @@ mod tests {
         let sup = Ty::Int {
             attr: TyAttr::default(),
         };
-        assert!(is_subtype_of(&sub, &sup, &aliases));
+        assert!(is_subtype_of(
+            &sub,
+            &sup,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -2654,7 +2735,11 @@ mod tests {
             }),
             TyAttr::default(),
         );
-        assert!(is_subtype_of(&sub, &sup, &aliases));
+        assert!(is_subtype_of(
+            &sub,
+            &sup,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -2678,7 +2763,11 @@ mod tests {
         let sup = Ty::Float {
             attr: TyAttr::default(),
         };
-        assert!(!is_subtype_of(&sub, &sup, &aliases));
+        assert!(!is_subtype_of(
+            &sub,
+            &sup,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -2695,7 +2784,11 @@ mod tests {
             TyAttr::default(),
         );
         // T <: T | String should hold
-        assert!(is_subtype_of(&t, &union, &aliases));
+        assert!(is_subtype_of(
+            &t,
+            &union,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -2714,7 +2807,11 @@ mod tests {
             TyAttr::default(),
         );
         // T <: Int | String should NOT hold (T is opaque)
-        assert!(!is_subtype_of(&t, &union, &aliases));
+        assert!(!is_subtype_of(
+            &t,
+            &union,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -2723,7 +2820,11 @@ mod tests {
         let t = Ty::TypeVar(Name::new("T"), TyAttr::default());
         let opt_t = Ty::optional(t.clone());
         // T <: T? should hold
-        assert!(is_subtype_of(&t, &opt_t, &aliases));
+        assert!(is_subtype_of(
+            &t,
+            &opt_t,
+            &crate::normalize::resolved_aliases_from_map(aliases)
+        ));
     }
 
     #[test]
@@ -2736,7 +2837,7 @@ mod tests {
             &Ty::Int {
                 attr: TyAttr::default()
             },
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases.clone())
         ));
         // Int <: T should NOT hold
         assert!(!is_subtype_of(
@@ -2744,7 +2845,7 @@ mod tests {
                 attr: TyAttr::default()
             },
             &t,
-            &aliases
+            &crate::normalize::resolved_aliases_from_map(aliases)
         ));
     }
 

--- a/baml_language/crates/baml_compiler2_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/normalize.rs
@@ -16,6 +16,13 @@ use crate::ty::{FunctionParamMode, LiteralValue, MediaKind, QualifiedTypeName, T
 
 /// Check if `sub` is a subtype of `sup`, resolving type aliases.
 pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, aliases: &HashMap<QualifiedTypeName, Ty>) -> bool {
+    // Fast path: `normalize` is a pure function of `(ty, aliases)`, so
+    // structurally identical types always normalize identically, and
+    // `StructuralTy::is_subtype_of` is reflexive. Skips the alias-graph
+    // walk + double normalization for the common `T <: T` query.
+    if sub == sup {
+        return true;
+    }
     let recursive = find_recursive_aliases(aliases);
     let sub_norm = normalize(sub, aliases, &recursive);
     let sup_norm = normalize(sup, aliases, &recursive);
@@ -33,20 +40,33 @@ pub fn is_same_normalized_type(
     rhs: &Ty,
     aliases: &HashMap<QualifiedTypeName, Ty>,
 ) -> bool {
+    // Fast path: `normalize` is a pure function of `(ty, aliases)`, so
+    // structurally identical types always normalize (and canonicalize)
+    // identically. Skips the alias-graph walk + double normalization for
+    // the very common identical-spelling case.
+    if lhs == rhs {
+        return true;
+    }
     let recursive = find_recursive_aliases(aliases);
     normalize(lhs, aliases, &recursive).canonicalize()
         == normalize(rhs, aliases, &recursive).canonicalize()
 }
 
 /// Find all recursive type aliases via DFS.
+///
+/// A single memoized DFS over the whole alias graph: `state` maps each alias
+/// to `None` while it is on the DFS stack and to `Some(reaches_cycle)` once
+/// fully explored, so every alias body is walked at most once — O(nodes +
+/// edges) total rather than a fresh DFS per alias. ("Reaches a cycle" is a
+/// property of the alias alone, independent of which root the DFS entered
+/// from, so memoizing it across roots is sound.)
 pub fn find_recursive_aliases(
     aliases: &HashMap<QualifiedTypeName, Ty>,
 ) -> HashSet<QualifiedTypeName> {
+    let mut state = HashMap::new();
     let mut recursive = HashSet::new();
     for name in aliases.keys() {
-        let mut visited = HashSet::new();
-        let mut stack = HashSet::new();
-        if has_cycle(name, aliases, &mut visited, &mut stack) {
+        if has_cycle(name, aliases, &mut state) {
             recursive.insert(name.clone());
         }
     }
@@ -690,64 +710,56 @@ fn normalize_impl(
 // CYCLE DETECTION
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Does expanding `name` ever reach a cycle in the alias graph?
+///
+/// `state` is the shared memo for [`find_recursive_aliases`]: `None` marks an
+/// alias currently on the DFS stack (so hitting it again is a back-edge, i.e.
+/// a real cycle), `Some(result)` a fully explored alias.
 fn has_cycle(
     name: &QualifiedTypeName,
     aliases: &HashMap<QualifiedTypeName, Ty>,
-    visited: &mut HashSet<QualifiedTypeName>,
-    stack: &mut HashSet<QualifiedTypeName>,
+    state: &mut HashMap<QualifiedTypeName, Option<bool>>,
 ) -> bool {
-    if stack.contains(name) {
-        return true;
+    match state.get(name) {
+        // On the current DFS stack — a back-edge, i.e. a real cycle.
+        Some(None) => return true,
+        // Fully explored on an earlier visit.
+        Some(&Some(result)) => return result,
+        None => {}
     }
-    if visited.contains(name) {
-        return false;
-    }
-    visited.insert(name.clone());
-    stack.insert(name.clone());
+    state.insert(name.clone(), None);
     let result = aliases
         .get(name)
-        .is_some_and(|ty| ty_has_cycle(ty, aliases, visited, stack));
-    stack.remove(name);
+        .is_some_and(|ty| ty_has_cycle(ty, aliases, state));
+    state.insert(name.clone(), Some(result));
     result
 }
 
 fn ty_has_cycle(
     ty: &Ty,
     aliases: &HashMap<QualifiedTypeName, Ty>,
-    visited: &mut HashSet<QualifiedTypeName>,
-    stack: &mut HashSet<QualifiedTypeName>,
+    state: &mut HashMap<QualifiedTypeName, Option<bool>>,
 ) -> bool {
     match ty {
-        Ty::TypeAlias(qn, _) if aliases.contains_key(qn) => has_cycle(qn, aliases, visited, stack),
-        Ty::List(inner, _) | Ty::EvolvingList(inner, _) => {
-            ty_has_cycle(inner, aliases, visited, stack)
-        }
+        Ty::TypeAlias(qn, _) if aliases.contains_key(qn) => has_cycle(qn, aliases, state),
+        Ty::List(inner, _) | Ty::EvolvingList(inner, _) => ty_has_cycle(inner, aliases, state),
         Ty::Map { key, value, .. } | Ty::EvolvingMap(key, value, _) => {
-            ty_has_cycle(key, aliases, visited, stack)
-                || ty_has_cycle(value, aliases, visited, stack)
+            ty_has_cycle(key, aliases, state) || ty_has_cycle(value, aliases, state)
         }
-        Ty::Union(types, _) => types
-            .iter()
-            .any(|t| ty_has_cycle(t, aliases, visited, stack)),
-        Ty::Class(_, type_args, _) => type_args
-            .iter()
-            .any(|t| ty_has_cycle(t, aliases, visited, stack)),
+        Ty::Union(types, _) => types.iter().any(|t| ty_has_cycle(t, aliases, state)),
+        Ty::Class(_, type_args, _) => type_args.iter().any(|t| ty_has_cycle(t, aliases, state)),
         Ty::Interface(_, type_args, associated_bindings, _) => {
-            type_args
-                .iter()
-                .any(|t| ty_has_cycle(t, aliases, visited, stack))
+            type_args.iter().any(|t| ty_has_cycle(t, aliases, state))
                 || associated_bindings
                     .iter()
-                    .any(|(_, ty)| ty_has_cycle(ty, aliases, visited, stack))
+                    .any(|(_, ty)| ty_has_cycle(ty, aliases, state))
         }
         Ty::AssociatedTypeProjection {
             base, interface, ..
         } => {
-            ty_has_cycle(base, aliases, visited, stack)
+            ty_has_cycle(base, aliases, state)
                 || interface.as_ref().is_some_and(|interface| {
-                    interface
-                        .tys()
-                        .any(|t| ty_has_cycle(t, aliases, visited, stack))
+                    interface.tys().any(|t| ty_has_cycle(t, aliases, state))
                 })
         }
         Ty::Function {
@@ -758,9 +770,9 @@ fn ty_has_cycle(
         } => {
             params
                 .iter()
-                .any(|param| ty_has_cycle(&param.ty, aliases, visited, stack))
-                || ty_has_cycle(ret, aliases, visited, stack)
-                || ty_has_cycle(throws, aliases, visited, stack)
+                .any(|param| ty_has_cycle(&param.ty, aliases, state))
+                || ty_has_cycle(ret, aliases, state)
+                || ty_has_cycle(throws, aliases, state)
         }
         _ => false,
     }

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -374,7 +374,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
                 res_ctx,
                 pkg_id,
                 scope_id,
-                aliases.clone(),
+                aliases.aliases.clone(),
             );
             builder.set_generic_params(generic_params);
             for (name, ty) in &param_types {
@@ -504,7 +504,7 @@ fn check_interfaces<'db>(
     items: &[baml_compiler2_ast::Item],
     pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
     namespace_path: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
 ) -> Vec<Diagnostic> {
     use baml_compiler2_hir::diagnostic::Hir2Diagnostic;
 
@@ -927,7 +927,7 @@ struct SignatureMatchContext<'a, 'db> {
     expected_namespace_path: &'a [Name],
     actual_pkg_items: &'a baml_compiler2_hir::package::PackageItems<'db>,
     actual_namespace_path: &'a [Name],
-    aliases: &'a std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &'a baml_compiler2_tir::normalize::ResolvedAliases,
     ignore_param_names: bool,
     /// Generic params of the enclosing class / `implements` target. Method
     /// signatures in an impl may reference them (e.g. `type Item = T` on a
@@ -946,7 +946,7 @@ struct InterfaceRequiresQuery<'a> {
     sup_qtn: &'a QualifiedTypeName,
     sup_args: &'a [Ty],
     sup_assoc: &'a [(Name, Ty)],
-    aliases: &'a std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &'a baml_compiler2_tir::normalize::ResolvedAliases,
 }
 
 impl MethodSignature {
@@ -1379,7 +1379,7 @@ fn validate_associated_type_binding_defs(
     generic_bounds: &GenericBoundExprMap,
     generic_subst: &std::collections::HashMap<Name, baml_compiler2_ast::TypeExpr>,
     bindings: &[baml_compiler2_ast::AssociatedTypeBindingDef],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let associated: IndexMap<Name, &baml_compiler2_ast::AssociatedTypeDef> = iface
@@ -1549,7 +1549,7 @@ fn validate_associated_type_default_bounds(
     iface: &baml_compiler2_ast::InterfaceDef,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
     namespace_path: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut associated_subst: std::collections::HashMap<Name, baml_compiler2_ast::TypeExpr> =
@@ -1627,7 +1627,7 @@ fn ty_nominal_subtype_with_generic_bounds(
     namespace_path: &[Name],
     generic_params: &[Name],
     generic_bounds: &GenericBoundExprMap,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
 ) -> bool {
     match sub {
         Ty::Unknown { .. } | Ty::Error { .. } => true,
@@ -1670,7 +1670,7 @@ fn validate_associated_type_bindings_in_items(
     items: &[baml_compiler2_ast::Item],
     pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
     namespace_path: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -2041,7 +2041,7 @@ fn validate_associated_type_bindings_in_function(
     outer_generic_bounds: &GenericBoundExprMap,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
     namespace_path: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut generic_params = outer_generic_params.to_vec();
@@ -2150,7 +2150,7 @@ fn validate_associated_type_bindings_in_method_sig(
     outer_generic_bounds: &GenericBoundExprMap,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
     namespace_path: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut generic_params = outer_generic_params.to_vec();
@@ -2260,7 +2260,7 @@ fn validate_associated_type_bindings_in_type_expr(
     namespace_path: &[Name],
     generic_params: &[Name],
     generic_bounds: &GenericBoundExprMap,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     use baml_compiler2_ast::TypeExprKind;
@@ -2495,7 +2495,7 @@ fn validate_unqualified_associated_type_projection(
     namespace_path: &[Name],
     generic_params: &[Name],
     _generic_bounds: &GenericBoundExprMap,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let Some(member) = segments.last() else {
@@ -2591,7 +2591,7 @@ fn validate_qualified_associated_type_projection(
     namespace_path: &[Name],
     generic_params: &[Name],
     generic_bounds: &GenericBoundExprMap,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let baml_compiler2_ast::TypeExprKind::AssociatedTypeProjection {
@@ -2699,7 +2699,7 @@ fn typevar_bound_nominal_subtype(
     namespace_path: &[Name],
     generic_params: &[Name],
     generic_bounds: &GenericBoundExprMap,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     visited: &mut HashSet<Name>,
 ) -> bool {
     if !visited.insert(name.clone()) {
@@ -2743,7 +2743,7 @@ fn typevar_bound_nominal_subtype(
     }
 }
 
-fn expand_alias_chain(ty: Ty, aliases: &std::collections::HashMap<QualifiedTypeName, Ty>) -> Ty {
+fn expand_alias_chain(ty: Ty, aliases: &baml_compiler2_tir::normalize::ResolvedAliases) -> Ty {
     let mut current = ty;
     let mut seen = HashSet::new();
     loop {
@@ -2753,7 +2753,7 @@ fn expand_alias_chain(ty: Ty, aliases: &std::collections::HashMap<QualifiedTypeN
         if !seen.insert(qtn.clone()) {
             return current;
         }
-        let Some(next) = aliases.get(qtn).cloned() else {
+        let Some(next) = aliases.aliases.get(qtn).cloned() else {
             return current;
         };
         current = next;
@@ -3115,7 +3115,7 @@ fn validate_associated_type_bindings_on_interface_type(
     namespace_path: &[Name],
     generic_params: &[Name],
     generic_bounds: &GenericBoundExprMap,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let baml_compiler2_ast::TypeExprKind::Path {
@@ -3613,7 +3613,7 @@ fn interface_origin_matches_target_expr<'db>(
     pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
     namespace_path: &[Name],
     generic_params: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     origin: &InterfaceMemberOrigin,
 ) -> bool {
     let Some(resolved) = resolve_interface_path(db, target, pkg_items, namespace_path) else {
@@ -3653,7 +3653,7 @@ struct InterfaceValidationCtx<'db, 'a> {
     db: &'db dyn Db,
     pkg_items: &'a baml_compiler2_hir::package::PackageItems<'db>,
     namespace_path: &'a [Name],
-    aliases: &'a std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &'a baml_compiler2_tir::normalize::ResolvedAliases,
 }
 
 fn interface_target_matches_required_parent(
@@ -4105,7 +4105,7 @@ fn validate_interface_extends_fields(
 /// Recursive aliases (`type A = List<A>`) survive lowering unexpanded; the
 /// `seen` set guards against looping on those by leaving an already-visited
 /// alias in place once re-encountered along a single chain.
-fn expand_type_alias(ty: &Ty, aliases: &std::collections::HashMap<QualifiedTypeName, Ty>) -> Ty {
+fn expand_type_alias(ty: &Ty, aliases: &baml_compiler2_tir::normalize::ResolvedAliases) -> Ty {
     expand_type_alias_rec(ty, aliases, &mut HashSet::new())
 }
 
@@ -4114,7 +4114,7 @@ fn expand_type_alias(ty: &Ty, aliases: &std::collections::HashMap<QualifiedTypeN
 /// instead of recursing forever.
 fn expand_type_alias_rec(
     ty: &Ty,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     seen: &mut HashSet<QualifiedTypeName>,
 ) -> Ty {
     let recurse =
@@ -4127,7 +4127,7 @@ fn expand_type_alias_rec(
             if !seen.insert(qtn.clone()) {
                 return ty.clone();
             }
-            let expanded = match aliases.get(qtn) {
+            let expanded = match aliases.aliases.get(qtn) {
                 Some(next) => recurse(next, seen),
                 None => ty.clone(),
             };
@@ -4290,7 +4290,7 @@ fn validate_implements_for<'db>(
     all_items: &[baml_compiler2_ast::Item],
     pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
     namespace_path: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     use baml_compiler2_hir::diagnostic::Hir2Diagnostic;
@@ -4683,7 +4683,7 @@ fn validate_class_implements<'db>(
     class: &baml_compiler2_ast::ClassDef,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
     namespace_path: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     use baml_compiler2_hir::diagnostic::Hir2Diagnostic;
@@ -5202,7 +5202,7 @@ fn type_exprs_compatible(
     rhs_namespace_path: &[Name],
     rhs_generic_params: &[Name],
     rhs: &baml_compiler2_ast::TypeExpr,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
 ) -> bool {
     let mut diagnostics = Vec::new();
     let lhs_ty = baml_compiler2_tir::lower_type_expr::lower_type_expr_in_ns(
@@ -5240,7 +5240,7 @@ fn ty_nominal_subtype(
     db: &dyn Db,
     sub: &Ty,
     sup: &Ty,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &baml_compiler2_tir::normalize::ResolvedAliases,
 ) -> bool {
     if baml_compiler2_tir::normalize::is_same_normalized_type(sub, sup, aliases) {
         return true;
@@ -5904,8 +5904,7 @@ fn jinja_diagnostic_id(message: &str) -> DiagnosticId {
 fn collect_type_aliases_for_resolution_context<'db>(
     db: &'db dyn Db,
     res_ctx: &'db baml_compiler2_tir::package_interface::PackageResolutionContext<'db>,
-) -> std::collections::HashMap<baml_compiler2_tir::ty::QualifiedTypeName, baml_compiler2_tir::ty::Ty>
-{
+) -> baml_compiler2_tir::normalize::ResolvedAliases {
     let mut aliases = baml_compiler2_tir::inference::collect_type_aliases(db, &res_ctx.own_items);
     for (_dep_name, dep_iface) in &res_ctx.dep_interfaces {
         for types_in_ns in dep_iface.types.values() {
@@ -5920,7 +5919,7 @@ fn collect_type_aliases_for_resolution_context<'db>(
             }
         }
     }
-    aliases
+    baml_compiler2_tir::normalize::resolved_aliases_from_map(aliases)
 }
 
 fn function_scope_id<'db>(

--- a/baml_language/crates/baml_tests/src/compiler2_hir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_hir.rs
@@ -368,7 +368,7 @@ mod tests {
 
         let pkg_id = PackageId::new(&db, Name::new("user"));
         let tree = baml_compiler2_hir::file_item_tree(&db, file);
-        let aliases = std::collections::HashMap::new();
+        let aliases = baml_type::ResolvedAliases::default();
 
         let class_ty = |class_name: &str| {
             let (id, data) = tree


### PR DESCRIPTION
Stacked on #3911. Second PR in the incremental compiler-perf series: after #3911 lands, this one takes the empty-project cold compile from 482ms to **281ms median** (−42%). Cumulative from the 1.41s baseline: **5× faster**.

## The problem

Every type-comparison entry point (`is_same_normalized_type`, `is_subtype_of`, the `match_ty_pattern` family) took a bare alias `HashMap` and re-derived the recursive-alias set internally, on **every call**:

```rust
pub fn is_same_normalized_type(lhs: &Ty, rhs: &Ty, aliases: &HashMap<..>) -> bool {
    let recursive = find_recursive_aliases(aliases);   // full DFS over the alias graph, per comparison
    ...
}
```

These are called from the hottest loops in the compiler: interface-dispatch candidate resolution in MIR lowering, pattern matching in TIR inference, coherence checking. Profile of the 482ms compile: `find_recursive_aliases` at 35% inclusive (~168ms), almost all of it under `is_same_normalized_type` (37%).

The irony: MIR lowering already carried the precomputed set in `ResolvedAliases { aliases, recursive }`, the old signatures just couldn't accept it.

## The change (architectural)

**The alias environment's currency is now `&ResolvedAliases`** (the existing `baml_type` struct: alias map + its recursive set) instead of a bare `&HashMap`. The recursive-alias analysis is computed exactly once per environment, at construction, via the new sanctioned constructor `normalize::resolved_aliases_from_map`:

| Construction site | When the set is computed |
|---|---|
| `TypeInferenceBuilder::new` | once per scope inference |
| MIR `LoweringContext` | already had it per package (now actually used) |
| coherence registry build | once per tracked-query invocation |
| callable-throws analysis | once per callable |
| LSP `check.rs` alias helper | once per check pass |

Signature ripple: 6 params in `interfaces.rs` + 15 in `coherence.rs` + 4 in `impl_rules.rs` + 2 in `callable.rs` + 6 in MIR `lower.rs` + 23 in LSP `check.rs`; ~130 call sites converted. Purely a plumbing change: no comparison logic was touched, and `normalize`'s internal machinery still works on the raw map (it is the thing that *computes* the set).

## Also included: registry dispatch-target memo

`registry_dispatch_target_for_concrete` (blanket-impl method lookup for concrete receivers) scans every impl rule of every package per call site, and its **negative** answer ("no interface provides this method") is both the common case and the most expensive (the scan never short-circuits). It is now memoized in the package-shared `DispatchCandidateCache` keyed `(receiver type, method)`, caching misses too.

Honest note: on the empty-project benchmark this adds only ~1% (~3ms), because the currency change above already removed the per-call DFS that dominated its cost. It is included because it bounds the rule scan for real projects with more impl rules and call sites, and it reuses the cache infrastructure from #3911 verbatim.

## Numbers

| State | Median (empty project, cold) |
|---|---|
| baseline (canary) | 1410 ms |
| after #3911 | 482 ms |
| **after this PR** | **281 ms** |

Benchmark: `cargo bench --bench compiler_benchmark -- compile_empty_project` (100 samples, idle machine).

## Validation

- `baml_compiler2_tir` / `mir` / `emit` / `lsp2_actions` unit suites: 337 tests, all green
- workspace-wide `cargo clippy --all-targets --all-features -- -D warnings`: clean
- full `baml_tests` integration suite: deferred to CI (per the incremental-PR plan; #3911's four changes passed the full 2,600-test suite locally)

## Not in this PR (next in series)

- tracked `package_alias_env` salsa query (kills the per-scope alias-map rebuild in `infer_scope_types`)
- type interning (SipHash string hashing is now the top remaining leaf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)