### PR TITLE
Fix guard-if with parenthesized return expression misparsed as a call (B-622)

### DIFF
--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -638,6 +638,36 @@ impl<'a> Parser<'a> {
             .is_some_and(|t| t.kind == TokenKind::Word)
     }
 
+    /// True when a postfix `(` must NOT be glued onto the expression parsed so
+    /// far as a call, because that expression is *block-terminated* (its last
+    /// real token is `}` — an `if`/`match`/block/loop body) and the `(` opens a
+    /// fresh line.
+    ///
+    /// This is the guard-`if` early-return case (B-622):
+    ///   if (x < 0) { throw ... }
+    ///   (x * 2)
+    /// Without it the parser glues `{ ... }(x * 2)` into a call on the void
+    /// `if` result. Keying on a block-terminating `}` (rather than any callee)
+    /// keeps ordinary multi-line calls — a method chain whose `(` lands on a
+    /// later line than an identifier/`)` callee — parsing as calls, matching
+    /// the deliberately-tested `foo()`-then-`(1)` chained-call behavior. The
+    /// newline requirement keeps same-line `<block>(…)` forms (e.g. an
+    /// immediately-invoked block) untouched.
+    fn newline_separates_block_expr_from_paren(&self) -> bool {
+        self.has_newline_ahead() && self.last_significant_emitted_token_is_block_close()
+    }
+
+    /// Kind-check on the most recently *emitted* significant token: is it a
+    /// closing `}`? Trailing trivia after the current expression has not been
+    /// emitted yet at postfix-decision time, so the last non-trivia token event
+    /// is the final real token of the expression parsed so far.
+    fn last_significant_emitted_token_is_block_close(&self) -> bool {
+        self.events.iter().rev().find_map(|event| match event {
+            Event::Token { kind, .. } if !kind.is_trivia() => Some(*kind),
+            _ => None,
+        }) == Some(SyntaxKind::R_BRACE)
+    }
+
     /// Check if there's a newline before the next non-trivia token.
     /// Comments are treated as trivia for this purpose.
     fn has_newline_ahead(&self) -> bool {
@@ -5811,8 +5841,22 @@ impl<'a> Parser<'a> {
                 self.parse_expr_bp(5); // right_bp = 5 (left associative)
                 self.wrap_events_in_node(lhs_start, SyntaxKind::BINARY_EXPR);
                 self.finish_node();
-            } else if op == TokenKind::LParen {
-                // Function call
+            } else if op == TokenKind::LParen && !self.newline_separates_block_expr_from_paren() {
+                // Function call.
+                //
+                // The `newline_separates_block_expr_from_paren()` guard fixes a
+                // guard-style early return (B-622): a block-terminated
+                // statement whose value is discarded, followed on the *next
+                // line* by a parenthesized expression, must not glue into a
+                // call on that value. For example
+                //   if (x < 0) { throw ... }
+                //   (x * 2)
+                // would otherwise parse as `{ ... }(x * 2)`, invoking the void
+                // `if` result (E0006 "`void` is not a function"). Only the
+                // block-terminated + newline shape is separated (mirroring
+                // Rust's expression-statement rule); ordinary calls whose `(`
+                // sits on a later line than a non-`}` callee — e.g. a method
+                // chain broken across lines by comments — still parse as calls.
                 let lhs_start = self.find_previous_expr_start_after(expr_start);
                 self.wrap_events_in_node(lhs_start, SyntaxKind::CALL_EXPR);
                 self.parse_call_args();
@@ -11623,5 +11667,87 @@ function f() -> int {
 "#;
         let (_root, errors) = parse_source(source);
         assert_no_errors(&errors);
+    }
+
+    #[test]
+    fn guard_if_then_parenthesized_return_on_next_line_is_two_statements() {
+        // Regression (B-622): a guard `if (cond) { throw ... }` with no else,
+        // followed on the next line by a parenthesized return expression, must
+        // parse as TWO statements. Without the newline guard on the postfix
+        // call branch the parser glued `{ ... }(x * 2)` into a call on the void
+        // `if` result, producing a misleading E0006 downstream.
+        let source = r#"function f(x: int) -> int {
+    if (x < 0) { throw baml.errors.InvalidArgument { message: "neg" } }
+    (x * 2)
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        // The `if` and the `(x * 2)` are separate statements: the parenthesized
+        // return must NOT be wrapped in a CALL_EXPR on the if-result.
+        let call_exprs = root
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::CALL_EXPR)
+            .count();
+        assert_eq!(
+            call_exprs, 0,
+            "the parenthesized return must not be parsed as a call on the void `if` result"
+        );
+    }
+
+    #[test]
+    fn call_with_paren_on_same_line_still_parses_as_call() {
+        // The block-close guard must not disturb ordinary calls whose `(`
+        // follows the callee on the same line — including multi-line argument
+        // lists, where the `(` still sits on the callee's line.
+        let source = r#"function f() -> int {
+    let a = g(1, 2)
+    let b = g(
+        3,
+        4,
+    )
+    a + b
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let call_exprs = root
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::CALL_EXPR)
+            .count();
+        assert_eq!(
+            call_exprs, 2,
+            "both same-line and multi-line-argument calls must still parse as calls"
+        );
+    }
+
+    #[test]
+    fn non_block_callee_then_paren_on_next_line_still_chains() {
+        // The B-622 fix keys strictly on a block-terminating `}` callee: a
+        // *non*-block callee (here a call `g()`, ending in `)`) followed by `(`
+        // on the next line must STILL glue into a chained call `g()(1)`. This
+        // preserves the deliberately-tested `foo()`-then-`(1)` behavior and
+        // guards against a future over-broad "newline separates" change.
+        let source = r#"function f(g: () -> (int) -> int) -> int {
+    g()
+    (1)
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        // `g()(1)` is one CALL_EXPR wrapping another (the outer call applies the
+        // returned lambda), so two CALL_EXPR nodes total — the newline did NOT
+        // split them into separate statements.
+        let call_exprs = root
+            .descendants()
+            .filter(|n| n.kind() == SyntaxKind::CALL_EXPR)
+            .count();
+        assert_eq!(
+            call_exprs, 2,
+            "a non-block callee followed by `(` on the next line must still chain as a call"
+        );
     }
 }


### PR DESCRIPTION
## What

A guard `if (cond) { throw ... }` with no `else`, followed on the **next line** by a parenthesized return expression like `(x * 2)`, was rejected with a misleading error:

```baml
function f(x: int) -> int {
    if (x < 0) { throw baml.errors.InvalidArgument { message: "neg" } }
    (x * 2)
}
```

```
error: `void` is not a function — it cannot be called  (E0006)
```

The span underlined the whole `if` block. Adding a `;` after the guard block, or dropping the parens, both worked around it.

## Why

In the Pratt parser's postfix loop (`parse_expr_bp`), the `LParen` (call) branch was unconditional: after parsing the `if` expression it saw the `(` on the next line and glued `{ ... }(x * 2)` into a `CALL_EXPR`, invoking the void `if` result. The tagged-template (`` ` ``) and trailing-`!` branches already guard against gluing across a newline, but the call branch did not.

A blanket "newline separates" guard is wrong here: BAML deliberately supports multi-line calls where the `(` lands on a later line than the callee (e.g. method chains broken by comments), and there is an existing test locking in `foo()`-then-`(1)` as a chained call. Keying only on the newline broke those.

## How

The postfix `(` branch now suppresses the call **only when the expression parsed so far is block-terminated** — its last real token is `}` (an `if`/`match`/block/loop body) — **and** the `(` opens a new line. This mirrors Rust's expression-statement rule and precisely targets the guard-`if` shape while leaving every ordinary call untouched:

- block-terminated callee + newline + `(` → two statements (the fix)
- non-block callee (`foo()`, `items.get`) + newline + `(` → still a chained/multi-line call
- any callee + same-line `(` → still a call (including multi-line argument lists)

Implemented with a small `newline_separates_block_expr_from_paren()` helper that checks `has_newline_ahead()` and whether the last emitted significant token is `}`.

## Tests

Added parser regression tests: the guard-`if` fix (asserts the parenthesized return is not wrapped in a `CALL_EXPR`), same-line and multi-line-argument calls still parse as calls, and a non-block callee followed by `(` on the next line still chains.

Verified via `baml-cli check` that the exact repro now compiles, and that multi-line/chained calls still parse. `cargo test -p baml_tests` passes with **no snapshot changes**; scoped `cargo clippy -p baml_compiler_parser --all-targets -- -D warnings` and `cargo fmt --check` are clean.

Fixes B-622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of parenthesized expressions after block-ending constructs, so guard-style early returns no longer get incorrectly treated as function calls.
  * Fixed newline handling to distinguish a true next statement from a call continuation.
  * Preserved normal call chaining and same-line function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->