### PR TITLE
Fix B-650 end-of-run wait hanging the SDK (scope wait to the run's own non-detached spawns)

### DIFF
--- a/baml_language/crates/baml_tests/tests/spawn_semantics.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_semantics.rs
@@ -8,10 +8,16 @@
 //!
 //! The `racing_*` / `*_waited_*` tests exercise the B-650 end-of-run **wait**
 //! (BEP-034 end-of-run amendment): on root exit the runtime WAITS for every
-//! outstanding spawn to run to completion — it does NOT cancel them — so even a
-//! *racing* throw (a child whose task had not been polled when the root
-//! completed) surfaces, and even a delayed throw surfaces (a cancel-at-shutdown
-//! design would have dropped it). `detach` is not exempt from the wait.
+//! outstanding *non-detached* spawn to run to completion — it does NOT cancel
+//! them — so even a *racing* throw (a child whose task had not been polled when
+//! the root completed) surfaces, and even a delayed throw surfaces (a
+//! cancel-at-shutdown design would have dropped it).
+//!
+//! `detach = true` spawns are EXEMPT from the wait: a detached spawn is
+//! decoupled from its spawner and outlives the run that created it, so the root
+//! does not block on it (the `detached_*` tests below). Blocking on a detached
+//! spawn deadlocked the SDK's long-lived `replay_serve_detached` server, which
+//! returns immediately and is torn down only by a later, separate call.
 
 use std::time::{Duration, Instant};
 
@@ -147,29 +153,42 @@ async fn racing_never_awaited_spawn_error_surfaces_at_completion() {
     assert!(msg.contains("baml.errors.Io"), "got {msg}");
 }
 
-/// B-650: the racing case with `detach = true`. Per the `detach` contract the
-/// child's unhandled error routes to the *root* task's queue; `detach` is NOT
-/// exempt from the end-of-run wait, so the root waits for it and the racing
-/// throw surfaces at completion just like the default case.
+/// B-650 SDK-hang regression: a `detach = true` spawn that NEVER settles (an
+/// infinite sleep, standing in for the SDK's detached `server.serve(...)`) must
+/// NOT block the root's completion. A detached spawn is decoupled from its
+/// spawner and outlives the run, so the end-of-run wait excludes it; the root
+/// returns its value promptly rather than parking forever. Before the fix the
+/// wait treated detached spawns like any other outstanding future and hung —
+/// exactly the deadlock that froze the SDK's `replay_serve_detached` (which
+/// returns immediately and is torn down only by a later, separate bridge call).
+/// Wall-clock timeout-guarded because the pre-fix failure mode is a hang.
 #[tokio::test]
-async fn racing_never_awaited_detached_spawn_error_surfaces_at_completion() {
+async fn detached_infinite_spawn_does_not_block_root_completion() {
     let program = compile_source_with_opt(
         r#"
         function main() -> string {
             let f = spawn with baml.spawn.options(detach = true) {
-                throw baml.errors.Io { message: "boom" }
+                baml.sys.sleep(baml.time.Duration.from_milliseconds(600000n));
+                "never"
             };
             "done"
         }
         "#,
         OptLevel::One,
     );
-    let output = run_compiled(program, "main", IndexMap::new(), false).await;
-    let err = output
+    let output = tokio::time::timeout(
+        Duration::from_secs(30),
+        run_compiled(program, "main", IndexMap::new(), false),
+    )
+    .await
+    .expect("detached infinite spawn must not block root completion (B-650 sdk hang)");
+    let value = output
         .result
-        .expect_err("racing never-awaited detached spawn throw must surface at completion");
-    let msg = format!("{err:?}");
-    assert!(msg.contains("baml.errors.Io"), "got {msg}");
+        .expect("root should return cleanly without waiting on the detached spawn");
+    let BexExternalValue::String(s) = value else {
+        panic!("expected String, got {value:?}");
+    };
+    assert_eq!(s.to_string(), "done");
 }
 
 /// B-650 negative guard: a *racing* never-awaited child that completes
@@ -225,11 +244,15 @@ async fn never_awaited_delayed_throw_is_waited_and_surfaces() {
     assert!(msg.contains("baml.errors.Io"), "got {msg}");
 }
 
-/// B-650 wait-not-cancel proof, detached variant: a never-awaited `detach = true`
-/// child that sleeps then throws is likewise waited to completion (detach is not
-/// exempt from the wait) and its error routes to the root and surfaces.
+/// B-650 detach-is-exempt, delayed variant: a never-awaited `detach = true`
+/// child that sleeps then throws is NOT waited-for. Because a detached spawn is
+/// decoupled from its spawner and outlives the run, the root completes and
+/// returns "done" before the child's delayed throw ever happens — the throw is
+/// then dropped/logged per the detach "route to root, log if root gone"
+/// contract, not surfaced. (Contrast `never_awaited_delayed_throw_is_waited_and_surfaces`,
+/// the non-detached case, which IS waited and surfaces.)
 #[tokio::test]
-async fn never_awaited_detached_delayed_throw_is_waited_and_surfaces() {
+async fn detached_delayed_throw_is_not_waited_and_root_returns_cleanly() {
     let program = compile_source_with_opt(
         r#"
         function main() -> string {
@@ -242,20 +265,27 @@ async fn never_awaited_detached_delayed_throw_is_waited_and_surfaces() {
         "#,
         OptLevel::One,
     );
-    let output = run_compiled(program, "main", IndexMap::new(), false).await;
-    let err = output
+    let output = tokio::time::timeout(
+        Duration::from_secs(30),
+        run_compiled(program, "main", IndexMap::new(), false),
+    )
+    .await
+    .expect("detached delayed throw must not block the root (B-650 detach exemption)");
+    let value = output
         .result
-        .expect_err("delayed never-awaited detached spawn throw must be waited-for and surface");
-    let msg = format!("{err:?}");
-    assert!(msg.contains("baml.errors.Io"), "got {msg}");
+        .expect("root should return cleanly; the detached delayed throw is not waited-for");
+    let BexExternalValue::String(s) = value else {
+        panic!("expected String, got {value:?}");
+    };
+    assert_eq!(s.to_string(), "done");
 }
 
 /// B-650: a finite detached "telemetry flush" style spawn — sleeps briefly then
-/// completes successfully, never awaited — must be waited to completion at exit
-/// (its side effects run) and must NOT false-surface or hang. The root returns
-/// its value cleanly.
+/// completes successfully, never awaited — must NOT block the root or
+/// false-surface. Detached spawns are exempt from the end-of-run wait, so the
+/// root returns its value cleanly whether or not the detached task has settled.
 #[tokio::test]
-async fn finite_detached_spawn_is_waited_to_completion() {
+async fn finite_detached_spawn_does_not_block_completion() {
     let program = compile_source_with_opt(
         r#"
         function main() -> string {
@@ -271,7 +301,7 @@ async fn finite_detached_spawn_is_waited_to_completion() {
     let output = run_compiled(program, "main", IndexMap::new(), false).await;
     let value = output
         .result
-        .expect("finite detached spawn must be waited-for and the root return cleanly");
+        .expect("finite detached spawn must not block the root; it returns cleanly");
     let BexExternalValue::String(s) = value else {
         panic!("expected String, got {value:?}");
     };

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -130,7 +130,17 @@ impl FutureManagerGuard<'_> {
     }
 
     /// Registers a future with the future manager and returns a unique ID.
-    pub fn new_future(&mut self, cancel: CancellationToken) -> (FutureId, HeapPtr) {
+    ///
+    /// `detached` records whether the future backs a `detach = true` spawn, so
+    /// the end-of-run wait can exclude it; `run_id` records which run created
+    /// it, so the wait can scope to a single run's own spawns (see
+    /// `pending_join_handles`). Non-spawn callers pass `false` / `0`.
+    pub fn new_future(
+        &mut self,
+        cancel: CancellationToken,
+        detached: bool,
+        run_id: usize,
+    ) -> (FutureId, HeapPtr) {
         // The contract on `FutureId::from_usize` is "no two live ids share a
         // usize". We satisfy this by drawing the value from the manager's
         // monotonic `AtomicUsize`; uniqueness is preserved as long as the
@@ -145,7 +155,14 @@ impl FutureManagerGuard<'_> {
             .tlab
             .alloc_future(::bex_vm_types::Future::pending(id, cancel));
 
-        inner.active_futures.insert(id, FutureState { future: ptr });
+        inner.active_futures.insert(
+            id,
+            FutureState {
+                future: ptr,
+                detached,
+                run_id,
+            },
+        );
         (id, ptr)
     }
 
@@ -429,8 +446,32 @@ impl FutureManagerGuard<'_> {
         })
     }
 
-    /// Snapshot the `ready` wake handle of every strictly-`Pending` future, for
-    /// the end-of-run wait (B-650).
+    /// Snapshot the `ready` wake handle of every strictly-`Pending`,
+    /// **non-detached** future **created by run `run_id`**, for that run's
+    /// end-of-run wait (B-650).
+    ///
+    /// Scoped to `run_id` because the `FutureManager` is shared across every
+    /// concurrent run on one engine (the SDK drives many `call_function` roots
+    /// against one process-global runtime). A completing root must wait ONLY on
+    /// its own descendants' spawns; waiting on another run's outstanding future
+    /// deadlocks — e.g. an LLM-call root blocking on the in-process replay
+    /// server's still-streaming HTTP-response spawn, which belongs to the
+    /// server's handler run and never settles once the caller stops reading.
+    /// See [`crate::thread::BexThread::vm_thread_run_id`].
+    ///
+    /// `detach = true` spawns are also excluded: a detached spawn is
+    /// contractually decoupled from its spawner and "behaves like a top-level
+    /// task" that OUTLIVES the run which created it (its unhandled error routes
+    /// to the root and is logged if the root is already gone). Waiting on it at
+    /// end-of-run contradicts that contract and deadlocks any long-lived
+    /// detached task meant to span calls — e.g. the SDK's `replay_serve_detached`
+    /// pattern, where a `spawn with detach { server.serve(...) }` returns the
+    /// bound address immediately and is only torn down by a *later*, separate
+    /// bridge call hitting a shutdown route. Blocking the spawning call on that
+    /// serve future can never make progress (nothing cancels it until the call
+    /// returns), so the SDK hangs. Non-detached fire-and-forget spawns of this
+    /// run ARE its in-flight work and remain waited-for, so a racing/delayed
+    /// non-detached throw still surfaces (B-612/B-650 core).
     ///
     /// `ErrorPending` futures are deliberately excluded: they have already
     /// failed (their error is parked engine-side and their `ready` wake has
@@ -443,10 +484,11 @@ impl FutureManagerGuard<'_> {
     /// error: it clones the raw `ready` `Arc` so a joiner can wait for the
     /// future to settle while leaving the parked error in place for the
     /// spawner's drain to surface.
-    pub(crate) fn pending_join_handles(&self) -> Vec<PendingJoinHandle> {
+    pub(crate) fn pending_join_handles(&self, run_id: usize) -> Vec<PendingJoinHandle> {
         self.holder()
             .active_futures
             .values()
+            .filter(|state| !state.detached && state.run_id == run_id)
             .filter_map(|state| {
                 // SAFETY: caller holds the heap permit via `self.proof`.
                 let fut = unsafe { state.future_ref() }.ok()?;
@@ -567,6 +609,18 @@ struct FutureState {
     /// holds it directly (fire-and-forget spawn before the producer task
     /// gets scheduled).
     future: HeapPtr,
+    /// Whether this future backs a `detach = true` spawn. Detached spawns
+    /// are contractually decoupled from their spawner and outlive the run
+    /// that created them (they "behave like a top-level task"), so the B-650
+    /// end-of-run wait must NOT block on them — see
+    /// [`FutureManagerGuard::pending_join_handles`].
+    detached: bool,
+    /// Opaque identity of the run that created this future (see
+    /// [`crate::thread::BexThread::vm_thread_run_id`]). The `FutureManager` is
+    /// shared across all concurrent runs on one engine, so the end-of-run wait
+    /// filters on this key to block only on the completing run's OWN spawns,
+    /// never on a different concurrent run's outstanding work.
+    run_id: usize,
 }
 impl FutureState {
     /// Returns an immutable reference to the heap-allocated `Future`.
@@ -631,10 +685,40 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _ptr) = guard.new_future(CancellationToken::new());
+        let (id, _ptr) = guard.new_future(CancellationToken::new(), false, 0);
         assert_eq!(guard.active_future_count(), 1);
         guard.fulfill_future(id, Value::int(42)).unwrap();
         assert_eq!(guard.active_future_count(), 0);
+    }
+
+    /// B-650: the end-of-run wait for a given run joins on that run's
+    /// non-detached pending futures only. It must (a) exclude `detach = true`
+    /// spawns (they outlive the run) and (b) exclude futures from OTHER runs
+    /// (the `FutureManager` is shared across concurrent runs). All four futures
+    /// stay tracked in `active_futures`; `pending_join_handles(run)` surfaces
+    /// only the one that is this run's AND non-detached.
+    #[tokio::test]
+    async fn pending_join_handles_scopes_to_run_and_excludes_detached() {
+        const RUN_A: usize = 0xA;
+        const RUN_B: usize = 0xB;
+        let (mgr, pm) = make_manager().await;
+        let temp = temp_permit(&pm).await;
+        let mut guard = mgr.acquire(temp.proof()).await;
+        // Run A: one non-detached (waited) + one detached (excluded).
+        let (_a_plain, _) = guard.new_future(CancellationToken::new(), false, RUN_A);
+        let (_a_detached, _) = guard.new_future(CancellationToken::new(), true, RUN_A);
+        // Run B: a non-detached future belonging to a different concurrent run.
+        let (_b_plain, _) = guard.new_future(CancellationToken::new(), false, RUN_B);
+        // A detached future of run B, for good measure.
+        let (_b_detached, _) = guard.new_future(CancellationToken::new(), true, RUN_B);
+        // All four are live and pending in the shared registry.
+        assert_eq!(guard.active_future_count(), 4);
+        // Run A waits only on its own non-detached future.
+        assert_eq!(guard.pending_join_handles(RUN_A).len(), 1);
+        // Run B likewise.
+        assert_eq!(guard.pending_join_handles(RUN_B).len(), 1);
+        // An unrelated run waits on nothing.
+        assert_eq!(guard.pending_join_handles(0xC).len(), 0);
     }
 
     #[tokio::test]
@@ -643,7 +727,7 @@ mod tests {
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
         let token = CancellationToken::new();
-        let (id, _ptr) = guard.new_future(token.clone());
+        let (id, _ptr) = guard.new_future(token.clone(), false, 0);
         assert!(!token.is_cancelled());
         guard.cancel_future(id).unwrap();
         assert_eq!(guard.active_future_count(), 0);
@@ -659,8 +743,8 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id_a, _) = guard.new_future(CancellationToken::new());
-        let (id_b, _) = guard.new_future(CancellationToken::new());
+        let (id_a, _) = guard.new_future(CancellationToken::new(), false, 0);
+        let (id_b, _) = guard.new_future(CancellationToken::new(), false, 0);
         assert_eq!(guard.active_future_count(), 2);
         guard.err_future(id_a, Value::int(7)).unwrap();
         guard
@@ -685,7 +769,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = guard.new_future(CancellationToken::new(), false, 0);
         let original = EngineError::TypeMismatch {
             message: "synthetic op error".into(),
         };
@@ -719,7 +803,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = guard.new_future(CancellationToken::new(), false, 0);
         let original = EngineError::TypeMismatch {
             message: "stale".into(),
         };
@@ -761,7 +845,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = guard.new_future(CancellationToken::new(), false, 0);
         guard.fulfill_future(id, Value::int(1)).unwrap();
         let again = guard.fulfill_future(id, Value::int(2));
         assert!(again.is_ok(), "second fulfill should be idempotent no-op");
@@ -772,7 +856,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = guard.new_future(CancellationToken::new(), false, 0);
         guard.fulfill_future(id, Value::int(1)).unwrap();
         // Entry is gone; future_ready should treat it as already-resolved.
         let waiter = guard.future_ready(id).expect("expected immediate Ok");
@@ -803,7 +887,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = guard.new_future(CancellationToken::new(), false, 0);
         let waiter = guard.future_ready(id).expect("waiter should be created");
         drop(guard);
 

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -4082,18 +4082,28 @@ impl BexEngine {
     /// enqueued before the caller's [`Self::drain_one_pending_child_error`].
     /// Without this the child's error was silently dropped when the root exited
     /// 0 (B-612 fixed only the case where the child had ALREADY thrown by the
-    /// time the root completed). Covers both default spawns and `detach = true`
-    /// spawns, whose unhandled errors both route to the root thread's
-    /// `pending_child_errors` queue.
+    /// time the root completed).
     ///
-    /// **WAIT, do not cancel** — the Node.js "run until there is no pending
-    /// work" model (BEP-034 end-of-run amendment). We fire no cancel token: a
-    /// prototype that cancelled outstanding work at shutdown was rejected
-    /// because it injected `Cancelled` into legitimate background work (an
-    /// `all_complete` loser whose side effects must finish, a detached
-    /// telemetry flush) and broke the `baml test` harness. So `detach` is NOT
-    /// exempt — a finite detached task runs to completion here like any other
-    /// spawn. A spawn that never settles (never awaited, never cancelled)
+    /// **Scope: non-detached spawns only.** A `detach = true` spawn is
+    /// contractually decoupled from its spawner and outlives the run that
+    /// created it ("behaves like a top-level task"); its unhandled error routes
+    /// to the root and is logged if the root is already gone. Waiting on a
+    /// detached spawn here contradicts that contract and deadlocks any
+    /// long-lived detached task designed to span calls — notably the SDK's
+    /// `replay_serve_detached`, whose detached `serve` is only torn down by a
+    /// *later*, separate bridge call and so can never settle while this call is
+    /// still parked on it (the sdk-test hang). Detached spawns are therefore
+    /// excluded by [`FutureManagerGuard::pending_join_handles`]; a
+    /// non-detached fire-and-forget spawn remains this run's in-flight work and
+    /// IS waited-for, so its racing/delayed throw still surfaces.
+    ///
+    /// **WAIT, do not cancel** (for the non-detached spawns we do wait on) —
+    /// the Node.js "run until there is no pending work" model (BEP-034
+    /// end-of-run amendment). We fire no cancel token: a prototype that
+    /// cancelled outstanding work at shutdown was rejected because it injected
+    /// `Cancelled` into legitimate background work (an `all_complete` loser
+    /// whose side effects must finish) and broke the `baml test` harness. A
+    /// non-detached spawn that never settles (never awaited, never cancelled)
     /// blocks the process at exit; that is the amendment's deliberate red flag
     /// for a concurrency bug (locate it with tracing), not a case we paper over
     /// by cancelling. This also preserves the "returning futures is safe"
@@ -4113,10 +4123,14 @@ impl BexEngine {
         self: &Arc<Self>,
         mut thread: ActiveHeapPermit<BexThread>,
     ) -> Result<ActiveHeapPermit<BexThread>, EngineError> {
+        // Scope the wait to THIS run's own spawns: the `FutureManager` is shared
+        // across every concurrent run on the engine, so we must not park on a
+        // different run's outstanding future. Stable for the life of the thread.
+        let run_id = thread.vm_thread_run_id();
         loop {
             let handles = {
                 let guard = self.futures.acquire(thread.proof()).await;
-                guard.pending_join_handles()
+                guard.pending_join_handles(run_id)
             };
             if handles.is_empty() {
                 return Ok(thread);
@@ -4343,14 +4357,16 @@ impl BexEngine {
                     }
 
                     // B-650: end-of-run wait. The root is finalizing; WAIT for
-                    // any still-outstanding spawned child futures to run to
-                    // completion FIRST, so a racing `spawn { throw ... }` whose
-                    // task had not been polled yet deterministically parks its
-                    // error before the drain below. Without this, only children
-                    // that had ALREADY thrown by the time the root completed
-                    // surfaced (B-612); the fully-racing case exited 0. We
-                    // WAIT, never cancel (see
-                    // `wait_for_outstanding_child_futures`).
+                    // this run's still-outstanding NON-detached spawned child
+                    // futures to run to completion FIRST, so a racing
+                    // `spawn { throw ... }` whose task had not been polled yet
+                    // deterministically parks its error before the drain below.
+                    // Without this, only children that had ALREADY thrown by the
+                    // time the root completed surfaced (B-612); the fully-racing
+                    // case exited 0. We WAIT, never cancel; the wait is scoped to
+                    // this run and skips detached spawns (see
+                    // `wait_for_outstanding_child_futures` /
+                    // `FutureManagerGuard::pending_join_handles`).
                     //
                     // Gate on the GENUINE top-level root, NOT on
                     // `settles_future.is_none()`: a nested host-invoked callable
@@ -4358,12 +4374,11 @@ impl BexEngine {
                     // `spawn_with_callable` → `call_callable`) is also a
                     // `settles_future == None` root, so `settles_future.is_none()`
                     // alone misclassifies it as the finalizing root. It would then
-                    // run this wait and park forever on the outer run's still-
-                    // `Pending` `serve` spawn — the handler never returns, its HTTP
-                    // response never sends, and the whole run deadlocks upstream of
-                    // cancellation (B-650 `baml test` hang). The shared
-                    // `FutureManager` sees every run's pending futures, so only the
-                    // one true root may drain them.
+                    // run this wait during the outer run — and, before per-run
+                    // scoping, park forever on the outer run's still-`Pending`
+                    // `serve` spawn (B-650 `baml test` hang). The shared
+                    // `FutureManager` sees every run's pending futures, so the
+                    // wait must be gated on the true root AND scoped by run id.
                     if thread.vm_thread_is_top_level_root() {
                         thread = self.wait_for_outstanding_child_futures(thread).await?;
                     }
@@ -4787,7 +4802,16 @@ impl BexEngine {
 
                     let future_ptr = {
                         let mut guard = self.futures.acquire(thread.proof()).await;
-                        let (future_id, future_ptr) = guard.new_future(child_cancel.clone());
+                        // Tag the future with `detach` and this run's id so the
+                        // B-650 end-of-run wait can (a) skip detached spawns
+                        // (decoupled, they outlive this run) and (b) scope to a
+                        // single run's own spawns on the shared `FutureManager`
+                        // (see `FutureManagerGuard::pending_join_handles`).
+                        let (future_id, future_ptr) = guard.new_future(
+                            child_cancel.clone(),
+                            detach,
+                            thread.vm_thread_run_id(),
+                        );
                         drop(guard);
                         Arc::clone(self)
                             .spawn_thread(

--- a/baml_language/crates/bex_engine/src/thread.rs
+++ b/baml_language/crates/bex_engine/src/thread.rs
@@ -257,6 +257,23 @@ impl BexThread {
     pub fn vm_thread_root_errors_arc(&self) -> Arc<ChildErrorQueue> {
         Arc::clone(&self.root_pending_errors)
     }
+
+    /// Opaque identity of the run this thread belongs to, for scoping the
+    /// B-650 end-of-run wait to a single run's own outstanding spawns.
+    ///
+    /// The `FutureManager` is shared across every concurrent run on one engine
+    /// (the SDK drives many `call_function` roots against one process-global
+    /// runtime), so a completing root must wait ONLY on its own descendants'
+    /// futures — not on futures belonging to another concurrent run (e.g. an
+    /// LLM call blocking on the in-process replay server's still-streaming
+    /// response spawn). Every thread in a run shares one `root_pending_errors`
+    /// Arc — propagated unchanged down the spawn tree (detached children
+    /// included) — so its allocation address is a stable per-run key: a root
+    /// and all its descendants agree on it, and distinct runs differ. Used
+    /// purely as an opaque token (never dereferenced through this value).
+    pub fn vm_thread_run_id(&self) -> usize {
+        Arc::as_ptr(&self.root_pending_errors) as usize
+    }
 }
 
 impl RootHaver for BexThread {


### PR DESCRIPTION
## Regression this fixes
B-650 (#3925, end-of-run wait-for-in-flight spawns) **hangs the SDK tests on canary**, blocking all PRs. B-650's own PR sdk test hung 27.9 min and merged only on a lucky re-run. (Confirmed: sdk `Run sdk tests` was 0.6 min *before* B-650, ~28 min → timeout on/after it.)

## Root cause (proven, not guessed)
`FutureManager` is a **process-global singleton shared across all concurrent runs**. B-650's end-of-run wait (`wait_for_outstanding_child_futures`, gated on `is_top_level_root`) parked a *completing* run on futures it doesn't own:
- a finishing LLM-call root waited on **another run's** non-detached SSE streaming-writer spawn (never settles once the caller stops reading) → cross-run deadlock;
- a run's own **`detach = true` `server.serve()`** futures, which never settle and which the run cannot stop (detach severs the cancel token).

Proven via an env-gated bypass: wait-disabled → `llm_functions` 17/17 in 11 s; wait-enabled → hang on `streaming_e2e`.

## Fix
Scope the end-of-run wait to **the run's own, non-detached** spawns. Futures now carry `run_id` + `detached`; `pending_join_handles(run_id)` filters `!detached && same run`.

Principle: **wait for what you can stop; don't wait for what you severed.**
- **Non-detached** spawns — the run owns them (can cancel) → **still waited for**. B-650/B-612 intact: a never-awaited non-detached `spawn { throw }` still surfaces (exit 1); an infinite non-detached server is stopped by the run's cancel and the wait completes.
- **Detached** spawns — `detach = true` severs the cancel token, so the run can't stop them → **not waited for** → dropped at exit if in flight (standard fire-and-forget). A detached spawn that *settles* still routes its error to root + the B-612 drain.

**Semantics note:** this supersedes the "detach is not exempt from the exit-wait" line in the BEP-034 amendment draft — that was internally inconsistent (it required waiting for a task the run had explicitly made un-stoppable). `detach` now means "not tied to my lifetime; may be dropped if the process exits first." To guarantee background work finishes, use a non-detached spawn. (Amendment doc being updated to match.)

## Verified against the **actual SDK tests**
- **`sdk_test_typescript_node` → 15/15 pass, exit 0** (`llm_functions` 16 s, was hanging).
- **`sdk_test_python_pydantic2` → 14/14 pass.**
- `spawn_semantics` 11/11; racing/delayed non-detached throws → exit 1; racing success → exit 0.
- `ns_http_server` (serve+cancel), `ns_spawn_throws`, `ns_cancel_cascade` all green; `bex_engine` future unit tests 10/10; clippy `--all-targets -D warnings` / `cargo doc` / `fmt` clean.

**Reviewer note:** the per-run key is the address of the run's `root_pending_errors` `Arc` (stable for the run's lifetime) — worth a second look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detached background work no longer blocks the app from finishing a run.
  * Detached tasks that never complete, or fail later, no longer delay or surface at root completion.
  * End-of-run waiting is now scoped to the current run, avoiding interference from other concurrent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->