### PR TITLE
Don't print a green PASS for a no-match test selector (B-628)

### DIFF
--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -495,6 +495,15 @@ fn consume_flat_report(
     *tolerated += flat.tolerated;
     *total += flat.total;
 
+    // An empty selection (a filter that matched no testset tests) aggregates
+    // to a vacuous `pass` over zero tests. Printing a green `PASS testing::*`
+    // for that contradicts the `NoTestsRun` exit the caller then returns and
+    // reads as success to anything parsing stdout, so skip the aggregate line
+    // entirely and let the caller's "no tests selected" guard speak.
+    if flat.total == 0 {
+        return;
+    }
+
     if flat.outcome == "pass" {
         if flat.tolerated > 0 {
             println!(
@@ -765,6 +774,17 @@ mod tests {
             &mut command_failed,
         );
         (passed, failed, tolerated, total, command_failed)
+    }
+
+    #[test]
+    fn consume_empty_report_folds_zero_counts_without_printing_pass() {
+        // A no-match selector aggregates to a vacuous `pass` over zero tests.
+        // Folding it must leave every counter at zero (so the caller's
+        // `total == 0` guard fires "no tests selected") and must NOT print a
+        // green `PASS testing::*` line contradicting the non-zero exit (B-628).
+        let parsed =
+            parse_flat_report(&flat_report("pass", 0, 0, 0, 0, Vec::new(), Vec::new())).unwrap();
+        assert_eq!(consume(&parsed), (0, 0, 0, 0, false));
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -500,7 +500,12 @@ fn consume_flat_report(
     // for that contradicts the `NoTestsRun` exit the caller then returns and
     // reads as success to anything parsing stdout, so skip the aggregate line
     // entirely and let the caller's "no tests selected" guard speak.
-    if flat.total == 0 {
+    //
+    // Guard *only* the vacuous-pass case: a zero-test report with a non-pass
+    // outcome must still fall through to the FAIL branch so it prints, sets
+    // `command_failed`, and synthesizes a displayed failure — a real failure
+    // is never silently dropped just because it carried no leaves.
+    if flat.total == 0 && flat.outcome == "pass" {
         return;
     }
 
@@ -785,6 +790,18 @@ mod tests {
         let parsed =
             parse_flat_report(&flat_report("pass", 0, 0, 0, 0, Vec::new(), Vec::new())).unwrap();
         assert_eq!(consume(&parsed), (0, 0, 0, 0, false));
+    }
+
+    #[test]
+    fn consume_empty_report_with_fail_outcome_still_propagates_failure() {
+        // The vacuous-pass skip must NOT swallow a zero-test report that
+        // reports a failure. A `total == 0 && outcome == "fail"` report has to
+        // fall through to the FAIL branch: it sets `command_failed` and
+        // synthesizes one displayed failure (so the summary isn't "0 failed"
+        // while the aggregate failed). Regression guard for the narrowed guard.
+        let parsed =
+            parse_flat_report(&flat_report("fail", 0, 0, 0, 0, Vec::new(), Vec::new())).unwrap();
+        assert_eq!(consume(&parsed), (0, 1, 0, 1, true));
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -379,6 +379,56 @@ fn test_no_tests_returns_specific_exit_code() {
     );
 }
 
+/// A selector that matches no test must NOT print a green `PASS testing::*`
+/// line: the aggregate of zero tests is a vacuous pass, but stdout that says
+/// PASS while the command exits 5 (`NoTestsRun`) misleads anything parsing it.
+/// Regression for B-628.
+#[test]
+fn test_no_match_selector_does_not_print_pass() {
+    let built = common::ensure_built();
+    let tmp = tempfile::tempdir().unwrap();
+
+    // A project that DOES have tests, so discovery yields a registry — the
+    // empty selection has to come from the filter, not an empty project.
+    create_project(
+        tmp.path(),
+        r#"
+testset "suite" {
+  test "one" { assert.is_true(true) }
+  test "two" { assert.is_true(true) }
+}
+"#,
+    );
+
+    let output = run_baml_cli(
+        built,
+        tmp.path(),
+        &["test", "--from", ".", "-i", "totally-bogus-selector-xyz"],
+    );
+
+    // Exit-code semantics are preserved: no tests selected is exit 5.
+    assert_eq!(
+        output.status.code(),
+        Some(5),
+        "Expected NoTestsRun (5) for a no-match selector, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        !combined.contains("PASS"),
+        "A no-match selector must not print a PASS line, got:\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        combined.contains("no tests selected"),
+        "Expected a `no tests selected` message, got:\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
 /// `baml test` should not emit the compile file-count status pair.
 #[test]
 fn test_valid_project_omits_compile_file_status() {


### PR DESCRIPTION
## Problem

`baml test -i <selector>` with a selector that matches no test printed a green `PASS testing::*` line while exiting non-zero (5, `NoTestsRun`):

```
$ baml test -i "totally-bogus-selector-xyz"
 Discovering tests
PASS testing::*                    <-- misleading
    Finished no tests selected in 1s
$ echo $?  => 5
```

The `PASS` contradicts the exit code and reads as success to anything parsing stdout.

## Root cause

`consume_flat_report` in `crates/baml_cli/src/test_command.rs` prints an aggregate `PASS testing::*` line whenever the flat report's `outcome == "pass"`. A no-match selector runs `testing.TestRegistry.run_filtered` over zero tests, which aggregates to a vacuous `pass` (0 passed, 0 failed, 0 total) — so the driver printed a green PASS. The caller then hits its `total == 0` guard, prints `Finished no tests selected`, and returns exit 5.

## Fix

Skip the aggregate `PASS/FAIL testing::*` line when the flat report covers zero tests (`flat.total == 0`). The counters are all zero, so folding is a no-op; the caller's existing `total == 0` guard emits the coherent `no tests selected` line and returns exit 5. Exit-code semantics are unchanged.

## Before / after

Before (no-match selector): prints `PASS testing::*`, exit 5.
After (no-match selector): prints only `Finished no tests selected`, exit 5.
A normal run and a matching selector still print real `PASS testing::*` / summary lines and exit 0 — unchanged.

## Tests

- `test_no_match_selector_does_not_print_pass` (CLI e2e): a project with tests + a no-match `-i` selector must not print `PASS`, must say `no tests selected`, and must exit 5.
- `consume_empty_report_folds_zero_counts_without_printing_pass` (unit): an empty flat report folds to all-zero counters.

Fixes B-628.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `baml test` so “pass” reports with zero executed tests no longer produce misleading green `PASS` output.
  * Enhanced selector-filter behavior: when no tests match, the command exits with the expected “no tests run” code and shows a clear “no tests selected” message.
* **Tests**
  * Added unit coverage for empty report folding behavior (including pass vs fail outcomes).
  * Added an end-to-end CLI test for selector filtering with no matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->