### PR TITLE
Add Array.sum() method for int[] and float[] (B-637)

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/containers.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/containers.baml
@@ -596,3 +596,57 @@ class Map<K, V> {
     $rust_function
   }
 }
+
+/// Summation for numeric arrays.
+///
+/// Implemented for `int[]` (returning `int`) and `float[]` (returning `float`).
+/// `Sum` is the element's own numeric type, so `xs.sum()` stays in the array's
+/// number domain with no implicit widening — `int` and `float` are distinct
+/// types, and there is deliberately no `int[] -> float` sum. To sum integer
+/// data as floats, map first: `ints.map((x: int) -> float { x * 1.0 }).sum()`.
+///
+/// The method form (`xs.sum()`) is the canonical surface; the free function
+/// `baml.math.sum` (over `float[]`) remains for a functional call style.
+interface Summable {
+  type Sum
+
+  function sum(self) -> Sum throws never
+}
+
+/// Sums an `int[]` and returns an `int`.
+///
+/// Adds every element left-to-right starting from `0`, so an empty array sums
+/// to `0`. Like repeated `+`, a running total that leaves the `int` range
+/// raises `baml.panics.IntegerOverflow`.
+///
+/// # Examples
+/// ```
+/// [1, 2, 3].sum()   // 6
+/// [].sum()          // 0
+/// [-5, 5].sum()     // 0
+/// ```
+implements Summable for int[] {
+  type Sum = int
+
+  function sum(self) -> int throws never {
+    root.math._sum_int(self)
+  }
+}
+
+/// Sums a `float[]` and returns a `float`.
+///
+/// Adds every element left-to-right starting from `0.0`, so an empty array sums
+/// to `0.0`. Never throws.
+///
+/// # Examples
+/// ```
+/// [1.0, 2.0, 3.0].sum()   // 6.0
+/// [].sum()                // 0.0
+/// ```
+implements Summable for float[] {
+  type Sum = float
+
+  function sum(self) -> float throws never {
+    root.math.sum(self)
+  }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_math/math.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_math/math.baml
@@ -23,6 +23,18 @@ function sum(values: float[]) -> float throws never {
   $rust_function
 }
 
+/// Sums an `int[]` left-to-right starting from `0`, returning an `int`.
+///
+/// Internal helper backing `int[].sum()` (the `Summable` method); prefer the
+/// method form `ints.sum()` at call sites. Like repeated `+`, every running
+/// total must stay within the `int` range, so a sum that leaves it raises
+/// `baml.panics.IntegerOverflow`. The empty array sums to `0`. Internal (the
+/// leading underscore is the convention for non-public stdlib helpers).
+//baml:fallible
+function _sum_int(values: int[]) -> int throws never {
+  $rust_function
+}
+
 /// Returns the arithmetic mean (average) of `values`.
 ///
 /// Computed as `sum(values) / values.length()`. Throws

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_namespace_math.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_namespace_math.snap
@@ -4,5 +4,6 @@ expression: output
 ---
 function         baml.math.trunc                  <builtin>/baml/ns_math/math.baml:2
 function         baml.math.sum                    <builtin>/baml/ns_math/math.baml:22
-function         baml.math.mean                   <builtin>/baml/ns_math/math.baml:39
-function         baml.math.median                 <builtin>/baml/ns_math/math.baml:60
+function         baml.math._sum_int               <builtin>/baml/ns_math/math.baml:34
+function         baml.math.mean                   <builtin>/baml/ns_math/math.baml:51
+function         baml.math.median                 <builtin>/baml/ns_math/math.baml:72

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -12,6 +12,7 @@ function         baml._is_primitive_array         <builtin>/baml/comparable.baml
 function         baml._rust_sort                  <builtin>/baml/comparable.baml:172
 class            baml.Array                       <builtin>/baml/containers.baml:2
 class            baml.Map                         <builtin>/baml/containers.baml:501
+interface        baml.Summable                    <builtin>/baml/containers.baml:610
 interface        baml.ToString                    <builtin>/baml/conversions.baml:25
 function         baml._to_string_default          <builtin>/baml/conversions.baml:39
 function         baml._to_string_shim             <builtin>/baml/conversions.baml:57
@@ -208,8 +209,9 @@ function         baml.llm.__sap_parse_final       <builtin>/baml/ns_llm/llm_type
 function         baml.llm.__sap_parse_partial     <builtin>/baml/ns_llm/llm_types.baml:801
 function         baml.math.trunc                  <builtin>/baml/ns_math/math.baml:2
 function         baml.math.sum                    <builtin>/baml/ns_math/math.baml:22
-function         baml.math.mean                   <builtin>/baml/ns_math/math.baml:39
-function         baml.math.median                 <builtin>/baml/ns_math/math.baml:60
+function         baml.math._sum_int               <builtin>/baml/ns_math/math.baml:34
+function         baml.math.mean                   <builtin>/baml/ns_math/math.baml:51
+function         baml.math.median                 <builtin>/baml/ns_math/math.baml:72
 class            baml.media.Pdf                   <builtin>/baml/ns_media/media.baml:2
 class            baml.media.Audio                 <builtin>/baml/ns_media/media.baml:46
 class            baml.media.Video                 <builtin>/baml/ns_media/media.baml:90

--- a/baml_language/crates/baml_tests/baml_src/ns_arrays/sum.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_arrays/sum.baml
@@ -1,0 +1,77 @@
+// Tests for `Array.sum()` (the `Summable` interface in stdlib `containers.baml`).
+//
+// `sum()` is a method — the canonical surface for array summation — implemented
+// for `int[]` (returning `int`, native `_sum_int`) and `float[]` (returning
+// `float`, delegating to `baml.math.sum`). `int` and `float` are distinct types
+// with no widening, so each impl stays in its own number domain. Results are
+// compared with `baml.deep_equals`, which is type-aware: an `int` `6` does not
+// deep-equal a `float` `6.0`, so these also pin the return type.
+//
+// The overflow / boundary helpers take runtime args so the array is built (and
+// summed) at runtime rather than being constant-folded away.
+
+// ─── int[].sum() ──────────────────────────────────────────────────────────────
+
+test "array_sum_int_basic" {
+  assert.is_true(baml.deep_equals([1, 2, 3].sum(), 6))
+}
+
+test "array_sum_int_single" {
+  assert.is_true(baml.deep_equals([42].sum(), 42))
+}
+
+// Summation of no elements is well-defined: the empty array sums to `0`.
+test "array_sum_int_empty_is_zero" {
+  let xs: int[] = [];
+  assert.is_true(baml.deep_equals(xs.sum(), 0))
+}
+
+test "array_sum_int_negatives" {
+  assert.is_true(baml.deep_equals([-5, 10, -3].sum(), 2))
+}
+
+// Mixed magnitudes add exactly (no float rounding in the int domain):
+// 1000000 + 20 + 300 == 1000320.
+test "array_sum_int_mixed_magnitudes" {
+  assert.is_true(baml.deep_equals([1000000, 20, 300].sum(), 1000320))
+}
+
+// A running total that leaves the `int` range raises a catchable
+// `baml.panics.IntegerOverflow`, exactly like the `+` it stands in for.
+function sum_int_overflow_(a: int, b: int) -> int {
+  [a, b].sum() catch (e) { baml.panics.IntegerOverflow => -1 }
+}
+
+test "array_sum_int_overflow_throws" {
+  assert.is_true(baml.deep_equals(sum_int_overflow_(int.max_value(), 1), -1))
+}
+
+// Summing right up to the boundary must NOT spuriously overflow:
+// (MAX - 1) + 1 == MAX.
+function sum_int_two_(a: int, b: int) -> int {
+  [a, b].sum()
+}
+
+test "array_sum_int_boundary_no_overflow" {
+  assert.is_true(baml.deep_equals(sum_int_two_(int.max_value() - 1, 1), int.max_value()))
+}
+
+// ─── float[].sum() ────────────────────────────────────────────────────────────
+
+test "array_sum_float_basic" {
+  assert.is_true(baml.deep_equals([1.0, 2.0, 3.0].sum(), 6.0))
+}
+
+test "array_sum_float_single" {
+  assert.is_true(baml.deep_equals([42.0].sum(), 42.0))
+}
+
+test "array_sum_float_empty_is_zero" {
+  let xs: float[] = [];
+  assert.is_true(baml.deep_equals(xs.sum(), 0.0))
+}
+
+// Mixed magnitudes and signs: -1.5 + 2.5 + 1.0 == 2.0.
+test "array_sum_float_mixed" {
+  assert.is_true(baml.deep_equals([-1.5, 2.5, 1.0].sum(), 2.0))
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -213,6 +213,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/arrays.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/arrays.snap
@@ -893,6 +893,77 @@ function arrays.$init_test_ns_arrays_sort_comparable(registry: testing.TestColle
     return
 }
 
+function arrays.$init_test_ns_arrays_sum(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "array_sum_int_basic"
+    make_closure .<lambda($init_test_ns_arrays_sum, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_int_single"
+    make_closure .<lambda($init_test_ns_arrays_sum, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_int_empty_is_zero"
+    make_closure .<lambda($init_test_ns_arrays_sum, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_int_negatives"
+    make_closure .<lambda($init_test_ns_arrays_sum, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_int_mixed_magnitudes"
+    make_closure .<lambda($init_test_ns_arrays_sum, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_int_overflow_throws"
+    make_closure .<lambda($init_test_ns_arrays_sum, 5)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_int_boundary_no_overflow"
+    make_closure .<lambda($init_test_ns_arrays_sum, 6)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_float_basic"
+    make_closure .<lambda($init_test_ns_arrays_sum, 7)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_float_single"
+    make_closure .<lambda($init_test_ns_arrays_sum, 8)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_float_empty_is_zero"
+    make_closure .<lambda($init_test_ns_arrays_sum, 9)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "array_sum_float_mixed"
+    make_closure .<lambda($init_test_ns_arrays_sum, 10)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_const null
+    return
+}
+
 function arrays.ComparableFlaky$stream.baml.Comparable.compare(self: arrays.ComparableFlaky$stream, other: arrays.ComparableFlaky$stream) -> int {
     load_var self
     load_field .0
@@ -1095,5 +1166,36 @@ function arrays.sort_strings(xs: string[]) -> string[] {
     load_type string
     load_var xs
     call baml.Sortable$for$T[].sort
+    return
+}
+
+function arrays.sum_int_overflow_(a: int, b: int) -> int {
+    load_var2 1 2
+    load_type int
+    alloc_array 2
+    call baml.Summable$for$int[].sum
+    jump L2
+    load_var e
+    is_type baml.panics.IntegerOverflow
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const 1
+    unary_op -
+
+  L2:
+    return
+}
+
+function arrays.sum_int_two_(a: int, b: int) -> int {
+    load_var2 1 2
+    load_type int
+    alloc_array 2
+    call baml.Summable$for$int[].sum
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -93,6 +93,12 @@ function baml.sort_by_key(self: ?, key: (T) -> U throws E) -> T[]  [expr] {
   { let n = self.length(); if (n Le 1) { return self }; let items = self.slice(0, n); let keys: U[] = []; for x in items { keys.push(key(x)) }; let order: int[] = []; let p = 0; while p Lt n { order.push(p); p Add= 1 }; order.sort_by((i: int, j: int) -> int throws U.CompareError { {  } match (keys.at(i)) { null => 0, ki: U => match (keys.at(j)) { null => 0, kj: U => ki.compare(kj) } } }); let sorted: T[] = []; for i in order {  } match (items.at(i)) { null => {  }, item: T => { sorted.push(item) } }; self.clear(); for s in sorted { self.push(s) }; return self }
 }
 function baml.splice(self: ?, start: int, count: int, replace: T[]) -> null  [builtin]
+function baml.sum(self: ?) -> float  [expr] {
+  {  } root.math.sum(self)
+}
+function baml.sum(self: ?) -> int  [expr] {
+  {  } root.math._sum_int(self)
+}
 function baml.unshift(self: ?, item: T) -> int  [builtin]
 function baml.values(self: ?) -> V[]  [builtin]
 
@@ -1095,6 +1101,7 @@ function baml.llm.validate_finish_reason(self: ?, finish_reason: string) -> null
 lambda (ctx) in prompt: captures [body]
 
 --- <builtin>/baml/ns_math/math.baml ---
+function baml.math._sum_int(values: int[]) -> int  [builtin]
 function baml.math.mean(values: float[]) -> float  [builtin]
 function baml.math.median(values: float[]) -> float  [builtin]
 function baml.math.sum(values: float[]) -> float  [builtin]

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -1415,6 +1415,34 @@ fn .<lambda(Array.sort_by_key, 0)>(i: int, j: int) -> null {
 
 fn baml.Array.splice = builtin(vm)
 
+fn baml.Summable$for$float[].sum(self: float[]) -> float {
+    // Locals:
+    let _0: float // _0 // return
+    let _1: float[] // self // param
+
+    bb0: {
+        _0 = call const fn baml.math.sum(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.Summable$for$int[].sum(self: int[]) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: int[] // self // param
+
+    bb0: {
+        _0 = call const fn baml.math._sum_int(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
 fn baml.Array.unshift = builtin(vm)
 
 fn baml.Map.values = builtin(vm)
@@ -10052,6 +10080,8 @@ fn baml.llm.Client.to_primitive_client(self: baml.llm.Client) -> baml.llm.Primit
 }
 
 fn baml.llm.PrimitiveClient.validate_finish_reason = builtin(io)
+
+fn baml.math._sum_int = builtin(vm)
 
 fn baml.math.mean = builtin(vm)
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -170,6 +170,16 @@ lambda baml.Array.sort_by_key {
 }
 class baml.Map {
 }
+function baml.sum(self: unknown) -> int throws never {
+  { : int
+    root.math._sum_int(self) : int
+  }
+}
+function baml.sum(self: unknown) -> float throws never {
+  { : float
+    root.math.sum(self) : float
+  }
+}
 class baml.Array$stream {
 }
 class baml.Map$stream {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -1548,6 +1548,18 @@ function baml.String.trim_end(self: baml.String) -> string {
 function baml.String.trim_start(self: baml.String) -> string {
 }
 
+function baml.Summable$for$float[].sum(self: float[]) -> float {
+    load_var self
+    call baml.math.sum
+    return
+}
+
+function baml.Summable$for$int[].sum(self: int[]) -> int {
+    load_var self
+    call baml.math._sum_int
+    return
+}
+
 function baml.ToJson.to_json(self: baml.ToJson) -> baml.json.json {
     load_var self
     call baml._to_json_default
@@ -9338,6 +9350,9 @@ function baml.llm.stream_llm_function(client: baml.llm.Client, function_name: st
     load_const 0
     call baml.llm.Client.execute_stream
     return
+}
+
+function baml.math._sum_int(values: int[]) -> int {
 }
 
 function baml.math.mean(values: float[]) -> float {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -14,6 +14,7 @@ namespace baml:
   class Null { methods: [] }
   type Sortable
   class String { methods: [from, length, char_count, byte_length, to_lower_case, to_upper_case, trim, trim_start, trim_end, includes, starts_with, ends_with, split, chars, lines, substring, replace, index_of, char_at, code_point_at, repeat, matches, replace_all, is_numeric, is_alphabetic, is_alphanumeric, is_uppercase, is_lowercase, is_whitespace, is_control, is_graphic, is_ascii, is_ascii_numeric, is_ascii_alphabetic, is_ascii_alphanumeric, is_ascii_uppercase, is_ascii_lowercase, is_ascii_whitespace, is_ascii_control, is_ascii_graphic, is_ascii_hex, to_utf8, from_utf8, to_code_points, from_code_points] }
+  type Summable
   class TaggedString { methods: [] }
   type ToJson
   type ToString
@@ -222,6 +223,7 @@ namespace baml.llm:
   function render_prompt
   function stream_llm_function<TStream, TFinal>
 namespace baml.math:
+  function _sum_int
   function mean
   function median
   function sum

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -9,17 +9,17 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        4    jump +4                (to 8)
        5    pop 1                  
        6    load_var 3             (eps)
-       7    call 129 ntypeargs=0   (baml.Float.is_nan)
+       7    call 131 ntypeargs=0   (baml.Float.is_nan)
        8    pop_jump_if_false +2   (to 10)
        9    jump +45               (to 54)
 
   80   10   load_var2 1 2          
        11   sub_float              
-       12   call 122 ntypeargs=0   (baml.Float.abs)
+       12   call 124 ntypeargs=0   (baml.Float.abs)
        13   store_var 4            (delta)
 
   81   14   load_var 4             (delta)
-       15   call 129 ntypeargs=0   (baml.Float.is_nan)
+       15   call 131 ntypeargs=0   (baml.Float.is_nan)
        16   jump_if_false +2       (to 18)
        17   jump +4                (to 21)
        18   pop 1                  
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 750 ntypeargs=0   (assert.format_operand)
+       26   call 753 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 750 ntypeargs=0   (assert.format_operand)
+       29   call 753 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 750 ntypeargs=0   (assert.format_operand)
+       32   call 753 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 750 ntypeargs=0   (assert.format_operand)
+       35   call 753 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -63,17 +63,17 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        49   bin_op +               
        50   load_var 8             (_22)
        51   bin_op +               
-       52   call 244 ntypeargs=0   (baml.sys.panic)
+       52   call 247 ntypeargs=0   (baml.sys.panic)
        53   jump +3                (to 56)
 
   78   54   load_const 6           ("assertion failed: epsilon must be a non-negative number")
-       55   call 244 ntypeargs=0   (baml.sys.panic)
+       55   call 247 ntypeargs=0   (baml.sys.panic)
        56   return                 
 }
 
 function assert.contains(haystack: string, needle: string) -> null {
   100   0   load_var2 1 2          
-        1   call 174 ntypeargs=0   (baml.String.includes)
+        1   call 176 ntypeargs=0   (baml.String.includes)
         2   unary_op !             
         3   pop_jump_if_false +2   (to 5)
         4   jump +3                (to 7)
@@ -83,13 +83,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   100   6   jump +3                (to 9)
 
   101   7   load_const 1           ("assertion failed: string does not contain expected substring")
-        8   call 244 ntypeargs=0   (baml.sys.panic)
+        8   call 247 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 687 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 690 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 750 ntypeargs=0   (assert.format_operand)
+       8    call 753 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 750 ntypeargs=0   (assert.format_operand)
+       11   call 753 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -113,13 +113,13 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 244 ntypeargs=0   (baml.sys.panic)
+       20   call 247 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
 function assert.format_operand(value: unknown) -> string {
   32   0   load_var 1             (value)
-       1   call 146 ntypeargs=0   (baml.String.from)
+       1   call 148 ntypeargs=0   (baml.String.from)
        2   return                 
 }
 
@@ -134,14 +134,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 244 ntypeargs=0   (baml.sys.panic)
+      7   call 247 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 687 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 690 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -150,7 +150,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 244 ntypeargs=0   (baml.sys.panic)
+       8   call 247 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -170,7 +170,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1289 0   
+  101   0   make_closure 1293 0   
         1   return                
 }
 
@@ -191,11 +191,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 244 ntypeargs=0   (baml.sys.panic)
+       14   call 247 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1300 1    
+       17   make_closure 1304 1    
        18   return                 
 }
 
@@ -225,16 +225,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 244 ntypeargs=0   (baml.sys.panic)
+       22   call 247 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 244 ntypeargs=0   (baml.sys.panic)
+       26   call 247 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1314 2    
+       29   make_closure 1318 2    
        30   return                 
 }
 
@@ -249,16 +249,16 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 244 ntypeargs=0   (baml.sys.panic)
+       8    call 247 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1307 1    
+       11   make_closure 1311 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1293 0   
+  95   0   make_closure 1297 0   
        1   return                
 }
 
@@ -268,7 +268,7 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        2     store_var 3              (_3)
        3     load_type 0              
        4     load_var 3               (_3)
-       5     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 4              (_4)
        7     load_var 4               (_4)
        8     is_type 1                
@@ -312,16 +312,16 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        46    load_type 0              
        47    load_type 11             
        48    load_var 4               (_4)
-       49    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 5              (_6)
        51    jump +50                 (to 101)
        52    load_var 4               (_4)
-       53    make_bound_method 507    
+       53    make_bound_method 510    
        54    call_indirect            
        55    store_var 5              (_6)
        56    jump +45                 (to 101)
        57    load_var 4               (_4)
-       58    make_bound_method 516    
+       58    make_bound_method 519    
        59    call_indirect            
        60    store_var 5              (_6)
        61    jump +40                 (to 101)
@@ -329,39 +329,39 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        63    load_type 11             
        64    load_type 11             
        65    load_var 4               (_4)
-       66    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 5              (_6)
        68    jump +33                 (to 101)
        69    load_var 4               (_4)
-       70    make_bound_method 468    
+       70    make_bound_method 471    
        71    call_indirect            
        72    store_var 5              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 4               (_4)
-       76    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 5              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 4               (_4)
-       83    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 5              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 4               (_4)
-       89    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 5              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 4               (_4)
-       94    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 5              (_6)
        96    jump +5                  (to 101)
        97    load_var 4               (_4)
-       98    make_bound_method 495    
+       98    make_bound_method 498    
        99    call_indirect            
        100   store_var 5              (_6)
        101   load_var 5               (_6)
@@ -392,7 +392,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        2     store_var 3              (_3)
        3     load_type 0              
        4     load_var 3               (_3)
-       5     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 4              (_4)
        7     load_var 4               (_4)
        8     is_type 1                
@@ -436,16 +436,16 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        46    load_type 0              
        47    load_type 11             
        48    load_var 4               (_4)
-       49    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 5              (_6)
        51    jump +50                 (to 101)
        52    load_var 4               (_4)
-       53    make_bound_method 507    
+       53    make_bound_method 510    
        54    call_indirect            
        55    store_var 5              (_6)
        56    jump +45                 (to 101)
        57    load_var 4               (_4)
-       58    make_bound_method 516    
+       58    make_bound_method 519    
        59    call_indirect            
        60    store_var 5              (_6)
        61    jump +40                 (to 101)
@@ -453,39 +453,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        63    load_type 11             
        64    load_type 11             
        65    load_var 4               (_4)
-       66    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 5              (_6)
        68    jump +33                 (to 101)
        69    load_var 4               (_4)
-       70    make_bound_method 468    
+       70    make_bound_method 471    
        71    call_indirect            
        72    store_var 5              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 4               (_4)
-       76    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 5              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 4               (_4)
-       83    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 5              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 4               (_4)
-       89    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 5              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 4               (_4)
-       94    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 5              (_6)
        96    jump +5                  (to 101)
        97    load_var 4               (_4)
-       98    make_bound_method 495    
+       98    make_bound_method 498    
        99    call_indirect            
        100   store_var 5              (_6)
        101   load_var 5               (_6)
@@ -551,7 +551,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        24    store_var 8              (_13)
        25    load_type 4              
        26    load_var 8               (_13)
-       27    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 9              (_14)
        29    load_var 9               (_14)
        30    is_type 5                
@@ -595,16 +595,16 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        68    load_type 4              
        69    load_type 15             
        70    load_var 9               (_14)
-       71    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 10             (_16)
        73    jump +50                 (to 123)
        74    load_var 9               (_14)
-       75    make_bound_method 507    
+       75    make_bound_method 510    
        76    call_indirect            
        77    store_var 10             (_16)
        78    jump +45                 (to 123)
        79    load_var 9               (_14)
-       80    make_bound_method 516    
+       80    make_bound_method 519    
        81    call_indirect            
        82    store_var 10             (_16)
        83    jump +40                 (to 123)
@@ -612,39 +612,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        85    load_type 15             
        86    load_type 15             
        87    load_var 9               (_14)
-       88    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 10             (_16)
        90    jump +33                 (to 123)
        91    load_var 9               (_14)
-       92    make_bound_method 468    
+       92    make_bound_method 471    
        93    call_indirect            
        94    store_var 10             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 9               (_14)
-       98    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 10             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 9               (_14)
-       105   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 10             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 9               (_14)
-       111   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 10             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 9               (_14)
-       116   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 10             (_16)
        118   jump +5                  (to 123)
        119   load_var 9               (_14)
-       120   make_bound_method 495    
+       120   make_bound_method 498    
        121   call_indirect            
        122   store_var 10             (_16)
        123   load_var 10              (_16)
@@ -663,7 +663,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        135   load_var 11              (t)
        136   load_field 0             (name)
        137   load_var 7               (hash_prefix)
-       138   call 145 ntypeargs=0     (baml.String.starts_with)
+       138   call 147 ntypeargs=0     (baml.String.starts_with)
        139   pop_jump_if_false -110   (to 29)
        140   load_var 6               (count)
        141   load_const 17            (1)
@@ -687,7 +687,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        158   load_var 6               (count)
        159   load_const 17            (1)
        160   add_int                  
-       161   call 146 ntypeargs=1     (baml.String.from)
+       161   call 148 ntypeargs=1     (baml.String.from)
        162   store_var 14             (_57)
        163   load_var2 13 14          
        164   bin_op +                 
@@ -699,7 +699,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        169   load_var2 12 3           
        170   load_var 4               (runner)
        171   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       172   call 9 ntypeargs=1       (baml.Array.push)
+       172   call 10 ntypeargs=1      (baml.Array.push)
        173   pop 1                    
 
   26   174   load_const 20            (null)
@@ -738,7 +738,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        24    store_var 8              (_13)
        25    load_type 4              
        26    load_var 8               (_13)
-       27    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 9              (_14)
        29    load_var 9               (_14)
        30    is_type 5                
@@ -782,16 +782,16 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        68    load_type 4              
        69    load_type 15             
        70    load_var 9               (_14)
-       71    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 10             (_16)
        73    jump +50                 (to 123)
        74    load_var 9               (_14)
-       75    make_bound_method 507    
+       75    make_bound_method 510    
        76    call_indirect            
        77    store_var 10             (_16)
        78    jump +45                 (to 123)
        79    load_var 9               (_14)
-       80    make_bound_method 516    
+       80    make_bound_method 519    
        81    call_indirect            
        82    store_var 10             (_16)
        83    jump +40                 (to 123)
@@ -799,39 +799,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        85    load_type 15             
        86    load_type 15             
        87    load_var 9               (_14)
-       88    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 10             (_16)
        90    jump +33                 (to 123)
        91    load_var 9               (_14)
-       92    make_bound_method 468    
+       92    make_bound_method 471    
        93    call_indirect            
        94    store_var 10             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 9               (_14)
-       98    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 10             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 9               (_14)
-       105   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 10             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 9               (_14)
-       111   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 10             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 9               (_14)
-       116   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 10             (_16)
        118   jump +5                  (to 123)
        119   load_var 9               (_14)
-       120   make_bound_method 495    
+       120   make_bound_method 498    
        121   call_indirect            
        122   store_var 10             (_16)
        123   load_var 10              (_16)
@@ -850,7 +850,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        135   load_var 11              (ts)
        136   load_field 0             (name)
        137   load_var 7               (hash_prefix)
-       138   call 145 ntypeargs=0     (baml.String.starts_with)
+       138   call 147 ntypeargs=0     (baml.String.starts_with)
        139   pop_jump_if_false -110   (to 29)
        140   load_var 6               (count)
        141   load_const 17            (1)
@@ -874,7 +874,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        158   load_var 6               (count)
        159   load_const 17            (1)
        160   add_int                  
-       161   call 146 ntypeargs=1     (baml.String.from)
+       161   call 148 ntypeargs=1     (baml.String.from)
        162   store_var 14             (_57)
        163   load_var2 13 14          
        164   bin_op +                 
@@ -886,7 +886,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        169   load_var2 12 3           
        170   load_var 4               (runner)
        171   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       172   call 9 ntypeargs=1       (baml.Array.push)
+       172   call 10 ntypeargs=1      (baml.Array.push)
        173   pop 1                    
 
   37   174   load_const 20            (null)
@@ -901,7 +901,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -945,16 +945,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 507    
+        54    make_bound_method 510    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 516    
+        59    make_bound_method 519    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -962,39 +962,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 468    
+        71    make_bound_method 471    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 495    
+        99    make_bound_method 498    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1010,22 +1010,22 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         111   pop_jump_if_false -103   (to 8)
 
   198   112   load_var2 1 6            
-        113   call 727 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        113   call 730 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
         114   pop 1                    
 
   199   115   load_var 1               (self)
-        116   call 710 ntypeargs=0     (testing.TestRegistry.serialize)
+        116   call 713 ntypeargs=0     (testing.TestRegistry.serialize)
         117   jump +123                (to 240)
 
   203   118   load_type 13             
         119   load_type 14             
         120   load_var 1               (self)
         121   load_field 1             (expansions)
-        122   call 11 ntypeargs=2      (baml.Map.keys)
+        122   call 12 ntypeargs=2      (baml.Map.keys)
         123   store_var 7              (_40)
         124   load_type 13             
         125   load_var 7               (_40)
-        126   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1069,16 +1069,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 507    
+        174   make_bound_method 510    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 516    
+        179   make_bound_method 519    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1086,39 +1086,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 468    
+        191   make_bound_method 471    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 495    
+        219   make_bound_method 498    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1137,11 +1137,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   205   233   load_var2 2 10           
         234   load_const 25            ("/")
         235   bin_op +                 
-        236   call 145 ntypeargs=0     (baml.String.starts_with)
+        236   call 147 ntypeargs=0     (baml.String.starts_with)
         237   pop_jump_if_false -109   (to 128)
 
   206   238   load_var2 11 2           
-        239   call 715 ntypeargs=0     (testing.TestRegistry.expand_set)
+        239   call 718 ntypeargs=0     (testing.TestRegistry.expand_set)
         240   return                   
 
   209   241   load_const 26            ("TestSet not found for expansion: ")
@@ -1158,14 +1158,14 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         3    load_field 1           (expansions)
         4    load_var 2             (ts)
         5    load_field 0           (name)
-        6    call 39 ntypeargs=2    (baml.Map.get)
+        6    call 41 ntypeargs=2    (baml.Map.get)
         7    store_var 3            (_3)
         8    load_var 3             (_3)
         9    is_type 2              
         10   pop_jump_if_false +2   (to 12)
         11   jump +36               (to 47)
 
-  216   12   call 249 ntypeargs=0   (baml.sys.now_ms)
+  216   12   call 252 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 4            (start)
 
   217   14   load_var 2             (ts)
@@ -1182,7 +1182,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         24   call_indirect          
         25   pop 1                  
 
-  219   26   call 249 ntypeargs=0   (baml.sys.now_ms)
+  219   26   call 252 ntypeargs=0   (baml.sys.now_ms)
         27   store_var 6            (_19)
 
   221   28   load_var 5             (sub_collector)
@@ -1203,7 +1203,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         40   load_var 2             (ts)
         41   load_field 0           (name)
         42   load_var 7             (sub_registry)
-        43   call 12 ntypeargs=2    (baml.Map.set)
+        43   call 13 ntypeargs=2    (baml.Map.set)
         44   pop 1                  
 
   226   45   load_var 7             (sub_registry)
@@ -1216,7 +1216,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 709 ntypeargs=0   (testing.select_names)
+        2   call 712 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -1233,9 +1233,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 725 ntypeargs=0   (testing.testset_children)
+        1   call 728 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 703 ntypeargs=0   (testing.run_testset)
+        3   call 706 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1259,24 +1259,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   16   load_var2 1 2          
         17   load_var 3             (exclude)
-        18   call 709 ntypeargs=0   (testing.select_names)
+        18   call 712 ntypeargs=0   (testing.select_names)
         19   store_var 6            (_9)
         20   load_var2 1 6          
-        21   call 700 ntypeargs=0   (testing.TestRegistry.run_selected)
+        21   call 703 ntypeargs=0   (testing.TestRegistry.run_selected)
         22   jump +3                (to 25)
 
   180   23   load_var 1             (self)
-        24   call 722 ntypeargs=0   (testing.TestRegistry.run_all)
+        24   call 725 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   25   call 738 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   25   call 741 ntypeargs=0   (testing.flatten_with_tolerated)
         26   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 706 ntypeargs=0   (testing.testset_children_selected)
+        1   call 709 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 703 ntypeargs=0   (testing.run_testset)
+        3   call 706 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1287,7 +1287,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1331,16 +1331,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 507    
+        54    make_bound_method 510    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 516    
+        59    make_bound_method 519    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1348,39 +1348,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 468    
+        71    make_bound_method 471    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 495    
+        99    make_bound_method 498    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1399,18 +1399,18 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         113   load_field 1             (body)
         114   load_var 6               (t)
         115   load_field 2             (runner)
-        116   call 737 ntypeargs=0     (testing.run_test)
+        116   call 740 ntypeargs=0     (testing.run_test)
         117   jump +123                (to 240)
 
   140   118   load_type 13             
         119   load_type 14             
         120   load_var 1               (self)
         121   load_field 1             (expansions)
-        122   call 11 ntypeargs=2      (baml.Map.keys)
+        122   call 12 ntypeargs=2      (baml.Map.keys)
         123   store_var 7              (_40)
         124   load_type 13             
         125   load_var 7               (_40)
-        126   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1454,16 +1454,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 507    
+        174   make_bound_method 510    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 516    
+        179   make_bound_method 519    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1471,39 +1471,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 468    
+        191   make_bound_method 471    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 495    
+        219   make_bound_method 498    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1522,11 +1522,11 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
   143   233   load_var2 2 10           
         234   load_const 25            ("/")
         235   bin_op +                 
-        236   call 145 ntypeargs=0     (baml.String.starts_with)
+        236   call 147 ntypeargs=0     (baml.String.starts_with)
         237   pop_jump_if_false -109   (to 128)
 
   144   238   load_var2 11 2           
-        239   call 714 ntypeargs=0     (testing.TestRegistry.run_test)
+        239   call 717 ntypeargs=0     (testing.TestRegistry.run_test)
         240   return                   
 
   147   241   load_const 26            ("Test not found: ")
@@ -1543,7 +1543,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1587,16 +1587,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 507    
+        54    make_bound_method 510    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 516    
+        59    make_bound_method 519    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1604,39 +1604,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 468    
+        71    make_bound_method 471    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 495    
+        99    make_bound_method 498    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1652,22 +1652,22 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         111   pop_jump_if_false -103   (to 8)
 
   153   112   load_var2 1 6            
-        113   call 727 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
-        114   call 725 ntypeargs=0     (testing.testset_children)
+        113   call 730 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        114   call 728 ntypeargs=0     (testing.testset_children)
         115   load_var 6               (ts)
         116   load_field 2             (runner)
-        117   call 703 ntypeargs=0     (testing.run_testset)
+        117   call 706 ntypeargs=0     (testing.run_testset)
         118   jump +123                (to 241)
 
   156   119   load_type 13             
         120   load_type 14             
         121   load_var 1               (self)
         122   load_field 1             (expansions)
-        123   call 11 ntypeargs=2      (baml.Map.keys)
+        123   call 12 ntypeargs=2      (baml.Map.keys)
         124   store_var 7              (_42)
         125   load_type 13             
         126   load_var 7               (_42)
-        127   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         128   store_var 8              (_46)
         129   load_var 8               (_46)
         130   is_type 15               
@@ -1711,16 +1711,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         168   load_type 13             
         169   load_type 11             
         170   load_var 8               (_46)
-        171   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         172   store_var 9              (_48)
         173   jump +50                 (to 223)
         174   load_var 8               (_46)
-        175   make_bound_method 507    
+        175   make_bound_method 510    
         176   call_indirect            
         177   store_var 9              (_48)
         178   jump +45                 (to 223)
         179   load_var 8               (_46)
-        180   make_bound_method 516    
+        180   make_bound_method 519    
         181   call_indirect            
         182   store_var 9              (_48)
         183   jump +40                 (to 223)
@@ -1728,39 +1728,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         185   load_type 11             
         186   load_type 11             
         187   load_var 8               (_46)
-        188   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         189   store_var 9              (_48)
         190   jump +33                 (to 223)
         191   load_var 8               (_46)
-        192   make_bound_method 468    
+        192   make_bound_method 471    
         193   call_indirect            
         194   store_var 9              (_48)
         195   jump +28                 (to 223)
         196   load_type 13             
         197   load_var 8               (_46)
-        198   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         199   store_var 9              (_48)
         200   jump +23                 (to 223)
         201   load_type 13             
         202   load_type 11             
         203   load_type 11             
         204   load_var 8               (_46)
-        205   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         206   store_var 9              (_48)
         207   jump +16                 (to 223)
         208   load_type 13             
         209   load_type 11             
         210   load_var 8               (_46)
-        211   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         212   store_var 9              (_48)
         213   jump +10                 (to 223)
         214   load_type 13             
         215   load_var 8               (_46)
-        216   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         217   store_var 9              (_48)
         218   jump +5                  (to 223)
         219   load_var 8               (_46)
-        220   make_bound_method 495    
+        220   make_bound_method 498    
         221   call_indirect            
         222   store_var 9              (_48)
         223   load_var 9               (_48)
@@ -1779,11 +1779,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
   158   234   load_var2 2 10           
         235   load_const 25            ("/")
         236   bin_op +                 
-        237   call 145 ntypeargs=0     (baml.String.starts_with)
+        237   call 147 ntypeargs=0     (baml.String.starts_with)
         238   pop_jump_if_false -109   (to 129)
 
   159   239   load_var2 11 2           
-        240   call 718 ntypeargs=0     (testing.TestRegistry.run_testset)
+        240   call 721 ntypeargs=0     (testing.TestRegistry.run_testset)
         241   return                   
 
   162   242   load_const 26            ("TestSet not found: ")
@@ -1804,7 +1804,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         6     store_var 3              (_3)
         7     load_type 1              
         8     load_var 3               (_3)
-        9     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 4              (_4)
         11    load_var 4               (_4)
         12    is_type 2                
@@ -1848,16 +1848,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         50    load_type 1              
         51    load_type 12             
         52    load_var 4               (_4)
-        53    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 5              (_6)
         55    jump +50                 (to 105)
         56    load_var 4               (_4)
-        57    make_bound_method 507    
+        57    make_bound_method 510    
         58    call_indirect            
         59    store_var 5              (_6)
         60    jump +45                 (to 105)
         61    load_var 4               (_4)
-        62    make_bound_method 516    
+        62    make_bound_method 519    
         63    call_indirect            
         64    store_var 5              (_6)
         65    jump +40                 (to 105)
@@ -1865,39 +1865,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         67    load_type 12             
         68    load_type 12             
         69    load_var 4               (_4)
-        70    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 5              (_6)
         72    jump +33                 (to 105)
         73    load_var 4               (_4)
-        74    make_bound_method 468    
+        74    make_bound_method 471    
         75    call_indirect            
         76    store_var 5              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 4               (_4)
-        80    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 5              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 4               (_4)
-        87    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 5              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 4               (_4)
-        93    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 5              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 4               (_4)
-        98    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 5              (_6)
         100   jump +5                  (to 105)
         101   load_var 4               (_4)
-        102   make_bound_method 495    
+        102   make_bound_method 498    
         103   call_indirect            
         104   store_var 5              (_6)
         105   load_var 5               (_6)
@@ -1911,7 +1911,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
   110   111   load_var 5               (_6)
         112   load_field 0             (name)
         113   init_instance 0          (testing.SerializedTest .type, .name)
-        114   call 9 ntypeargs=0       (baml.Array.push)
+        114   call 10 ntypeargs=0      (baml.Array.push)
         115   pop 1                    
         116   jump -105                (to 11)
 
@@ -1921,7 +1921,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         120   store_var 6              (_39)
         121   load_type 15             
         122   load_var 6               (_39)
-        123   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        123   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         124   store_var 7              (_40)
         125   load_var 7               (_40)
         126   is_type 16               
@@ -1965,16 +1965,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         164   load_type 15             
         165   load_type 12             
         166   load_var 7               (_40)
-        167   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        167   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         168   store_var 8              (_42)
         169   jump +50                 (to 219)
         170   load_var 7               (_40)
-        171   make_bound_method 507    
+        171   make_bound_method 510    
         172   call_indirect            
         173   store_var 8              (_42)
         174   jump +45                 (to 219)
         175   load_var 7               (_40)
-        176   make_bound_method 516    
+        176   make_bound_method 519    
         177   call_indirect            
         178   store_var 8              (_42)
         179   jump +40                 (to 219)
@@ -1982,39 +1982,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         181   load_type 12             
         182   load_type 12             
         183   load_var 7               (_40)
-        184   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        184   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         185   store_var 8              (_42)
         186   jump +33                 (to 219)
         187   load_var 7               (_40)
-        188   make_bound_method 468    
+        188   make_bound_method 471    
         189   call_indirect            
         190   store_var 8              (_42)
         191   jump +28                 (to 219)
         192   load_type 15             
         193   load_var 7               (_40)
-        194   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        194   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         195   store_var 8              (_42)
         196   jump +23                 (to 219)
         197   load_type 15             
         198   load_type 12             
         199   load_type 12             
         200   load_var 7               (_40)
-        201   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        201   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         202   store_var 8              (_42)
         203   jump +16                 (to 219)
         204   load_type 15             
         205   load_type 12             
         206   load_var 7               (_40)
-        207   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        207   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         208   store_var 8              (_42)
         209   jump +10                 (to 219)
         210   load_type 15             
         211   load_var 7               (_40)
-        212   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        212   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         213   store_var 8              (_42)
         214   jump +5                  (to 219)
         215   load_var 7               (_40)
-        216   make_bound_method 495    
+        216   make_bound_method 498    
         217   call_indirect            
         218   store_var 8              (_42)
         219   load_var 8               (_42)
@@ -2030,7 +2030,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         228   load_field 1             (expansions)
         229   load_var 9               (ts)
         230   load_field 0             (name)
-        231   call 39 ntypeargs=2      (baml.Map.get)
+        231   call 41 ntypeargs=2      (baml.Map.get)
         232   store_var 10             (expanded)
 
   115   233   load_var 10              (expanded)
@@ -2043,7 +2043,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         239   load_var 9               (ts)
         240   load_field 0             (name)
         241   init_instance 1          (testing.SerializedTest .type, .name)
-        242   call 9 ntypeargs=0       (baml.Array.push)
+        242   call 10 ntypeargs=0      (baml.Array.push)
         243   pop 1                    
         244   jump -119                (to 125)
 
@@ -2055,7 +2055,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         249   store_var 12             (_81)
 
   119   250   load_var 11              (sub)
-        251   call 710 ntypeargs=0     (testing.TestRegistry.serialize)
+        251   call 713 ntypeargs=0     (testing.TestRegistry.serialize)
         252   store_var 13             (_82)
 
   117   253   load_var2 2 12           
@@ -2063,7 +2063,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 
   120   255   load_field 2             (loading_time_ms)
         256   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        257   call 9 ntypeargs=0       (baml.Array.push)
+        257   call 10 ntypeargs=0      (baml.Array.push)
         258   pop 1                    
         259   jump -134                (to 125)
 
@@ -2075,7 +2075,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 function testing._has_selected_descendant(prefix: string, names: string[]) -> bool {
   311   0     load_type 0              
         1     load_var 2               (names)
-        2     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 3              (_4)
         4     load_var 3               (_4)
         5     is_type 1                
@@ -2119,16 +2119,16 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         43    load_type 0              
         44    load_type 11             
         45    load_var 3               (_4)
-        46    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 4              (_6)
         48    jump +50                 (to 98)
         49    load_var 3               (_4)
-        50    make_bound_method 507    
+        50    make_bound_method 510    
         51    call_indirect            
         52    store_var 4              (_6)
         53    jump +45                 (to 98)
         54    load_var 3               (_4)
-        55    make_bound_method 516    
+        55    make_bound_method 519    
         56    call_indirect            
         57    store_var 4              (_6)
         58    jump +40                 (to 98)
@@ -2136,39 +2136,39 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         60    load_type 11             
         61    load_type 11             
         62    load_var 3               (_4)
-        63    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 4              (_6)
         65    jump +33                 (to 98)
         66    load_var 3               (_4)
-        67    make_bound_method 468    
+        67    make_bound_method 471    
         68    call_indirect            
         69    store_var 4              (_6)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 3               (_4)
-        73    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 4              (_6)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 3               (_4)
-        80    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 4              (_6)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 3               (_4)
-        86    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 4              (_6)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 3               (_4)
-        91    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 4              (_6)
         93    jump +5                  (to 98)
         94    load_var 3               (_4)
-        95    make_bound_method 495    
+        95    make_bound_method 498    
         96    call_indirect            
         97    store_var 4              (_6)
         98    load_var 4               (_6)
@@ -2179,7 +2179,7 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
 
   310   103   load_const 13            ("/")
         104   bin_op +                 
-        105   call 145 ntypeargs=0     (baml.String.starts_with)
+        105   call 147 ntypeargs=0     (baml.String.starts_with)
 
   312   106   pop_jump_if_false -102   (to 4)
 
@@ -2194,21 +2194,21 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
 function testing._int_to_float(value: int) -> float {
   125   0   load_type 0            
         1   load_var 1             (value)
-        2   call 146 ntypeargs=1   (baml.String.from)
-        3   call 120 ntypeargs=0   (baml.Float.parse)
+        2   call 148 ntypeargs=1   (baml.String.from)
+        3   call 122 ntypeargs=0   (baml.Float.parse)
         4   jump +5                (to 9)
         5   load_var 2             (e)
         6   throw_if_panic         
 
   126   7   load_const 1           ("failed to convert int to float")
-        8   call 244 ntypeargs=0   (baml.sys.panic)
+        8   call 247 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function testing._name_selected(name: string, names: string[]) -> bool {
   299   0     load_type 0              
         1     load_var 2               (names)
-        2     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 3              (_3)
         4     load_var 3               (_3)
         5     is_type 1                
@@ -2252,16 +2252,16 @@ function testing._name_selected(name: string, names: string[]) -> bool {
         43    load_type 0              
         44    load_type 11             
         45    load_var 3               (_3)
-        46    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 4              (_5)
         48    jump +50                 (to 98)
         49    load_var 3               (_3)
-        50    make_bound_method 507    
+        50    make_bound_method 510    
         51    call_indirect            
         52    store_var 4              (_5)
         53    jump +45                 (to 98)
         54    load_var 3               (_3)
-        55    make_bound_method 516    
+        55    make_bound_method 519    
         56    call_indirect            
         57    store_var 4              (_5)
         58    jump +40                 (to 98)
@@ -2269,39 +2269,39 @@ function testing._name_selected(name: string, names: string[]) -> bool {
         60    load_type 11             
         61    load_type 11             
         62    load_var 3               (_3)
-        63    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 4              (_5)
         65    jump +33                 (to 98)
         66    load_var 3               (_3)
-        67    make_bound_method 468    
+        67    make_bound_method 471    
         68    call_indirect            
         69    store_var 4              (_5)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 3               (_3)
-        73    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 4              (_5)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 3               (_3)
-        80    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 4              (_5)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 3               (_3)
-        86    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 4              (_5)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 3               (_3)
-        91    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 4              (_5)
         93    jump +5                  (to 98)
         94    load_var 3               (_3)
-        95    make_bound_method 495    
+        95    make_bound_method 498    
         96    call_indirect            
         97    store_var 4              (_5)
         98    load_var 4               (_5)
@@ -2340,7 +2340,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   327   12    load_type 4              
         13    load_var 1               (named_results)
-        14    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        14    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         15    store_var 7              (_7)
         16    load_var 7               (_7)
         17    is_type 5                
@@ -2384,16 +2384,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         55    load_type 4              
         56    load_type 15             
         57    load_var 7               (_7)
-        58    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        58    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         59    store_var 8              (_9)
         60    jump +50                 (to 110)
         61    load_var 7               (_7)
-        62    make_bound_method 507    
+        62    make_bound_method 510    
         63    call_indirect            
         64    store_var 8              (_9)
         65    jump +45                 (to 110)
         66    load_var 7               (_7)
-        67    make_bound_method 516    
+        67    make_bound_method 519    
         68    call_indirect            
         69    store_var 8              (_9)
         70    jump +40                 (to 110)
@@ -2401,39 +2401,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         72    load_type 15             
         73    load_type 15             
         74    load_var 7               (_7)
-        75    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        75    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         76    store_var 8              (_9)
         77    jump +33                 (to 110)
         78    load_var 7               (_7)
-        79    make_bound_method 468    
+        79    make_bound_method 471    
         80    call_indirect            
         81    store_var 8              (_9)
         82    jump +28                 (to 110)
         83    load_type 4              
         84    load_var 7               (_7)
-        85    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        85    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         86    store_var 8              (_9)
         87    jump +23                 (to 110)
         88    load_type 4              
         89    load_type 15             
         90    load_type 15             
         91    load_var 7               (_7)
-        92    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        92    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         93    store_var 8              (_9)
         94    jump +16                 (to 110)
         95    load_type 4              
         96    load_type 15             
         97    load_var 7               (_7)
-        98    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        98    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         99    store_var 8              (_9)
         100   jump +10                 (to 110)
         101   load_type 4              
         102   load_var 7               (_7)
-        103   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        103   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         104   store_var 8              (_9)
         105   jump +5                  (to 110)
         106   load_var 7               (_7)
-        107   make_bound_method 495    
+        107   make_bound_method 498    
         108   call_indirect            
         109   store_var 8              (_9)
         110   load_var 8               (_9)
@@ -2448,7 +2448,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         118   store_var 10             (result)
 
   329   119   load_var2 6 10           
-        120   call 9 ntypeargs=0       (baml.Array.push)
+        120   call 10 ntypeargs=0      (baml.Array.push)
         121   pop 1                    
 
   330   122   load_var 10              (result)
@@ -2465,7 +2465,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   334   133   load_var 11              (outcome)
         134   load_const 18            ("pass")
-        135   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        135   call 690 ntypeargs=0     (baml.ops.equals_equals)
         136   pop_jump_if_false +2     (to 138)
         137   jump +145                (to 282)
 
@@ -2510,7 +2510,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
   346   168   store_var 14             (_56)
         169   load_type 2              
         170   load_var 14              (_56)
-        171   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        171   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         172   store_var 15             (_57)
         173   load_var 15              (_57)
         174   is_type 20               
@@ -2554,16 +2554,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         212   load_type 2              
         213   load_type 15             
         214   load_var 15              (_57)
-        215   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        215   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         216   store_var 16             (_59)
         217   jump +50                 (to 267)
         218   load_var 15              (_57)
-        219   make_bound_method 507    
+        219   make_bound_method 510    
         220   call_indirect            
         221   store_var 16             (_59)
         222   jump +45                 (to 267)
         223   load_var 15              (_57)
-        224   make_bound_method 516    
+        224   make_bound_method 519    
         225   call_indirect            
         226   store_var 16             (_59)
         227   jump +40                 (to 267)
@@ -2571,39 +2571,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         229   load_type 15             
         230   load_type 15             
         231   load_var 15              (_57)
-        232   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        232   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         233   store_var 16             (_59)
         234   jump +33                 (to 267)
         235   load_var 15              (_57)
-        236   make_bound_method 468    
+        236   make_bound_method 471    
         237   call_indirect            
         238   store_var 16             (_59)
         239   jump +28                 (to 267)
         240   load_type 2              
         241   load_var 15              (_57)
-        242   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        242   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         243   store_var 16             (_59)
         244   jump +23                 (to 267)
         245   load_type 2              
         246   load_type 15             
         247   load_type 15             
         248   load_var 15              (_57)
-        249   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        249   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         250   store_var 16             (_59)
         251   jump +16                 (to 267)
         252   load_type 2              
         253   load_type 15             
         254   load_var 15              (_57)
-        255   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        255   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         256   store_var 16             (_59)
         257   jump +10                 (to 267)
         258   load_type 2              
         259   load_var 15              (_57)
-        260   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        260   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         261   store_var 16             (_59)
         262   jump +5                  (to 267)
         263   load_var 15              (_57)
-        264   make_bound_method 495    
+        264   make_bound_method 498    
         265   call_indirect            
         266   store_var 16             (_59)
         267   load_var 16              (_59)
@@ -2613,13 +2613,13 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   347   271   load_var2 5 16           
 
-  346   272   call 9 ntypeargs=0       (baml.Array.push)
+  346   272   call 10 ntypeargs=0      (baml.Array.push)
         273   pop 1                    
         274   jump -101                (to 173)
 
   349   275   load_var 11              (outcome)
         276   load_const 30            ("error")
-        277   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        277   call 690 ntypeargs=0     (baml.ops.equals_equals)
         278   pop_jump_if_false -262   (to 16)
 
   350   279   load_const 31            (true)
@@ -2673,7 +2673,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: string, test_name: string) -> bool {
   525   0     load_type 0              
         1     load_var 1               (pats)
-        2     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 4              (_4)
         4     load_var 4               (_4)
         5     is_type 1                
@@ -2717,16 +2717,16 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
         43    load_type 0              
         44    load_type 11             
         45    load_var 4               (_4)
-        46    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 5              (_6)
         48    jump +50                 (to 98)
         49    load_var 4               (_4)
-        50    make_bound_method 507    
+        50    make_bound_method 510    
         51    call_indirect            
         52    store_var 5              (_6)
         53    jump +45                 (to 98)
         54    load_var 4               (_4)
-        55    make_bound_method 516    
+        55    make_bound_method 519    
         56    call_indirect            
         57    store_var 5              (_6)
         58    jump +40                 (to 98)
@@ -2734,39 +2734,39 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
         60    load_type 11             
         61    load_type 11             
         62    load_var 4               (_4)
-        63    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 5              (_6)
         65    jump +33                 (to 98)
         66    load_var 4               (_4)
-        67    make_bound_method 468    
+        67    make_bound_method 471    
         68    call_indirect            
         69    store_var 5              (_6)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 4               (_4)
-        73    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 5              (_6)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 4               (_4)
-        80    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 5              (_6)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 4               (_4)
-        86    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 5              (_6)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 4               (_4)
-        91    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 5              (_6)
         93    jump +5                  (to 98)
         94    load_var 4               (_4)
-        95    make_bound_method 495    
+        95    make_bound_method 498    
         96    call_indirect            
         97    store_var 5              (_6)
         98    load_var 5               (_6)
@@ -2778,13 +2778,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   104   load_field 0             (func_pat)
         105   load_var 2               (function_name)
-        106   call 723 ntypeargs=0     (testing.filter_match)
+        106   call 726 ntypeargs=0     (testing.filter_match)
         107   jump_if_false +6         (to 113)
         108   pop 1                    
         109   load_var 6               (p)
         110   load_field 1             (test_pat)
         111   load_var 3               (test_name)
-        112   call 723 ntypeargs=0     (testing.filter_match)
+        112   call 726 ntypeargs=0     (testing.filter_match)
         113   pop_jump_if_false -109   (to 4)
 
   527   114   load_const 13            (true)
@@ -2798,7 +2798,7 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 function testing.collect_leaf_messages(results: (testing.TestReport | testing.TestSetReport)[], out: string[]) -> void {
   661   0     load_type 0              
         1     load_var 1               (results)
-        2     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 3              (_3)
         4     load_var 3               (_3)
         5     is_type 1                
@@ -2842,16 +2842,16 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         43    load_type 0              
         44    load_type 11             
         45    load_var 3               (_3)
-        46    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 4              (_5)
         48    jump +50                 (to 98)
         49    load_var 3               (_3)
-        50    make_bound_method 507    
+        50    make_bound_method 510    
         51    call_indirect            
         52    store_var 4              (_5)
         53    jump +45                 (to 98)
         54    load_var 3               (_3)
-        55    make_bound_method 516    
+        55    make_bound_method 519    
         56    call_indirect            
         57    store_var 4              (_5)
         58    jump +40                 (to 98)
@@ -2859,39 +2859,39 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         60    load_type 11             
         61    load_type 11             
         62    load_var 3               (_3)
-        63    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 4              (_5)
         65    jump +33                 (to 98)
         66    load_var 3               (_3)
-        67    make_bound_method 468    
+        67    make_bound_method 471    
         68    call_indirect            
         69    store_var 4              (_5)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 3               (_3)
-        73    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 4              (_5)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 3               (_3)
-        80    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 4              (_5)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 3               (_3)
-        86    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 4              (_5)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 3               (_3)
-        91    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 4              (_5)
         93    jump +5                  (to 98)
         94    load_var 3               (_3)
-        95    make_bound_method 495    
+        95    make_bound_method 498    
         96    call_indirect            
         97    store_var 4              (_5)
         98    load_var 4               (_5)
@@ -2907,7 +2907,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         107   load_var 5               (r)
         108   load_field 5             (results)
         109   load_var 2               (out)
-        110   call 716 ntypeargs=0     (testing.collect_leaf_messages)
+        110   call 719 ntypeargs=0     (testing.collect_leaf_messages)
         111   pop 1                    
         112   jump -108                (to 4)
         113   load_var 5               (r)
@@ -2916,7 +2916,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   664   116   load_type 14             
         117   load_var 6               (_37)
-        118   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        118   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         119   store_var 7              (_38)
         120   load_var 7               (_38)
         121   is_type 15               
@@ -2960,16 +2960,16 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         159   load_type 14             
         160   load_type 11             
         161   load_var 7               (_38)
-        162   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        162   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         163   store_var 8              (_40)
         164   jump +50                 (to 214)
         165   load_var 7               (_38)
-        166   make_bound_method 507    
+        166   make_bound_method 510    
         167   call_indirect            
         168   store_var 8              (_40)
         169   jump +45                 (to 214)
         170   load_var 7               (_38)
-        171   make_bound_method 516    
+        171   make_bound_method 519    
         172   call_indirect            
         173   store_var 8              (_40)
         174   jump +40                 (to 214)
@@ -2977,39 +2977,39 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         176   load_type 11             
         177   load_type 11             
         178   load_var 7               (_38)
-        179   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        179   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         180   store_var 8              (_40)
         181   jump +33                 (to 214)
         182   load_var 7               (_38)
-        183   make_bound_method 468    
+        183   make_bound_method 471    
         184   call_indirect            
         185   store_var 8              (_40)
         186   jump +28                 (to 214)
         187   load_type 14             
         188   load_var 7               (_38)
-        189   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        189   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         190   store_var 8              (_40)
         191   jump +23                 (to 214)
         192   load_type 14             
         193   load_type 11             
         194   load_type 11             
         195   load_var 7               (_38)
-        196   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        196   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         197   store_var 8              (_40)
         198   jump +16                 (to 214)
         199   load_type 14             
         200   load_type 11             
         201   load_var 7               (_38)
-        202   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        202   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         203   store_var 8              (_40)
         204   jump +10                 (to 214)
         205   load_type 14             
         206   load_var 7               (_38)
-        207   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        207   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         208   store_var 8              (_40)
         209   jump +5                  (to 214)
         210   load_var 7               (_38)
-        211   make_bound_method 495    
+        211   make_bound_method 498    
         212   call_indirect            
         213   store_var 8              (_40)
         214   load_var 8               (_40)
@@ -3021,7 +3021,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   665   220   load_field 0             (outcome)
         221   load_const 25            ("pass")
-        222   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        222   call 690 ntypeargs=0     (baml.ops.equals_equals)
         223   unary_op !               
         224   pop_jump_if_false -104   (to 120)
 
@@ -3033,7 +3033,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   667   230   load_var2 2 10           
 
-  666   231   call 9 ntypeargs=0       (baml.Array.push)
+  666   231   call 10 ntypeargs=0      (baml.Array.push)
         232   pop 1                    
         233   jump -113                (to 120)
 
@@ -3053,7 +3053,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         6     store_var 3              (_3)
         7     load_type 1              
         8     load_var 3               (_3)
-        9     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 4              (_4)
         11    load_var 4               (_4)
         12    is_type 2                
@@ -3097,16 +3097,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         50    load_type 1              
         51    load_type 12             
         52    load_var 4               (_4)
-        53    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 5              (_6)
         55    jump +50                 (to 105)
         56    load_var 4               (_4)
-        57    make_bound_method 507    
+        57    make_bound_method 510    
         58    call_indirect            
         59    store_var 5              (_6)
         60    jump +45                 (to 105)
         61    load_var 4               (_4)
-        62    make_bound_method 516    
+        62    make_bound_method 519    
         63    call_indirect            
         64    store_var 5              (_6)
         65    jump +40                 (to 105)
@@ -3114,39 +3114,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         67    load_type 12             
         68    load_type 12             
         69    load_var 4               (_4)
-        70    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 5              (_6)
         72    jump +33                 (to 105)
         73    load_var 4               (_4)
-        74    make_bound_method 468    
+        74    make_bound_method 471    
         75    call_indirect            
         76    store_var 5              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 4               (_4)
-        80    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 5              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 4               (_4)
-        87    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 5              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 4               (_4)
-        93    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 5              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 4               (_4)
-        98    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 5              (_6)
         100   jump +5                  (to 105)
         101   load_var 4               (_4)
-        102   make_bound_method 495    
+        102   make_bound_method 498    
         103   call_indirect            
         104   store_var 5              (_6)
         105   load_var 5               (_6)
@@ -3157,7 +3157,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
   564   109   load_var2 2 5            
 
   563   110   load_field 0             (name)
-        111   call 9 ntypeargs=0       (baml.Array.push)
+        111   call 10 ntypeargs=0      (baml.Array.push)
         112   pop 1                    
         113   jump -102                (to 11)
 
@@ -3167,7 +3167,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         117   store_var 6              (_38)
         118   load_type 14             
         119   load_var 6               (_38)
-        120   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        120   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         121   store_var 7              (_39)
         122   load_var 7               (_39)
         123   is_type 15               
@@ -3211,16 +3211,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         161   load_type 14             
         162   load_type 12             
         163   load_var 7               (_39)
-        164   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        164   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         165   store_var 8              (_41)
         166   jump +50                 (to 216)
         167   load_var 7               (_39)
-        168   make_bound_method 507    
+        168   make_bound_method 510    
         169   call_indirect            
         170   store_var 8              (_41)
         171   jump +45                 (to 216)
         172   load_var 7               (_39)
-        173   make_bound_method 516    
+        173   make_bound_method 519    
         174   call_indirect            
         175   store_var 8              (_41)
         176   jump +40                 (to 216)
@@ -3228,39 +3228,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         178   load_type 12             
         179   load_type 12             
         180   load_var 7               (_39)
-        181   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        181   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         182   store_var 8              (_41)
         183   jump +33                 (to 216)
         184   load_var 7               (_39)
-        185   make_bound_method 468    
+        185   make_bound_method 471    
         186   call_indirect            
         187   store_var 8              (_41)
         188   jump +28                 (to 216)
         189   load_type 14             
         190   load_var 7               (_39)
-        191   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        191   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         192   store_var 8              (_41)
         193   jump +23                 (to 216)
         194   load_type 14             
         195   load_type 12             
         196   load_type 12             
         197   load_var 7               (_39)
-        198   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        198   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         199   store_var 8              (_41)
         200   jump +16                 (to 216)
         201   load_type 14             
         202   load_type 12             
         203   load_var 7               (_39)
-        204   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        204   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         205   store_var 8              (_41)
         206   jump +10                 (to 216)
         207   load_type 14             
         208   load_var 7               (_39)
-        209   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        209   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         210   store_var 8              (_41)
         211   jump +5                  (to 216)
         212   load_var 7               (_39)
-        213   make_bound_method 495    
+        213   make_bound_method 498    
         214   call_indirect            
         215   store_var 8              (_41)
         216   load_var 8               (_41)
@@ -3270,12 +3270,12 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   567   220   load_var2 1 8            
 
-  566   221   call 728 ntypeargs=0     (testing.collect_subtree_names)
+  566   221   call 731 ntypeargs=0     (testing.collect_subtree_names)
         222   store_var 9              (_71)
 
   567   223   load_type 0              
         224   load_var 9               (_71)
-        225   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        225   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         226   store_var 10             (_73)
         227   load_var 10              (_73)
         228   is_type 25               
@@ -3319,16 +3319,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         266   load_type 0              
         267   load_type 12             
         268   load_var 10              (_73)
-        269   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        269   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         270   store_var 11             (_75)
         271   jump +50                 (to 321)
         272   load_var 10              (_73)
-        273   make_bound_method 507    
+        273   make_bound_method 510    
         274   call_indirect            
         275   store_var 11             (_75)
         276   jump +45                 (to 321)
         277   load_var 10              (_73)
-        278   make_bound_method 516    
+        278   make_bound_method 519    
         279   call_indirect            
         280   store_var 11             (_75)
         281   jump +40                 (to 321)
@@ -3336,39 +3336,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         283   load_type 12             
         284   load_type 12             
         285   load_var 10              (_73)
-        286   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        286   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         287   store_var 11             (_75)
         288   jump +33                 (to 321)
         289   load_var 10              (_73)
-        290   make_bound_method 468    
+        290   make_bound_method 471    
         291   call_indirect            
         292   store_var 11             (_75)
         293   jump +28                 (to 321)
         294   load_type 0              
         295   load_var 10              (_73)
-        296   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        296   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         297   store_var 11             (_75)
         298   jump +23                 (to 321)
         299   load_type 0              
         300   load_type 12             
         301   load_type 12             
         302   load_var 10              (_73)
-        303   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        303   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         304   store_var 11             (_75)
         305   jump +16                 (to 321)
         306   load_type 0              
         307   load_type 12             
         308   load_var 10              (_73)
-        309   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        309   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         310   store_var 11             (_75)
         311   jump +10                 (to 321)
         312   load_type 0              
         313   load_var 10              (_73)
-        314   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        314   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         315   store_var 11             (_75)
         316   jump +5                  (to 321)
         317   load_var 10              (_73)
-        318   make_bound_method 495    
+        318   make_bound_method 498    
         319   call_indirect            
         320   store_var 11             (_75)
         321   load_var 11              (_75)
@@ -3378,7 +3378,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   568   325   load_var2 2 11           
 
-  567   326   call 9 ntypeargs=0       (baml.Array.push)
+  567   326   call 10 ntypeargs=0      (baml.Array.push)
         327   pop 1                    
         328   jump -101                (to 227)
 
@@ -3389,8 +3389,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 727 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 711 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 730 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 714 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +19               (to 22)
         4    load_var 3             (e)
         5    type_tag               
@@ -3431,7 +3431,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   602   8     load_type 1              
         9     load_var 1               (results)
-        10    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        10    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         11    store_var 7              (_7)
         12    load_var 7               (_7)
         13    is_type 2                
@@ -3475,16 +3475,16 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         51    load_type 1              
         52    load_type 12             
         53    load_var 7               (_7)
-        54    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        54    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         55    store_var 8              (_9)
         56    jump +50                 (to 106)
         57    load_var 7               (_7)
-        58    make_bound_method 507    
+        58    make_bound_method 510    
         59    call_indirect            
         60    store_var 8              (_9)
         61    jump +45                 (to 106)
         62    load_var 7               (_7)
-        63    make_bound_method 516    
+        63    make_bound_method 519    
         64    call_indirect            
         65    store_var 8              (_9)
         66    jump +40                 (to 106)
@@ -3492,39 +3492,39 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         68    load_type 12             
         69    load_type 12             
         70    load_var 7               (_7)
-        71    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        71    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         72    store_var 8              (_9)
         73    jump +33                 (to 106)
         74    load_var 7               (_7)
-        75    make_bound_method 468    
+        75    make_bound_method 471    
         76    call_indirect            
         77    store_var 8              (_9)
         78    jump +28                 (to 106)
         79    load_type 1              
         80    load_var 7               (_7)
-        81    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        81    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         82    store_var 8              (_9)
         83    jump +23                 (to 106)
         84    load_type 1              
         85    load_type 12             
         86    load_type 12             
         87    load_var 7               (_7)
-        88    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        88    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         89    store_var 8              (_9)
         90    jump +16                 (to 106)
         91    load_type 1              
         92    load_type 12             
         93    load_var 7               (_7)
-        94    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        94    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         95    store_var 8              (_9)
         96    jump +10                 (to 106)
         97    load_type 1              
         98    load_var 7               (_7)
-        99    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        99    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         100   store_var 8              (_9)
         101   jump +5                  (to 106)
         102   load_var 7               (_7)
-        103   make_bound_method 495    
+        103   make_bound_method 498    
         104   call_indirect            
         105   store_var 8              (_9)
         106   load_var 8               (_9)
@@ -3548,7 +3548,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         122   load_var 11              (tsr)
         123   load_field 0             (outcome)
         124   load_const 15            ("pass")
-        125   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        125   call 690 ntypeargs=0     (baml.ops.equals_equals)
         126   store_var 12             (ft)
 
   615   127   load_var 11              (tsr)
@@ -3592,14 +3592,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   159   load_var 11              (tsr)
         160   load_field 5             (results)
         161   load_var 12              (ft)
-        162   call 713 ntypeargs=0     (testing.count_leaves)
+        162   call 716 ntypeargs=0     (testing.count_leaves)
         163   store_var 10             (delta)
         164   jump +30                 (to 194)
 
   603   165   load_var 9               (r)
         166   load_field 0             (outcome)
         167   load_const 16            ("pass")
-        168   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        168   call 690 ntypeargs=0     (baml.ops.equals_equals)
 
   605   169   pop_jump_if_false +2     (to 171)
         170   jump +18                 (to 188)
@@ -3688,7 +3688,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 721 ntypeargs=0   (testing.glob_match)
+        6   call 724 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -3699,7 +3699,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   637   0    load_var 1             (report)
         1    load_field 0           (outcome)
         2    load_const 0           ("pass")
-        3    call 687 ntypeargs=0   (baml.ops.equals_equals)
+        3    call 690 ntypeargs=0   (baml.ops.equals_equals)
         4    store_var 2            (top_tolerated)
 
   638   5    load_var 1             (report)
@@ -3743,7 +3743,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   37   load_var 1             (report)
         38   load_field 5           (results)
         39   load_var 2             (top_tolerated)
-        40   call 713 ntypeargs=0   (testing.count_leaves)
+        40   call 716 ntypeargs=0   (testing.count_leaves)
         41   store_var 3            (counts)
 
   645   42   load_type 2            
@@ -3753,7 +3753,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   45   load_var 1             (report)
         46   load_field 5           (results)
         47   load_var 5             (messages)
-        48   call 716 ntypeargs=0   (testing.collect_leaf_messages)
+        48   call 719 ntypeargs=0   (testing.collect_leaf_messages)
         49   pop 1                  
 
   648   50   load_var 1             (report)
@@ -3782,7 +3782,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
 function testing.glob_match(subject: string, pattern: string) -> bool {
   489   0    load_var 2              (pattern)
         1    load_const 0            ("*")
-        2    call 137 ntypeargs=0    (baml.String.split)
+        2    call 139 ntypeargs=0    (baml.String.split)
         3    store_var 3             (parts)
 
   490   4    load_var 3              (parts)
@@ -3807,26 +3807,26 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
         20   store_var 6             (last)
 
   496   21   load_var2 1 5           
-        22   call 145 ntypeargs=0    (baml.String.starts_with)
+        22   call 147 ntypeargs=0    (baml.String.starts_with)
         23   unary_op !              
         24   pop_jump_if_false +2    (to 26)
         25   jump +69                (to 94)
 
   497   26   load_var2 1 6           
-        27   call 133 ntypeargs=0    (baml.String.ends_with)
+        27   call 135 ntypeargs=0    (baml.String.ends_with)
         28   unary_op !              
         29   pop_jump_if_false +2    (to 31)
         30   jump +62                (to 92)
 
   498   31   load_var 5              (first)
-        32   call 153 ntypeargs=0    (baml.String.length)
+        32   call 155 ntypeargs=0    (baml.String.length)
         33   store_var 7             (start)
 
   499   34   load_var 1              (subject)
-        35   call 153 ntypeargs=0    (baml.String.length)
+        35   call 155 ntypeargs=0    (baml.String.length)
         36   store_var 9             (_22)
         37   load_var 6              (last)
-        38   call 153 ntypeargs=0    (baml.String.length)
+        38   call 155 ntypeargs=0    (baml.String.length)
         39   store_var 10            (_23)
         40   load_var2 9 10          
         41   sub_int                 
@@ -3862,9 +3862,9 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
   505   65   load_var2 1 11          
         66   load_var 8              (end_limit)
-        67   call 156 ntypeargs=0    (baml.String.substring)
+        67   call 158 ntypeargs=0    (baml.String.substring)
         68   load_var 13             (part)
-        69   call 166 ntypeargs=0    (baml.String.index_of)
+        69   call 168 ntypeargs=0    (baml.String.index_of)
         70   store_var 14            (_38)
         71   load_var 14             (_38)
         72   is_type 2               
@@ -3880,7 +3880,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
         79   store_var 15            (_45)
 
   506   80   load_var 13             (part)
-        81   call 153 ntypeargs=0    (baml.String.length)
+        81   call 155 ntypeargs=0    (baml.String.length)
         82   load_var 15             (_45)
         83   add_int                 
         84   store_var 11            (pos)
@@ -3907,14 +3907,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 733 ntypeargs=0   (testing.split_top)
+        1    call 736 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 735 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 738 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +17               (to 26)
 
@@ -3931,7 +3931,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         19   load_field 0           (head)
         20   load_var 4             (split)
         21   load_field 1           (tail)
-        22   call 735 ntypeargs=0   (testing.any_pattern_matches)
+        22   call 738 ntypeargs=0   (testing.any_pattern_matches)
         23   jump +4                (to 27)
 
   541   24   load_const 1           (true)
@@ -3948,7 +3948,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
 
   475   3     load_type 1              
         4     load_var 1               (raw)
-        5     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        5     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 3              (_3)
         7     load_var 3               (_3)
         8     is_type 2                
@@ -3992,16 +3992,16 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         46    load_type 1              
         47    load_type 12             
         48    load_var 3               (_3)
-        49    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        49    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         50    store_var 4              (_5)
         51    jump +50                 (to 101)
         52    load_var 3               (_3)
-        53    make_bound_method 507    
+        53    make_bound_method 510    
         54    call_indirect            
         55    store_var 4              (_5)
         56    jump +45                 (to 101)
         57    load_var 3               (_3)
-        58    make_bound_method 516    
+        58    make_bound_method 519    
         59    call_indirect            
         60    store_var 4              (_5)
         61    jump +40                 (to 101)
@@ -4009,39 +4009,39 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         63    load_type 12             
         64    load_type 12             
         65    load_var 3               (_3)
-        66    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        66    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         67    store_var 4              (_5)
         68    jump +33                 (to 101)
         69    load_var 3               (_3)
-        70    make_bound_method 468    
+        70    make_bound_method 471    
         71    call_indirect            
         72    store_var 4              (_5)
         73    jump +28                 (to 101)
         74    load_type 1              
         75    load_var 3               (_3)
-        76    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        76    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         77    store_var 4              (_5)
         78    jump +23                 (to 101)
         79    load_type 1              
         80    load_type 12             
         81    load_type 12             
         82    load_var 3               (_3)
-        83    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        83    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         84    store_var 4              (_5)
         85    jump +16                 (to 101)
         86    load_type 1              
         87    load_type 12             
         88    load_var 3               (_3)
-        89    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        89    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         90    store_var 4              (_5)
         91    jump +10                 (to 101)
         92    load_type 1              
         93    load_var 3               (_3)
-        94    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        94    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         95    store_var 4              (_5)
         96    jump +5                  (to 101)
         97    load_var 3               (_3)
-        98    make_bound_method 495    
+        98    make_bound_method 498    
         99    call_indirect            
         100   store_var 4              (_5)
         101   load_var 4               (_5)
@@ -4053,7 +4053,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
 
   476   107   load_var 5               (s)
         108   load_const 14            ("::")
-        109   call 166 ntypeargs=0     (baml.String.index_of)
+        109   call 168 ntypeargs=0     (baml.String.index_of)
         110   store_var 6              (_36)
         111   load_var 6               (_36)
         112   is_type 15               
@@ -4063,14 +4063,14 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
   479   115   load_var2 2 5            
         116   load_const 16            ("")
         117   init_instance 0          (testing.FilterPat .func_pat, .test_pat)
-        118   call 9 ntypeargs=0       (baml.Array.push)
+        118   call 10 ntypeargs=0      (baml.Array.push)
         119   pop 1                    
 
   480   120   load_var 2               (out)
         121   load_const 17            ("")
         122   load_var 5               (s)
         123   init_instance 1          (testing.FilterPat .func_pat, .test_pat)
-        124   call 9 ntypeargs=0       (baml.Array.push)
+        124   call 10 ntypeargs=0      (baml.Array.push)
         125   pop 1                    
         126   jump -119                (to 7)
 
@@ -4080,21 +4080,21 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
   477   129   load_var 5               (s)
         130   load_const 15            (0)
         131   load_var 7               (idx)
-        132   call 156 ntypeargs=0     (baml.String.substring)
+        132   call 158 ntypeargs=0     (baml.String.substring)
         133   store_var 8              (_40)
         134   load_var 5               (s)
-        135   call 153 ntypeargs=0     (baml.String.length)
+        135   call 155 ntypeargs=0     (baml.String.length)
         136   store_var 10             (_45)
         137   load_var2 5 7            
         138   load_const 18            (2)
         139   add_int                  
         140   load_var 10              (_45)
-        141   call 156 ntypeargs=0     (baml.String.substring)
+        141   call 158 ntypeargs=0     (baml.String.substring)
         142   store_var 9              (_42)
         143   load_var2 2 8            
         144   load_var 9               (_42)
         145   init_instance 2          (testing.FilterPat .func_pat, .test_pat)
-        146   call 9 ntypeargs=0       (baml.Array.push)
+        146   call 10 ntypeargs=0      (baml.Array.push)
         147   pop 1                    
         148   jump -141                (to 7)
 
@@ -4114,7 +4114,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
 
   369   6     load_type 1             
         7     load_var 1              (children)
-        8     call 480 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
+        8     call 483 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
         9     store_var 3             (_3)
         10    load_var 3              (_3)
         11    is_type 2               
@@ -4158,16 +4158,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         49    load_type 1             
         50    load_type 12            
         51    load_var 3              (_3)
-        52    call 483 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
+        52    call 486 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
         53    store_var 4             (_5)
         54    jump +50                (to 104)
         55    load_var 3              (_3)
-        56    make_bound_method 507   
+        56    make_bound_method 510   
         57    call_indirect           
         58    store_var 4             (_5)
         59    jump +45                (to 104)
         60    load_var 3              (_3)
-        61    make_bound_method 516   
+        61    make_bound_method 519   
         62    call_indirect           
         63    store_var 4             (_5)
         64    jump +40                (to 104)
@@ -4175,39 +4175,39 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         66    load_type 12            
         67    load_type 12            
         68    load_var 3              (_3)
-        69    call 459 ntypeargs=3    (baml.iter.Filter.Iterator.next)
+        69    call 462 ntypeargs=3    (baml.iter.Filter.Iterator.next)
         70    store_var 4             (_5)
         71    jump +33                (to 104)
         72    load_var 3              (_3)
-        73    make_bound_method 468   
+        73    make_bound_method 471   
         74    call_indirect           
         75    store_var 4             (_5)
         76    jump +28                (to 104)
         77    load_type 1             
         78    load_var 3              (_3)
-        79    call 479 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
+        79    call 482 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
         80    store_var 4             (_5)
         81    jump +23                (to 104)
         82    load_type 1             
         83    load_type 12            
         84    load_type 12            
         85    load_var 3              (_3)
-        86    call 461 ntypeargs=3    (baml.iter.Chain.Iterator.next)
+        86    call 464 ntypeargs=3    (baml.iter.Chain.Iterator.next)
         87    store_var 4             (_5)
         88    jump +16                (to 104)
         89    load_type 1             
         90    load_type 12            
         91    load_var 3              (_3)
-        92    call 471 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
+        92    call 474 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
         93    store_var 4             (_5)
         94    jump +10                (to 104)
         95    load_type 1             
         96    load_var 3              (_3)
-        97    call 503 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
+        97    call 506 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
         98    store_var 4             (_5)
         99    jump +5                 (to 104)
         100   load_var 3              (_3)
-        101   make_bound_method 495   
+        101   make_bound_method 498   
         102   call_indirect           
         103   store_var 4             (_5)
         104   load_var 4              (_5)
@@ -4221,29 +4221,29 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         112   store_deref 5           
 
   370   113   load_var 5              (child)
-        114   make_closure 1247 1     
+        114   make_closure 1251 1     
         115   load_const 14           (null)
         116   load_const 14           (null)
         117   spawn                   
         118   store_var 6             (_38)
         119   load_var2 2 6           
-        120   call 9 ntypeargs=0      (baml.Array.push)
+        120   call 10 ntypeargs=0     (baml.Array.push)
         121   pop 1                   
         122   jump -112               (to 10)
 
   374   123   load_type 15            
         124   load_type 16            
         125   load_var 2              (futures)
-        126   call 526 ntypeargs=2    (baml.future.all_complete)
+        126   call 529 ntypeargs=2    (baml.future.all_complete)
         127   await                   
         128   jump +5                 (to 133)
         129   load_var 7              (e)
         130   throw_if_panic          
 
   375   131   load_const 17           ("unexpected test child failure")
-        132   call 244 ntypeargs=0    (baml.sys.panic)
+        132   call 247 ntypeargs=0    (baml.sys.panic)
 
-  377   133   call 707 ntypeargs=0    (testing.aggregate_reports)
+  377   133   call 710 ntypeargs=0    (testing.aggregate_reports)
         134   return                  
         135   unreachable             
 }
@@ -4255,7 +4255,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
 
   108   3     load_type 1              
         4     load_var 1               (children)
-        5     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        5     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 4              (_4)
         7     load_var 4               (_4)
         8     is_type 2                
@@ -4299,16 +4299,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         46    load_type 1              
         47    load_type 12             
         48    load_var 4               (_4)
-        49    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        49    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         50    store_var 5              (_6)
         51    jump +50                 (to 101)
         52    load_var 4               (_4)
-        53    make_bound_method 507    
+        53    make_bound_method 510    
         54    call_indirect            
         55    store_var 5              (_6)
         56    jump +45                 (to 101)
         57    load_var 4               (_4)
-        58    make_bound_method 516    
+        58    make_bound_method 519    
         59    call_indirect            
         60    store_var 5              (_6)
         61    jump +40                 (to 101)
@@ -4316,39 +4316,39 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         63    load_type 12             
         64    load_type 12             
         65    load_var 4               (_4)
-        66    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        66    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         67    store_var 5              (_6)
         68    jump +33                 (to 101)
         69    load_var 4               (_4)
-        70    make_bound_method 468    
+        70    make_bound_method 471    
         71    call_indirect            
         72    store_var 5              (_6)
         73    jump +28                 (to 101)
         74    load_type 1              
         75    load_var 4               (_4)
-        76    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        76    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         77    store_var 5              (_6)
         78    jump +23                 (to 101)
         79    load_type 1              
         80    load_type 12             
         81    load_type 12             
         82    load_var 4               (_4)
-        83    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        83    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         84    store_var 5              (_6)
         85    jump +16                 (to 101)
         86    load_type 1              
         87    load_type 12             
         88    load_var 4               (_4)
-        89    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        89    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         90    store_var 5              (_6)
         91    jump +10                 (to 101)
         92    load_type 1              
         93    load_var 4               (_4)
-        94    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        94    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         95    store_var 5              (_6)
         96    jump +5                  (to 101)
         97    load_var 4               (_4)
-        98    make_bound_method 495    
+        98    make_bound_method 498    
         99    call_indirect            
         100   store_var 5              (_6)
         101   load_var 5               (_6)
@@ -4366,7 +4366,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         111   load_field 0             (name)
         112   load_var 7               (report)
         113   init_instance 0          (testing.NamedChildReport .name, .report)
-        114   call 9 ntypeargs=0       (baml.Array.push)
+        114   call 10 ntypeargs=0      (baml.Array.push)
         115   pop 1                    
 
   111   116   load_var 7               (report)
@@ -4386,16 +4386,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         129   pop 1                    
         130   load_var 8               (outcome)
         131   load_const 15            ("pass")
-        132   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        132   call 690 ntypeargs=0     (baml.ops.equals_equals)
         133   unary_op !               
         134   pop_jump_if_false -127   (to 7)
 
   116   135   load_var 3               (named_results)
-        136   call 707 ntypeargs=0     (testing.aggregate_reports)
+        136   call 710 ntypeargs=0     (testing.aggregate_reports)
         137   jump +3                  (to 140)
 
   121   138   load_var 3               (named_results)
-        139   call 707 ntypeargs=0     (testing.aggregate_reports)
+        139   call 710 ntypeargs=0     (testing.aggregate_reports)
         140   return                   
         141   unreachable              
 }
@@ -4406,7 +4406,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1283 1    
+        4    make_closure 1287 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -4438,17 +4438,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   418   8    load_var 1             (children)
-        9    call 720 ntypeargs=0   (testing.run_children_parallel)
+        9    call 723 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0     load_var 2               (include)
-        1     call 708 ntypeargs=0     (testing.parse_filter_patterns)
+        1     call 711 ntypeargs=0     (testing.parse_filter_patterns)
         2     store_var 4              (inc)
 
   550   3     load_var 3               (exclude)
-        4     call 708 ntypeargs=0     (testing.parse_filter_patterns)
+        4     call 711 ntypeargs=0     (testing.parse_filter_patterns)
         5     store_var 5              (exc)
 
   551   6     load_type 0              
@@ -4456,11 +4456,11 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8     store_var 6              (out)
 
   552   9     load_var 1               (registry)
-        10    call 711 ntypeargs=0     (testing.collect_leaf_names)
+        10    call 714 ntypeargs=0     (testing.collect_leaf_names)
         11    store_var 7              (_7)
         12    load_type 0              
         13    load_var 7               (_7)
-        14    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        14    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         15    store_var 8              (_8)
         16    load_var 8               (_8)
         17    is_type 1                
@@ -4504,16 +4504,16 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         55    load_type 0              
         56    load_type 11             
         57    load_var 8               (_8)
-        58    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        58    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         59    store_var 9              (_10)
         60    jump +50                 (to 110)
         61    load_var 8               (_8)
-        62    make_bound_method 507    
+        62    make_bound_method 510    
         63    call_indirect            
         64    store_var 9              (_10)
         65    jump +45                 (to 110)
         66    load_var 8               (_8)
-        67    make_bound_method 516    
+        67    make_bound_method 519    
         68    call_indirect            
         69    store_var 9              (_10)
         70    jump +40                 (to 110)
@@ -4521,39 +4521,39 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         72    load_type 11             
         73    load_type 11             
         74    load_var 8               (_8)
-        75    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        75    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         76    store_var 9              (_10)
         77    jump +33                 (to 110)
         78    load_var 8               (_8)
-        79    make_bound_method 468    
+        79    make_bound_method 471    
         80    call_indirect            
         81    store_var 9              (_10)
         82    jump +28                 (to 110)
         83    load_type 0              
         84    load_var 8               (_8)
-        85    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        85    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         86    store_var 9              (_10)
         87    jump +23                 (to 110)
         88    load_type 0              
         89    load_type 11             
         90    load_type 11             
         91    load_var 8               (_8)
-        92    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        92    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         93    store_var 9              (_10)
         94    jump +16                 (to 110)
         95    load_type 0              
         96    load_type 11             
         97    load_var 8               (_8)
-        98    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        98    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         99    store_var 9              (_10)
         100   jump +10                 (to 110)
         101   load_type 0              
         102   load_var 8               (_8)
-        103   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        103   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         104   store_var 9              (_10)
         105   jump +5                  (to 110)
         106   load_var 8               (_8)
-        107   make_bound_method 495    
+        107   make_bound_method 498    
         108   call_indirect            
         109   store_var 9              (_10)
         110   load_var 9               (_10)
@@ -4564,11 +4564,11 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         115   store_var_load_var 10    (name)
 
   553   116   load_var2 4 5            
-        117   call 736 ntypeargs=0     (testing.leaf_selected)
+        117   call 739 ntypeargs=0     (testing.leaf_selected)
         118   pop_jump_if_false -102   (to 16)
 
   554   119   load_var2 6 10           
-        120   call 9 ntypeargs=0       (baml.Array.push)
+        120   call 10 ntypeargs=0      (baml.Array.push)
         121   pop 1                    
         122   jump -106                (to 16)
 
@@ -4580,7 +4580,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
 function testing.split_top(path: string) -> testing.NameSplit {
   463   0    load_var 1             (path)
         1    load_const 0           ("/")
-        2    call 166 ntypeargs=0   (baml.String.index_of)
+        2    call 168 ntypeargs=0   (baml.String.index_of)
         3    store_var 2            (_2)
         4    load_var 2             (_2)
         5    is_type 1              
@@ -4598,15 +4598,15 @@ function testing.split_top(path: string) -> testing.NameSplit {
   464   14   load_var 1             (path)
         15   load_const 1           (0)
         16   load_var 3             (idx)
-        17   call 156 ntypeargs=0   (baml.String.substring)
+        17   call 158 ntypeargs=0   (baml.String.substring)
         18   load_var 1             (path)
-        19   call 153 ntypeargs=0   (baml.String.length)
+        19   call 155 ntypeargs=0   (baml.String.length)
         20   store_var 4            (_10)
         21   load_var2 1 3          
         22   load_const 3           (1)
         23   add_int                
         24   load_var 4             (_10)
-        25   call 156 ntypeargs=0   (baml.String.substring)
+        25   call 158 ntypeargs=0   (baml.String.substring)
         26   init_instance 1        (testing.NameSplit .head, .tail)
         27   return                 
 }
@@ -4622,7 +4622,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1260 2   
+        8    make_closure 1264 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -4639,7 +4639,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1274 2   
+        9    make_closure 1278 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -4660,7 +4660,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1287 3   
+        13   make_closure 1291 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -4676,7 +4676,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         6     store_var 3              (_3)
         7     load_type 1              
         8     load_var 3               (_3)
-        9     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 4              (_4)
         11    load_var 4               (_4)
         12    is_type 2                
@@ -4720,16 +4720,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         50    load_type 1              
         51    load_type 12             
         52    load_var 4               (_4)
-        53    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 5              (_6)
         55    jump +50                 (to 105)
         56    load_var 4               (_4)
-        57    make_bound_method 507    
+        57    make_bound_method 510    
         58    call_indirect            
         59    store_var 5              (_6)
         60    jump +45                 (to 105)
         61    load_var 4               (_4)
-        62    make_bound_method 516    
+        62    make_bound_method 519    
         63    call_indirect            
         64    store_var 5              (_6)
         65    jump +40                 (to 105)
@@ -4737,39 +4737,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         67    load_type 12             
         68    load_type 12             
         69    load_var 4               (_4)
-        70    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 5              (_6)
         72    jump +33                 (to 105)
         73    load_var 4               (_4)
-        74    make_bound_method 468    
+        74    make_bound_method 471    
         75    call_indirect            
         76    store_var 5              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 4               (_4)
-        80    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 5              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 4               (_4)
-        87    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 5              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 4               (_4)
-        93    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 5              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 4               (_4)
-        98    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 5              (_6)
         100   jump +5                  (to 105)
         101   load_var 4               (_4)
-        102   make_bound_method 495    
+        102   make_bound_method 498    
         103   call_indirect            
         104   store_var 5              (_6)
         105   load_var 5               (_6)
@@ -4784,10 +4784,10 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         113   load_field 1             (body)
         114   load_var 6               (t)
         115   load_field 2             (runner)
-        116   call 726 ntypeargs=0     (testing.test_child)
+        116   call 729 ntypeargs=0     (testing.test_child)
         117   store_var 7              (_37)
         118   load_var2 2 7            
-        119   call 9 ntypeargs=0       (baml.Array.push)
+        119   call 10 ntypeargs=0      (baml.Array.push)
         120   pop 1                    
         121   jump -110                (to 11)
 
@@ -4797,7 +4797,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         125   store_var 8              (_41)
         126   load_type 14             
         127   load_var 8               (_41)
-        128   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        128   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         129   store_var 9              (_42)
         130   load_var 9               (_42)
         131   is_type 15               
@@ -4841,16 +4841,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         169   load_type 14             
         170   load_type 12             
         171   load_var 9               (_42)
-        172   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        172   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         173   store_var 10             (_44)
         174   jump +50                 (to 224)
         175   load_var 9               (_42)
-        176   make_bound_method 507    
+        176   make_bound_method 510    
         177   call_indirect            
         178   store_var 10             (_44)
         179   jump +45                 (to 224)
         180   load_var 9               (_42)
-        181   make_bound_method 516    
+        181   make_bound_method 519    
         182   call_indirect            
         183   store_var 10             (_44)
         184   jump +40                 (to 224)
@@ -4858,39 +4858,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         186   load_type 12             
         187   load_type 12             
         188   load_var 9               (_42)
-        189   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        189   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         190   store_var 10             (_44)
         191   jump +33                 (to 224)
         192   load_var 9               (_42)
-        193   make_bound_method 468    
+        193   make_bound_method 471    
         194   call_indirect            
         195   store_var 10             (_44)
         196   jump +28                 (to 224)
         197   load_type 14             
         198   load_var 9               (_42)
-        199   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        199   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         200   store_var 10             (_44)
         201   jump +23                 (to 224)
         202   load_type 14             
         203   load_type 12             
         204   load_type 12             
         205   load_var 9               (_42)
-        206   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        206   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         207   store_var 10             (_44)
         208   jump +16                 (to 224)
         209   load_type 14             
         210   load_type 12             
         211   load_var 9               (_42)
-        212   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        212   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         213   store_var 10             (_44)
         214   jump +10                 (to 224)
         215   load_type 14             
         216   load_var 9               (_42)
-        217   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        217   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         218   store_var 10             (_44)
         219   jump +5                  (to 224)
         220   load_var 9               (_42)
-        221   make_bound_method 495    
+        221   make_bound_method 498    
         222   call_indirect            
         223   store_var 10             (_44)
         224   load_var 10              (_44)
@@ -4900,11 +4900,11 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   238   228   load_var2 1 10           
 
-  237   229   call 734 ntypeargs=0     (testing.testset_child)
+  237   229   call 737 ntypeargs=0     (testing.testset_child)
         230   store_var 11             (_75)
 
   238   231   load_var2 2 11           
-        232   call 9 ntypeargs=0       (baml.Array.push)
+        232   call 10 ntypeargs=0      (baml.Array.push)
         233   pop 1                    
         234   jump -104                (to 130)
 
@@ -4924,7 +4924,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         6     store_var 4              (_4)
         7     load_type 1              
         8     load_var 4               (_4)
-        9     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 5              (_5)
         11    load_var 5               (_5)
         12    is_type 2                
@@ -4968,16 +4968,16 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         50    load_type 1              
         51    load_type 12             
         52    load_var 5               (_5)
-        53    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 6              (_7)
         55    jump +50                 (to 105)
         56    load_var 5               (_5)
-        57    make_bound_method 507    
+        57    make_bound_method 510    
         58    call_indirect            
         59    store_var 6              (_7)
         60    jump +45                 (to 105)
         61    load_var 5               (_5)
-        62    make_bound_method 516    
+        62    make_bound_method 519    
         63    call_indirect            
         64    store_var 6              (_7)
         65    jump +40                 (to 105)
@@ -4985,39 +4985,39 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         67    load_type 12             
         68    load_type 12             
         69    load_var 5               (_5)
-        70    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 6              (_7)
         72    jump +33                 (to 105)
         73    load_var 5               (_5)
-        74    make_bound_method 468    
+        74    make_bound_method 471    
         75    call_indirect            
         76    store_var 6              (_7)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 5               (_5)
-        80    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 6              (_7)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 5               (_5)
-        87    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 6              (_7)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 5               (_5)
-        93    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 6              (_7)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 5               (_5)
-        98    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 6              (_7)
         100   jump +5                  (to 105)
         101   load_var 5               (_5)
-        102   make_bound_method 495    
+        102   make_bound_method 498    
         103   call_indirect            
         104   store_var 6              (_7)
         105   load_var 6               (_7)
@@ -5029,7 +5029,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   111   load_field 0             (name)
         112   load_var 2               (names)
-        113   call 730 ntypeargs=0     (testing._name_selected)
+        113   call 733 ntypeargs=0     (testing._name_selected)
         114   pop_jump_if_false -103   (to 11)
 
   247   115   load_var 7               (t)
@@ -5038,10 +5038,10 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         118   load_field 1             (body)
         119   load_var 7               (t)
         120   load_field 2             (runner)
-        121   call 726 ntypeargs=0     (testing.test_child)
+        121   call 729 ntypeargs=0     (testing.test_child)
         122   store_var 8              (_40)
         123   load_var2 3 8            
-        124   call 9 ntypeargs=0       (baml.Array.push)
+        124   call 10 ntypeargs=0      (baml.Array.push)
         125   pop 1                    
         126   jump -115                (to 11)
 
@@ -5051,7 +5051,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         130   store_var 9              (_44)
         131   load_type 14             
         132   load_var 9               (_44)
-        133   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        133   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         134   store_var 10             (_45)
         135   load_var 10              (_45)
         136   is_type 15               
@@ -5095,16 +5095,16 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         174   load_type 14             
         175   load_type 12             
         176   load_var 10              (_45)
-        177   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        177   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         178   store_var 11             (_47)
         179   jump +50                 (to 229)
         180   load_var 10              (_45)
-        181   make_bound_method 507    
+        181   make_bound_method 510    
         182   call_indirect            
         183   store_var 11             (_47)
         184   jump +45                 (to 229)
         185   load_var 10              (_45)
-        186   make_bound_method 516    
+        186   make_bound_method 519    
         187   call_indirect            
         188   store_var 11             (_47)
         189   jump +40                 (to 229)
@@ -5112,39 +5112,39 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         191   load_type 12             
         192   load_type 12             
         193   load_var 10              (_45)
-        194   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        194   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         195   store_var 11             (_47)
         196   jump +33                 (to 229)
         197   load_var 10              (_45)
-        198   make_bound_method 468    
+        198   make_bound_method 471    
         199   call_indirect            
         200   store_var 11             (_47)
         201   jump +28                 (to 229)
         202   load_type 14             
         203   load_var 10              (_45)
-        204   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        204   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         205   store_var 11             (_47)
         206   jump +23                 (to 229)
         207   load_type 14             
         208   load_type 12             
         209   load_type 12             
         210   load_var 10              (_45)
-        211   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        211   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         212   store_var 11             (_47)
         213   jump +16                 (to 229)
         214   load_type 14             
         215   load_type 12             
         216   load_var 10              (_45)
-        217   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        217   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         218   store_var 11             (_47)
         219   jump +10                 (to 229)
         220   load_type 14             
         221   load_var 10              (_45)
-        222   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        222   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         223   store_var 11             (_47)
         224   jump +5                  (to 229)
         225   load_var 10              (_45)
-        226   make_bound_method 495    
+        226   make_bound_method 498    
         227   call_indirect            
         228   store_var 11             (_47)
         229   load_var 11              (_47)
@@ -5156,15 +5156,15 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   235   load_field 0             (name)
         236   load_var 2               (names)
-        237   call 712 ntypeargs=0     (testing._has_selected_descendant)
+        237   call 715 ntypeargs=0     (testing._has_selected_descendant)
         238   pop_jump_if_false -103   (to 135)
 
   259   239   load_var2 1 12           
         240   load_var 2               (names)
-        241   call 739 ntypeargs=0     (testing.testset_child_selected)
+        241   call 742 ntypeargs=0     (testing.testset_child_selected)
         242   store_var 13             (_80)
         243   load_var2 3 13           
-        244   call 9 ntypeargs=0       (baml.Array.push)
+        244   call 10 ntypeargs=0      (baml.Array.push)
         245   pop 1                    
         246   jump -111                (to 135)
 

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -9,17 +9,17 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        4    jump +4                (to 8)
        5    pop 1                  
        6    load_var 3             (eps)
-       7    call 129 ntypeargs=0   (baml.Float.is_nan)
+       7    call 131 ntypeargs=0   (baml.Float.is_nan)
        8    pop_jump_if_false +2   (to 10)
        9    jump +45               (to 54)
 
   80   10   load_var2 1 2          
        11   sub_float              
-       12   call 122 ntypeargs=0   (baml.Float.abs)
+       12   call 124 ntypeargs=0   (baml.Float.abs)
        13   store_var 4            (delta)
 
   81   14   load_var 4             (delta)
-       15   call 129 ntypeargs=0   (baml.Float.is_nan)
+       15   call 131 ntypeargs=0   (baml.Float.is_nan)
        16   jump_if_false +2       (to 18)
        17   jump +4                (to 21)
        18   pop 1                  
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 750 ntypeargs=0   (assert.format_operand)
+       26   call 753 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 750 ntypeargs=0   (assert.format_operand)
+       29   call 753 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 750 ntypeargs=0   (assert.format_operand)
+       32   call 753 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 750 ntypeargs=0   (assert.format_operand)
+       35   call 753 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -63,17 +63,17 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        49   bin_op +               
        50   load_var 8             (_22)
        51   bin_op +               
-       52   call 244 ntypeargs=0   (baml.sys.panic)
+       52   call 247 ntypeargs=0   (baml.sys.panic)
        53   jump +3                (to 56)
 
   78   54   load_const 6           ("assertion failed: epsilon must be a non-negative number")
-       55   call 244 ntypeargs=0   (baml.sys.panic)
+       55   call 247 ntypeargs=0   (baml.sys.panic)
        56   return                 
 }
 
 function assert.contains(haystack: string, needle: string) -> null {
   100   0   load_var2 1 2          
-        1   call 174 ntypeargs=0   (baml.String.includes)
+        1   call 176 ntypeargs=0   (baml.String.includes)
         2   unary_op !             
         3   pop_jump_if_false +2   (to 5)
         4   jump +3                (to 7)
@@ -83,13 +83,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   100   6   jump +3                (to 9)
 
   101   7   load_const 1           ("assertion failed: string does not contain expected substring")
-        8   call 244 ntypeargs=0   (baml.sys.panic)
+        8   call 247 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 687 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 690 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 750 ntypeargs=0   (assert.format_operand)
+       8    call 753 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 750 ntypeargs=0   (assert.format_operand)
+       11   call 753 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -113,13 +113,13 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 244 ntypeargs=0   (baml.sys.panic)
+       20   call 247 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
 function assert.format_operand(value: unknown) -> string {
   32   0   load_var 1             (value)
-       1   call 146 ntypeargs=0   (baml.String.from)
+       1   call 148 ntypeargs=0   (baml.String.from)
        2   return                 
 }
 
@@ -134,14 +134,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 244 ntypeargs=0   (baml.sys.panic)
+      7   call 247 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 687 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 690 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -150,7 +150,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 244 ntypeargs=0   (baml.sys.panic)
+       8   call 247 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -170,7 +170,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1289 0   
+  101   0   make_closure 1293 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -193,11 +193,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 244 ntypeargs=0   (baml.sys.panic)
+       14   call 247 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1300 1    
+       17   make_closure 1304 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -229,16 +229,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 244 ntypeargs=0   (baml.sys.panic)
+       22   call 247 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 244 ntypeargs=0   (baml.sys.panic)
+       26   call 247 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1314 2    
+       29   make_closure 1318 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -255,18 +255,18 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 244 ntypeargs=0   (baml.sys.panic)
+       8    call 247 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1307 1    
+       11   make_closure 1311 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1293 0   
+  95   0   make_closure 1297 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -278,7 +278,7 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        2     store_var 4              (_3)
        3     load_type 0              
        4     load_var 4               (_3)
-       5     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 5              (_4)
        7     load_var 5               (_4)
        8     is_type 1                
@@ -322,16 +322,16 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        46    load_type 0              
        47    load_type 11             
        48    load_var 5               (_4)
-       49    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 6              (_6)
        51    jump +50                 (to 101)
        52    load_var 5               (_4)
-       53    make_bound_method 507    
+       53    make_bound_method 510    
        54    call_indirect            
        55    store_var 6              (_6)
        56    jump +45                 (to 101)
        57    load_var 5               (_4)
-       58    make_bound_method 516    
+       58    make_bound_method 519    
        59    call_indirect            
        60    store_var 6              (_6)
        61    jump +40                 (to 101)
@@ -339,39 +339,39 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
        63    load_type 11             
        64    load_type 11             
        65    load_var 5               (_4)
-       66    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 6              (_6)
        68    jump +33                 (to 101)
        69    load_var 5               (_4)
-       70    make_bound_method 468    
+       70    make_bound_method 471    
        71    call_indirect            
        72    store_var 6              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 5               (_4)
-       76    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 6              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 5               (_4)
-       83    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 6              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 5               (_4)
-       89    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 6              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 5               (_4)
-       94    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 6              (_6)
        96    jump +5                  (to 101)
        97    load_var 5               (_4)
-       98    make_bound_method 495    
+       98    make_bound_method 498    
        99    call_indirect            
        100   store_var 6              (_6)
        101   load_var 6               (_6)
@@ -404,7 +404,7 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        2     store_var 4              (_3)
        3     load_type 0              
        4     load_var 4               (_3)
-       5     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       5     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        6     store_var 5              (_4)
        7     load_var 5               (_4)
        8     is_type 1                
@@ -448,16 +448,16 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        46    load_type 0              
        47    load_type 11             
        48    load_var 5               (_4)
-       49    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       49    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        50    store_var 6              (_6)
        51    jump +50                 (to 101)
        52    load_var 5               (_4)
-       53    make_bound_method 507    
+       53    make_bound_method 510    
        54    call_indirect            
        55    store_var 6              (_6)
        56    jump +45                 (to 101)
        57    load_var 5               (_4)
-       58    make_bound_method 516    
+       58    make_bound_method 519    
        59    call_indirect            
        60    store_var 6              (_6)
        61    jump +40                 (to 101)
@@ -465,39 +465,39 @@ function testing.TestCollector.find_testset(self: testing.TestCollector, name: s
        63    load_type 11             
        64    load_type 11             
        65    load_var 5               (_4)
-       66    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       66    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        67    store_var 6              (_6)
        68    jump +33                 (to 101)
        69    load_var 5               (_4)
-       70    make_bound_method 468    
+       70    make_bound_method 471    
        71    call_indirect            
        72    store_var 6              (_6)
        73    jump +28                 (to 101)
        74    load_type 0              
        75    load_var 5               (_4)
-       76    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       76    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        77    store_var 6              (_6)
        78    jump +23                 (to 101)
        79    load_type 0              
        80    load_type 11             
        81    load_type 11             
        82    load_var 5               (_4)
-       83    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       83    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        84    store_var 6              (_6)
        85    jump +16                 (to 101)
        86    load_type 0              
        87    load_type 11             
        88    load_var 5               (_4)
-       89    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       89    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        90    store_var 6              (_6)
        91    jump +10                 (to 101)
        92    load_type 0              
        93    load_var 5               (_4)
-       94    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       94    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        95    store_var 6              (_6)
        96    jump +5                  (to 101)
        97    load_var 5               (_4)
-       98    make_bound_method 495    
+       98    make_bound_method 498    
        99    call_indirect            
        100   store_var 6              (_6)
        101   load_var 6               (_6)
@@ -567,7 +567,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        24    store_var 9              (_13)
        25    load_type 4              
        26    load_var 9               (_13)
-       27    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 10             (_14)
        29    load_var 10              (_14)
        30    is_type 5                
@@ -611,16 +611,16 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        68    load_type 4              
        69    load_type 15             
        70    load_var 10              (_14)
-       71    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 11             (_16)
        73    jump +50                 (to 123)
        74    load_var 10              (_14)
-       75    make_bound_method 507    
+       75    make_bound_method 510    
        76    call_indirect            
        77    store_var 11             (_16)
        78    jump +45                 (to 123)
        79    load_var 10              (_14)
-       80    make_bound_method 516    
+       80    make_bound_method 519    
        81    call_indirect            
        82    store_var 11             (_16)
        83    jump +40                 (to 123)
@@ -628,39 +628,39 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        85    load_type 15             
        86    load_type 15             
        87    load_var 10              (_14)
-       88    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 11             (_16)
        90    jump +33                 (to 123)
        91    load_var 10              (_14)
-       92    make_bound_method 468    
+       92    make_bound_method 471    
        93    call_indirect            
        94    store_var 11             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 10              (_14)
-       98    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 11             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 10              (_14)
-       105   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 11             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 10              (_14)
-       111   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 11             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 10              (_14)
-       116   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 11             (_16)
        118   jump +5                  (to 123)
        119   load_var 10              (_14)
-       120   make_bound_method 495    
+       120   make_bound_method 498    
        121   call_indirect            
        122   store_var 11             (_16)
        123   load_var 11              (_16)
@@ -679,7 +679,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        135   load_var 12              (t)
        136   load_field 0             (name)
        137   load_var 8               (hash_prefix)
-       138   call 145 ntypeargs=0     (baml.String.starts_with)
+       138   call 147 ntypeargs=0     (baml.String.starts_with)
        139   pop_jump_if_false -110   (to 29)
        140   load_var 7               (count)
        141   load_const 17            (1)
@@ -703,7 +703,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        158   load_var 7               (count)
        159   load_const 17            (1)
        160   add_int                  
-       161   call 146 ntypeargs=1     (baml.String.from)
+       161   call 148 ntypeargs=1     (baml.String.from)
        162   store_var 15             (_57)
        163   load_var2 14 15          
        164   bin_op +                 
@@ -715,7 +715,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
        169   load_var2 13 3           
        170   load_var 4               (runner)
        171   init_instance 0          (testing.TestRegistration .name, .body, .runner)
-       172   call 9 ntypeargs=1       (baml.Array.push)
+       172   call 10 ntypeargs=1      (baml.Array.push)
        173   pop 1                    
 
   26   174   load_const 20            (null)
@@ -756,7 +756,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        24    store_var 9              (_13)
        25    load_type 4              
        26    load_var 9               (_13)
-       27    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+       27    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
        28    store_var 10             (_14)
        29    load_var 10              (_14)
        30    is_type 5                
@@ -800,16 +800,16 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        68    load_type 4              
        69    load_type 15             
        70    load_var 10              (_14)
-       71    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+       71    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
        72    store_var 11             (_16)
        73    jump +50                 (to 123)
        74    load_var 10              (_14)
-       75    make_bound_method 507    
+       75    make_bound_method 510    
        76    call_indirect            
        77    store_var 11             (_16)
        78    jump +45                 (to 123)
        79    load_var 10              (_14)
-       80    make_bound_method 516    
+       80    make_bound_method 519    
        81    call_indirect            
        82    store_var 11             (_16)
        83    jump +40                 (to 123)
@@ -817,39 +817,39 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        85    load_type 15             
        86    load_type 15             
        87    load_var 10              (_14)
-       88    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+       88    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
        89    store_var 11             (_16)
        90    jump +33                 (to 123)
        91    load_var 10              (_14)
-       92    make_bound_method 468    
+       92    make_bound_method 471    
        93    call_indirect            
        94    store_var 11             (_16)
        95    jump +28                 (to 123)
        96    load_type 4              
        97    load_var 10              (_14)
-       98    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+       98    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
        99    store_var 11             (_16)
        100   jump +23                 (to 123)
        101   load_type 4              
        102   load_type 15             
        103   load_type 15             
        104   load_var 10              (_14)
-       105   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+       105   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
        106   store_var 11             (_16)
        107   jump +16                 (to 123)
        108   load_type 4              
        109   load_type 15             
        110   load_var 10              (_14)
-       111   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+       111   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
        112   store_var 11             (_16)
        113   jump +10                 (to 123)
        114   load_type 4              
        115   load_var 10              (_14)
-       116   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+       116   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
        117   store_var 11             (_16)
        118   jump +5                  (to 123)
        119   load_var 10              (_14)
-       120   make_bound_method 495    
+       120   make_bound_method 498    
        121   call_indirect            
        122   store_var 11             (_16)
        123   load_var 11              (_16)
@@ -868,7 +868,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        135   load_var 12              (ts)
        136   load_field 0             (name)
        137   load_var 8               (hash_prefix)
-       138   call 145 ntypeargs=0     (baml.String.starts_with)
+       138   call 147 ntypeargs=0     (baml.String.starts_with)
        139   pop_jump_if_false -110   (to 29)
        140   load_var 7               (count)
        141   load_const 17            (1)
@@ -892,7 +892,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        158   load_var 7               (count)
        159   load_const 17            (1)
        160   add_int                  
-       161   call 146 ntypeargs=1     (baml.String.from)
+       161   call 148 ntypeargs=1     (baml.String.from)
        162   store_var 15             (_57)
        163   load_var2 14 15          
        164   bin_op +                 
@@ -904,7 +904,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
        169   load_var2 13 3           
        170   load_var 4               (runner)
        171   init_instance 0          (testing.TestSetRegistration .name, .collector, .runner)
-       172   call 9 ntypeargs=1       (baml.Array.push)
+       172   call 10 ntypeargs=1      (baml.Array.push)
        173   pop 1                    
 
   37   174   load_const 20            (null)
@@ -921,7 +921,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -965,16 +965,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 507    
+        54    make_bound_method 510    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 516    
+        59    make_bound_method 519    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -982,39 +982,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 468    
+        71    make_bound_method 471    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 495    
+        99    make_bound_method 498    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1030,22 +1030,22 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         111   pop_jump_if_false -103   (to 8)
 
   198   112   load_var2 1 6            
-        113   call 727 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        113   call 730 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
         114   pop 1                    
 
   199   115   load_var 1               (self)
-        116   call 710 ntypeargs=0     (testing.TestRegistry.serialize)
+        116   call 713 ntypeargs=0     (testing.TestRegistry.serialize)
         117   jump +123                (to 240)
 
   203   118   load_type 13             
         119   load_type 14             
         120   load_var 1               (self)
         121   load_field 1             (expansions)
-        122   call 11 ntypeargs=2      (baml.Map.keys)
+        122   call 12 ntypeargs=2      (baml.Map.keys)
         123   store_var 7              (_40)
         124   load_type 13             
         125   load_var 7               (_40)
-        126   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1089,16 +1089,16 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 507    
+        174   make_bound_method 510    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 516    
+        179   make_bound_method 519    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1106,39 +1106,39 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 468    
+        191   make_bound_method 471    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 495    
+        219   make_bound_method 498    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1157,11 +1157,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
   205   233   load_var2 2 10           
         234   load_const 25            ("/")
         235   bin_op +                 
-        236   call 145 ntypeargs=0     (baml.String.starts_with)
+        236   call 147 ntypeargs=0     (baml.String.starts_with)
         237   pop_jump_if_false -109   (to 128)
 
   206   238   load_var2 11 2           
-        239   call 715 ntypeargs=0     (testing.TestRegistry.expand_set)
+        239   call 718 ntypeargs=0     (testing.TestRegistry.expand_set)
         240   return                   
 
   209   241   load_const 26            ("TestSet not found for expansion: ")
@@ -1178,14 +1178,14 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         3    load_field 1           (expansions)
         4    load_var 2             (ts)
         5    load_field 0           (name)
-        6    call 39 ntypeargs=2    (baml.Map.get)
+        6    call 41 ntypeargs=2    (baml.Map.get)
         7    store_var 3            (_3)
         8    load_var 3             (_3)
         9    is_type 2              
         10   pop_jump_if_false +2   (to 12)
         11   jump +37               (to 48)
 
-  216   12   call 249 ntypeargs=0   (baml.sys.now_ms)
+  216   12   call 252 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 5            (start)
 
   217   14   load_var 2             (ts)
@@ -1202,7 +1202,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         24   call_indirect          
         25   pop 1                  
 
-  219   26   call 249 ntypeargs=0   (baml.sys.now_ms)
+  219   26   call 252 ntypeargs=0   (baml.sys.now_ms)
         27   load_var 5             (start)
         28   sub_int                
         29   store_var 7            (elapsed)
@@ -1224,7 +1224,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         41   load_var 2             (ts)
         42   load_field 0           (name)
         43   load_var 8             (sub_registry)
-        44   call 12 ntypeargs=2    (baml.Map.set)
+        44   call 13 ntypeargs=2    (baml.Map.set)
         45   pop 1                  
 
   226   46   load_var 8             (sub_registry)
@@ -1240,7 +1240,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 709 ntypeargs=0   (testing.select_names)
+        2   call 712 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -1259,9 +1259,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 725 ntypeargs=0   (testing.testset_children)
+        1   call 728 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 703 ntypeargs=0   (testing.run_testset)
+        3   call 706 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1285,24 +1285,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   16   load_var2 1 2          
         17   load_var 3             (exclude)
-        18   call 709 ntypeargs=0   (testing.select_names)
+        18   call 712 ntypeargs=0   (testing.select_names)
         19   store_var 6            (_9)
         20   load_var2 1 6          
-        21   call 700 ntypeargs=0   (testing.TestRegistry.run_selected)
+        21   call 703 ntypeargs=0   (testing.TestRegistry.run_selected)
         22   jump +3                (to 25)
 
   180   23   load_var 1             (self)
-        24   call 722 ntypeargs=0   (testing.TestRegistry.run_all)
+        24   call 725 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   25   call 738 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   25   call 741 ntypeargs=0   (testing.flatten_with_tolerated)
         26   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 706 ntypeargs=0   (testing.testset_children_selected)
+        1   call 709 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 703 ntypeargs=0   (testing.run_testset)
+        3   call 706 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -1313,7 +1313,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1357,16 +1357,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 507    
+        54    make_bound_method 510    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 516    
+        59    make_bound_method 519    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1374,39 +1374,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 468    
+        71    make_bound_method 471    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 495    
+        99    make_bound_method 498    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1425,18 +1425,18 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         113   load_field 1             (body)
         114   load_var 6               (t)
         115   load_field 2             (runner)
-        116   call 737 ntypeargs=0     (testing.run_test)
+        116   call 740 ntypeargs=0     (testing.run_test)
         117   jump +123                (to 240)
 
   140   118   load_type 13             
         119   load_type 14             
         120   load_var 1               (self)
         121   load_field 1             (expansions)
-        122   call 11 ntypeargs=2      (baml.Map.keys)
+        122   call 12 ntypeargs=2      (baml.Map.keys)
         123   store_var 7              (_40)
         124   load_type 13             
         125   load_var 7               (_40)
-        126   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        126   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         127   store_var 8              (_44)
         128   load_var 8               (_44)
         129   is_type 15               
@@ -1480,16 +1480,16 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         167   load_type 13             
         168   load_type 11             
         169   load_var 8               (_44)
-        170   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        170   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         171   store_var 9              (_46)
         172   jump +50                 (to 222)
         173   load_var 8               (_44)
-        174   make_bound_method 507    
+        174   make_bound_method 510    
         175   call_indirect            
         176   store_var 9              (_46)
         177   jump +45                 (to 222)
         178   load_var 8               (_44)
-        179   make_bound_method 516    
+        179   make_bound_method 519    
         180   call_indirect            
         181   store_var 9              (_46)
         182   jump +40                 (to 222)
@@ -1497,39 +1497,39 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         184   load_type 11             
         185   load_type 11             
         186   load_var 8               (_44)
-        187   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        187   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         188   store_var 9              (_46)
         189   jump +33                 (to 222)
         190   load_var 8               (_44)
-        191   make_bound_method 468    
+        191   make_bound_method 471    
         192   call_indirect            
         193   store_var 9              (_46)
         194   jump +28                 (to 222)
         195   load_type 13             
         196   load_var 8               (_44)
-        197   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        197   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         198   store_var 9              (_46)
         199   jump +23                 (to 222)
         200   load_type 13             
         201   load_type 11             
         202   load_type 11             
         203   load_var 8               (_44)
-        204   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        204   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         205   store_var 9              (_46)
         206   jump +16                 (to 222)
         207   load_type 13             
         208   load_type 11             
         209   load_var 8               (_44)
-        210   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        210   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         211   store_var 9              (_46)
         212   jump +10                 (to 222)
         213   load_type 13             
         214   load_var 8               (_44)
-        215   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        215   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         216   store_var 9              (_46)
         217   jump +5                  (to 222)
         218   load_var 8               (_44)
-        219   make_bound_method 495    
+        219   make_bound_method 498    
         220   call_indirect            
         221   store_var 9              (_46)
         222   load_var 9               (_46)
@@ -1548,11 +1548,11 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
   143   233   load_var2 2 10           
         234   load_const 25            ("/")
         235   bin_op +                 
-        236   call 145 ntypeargs=0     (baml.String.starts_with)
+        236   call 147 ntypeargs=0     (baml.String.starts_with)
         237   pop_jump_if_false -109   (to 128)
 
   144   238   load_var2 11 2           
-        239   call 714 ntypeargs=0     (testing.TestRegistry.run_test)
+        239   call 717 ntypeargs=0     (testing.TestRegistry.run_test)
         240   return                   
 
   147   241   load_const 26            ("Test not found: ")
@@ -1569,7 +1569,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         3     store_var 3              (_3)
         4     load_type 0              
         5     load_var 3               (_3)
-        6     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 1                
@@ -1613,16 +1613,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         47    load_type 0              
         48    load_type 11             
         49    load_var 4               (_4)
-        50    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 507    
+        54    make_bound_method 510    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 516    
+        59    make_bound_method 519    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -1630,39 +1630,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         64    load_type 11             
         65    load_type 11             
         66    load_var 4               (_4)
-        67    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 468    
+        71    make_bound_method 471    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 0              
         76    load_var 4               (_4)
-        77    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 0              
         81    load_type 11             
         82    load_type 11             
         83    load_var 4               (_4)
-        84    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 0              
         88    load_type 11             
         89    load_var 4               (_4)
-        90    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 0              
         94    load_var 4               (_4)
-        95    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 495    
+        99    make_bound_method 498    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -1678,22 +1678,22 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         111   pop_jump_if_false -103   (to 8)
 
   153   112   load_var2 1 6            
-        113   call 727 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
-        114   call 725 ntypeargs=0     (testing.testset_children)
+        113   call 730 ntypeargs=0     (testing.TestRegistry.expand_testset_registry)
+        114   call 728 ntypeargs=0     (testing.testset_children)
         115   load_var 6               (ts)
         116   load_field 2             (runner)
-        117   call 703 ntypeargs=0     (testing.run_testset)
+        117   call 706 ntypeargs=0     (testing.run_testset)
         118   jump +123                (to 241)
 
   156   119   load_type 13             
         120   load_type 14             
         121   load_var 1               (self)
         122   load_field 1             (expansions)
-        123   call 11 ntypeargs=2      (baml.Map.keys)
+        123   call 12 ntypeargs=2      (baml.Map.keys)
         124   store_var 7              (_42)
         125   load_type 13             
         126   load_var 7               (_42)
-        127   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        127   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         128   store_var 8              (_46)
         129   load_var 8               (_46)
         130   is_type 15               
@@ -1737,16 +1737,16 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         168   load_type 13             
         169   load_type 11             
         170   load_var 8               (_46)
-        171   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        171   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         172   store_var 9              (_48)
         173   jump +50                 (to 223)
         174   load_var 8               (_46)
-        175   make_bound_method 507    
+        175   make_bound_method 510    
         176   call_indirect            
         177   store_var 9              (_48)
         178   jump +45                 (to 223)
         179   load_var 8               (_46)
-        180   make_bound_method 516    
+        180   make_bound_method 519    
         181   call_indirect            
         182   store_var 9              (_48)
         183   jump +40                 (to 223)
@@ -1754,39 +1754,39 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         185   load_type 11             
         186   load_type 11             
         187   load_var 8               (_46)
-        188   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        188   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         189   store_var 9              (_48)
         190   jump +33                 (to 223)
         191   load_var 8               (_46)
-        192   make_bound_method 468    
+        192   make_bound_method 471    
         193   call_indirect            
         194   store_var 9              (_48)
         195   jump +28                 (to 223)
         196   load_type 13             
         197   load_var 8               (_46)
-        198   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        198   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         199   store_var 9              (_48)
         200   jump +23                 (to 223)
         201   load_type 13             
         202   load_type 11             
         203   load_type 11             
         204   load_var 8               (_46)
-        205   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        205   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         206   store_var 9              (_48)
         207   jump +16                 (to 223)
         208   load_type 13             
         209   load_type 11             
         210   load_var 8               (_46)
-        211   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        211   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         212   store_var 9              (_48)
         213   jump +10                 (to 223)
         214   load_type 13             
         215   load_var 8               (_46)
-        216   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        216   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         217   store_var 9              (_48)
         218   jump +5                  (to 223)
         219   load_var 8               (_46)
-        220   make_bound_method 495    
+        220   make_bound_method 498    
         221   call_indirect            
         222   store_var 9              (_48)
         223   load_var 9               (_48)
@@ -1805,11 +1805,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
   158   234   load_var2 2 10           
         235   load_const 25            ("/")
         236   bin_op +                 
-        237   call 145 ntypeargs=0     (baml.String.starts_with)
+        237   call 147 ntypeargs=0     (baml.String.starts_with)
         238   pop_jump_if_false -109   (to 129)
 
   159   239   load_var2 11 2           
-        240   call 718 ntypeargs=0     (testing.TestRegistry.run_testset)
+        240   call 721 ntypeargs=0     (testing.TestRegistry.run_testset)
         241   return                   
 
   162   242   load_const 26            ("TestSet not found: ")
@@ -1830,7 +1830,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         6     store_var 4              (_3)
         7     load_type 1              
         8     load_var 4               (_3)
-        9     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 5              (_4)
         11    load_var 5               (_4)
         12    is_type 2                
@@ -1874,16 +1874,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         50    load_type 1              
         51    load_type 12             
         52    load_var 5               (_4)
-        53    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 6              (_6)
         55    jump +50                 (to 105)
         56    load_var 5               (_4)
-        57    make_bound_method 507    
+        57    make_bound_method 510    
         58    call_indirect            
         59    store_var 6              (_6)
         60    jump +45                 (to 105)
         61    load_var 5               (_4)
-        62    make_bound_method 516    
+        62    make_bound_method 519    
         63    call_indirect            
         64    store_var 6              (_6)
         65    jump +40                 (to 105)
@@ -1891,39 +1891,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         67    load_type 12             
         68    load_type 12             
         69    load_var 5               (_4)
-        70    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 6              (_6)
         72    jump +33                 (to 105)
         73    load_var 5               (_4)
-        74    make_bound_method 468    
+        74    make_bound_method 471    
         75    call_indirect            
         76    store_var 6              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 5               (_4)
-        80    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 6              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 5               (_4)
-        87    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 6              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 5               (_4)
-        93    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 6              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 5               (_4)
-        98    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 6              (_6)
         100   jump +5                  (to 105)
         101   load_var 5               (_4)
-        102   make_bound_method 495    
+        102   make_bound_method 498    
         103   call_indirect            
         104   store_var 6              (_6)
         105   load_var 6               (_6)
@@ -1938,7 +1938,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         113   load_var 7               (t)
         114   load_field 0             (name)
         115   init_instance 0          (testing.SerializedTest .type, .name)
-        116   call 9 ntypeargs=0       (baml.Array.push)
+        116   call 10 ntypeargs=0      (baml.Array.push)
         117   pop 1                    
         118   jump -107                (to 11)
 
@@ -1948,7 +1948,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         122   store_var 8              (_39)
         123   load_type 15             
         124   load_var 8               (_39)
-        125   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        125   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         126   store_var 9              (_40)
         127   load_var 9               (_40)
         128   is_type 16               
@@ -1992,16 +1992,16 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         166   load_type 15             
         167   load_type 12             
         168   load_var 9               (_40)
-        169   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        169   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         170   store_var 10             (_42)
         171   jump +50                 (to 221)
         172   load_var 9               (_40)
-        173   make_bound_method 507    
+        173   make_bound_method 510    
         174   call_indirect            
         175   store_var 10             (_42)
         176   jump +45                 (to 221)
         177   load_var 9               (_40)
-        178   make_bound_method 516    
+        178   make_bound_method 519    
         179   call_indirect            
         180   store_var 10             (_42)
         181   jump +40                 (to 221)
@@ -2009,39 +2009,39 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         183   load_type 12             
         184   load_type 12             
         185   load_var 9               (_40)
-        186   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        186   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         187   store_var 10             (_42)
         188   jump +33                 (to 221)
         189   load_var 9               (_40)
-        190   make_bound_method 468    
+        190   make_bound_method 471    
         191   call_indirect            
         192   store_var 10             (_42)
         193   jump +28                 (to 221)
         194   load_type 15             
         195   load_var 9               (_40)
-        196   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        196   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         197   store_var 10             (_42)
         198   jump +23                 (to 221)
         199   load_type 15             
         200   load_type 12             
         201   load_type 12             
         202   load_var 9               (_40)
-        203   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        203   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         204   store_var 10             (_42)
         205   jump +16                 (to 221)
         206   load_type 15             
         207   load_type 12             
         208   load_var 9               (_40)
-        209   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        209   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         210   store_var 10             (_42)
         211   jump +10                 (to 221)
         212   load_type 15             
         213   load_var 9               (_40)
-        214   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        214   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         215   store_var 10             (_42)
         216   jump +5                  (to 221)
         217   load_var 9               (_40)
-        218   make_bound_method 495    
+        218   make_bound_method 498    
         219   call_indirect            
         220   store_var 10             (_42)
         221   load_var 10              (_42)
@@ -2057,7 +2057,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         230   load_field 1             (expansions)
         231   load_var 11              (ts)
         232   load_field 0             (name)
-        233   call 39 ntypeargs=2      (baml.Map.get)
+        233   call 41 ntypeargs=2      (baml.Map.get)
         234   store_var 12             (expanded)
 
   115   235   load_var 12              (expanded)
@@ -2070,7 +2070,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         241   load_var 11              (ts)
         242   load_field 0             (name)
         243   init_instance 1          (testing.SerializedTest .type, .name)
-        244   call 9 ntypeargs=0       (baml.Array.push)
+        244   call 10 ntypeargs=0      (baml.Array.push)
         245   pop 1                    
         246   jump -119                (to 127)
 
@@ -2082,7 +2082,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         251   store_var 14             (_81)
 
   119   252   load_var 13              (sub)
-        253   call 710 ntypeargs=0     (testing.TestRegistry.serialize)
+        253   call 713 ntypeargs=0     (testing.TestRegistry.serialize)
         254   store_var 15             (_82)
 
   117   255   load_var2 3 14           
@@ -2090,7 +2090,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 
   120   257   load_field 2             (loading_time_ms)
         258   init_instance 2          (testing.SerializedTestSet .name, .items, .loadingTimeMs)
-        259   call 9 ntypeargs=0       (baml.Array.push)
+        259   call 10 ntypeargs=0      (baml.Array.push)
         260   pop 1                    
         261   jump -134                (to 127)
 
@@ -2109,7 +2109,7 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
 
   311   4     load_type 1              
         5     load_var 2               (names)
-        6     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        6     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         7     store_var 4              (_4)
         8     load_var 4               (_4)
         9     is_type 2                
@@ -2153,16 +2153,16 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         47    load_type 1              
         48    load_type 12             
         49    load_var 4               (_4)
-        50    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        50    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         51    store_var 5              (_6)
         52    jump +50                 (to 102)
         53    load_var 4               (_4)
-        54    make_bound_method 507    
+        54    make_bound_method 510    
         55    call_indirect            
         56    store_var 5              (_6)
         57    jump +45                 (to 102)
         58    load_var 4               (_4)
-        59    make_bound_method 516    
+        59    make_bound_method 519    
         60    call_indirect            
         61    store_var 5              (_6)
         62    jump +40                 (to 102)
@@ -2170,39 +2170,39 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         64    load_type 12             
         65    load_type 12             
         66    load_var 4               (_4)
-        67    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        67    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         68    store_var 5              (_6)
         69    jump +33                 (to 102)
         70    load_var 4               (_4)
-        71    make_bound_method 468    
+        71    make_bound_method 471    
         72    call_indirect            
         73    store_var 5              (_6)
         74    jump +28                 (to 102)
         75    load_type 1              
         76    load_var 4               (_4)
-        77    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        77    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         78    store_var 5              (_6)
         79    jump +23                 (to 102)
         80    load_type 1              
         81    load_type 12             
         82    load_type 12             
         83    load_var 4               (_4)
-        84    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        84    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         85    store_var 5              (_6)
         86    jump +16                 (to 102)
         87    load_type 1              
         88    load_type 12             
         89    load_var 4               (_4)
-        90    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        90    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         91    store_var 5              (_6)
         92    jump +10                 (to 102)
         93    load_type 1              
         94    load_var 4               (_4)
-        95    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        95    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         96    store_var 5              (_6)
         97    jump +5                  (to 102)
         98    load_var 4               (_4)
-        99    make_bound_method 495    
+        99    make_bound_method 498    
         100   call_indirect            
         101   store_var 5              (_6)
         102   load_var 5               (_6)
@@ -2213,7 +2213,7 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
         107   store_var 6              (selected)
 
   312   108   load_var2 6 3            
-        109   call 145 ntypeargs=0     (baml.String.starts_with)
+        109   call 147 ntypeargs=0     (baml.String.starts_with)
         110   pop_jump_if_false -102   (to 8)
 
   313   111   load_const 14            (true)
@@ -2227,21 +2227,21 @@ function testing._has_selected_descendant(prefix: string, names: string[]) -> bo
 function testing._int_to_float(value: int) -> float {
   125   0   load_type 0            
         1   load_var 1             (value)
-        2   call 146 ntypeargs=1   (baml.String.from)
-        3   call 120 ntypeargs=0   (baml.Float.parse)
+        2   call 148 ntypeargs=1   (baml.String.from)
+        3   call 122 ntypeargs=0   (baml.Float.parse)
         4   jump +5                (to 9)
         5   load_var 2             (e)
         6   throw_if_panic         
 
   126   7   load_const 1           ("failed to convert int to float")
-        8   call 244 ntypeargs=0   (baml.sys.panic)
+        8   call 247 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function testing._name_selected(name: string, names: string[]) -> bool {
   299   0     load_type 0              
         1     load_var 2               (names)
-        2     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 3              (_3)
         4     load_var 3               (_3)
         5     is_type 1                
@@ -2285,16 +2285,16 @@ function testing._name_selected(name: string, names: string[]) -> bool {
         43    load_type 0              
         44    load_type 11             
         45    load_var 3               (_3)
-        46    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 4              (_5)
         48    jump +50                 (to 98)
         49    load_var 3               (_3)
-        50    make_bound_method 507    
+        50    make_bound_method 510    
         51    call_indirect            
         52    store_var 4              (_5)
         53    jump +45                 (to 98)
         54    load_var 3               (_3)
-        55    make_bound_method 516    
+        55    make_bound_method 519    
         56    call_indirect            
         57    store_var 4              (_5)
         58    jump +40                 (to 98)
@@ -2302,39 +2302,39 @@ function testing._name_selected(name: string, names: string[]) -> bool {
         60    load_type 11             
         61    load_type 11             
         62    load_var 3               (_3)
-        63    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 4              (_5)
         65    jump +33                 (to 98)
         66    load_var 3               (_3)
-        67    make_bound_method 468    
+        67    make_bound_method 471    
         68    call_indirect            
         69    store_var 4              (_5)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 3               (_3)
-        73    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 4              (_5)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 3               (_3)
-        80    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 4              (_5)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 3               (_3)
-        86    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 4              (_5)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 3               (_3)
-        91    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 4              (_5)
         93    jump +5                  (to 98)
         94    load_var 3               (_3)
-        95    make_bound_method 495    
+        95    make_bound_method 498    
         96    call_indirect            
         97    store_var 4              (_5)
         98    load_var 4               (_5)
@@ -2376,7 +2376,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   327   12    load_type 4              
         13    load_var 1               (named_results)
-        14    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        14    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         15    store_var 8              (_7)
         16    load_var 8               (_7)
         17    is_type 5                
@@ -2420,16 +2420,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         55    load_type 4              
         56    load_type 15             
         57    load_var 8               (_7)
-        58    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        58    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         59    store_var 9              (_9)
         60    jump +50                 (to 110)
         61    load_var 8               (_7)
-        62    make_bound_method 507    
+        62    make_bound_method 510    
         63    call_indirect            
         64    store_var 9              (_9)
         65    jump +45                 (to 110)
         66    load_var 8               (_7)
-        67    make_bound_method 516    
+        67    make_bound_method 519    
         68    call_indirect            
         69    store_var 9              (_9)
         70    jump +40                 (to 110)
@@ -2437,39 +2437,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         72    load_type 15             
         73    load_type 15             
         74    load_var 8               (_7)
-        75    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        75    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         76    store_var 9              (_9)
         77    jump +33                 (to 110)
         78    load_var 8               (_7)
-        79    make_bound_method 468    
+        79    make_bound_method 471    
         80    call_indirect            
         81    store_var 9              (_9)
         82    jump +28                 (to 110)
         83    load_type 4              
         84    load_var 8               (_7)
-        85    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        85    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         86    store_var 9              (_9)
         87    jump +23                 (to 110)
         88    load_type 4              
         89    load_type 15             
         90    load_type 15             
         91    load_var 8               (_7)
-        92    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        92    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         93    store_var 9              (_9)
         94    jump +16                 (to 110)
         95    load_type 4              
         96    load_type 15             
         97    load_var 8               (_7)
-        98    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        98    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         99    store_var 9              (_9)
         100   jump +10                 (to 110)
         101   load_type 4              
         102   load_var 8               (_7)
-        103   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        103   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         104   store_var 9              (_9)
         105   jump +5                  (to 110)
         106   load_var 8               (_7)
-        107   make_bound_method 495    
+        107   make_bound_method 498    
         108   call_indirect            
         109   store_var 9              (_9)
         110   load_var 9               (_9)
@@ -2484,7 +2484,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         118   store_var 11             (result)
 
   329   119   load_var2 7 11           
-        120   call 9 ntypeargs=0       (baml.Array.push)
+        120   call 10 ntypeargs=0      (baml.Array.push)
         121   pop 1                    
 
   330   122   load_var 11              (result)
@@ -2508,7 +2508,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   334   137   load_var 12              (outcome)
         138   load_const 18            ("pass")
-        139   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        139   call 690 ntypeargs=0     (baml.ops.equals_equals)
         140   pop_jump_if_false +2     (to 142)
         141   jump +147                (to 288)
 
@@ -2553,7 +2553,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
   346   172   store_var 17             (_56)
         173   load_type 2              
         174   load_var 17              (_56)
-        175   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        175   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         176   store_var 18             (_57)
         177   load_var 18              (_57)
         178   is_type 20               
@@ -2597,16 +2597,16 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         216   load_type 2              
         217   load_type 15             
         218   load_var 18              (_57)
-        219   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        219   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         220   store_var 19             (_59)
         221   jump +50                 (to 271)
         222   load_var 18              (_57)
-        223   make_bound_method 507    
+        223   make_bound_method 510    
         224   call_indirect            
         225   store_var 19             (_59)
         226   jump +45                 (to 271)
         227   load_var 18              (_57)
-        228   make_bound_method 516    
+        228   make_bound_method 519    
         229   call_indirect            
         230   store_var 19             (_59)
         231   jump +40                 (to 271)
@@ -2614,39 +2614,39 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         233   load_type 15             
         234   load_type 15             
         235   load_var 18              (_57)
-        236   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        236   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         237   store_var 19             (_59)
         238   jump +33                 (to 271)
         239   load_var 18              (_57)
-        240   make_bound_method 468    
+        240   make_bound_method 471    
         241   call_indirect            
         242   store_var 19             (_59)
         243   jump +28                 (to 271)
         244   load_type 2              
         245   load_var 18              (_57)
-        246   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        246   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         247   store_var 19             (_59)
         248   jump +23                 (to 271)
         249   load_type 2              
         250   load_type 15             
         251   load_type 15             
         252   load_var 18              (_57)
-        253   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        253   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         254   store_var 19             (_59)
         255   jump +16                 (to 271)
         256   load_type 2              
         257   load_type 15             
         258   load_var 18              (_57)
-        259   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        259   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         260   store_var 19             (_59)
         261   jump +10                 (to 271)
         262   load_type 2              
         263   load_var 18              (_57)
-        264   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        264   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         265   store_var 19             (_59)
         266   jump +5                  (to 271)
         267   load_var 18              (_57)
-        268   make_bound_method 495    
+        268   make_bound_method 498    
         269   call_indirect            
         270   store_var 19             (_59)
         271   load_var 19              (_59)
@@ -2657,13 +2657,13 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
         276   store_var 20             (name)
 
   347   277   load_var2 6 20           
-        278   call 9 ntypeargs=0       (baml.Array.push)
+        278   call 10 ntypeargs=0      (baml.Array.push)
         279   pop 1                    
         280   jump -103                (to 177)
 
   349   281   load_var 12              (outcome)
         282   load_const 30            ("error")
-        283   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        283   call 690 ntypeargs=0     (baml.ops.equals_equals)
         284   pop_jump_if_false -268   (to 16)
 
   350   285   load_const 31            (true)
@@ -2719,7 +2719,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: string, test_name: string) -> bool {
   525   0     load_type 0              
         1     load_var 1               (pats)
-        2     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 4              (_4)
         4     load_var 4               (_4)
         5     is_type 1                
@@ -2763,16 +2763,16 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
         43    load_type 0              
         44    load_type 11             
         45    load_var 4               (_4)
-        46    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 5              (_6)
         48    jump +50                 (to 98)
         49    load_var 4               (_4)
-        50    make_bound_method 507    
+        50    make_bound_method 510    
         51    call_indirect            
         52    store_var 5              (_6)
         53    jump +45                 (to 98)
         54    load_var 4               (_4)
-        55    make_bound_method 516    
+        55    make_bound_method 519    
         56    call_indirect            
         57    store_var 5              (_6)
         58    jump +40                 (to 98)
@@ -2780,39 +2780,39 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
         60    load_type 11             
         61    load_type 11             
         62    load_var 4               (_4)
-        63    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 5              (_6)
         65    jump +33                 (to 98)
         66    load_var 4               (_4)
-        67    make_bound_method 468    
+        67    make_bound_method 471    
         68    call_indirect            
         69    store_var 5              (_6)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 4               (_4)
-        73    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 5              (_6)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 4               (_4)
-        80    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 5              (_6)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 4               (_4)
-        86    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 5              (_6)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 4               (_4)
-        91    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 5              (_6)
         93    jump +5                  (to 98)
         94    load_var 4               (_4)
-        95    make_bound_method 495    
+        95    make_bound_method 498    
         96    call_indirect            
         97    store_var 5              (_6)
         98    load_var 5               (_6)
@@ -2824,13 +2824,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   104   load_field 0             (func_pat)
         105   load_var 2               (function_name)
-        106   call 723 ntypeargs=0     (testing.filter_match)
+        106   call 726 ntypeargs=0     (testing.filter_match)
         107   jump_if_false +6         (to 113)
         108   pop 1                    
         109   load_var 6               (p)
         110   load_field 1             (test_pat)
         111   load_var 3               (test_name)
-        112   call 723 ntypeargs=0     (testing.filter_match)
+        112   call 726 ntypeargs=0     (testing.filter_match)
         113   pop_jump_if_false -109   (to 4)
 
   527   114   load_const 13            (true)
@@ -2844,7 +2844,7 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 function testing.collect_leaf_messages(results: (testing.TestReport | testing.TestSetReport)[], out: string[]) -> void {
   661   0     load_type 0              
         1     load_var 1               (results)
-        2     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        2     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         3     store_var 4              (_3)
         4     load_var 4               (_3)
         5     is_type 1                
@@ -2888,16 +2888,16 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         43    load_type 0              
         44    load_type 11             
         45    load_var 4               (_3)
-        46    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        46    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         47    store_var 5              (_5)
         48    jump +50                 (to 98)
         49    load_var 4               (_3)
-        50    make_bound_method 507    
+        50    make_bound_method 510    
         51    call_indirect            
         52    store_var 5              (_5)
         53    jump +45                 (to 98)
         54    load_var 4               (_3)
-        55    make_bound_method 516    
+        55    make_bound_method 519    
         56    call_indirect            
         57    store_var 5              (_5)
         58    jump +40                 (to 98)
@@ -2905,39 +2905,39 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         60    load_type 11             
         61    load_type 11             
         62    load_var 4               (_3)
-        63    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        63    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         64    store_var 5              (_5)
         65    jump +33                 (to 98)
         66    load_var 4               (_3)
-        67    make_bound_method 468    
+        67    make_bound_method 471    
         68    call_indirect            
         69    store_var 5              (_5)
         70    jump +28                 (to 98)
         71    load_type 0              
         72    load_var 4               (_3)
-        73    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        73    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         74    store_var 5              (_5)
         75    jump +23                 (to 98)
         76    load_type 0              
         77    load_type 11             
         78    load_type 11             
         79    load_var 4               (_3)
-        80    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        80    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         81    store_var 5              (_5)
         82    jump +16                 (to 98)
         83    load_type 0              
         84    load_type 11             
         85    load_var 4               (_3)
-        86    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        86    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         87    store_var 5              (_5)
         88    jump +10                 (to 98)
         89    load_type 0              
         90    load_var 4               (_3)
-        91    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        91    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         92    store_var 5              (_5)
         93    jump +5                  (to 98)
         94    load_var 4               (_3)
-        95    make_bound_method 495    
+        95    make_bound_method 498    
         96    call_indirect            
         97    store_var 5              (_5)
         98    load_var 5               (_5)
@@ -2955,7 +2955,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   673   109   load_field 5             (results)
         110   load_var 2               (out)
-        111   call 716 ntypeargs=0     (testing.collect_leaf_messages)
+        111   call 719 ntypeargs=0     (testing.collect_leaf_messages)
         112   pop 1                    
         113   jump -109                (to 4)
 
@@ -2967,7 +2967,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         118   store_var 8              (_37)
         119   load_type 14             
         120   load_var 8               (_37)
-        121   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        121   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         122   store_var 9              (_38)
         123   load_var 9               (_38)
         124   is_type 15               
@@ -3011,16 +3011,16 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         162   load_type 14             
         163   load_type 11             
         164   load_var 9               (_38)
-        165   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        165   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         166   store_var 10             (_40)
         167   jump +50                 (to 217)
         168   load_var 9               (_38)
-        169   make_bound_method 507    
+        169   make_bound_method 510    
         170   call_indirect            
         171   store_var 10             (_40)
         172   jump +45                 (to 217)
         173   load_var 9               (_38)
-        174   make_bound_method 516    
+        174   make_bound_method 519    
         175   call_indirect            
         176   store_var 10             (_40)
         177   jump +40                 (to 217)
@@ -3028,39 +3028,39 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         179   load_type 11             
         180   load_type 11             
         181   load_var 9               (_38)
-        182   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        182   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         183   store_var 10             (_40)
         184   jump +33                 (to 217)
         185   load_var 9               (_38)
-        186   make_bound_method 468    
+        186   make_bound_method 471    
         187   call_indirect            
         188   store_var 10             (_40)
         189   jump +28                 (to 217)
         190   load_type 14             
         191   load_var 9               (_38)
-        192   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        192   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         193   store_var 10             (_40)
         194   jump +23                 (to 217)
         195   load_type 14             
         196   load_type 11             
         197   load_type 11             
         198   load_var 9               (_38)
-        199   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        199   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         200   store_var 10             (_40)
         201   jump +16                 (to 217)
         202   load_type 14             
         203   load_type 11             
         204   load_var 9               (_38)
-        205   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        205   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         206   store_var 10             (_40)
         207   jump +10                 (to 217)
         208   load_type 14             
         209   load_var 9               (_38)
-        210   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        210   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         211   store_var 10             (_40)
         212   jump +5                  (to 217)
         213   load_var 9               (_38)
-        214   make_bound_method 495    
+        214   make_bound_method 498    
         215   call_indirect            
         216   store_var 10             (_40)
         217   load_var 10              (_40)
@@ -3072,7 +3072,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   665   223   load_field 0             (outcome)
         224   load_const 25            ("pass")
-        225   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        225   call 690 ntypeargs=0     (baml.ops.equals_equals)
         226   unary_op !               
         227   pop_jump_if_false -104   (to 123)
 
@@ -3085,7 +3085,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         234   store_var 13             (m)
 
   667   235   load_var2 2 13           
-        236   call 9 ntypeargs=0       (baml.Array.push)
+        236   call 10 ntypeargs=0      (baml.Array.push)
         237   pop 1                    
         238   jump -115                (to 123)
 
@@ -3107,7 +3107,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         6     store_var 4              (_3)
         7     load_type 1              
         8     load_var 4               (_3)
-        9     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 5              (_4)
         11    load_var 5               (_4)
         12    is_type 2                
@@ -3151,16 +3151,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         50    load_type 1              
         51    load_type 12             
         52    load_var 5               (_4)
-        53    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 6              (_6)
         55    jump +50                 (to 105)
         56    load_var 5               (_4)
-        57    make_bound_method 507    
+        57    make_bound_method 510    
         58    call_indirect            
         59    store_var 6              (_6)
         60    jump +45                 (to 105)
         61    load_var 5               (_4)
-        62    make_bound_method 516    
+        62    make_bound_method 519    
         63    call_indirect            
         64    store_var 6              (_6)
         65    jump +40                 (to 105)
@@ -3168,39 +3168,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         67    load_type 12             
         68    load_type 12             
         69    load_var 5               (_4)
-        70    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 6              (_6)
         72    jump +33                 (to 105)
         73    load_var 5               (_4)
-        74    make_bound_method 468    
+        74    make_bound_method 471    
         75    call_indirect            
         76    store_var 6              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 5               (_4)
-        80    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 6              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 5               (_4)
-        87    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 6              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 5               (_4)
-        93    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 6              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 5               (_4)
-        98    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 6              (_6)
         100   jump +5                  (to 105)
         101   load_var 5               (_4)
-        102   make_bound_method 495    
+        102   make_bound_method 498    
         103   call_indirect            
         104   store_var 6              (_6)
         105   load_var 6               (_6)
@@ -3212,7 +3212,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   564   111   load_var2 3 7            
         112   load_field 0             (name)
-        113   call 9 ntypeargs=0       (baml.Array.push)
+        113   call 10 ntypeargs=0      (baml.Array.push)
         114   pop 1                    
         115   jump -104                (to 11)
 
@@ -3222,7 +3222,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         119   store_var 8              (_38)
         120   load_type 14             
         121   load_var 8               (_38)
-        122   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        122   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         123   store_var 9              (_39)
         124   load_var 9               (_39)
         125   is_type 15               
@@ -3266,16 +3266,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         163   load_type 14             
         164   load_type 12             
         165   load_var 9               (_39)
-        166   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        166   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         167   store_var 10             (_41)
         168   jump +50                 (to 218)
         169   load_var 9               (_39)
-        170   make_bound_method 507    
+        170   make_bound_method 510    
         171   call_indirect            
         172   store_var 10             (_41)
         173   jump +45                 (to 218)
         174   load_var 9               (_39)
-        175   make_bound_method 516    
+        175   make_bound_method 519    
         176   call_indirect            
         177   store_var 10             (_41)
         178   jump +40                 (to 218)
@@ -3283,39 +3283,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         180   load_type 12             
         181   load_type 12             
         182   load_var 9               (_39)
-        183   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        183   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         184   store_var 10             (_41)
         185   jump +33                 (to 218)
         186   load_var 9               (_39)
-        187   make_bound_method 468    
+        187   make_bound_method 471    
         188   call_indirect            
         189   store_var 10             (_41)
         190   jump +28                 (to 218)
         191   load_type 14             
         192   load_var 9               (_39)
-        193   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        193   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         194   store_var 10             (_41)
         195   jump +23                 (to 218)
         196   load_type 14             
         197   load_type 12             
         198   load_type 12             
         199   load_var 9               (_39)
-        200   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        200   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         201   store_var 10             (_41)
         202   jump +16                 (to 218)
         203   load_type 14             
         204   load_type 12             
         205   load_var 9               (_39)
-        206   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        206   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         207   store_var 10             (_41)
         208   jump +10                 (to 218)
         209   load_type 14             
         210   load_var 9               (_39)
-        211   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        211   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         212   store_var 10             (_41)
         213   jump +5                  (to 218)
         214   load_var 9               (_39)
-        215   make_bound_method 495    
+        215   make_bound_method 498    
         216   call_indirect            
         217   store_var 10             (_41)
         218   load_var 10              (_41)
@@ -3326,11 +3326,11 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         223   store_var 11             (ts)
 
   567   224   load_var2 1 11           
-        225   call 728 ntypeargs=0     (testing.collect_subtree_names)
+        225   call 731 ntypeargs=0     (testing.collect_subtree_names)
         226   store_var 12             (_71)
         227   load_type 0              
         228   load_var 12              (_71)
-        229   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        229   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         230   store_var 13             (_73)
         231   load_var 13              (_73)
         232   is_type 25               
@@ -3374,16 +3374,16 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         270   load_type 0              
         271   load_type 12             
         272   load_var 13              (_73)
-        273   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        273   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         274   store_var 14             (_75)
         275   jump +50                 (to 325)
         276   load_var 13              (_73)
-        277   make_bound_method 507    
+        277   make_bound_method 510    
         278   call_indirect            
         279   store_var 14             (_75)
         280   jump +45                 (to 325)
         281   load_var 13              (_73)
-        282   make_bound_method 516    
+        282   make_bound_method 519    
         283   call_indirect            
         284   store_var 14             (_75)
         285   jump +40                 (to 325)
@@ -3391,39 +3391,39 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         287   load_type 12             
         288   load_type 12             
         289   load_var 13              (_73)
-        290   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        290   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         291   store_var 14             (_75)
         292   jump +33                 (to 325)
         293   load_var 13              (_73)
-        294   make_bound_method 468    
+        294   make_bound_method 471    
         295   call_indirect            
         296   store_var 14             (_75)
         297   jump +28                 (to 325)
         298   load_type 0              
         299   load_var 13              (_73)
-        300   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        300   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         301   store_var 14             (_75)
         302   jump +23                 (to 325)
         303   load_type 0              
         304   load_type 12             
         305   load_type 12             
         306   load_var 13              (_73)
-        307   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        307   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         308   store_var 14             (_75)
         309   jump +16                 (to 325)
         310   load_type 0              
         311   load_type 12             
         312   load_var 13              (_73)
-        313   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        313   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         314   store_var 14             (_75)
         315   jump +10                 (to 325)
         316   load_type 0              
         317   load_var 13              (_73)
-        318   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        318   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         319   store_var 14             (_75)
         320   jump +5                  (to 325)
         321   load_var 13              (_73)
-        322   make_bound_method 495    
+        322   make_bound_method 498    
         323   call_indirect            
         324   store_var 14             (_75)
         325   load_var 14              (_75)
@@ -3434,7 +3434,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         330   store_var 15             (name)
 
   568   331   load_var2 3 15           
-        332   call 9 ntypeargs=0       (baml.Array.push)
+        332   call 10 ntypeargs=0      (baml.Array.push)
         333   pop 1                    
         334   jump -103                (to 231)
 
@@ -3447,8 +3447,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 727 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 711 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 730 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 714 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +19               (to 22)
         4    load_var 3             (e)
         5    type_tag               
@@ -3489,7 +3489,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   602   8     load_type 1              
         9     load_var 1               (results)
-        10    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        10    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         11    store_var 7              (_7)
         12    load_var 7               (_7)
         13    is_type 2                
@@ -3533,16 +3533,16 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         51    load_type 1              
         52    load_type 12             
         53    load_var 7               (_7)
-        54    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        54    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         55    store_var 8              (_9)
         56    jump +50                 (to 106)
         57    load_var 7               (_7)
-        58    make_bound_method 507    
+        58    make_bound_method 510    
         59    call_indirect            
         60    store_var 8              (_9)
         61    jump +45                 (to 106)
         62    load_var 7               (_7)
-        63    make_bound_method 516    
+        63    make_bound_method 519    
         64    call_indirect            
         65    store_var 8              (_9)
         66    jump +40                 (to 106)
@@ -3550,39 +3550,39 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         68    load_type 12             
         69    load_type 12             
         70    load_var 7               (_7)
-        71    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        71    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         72    store_var 8              (_9)
         73    jump +33                 (to 106)
         74    load_var 7               (_7)
-        75    make_bound_method 468    
+        75    make_bound_method 471    
         76    call_indirect            
         77    store_var 8              (_9)
         78    jump +28                 (to 106)
         79    load_type 1              
         80    load_var 7               (_7)
-        81    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        81    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         82    store_var 8              (_9)
         83    jump +23                 (to 106)
         84    load_type 1              
         85    load_type 12             
         86    load_type 12             
         87    load_var 7               (_7)
-        88    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        88    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         89    store_var 8              (_9)
         90    jump +16                 (to 106)
         91    load_type 1              
         92    load_type 12             
         93    load_var 7               (_7)
-        94    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        94    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         95    store_var 8              (_9)
         96    jump +10                 (to 106)
         97    load_type 1              
         98    load_var 7               (_7)
-        99    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        99    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         100   store_var 8              (_9)
         101   jump +5                  (to 106)
         102   load_var 7               (_7)
-        103   make_bound_method 495    
+        103   make_bound_method 498    
         104   call_indirect            
         105   store_var 8              (_9)
         106   load_var 8               (_9)
@@ -3606,7 +3606,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         122   load_var 12              (tsr)
         123   load_field 0             (outcome)
         124   load_const 15            ("pass")
-        125   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        125   call 690 ntypeargs=0     (baml.ops.equals_equals)
         126   store_var 13             (ft)
 
   615   127   load_var 12              (tsr)
@@ -3650,7 +3650,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   159   load_var 12              (tsr)
         160   load_field 5             (results)
         161   load_var 13              (ft)
-        162   call 713 ntypeargs=0     (testing.count_leaves)
+        162   call 716 ntypeargs=0     (testing.count_leaves)
         163   store_var 10             (delta)
         164   jump +31                 (to 195)
 
@@ -3659,7 +3659,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   605   167   load_field 0             (outcome)
         168   load_const 16            ("pass")
-        169   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        169   call 690 ntypeargs=0     (baml.ops.equals_equals)
         170   pop_jump_if_false +2     (to 172)
         171   jump +18                 (to 189)
 
@@ -3749,7 +3749,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 721 ntypeargs=0   (testing.glob_match)
+        6   call 724 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -3760,7 +3760,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   637   0    load_var 1             (report)
         1    load_field 0           (outcome)
         2    load_const 0           ("pass")
-        3    call 687 ntypeargs=0   (baml.ops.equals_equals)
+        3    call 690 ntypeargs=0   (baml.ops.equals_equals)
         4    store_var 2            (top_tolerated)
 
   638   5    load_var 1             (report)
@@ -3804,7 +3804,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   37   load_var 1             (report)
         38   load_field 5           (results)
         39   load_var 2             (top_tolerated)
-        40   call 713 ntypeargs=0   (testing.count_leaves)
+        40   call 716 ntypeargs=0   (testing.count_leaves)
         41   store_var 3            (counts)
 
   645   42   load_type 2            
@@ -3814,7 +3814,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   45   load_var 1             (report)
         46   load_field 5           (results)
         47   load_var 5             (messages)
-        48   call 716 ntypeargs=0   (testing.collect_leaf_messages)
+        48   call 719 ntypeargs=0   (testing.collect_leaf_messages)
         49   pop 1                  
 
   648   50   load_var 1             (report)
@@ -3843,7 +3843,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
 function testing.glob_match(subject: string, pattern: string) -> bool {
   489   0     load_var 2              (pattern)
         1     load_const 0            ("*")
-        2     call 137 ntypeargs=0    (baml.String.split)
+        2     call 139 ntypeargs=0    (baml.String.split)
         3     store_var 3             (parts)
 
   490   4     load_var 3              (parts)
@@ -3868,26 +3868,26 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
         20    store_var 6             (last)
 
   496   21    load_var2 1 5           
-        22    call 145 ntypeargs=0    (baml.String.starts_with)
+        22    call 147 ntypeargs=0    (baml.String.starts_with)
         23    unary_op !              
         24    pop_jump_if_false +2    (to 26)
         25    jump +71                (to 96)
 
   497   26    load_var2 1 6           
-        27    call 133 ntypeargs=0    (baml.String.ends_with)
+        27    call 135 ntypeargs=0    (baml.String.ends_with)
         28    unary_op !              
         29    pop_jump_if_false +2    (to 31)
         30    jump +64                (to 94)
 
   498   31    load_var 5              (first)
-        32    call 153 ntypeargs=0    (baml.String.length)
+        32    call 155 ntypeargs=0    (baml.String.length)
         33    store_var 7             (start)
 
   499   34    load_var 1              (subject)
-        35    call 153 ntypeargs=0    (baml.String.length)
+        35    call 155 ntypeargs=0    (baml.String.length)
         36    store_var 9             (_22)
         37    load_var 6              (last)
-        38    call 153 ntypeargs=0    (baml.String.length)
+        38    call 155 ntypeargs=0    (baml.String.length)
         39    store_var 10            (_23)
         40    load_var2 9 10          
         41    sub_int                 
@@ -3923,9 +3923,9 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
   505   65    load_var2 1 11          
         66    load_var 8              (end_limit)
-        67    call 156 ntypeargs=0    (baml.String.substring)
+        67    call 158 ntypeargs=0    (baml.String.substring)
         68    load_var 13             (part)
-        69    call 166 ntypeargs=0    (baml.String.index_of)
+        69    call 168 ntypeargs=0    (baml.String.index_of)
         70    store_var 14            (_38)
         71    load_var 14             (_38)
         72    is_type 2               
@@ -3942,7 +3942,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
         80    add_int                 
         81    store_var 16            (_45)
         82    load_var 13             (part)
-        83    call 153 ntypeargs=0    (baml.String.length)
+        83    call 155 ntypeargs=0    (baml.String.length)
         84    load_var 16             (_45)
         85    add_int                 
         86    store_var 11            (pos)
@@ -3969,14 +3969,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 733 ntypeargs=0   (testing.split_top)
+        1    call 736 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 735 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 738 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +17               (to 26)
 
@@ -3993,7 +3993,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         19   load_field 0           (head)
         20   load_var 4             (split)
         21   load_field 1           (tail)
-        22   call 735 ntypeargs=0   (testing.any_pattern_matches)
+        22   call 738 ntypeargs=0   (testing.any_pattern_matches)
         23   jump +4                (to 27)
 
   541   24   load_const 1           (true)
@@ -4010,7 +4010,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
 
   475   3     load_type 1              
         4     load_var 1               (raw)
-        5     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        5     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 4              (_3)
         7     load_var 4               (_3)
         8     is_type 2                
@@ -4054,16 +4054,16 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         46    load_type 1              
         47    load_type 12             
         48    load_var 4               (_3)
-        49    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        49    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         50    store_var 5              (_5)
         51    jump +50                 (to 101)
         52    load_var 4               (_3)
-        53    make_bound_method 507    
+        53    make_bound_method 510    
         54    call_indirect            
         55    store_var 5              (_5)
         56    jump +45                 (to 101)
         57    load_var 4               (_3)
-        58    make_bound_method 516    
+        58    make_bound_method 519    
         59    call_indirect            
         60    store_var 5              (_5)
         61    jump +40                 (to 101)
@@ -4071,39 +4071,39 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
         63    load_type 12             
         64    load_type 12             
         65    load_var 4               (_3)
-        66    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        66    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         67    store_var 5              (_5)
         68    jump +33                 (to 101)
         69    load_var 4               (_3)
-        70    make_bound_method 468    
+        70    make_bound_method 471    
         71    call_indirect            
         72    store_var 5              (_5)
         73    jump +28                 (to 101)
         74    load_type 1              
         75    load_var 4               (_3)
-        76    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        76    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         77    store_var 5              (_5)
         78    jump +23                 (to 101)
         79    load_type 1              
         80    load_type 12             
         81    load_type 12             
         82    load_var 4               (_3)
-        83    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        83    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         84    store_var 5              (_5)
         85    jump +16                 (to 101)
         86    load_type 1              
         87    load_type 12             
         88    load_var 4               (_3)
-        89    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        89    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         90    store_var 5              (_5)
         91    jump +10                 (to 101)
         92    load_type 1              
         93    load_var 4               (_3)
-        94    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        94    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         95    store_var 5              (_5)
         96    jump +5                  (to 101)
         97    load_var 4               (_3)
-        98    make_bound_method 495    
+        98    make_bound_method 498    
         99    call_indirect            
         100   store_var 5              (_5)
         101   load_var 5               (_5)
@@ -4115,7 +4115,7 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
 
   476   107   load_var 6               (s)
         108   load_const 14            ("::")
-        109   call 166 ntypeargs=0     (baml.String.index_of)
+        109   call 168 ntypeargs=0     (baml.String.index_of)
         110   store_var 7              (_36)
         111   load_var 7               (_36)
         112   is_type 15               
@@ -4125,14 +4125,14 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
   479   115   load_var2 3 6            
         116   load_const 16            ("")
         117   init_instance 0          (testing.FilterPat .func_pat, .test_pat)
-        118   call 9 ntypeargs=0       (baml.Array.push)
+        118   call 10 ntypeargs=0      (baml.Array.push)
         119   pop 1                    
 
   480   120   load_var 3               (out)
         121   load_const 17            ("")
         122   load_var 6               (s)
         123   init_instance 1          (testing.FilterPat .func_pat, .test_pat)
-        124   call 9 ntypeargs=0       (baml.Array.push)
+        124   call 10 ntypeargs=0      (baml.Array.push)
         125   pop 1                    
         126   jump -119                (to 7)
 
@@ -4142,21 +4142,21 @@ function testing.parse_filter_patterns(raw: string[]) -> testing.FilterPat[] {
   477   129   load_var 6               (s)
         130   load_const 15            (0)
         131   load_var 8               (idx)
-        132   call 156 ntypeargs=0     (baml.String.substring)
+        132   call 158 ntypeargs=0     (baml.String.substring)
         133   store_var 9              (_40)
         134   load_var 6               (s)
-        135   call 153 ntypeargs=0     (baml.String.length)
+        135   call 155 ntypeargs=0     (baml.String.length)
         136   store_var 11             (_45)
         137   load_var2 6 8            
         138   load_const 18            (2)
         139   add_int                  
         140   load_var 11              (_45)
-        141   call 156 ntypeargs=0     (baml.String.substring)
+        141   call 158 ntypeargs=0     (baml.String.substring)
         142   store_var 10             (_42)
         143   load_var2 3 9            
         144   load_var 10              (_42)
         145   init_instance 2          (testing.FilterPat .func_pat, .test_pat)
-        146   call 9 ntypeargs=0       (baml.Array.push)
+        146   call 10 ntypeargs=0      (baml.Array.push)
         147   pop 1                    
         148   jump -141                (to 7)
 
@@ -4178,7 +4178,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
 
   369   6     load_type 1             
         7     load_var 1              (children)
-        8     call 480 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
+        8     call 483 ntypeargs=1    (baml.iter.Iterable$for$T[].iter)
         9     store_var 3             (_3)
         10    load_var 3              (_3)
         11    is_type 2               
@@ -4222,16 +4222,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         49    load_type 1             
         50    load_type 12            
         51    load_var 3              (_3)
-        52    call 483 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
+        52    call 486 ntypeargs=2    (baml.iter.Peekable.Iterator.next)
         53    store_var 4             (_5)
         54    jump +50                (to 104)
         55    load_var 3              (_3)
-        56    make_bound_method 507   
+        56    make_bound_method 510   
         57    call_indirect           
         58    store_var 4             (_5)
         59    jump +45                (to 104)
         60    load_var 3              (_3)
-        61    make_bound_method 516   
+        61    make_bound_method 519   
         62    call_indirect           
         63    store_var 4             (_5)
         64    jump +40                (to 104)
@@ -4239,39 +4239,39 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         66    load_type 12            
         67    load_type 12            
         68    load_var 3              (_3)
-        69    call 459 ntypeargs=3    (baml.iter.Filter.Iterator.next)
+        69    call 462 ntypeargs=3    (baml.iter.Filter.Iterator.next)
         70    store_var 4             (_5)
         71    jump +33                (to 104)
         72    load_var 3              (_3)
-        73    make_bound_method 468   
+        73    make_bound_method 471   
         74    call_indirect           
         75    store_var 4             (_5)
         76    jump +28                (to 104)
         77    load_type 1             
         78    load_var 3              (_3)
-        79    call 479 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
+        79    call 482 ntypeargs=1    (baml.iter.Repeat.Iterator.next)
         80    store_var 4             (_5)
         81    jump +23                (to 104)
         82    load_type 1             
         83    load_type 12            
         84    load_type 12            
         85    load_var 3              (_3)
-        86    call 461 ntypeargs=3    (baml.iter.Chain.Iterator.next)
+        86    call 464 ntypeargs=3    (baml.iter.Chain.Iterator.next)
         87    store_var 4             (_5)
         88    jump +16                (to 104)
         89    load_type 1             
         90    load_type 12            
         91    load_var 3              (_3)
-        92    call 471 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
+        92    call 474 ntypeargs=2    (baml.iter.StepBy.Iterator.next)
         93    store_var 4             (_5)
         94    jump +10                (to 104)
         95    load_type 1             
         96    load_var 3              (_3)
-        97    call 503 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
+        97    call 506 ntypeargs=1    (baml.iter.ArrayIterator.Iterator.next)
         98    store_var 4             (_5)
         99    jump +5                 (to 104)
         100   load_var 3              (_3)
-        101   make_bound_method 495   
+        101   make_bound_method 498   
         102   call_indirect           
         103   store_var 4             (_5)
         104   load_var 4              (_5)
@@ -4285,29 +4285,29 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         112   store_deref 5           
 
   370   113   load_var 5              (child)
-        114   make_closure 1247 1     
+        114   make_closure 1251 1     
         115   load_const 14           (null)
         116   load_const 14           (null)
         117   spawn                   
         118   store_var 6             (_38)
         119   load_var2 2 6           
-        120   call 9 ntypeargs=0      (baml.Array.push)
+        120   call 10 ntypeargs=0     (baml.Array.push)
         121   pop 1                   
         122   jump -112               (to 10)
 
   374   123   load_type 15            
         124   load_type 16            
         125   load_var 2              (futures)
-        126   call 526 ntypeargs=2    (baml.future.all_complete)
+        126   call 529 ntypeargs=2    (baml.future.all_complete)
         127   await                   
         128   jump +5                 (to 133)
         129   load_var 7              (e)
         130   throw_if_panic          
 
   375   131   load_const 17           ("unexpected test child failure")
-        132   call 244 ntypeargs=0    (baml.sys.panic)
+        132   call 247 ntypeargs=0    (baml.sys.panic)
 
-  377   133   call 707 ntypeargs=0    (testing.aggregate_reports)
+  377   133   call 710 ntypeargs=0    (testing.aggregate_reports)
         134   return                  
         135   unreachable             
 }
@@ -4319,7 +4319,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
 
   108   3     load_type 1              
         4     load_var 1               (children)
-        5     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        5     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         6     store_var 4              (_4)
         7     load_var 4               (_4)
         8     is_type 2                
@@ -4363,16 +4363,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         46    load_type 1              
         47    load_type 12             
         48    load_var 4               (_4)
-        49    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        49    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         50    store_var 5              (_6)
         51    jump +50                 (to 101)
         52    load_var 4               (_4)
-        53    make_bound_method 507    
+        53    make_bound_method 510    
         54    call_indirect            
         55    store_var 5              (_6)
         56    jump +45                 (to 101)
         57    load_var 4               (_4)
-        58    make_bound_method 516    
+        58    make_bound_method 519    
         59    call_indirect            
         60    store_var 5              (_6)
         61    jump +40                 (to 101)
@@ -4380,39 +4380,39 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         63    load_type 12             
         64    load_type 12             
         65    load_var 4               (_4)
-        66    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        66    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         67    store_var 5              (_6)
         68    jump +33                 (to 101)
         69    load_var 4               (_4)
-        70    make_bound_method 468    
+        70    make_bound_method 471    
         71    call_indirect            
         72    store_var 5              (_6)
         73    jump +28                 (to 101)
         74    load_type 1              
         75    load_var 4               (_4)
-        76    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        76    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         77    store_var 5              (_6)
         78    jump +23                 (to 101)
         79    load_type 1              
         80    load_type 12             
         81    load_type 12             
         82    load_var 4               (_4)
-        83    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        83    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         84    store_var 5              (_6)
         85    jump +16                 (to 101)
         86    load_type 1              
         87    load_type 12             
         88    load_var 4               (_4)
-        89    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        89    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         90    store_var 5              (_6)
         91    jump +10                 (to 101)
         92    load_type 1              
         93    load_var 4               (_4)
-        94    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        94    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         95    store_var 5              (_6)
         96    jump +5                  (to 101)
         97    load_var 4               (_4)
-        98    make_bound_method 495    
+        98    make_bound_method 498    
         99    call_indirect            
         100   store_var 5              (_6)
         101   load_var 5               (_6)
@@ -4430,7 +4430,7 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         111   load_field 0             (name)
         112   load_var 7               (report)
         113   init_instance 0          (testing.NamedChildReport .name, .report)
-        114   call 9 ntypeargs=0       (baml.Array.push)
+        114   call 10 ntypeargs=0      (baml.Array.push)
         115   pop 1                    
 
   111   116   load_var 7               (report)
@@ -4457,16 +4457,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         133   pop 1                    
         134   load_var 8               (outcome)
         135   load_const 15            ("pass")
-        136   call 687 ntypeargs=0     (baml.ops.equals_equals)
+        136   call 690 ntypeargs=0     (baml.ops.equals_equals)
         137   unary_op !               
         138   pop_jump_if_false -131   (to 7)
 
   116   139   load_var 3               (named_results)
-        140   call 707 ntypeargs=0     (testing.aggregate_reports)
+        140   call 710 ntypeargs=0     (testing.aggregate_reports)
         141   jump +3                  (to 144)
 
   121   142   load_var 3               (named_results)
-        143   call 707 ntypeargs=0     (testing.aggregate_reports)
+        143   call 710 ntypeargs=0     (testing.aggregate_reports)
         144   return                   
         145   unreachable              
 }
@@ -4477,7 +4477,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1283 1    
+        4    make_closure 1287 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -4513,17 +4513,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   418   10   load_var 1             (children)
-        11   call 720 ntypeargs=0   (testing.run_children_parallel)
+        11   call 723 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0     load_var 2               (include)
-        1     call 708 ntypeargs=0     (testing.parse_filter_patterns)
+        1     call 711 ntypeargs=0     (testing.parse_filter_patterns)
         2     store_var 5              (inc)
 
   550   3     load_var 3               (exclude)
-        4     call 708 ntypeargs=0     (testing.parse_filter_patterns)
+        4     call 711 ntypeargs=0     (testing.parse_filter_patterns)
         5     store_var 6              (exc)
 
   551   6     load_type 0              
@@ -4531,11 +4531,11 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8     store_var 7              (out)
 
   552   9     load_var 1               (registry)
-        10    call 711 ntypeargs=0     (testing.collect_leaf_names)
+        10    call 714 ntypeargs=0     (testing.collect_leaf_names)
         11    store_var 8              (_7)
         12    load_type 0              
         13    load_var 8               (_7)
-        14    call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        14    call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         15    store_var 9              (_8)
         16    load_var 9               (_8)
         17    is_type 1                
@@ -4579,16 +4579,16 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         55    load_type 0              
         56    load_type 11             
         57    load_var 9               (_8)
-        58    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        58    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         59    store_var 10             (_10)
         60    jump +50                 (to 110)
         61    load_var 9               (_8)
-        62    make_bound_method 507    
+        62    make_bound_method 510    
         63    call_indirect            
         64    store_var 10             (_10)
         65    jump +45                 (to 110)
         66    load_var 9               (_8)
-        67    make_bound_method 516    
+        67    make_bound_method 519    
         68    call_indirect            
         69    store_var 10             (_10)
         70    jump +40                 (to 110)
@@ -4596,39 +4596,39 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         72    load_type 11             
         73    load_type 11             
         74    load_var 9               (_8)
-        75    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        75    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         76    store_var 10             (_10)
         77    jump +33                 (to 110)
         78    load_var 9               (_8)
-        79    make_bound_method 468    
+        79    make_bound_method 471    
         80    call_indirect            
         81    store_var 10             (_10)
         82    jump +28                 (to 110)
         83    load_type 0              
         84    load_var 9               (_8)
-        85    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        85    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         86    store_var 10             (_10)
         87    jump +23                 (to 110)
         88    load_type 0              
         89    load_type 11             
         90    load_type 11             
         91    load_var 9               (_8)
-        92    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        92    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         93    store_var 10             (_10)
         94    jump +16                 (to 110)
         95    load_type 0              
         96    load_type 11             
         97    load_var 9               (_8)
-        98    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        98    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         99    store_var 10             (_10)
         100   jump +10                 (to 110)
         101   load_type 0              
         102   load_var 9               (_8)
-        103   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        103   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         104   store_var 10             (_10)
         105   jump +5                  (to 110)
         106   load_var 9               (_8)
-        107   make_bound_method 495    
+        107   make_bound_method 498    
         108   call_indirect            
         109   store_var 10             (_10)
         110   load_var 10              (_10)
@@ -4639,11 +4639,11 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         115   store_var_load_var 11    (name)
 
   553   116   load_var2 5 6            
-        117   call 736 ntypeargs=0     (testing.leaf_selected)
+        117   call 739 ntypeargs=0     (testing.leaf_selected)
         118   pop_jump_if_false -102   (to 16)
 
   554   119   load_var2 7 11           
-        120   call 9 ntypeargs=0       (baml.Array.push)
+        120   call 10 ntypeargs=0      (baml.Array.push)
         121   pop 1                    
         122   jump -106                (to 16)
 
@@ -4657,7 +4657,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
 function testing.split_top(path: string) -> testing.NameSplit {
   463   0    load_var 1             (path)
         1    load_const 0           ("/")
-        2    call 166 ntypeargs=0   (baml.String.index_of)
+        2    call 168 ntypeargs=0   (baml.String.index_of)
         3    store_var 2            (_2)
         4    load_var 2             (_2)
         5    is_type 1              
@@ -4675,15 +4675,15 @@ function testing.split_top(path: string) -> testing.NameSplit {
   464   14   load_var 1             (path)
         15   load_const 1           (0)
         16   load_var 3             (idx)
-        17   call 156 ntypeargs=0   (baml.String.substring)
+        17   call 158 ntypeargs=0   (baml.String.substring)
         18   load_var 1             (path)
-        19   call 153 ntypeargs=0   (baml.String.length)
+        19   call 155 ntypeargs=0   (baml.String.length)
         20   store_var 4            (_10)
         21   load_var2 1 3          
         22   load_const 3           (1)
         23   add_int                
         24   load_var 4             (_10)
-        25   call 156 ntypeargs=0   (baml.String.substring)
+        25   call 158 ntypeargs=0   (baml.String.substring)
         26   init_instance 1        (testing.NameSplit .head, .tail)
         27   return                 
 }
@@ -4699,7 +4699,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1260 2   
+        8    make_closure 1264 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -4718,7 +4718,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1274 2   
+        9    make_closure 1278 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -4741,7 +4741,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1287 3   
+        13   make_closure 1291 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -4759,7 +4759,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         6     store_var 4              (_3)
         7     load_type 1              
         8     load_var 4               (_3)
-        9     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 5              (_4)
         11    load_var 5               (_4)
         12    is_type 2                
@@ -4803,16 +4803,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         50    load_type 1              
         51    load_type 12             
         52    load_var 5               (_4)
-        53    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 6              (_6)
         55    jump +50                 (to 105)
         56    load_var 5               (_4)
-        57    make_bound_method 507    
+        57    make_bound_method 510    
         58    call_indirect            
         59    store_var 6              (_6)
         60    jump +45                 (to 105)
         61    load_var 5               (_4)
-        62    make_bound_method 516    
+        62    make_bound_method 519    
         63    call_indirect            
         64    store_var 6              (_6)
         65    jump +40                 (to 105)
@@ -4820,39 +4820,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         67    load_type 12             
         68    load_type 12             
         69    load_var 5               (_4)
-        70    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 6              (_6)
         72    jump +33                 (to 105)
         73    load_var 5               (_4)
-        74    make_bound_method 468    
+        74    make_bound_method 471    
         75    call_indirect            
         76    store_var 6              (_6)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 5               (_4)
-        80    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 6              (_6)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 5               (_4)
-        87    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 6              (_6)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 5               (_4)
-        93    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 6              (_6)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 5               (_4)
-        98    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 6              (_6)
         100   jump +5                  (to 105)
         101   load_var 5               (_4)
-        102   make_bound_method 495    
+        102   make_bound_method 498    
         103   call_indirect            
         104   store_var 6              (_6)
         105   load_var 6               (_6)
@@ -4867,10 +4867,10 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         113   load_field 1             (body)
         114   load_var 7               (t)
         115   load_field 2             (runner)
-        116   call 726 ntypeargs=0     (testing.test_child)
+        116   call 729 ntypeargs=0     (testing.test_child)
         117   store_var 8              (_37)
         118   load_var2 3 8            
-        119   call 9 ntypeargs=0       (baml.Array.push)
+        119   call 10 ntypeargs=0      (baml.Array.push)
         120   pop 1                    
         121   jump -110                (to 11)
 
@@ -4880,7 +4880,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         125   store_var 9              (_41)
         126   load_type 14             
         127   load_var 9               (_41)
-        128   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        128   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         129   store_var 10             (_42)
         130   load_var 10              (_42)
         131   is_type 15               
@@ -4924,16 +4924,16 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         169   load_type 14             
         170   load_type 12             
         171   load_var 10              (_42)
-        172   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        172   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         173   store_var 11             (_44)
         174   jump +50                 (to 224)
         175   load_var 10              (_42)
-        176   make_bound_method 507    
+        176   make_bound_method 510    
         177   call_indirect            
         178   store_var 11             (_44)
         179   jump +45                 (to 224)
         180   load_var 10              (_42)
-        181   make_bound_method 516    
+        181   make_bound_method 519    
         182   call_indirect            
         183   store_var 11             (_44)
         184   jump +40                 (to 224)
@@ -4941,39 +4941,39 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         186   load_type 12             
         187   load_type 12             
         188   load_var 10              (_42)
-        189   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        189   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         190   store_var 11             (_44)
         191   jump +33                 (to 224)
         192   load_var 10              (_42)
-        193   make_bound_method 468    
+        193   make_bound_method 471    
         194   call_indirect            
         195   store_var 11             (_44)
         196   jump +28                 (to 224)
         197   load_type 14             
         198   load_var 10              (_42)
-        199   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        199   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         200   store_var 11             (_44)
         201   jump +23                 (to 224)
         202   load_type 14             
         203   load_type 12             
         204   load_type 12             
         205   load_var 10              (_42)
-        206   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        206   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         207   store_var 11             (_44)
         208   jump +16                 (to 224)
         209   load_type 14             
         210   load_type 12             
         211   load_var 10              (_42)
-        212   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        212   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         213   store_var 11             (_44)
         214   jump +10                 (to 224)
         215   load_type 14             
         216   load_var 10              (_42)
-        217   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        217   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         218   store_var 11             (_44)
         219   jump +5                  (to 224)
         220   load_var 10              (_42)
-        221   make_bound_method 495    
+        221   make_bound_method 498    
         222   call_indirect            
         223   store_var 11             (_44)
         224   load_var 11              (_44)
@@ -4984,10 +4984,10 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         229   store_var 12             (ts)
 
   238   230   load_var2 1 12           
-        231   call 734 ntypeargs=0     (testing.testset_child)
+        231   call 737 ntypeargs=0     (testing.testset_child)
         232   store_var 13             (_75)
         233   load_var2 3 13           
-        234   call 9 ntypeargs=0       (baml.Array.push)
+        234   call 10 ntypeargs=0      (baml.Array.push)
         235   pop 1                    
         236   jump -106                (to 130)
 
@@ -5009,7 +5009,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         6     store_var 5              (_4)
         7     load_type 1              
         8     load_var 5               (_4)
-        9     call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        9     call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         10    store_var 6              (_5)
         11    load_var 6               (_5)
         12    is_type 2                
@@ -5053,16 +5053,16 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         50    load_type 1              
         51    load_type 12             
         52    load_var 6               (_5)
-        53    call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        53    call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         54    store_var 7              (_7)
         55    jump +50                 (to 105)
         56    load_var 6               (_5)
-        57    make_bound_method 507    
+        57    make_bound_method 510    
         58    call_indirect            
         59    store_var 7              (_7)
         60    jump +45                 (to 105)
         61    load_var 6               (_5)
-        62    make_bound_method 516    
+        62    make_bound_method 519    
         63    call_indirect            
         64    store_var 7              (_7)
         65    jump +40                 (to 105)
@@ -5070,39 +5070,39 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         67    load_type 12             
         68    load_type 12             
         69    load_var 6               (_5)
-        70    call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        70    call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         71    store_var 7              (_7)
         72    jump +33                 (to 105)
         73    load_var 6               (_5)
-        74    make_bound_method 468    
+        74    make_bound_method 471    
         75    call_indirect            
         76    store_var 7              (_7)
         77    jump +28                 (to 105)
         78    load_type 1              
         79    load_var 6               (_5)
-        80    call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        80    call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         81    store_var 7              (_7)
         82    jump +23                 (to 105)
         83    load_type 1              
         84    load_type 12             
         85    load_type 12             
         86    load_var 6               (_5)
-        87    call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        87    call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         88    store_var 7              (_7)
         89    jump +16                 (to 105)
         90    load_type 1              
         91    load_type 12             
         92    load_var 6               (_5)
-        93    call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        93    call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         94    store_var 7              (_7)
         95    jump +10                 (to 105)
         96    load_type 1              
         97    load_var 6               (_5)
-        98    call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        98    call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         99    store_var 7              (_7)
         100   jump +5                  (to 105)
         101   load_var 6               (_5)
-        102   make_bound_method 495    
+        102   make_bound_method 498    
         103   call_indirect            
         104   store_var 7              (_7)
         105   load_var 7               (_7)
@@ -5114,7 +5114,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   111   load_field 0             (name)
         112   load_var 2               (names)
-        113   call 730 ntypeargs=0     (testing._name_selected)
+        113   call 733 ntypeargs=0     (testing._name_selected)
         114   pop_jump_if_false -103   (to 11)
 
   247   115   load_var 8               (t)
@@ -5123,10 +5123,10 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         118   load_field 1             (body)
         119   load_var 8               (t)
         120   load_field 2             (runner)
-        121   call 726 ntypeargs=0     (testing.test_child)
+        121   call 729 ntypeargs=0     (testing.test_child)
         122   store_var 9              (_40)
         123   load_var2 4 9            
-        124   call 9 ntypeargs=0       (baml.Array.push)
+        124   call 10 ntypeargs=0      (baml.Array.push)
         125   pop 1                    
         126   jump -115                (to 11)
 
@@ -5136,7 +5136,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         130   store_var 10             (_44)
         131   load_type 14             
         132   load_var 10              (_44)
-        133   call 480 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
+        133   call 483 ntypeargs=1     (baml.iter.Iterable$for$T[].iter)
         134   store_var 11             (_45)
         135   load_var 11              (_45)
         136   is_type 15               
@@ -5180,16 +5180,16 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         174   load_type 14             
         175   load_type 12             
         176   load_var 11              (_45)
-        177   call 483 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
+        177   call 486 ntypeargs=2     (baml.iter.Peekable.Iterator.next)
         178   store_var 12             (_47)
         179   jump +50                 (to 229)
         180   load_var 11              (_45)
-        181   make_bound_method 507    
+        181   make_bound_method 510    
         182   call_indirect            
         183   store_var 12             (_47)
         184   jump +45                 (to 229)
         185   load_var 11              (_45)
-        186   make_bound_method 516    
+        186   make_bound_method 519    
         187   call_indirect            
         188   store_var 12             (_47)
         189   jump +40                 (to 229)
@@ -5197,39 +5197,39 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         191   load_type 12             
         192   load_type 12             
         193   load_var 11              (_45)
-        194   call 459 ntypeargs=3     (baml.iter.Filter.Iterator.next)
+        194   call 462 ntypeargs=3     (baml.iter.Filter.Iterator.next)
         195   store_var 12             (_47)
         196   jump +33                 (to 229)
         197   load_var 11              (_45)
-        198   make_bound_method 468    
+        198   make_bound_method 471    
         199   call_indirect            
         200   store_var 12             (_47)
         201   jump +28                 (to 229)
         202   load_type 14             
         203   load_var 11              (_45)
-        204   call 479 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
+        204   call 482 ntypeargs=1     (baml.iter.Repeat.Iterator.next)
         205   store_var 12             (_47)
         206   jump +23                 (to 229)
         207   load_type 14             
         208   load_type 12             
         209   load_type 12             
         210   load_var 11              (_45)
-        211   call 461 ntypeargs=3     (baml.iter.Chain.Iterator.next)
+        211   call 464 ntypeargs=3     (baml.iter.Chain.Iterator.next)
         212   store_var 12             (_47)
         213   jump +16                 (to 229)
         214   load_type 14             
         215   load_type 12             
         216   load_var 11              (_45)
-        217   call 471 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
+        217   call 474 ntypeargs=2     (baml.iter.StepBy.Iterator.next)
         218   store_var 12             (_47)
         219   jump +10                 (to 229)
         220   load_type 14             
         221   load_var 11              (_45)
-        222   call 503 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
+        222   call 506 ntypeargs=1     (baml.iter.ArrayIterator.Iterator.next)
         223   store_var 12             (_47)
         224   jump +5                  (to 229)
         225   load_var 11              (_45)
-        226   make_bound_method 495    
+        226   make_bound_method 498    
         227   call_indirect            
         228   store_var 12             (_47)
         229   load_var 12              (_47)
@@ -5241,15 +5241,15 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   235   load_field 0             (name)
         236   load_var 2               (names)
-        237   call 712 ntypeargs=0     (testing._has_selected_descendant)
+        237   call 715 ntypeargs=0     (testing._has_selected_descendant)
         238   pop_jump_if_false -103   (to 135)
 
   259   239   load_var2 1 13           
         240   load_var 2               (names)
-        241   call 739 ntypeargs=0     (testing.testset_child_selected)
+        241   call 742 ntypeargs=0     (testing.testset_child_selected)
         242   store_var 14             (_80)
         243   load_var2 4 14           
-        244   call 9 ntypeargs=0       (baml.Array.push)
+        244   call 10 ntypeargs=0      (baml.Array.push)
         245   pop 1                    
         246   jump -111                (to 135)
 

--- a/baml_language/crates/bex_vm/src/package_baml/math.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/math.rs
@@ -2,7 +2,7 @@ use bex_vm_types::{Object, ObjectType, Value};
 
 use super::{BamlNamespaceMath, PackageBamlImpl};
 use crate::{
-    BexVm,
+    BexVm, VmPanic,
     errors::{VmBamlError, VmRustFnError},
 };
 
@@ -47,6 +47,17 @@ fn expect_float(vm: &BexVm, value: Value, fn_name: &str, index: usize) -> f64 {
     }
 }
 
+/// Extracts an `i64` from a validated `int[]` element.
+///
+/// `int[].sum()` reaches this native path only after the type system has proven
+/// every element is an `int` (ints are unboxed tagged values, so no heap read is
+/// needed). Any other tag means an invariant was violated upstream.
+fn expect_int(value: Value, fn_name: &str, index: usize) -> i64 {
+    value
+        .as_int()
+        .unwrap_or_else(|| unreachable!("{fn_name}: expected int at index {index}"))
+}
+
 impl BamlNamespaceMath for PackageBamlImpl {
     #[allow(clippy::cast_possible_truncation)]
     fn trunc(value: f64) -> i64 {
@@ -60,6 +71,31 @@ impl BamlNamespaceMath for PackageBamlImpl {
             .enumerate()
             .map(|(index, value)| expect_float(vm, *value, "math.sum", index))
             .sum()
+    }
+
+    /// Returns the arithmetic sum of all values in an `int[]`.
+    ///
+    /// Accumulates left-to-right from `0`, checking the running total against
+    /// the `int` (i63) range at each step so overflow raises `IntegerOverflow`
+    /// exactly like repeated `+` would. Both `acc` and each element are already
+    /// in the i63 range, so the intermediate i64 add never wraps; the meaningful
+    /// bound is the tighter i63 range check. Internal helper backing
+    /// `int[].sum()`; the empty array sums to `0`.
+    fn _sum_int(values: &[Value]) -> Result<i64, VmRustFnError> {
+        let mut acc: i64 = 0;
+        for (index, value) in values.iter().enumerate() {
+            let x = expect_int(*value, "math._sum_int", index);
+            match acc.checked_add(x) {
+                Some(v) if (Value::INT_MIN..=Value::INT_MAX).contains(&v) => acc = v,
+                _ => {
+                    return Err(VmPanic::IntegerOverflow {
+                        message: format!("{acc} + {x} overflows int"),
+                    }
+                    .into());
+                }
+            }
+        }
+        Ok(acc)
     }
 
     /// Returns the arithmetic mean of `values`.


### PR DESCRIPTION
## Summary

Follow-up to B-492 / #3824 (which landed `baml.math.sum`/`mean`/`median` over `float[]` as free functions). This adds the missing **`Array.sum()` method** — the canonical surface the ticket asked for — and extends summation to `int[]`:

- `[1, 2, 3].sum()` → `6` (`int`)
- `[1.0, 2.0, 3.0].sum()` → `6.0` (`float`)

`int` and `float` are distinct types with no widening, so each stays in its own number domain (`int[] -> int`, `float[] -> float`). The `int * 1.0` promotion idiom remains the way to sum integers as floats.

## Design

Method attachment mirrors the existing `Sortable` interface (`comparable.baml`): a small `Summable` interface with an associated `type Sum`, implemented for two **disjoint concrete** receivers.

- `interface Summable { type Sum; function sum(self) -> Sum throws never }`
- `implements Summable for int[]` (`Sum = int`) → delegates to a new internal native `baml.math._sum_int`
- `implements Summable for float[]` (`Sum = float`) → delegates to the existing `baml.math.sum`

Disjoint concrete impls of one interface are already supported (precedent: `Comparable for int` / `for float`), so **no `baml_compiler2_tir` changes** were needed — the change is confined to stdlib decls, one native runtime impl, and regenerated snapshots.

`int[].sum()` accumulates left-to-right and range-checks the running total each step, raising a catchable `baml.panics.IntegerOverflow` on overflow, exactly like repeated `+`. The empty array sums to `0` / `0.0`.

## Changes

- `baml_std/baml/containers.baml` — `Summable` interface + `int[]`/`float[]` impls.
- `baml_std/baml/ns_math/math.baml` — internal `_sum_int(int[]) -> int` decl (`//baml:fallible`).
- `bex_vm/src/package_baml/math.rs` — `_sum_int` runtime impl (checked i63 accumulation).
- `baml_tests/baml_src/ns_arrays/sum.baml` — new tests (int/float: basic, single, empty, negatives, mixed magnitudes; int overflow + boundary).
- Regenerated snapshots (stdlib HIR/TIR/MIR/codegen, package items, bytecode-format index shift, ns_arrays bytecode, and `baml describe` listings) — deltas are only the new `sum`/`Summable`/`_sum_int` surface.

## Verification

- `ns_arrays` BAML tests: 2008 passed, 0 failed (all `.sum()` cases).
- `cargo test -p baml_tests`: 0 failed (after snapshot regen).
- `cargo nextest run` (verification set): 4149 passed, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt`: clean.

Fixes B-637.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sum()` support for arrays of integers and floats.
  * Empty arrays now return `0` for integers and `0.0` for floats.
  * Integer sums now detect overflow and report an error instead of silently wrapping.

* **Tests**
  * Added coverage for integer and float array summation, including edge cases like empty arrays, negative values, and overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->