### PR TITLE
fix(jinja): render map<K,V> as a JSON object shape in ctx.output_format (B-630)

### DIFF
--- a/baml_language/crates/sys_llm/src/jinja/output_format_object.rs
+++ b/baml_language/crates/sys_llm/src/jinja/output_format_object.rs
@@ -194,8 +194,8 @@ fn parse_hoist_classes_kwarg(kwargs: &Kwargs) -> Result<HoistClasses, minijinja:
 }
 
 /// Parse `map_style` kwarg:
-/// - Not present -> `TypeParameters` (default)
-/// - "`type_parameters`" -> `TypeParameters`
+/// - Not present -> `ObjectLiteral` (default JSON object shape)
+/// - "`type_parameters`" -> `TypeParameters` (opt-in `map<K, V>` escape hatch)
 /// - "`object_literal`" -> `ObjectLiteral`
 fn parse_map_style_kwarg(kwargs: &Kwargs) -> Result<MapStyle, minijinja::Error> {
     if !kwargs.has("map_style") {

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -160,8 +160,10 @@ pub fn render_output_format_content(
         quote_class_fields: setting(quote_class_fields),
         hoist_classes: hoist_classes.map_or(HoistClasses::Auto, HoistClasses::Subset),
         map_style: match map_style.as_deref() {
-            Some("object_literal") => MapStyle::ObjectLiteral,
-            _ => MapStyle::TypeParameters,
+            // `type_parameters` is the opt-in escape hatch (`map<K, V>`); every
+            // other value (including the default) renders the JSON object shape.
+            Some("type_parameters") => MapStyle::TypeParameters,
+            _ => MapStyle::ObjectLiteral,
         },
         render_null_as: setting(render_null_as),
     };

--- a/baml_language/crates/sys_llm/src/types/output_format.rs
+++ b/baml_language/crates/sys_llm/src/types/output_format.rs
@@ -517,7 +517,7 @@ impl OutputFormatContent {
                 match options.map_style {
                     MapStyle::TypeParameters => Ok(Some(format!("map<{key_str}, {value_str}>"))),
                     MapStyle::ObjectLiteral => {
-                        Ok(Some(format!("{{ [key: {key_str}]: {value_str} }}")))
+                        Ok(Some(format!("{{ \"<{key_str}>\": {value_str} }}")))
                     }
                 }
             }
@@ -816,10 +816,13 @@ pub enum RenderSetting<T> {
 /// Ported from engine/baml-lib/jinja-runtime/src/output_format/types.rs:201-208
 #[derive(Clone, Debug, Default)]
 pub enum MapStyle {
-    /// Render as `map<K, V>` (angle bracket style)
-    #[default]
+    /// Render as `map<K, V>` (angle bracket style). Opt-in escape hatch: the
+    /// raw BAML type gives the model no example of the JSON object it must emit.
     TypeParameters,
-    /// Render as `{ [key: K]: V }` (object literal style)
+    /// Render as `{ "<K>": V }` (JSON object shape). Default: the model answers
+    /// with JSON, so the hint mirrors the object it needs to produce (consistent
+    /// with how classes and lists render) instead of leaking BAML type syntax.
+    #[default]
     ObjectLiteral,
 }
 
@@ -869,7 +872,7 @@ impl Default for RenderOptions {
             hoisted_class_prefix: RenderSetting::Auto,
             hoist_classes: HoistClasses::Auto,
             always_hoist_enums: RenderSetting::Auto,
-            map_style: MapStyle::TypeParameters,
+            map_style: MapStyle::ObjectLiteral,
             quote_class_fields: RenderSetting::Auto,
             render_null_as: RenderSetting::Auto,
         }
@@ -1140,7 +1143,54 @@ mod tests {
         let rendered = content.render(&RenderOptions::default()).unwrap();
         assert_eq!(
             rendered,
+            Some("Answer in JSON using this schema:\n{ \"<string>\": int }".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_map_type_parameters_opt_in() {
+        // `map_style='type_parameters'` stays available as an opt-in escape hatch
+        // that renders the literal BAML type syntax.
+        let content = OutputFormatContent::new(RuntimeTy::Map {
+            key: Box::new(RuntimeTy::String {
+                attr: TyAttr::default(),
+            }),
+            value: Box::new(RuntimeTy::Int {
+                attr: TyAttr::default(),
+            }),
+            attr: TyAttr::default(),
+        });
+        let rendered = content
+            .render(&RenderOptions {
+                map_style: MapStyle::TypeParameters,
+                ..RenderOptions::default()
+            })
+            .unwrap();
+        assert_eq!(
+            rendered,
             Some("Answer in JSON using this schema:\nmap<string, int>".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_class_with_map_field_object_shape() {
+        // B-630 repro: a `map<string, T>` field must render as a JSON object
+        // shape so the model sees the object it has to emit, rather than leaking
+        // the literal BAML type syntax `map<string, int>`.
+        let content = OutputFormatContent::new(ty_class("Review")).with_class(mk_class(
+            "Review",
+            vec![("scores", ty_map(ty_string(), ty_int()))],
+        ));
+
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some(String::from(
+                r#"Answer in JSON using this schema:
+{
+  scores: { "<string>": int },
+}"#
+            ))
         );
     }
 
@@ -2036,7 +2086,7 @@ Node[]"#
             rendered,
             Some(String::from(
                 r#"RecursiveMap {
-  data: map<string, RecursiveMap>,
+  data: { "<string>": RecursiveMap },
 }
 
 Answer in JSON using this schema: RecursiveMap"#
@@ -2062,7 +2112,7 @@ Answer in JSON using this schema: RecursiveMap"#
             rendered,
             Some(String::from(
                 r#"RecursiveMap {
-  data: map<string, RecursiveMap>,
+  data: { "<string>": RecursiveMap },
 }
 
 Answer in JSON using this schema:
@@ -2092,7 +2142,7 @@ Answer in JSON using this schema:
 }
 
 Answer in JSON using this schema:
-map<string, Node>"#
+{ "<string>": Node }"#
             ))
         );
     }
@@ -2121,7 +2171,7 @@ map<string, Node>"#
 
 Answer in JSON using this schema:
 {
-  data: map<string, Node>,
+  data: { "<string>": Node },
 }"#
             ))
         );
@@ -2151,7 +2201,7 @@ Answer in JSON using this schema:
 
 Answer in JSON using this schema:
 {
-  data: map<string, Node or null>,
+  data: { "<string>": Node or null },
 }"#
             ))
         );
@@ -2183,10 +2233,10 @@ Answer in JSON using this schema:
 }
 
 Answer in JSON using this schema:
-map<string, Node or int or {
+{ "<string>": Node or int or {
   field: string,
   data: int,
-}>"#
+} }"#
             ))
         );
     }
@@ -2225,10 +2275,10 @@ map<string, Node or int or {
 
 Answer in JSON using this schema:
 {
-  data: map<string, Node or int or {
+  data: { "<string>": Node or int or {
     field: string,
     data: int,
-  }>,
+  } },
 }"#
             ))
         );
@@ -2957,7 +3007,7 @@ Answer in JSON using this schema: SelfReferential"#
         assert_eq!(
             rendered,
             Some(String::from(
-                r#"RecursiveMapAlias = map<string, RecursiveMapAlias>
+                r#"RecursiveMapAlias = { "<string>": RecursiveMapAlias }
 
 Answer in JSON using this schema: RecursiveMapAlias"#
             ))


### PR DESCRIPTION
## Problem

A `map<string, T>` field rendered as the raw BAML type syntax inside the
`${ctx.output_format}` prompt hint:

```baml
class Review { scores: map<string, int> }
```

produced

```
scores: map<string, int>,
```

Since the model must answer with **JSON**, leaking the literal BAML type gives
it no example of the object shape it has to emit.

## Fix

The default map rendering is now a JSON object shape, consistent with how
classes (`{ field: T }`) and lists (`T[]`) already render:

```
scores: { "<string>": int },
```

In `baml_language/crates/sys_llm/src/types/output_format.rs` (the maintained
output_format renderer):

- The default `map_style` is now `ObjectLiteral` instead of `TypeParameters`.
- `ObjectLiteral` renders `{ "<key>": value }` (a quoted placeholder key that
  reads as "any string key") instead of the ambiguous `{ [key: K]: V }`.
- `map_style='type_parameters'` remains available as an opt-in escape hatch that
  keeps the literal `map<K, V>` syntax.

> Note: `engine/` is legacy/deprecated and intentionally not modified — only
> `baml_language/` is maintained.

## Tests

- Added `test_render_class_with_map_field_object_shape` (the exact ticket repro:
  `class Review { scores: map<string, int> }`) and
  `test_render_map_type_parameters_opt_in` (escape-hatch regression guard).
- Updated existing `sys_llm` map render assertions to the new object shape.

All `sys_llm` tests pass; `cargo fmt --check` and `cargo clippy` clean on the
touched crate.

Ticket: https://linear.app/boundaryml2/issue/B-630

Fixes B-630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Map schemas now default to a JSON-object-style representation, improving the readability of generated output.
  * Only the explicit `type_parameters` option now uses the alternate angle-bracket map format; all other values fall back to the standard object style.
  * Updated recursive and nested map outputs to match the new format consistently.

* **Documentation**
  * Clarified the available map rendering options and the default behavior in comments and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->