### PR TITLE
CI: retry wasm32 toolchain install so a stalled download can't dequeue PRs

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -576,8 +576,22 @@ jobs:
 
       - name: "Install Rust toolchain"
         run: |
+          set -euo pipefail
           rustup show
-          rustup target add wasm32-unknown-unknown
+          # `rustup target add wasm32` fetches a small (~20MB) std component that
+          # normally installs in seconds. A multi-minute duration means a stalled
+          # download (rustup has no idle timeout), which otherwise burns the whole
+          # job timeout and dequeues the PR from the merge queue. Cap each attempt
+          # well above the normal time and retry on a fresh connection; surface a
+          # genuine outage after 3 tries instead of hanging.
+          for attempt in 1 2 3; do
+            if timeout 300 rustup target add wasm32-unknown-unknown; then
+              break
+            fi
+            echo "::warning::rustup target add wasm32 attempt $attempt stalled/failed; retrying" >&2
+            [ "$attempt" = 3 ] && { echo "::error::rustup target add wasm32 failed after 3 attempts"; exit 1; }
+            sleep 5
+          done
         working-directory: baml_language
 
       - name: "Install sccache and direnv"

--- a/.github/workflows/wasm-pack-tests.reusable.yaml
+++ b/.github/workflows/wasm-pack-tests.reusable.yaml
@@ -33,8 +33,22 @@ jobs:
       # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: |
+          set -euo pipefail
           rustup show
-          rustup target add wasm32-unknown-unknown
+          # `rustup target add wasm32` fetches a small (~20MB) std component that
+          # normally installs in seconds. A multi-minute duration means a stalled
+          # download (rustup has no idle timeout), which otherwise burns the whole
+          # 20-min job timeout and dequeues the PR from the merge queue. Cap each
+          # attempt well above the normal time and retry on a fresh connection;
+          # surface a genuine outage after 3 tries instead of hanging.
+          for attempt in 1 2 3; do
+            if timeout 300 rustup target add wasm32-unknown-unknown; then
+              break
+            fi
+            echo "::warning::rustup target add wasm32 attempt $attempt stalled/failed; retrying" >&2
+            [ "$attempt" = 3 ] && { echo "::error::rustup target add wasm32 failed after 3 attempts"; exit 1; }
+            sleep 5
+          done
         working-directory: baml_language
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Problem
Merge-queue runs intermittently dequeue PRs because `rustup target add wasm32-unknown-unknown` occasionally **stalls** — a silent stuck download (rustup has no idle timeout) — which burns the entire job's `timeout-minutes` and hard-fails. Confirmed on the wasm-pack job that hung 10+ min at exactly that step. The wasm32 std is a small (~20 MB) component that normally installs in **seconds**, so a multi-minute duration is always a stalled connection, never legitimate slowness.

## Fix
Wrap the `rustup target add wasm32` step in a **per-attempt `timeout 300` + 3× retry**, in the two CI reusables that install it: `wasm-pack-tests.reusable.yaml` and `cargo-tests.reusable.yaml` (cargo-test-wasm). A stall now fails one attempt in ≤5 min and retries on a fresh connection instead of hanging the whole job; a genuine outage surfaces cleanly after 3 tries.

The timeout margin is safe: normal success is seconds, so 5 min/attempt is **15–60× headroom** — it can't kill a legitimately-progressing download, only a true stall.

**Why not cache the target?** It's a ~20 MB fast download; caching it *correctly* means caching all of `~/.rustup` (~1 GB, for rustup's component metadata) — a bad trade to skip a ~5 s download. Caching pays off for large dep sets, not this.

## Scope / safety
- Touches **only** the two CI test reusables. **No release workflow is affected** — `release.yml` / `release-baml-language.yml` use a separate set of `build-*-release` / `build2-*-sdk` workflows that never call these files.
- Behavior-preserving: retry/timeout can't change build output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of WASM-related test runs by retrying Rust `wasm32-unknown-unknown` target installation up to 3 times when it fails or times out (with a 300-second cap per attempt).
  * Enhanced feedback during setup by emitting warnings on intermediate failures and a clearer error if all attempts fail.
* **Chores**
  * Strengthened workflow shell behavior and added additional status output during toolchain setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->