### PR TITLE
feat(beps): enable "Open in new tab" on left panel nav items

### DIFF
--- a/typescript/apps/beps/src/components/bep/bep-nav.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-nav.tsx
@@ -3,6 +3,8 @@
 import { Plus, MessageSquare } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { buildBepPath, MAIN_CONTENT_ID } from "@/lib/bep-routes";
+import type { MouseEvent } from "react";
 
 interface Section {
   id: string;
@@ -16,21 +18,62 @@ interface BepNavProps {
   sections: Section[];
   activeSection: string;
   onSectionClick: (id: string) => void;
+  bepNumber: number;
+  versionNumber?: number | null;
   commentCounts?: Record<string, number>;
   totalCommentCount?: number;
   openIssueCount?: number;
   decisionCount?: number;
-  hideMetaSections?: boolean; // Hide issues, decisions (for historical viewing)
-  // Edit mode props
+  hideMetaSections?: boolean;
   isEditMode?: boolean;
-  pageStatuses?: Record<string, PageStatus>; // Maps section id to status
+  pageStatuses?: Record<string, PageStatus>;
   onAddPage?: () => void;
+}
+
+function sectionHref(
+  sectionId: string,
+  bepNumber: number,
+  versionNumber?: number | null
+): string {
+  if (sectionId === MAIN_CONTENT_ID) {
+    return buildBepPath({ bepNumber, section: "readme", versionNumber });
+  }
+  if (sectionId === "issues") {
+    return buildBepPath({ bepNumber, section: "issues" });
+  }
+  if (sectionId === "decisions") {
+    return buildBepPath({ bepNumber, section: "decisions" });
+  }
+  if (sectionId === "ai") {
+    return buildBepPath({ bepNumber, section: "ai" });
+  }
+  if (sectionId === "comments") {
+    return buildBepPath({ bepNumber, section: "comments" });
+  }
+  return buildBepPath({
+    bepNumber,
+    section: "page",
+    pageSlug: sectionId,
+    versionNumber,
+  });
+}
+
+function handleNavClick(
+  e: MouseEvent,
+  sectionId: string,
+  onSectionClick: (id: string) => void
+) {
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
+  e.preventDefault();
+  onSectionClick(sectionId);
 }
 
 export function BepNav({
   sections,
   activeSection,
   onSectionClick,
+  bepNumber,
+  versionNumber,
   commentCounts = {},
   totalCommentCount = 0,
   openIssueCount = 0,
@@ -49,11 +92,12 @@ export function BepNav({
           const isDeleted = status === "deleted";
 
           return (
-            <button
+            <a
               key={section.id}
-              onClick={() => onSectionClick(section.id)}
+              href={sectionHref(section.id, bepNumber, versionNumber)}
+              onClick={(e) => handleNavClick(e, section.id, onSectionClick)}
               className={cn(
-                "w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
+                "block w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
                 "hover:bg-accent hover:text-accent-foreground",
                 activeSection === section.id
                   ? "bg-accent text-accent-foreground font-medium"
@@ -64,7 +108,6 @@ export function BepNav({
               <span className="flex items-center justify-between gap-2">
                 <span className="truncate">{section.title}</span>
                 <span className="flex items-center gap-1 shrink-0">
-                  {/* Edit mode status badge */}
                   {isEditMode && status && (
                     <span
                       className={cn(
@@ -76,7 +119,6 @@ export function BepNav({
                       title={status}
                     />
                   )}
-                  {/* Comment count (only in view mode) */}
                   {!isEditMode && (commentCounts[section.id] ?? 0) > 0 && (
                     <span className="text-xs bg-muted px-1.5 py-0.5 rounded">
                       {commentCounts[section.id]}
@@ -84,11 +126,10 @@ export function BepNav({
                   )}
                 </span>
               </span>
-            </button>
+            </a>
           );
         })}
 
-      {/* Add page button (only in edit mode) */}
       {isEditMode && onAddPage && (
         <Button
           variant="ghost"
@@ -105,10 +146,11 @@ export function BepNav({
         <>
           <div className="border-t my-3" />
 
-          <button
-            onClick={() => onSectionClick("issues")}
+          <a
+            href={sectionHref("issues", bepNumber)}
+            onClick={(e) => handleNavClick(e, "issues", onSectionClick)}
             className={cn(
-              "w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
+              "block w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
               "hover:bg-accent hover:text-accent-foreground",
               activeSection === "issues"
                 ? "bg-accent text-accent-foreground font-medium"
@@ -123,12 +165,13 @@ export function BepNav({
                 </span>
               )}
             </span>
-          </button>
+          </a>
 
-          <button
-            onClick={() => onSectionClick("decisions")}
+          <a
+            href={sectionHref("decisions", bepNumber)}
+            onClick={(e) => handleNavClick(e, "decisions", onSectionClick)}
             className={cn(
-              "w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
+              "block w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
               "hover:bg-accent hover:text-accent-foreground",
               activeSection === "decisions"
                 ? "bg-accent text-accent-foreground font-medium"
@@ -143,12 +186,13 @@ export function BepNav({
                 </span>
               )}
             </span>
-          </button>
+          </a>
 
-          <button
-            onClick={() => onSectionClick("comments")}
+          <a
+            href={sectionHref("comments", bepNumber)}
+            onClick={(e) => handleNavClick(e, "comments", onSectionClick)}
             className={cn(
-              "w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
+              "block w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
               "hover:bg-accent hover:text-accent-foreground",
               activeSection === "comments"
                 ? "bg-accent text-accent-foreground font-medium"
@@ -166,28 +210,28 @@ export function BepNav({
                 </span>
               )}
             </span>
-          </button>
+          </a>
 
           <div className="border-t mb-3" />
 
-          <button
-            onClick={() => onSectionClick("ai")}
+          <a
+            href={sectionHref("ai", bepNumber)}
+            onClick={(e) => handleNavClick(e, "ai", onSectionClick)}
             className={cn(
-              "w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
+              "block w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
               "hover:bg-accent hover:text-accent-foreground",
               activeSection === "ai"
                 ? "bg-accent text-accent-foreground font-medium"
                 : "text-muted-foreground"
             )}
           >
-
             <span className="flex items-center justify-between">
               AI Assistant
               <span className="text-xs bg-purple-100 text-purple-800 px-1.5 py-0.5 rounded">
                 Beta
               </span>
             </span>
-          </button>
+          </a>
         </>
       )}
     </nav>

--- a/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
@@ -922,6 +922,12 @@ const [copied, setCopied] = useState(false);
                 sections={allSections}
                 activeSection={activeSection}
                 onSectionClick={handleSectionChange}
+                bepNumber={bepNumber}
+                versionNumber={
+                  isViewingHistorical && routeInfo.versionNumber !== latestVersionNumber
+                    ? routeInfo.versionNumber
+                    : null
+                }
                 commentCounts={commentCounts ?? {}}
                 totalCommentCount={isViewingHistorical ? 0 : totalCommentCount}
                 openIssueCount={isViewingHistorical ? 0 : openIssueCount}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

## Issue Reference
- [x] Fixes missing "Open in new tab" option when right-clicking pages in the beps left panel

## Changes
Converted all navigation items in the beps left panel (`BepNav`) from `<button>` elements to `<a>` elements with proper `href` attributes. This enables the browser's native right-click context menu to show "Open in new tab" / "Open in new window".

**Key changes:**
- **`bep-nav.tsx`**: Replaced all `<button>` nav items with `<a>` tags. Added a `sectionHref()` helper that uses `buildBepPath` to generate correct URLs for each section (readme, pages, issues, decisions, comments, ai). Normal left-clicks still use SPA navigation via `preventDefault()`, while Cmd/Ctrl+click and right-click "Open in new tab" work natively.
- **`bep-route-shell.tsx`**: Passes new `bepNumber` and `versionNumber` props to `BepNav` so it can generate correct hrefs, including for historical version views.

## Testing
- [x] TypeScript compilation passes (`npx tsc --noEmit` — zero errors)
- [x] Manual code review of all anchor elements and href generation

## PR Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1783448602176029?thread_ts=1783448602.176029&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-d390bbc7-6724-54b4-bb93-50eb3e51b6d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d390bbc7-6724-54b4-bb93-50eb3e51b6d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation links in BEP pages now use normal page links, making sections and related areas easier to open, copy, and share.
  * Historical BEP versions are now handled in navigation so links reflect the version being viewed.

* **Bug Fixes**
  * Improved section navigation behavior by keeping standard click interactions while preserving in-page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->