### PR TITLE
Make Server.serve honor task.cancel() (B-681)

### DIFF
--- a/baml_language/crates/baml_tests/baml_src/ns_http_server/http_server.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_http_server/http_server.baml
@@ -185,6 +185,26 @@ test "server_reserve_after_cancel" {
     assert.equal(server_reserve_after_cancel(), "first/second")
 }
 
+// A spawned `serve` honors `task.cancel()` (B-681): the accept loop selects on
+// the future's cancel token, so cancelling stops it and `await task` settles
+// `Cancelled` promptly (a catchable `baml.panics.Cancelled`) rather than hanging.
+// The `fetch` before the cancel proves the server actually came up first.
+function server_serve_honors_cancel() -> int {
+    let server = baml.http.Server.bind("127.0.0.1:0");
+    let task = spawn {
+        server.serve((req: baml.http.Request) -> baml.http.Response {
+            baml.http.Response.new(200, { }, "ok".to_utf8())
+        })
+    };
+    let _ = baml.http.fetch("http://" + server.addr + "/").text();
+    let _ = task.cancel();
+    (await task) catch (e) { baml.panics.Cancelled => 0 }
+}
+
+test "server_serve_honors_cancel" {
+    assert.equal(server_serve_honors_cancel(), 0)
+}
+
 // A bound method used as the handler: `server.serve(greeter.handle)`. Proves the
 // callable path injects the receiver as `self` (so `self.prefix` is visible).
 class Greeter {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/http_server.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/http_server.snap
@@ -51,26 +51,32 @@ function http_server.$init_test_ns_http_server_http_server(registry: testing.Tes
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "server_bound_method_handler"
+    load_const "server_serve_honors_cancel"
     make_closure .<lambda($init_test_ns_http_server_http_server, 8)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "tls_config_new_default_arg"
+    load_const "server_bound_method_handler"
     make_closure .<lambda($init_test_ns_http_server_http_server, 9)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "server_custom_config"
+    load_const "tls_config_new_default_arg"
     make_closure .<lambda($init_test_ns_http_server_http_server, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "tls_config_handshake_timeout_arg"
+    load_const "server_custom_config"
     make_closure .<lambda($init_test_ns_http_server_http_server, 11)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "tls_config_handshake_timeout_arg"
+    make_closure .<lambda($init_test_ns_http_server_http_server, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
@@ -406,6 +412,53 @@ function http_server.server_roundtrip() -> string {
     call baml.future.Future.cancel
     pop 1
     load_var body
+    return
+}
+
+function http_server.server_serve_honors_cancel() -> int {
+    load_var ?1
+    make_cell
+    store_var ?1
+    load_const "127.0.0.1:0"
+    sys_op baml.http.Server.bind
+    store_deref ?1
+    load_var server
+    make_closure .<lambda(server_serve_honors_cancel, 0)>, 1
+    load_const null
+    load_const null
+    spawn
+    store_var _4
+    load_var _4
+    store_var task
+    load_const "http://"
+    load_deref ?1
+    load_field .addr
+    bin_op +
+    load_const "/"
+    bin_op +
+    load_const <omitted>
+    call baml.http.fetch
+    sys_op baml.http.Response.text
+    pop 1
+    load_var task
+    call baml.future.Future.cancel
+    pop 1
+    load_var task
+    await
+    jump L2
+    load_var e
+    is_type baml.panics.Cancelled
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const 0
+
+  L2:
     return
 }
 

--- a/baml_language/crates/sys_native/src/http_server.rs
+++ b/baml_language/crates/sys_native/src/http_server.rs
@@ -33,7 +33,7 @@ use hyper::{
 };
 use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use indexmap::IndexMap;
-use sys_ops::io::{SysOpOutput, VmBamlError, owned};
+use sys_ops::io::{SysOpOutput, VmBamlError, VmPanic, VmRustFnError, owned};
 use sys_types::{AsBexExternalValue, BexExternalValue, CancellationToken, Handle, VmSpawner};
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
@@ -347,11 +347,13 @@ pub(crate) fn bind(addr: String) -> SysOpOutput<owned::http::Server> {
 }
 
 /// Backs `Server.serve`: run the accept loop on the server's already-bound
-/// listener until cancelled. The returned future never resolves on its own; the
-/// sys-op dispatcher drops it on cancellation (serve shutdown), which clears the
-/// "serving" flag (so the `Server` can be served again) and — via the connection
-/// `JoinSet`'s `Drop` — aborts every in-flight connection task. The listener
-/// stays bound (it lives in the `Server`), so the port is retained for a restart.
+/// listener until cancelled. The loop `select!`s on the future's own cancel
+/// token (B-681), so a `task.cancel()` on a spawned `serve` returns `Cancelled`
+/// cooperatively; the sys-op dispatcher would also drop the future on
+/// cancellation, and either path clears the "serving" flag (so the `Server` can
+/// be served again) and — via the connection `JoinSet`'s `Drop` — aborts every
+/// in-flight connection task. The listener stays bound (it lives in the
+/// `Server`), so the port is retained for a restart.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn serve(
     server: owned::http::Server,
@@ -418,6 +420,19 @@ pub(crate) fn serve(
         let mut accept_backoff_ms: u64 = 0;
         loop {
             let accepted = tokio::select! {
+                biased;
+                // B-681: observe the future's own cancel token directly, so a
+                // `task.cancel()` on a spawned `serve` stops the accept loop and
+                // settles `Cancelled` cooperatively — token-based, not relying
+                // solely on the sys-op dispatcher dropping this future. Returning
+                // here drops `conns` (aborting in-flight connections) and
+                // `_serving_guard` (releasing the "serving" flag); the listener
+                // stays bound (it lives in the `Server`), so the port is retained
+                // for a restart. (`biased` checks cancel first every poll so a
+                // hot accept loop can't starve it.)
+                () = cancel.cancelled() => {
+                    return Err(VmRustFnError::Panic(VmPanic::Cancelled));
+                }
                 result = state.listener.accept() => result,
                 // Reap finished connections so the set doesn't grow unbounded;
                 // only polled when there is something to reap.


### PR DESCRIPTION
## What

`baml.http.Server.serve`'s accept loop now `select!`s on the future's own cancel token, so a `task.cancel()` on a spawned `serve` stops the accept loop cooperatively and settles `Cancelled` — token-based, rather than relying solely on the sys-op dispatcher dropping the still-pending future.

```rust
let accepted = tokio::select! {
    biased;
    // B-681: observe the future's own cancel token directly.
    () = cancel.cancelled() => {
        return Err(VmRustFnError::Panic(VmPanic::Cancelled));
    }
    result = state.listener.accept() => result,
    Some(_) = conns.join_next(), if !conns.is_empty() => continue,
};
```

On cancel, returning from `serve` drops `conns` (aborting in-flight connection tasks via `JoinSet`'s `Drop`) and `_serving_guard` (releasing the "serving" flag so the same `Server` can be re-served). The listener stays bound (it lives in the `Server`), so the port is retained for a restart. `biased` checks cancel first on every poll, so a hot accept loop can't starve it.

## How `sleep`'s pattern was mirrored — and an important finding for B-682

`baml.sys.sleep` does **not** observe a cancel token itself. Its cancel-awareness is entirely **engine-wrapped**: the engine races *every* async sys-op's future against the thread cancel token in a biased `tokio::select!` at `bex_engine/src/lib.rs:4423-4427`, and drops the still-pending future when cancel wins. `task.cancel()` fires that exact token (`FutureManager::cancel_future` → `Future::settle_cancelled` → `self.cancel.cancel()`, `bex_vm_types/.../future.rs:450`), and `serve` receives a clone of the same token as its `cancel` argument.

That means **`serve` already honored `task.cancel()` on canary** via the engine's select — verified empirically: after `task.cancel()`, a fresh request to the still-bound port times out (the loop stopped accepting) rather than being serviced. This PR makes `serve` observe its own token **cooperatively** (the explicit, per-op form of that mechanism) instead of depending only on the dispatcher dropping it. On canary the engine's biased cancel arm still wins the outer race and drops the future first, so behavior is unchanged and all existing tests stay green; the change hardens `serve` to be self-sufficient and encodes the token-based-cancellation contract in the op.

This is the tactical, per-op stopgap. Because the general mechanism is already engine-level (the `lib.rs:4423` select), the proper central solution is tracked in **B-682**, which can supersede / remove this per-op arm.

## Test

Added `server_serve_honors_cancel` to `ns_http_server/http_server.baml`: `spawn { server.serve(...) }`, `fetch` (proves the server came up), `task.cancel()`, then `(await task) catch (Cancelled) { 0 }` — asserting the awaiter observes `Cancelled` promptly (not a hang). Mirrors `cancel_from_handle_then_await_catches_cancelled`.

## Verification

- `cargo test -p baml_tests` — 2009 baml tests passed / 0 failed; bytecode snapshot updated for the `http_server` namespace (the added test function only; no stdlib snapshots moved).
- `cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/) and not binary(=pack_e2e)'` — 4152 passed / 0 failed / 33 skipped.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo doc --no-deps --all-features` — succeeds.
- `cargo fmt` — no changes.

Fixes B-681. Note: tactical per-op fix; the general engine-level solution is tracked in B-682.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown behavior so cancellation is handled promptly instead of leaving the server hanging.
  * Confirmed the server can be reached before cancellation and then exits cleanly when stopped.
  * Preserved server restart readiness after cancellation by ensuring cleanup completes correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->