### PR TITLE
Fix Windows LSP/playground project path handling

### DIFF
--- a/baml_language/crates/baml_lsp_server/src/native_vfs.rs
+++ b/baml_language/crates/baml_lsp_server/src/native_vfs.rs
@@ -3,7 +3,7 @@
 //! Wraps `vfs::PhysicalFS` and implements `BulkReadFileSystem` by walking
 //! only the glob's base directory (not the entire filesystem).
 
-use std::io::Read;
+use std::{borrow::Cow, io::Read};
 
 /// Wrapper around `vfs::PhysicalFS` that implements `BulkReadFileSystem`.
 #[derive(Debug)]
@@ -74,8 +74,9 @@ impl bex_project::BulkReadFileSystem for NativeVfs {
         // Extract the base directory from the glob (everything before the
         // first `*` or `?` wildcard). This lets us walk only the relevant
         // subtree instead of the entire filesystem.
-        let base_dir = glob_base_dir(glob);
-        let pattern = glob_to_regex(glob);
+        let native_glob = native_glob_for_fs(glob);
+        let base_dir = glob_base_dir(&native_glob);
+        let pattern = glob_to_regex(&native_glob);
 
         let base = std::path::Path::new(&base_dir);
         if !base.is_dir() {
@@ -102,16 +103,75 @@ fn walk_dir_native(
             walk_dir_native(&path, pattern, results);
         } else if path.is_file() {
             let path_str = path.to_string_lossy();
-            if pattern.is_match(&path_str)
+            let match_path = native_path_for_glob_match(&path_str);
+            if pattern.is_match(&match_path)
                 && let Ok(mut file) = std::fs::File::open(&path)
             {
                 let mut buf = Vec::new();
                 if file.read_to_end(&mut buf).is_ok() {
-                    results.push((path_str.into_owned(), buf));
+                    results.push((vfs_path_from_native_path(&match_path), buf));
                 }
             }
         }
     }
+}
+
+#[cfg(windows)]
+fn native_glob_for_fs(glob: &str) -> Cow<'_, str> {
+    let glob = normalize_windows_separators(glob);
+    let Some(stripped) = glob.strip_prefix('/') else {
+        return glob;
+    };
+
+    if is_windows_drive_path(stripped) {
+        Cow::Owned(stripped.to_string())
+    } else {
+        glob
+    }
+}
+
+#[cfg(not(windows))]
+fn native_glob_for_fs(glob: &str) -> Cow<'_, str> {
+    Cow::Borrowed(glob)
+}
+
+#[cfg(windows)]
+fn native_path_for_glob_match(path: &str) -> Cow<'_, str> {
+    normalize_windows_separators(path)
+}
+
+#[cfg(not(windows))]
+fn native_path_for_glob_match(path: &str) -> Cow<'_, str> {
+    Cow::Borrowed(path)
+}
+
+#[cfg(windows)]
+fn vfs_path_from_native_path(path: &str) -> String {
+    if is_windows_drive_path(path) {
+        format!("/{path}")
+    } else {
+        path.to_string()
+    }
+}
+
+#[cfg(not(windows))]
+fn vfs_path_from_native_path(path: &str) -> String {
+    path.to_string()
+}
+
+#[cfg(windows)]
+fn normalize_windows_separators(path: &str) -> Cow<'_, str> {
+    if path.contains('\\') {
+        Cow::Owned(path.replace('\\', "/"))
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
+#[cfg(windows)]
+fn is_windows_drive_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/'
 }
 
 /// Extract the directory prefix from a glob pattern (everything before the
@@ -157,4 +217,51 @@ fn glob_to_regex(glob: &str) -> regex::Regex {
     }
     re.push('$');
     regex::Regex::new(&re).unwrap_or_else(|_| regex::Regex::new("$^").unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(windows)]
+    fn read_many_accepts_vfs_drive_globs_and_returns_vfs_paths() {
+        use bex_project::BulkReadFileSystem;
+
+        let root = std::env::temp_dir().join(format!(
+            "baml_native_vfs_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let baml_src = root.join("baml_src");
+        std::fs::create_dir_all(&baml_src).unwrap();
+        std::fs::write(
+            baml_src.join("agent_flow.baml"),
+            "function Foo() -> string { \"x\" }",
+        )
+        .unwrap();
+        std::fs::write(baml_src.join("clients.baml"), "client<llm> FooClient {}").unwrap();
+
+        let native_root = root.to_string_lossy().replace('\\', "/");
+        let glob = format!("/{native_root}/baml_src/**/*.baml");
+        let mut entries = super::NativeVfs::new().read_many(&glob).unwrap();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|(path, _)| path.starts_with('/')));
+        assert!(entries.iter().all(|(path, _)| !path.contains('\\')));
+        assert!(
+            entries
+                .iter()
+                .any(|(path, _)| path.ends_with("/clients.baml"))
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|(path, _)| path.ends_with("/agent_flow.baml"))
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/baml_language/crates/bex_project/src/fs.rs
+++ b/baml_language/crates/bex_project/src/fs.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::{borrow::Cow, io::Read};
 
 use crate::LspError;
 
@@ -145,6 +145,8 @@ impl BamlVFS {
         context: &'static str,
     ) -> Result<vfs::VfsPath, LspError> {
         let vfs_path = vfs::VfsPath::from(self.clone());
+        let raw = normalize_windows_drive_path(raw);
+        let raw = raw.as_ref();
         #[cfg(target_arch = "wasm32")]
         let is_absolute = raw.starts_with("/");
         #[cfg(not(target_arch = "wasm32"))]
@@ -156,17 +158,58 @@ impl BamlVFS {
             raw.to_path_buf()
         };
 
-        let path_as_str = raw.to_string_lossy();
-        #[cfg(windows)]
-        let path_as_str = path_as_str.replace('\\', "/");
-        let path_as_str: &str = path_as_str.as_ref();
+        let path_as_str = path_for_vfs_join(&raw);
         vfs_path
-            .join(path_as_str)
+            .join(path_as_str.as_ref())
             .map_err(|e| LspError::InvalidPath {
                 path: raw.clone(),
                 message: format!("{context}: {e}"),
             })
     }
+}
+
+#[cfg(windows)]
+fn normalize_windows_drive_path(path: &std::path::Path) -> Cow<'_, std::path::Path> {
+    let path_as_str = path.to_string_lossy();
+    let slash_path = path_as_str.replace('\\', "/");
+    let Some(stripped) = slash_path.strip_prefix('/') else {
+        return Cow::Borrowed(path);
+    };
+
+    if is_windows_drive_path(stripped) {
+        Cow::Owned(std::path::PathBuf::from(stripped))
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
+#[cfg(not(windows))]
+fn normalize_windows_drive_path(path: &std::path::Path) -> Cow<'_, std::path::Path> {
+    Cow::Borrowed(path)
+}
+
+#[cfg(windows)]
+fn is_windows_drive_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/'
+}
+
+fn path_for_vfs_join(path: &std::path::Path) -> Cow<'_, str> {
+    normalize_path_separators_for_vfs(path.to_string_lossy())
+}
+
+#[cfg(windows)]
+fn normalize_path_separators_for_vfs(path: Cow<'_, str>) -> Cow<'_, str> {
+    if path.contains('\\') {
+        Cow::Owned(path.replace('\\', "/"))
+    } else {
+        path
+    }
+}
+
+#[cfg(not(windows))]
+fn normalize_path_separators_for_vfs(path: Cow<'_, str>) -> Cow<'_, str> {
+    path
 }
 
 impl vfs::FileSystem for BamlVFS {
@@ -234,5 +277,62 @@ impl vfs::FileSystem for BamlVFS {
 
     fn move_dir(&self, src: &str, dest: &str) -> vfs::VfsResult<()> {
         self.fs.move_dir(src, dest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(windows)]
+    fn windows_paths_use_vfs_separators_for_parent_traversal() {
+        let raw = std::path::Path::new(r"d:\ReframeWeb\agent-host\baml_src\agent_flow.baml");
+        let path_as_str = super::path_for_vfs_join(raw);
+        let vfs_path = vfs::VfsPath::new(vfs::MemoryFS::new())
+            .join(path_as_str.as_ref())
+            .unwrap();
+
+        assert_eq!(
+            vfs_path.as_str(),
+            "/d:/ReframeWeb/agent-host/baml_src/agent_flow.baml"
+        );
+        assert_eq!(
+            vfs_path.parent().as_str(),
+            "/d:/ReframeWeb/agent-host/baml_src"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_uri_drive_paths_are_treated_as_absolute() {
+        let raw = std::path::Path::new(r"/d:/ReframeWeb/agent-host/baml_src/agent_flow.baml");
+        let path = super::normalize_windows_drive_path(raw);
+
+        assert!(path.is_absolute());
+        assert_eq!(
+            super::path_for_vfs_join(path.as_ref()).as_ref(),
+            "d:/ReframeWeb/agent-host/baml_src/agent_flow.baml"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_backslash_uri_drive_paths_are_treated_as_absolute() {
+        let raw = std::path::Path::new(r"\d:\ReframeWeb\agent-host\baml_src\agent_flow.baml");
+        let path = super::normalize_windows_drive_path(raw);
+
+        assert!(path.is_absolute());
+        assert_eq!(
+            super::path_for_vfs_join(path.as_ref()).as_ref(),
+            "d:/ReframeWeb/agent-host/baml_src/agent_flow.baml"
+        );
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn non_windows_paths_are_unchanged_for_vfs() {
+        let raw = std::path::Path::new("/tmp/project/baml_src/main.baml");
+        let path_as_str = super::path_for_vfs_join(raw);
+
+        assert_eq!(path_as_str.as_ref(), "/tmp/project/baml_src/main.baml");
     }
 }


### PR DESCRIPTION
**Summary**
- Normalize Windows drive-letter paths before converting them into BAML VFS paths.
- Fix native source discovery so VFS-style Windows globs load all project `.baml` files from disk.
- Add Windows regression coverage for URI-style drive paths, backslash paths, parent traversal, and source glob loading.

**Codex Comment**
The bug was caused by Windows paths crossing between three path formats: native paths like `D:\...`, URI/VFS-style paths like `/d:/...`, and mixed forms like `\d:\...`. BAML's VFS path logic uses `/` as its separator, so raw backslash paths could not walk to parent directories correctly. Separately, `/d:/...` could be treated as relative and joined against the server cwd, producing duplicated paths like `/d:/d:/...`.

The playground/LSP source loader also built VFS-style globs such as `/d:/project/baml_src/**/*.baml`, then passed them directly into native filesystem matching on Windows. That meant sibling files like `clients.baml` could be skipped, leaving only the open in-memory file loaded. In practice, valid client declarations appeared as unresolved names because their defining file was absent from the project view.

This fix keeps the translation at the filesystem/VFS boundary: Windows-only normalization before VFS conversion, and Windows-only conversion between VFS drive globs and native disk paths during source discovery. Non-Windows behavior is left unchanged.

**Author Comment**
I used Codex to investigate the root cause of these issues. Its understanding of the issue looks accurate on the surface and the fix appears to work on my machine. I haven't manually confirmed the actual root cause analysis myself but its work looks good to me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform glob and file lookup behavior by normalizing platform-specific paths before matching.
  * Ensured Windows drive-root and separator formats are interpreted correctly for VFS path resolution.
  * Returned matching entries using consistent, VFS-friendly path formatting (forward slashes and correct leading `/` handling).
* **Tests**
  * Added Windows-focused coverage for drive-path and separator edge cases, plus a non-Windows sanity check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->