### PR TITLE
docs(cli): add describe entries for defer/cleanup and clarify catch_all panic behavior

### DIFF
--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -370,12 +370,36 @@ catch:
   details: "`expr catch (e) { ErrorType => handler, ... }` binds the caught error to `e` and dispatches on its type. Only the listed error types are handled; any other error keeps propagating, so `catch` need not be exhaustive. Chain a `catch_all` to handle the rest."
 
 catch_all:
-  summary: "Handles every error a preceding expression can throw (exhaustive)."
+  summary: "Handles every error type a preceding expression can throw (exhaustive over errors, not panics)."
   syntax: |
     let result = risky_call() catch_all (e) {
       _ => fallback_value,
     }
-  details: "`expr catch_all (e) { ... }` binds the caught error to `e` and must cover every error type the expression can throw — either list them all or end with the wildcard `_ => ...`. The compiler reports a non-exhaustive `catch_all` if a throw type is left unhandled."
+  details: "`expr catch_all (e) { ... }` binds the caught error to `e` and must cover every error type the expression can throw — either list them all or end with the wildcard `_ => ...`. The compiler reports a non-exhaustive `catch_all` if a throw type is left unhandled. Panics (`baml.panics.*`, such as `baml.panics.Cancelled`) are not part of an expression's throws-set, so the `_` wildcard does not catch them — a panic keeps unwinding past `catch_all`. To intercept a panic, name its type explicitly in an arm, e.g. `risky_call() catch (e) { baml.panics.Cancelled => ... }`; the bare `_` never catches panics."
+
+defer:
+  summary: "Schedules a block to run when the enclosing block exits, in LIFO order."
+  syntax: |
+    function process(path: string) -> string {
+      let handle = FileHandle { path: path }
+      defer {
+        handle.cleanup()
+      }
+      return handle.read()
+    }
+  details: "`defer { ... }` registers a block that runs on every exit of the enclosing block — normal completion, `return`, `break`/`continue`, and error unwinding — so it is the standard way to release a resource exactly once on all paths. Several defers in the same scope run in LIFO order: the last one declared runs first. The body reads the live enclosing scope at exit; it is not a closure that captures values at the `defer` site. A `throw` inside the body is allowed, but a `return`/`break`/`continue` that would escape the body is rejected. See `baml describe cleanup` for the per-instance finalizer that `defer` commonly invokes."
+
+cleanup:
+  summary: "Magic finalizer method, recognized by name, that runs at most once per instance."
+  syntax: |
+    class FileHandle {
+      path: string
+
+      function cleanup(self) -> void {
+        // release the underlying resource here
+      }
+    }
+  details: "`cleanup` is a magic method recognized by name (like `to_json`), not an interface: if a class defines `function cleanup(self) -> void { ... }`, that method is its finalizer. It runs at most once per instance — a per-instance latch skips every call after the first — whether it is invoked explicitly (`value.cleanup()`), scheduled with `defer`, or reclaimed by the garbage collector. The blessed shape is exactly one `self` parameter (no default), no generic parameters, an explicit `-> void` return, and no `throws` clause (an explicit `throws never` is also accepted). A finalizer must not propagate errors, so handle them internally with `... catch { ... }`; a method named `cleanup` with any other shape is a malformed finalizer and is rejected. See `baml describe defer`."
 
 match:
   summary: "Pattern matching — branches based on the shape or type of a value."

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -1082,6 +1082,18 @@ fn render_keyword_spawn() {
 }
 
 #[test]
+fn render_keyword_defer() {
+    let output = capture_keyword("defer");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn render_keyword_cleanup() {
+    let output = capture_keyword("cleanup");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn render_keyword_baml_sdk() {
     let output = capture_keyword("baml_sdk");
     insta::assert_snapshot!(output);
@@ -1103,6 +1115,19 @@ fn render_keyword_typescript() {
 fn render_keyword_patterns() {
     let output = capture_keyword("patterns");
     insta::assert_snapshot!(output);
+}
+
+/// `defer` and `cleanup` (BEP-042) resolve to keyword topics rather than
+/// falling through to "No symbol found" (regression test for B-632).
+#[test]
+fn dispatch_defer_and_cleanup_resolve_to_keyword() {
+    let db = simple_project();
+    for name in ["defer", "cleanup"] {
+        assert!(
+            matches!(dispatch(&db, name), Some(ResolvedTarget::Keyword(_))),
+            "`{name}` should resolve to a keyword topic, not fall through to 'No symbol found'"
+        );
+    }
 }
 
 #[test]

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_cleanup.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_cleanup.snap
@@ -1,0 +1,16 @@
+---
+source: crates/baml_cli/src/describe_command_tests.rs
+expression: output
+---
+cleanup — Magic finalizer method, recognized by name, that runs at most once per instance.
+
+Syntax:
+  class FileHandle {
+    path: string
+  
+    function cleanup(self) -> void {
+      // release the underlying resource here
+    }
+  }
+
+`cleanup` is a magic method recognized by name (like `to_json`), not an interface: if a class defines `function cleanup(self) -> void { ... }`, that method is its finalizer. It runs at most once per instance — a per-instance latch skips every call after the first — whether it is invoked explicitly (`value.cleanup()`), scheduled with `defer`, or reclaimed by the garbage collector. The blessed shape is exactly one `self` parameter (no default), no generic parameters, an explicit `-> void` return, and no `throws` clause (an explicit `throws never` is also accepted). A finalizer must not propagate errors, so handle them internally with `... catch { ... }`; a method named `cleanup` with any other shape is a malformed finalizer and is rejected. See `baml describe defer`.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_defer.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_defer.snap
@@ -1,0 +1,16 @@
+---
+source: crates/baml_cli/src/describe_command_tests.rs
+expression: output
+---
+defer — Schedules a block to run when the enclosing block exits, in LIFO order.
+
+Syntax:
+  function process(path: string) -> string {
+    let handle = FileHandle { path: path }
+    defer {
+      handle.cleanup()
+    }
+    return handle.read()
+  }
+
+`defer { ... }` registers a block that runs on every exit of the enclosing block — normal completion, `return`, `break`/`continue`, and error unwinding — so it is the standard way to release a resource exactly once on all paths. Several defers in the same scope run in LIFO order: the last one declared runs first. The body reads the live enclosing scope at exit; it is not a closure that captures values at the `defer` site. A `throw` inside the body is allowed, but a `return`/`break`/`continue` that would escape the body is rejected. See `baml describe cleanup` for the per-instance finalizer that `defer` commonly invokes.


### PR DESCRIPTION
## What

Two `baml describe` reference-docs fixes in one PR (same registry, `baml_keywords.yaml`):

### B-632 — add `defer` / `cleanup` entries
`baml describe defer` and `baml describe cleanup` returned **"No symbol found"** even though both features work in real code and are featured in the skill/docs (contrast: `catch`, `throw`, `throws`, `while` all resolve). Added reference-doc entries for:
- **`defer`** — the BEP-042 scope-exit block: runs on every exit of the enclosing block (normal completion, `return`, `break`/`continue`, error unwinding) in LIFO order; reads the live scope at exit (not a capture); `throw` allowed, escaping `return`/`break`/`continue` rejected.
- **`cleanup`** — the BEP-042 magic-method finalizer: recognized by name (like `to_json`), runs at most once per instance (per-instance latch), invoked explicitly / via `defer` / by the GC; blessed shape is `function cleanup(self) -> void` with no defaulted `self`, no generics, no propagating `throws` (`throws never` accepted).

Both are written to match the voice of the existing keyword entries.

### B-631 — clarify `catch_all` re: panics (docs-only, no behavior change)
The old entry implied `catch_all`'s `_` wildcard handles *everything*. Clarified that it is exhaustive over an expression's **error** types only. Panics (`baml.panics.*`, e.g. `baml.panics.Cancelled`) are outside the throws-set, so a `throw_if_panic` guard (inserted before the wildcard in MIR lowering) rethrows them past `catch_all` — the bare `_` never catches a panic. To intercept one, name its type explicitly in an arm.

## Tests
- New snapshot tests `render_keyword_defer` / `render_keyword_cleanup`.
- New dispatch regression test `dispatch_defer_and_cleanup_resolve_to_keyword` asserting both resolve to keyword topics instead of falling through to "No symbol found".
- Verified end-to-end against the built `baml-cli`: `describe defer`, `describe cleanup`, `describe catch_all` all exit 0 with the new text; `catch`/`throw`/`throws`/`while` still resolve.

## Links
https://linear.app/boundaryml2/issue/B-631
https://linear.app/boundaryml2/issue/B-632

Fixes B-631
Fixes B-632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for two new keywords: `defer` and `cleanup`.
  * Clarified error-handling behavior so exhaustive matching does not include panics, which must be handled explicitly.

* **Tests**
  * Added coverage for rendering the new keyword documentation.
  * Added a regression test to ensure both keywords are recognized correctly during dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->