### PR TITLE
test(sdk_tests): cover the stdlib `json` type in type_shapes

### DIFF
--- a/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_json_values.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_json_values.py
@@ -1,0 +1,89 @@
+"""Roundtrip coverage for `baml_sdk.json_values` — the stdlib `json` type.
+
+Every BAML function here is declared to return `json` (`baml.json.json`),
+but each returns a differently-shaped value. `return_json_*` functions
+exercise decode-only for each JSON shape; `round_trip_json` exercises the
+full encode/decode pair over the same shapes; `JsonContainer` covers
+`json` in a class field position.
+"""
+
+import baml_sdk  # noqa: F401  — initializes the BAML runtime
+from baml_sdk.json_values import (
+    JsonContainer,
+    return_json_null,
+    return_json_bool,
+    return_json_int,
+    return_json_float,
+    return_json_string,
+    return_json_array,
+    return_json_object,
+    return_json_nested,
+    round_trip_json,
+    round_trip_json_container,
+)
+
+
+def test_return_json_null():
+    assert return_json_null() is None
+
+
+def test_return_json_bool():
+    assert return_json_bool() is True
+
+
+def test_return_json_int():
+    assert return_json_int() == 42
+
+
+def test_return_json_float():
+    assert return_json_float() == 3.14
+
+
+def test_return_json_string():
+    assert return_json_string() == "hello"
+
+
+def test_return_json_array():
+    assert return_json_array() == [1, 2, 3]
+
+
+def test_return_json_object():
+    assert return_json_object() == {"key": "value"}
+
+
+def test_return_json_nested():
+    assert return_json_nested() == {"a": 1, "b": [2, 3], "c": {"nested": None}}
+
+
+def test_round_trip_json_null():
+    assert round_trip_json(j=None) is None
+
+
+def test_round_trip_json_bool():
+    assert round_trip_json(j=False) is False
+
+
+def test_round_trip_json_int():
+    assert round_trip_json(j=7) == 7
+
+
+def test_round_trip_json_float():
+    assert round_trip_json(j=2.5) == 2.5
+
+
+def test_round_trip_json_string():
+    assert round_trip_json(j="hi") == "hi"
+
+
+def test_round_trip_json_array():
+    assert round_trip_json(j=[1, "two", True, None]) == [1, "two", True, None]
+
+
+def test_round_trip_json_object():
+    nested = {"a": 1, "b": [2, 3], "c": {"nested": None}}
+    assert round_trip_json(j=nested) == nested
+
+
+def test_round_trip_json_container():
+    c = JsonContainer(data={"k": [1, 2, {"deep": None}]})
+    assert round_trip_json_container(c=c) == c

--- a/baml_language/sdk_tests/crates/typescript_node/type_shapes/customizable/roundtrip_json_values.test.ts
+++ b/baml_language/sdk_tests/crates/typescript_node/type_shapes/customizable/roundtrip_json_values.test.ts
@@ -1,0 +1,62 @@
+// Roundtrip coverage for baml_sdk/json_values — the stdlib `json` type.
+// Ported from python_pydantic2/.../roundtrip_tests/test_json_values.py.
+//
+// Every BAML function here is declared to return `json` (`baml.json.json`),
+// but each returns a differently-shaped value.
+import "./baml_sdk/index.js"; // initializes the BAML runtime
+import { describe, it, expect } from "vitest";
+import {
+  JsonContainer,
+  return_json_null,
+  return_json_bool,
+  return_json_int,
+  return_json_float,
+  return_json_string,
+  return_json_array,
+  return_json_object,
+  return_json_nested,
+  round_trip_json,
+  round_trip_json_container,
+} from "./baml_sdk/json_values/index.js";
+
+describe("roundtrip json_values", () => {
+  it("return_json_null", () => expect(return_json_null()).toBeNull());
+  it("return_json_bool", () => expect(return_json_bool()).toBe(true));
+  it("return_json_int", () => expect(return_json_int()).toBeCloseTo(42));
+  it("return_json_float", () => expect(return_json_float()).toBeCloseTo(3.14));
+  it("return_json_string", () => expect(return_json_string()).toBe("hello"));
+  it("return_json_array", () => expect(return_json_array()).toEqual([1, 2, 3]));
+  it("return_json_object", () =>
+    expect(return_json_object()).toEqual({ key: "value" }));
+  it("return_json_nested", () =>
+    expect(return_json_nested()).toEqual({
+      a: 1,
+      b: [2, 3],
+      c: { nested: null },
+    }));
+
+  it("round_trip_json null", () => expect(round_trip_json(null)).toBeNull());
+  it("round_trip_json bool", () => expect(round_trip_json(false)).toBe(false));
+  it("round_trip_json int", () => expect(round_trip_json(7)).toBeCloseTo(7));
+  it("round_trip_json float", () =>
+    expect(round_trip_json(2.5)).toBeCloseTo(2.5));
+  it("round_trip_json string", () => expect(round_trip_json("hi")).toBe("hi"));
+  it("round_trip_json array", () =>
+    expect(round_trip_json([1, "two", true, null])).toEqual([
+      1,
+      "two",
+      true,
+      null,
+    ]));
+  it("round_trip_json object", () => {
+    const nested = { a: 1, b: [2, 3], c: { nested: null } };
+    expect(round_trip_json(nested)).toEqual(nested);
+  });
+
+  it("round_trip_json_container", () => {
+    const c = new JsonContainer({ data: { k: [1, 2, { deep: null }] } });
+    const r = round_trip_json_container(c);
+    expect(r).toBeInstanceOf(JsonContainer);
+    expect(r.data).toEqual({ k: [1, 2, { deep: null }] });
+  });
+});

--- a/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_json_values/types.baml
+++ b/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_json_values/types.baml
@@ -1,0 +1,49 @@
+// Coverage for the stdlib `json` type (the `json` keyword resolves to
+// `baml.json.json`, a recursive JSON-shaped union). Each `return_json_*`
+// function returns a differently-shaped value whose declared return type
+// is `json`; `round_trip_json` exercises the encode/decode pair over the
+// same shapes, and `JsonContainer` puts `json` in a class field position.
+
+class JsonContainer {
+  data json
+}
+
+function return_json_null() -> json {
+  null
+}
+
+function return_json_bool() -> json {
+  true
+}
+
+function return_json_int() -> json {
+  42
+}
+
+function return_json_float() -> json {
+  3.14
+}
+
+function return_json_string() -> json {
+  "hello"
+}
+
+function return_json_array() -> json {
+  [1, 2, 3]
+}
+
+function return_json_object() -> json {
+  {"key": "value"}
+}
+
+function return_json_nested() -> json {
+  {"a": 1, "b": [2, 3], "c": {"nested": null}}
+}
+
+function round_trip_json(j: json) -> json {
+  j
+}
+
+function round_trip_json_container(c: JsonContainer) -> JsonContainer {
+  c
+}


### PR DESCRIPTION
Adds SDK e2e coverage for the stdlib `json` type (`baml.json.json`).

## Changes

- **New fixture** `sdk_tests/fixtures/type_shapes/baml_src/ns_json_values/types.baml`: every function is declared to return `json`, but each returns a differently-shaped value — `null`, `bool`, `int`, `float`, `string`, array, object, and a nested object. Also includes a `round_trip_json(j: json) -> json` encode/decode pair and a `JsonContainer` class with a `json` field.
- **Python roundtrip tests** (`crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_json_values.py`): asserts each shape decodes to the expected Python value and survives the encode → FFI → decode round trip, including a heterogeneous array.
- **TypeScript roundtrip tests** (`crates/typescript_node/type_shapes/customizable/roundtrip_json_values.test.ts`): same coverage ported to vitest.

The namespace is `ns_json_values` (→ `baml_sdk.json_values`) rather than `ns_json` to avoid colliding with the stdlib `baml.json` namespace and the Python stdlib `json` module.

## Test plan

- `cargo nextest run -p sdk_test_python_pydantic2 -p sdk_test_typescript_node` — 29/29 pass locally (ruff, pyright, pytest, tsc, esm_output, vitest across all fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader roundtrip coverage for JSON-shaped values across Python and TypeScript test suites.
  * Included support for null, booleans, numbers, strings, arrays, objects, nested objects, and container-wrapped JSON values.
* **Tests**
  * Added new fixture and test cases to verify JSON values preserve their shape and content through encode/decode cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->