### PR TITLE
Regression test: cancel-after-GC still settles (B-665)

### DIFF
--- a/baml_language/crates/baml_tests/baml_src/ns_cancel_cascade/cancel_cascade.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_cancel_cascade/cancel_cascade.baml
@@ -48,6 +48,42 @@ test "cancel_from_handle_then_await_catches_cancelled" {
     assert.is_true(baml.deep_equals(cancel_from_handle_then_await_catches_cancelled(), 0))
 }
 
+// B-665 regression: `f.cancel()` must still settle a spawn whose heap `Future`
+// was RELOCATED by a garbage collection between the spawn and the cancel. The
+// cancel reads the future through its (GC-updated) heap pointer and fires a
+// cancel token shared across the collector's clone, so a Gen0 minor GC in the
+// middle must not turn `cancel()` into a no-op. Concretely: spawn a long
+// sleeper, allocate well past the ~10,000-alloc Gen0 `should_collect` threshold
+// (one heap array per iteration) so the next safepoint collects and moves the
+// pending future, hit that safepoint (a 1ms sleep), THEN cancel and `await`.
+// If cancel-after-GC regressed, the future would never settle and `await f`
+// would hang forever; a healthy runtime observes `Cancelled` promptly and the
+// catch yields 0.
+function cancel_after_gc_relocation_still_settles() -> int {
+    let f = spawn { baml.sys.sleep(baml.time.Duration.from_milliseconds(60000n)); 42 };
+
+    // Churn the heap past the Gen0 minor-GC threshold: 20,000 short-lived
+    // array allocations (> the 10,000-alloc trigger) guarantee the collector
+    // relocates the still-pending spawn future at the following safepoint.
+    let sink = 0;
+    let i = 0;
+    while (i < 20000) {
+        let junk = [i, i + 1, i + 2];
+        sink += junk[0];
+        i += 1;
+    }
+    // Safepoint: lets the collector run (allocs-since-GC is now past the
+    // threshold) and move `f` before we cancel it.
+    baml.sys.sleep(baml.time.Duration.from_milliseconds(1n));
+
+    let _ = f.cancel();
+    (await f) catch (e) { baml.panics.Cancelled => 0 }
+}
+
+test "cancel_after_gc_relocation_still_settles" {
+    assert.is_true(baml.deep_equals(cancel_after_gc_relocation_still_settles(), 0))
+}
+
 // State observation: after `waiter` is cancelled mid-await, its Future state
 // must reflect Cancelled (not stay Pending).
 function cancelled_child_future_state_is_cancelled() -> baml.future.FutureState {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
@@ -9,8 +9,14 @@ function cancel_cascade.$init_test_ns_cancel_cascade_cancel_cascade(registry: te
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "cancelled_child_future_state_is_cancelled"
+    load_const "cancel_after_gc_relocation_still_settles"
     make_closure .<lambda($init_test_ns_cancel_cascade_cancel_cascade, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "cancelled_child_future_state_is_cancelled"
+    make_closure .<lambda($init_test_ns_cancel_cascade_cancel_cascade, 2)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -22,6 +28,73 @@ function cancel_cascade.boom_io() -> int {
     load_const "boom"
     init_instance baml.errors.Io .message
     throw
+}
+
+function cancel_cascade.cancel_after_gc_relocation_still_settles() -> int {
+    make_closure .<lambda(cancel_after_gc_relocation_still_settles, 0)>, 0
+    load_const null
+    load_const null
+    spawn
+    store_var _3
+    load_var _3
+    store_var f
+    load_const 0
+    store_var sink
+    load_const 0
+    store_var i
+
+  L0:
+    load_var i
+    load_const 20000
+    cmp_int_op <
+    pop_jump_if_false L1
+    jump L5
+
+  L1:
+    load_const 1n
+    call baml.time.Duration.from_milliseconds
+    sys_op baml.sys.sleep
+    pop 1
+    load_var f
+    call baml.future.Future.cancel
+    pop 1
+    load_var f
+    await
+    jump L4
+    load_var e
+    is_type baml.panics.Cancelled
+    pop_jump_if_false L2
+    jump L3
+
+  L2:
+    load_var e
+    rethrow
+
+  L3:
+    load_const 0
+
+  L4:
+    return
+
+  L5:
+    load_var2 3 4
+    load_var i
+    load_const 1
+    add_int
+    load_var i
+    load_const 2
+    add_int
+    load_type int
+    alloc_array 3
+    load_const 0
+    load_array_element
+    add_int
+    store_var sink
+    load_var i
+    load_const 1
+    add_int
+    store_var i
+    jump L0
 }
 
 function cancel_cascade.cancel_from_handle_then_await_catches_cancelled() -> int {


### PR DESCRIPTION
B-665 was found not reproducible on canary — task.cancel() correctly settles a spawn even after a GC relocates its future. This adds a permanent regression guard. Closes B-665.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new regression test covering cancellation behavior after garbage collection relocates a pending future.
  * Verified that canceling a spawned task still causes it to settle and return the expected canceled result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->