### PR TITLE
Wait for in-flight spawns at end of run, gated on the true top-level root (B-650)

### DIFF
--- a/baml_language/crates/baml_tests/baml_src/ns_cancel_cascade/cancel_cascade.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_cancel_cascade/cancel_cascade.baml
@@ -86,11 +86,18 @@ test "cancel_after_gc_relocation_still_settles" {
 
 // State observation: after `waiter` is cancelled mid-await, its Future state
 // must reflect Cancelled (not stay Pending).
+//
+// B-650: the root now WAITS for outstanding spawns at end of run. Cancelling
+// `waiter` does NOT cascade to its sibling `slow` (cancelling an awaiter does
+// not cancel the awaited future), so `slow`'s 60s sleep would keep the process
+// alive at shutdown. Tear it down explicitly after capturing `waiter`'s state.
 function cancelled_child_future_state_is_cancelled() -> baml.future.FutureState {
     let slow = spawn { baml.sys.sleep(baml.time.Duration.from_milliseconds(60000n)); 42 };
     let waiter = spawn { await slow };
     let _ = waiter.cancel();
-    waiter.state()
+    let observed = waiter.state();
+    let _ = slow.cancel();
+    observed
 }
 
 test "cancelled_child_future_state_is_cancelled" {

--- a/baml_language/crates/baml_tests/baml_src/ns_cancel_cascade/cancel_cascade.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_cancel_cascade/cancel_cascade.baml
@@ -58,7 +58,8 @@ test "cancel_from_handle_then_await_catches_cancelled" {
 // pending future, hit that safepoint (a 1ms sleep), THEN cancel and `await`.
 // If cancel-after-GC regressed, the future would never settle and `await f`
 // would hang forever; a healthy runtime observes `Cancelled` promptly and the
-// catch yields 0.
+// catch yields 0. (This also pins that B-650's end-of-run wait does not stall
+// on the now-cancelled, cancel-aware sleep.)
 function cancel_after_gc_relocation_still_settles() -> int {
     let f = spawn { baml.sys.sleep(baml.time.Duration.from_milliseconds(60000n)); 42 };
 

--- a/baml_language/crates/baml_tests/baml_src/ns_future_methods/future_methods.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_future_methods/future_methods.baml
@@ -30,11 +30,16 @@ test "methods_after_successful_settle" {
 }
 
 // Pending future (long sleep keeps the spawn body parked): state() returns
-// Pending. The orphaned 5s-sleep future is parked and does not block the test.
+// Pending. B-650: the root now WAITS for outstanding spawns at end of run, so
+// this 5s-sleep future can no longer be left orphaned — it would stall
+// shutdown. Capture the Pending state, then cancel it so it settles promptly
+// (a cancelled sleep is interrupted immediately, not run to term).
 function methods_on_pending_future() -> baml.future.FutureState {
     let f = spawn { baml.sys.sleep(baml.time.Duration.from_milliseconds(5000n)); 42 };
     let _ = f.is_settled();
-    f.state()
+    let observed = f.state();
+    let _ = f.cancel();
+    observed
 }
 
 test "methods_on_pending_future" {

--- a/baml_language/crates/baml_tests/baml_src/ns_spawn_throws/spawn_throws.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_spawn_throws/spawn_throws.baml
@@ -62,3 +62,35 @@ function caught_after_sleep_not_double_surfaced_fn() -> int {
 test "caught_after_sleep_not_double_surfaced" {
     assert.is_true(baml.deep_equals(caught_after_sleep_not_double_surfaced_fn(), 99))
 }
+
+// B-650: a *racing* erroring child that IS observed (awaited + caught) with NO
+// sleep must still not double-surface. Without the sleep the child has not run
+// when the `await` lands, so the await itself drives the child (via
+// `future_ready`) and consumes its deferred error into the `catch`. The
+// end-of-run wait then finds this future already settled (not `Pending`) and
+// the drain finds the stash entry already gone — returning the caught value
+// cleanly rather than re-surfacing an already-handled error.
+function racing_caught_not_double_surfaced_fn() -> int {
+    let f = spawn { boom_io_x() };
+    (await f) catch (e) { baml.errors.Io => 99 }
+}
+
+test "racing_caught_not_double_surfaced" {
+    assert.is_true(baml.deep_equals(racing_caught_not_double_surfaced_fn(), 99))
+}
+
+// B-650 negative guard: a *racing* never-awaited spawn (NO sleep) whose body
+// SUCCEEDS must return cleanly. The end-of-run wait drives the still-outstanding
+// child to completion before the root's drain; a child that completes settles
+// `Fulfilled`, so the wait must not false-surface an error or corrupt the
+// returned value. (Positive surfacing of a racing *throw* is a host-level exit-1
+// EngineError that a `test` block cannot observe; it is covered by the Rust
+// engine tests in crates/baml_tests/tests/spawn_semantics.rs.)
+function racing_successful_spawn_returns_cleanly_fn() -> int {
+    let f = spawn { 42 };
+    7
+}
+
+test "racing_successful_spawn_returns_cleanly" {
+    assert.is_true(baml.deep_equals(racing_successful_spawn_returns_cleanly_fn(), 7))
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
@@ -151,5 +151,10 @@ function cancel_cascade.cancelled_child_future_state_is_cancelled() -> baml.futu
     pop 1
     load_var waiter
     call baml.future.Future.state
+    store_var observed
+    load_deref ?1
+    call baml.future.Future.cancel
+    pop 1
+    load_var observed
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
@@ -116,5 +116,10 @@ function future_methods.methods_on_pending_future() -> baml.future.FutureState {
     pop 1
     load_var f
     call baml.future.Future.state
+    store_var observed
+    load_var f
+    call baml.future.Future.cancel
+    pop 1
+    load_var observed
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
@@ -20,6 +20,18 @@ function spawn_throws.$init_test_ns_spawn_throws_spawn_throws(registry: testing.
     load_const null
     call testing.TestCollector.register_test
     pop 1
+    load_var registry
+    load_const "racing_caught_not_double_surfaced"
+    make_closure .<lambda($init_test_ns_spawn_throws_spawn_throws, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "racing_successful_spawn_returns_cleanly"
+    make_closure .<lambda($init_test_ns_spawn_throws_spawn_throws, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
     load_const null
     return
 }
@@ -98,5 +110,40 @@ function spawn_throws.caught_after_sleep_not_double_surfaced_fn() -> int {
     load_const 99
 
   L2:
+    return
+}
+
+function spawn_throws.racing_caught_not_double_surfaced_fn() -> int {
+    make_closure .<lambda(racing_caught_not_double_surfaced_fn, 0)>, 0
+    load_const null
+    load_const null
+    spawn
+    store_var _3
+    load_var _3
+    await
+    jump L2
+    load_var e
+    is_type baml.errors.Io
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const 99
+
+  L2:
+    return
+}
+
+function spawn_throws.racing_successful_spawn_returns_cleanly_fn() -> int {
+    make_closure .<lambda(racing_successful_spawn_returns_cleanly_fn, 0)>, 0
+    load_const null
+    load_const null
+    spawn
+    pop 1
+    load_const 7
     return
 }

--- a/baml_language/crates/baml_tests/tests/spawn_semantics.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_semantics.rs
@@ -5,6 +5,13 @@
 //! exercise the end-of-run drain (B-612): a fire-and-forget child that throws
 //! must surface its error when the root finalizes, and a successful one must
 //! not false-surface.
+//!
+//! The `racing_*` / `*_waited_*` tests exercise the B-650 end-of-run **wait**
+//! (BEP-034 end-of-run amendment): on root exit the runtime WAITS for every
+//! outstanding spawn to run to completion — it does NOT cancel them — so even a
+//! *racing* throw (a child whose task had not been polled when the root
+//! completed) surfaces, and even a delayed throw surfaces (a cancel-at-shutdown
+//! design would have dropped it). `detach` is not exempt from the wait.
 
 use std::time::{Duration, Instant};
 
@@ -112,6 +119,163 @@ async fn never_awaited_detached_spawn_error_surfaces_at_completion() {
         .expect_err("never-awaited detached spawn throw must surface at completion");
     let msg = format!("{err:?}");
     assert!(msg.contains("baml.errors.Io"), "got {msg}");
+}
+
+/// B-650: the fully-*racing* case B-612 scoped out. With NO sleep, the child's
+/// tokio task has not run by the time the root reaches `Complete`, so nothing is
+/// enqueued yet and the B-612 drain alone would exit 0 — dropping the error. The
+/// end-of-run WAIT parks on the still-outstanding child's settle signal first;
+/// the child's body throws (settling `ErrorPending` and enqueuing its error via
+/// the enqueue-before-defer order), so the drain then surfaces it as an
+/// unhandled `baml.errors.Io`. No cancellation is involved.
+#[tokio::test]
+async fn racing_never_awaited_spawn_error_surfaces_at_completion() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn { throw baml.errors.Io { message: "boom" } };
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let err = output
+        .result
+        .expect_err("racing never-awaited spawn throw must surface at completion");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("baml.errors.Io"), "got {msg}");
+}
+
+/// B-650: the racing case with `detach = true`. Per the `detach` contract the
+/// child's unhandled error routes to the *root* task's queue; `detach` is NOT
+/// exempt from the end-of-run wait, so the root waits for it and the racing
+/// throw surfaces at completion just like the default case.
+#[tokio::test]
+async fn racing_never_awaited_detached_spawn_error_surfaces_at_completion() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn with baml.spawn.options(detach = true) {
+                throw baml.errors.Io { message: "boom" }
+            };
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let err = output
+        .result
+        .expect_err("racing never-awaited detached spawn throw must surface at completion");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("baml.errors.Io"), "got {msg}");
+}
+
+/// B-650 negative guard: a *racing* never-awaited child that completes
+/// successfully (no sleep, so the wait actually runs over an outstanding child)
+/// must still return cleanly. The child settles `Fulfilled`, so nothing is
+/// enqueued and the drain finds nothing.
+#[tokio::test]
+async fn racing_never_awaited_successful_spawn_returns_cleanly() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn { 42 };
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let value = output
+        .result
+        .expect("racing successful never-awaited spawn must return cleanly");
+    let BexExternalValue::String(s) = value else {
+        panic!("expected String, got {value:?}");
+    };
+    assert_eq!(s.to_string(), "done");
+}
+
+/// B-650 wait-not-cancel proof: a never-awaited child that *sleeps then throws*
+/// must be waited to completion and surface its error. This is the sharpest
+/// distinction from the rejected cancel-at-shutdown prototype: had the runtime
+/// cancelled outstanding work at exit, the child's `sleep` would settle
+/// `Cancelled` and the throw would never happen (exit 0). Because we WAIT, the
+/// child runs through the sleep, throws, and the error surfaces (exit 1).
+#[tokio::test]
+async fn never_awaited_delayed_throw_is_waited_and_surfaces() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn {
+                baml.sys.sleep(baml.time.Duration.from_milliseconds(200n));
+                throw baml.errors.Io { message: "boom" }
+            };
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let err = output
+        .result
+        .expect_err("delayed never-awaited spawn throw must be waited-for and surface");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("baml.errors.Io"), "got {msg}");
+}
+
+/// B-650 wait-not-cancel proof, detached variant: a never-awaited `detach = true`
+/// child that sleeps then throws is likewise waited to completion (detach is not
+/// exempt from the wait) and its error routes to the root and surfaces.
+#[tokio::test]
+async fn never_awaited_detached_delayed_throw_is_waited_and_surfaces() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn with baml.spawn.options(detach = true) {
+                baml.sys.sleep(baml.time.Duration.from_milliseconds(200n));
+                throw baml.errors.Io { message: "boom" }
+            };
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let err = output
+        .result
+        .expect_err("delayed never-awaited detached spawn throw must be waited-for and surface");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("baml.errors.Io"), "got {msg}");
+}
+
+/// B-650: a finite detached "telemetry flush" style spawn — sleeps briefly then
+/// completes successfully, never awaited — must be waited to completion at exit
+/// (its side effects run) and must NOT false-surface or hang. The root returns
+/// its value cleanly.
+#[tokio::test]
+async fn finite_detached_spawn_is_waited_to_completion() {
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> string {
+            let f = spawn with baml.spawn.options(detach = true) {
+                baml.sys.sleep(baml.time.Duration.from_milliseconds(150n));
+                1
+            };
+            "done"
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = run_compiled(program, "main", IndexMap::new(), false).await;
+    let value = output
+        .result
+        .expect("finite detached spawn must be waited-for and the root return cleanly");
+    let BexExternalValue::String(s) = value else {
+        panic!("expected String, got {value:?}");
+    };
+    assert_eq!(s.to_string(), "done");
 }
 
 /// B-612 negative guard: the end-of-run drain must not false-surface. A

--- a/baml_language/crates/baml_tests/tests/spawn_semantics.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_semantics.rs
@@ -302,3 +302,49 @@ async fn never_awaited_successful_spawn_returns_cleanly() {
     };
     assert_eq!(s.to_string(), "done");
 }
+
+/// B-650 nested-callable misclassification (the `baml test` hang). An HTTP
+/// request handler runs on its own BAML thread via `spawn_with_callable` →
+/// `call_callable`, which — like the genuine top-level root — has
+/// `settles_future == None`. The end-of-run wait must be gated on the *real*
+/// top-level root, NOT on `settles_future.is_none()`: otherwise the handler
+/// thread misclassifies itself as the finalizing root, runs the end-of-run wait,
+/// and parks forever on the still-`Pending` `serve` spawn. The handler never
+/// returns → the HTTP response never sends → `main`'s `fetch` never completes →
+/// `main` never reaches `task.cancel()`, deadlocking the whole run. Guarded by a
+/// wall-clock timeout because the pre-fix failure mode is a hang, not a wrong
+/// value.
+#[tokio::test]
+async fn serve_then_fetch_then_cancel_does_not_hang() {
+    // Compile OUTSIDE the timed region (stdlib compile is seconds and is not
+    // what this test measures).
+    let program = compile_source_with_opt(
+        r#"
+        function main() -> int {
+            let server = baml.http.Server.bind("127.0.0.1:0");
+            let task = spawn {
+                server.serve((req: baml.http.Request) -> baml.http.Response {
+                    baml.http.Response.new(503, { }, "down".to_utf8())
+                })
+            };
+            let resp = baml.http.fetch("http://" + server.addr + "/");
+            task.cancel();
+            resp.status_code
+        }
+        "#,
+        OptLevel::One,
+    );
+    let output = tokio::time::timeout(
+        Duration::from_secs(30),
+        run_compiled(program, "main", IndexMap::new(), false),
+    )
+    .await
+    .expect("serve+fetch+cancel must not hang (B-650 root misclassification)");
+    let value = output
+        .result
+        .expect("serve+fetch+cancel run should succeed");
+    let BexExternalValue::Int(status) = value else {
+        panic!("expected Int status code, got {value:?}");
+    };
+    assert_eq!(status, 503);
+}

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -45,14 +45,23 @@ use ::bex_heap::{
 };
 use ::bex_vm_types::{
     FutureRead, HeapPtr, Object, ObjectType, RootHaver, Value,
-    types::{FutureId, FutureType},
+    types::{FutureId, FutureInternalError, FutureType},
 };
 use ::core::sync::atomic::AtomicUsize;
 use ::std::{collections::HashMap, sync::Arc};
 use ::sys_types::CancellationToken;
-use ::tokio::sync::{Mutex, MutexGuard};
+use ::tokio::sync::{Mutex, MutexGuard, SetOnce};
 
 use crate::EngineError;
+
+/// One outstanding future's `ready` wake handle, snapshotted by
+/// [`FutureManagerGuard::pending_join_handles`] for the end-of-run wait
+/// (B-650). Cloning the `Arc<SetOnce>` lets the engine `.wait()` on the
+/// future's settle **without** consuming its parked fire-and-forget error
+/// (unlike [`FutureManagerGuard::future_ready`]), so the spawner's drain can
+/// still surface that error afterwards. No cancel token is captured: the
+/// end-of-run rule WAITS for outstanding work, it never cancels it.
+pub(crate) type PendingJoinHandle = Arc<SetOnce<Result<(), FutureInternalError>>>;
 
 /// Manages all futures for the Bex engine.
 ///
@@ -418,6 +427,32 @@ impl FutureManagerGuard<'_> {
                 None => Ok(()),
             }
         })
+    }
+
+    /// Snapshot the `ready` wake handle of every strictly-`Pending` future, for
+    /// the end-of-run wait (B-650).
+    ///
+    /// `ErrorPending` futures are deliberately excluded: they have already
+    /// failed (their error is parked engine-side and their `ready` wake has
+    /// already fired), so the spawner's drain surfaces them — waiting again
+    /// would return immediately and they are effectively settled. Ready /
+    /// Cancelled / Error futures are already removed from `active_futures`, so
+    /// they never appear here.
+    ///
+    /// Unlike [`Self::future_ready`], this does **not** consume any deferred
+    /// error: it clones the raw `ready` `Arc` so a joiner can wait for the
+    /// future to settle while leaving the parked error in place for the
+    /// spawner's drain to surface.
+    pub(crate) fn pending_join_handles(&self) -> Vec<PendingJoinHandle> {
+        self.holder()
+            .active_futures
+            .values()
+            .filter_map(|state| {
+                // SAFETY: caller holds the heap permit via `self.proof`.
+                let fut = unsafe { state.future_ref() }.ok()?;
+                matches!(fut.read(), FutureRead::Pending(_)).then(|| Arc::clone(&fut.ready))
+            })
+            .collect()
     }
 }
 impl TlabHolder for FutureManagerGuard<'_> {

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -2365,8 +2365,11 @@ impl BexEngine {
             })
             .collect::<Result<_, EngineError>>()?;
 
-        // Create the root thread (shared heap, own TLAB) and acquire its permit.
-        let mut thread = self.new_root_thread(cancel.clone(), profile_enabled).await;
+        // Create the root thread (shared heap, own TLAB) and acquire its
+        // permit. This named-entry path is the genuine top-level root run.
+        let mut thread = self
+            .new_root_thread(cancel.clone(), profile_enabled, true)
+            .await;
 
         // Reuse the (substituted) `param_types` to thread the expected
         // `RuntimeTy` into per-arg VM conversion. Binding a `HostValue` to an
@@ -2413,11 +2416,16 @@ impl BexEngine {
 
     /// Build a fresh root [`BexThread`] over the shared heap and acquire its
     /// heap permit. Shared by the named-entry (`call_function_bound_args`) and
-    /// callable-entry (`call_callable`) paths.
+    /// callable-entry (`call_callable`) paths. `is_top_level_root` marks the
+    /// genuine top-level entry run so only it runs the B-650 end-of-run wait —
+    /// the named-entry path passes `true`, the callable-entry path (nested
+    /// host-invoked callables such as HTTP handlers) passes `false`. See
+    /// [`BexThread::is_top_level_root`].
     async fn new_root_thread(
         self: &Arc<Self>,
         cancel: CancellationToken,
         profile_enabled: bool,
+        is_top_level_root: bool,
     ) -> ActiveHeapPermit<BexThread> {
         // Globals are shared as a frozen `Arc<[Value]>` — cloning is a refcount bump.
         let vm = BexVm::new(
@@ -2449,7 +2457,7 @@ impl BexEngine {
         // straight-line into run_thread_event_loop, whose every exit path
         // emits the EndThread), and the snapshot at the same spot plus each
         // loop-head resume.
-        let root_thread = BexThread::new_root(vm, cancel);
+        let root_thread = BexThread::new_root(vm, cancel, is_top_level_root);
         let inactive = self.heap_permit_manager.new_permit(root_thread).await;
         inactive.acquire().await
     }
@@ -2649,7 +2657,16 @@ impl BexEngine {
         if cancel.is_cancelled() {
             return Err(cancelled_unhandled_throw());
         }
-        let mut thread = self.new_root_thread(cancel.clone(), profile_enabled).await;
+        // A by-value callable invocation is a NESTED host-invoked run (an HTTP
+        // request handler dispatched via `spawn_with_callable`, or any host
+        // callback), never the genuine top-level entry — even though it, like
+        // the real root, has `settles_future == None`. Marking it non-root keeps
+        // it from running the B-650 end-of-run wait, which would park forever on
+        // the outer run's still-`Pending` `serve` spawn (B-650 `baml test`
+        // hang).
+        let mut thread = self
+            .new_root_thread(cancel.clone(), profile_enabled, false)
+            .await;
 
         // Resolve the handle to the live heap object. The handle keeps it rooted.
         let entry_ptr = self
@@ -4334,7 +4351,22 @@ impl BexEngine {
                     // surfaced (B-612); the fully-racing case exited 0. We
                     // WAIT, never cancel (see
                     // `wait_for_outstanding_child_futures`).
-                    thread = self.wait_for_outstanding_child_futures(thread).await?;
+                    //
+                    // Gate on the GENUINE top-level root, NOT on
+                    // `settles_future.is_none()`: a nested host-invoked callable
+                    // (an HTTP request handler running on its own BAML thread via
+                    // `spawn_with_callable` → `call_callable`) is also a
+                    // `settles_future == None` root, so `settles_future.is_none()`
+                    // alone misclassifies it as the finalizing root. It would then
+                    // run this wait and park forever on the outer run's still-
+                    // `Pending` `serve` spawn — the handler never returns, its HTTP
+                    // response never sends, and the whole run deadlocks upstream of
+                    // cancellation (B-650 `baml test` hang). The shared
+                    // `FutureManager` sees every run's pending futures, so only the
+                    // one true root may drain them.
+                    if thread.vm_thread_is_top_level_root() {
+                        thread = self.wait_for_outstanding_child_futures(thread).await?;
+                    }
 
                     // End-of-run drain: the root task is finalizing without
                     // ever having awaited. Fire-and-forget child errors

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3359,8 +3359,25 @@ impl BexEngine {
         value: Value,
     ) -> Result<(), EngineError> {
         let child_cancel = thread.vm_thread_cancel().clone();
-        let mut guard = self.futures.acquire(thread.proof()).await;
-        let settled_ptr = guard.future_heap_ptr(future_id);
+        let settled_ptr = {
+            let guard = self.futures.acquire(thread.proof()).await;
+            guard.future_heap_ptr(future_id)
+        };
+        // B-650: enqueue the parent-queue entry BEFORE deferring the error.
+        // `defer_error` fires the future's `ready` wake, and the end-of-run
+        // wait (`wait_for_outstanding_child_futures`) parks on that wake. The
+        // wake is set (Release) after this enqueue in program order on this
+        // child thread, and the joiner re-acquires the heap permit (Acquire)
+        // after its wait returns — so the queue entry is guaranteed visible to
+        // the joiner's post-wait drain. Enqueuing AFTER the wake (the previous
+        // order) left a window where the racing waiter saw an empty queue and
+        // dropped the error — the whole point of B-650. This is safe for the
+        // ordinary awaiter path too: the queue entry is only ever *consumed*
+        // (via `future_ready` / `remove_matching`), so its earlier presence
+        // changes nothing.
+        if let Some(ptr) = settled_ptr {
+            thread.vm_thread_notify_parent_of_error(future_id, ptr);
+        }
         // BEP-034 fire-and-forget: DEFER the error instead of settling the
         // heap `Future` to `Error` here. The future stays `Pending` (wake
         // signal fired), so any awaiter — including a sibling task — observes
@@ -3370,12 +3387,11 @@ impl BexEngine {
         // eagerly instead would let a sibling's `await`+`catch` run entirely
         // inside the VM (invisible to the engine), leaving the queue entry to
         // re-surface an already-handled error at the spawner.
-        guard.defer_error(future_id, value)?;
-        drop(guard);
-        child_cancel.cancel();
-        if let Some(ptr) = settled_ptr {
-            thread.vm_thread_notify_parent_of_error(future_id, ptr);
+        {
+            let mut guard = self.futures.acquire(thread.proof()).await;
+            guard.defer_error(future_id, value)?;
         }
+        child_cancel.cancel();
         Ok(())
     }
 
@@ -4042,6 +4058,68 @@ impl BexEngine {
         }
     }
 
+    /// B-650: end-of-run wait. Before the root finalizes, WAIT for every
+    /// outstanding spawned child future to run to completion, so a *racing*
+    /// unhandled error — a `spawn { throw ... }` whose tokio task had not been
+    /// polled yet when the root reached `Complete` — is deterministically
+    /// enqueued before the caller's [`Self::drain_one_pending_child_error`].
+    /// Without this the child's error was silently dropped when the root exited
+    /// 0 (B-612 fixed only the case where the child had ALREADY thrown by the
+    /// time the root completed). Covers both default spawns and `detach = true`
+    /// spawns, whose unhandled errors both route to the root thread's
+    /// `pending_child_errors` queue.
+    ///
+    /// **WAIT, do not cancel** — the Node.js "run until there is no pending
+    /// work" model (BEP-034 end-of-run amendment). We fire no cancel token: a
+    /// prototype that cancelled outstanding work at shutdown was rejected
+    /// because it injected `Cancelled` into legitimate background work (an
+    /// `all_complete` loser whose side effects must finish, a detached
+    /// telemetry flush) and broke the `baml test` harness. So `detach` is NOT
+    /// exempt — a finite detached task runs to completion here like any other
+    /// spawn. A spawn that never settles (never awaited, never cancelled)
+    /// blocks the process at exit; that is the amendment's deliberate red flag
+    /// for a concurrency bug (locate it with tracing), not a case we paper over
+    /// by cancelling. This also preserves the "returning futures is safe"
+    /// guarantee — nothing outstanding is torn down on normal exit.
+    ///
+    /// Loops until no strictly-`Pending` future remains, re-snapshotting to
+    /// catch grandchildren spawned while we waited.
+    ///
+    /// Deadlock-free: the heap permit is released before parking on the settles
+    /// (the wait is a safepoint), mirroring the `Await` arm, so a child task can
+    /// acquire a permit to write the heap and settle its future while we park.
+    /// No lock or permit the children need to make progress is held across the
+    /// wait — the `FutureManager` guard is dropped after the snapshot, and the
+    /// cloned `Arc<SetOnce>` wake handles survive any GC relocation of their
+    /// heap `Future`s (the moved copy shares the same `Arc`).
+    async fn wait_for_outstanding_child_futures(
+        self: &Arc<Self>,
+        mut thread: ActiveHeapPermit<BexThread>,
+    ) -> Result<ActiveHeapPermit<BexThread>, EngineError> {
+        loop {
+            let handles = {
+                let guard = self.futures.acquire(thread.proof()).await;
+                guard.pending_join_handles()
+            };
+            if handles.is_empty() {
+                return Ok(thread);
+            }
+            // Release the heap permit before parking — the wait is the
+            // safepoint (mirrors the `Await` arm). Opportunistically collect
+            // while parked; no permit dance is needed since we're released.
+            let inactive = thread.release();
+            self.maybe_collect_garbage().await;
+            for ready in handles {
+                // `ready` fires on every terminal transition AND on a deferred
+                // (fire-and-forget) error; we only need to know the future
+                // settled, so the payload (an internal-error box surfaced by
+                // the drain / a later `Await`) is discarded here.
+                let _ = ready.wait().await;
+            }
+            thread = inactive.acquire().await;
+        }
+    }
+
     /// Runs a thread's event loop (see [`Self::run_thread_event_loop_inner`])
     /// and closes its profiling lifecycle: one `EndThread` per `StartThread`,
     /// on every exit path (the inner loop has many early returns; thread
@@ -4246,6 +4324,17 @@ impl BexEngine {
                     if cancelled {
                         return Err(cancelled_unhandled_throw());
                     }
+
+                    // B-650: end-of-run wait. The root is finalizing; WAIT for
+                    // any still-outstanding spawned child futures to run to
+                    // completion FIRST, so a racing `spawn { throw ... }` whose
+                    // task had not been polled yet deterministically parks its
+                    // error before the drain below. Without this, only children
+                    // that had ALREADY thrown by the time the root completed
+                    // surfaced (B-612); the fully-racing case exited 0. We
+                    // WAIT, never cancel (see
+                    // `wait_for_outstanding_child_futures`).
+                    thread = self.wait_for_outstanding_child_futures(thread).await?;
 
                     // End-of-run drain: the root task is finalizing without
                     // ever having awaited. Fire-and-forget child errors

--- a/baml_language/crates/bex_engine/src/thread.rs
+++ b/baml_language/crates/bex_engine/src/thread.rs
@@ -114,6 +114,17 @@ pub struct BexThread {
     pub name: Option<String>,
     pub cancel: CancellationToken,
     pub settles_future: Option<FutureId>,
+    /// True ONLY for the genuine top-level entry run — the host's explicit
+    /// `call_function` / `start_run` for the entry expression. Nested
+    /// host-invoked callables (HTTP request handlers and other
+    /// `spawn_with_callable` callbacks, which enter through `call_callable`)
+    /// are also `settles_future == None` roots, so `settles_future.is_none()`
+    /// alone can NOT tell them apart from the real root. Only the real root
+    /// may run the B-650 end-of-run wait; a nested callable that ran it would
+    /// park on the still-`Pending` `serve` spawn of the outer run forever
+    /// (B-650 `baml test` hang). Spawned children set this `false` too, but
+    /// they never reach the wait (they settle a future and return early).
+    pub is_top_level_root: bool,
     /// Queue of errored child futures (heap ptrs) that this thread's
     /// children push onto when they terminate fire-and-forget with an
     /// unhandled throw. Drained at this thread's next engine yield to
@@ -137,14 +148,17 @@ pub struct BexThread {
 impl BexThread {
     /// Build a root thread — no parent, no future to settle. The root's own
     /// `pending_child_errors` queue is also its `root_pending_errors`, so
-    /// detached descendants route their errors back here.
-    pub fn new_root(vm: BexVm, cancel: CancellationToken) -> Self {
+    /// detached descendants route their errors back here. `is_top_level_root`
+    /// is `true` only for the host's genuine entry run and `false` for a nested
+    /// host-invoked callable (see [`BexThread::is_top_level_root`]).
+    pub fn new_root(vm: BexVm, cancel: CancellationToken, is_top_level_root: bool) -> Self {
         let pending = ChildErrorQueue::new();
         Self {
             vm,
             name: None,
             cancel,
             settles_future: None,
+            is_top_level_root,
             pending_child_errors: Arc::clone(&pending),
             parent_pending_errors: None,
             root_pending_errors: pending,
@@ -170,6 +184,9 @@ impl BexThread {
             name,
             cancel,
             settles_future: Some(settles_future),
+            // A spawned child is never the top-level root; regardless, it
+            // settles a future and returns early before the end-of-run wait.
+            is_top_level_root: false,
             pending_child_errors: ChildErrorQueue::new(),
             parent_pending_errors: Some(parent_pending_errors),
             root_pending_errors,
@@ -181,6 +198,15 @@ impl BexThread {
     /// clearly through an `ActiveHeapPermit<BexThread>` deref.
     pub fn vm_thread_settles_future(&self) -> Option<FutureId> {
         self.settles_future
+    }
+
+    /// Whether this is the genuine top-level entry run (see
+    /// [`BexThread::is_top_level_root`]). Only the true root may run the B-650
+    /// end-of-run wait; nested host-invoked callables (also `settles_future ==
+    /// None`) must not. Named with the `vm_thread_` prefix so the call site
+    /// reads clearly through an `ActiveHeapPermit<BexThread>` deref.
+    pub fn vm_thread_is_top_level_root(&self) -> bool {
+        self.is_top_level_root
     }
 
     /// This thread's own cancellation token.


### PR DESCRIPTION
## What

At end of run the runtime now WAITS for in-flight spawned tasks to settle instead of dropping them, so an unhandled error from a never-awaited (fire-and-forget) spawn is surfaced rather than silently lost. This is a follow-up to B-612 (which surfaced unhandled errors from never-awaited spawns): B-612 reported errors that had already settled, and this change additionally waits for spawns still in flight at shutdown so their errors are observed too.

## The top-level-root gate

The end-of-run wait (`wait_for_outstanding_child_futures`) must run ONLY on the genuine top-level root. A nested, host-invoked callable (e.g. an HTTP request handler dispatched via `spawn_with_callable`, or any host callback) also runs with `settles_future == None` and would otherwise be mistaken for the root. If such a nested run ran the wait, it would park forever on the outer run's still-`Pending` `serve` spawn — the `baml test` hang.

To prevent that, `BexThread` gains an `is_top_level_root` marker (with a `vm_thread_is_top_level_root()` getter): `new_child` sets it false; `new_root_thread`/`new_root` take it as a parameter, set true only at the named-entry (`call_function`/`start_run`) path and false at the by-value callable-entry (`call_callable`) path. The end-of-run wait is gated on the getter.

## Tests

- `serve_then_fetch_then_cancel_does_not_hang` (spawn_semantics): serve + fetch + cancel completes without hanging — the key regression signal for the gate.
- B-650 exit-code semantics in spawn_semantics: racing `spawn { throw }; "done"` -> exit 1; delayed never-awaited `spawn { sleep; throw }` -> exit 1; racing success -> exit 0.
- Cancel-after-GC regression coverage in `ns_cancel_cascade` (shared with B-665), plus a teardown fix to `cancelled_child_future_state_is_cancelled` so its sibling sleeper is torn down and does not keep the process alive under the new end-of-run wait.

Fixes B-650.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-of-run behavior so errors from racing, never-awaited, and delayed spawns are deterministically surfaced.
  * Refined cancellation and shutdown handling to prevent hangs by safely waiting for outstanding spawned work before final draining.
  * Addressed timing edge cases that could cause tasks to be double-surfaced or delay completion.
* **Tests**
  * Added regression and Tokio coverage for end-of-run spawn semantics, including detached behavior and cancellation-related hang prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->