### PR TITLE
Fix baml test hang: terminate .env self-referential variable expansion

### DIFF
--- a/engine/baml-runtime/src/cli/dotenv/mod.rs
+++ b/engine/baml-runtime/src/cli/dotenv/mod.rs
@@ -1,7 +1,7 @@
 mod tests;
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env,
     fs::File,
     io::{self, BufReader, Read},
@@ -65,10 +65,13 @@ pub fn load_env_file(path: PathBuf) -> Result<HashMap<String, String>> {
 
 pub fn load_env_from_string(content: &str) -> Result<HashMap<String, String>> {
     let mut env_vars = HashMap::new();
+    // Collect the lines up front: indexing into `content.lines()` on every
+    // iteration would make this O(n^2) in the number of lines.
+    let lines: Vec<&str> = content.lines().collect();
     let mut line_index = 0;
 
-    while line_index < content.lines().count() {
-        let raw_line = content.lines().nth(line_index).unwrap();
+    while line_index < lines.len() {
+        let raw_line = lines[line_index];
         line_index += 1;
 
         let line = raw_line.trim();
@@ -108,8 +111,8 @@ pub fn load_env_from_string(content: &str) -> Result<HashMap<String, String>> {
                 // Continue reading lines until we find the closing quote
                 let mut multiline_complete = false;
 
-                while line_index < content.lines().count() && !multiline_complete {
-                    let next_line = content.lines().nth(line_index).unwrap();
+                while line_index < lines.len() && !multiline_complete {
+                    let next_line = lines[line_index];
                     line_index += 1;
 
                     if next_line.trim().ends_with(quote) {
@@ -166,27 +169,84 @@ fn parse_escaped_chars(input: &str) -> String {
     result
 }
 
-/// Expands variable references in values (like $VAR or ${VAR})
+/// Expands variable references (`$VAR` / `${VAR}`) in every value.
+///
+/// Resolution follows standard `.env`/shell semantics:
+/// - A reference resolves to another variable defined in the same file
+///   (transitively), falling back to the process environment, and is left
+///   literal if neither defines it.
+/// - A self-reference, whether direct (`PATH=$PATH:/foo`) or via a cycle
+///   (`A=$B`, `B=$A`), resolves against the process environment only, never
+///   against the variable's own in-file value. This makes `PATH=$PATH:/foo`
+///   append to the real `PATH` and, crucially, guarantees termination: the old
+///   fixpoint loop expanded a var into its own growing value and looped
+///   forever, doubling memory each pass until the process hung/OOMed.
 fn expand_variables(env_vars: &mut HashMap<String, String>) -> Result<()> {
-    let keys: Vec<String> = env_vars.keys().cloned().collect();
-    let mut changes_made = true;
-    while changes_made {
-        changes_made = false;
-        for key in keys.clone() {
-            let value = env_vars.get(&key).unwrap().clone();
-            let expanded = expand_value(&value, env_vars)?;
-            if expanded != value {
-                env_vars.insert(key, expanded);
-                changes_made = true;
-            }
-        }
+    let raw = env_vars.clone();
+    let mut resolved: HashMap<String, String> = HashMap::new();
+    for key in raw.keys() {
+        let mut in_progress = HashSet::new();
+        resolve_key(key, &raw, &mut resolved, &mut in_progress);
     }
-
+    *env_vars = resolved;
     Ok(())
 }
 
-/// Expands a single value, replacing any variable references
-fn expand_value(value: &str, env_vars: &HashMap<String, String>) -> Result<String> {
+/// Resolves (and memoizes) a single key's value, expanding its references.
+///
+/// `in_progress` holds the keys on the current resolution stack so that a
+/// reference back to one of them is detected as a cycle instead of recursing
+/// forever.
+fn resolve_key(
+    key: &str,
+    raw: &HashMap<String, String>,
+    resolved: &mut HashMap<String, String>,
+    in_progress: &mut HashSet<String>,
+) -> String {
+    if let Some(value) = resolved.get(key) {
+        return value.clone();
+    }
+    let Some(raw_value) = raw.get(key).cloned() else {
+        // Referenced key isn't defined in the file: use the process env, if any.
+        return env::var(key).unwrap_or_default();
+    };
+
+    in_progress.insert(key.to_string());
+    let expanded = expand_value(&raw_value, raw, resolved, in_progress);
+    in_progress.remove(key);
+
+    resolved.insert(key.to_string(), expanded.clone());
+    expanded
+}
+
+/// Resolves a single `$VAR` reference encountered while expanding a value.
+///
+/// Returns `None` (leave the reference literal) when the variable is defined
+/// nowhere. A reference to a key currently being resolved is a cycle and is
+/// resolved against the process environment only.
+fn lookup_var(
+    var_name: &str,
+    raw: &HashMap<String, String>,
+    resolved: &mut HashMap<String, String>,
+    in_progress: &mut HashSet<String>,
+) -> Option<String> {
+    if in_progress.contains(var_name) {
+        // Self-reference / cycle: never recurse into the in-file value.
+        return env::var(var_name).ok();
+    }
+    if raw.contains_key(var_name) {
+        return Some(resolve_key(var_name, raw, resolved, in_progress));
+    }
+    env::var(var_name).ok()
+}
+
+/// Expands a single value, replacing any variable references.
+fn expand_value(
+    value: &str,
+    raw: &HashMap<String, String>,
+    resolved: &mut HashMap<String, String>,
+    in_progress: &mut HashSet<String>,
+) -> String {
     let mut result = String::new();
     let mut chars = value.chars().peekable();
 
@@ -207,17 +267,15 @@ fn expand_value(value: &str, env_vars: &HashMap<String, String>) -> Result<Strin
                     var_name.push(c);
                 }
 
-                // Try to find the variable in our env_vars or system env
-                if let Some(var_value) = env_vars.get(&var_name) {
-                    result.push_str(var_value);
-                } else if let Ok(var_value) = env::var(&var_name) {
-                    result.push_str(&var_value);
-                } else {
-                    // Variable not found, leave as is
-                    result.push('$');
-                    result.push('{');
-                    result.push_str(&var_name);
-                    result.push('}');
+                match lookup_var(&var_name, raw, resolved, in_progress) {
+                    Some(var_value) => result.push_str(&var_value),
+                    None => {
+                        // Variable not found, leave as is
+                        result.push('$');
+                        result.push('{');
+                        result.push_str(&var_name);
+                        result.push('}');
+                    }
                 }
             }
             // Handle $VAR format
@@ -236,15 +294,13 @@ fn expand_value(value: &str, env_vars: &HashMap<String, String>) -> Result<Strin
                     }
                 }
 
-                // Try to find the variable in our env_vars or system env
-                if let Some(var_value) = env_vars.get(&var_name) {
-                    result.push_str(var_value);
-                } else if let Ok(var_value) = env::var(&var_name) {
-                    result.push_str(&var_value);
-                } else {
-                    // Variable not found, leave as is
-                    result.push('$');
-                    result.push_str(&var_name);
+                match lookup_var(&var_name, raw, resolved, in_progress) {
+                    Some(var_value) => result.push_str(&var_value),
+                    None => {
+                        // Variable not found, leave as is
+                        result.push('$');
+                        result.push_str(&var_name);
+                    }
                 }
             } else {
                 result.push('$');
@@ -254,7 +310,7 @@ fn expand_value(value: &str, env_vars: &HashMap<String, String>) -> Result<Strin
         }
     }
 
-    Ok(result)
+    result
 }
 
 /// Loads environment variables from commonly used .env file locations

--- a/engine/baml-runtime/src/cli/dotenv/tests.rs
+++ b/engine/baml-runtime/src/cli/dotenv/tests.rs
@@ -189,6 +189,58 @@ AFTER=after_multiline
         Ok(())
     }
 
+    // Regression: a self-appending variable (`PATH=$PATH:/foo`) must terminate.
+    // The old fixpoint expander re-expanded the variable into its own growing
+    // value and looped forever, doubling memory each pass until the process
+    // hung / OOMed. It must instead append to the *process* value.
+    #[test]
+    fn test_self_reference_does_not_hang() -> Result<()> {
+        env::set_var("BAML_TEST_SELFREF_PATH", "/existing/bin");
+
+        let content = "BAML_TEST_SELFREF_PATH=${BAML_TEST_SELFREF_PATH}:/added/bin\n";
+        let vars = load_env_from_string(content)?;
+
+        assert_eq!(
+            vars.get("BAML_TEST_SELFREF_PATH"),
+            Some(&"/existing/bin:/added/bin".to_string())
+        );
+
+        env::remove_var("BAML_TEST_SELFREF_PATH");
+        Ok(())
+    }
+
+    // A self-append with no matching process variable leaves the reference
+    // literal (lookup returns None) and terminates without growth.
+    #[test]
+    fn test_self_reference_without_process_value_terminates() -> Result<()> {
+        env::remove_var("BAML_TEST_UNSET_SELFREF");
+
+        let content = "BAML_TEST_UNSET_SELFREF=$BAML_TEST_UNSET_SELFREF:/added\n";
+        let vars = load_env_from_string(content)?;
+
+        // No process value: `$BAML_TEST_UNSET_SELFREF` is left literal, no growth.
+        assert_eq!(
+            vars.get("BAML_TEST_UNSET_SELFREF"),
+            Some(&"$BAML_TEST_UNSET_SELFREF:/added".to_string())
+        );
+        Ok(())
+    }
+
+    // A reference cycle between two variables must terminate rather than hang.
+    #[test]
+    fn test_reference_cycle_terminates() -> Result<()> {
+        env::remove_var("BAML_TEST_CYCLE_A");
+        env::remove_var("BAML_TEST_CYCLE_B");
+
+        let content =
+            "BAML_TEST_CYCLE_A=${BAML_TEST_CYCLE_B}\nBAML_TEST_CYCLE_B=${BAML_TEST_CYCLE_A}\n";
+        // The only assertion that matters: this returns instead of hanging.
+        let vars = load_env_from_string(content)?;
+        assert!(vars.contains_key("BAML_TEST_CYCLE_A"));
+        assert!(vars.contains_key("BAML_TEST_CYCLE_B"));
+        Ok(())
+    }
+
     #[test]
     fn test_missing_variable() -> Result<()> {
         let content = r#"


### PR DESCRIPTION
## What

`baml-cli test` (and any command that loads a `.env`) could hang, ballooning memory to tens of GB, when the `.env` file contained a **self-appending variable** such as:

```
PYTHONPATH=$PYTHONPATH:./src
PATH=$PATH:/usr/local/bin
LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/lib
```

Symptom reported: the `Loading environment variables from .env file` warning prints, then the run hangs with **no further output**, RAM climbing to ~57 GB. Present in older versions too (the warning line is new in 0.223; the expansion bug predates it).

## Why

`expand_variables` ran `expand_value` to a fixpoint (`while changes_made`), resolving `$VAR` against the file's **own current value**. A self-reference never reaches a fixpoint — each pass copies the value into itself, so its length **doubles every pass** (~2^n):

```
FOO=x$FOO
pass 30: 1.07 GB
pass 34: 17 GB
pass 35: 34 GB
pass 36: 68 GB  -> thrash / OOM, process wedged
```

Because the pip `baml-cli` runs the Rust CLI in-process via PyO3 (`baml_py:invoke_runtime_cli`), the ballooning process shows up as `python3.10`, and it never reaches any output-producing code — matching "killing it ends the run with no output".

## Fix

Rewrite expansion to standard `.env`/shell semantics: resolve each variable **once** (memoized), with transitive resolution of file-to-file references (`NESTED_VAR -> LOGS_DIR -> BASE_DIR` still works), and break self-reference cycles by resolving against the **process environment only**, never the variable's own in-file value.

- `PATH=$PATH:/foo` now appends to the real `PATH` (the intended behavior).
- Cycles (`A=$B`, `B=$A`) terminate in one bounded pass.

Also collect `content.lines()` once in `load_env_from_string` instead of `.nth(i)`/`.count()` per iteration, removing a latent O(n^2) parse (adjacent, not the hang).

## Tests

New regression tests in `dotenv/tests.rs`:
- self-append terminates and appends to the process value
- self-append with no process value stays literal (no growth)
- an `A<->B` cycle returns instead of hanging

All existing dotenv tests (interpolation, transitive `NESTED_VAR`, complex file, system env) still pass.

## Workaround for affected users
Remove the self-referencing line from `.env` (or any `.env` in a parent dir — the loader walks up to `/`), or run `baml-cli test --dotenv false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `.env` variable interpolation to safely resolve self-references and cyclic references without hanging or unbounded expansion.
  * Missing variables now remain as the original `$VAR`/`${VAR}` text, while process environment values are used when available.
  * Optimized multiline `.env` parsing for more reliable line handling.
* **Tests**
  * Added regression tests for self-referential, unset, and two-variable cyclic interpolation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->