### PR TITLE
Preserve trailing line comment on defer statements in baml fmt (B-629)

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -53,7 +53,64 @@ pub enum Expression {
     /// block they append the `;` that a block-position `return` requires, so the
     /// output round-trips through `RETURN_STMT` (i.e. is idempotent).
     Return(TextRange),
-    Unknown(TextRange),
+    Unknown(UnknownExpr),
+}
+
+/// An unmodeled expression node (e.g. `defer { … }`, `throw e`, `await f`,
+/// `spawn { … }`, `x.as<T>`) that the strong AST does not model and prints
+/// verbatim.
+///
+/// Rather than a single whole-node span, this carries the node's true first and
+/// last *token* ranges. The trivia classifier keys leading/trailing comments to
+/// individual token ranges, so [`Printable::leftmost_token`] /
+/// [`Printable::rightmost_token`] must return those exact token ranges for a
+/// comment to attach and emit. A whole-node span never matches a token key, so
+/// a trailing comment on the node was silently dropped — the `defer` statement
+/// comment-loss bug (B-629). A whole-node span can also begin inside leading
+/// trivia (the parser attaches a preceding comment to the node), which would
+/// re-print that comment verbatim at the wrong indent; [`Self::content_range`]
+/// excludes it.
+#[derive(Debug)]
+pub struct UnknownExpr {
+    /// Range of the first non-trivia token — the leading-trivia anchor.
+    first_token: TextRange,
+    /// Range of the last non-trivia token — the trailing-trivia anchor.
+    last_token: TextRange,
+}
+
+impl UnknownExpr {
+    /// Build from the unmodeled syntax element, capturing its first and last
+    /// non-trivia token ranges. Any leading/trailing trivia that the CST
+    /// attaches inside the node is skipped so the anchors line up with the
+    /// classifier's per-token comment keys.
+    fn from_element(elem: &SyntaxElement) -> Self {
+        if let Some(node) = elem.as_node() {
+            let mut tokens = node
+                .descendants_with_tokens()
+                .filter_map(rowan::NodeOrToken::into_token)
+                .filter(|t| !t.kind().is_trivia());
+            if let Some(first) = tokens.next() {
+                let first_token = first.text_range();
+                let last_token = tokens.last().map_or(first_token, |t| t.text_range());
+                return UnknownExpr {
+                    first_token,
+                    last_token,
+                };
+            }
+        }
+        // A bare token, or a node with only trivia: the whole span is the token.
+        let whole = elem.text_range();
+        UnknownExpr {
+            first_token: whole,
+            last_token: whole,
+        }
+    }
+
+    /// The verbatim source span to print: from the first token to the last,
+    /// excluding any leading/trailing trivia the CST folded into the node.
+    fn content_range(&self) -> TextRange {
+        TextRange::new(self.first_token.start(), self.last_token.end())
+    }
 }
 
 impl Expression {
@@ -144,7 +201,7 @@ impl FromCST for Expression {
             }
             SyntaxKind::LAMBDA_EXPR => Expression::Lambda(Box::new(LambdaExpr::from_cst(elem)?)),
             SyntaxKind::RETURN_EXPR => Expression::Return(elem.text_range()),
-            _ => Expression::Unknown(elem.text_range()),
+            _ => Expression::Unknown(UnknownExpr::from_element(&elem)),
         };
         Ok(expr)
     }
@@ -194,14 +251,14 @@ impl Expression {
             Expression::ByteString(bs) => Some(usize::from(bs.span().len())),
             Expression::Lambda(_) => None,
             Expression::Return(_) => None,
-            Expression::Unknown(range) => {
+            Expression::Unknown(unknown) => {
                 // Unmodeled nodes (e.g. `await f`, `x.as<T>`, `spawn { … }`,
                 // `throw e`) print their source verbatim (see `print`). When that
                 // text is a single line it occupies a known width and can sit
                 // inline like any other fitting expression. Reporting `None` here
                 // used to force every *enclosing* expression to wrap even when the
                 // whole thing fit the width budget (B-231).
-                let text = &input.input[*range];
+                let text = &input.input[unknown.content_range()];
                 if text.contains('\n') {
                     None
                 } else {
@@ -258,10 +315,11 @@ impl Printable for Expression {
             // unknown node (`await f`, `x.as<T>`, …) must not claim to be
             // multi-line, or it force-wraps its parents even when everything fits
             // on one line (B-231).
-            Expression::Unknown(range) => {
-                printer.print_input_range_trimmed_start(*range);
+            Expression::Unknown(unknown) => {
+                let range = unknown.content_range();
+                printer.print_input_range_trimmed_start(range);
                 PrintInfo {
-                    multi_lined: printer.input[*range].contains('\n'),
+                    multi_lined: printer.input[range].contains('\n'),
                 }
             }
         }
@@ -294,7 +352,8 @@ impl Printable for Expression {
             Expression::BacktickString(bt) => bt.leftmost_token(),
             Expression::ByteString(bs) => bs.leftmost_token(),
             Expression::Lambda(lambda) => lambda.leftmost_token(),
-            Expression::Return(range) | Expression::Unknown(range) => *range,
+            Expression::Return(range) => *range,
+            Expression::Unknown(unknown) => unknown.first_token,
         }
     }
     fn rightmost_token(&self) -> TextRange {
@@ -325,7 +384,8 @@ impl Printable for Expression {
             Expression::BacktickString(bt) => bt.rightmost_token(),
             Expression::ByteString(bs) => bs.rightmost_token(),
             Expression::Lambda(lambda) => lambda.rightmost_token(),
-            Expression::Return(range) | Expression::Unknown(range) => *range,
+            Expression::Return(range) => *range,
+            Expression::Unknown(unknown) => unknown.last_token,
         }
     }
 }

--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -47,18 +47,20 @@ pub enum Expression {
     ByteString(t::ByteString),
     Lambda(Box<LambdaExpr>),
     /// A braceless `return …` in expression position (a `RETURN_EXPR`, e.g. a
-    /// `catch`/`match` arm value like `_ => return 0`). Held as a raw text range
-    /// like [`Expression::Unknown`], but kept as a distinct variant so the arm
-    /// printers can recognize it: when they wrap a braceless arm body into a
-    /// block they append the `;` that a block-position `return` requires, so the
-    /// output round-trips through `RETURN_STMT` (i.e. is idempotent).
-    Return(TextRange),
-    Unknown(UnknownExpr),
+    /// `catch`/`match` arm value like `_ => return 0`). Printed verbatim, like
+    /// [`Expression::Unknown`] and backed by the same [`VerbatimSpan`], but kept
+    /// as a distinct variant so the arm printers can recognize it: when they wrap
+    /// a braceless arm body into a block they append the `;` that a block-position
+    /// `return` requires, so the output round-trips through `RETURN_STMT` (i.e. is
+    /// idempotent).
+    Return(VerbatimSpan),
+    Unknown(VerbatimSpan),
 }
 
-/// An unmodeled expression node (e.g. `defer { … }`, `throw e`, `await f`,
-/// `spawn { … }`, `x.as<T>`) that the strong AST does not model and prints
-/// verbatim.
+/// A node the strong AST does not model and prints verbatim: an unmodeled
+/// expression (e.g. `defer { … }`, `throw e`, `await f`, `spawn { … }`,
+/// `x.as<T>`) held as [`Expression::Unknown`], or a braceless `return …` held as
+/// [`Expression::Return`].
 ///
 /// Rather than a single whole-node span, this carries the node's true first and
 /// last *token* ranges. The trivia classifier keys leading/trailing comments to
@@ -66,21 +68,22 @@ pub enum Expression {
 /// [`Printable::rightmost_token`] must return those exact token ranges for a
 /// comment to attach and emit. A whole-node span never matches a token key, so
 /// a trailing comment on the node was silently dropped — the `defer` statement
-/// comment-loss bug (B-629). A whole-node span can also begin inside leading
-/// trivia (the parser attaches a preceding comment to the node), which would
-/// re-print that comment verbatim at the wrong indent; [`Self::content_range`]
-/// excludes it.
+/// comment-loss bug (B-629), and the same class of bug for a braceless `return`
+/// arm. A whole-node span can also begin inside leading trivia (the parser
+/// attaches a preceding comment to the node), which would re-print that comment
+/// verbatim at the wrong indent; the `content_range` used for printing excludes
+/// it.
 #[derive(Debug)]
-pub struct UnknownExpr {
+pub struct VerbatimSpan {
     /// Range of the first non-trivia token — the leading-trivia anchor.
     first_token: TextRange,
     /// Range of the last non-trivia token — the trailing-trivia anchor.
     last_token: TextRange,
 }
 
-impl UnknownExpr {
-    /// Build from the unmodeled syntax element, capturing its first and last
-    /// non-trivia token ranges. Any leading/trailing trivia that the CST
+impl VerbatimSpan {
+    /// Build from the verbatim-printed syntax element, capturing its first and
+    /// last non-trivia token ranges. Any leading/trailing trivia that the CST
     /// attaches inside the node is skipped so the anchors line up with the
     /// classifier's per-token comment keys.
     fn from_element(elem: &SyntaxElement) -> Self {
@@ -92,7 +95,7 @@ impl UnknownExpr {
             if let Some(first) = tokens.next() {
                 let first_token = first.text_range();
                 let last_token = tokens.last().map_or(first_token, |t| t.text_range());
-                return UnknownExpr {
+                return VerbatimSpan {
                     first_token,
                     last_token,
                 };
@@ -100,7 +103,7 @@ impl UnknownExpr {
         }
         // A bare token, or a node with only trivia: the whole span is the token.
         let whole = elem.text_range();
-        UnknownExpr {
+        VerbatimSpan {
             first_token: whole,
             last_token: whole,
         }
@@ -200,8 +203,8 @@ impl FromCST for Expression {
                 t::ByteString::from_cst(elem).map(Expression::ByteString)?
             }
             SyntaxKind::LAMBDA_EXPR => Expression::Lambda(Box::new(LambdaExpr::from_cst(elem)?)),
-            SyntaxKind::RETURN_EXPR => Expression::Return(elem.text_range()),
-            _ => Expression::Unknown(UnknownExpr::from_element(&elem)),
+            SyntaxKind::RETURN_EXPR => Expression::Return(VerbatimSpan::from_element(&elem)),
+            _ => Expression::Unknown(VerbatimSpan::from_element(&elem)),
         };
         Ok(expr)
     }
@@ -306,8 +309,8 @@ impl Printable for Expression {
             // they wrap this into a block (see `CatchArm`/`MatchArm`). A braceless
             // `return` only appears as a whole arm value, never nested inside
             // another expression, so it always reports multi-lined.
-            Expression::Return(range) => {
-                printer.print_input_range_trimmed_start(*range);
+            Expression::Return(ret) => {
+                printer.print_input_range_trimmed_start(ret.content_range());
                 PrintInfo::default_multi_lined()
             }
             // Unmodeled nodes print their source verbatim. Report `multi_lined`
@@ -352,7 +355,7 @@ impl Printable for Expression {
             Expression::BacktickString(bt) => bt.leftmost_token(),
             Expression::ByteString(bs) => bs.leftmost_token(),
             Expression::Lambda(lambda) => lambda.leftmost_token(),
-            Expression::Return(range) => *range,
+            Expression::Return(ret) => ret.first_token,
             Expression::Unknown(unknown) => unknown.first_token,
         }
     }
@@ -384,7 +387,7 @@ impl Printable for Expression {
             Expression::BacktickString(bt) => bt.rightmost_token(),
             Expression::ByteString(bs) => bs.rightmost_token(),
             Expression::Lambda(lambda) => lambda.rightmost_token(),
-            Expression::Return(range) => *range,
+            Expression::Return(ret) => ret.last_token,
             Expression::Unknown(unknown) => unknown.last_token,
         }
     }
@@ -1823,6 +1826,24 @@ impl MatchArm {
     }
 }
 
+/// Print an arm body that is being wrapped into a `{ … }` block (the `{` and
+/// newline are already emitted; the caller emits the closing `}`).
+///
+/// `arm_indent` is the arm's own indent; the body is printed one level deeper.
+/// A braceless `return` body additionally gets its statement `;` — and its
+/// trailing trivia is deliberately left for the arm level so a same-line comment
+/// stays attached to the arm (emitted after the wrapped `},`) instead of being
+/// split from the `;` or dropped/duplicated when the arm has no comma (B-629).
+fn print_wrapped_arm_body(printer: &mut Printer, body: &Expression, arm_indent: usize) {
+    let inner_indent = arm_indent + printer.config.indent_width;
+    if matches!(body, Expression::Return(_)) {
+        printer.print_standalone_leading_and_body(body, inner_indent);
+        printer.print_str(";");
+    } else {
+        printer.print_standalone_with_trivia(body, inner_indent);
+    }
+}
+
 impl Printable for MatchArm {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         let condition_info = self.print_condition(&shape, printer);
@@ -1846,15 +1867,7 @@ impl Printable for MatchArm {
                 // put the body in a block expression
                 printer.print_str("{");
                 printer.print_newline();
-                printer.print_standalone_with_trivia(
-                    &self.body,
-                    shape.indent + printer.config.indent_width,
-                );
-                // A braceless `return` wrapped into a block needs its statement
-                // `;` so the output round-trips through `RETURN_STMT`.
-                if matches!(&self.body, Expression::Return(_)) {
-                    printer.print_str(";");
-                }
+                print_wrapped_arm_body(printer, &self.body, shape.indent);
                 printer.print_newline();
                 printer.print_spaces(shape.indent);
                 printer.print_str("},");
@@ -1911,15 +1924,7 @@ impl Printable for MatchArm {
             // create a block expression around it
             printer.print_str("{");
             printer.print_newline();
-            printer.print_standalone_with_trivia(
-                &self.body,
-                shape.indent + printer.config.indent_width,
-            );
-            // A braceless `return` wrapped into a block needs its statement `;`
-            // so the output round-trips through `RETURN_STMT`.
-            if matches!(&self.body, Expression::Return(_)) {
-                printer.print_str(";");
-            }
+            print_wrapped_arm_body(printer, &self.body, shape.indent);
             printer.print_newline();
             printer.print_spaces(shape.indent);
             printer.print_str("},");
@@ -2310,15 +2315,7 @@ impl Printable for CatchArm {
         if try_body_info.multi_lined || try_body.len() > line_len_remaining {
             printer.print_str("{");
             printer.print_newline();
-            printer.print_standalone_with_trivia(
-                &self.body,
-                shape.indent + printer.config.indent_width,
-            );
-            // A braceless `return` wrapped into a block needs its statement `;`
-            // so the output round-trips through `RETURN_STMT` (idempotent).
-            if matches!(&self.body, Expression::Return(_)) {
-                printer.print_str(";");
-            }
+            print_wrapped_arm_body(printer, &self.body, shape.indent);
             printer.print_newline();
             printer.print_spaces(shape.indent);
             printer.print_str("}");

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -977,3 +977,56 @@ mod over_split_regression_tests {
         assert_formats_to(source, source);
     }
 }
+
+#[cfg(test)]
+mod defer_comment_tests {
+    //! Regression tests for B-629: `baml fmt` silently deleted the trailing
+    //! line-comment on a `defer { … }` statement while an identical comment on a
+    //! normal statement survived. A `defer` statement is an unmodeled node held
+    //! as [`crate::ast::Expression::Unknown`] and printed verbatim; it used to
+    //! report the whole node span as its leftmost/rightmost token, but the trivia
+    //! classifier keys comments to individual *token* ranges, so the comment
+    //! attached to the closing `}` token never matched and was dropped. The fix
+    //! anchors the node's leading/trailing trivia to its true first/last tokens.
+
+    use super::*;
+
+    fn assert_formats_to(source: &str, expected: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert_eq!(
+            formatted, expected,
+            "formatter output didn't match expected\n--- got ---\n{formatted}\n--- want ---\n{expected}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// The headline case from the ticket: the trailing comment on a `defer`
+    /// statement must survive, exactly like the one on the normal statement.
+    #[test]
+    fn test_defer_trailing_comment_preserved() {
+        let source = "function f() -> string[] {\n  let out: string[] = [];\n  defer { out.push(\"x\") }   // THIS comment on a defer line\n  out.push(\"body\");         // this one on a normal line\n  out\n}\n";
+        let expected = "function f() -> string[] {\n    let out: string[] = [];\n    defer { out.push(\"x\") } // THIS comment on a defer line\n    out.push(\"body\"); // this one on a normal line\n    out\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// A trailing comment on a `defer` that is the last statement in the block
+    /// (no following statement to "absorb" it) is preserved too.
+    #[test]
+    fn test_defer_trailing_comment_last_statement_preserved() {
+        let source = "function f() -> int {\n    defer { cleanup() } // bye\n    42\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    /// A leading comment on its own line before a `defer` is preserved and
+    /// re-indented to the block indent (it used to be printed verbatim as part
+    /// of the node span, keeping its original indentation).
+    #[test]
+    fn test_defer_leading_comment_reindented() {
+        let source = "function f() -> int {\n  // set up cleanup\n  defer { cleanup() }\n  42\n}\n";
+        let expected =
+            "function f() -> int {\n    // set up cleanup\n    defer { cleanup() }\n    42\n}\n";
+        assert_formats_to(source, expected);
+    }
+}

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -1030,3 +1030,57 @@ mod defer_comment_tests {
         assert_formats_to(source, expected);
     }
 }
+
+#[cfg(test)]
+mod return_comment_tests {
+    //! Regression tests for the same comment-loss class as B-629, applied to a
+    //! braceless `return` arm. `return …` in expression position is an unmodeled
+    //! node printed verbatim ([`crate::ast::Expression::Return`]); it used to
+    //! report the whole node span as its rightmost token. When such an arm has no
+    //! trailing comma, the arm's rightmost token delegates to the `return` body,
+    //! so a trailing comment (anchored to the return value's last token) never
+    //! matched and was silently dropped. Anchoring `Return` to its true first/last
+    //! tokens — like the `Unknown` fix — preserves the comment.
+
+    use super::*;
+
+    fn assert_formats_to(source: &str, expected: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert_eq!(
+            formatted, expected,
+            "formatter output didn't match expected\n--- got ---\n{formatted}\n--- want ---\n{expected}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// A trailing comment on a braceless `return` arm with no trailing comma must
+    /// survive. The formatter wraps the arm into `{ return …; }` (its established
+    /// behavior) and keeps the comment at the arm level.
+    #[test]
+    fn test_braceless_return_arm_trailing_comment_no_comma_preserved() {
+        let source = "function f(x: int) -> int {\n    match (x) {\n        0 => 1,\n        _ => return 2 // fallback\n    }\n}\n";
+        let expected = "function f(x: int) -> int {\n    match (x) {\n        0 => 1,\n        _ => {\n            return 2;\n        }, // fallback\n    }\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// Same, but the arm already has a trailing comma. This case never dropped
+    /// the comment, but pins that the wrap + comment placement stays consistent
+    /// with the no-comma case.
+    #[test]
+    fn test_braceless_return_arm_trailing_comment_with_comma_preserved() {
+        let source = "function f(x: int) -> int {\n    match (x) {\n        0 => 1,\n        _ => return 2, // fallback\n    }\n}\n";
+        let expected = "function f(x: int) -> int {\n    match (x) {\n        0 => 1,\n        _ => {\n            return 2;\n        }, // fallback\n    }\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// A braceless `return` arm in a `catch` (no comment) still round-trips —
+    /// guards the shared wrap helper against regressing the existing behavior.
+    #[test]
+    fn test_braceless_return_catch_arm_no_comment_round_trips() {
+        let source = "function f(x: int) -> int {\n    let v = g(x) catch (e) {\n        _ => return -1,\n    };\n    v\n}\n";
+        let expected = "function f(x: int) -> int {\n    let v = g(x) catch (e) {\n        _ => {\n            return -1;\n        },\n    };\n    v\n}\n";
+        assert_formats_to(source, expected);
+    }
+}

--- a/baml_language/crates/baml_fmt/src/printer.rs
+++ b/baml_language/crates/baml_fmt/src/printer.rs
@@ -228,6 +228,27 @@ impl<'a> Printer<'a> {
         self.print_trivia_trailing(trailing_trivia);
     }
 
+    /// Like [`Self::print_standalone_with_trivia`] but omits the trailing trivia,
+    /// leaving it for an enclosing construct to emit.
+    ///
+    /// Used when wrapping a braceless `return` arm into a `{ … ; }` block: the
+    /// statement `;` must sit directly after the expression, and any same-line
+    /// trailing comment belongs to the whole arm (emitted after the wrapped
+    /// `},`). Printing the trailing trivia here would split the comment from its
+    /// `;` and — when the arm has no comma, so the arm's rightmost token *is* the
+    /// return value — duplicate it.
+    pub fn print_standalone_leading_and_body(&mut self, printable: &impl Printable, indent: usize) {
+        let leading_trivia = self.trivia.get_leading_for_element(printable);
+        self.print_trivia_with_newline(leading_trivia, indent);
+        self.print_spaces(indent);
+        let shape = Shape {
+            width: self.config.line_width.saturating_sub(indent),
+            indent,
+            first_line_offset: 0,
+        };
+        self.print(printable, shape);
+    }
+
     /// Checks that all the trivia can fit on a single line (no line comments or block comments containing newlines).
     /// If so, prints all the trivia with no spaces between and returns the length of the trivia.
     ///


### PR DESCRIPTION
## What

`baml fmt` silently **deleted** the trailing line-comment on a `defer { … }` statement, while an identical trailing comment on a normal statement survived. This is source-data loss, distinct from the known fmt over-expansion cluster (B-575/600/602/606).

Repro (before):
```baml
function f() -> string[] {
    let out: string[] = [];
    defer { out.push("x") }   // THIS comment on a defer line
    out.push("body");         // this one on a normal line
    out
}
```
After `baml fmt`, the `// THIS comment on a defer line` was gone; the normal-line comment stayed.

## Why

A `defer` statement (`DEFER_STMT`) is not modeled by the formatter's strong AST, so it is held as `Expression::Unknown` and printed verbatim. `Unknown` reported the **whole node span** as both its `leftmost_token` and `rightmost_token`. But the trivia classifier keys leading/trailing comments to **individual token ranges** (the comment after `defer { … }` is anchored to the closing `}` token). A whole-node span never matches a per-token key, so `get_trailing_for_element` returned nothing and the comment was dropped.

The whole-node span also begins inside leading trivia the CST folds into the node, which is why a leading comment on the line before a `defer` was re-printed verbatim at its original (wrong) indent.

## How

`Expression::Unknown` now carries the node's true first and last **non-trivia token** ranges instead of the whole span:

- `leftmost_token` / `rightmost_token` return those exact token ranges, so leading/trailing comments attach and emit like any normal statement.
- Printing uses a `content_range` (first-token start … last-token end), which excludes any leading/trailing trivia the CST folded into the node — so the leading comment is emitted once (via the trivia path) at the correct indent, not duplicated.

This is a general fix for all unmodeled nodes (`defer`, `throw`, `await`, `spawn`, `x.as<T>`), and it keeps them printed verbatim, so it does not touch the over-expansion behavior.

## Tests

Added `defer_comment_tests` in `baml_fmt`: trailing-comment preservation (ticket repro), trailing comment on a last-statement `defer`, and leading-comment re-indentation — each asserts idempotency. Full `baml_tests` suite passes with zero formatter-snapshot changes.

Fixes B-629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of comments around `defer` statements, preserving both leading and trailing `//` comments and aligning them to canonical indentation/spacing.
  * Refined formatting for unrecognized expressions to better preserve the original source slice, improving line-width decisions and multi-line behavior.
  * Improved wrapping/printing of braceless `return` bodies in match/catch arms so semicolons and inline comments remain correctly attached.

* **Tests**
  * Added regression tests to cover `defer` comment formatting and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->