### PR TITLE
fix(cli): render uncaught throw values readably instead of Rust Debug (B-623)

### DIFF
--- a/baml_language/crates/baml_exec/src/output.rs
+++ b/baml_language/crates/baml_exec/src/output.rs
@@ -92,47 +92,10 @@ async fn serialize_via_baml_json(
 }
 
 /// Human-readable formatting for `BexExternalValue`.
+///
+/// Thin wrapper over [`BexExternalValue::render_readable`] — the canonical
+/// structural renderer, shared with the engine's uncaught-throw rendering so
+/// `baml run` output and a leaked `throw` render identically.
 pub fn format_value(value: &BexExternalValue) -> String {
-    match value {
-        BexExternalValue::Null => "null".to_string(),
-        BexExternalValue::Int(i) => i.to_string(),
-        BexExternalValue::Float(f) => {
-            let s = f.to_string();
-            if s.contains('.') || !f.is_finite() {
-                s
-            } else {
-                format!("{s}.0")
-            }
-        }
-        BexExternalValue::Bool(b) => b.to_string(),
-        BexExternalValue::String(s) => format!("{s:?}"),
-        BexExternalValue::Array { items, .. } => {
-            let inner: Vec<String> = items.iter().map(format_value).collect();
-            format!("[{}]", inner.join(", "))
-        }
-        BexExternalValue::Map { entries, .. } => {
-            let inner: Vec<String> = entries
-                .iter()
-                .map(|(k, v)| format!("{k:?}: {}", format_value(v)))
-                .collect();
-            format!("{{{}}}", inner.join(", "))
-        }
-        BexExternalValue::Instance {
-            class_name, fields, ..
-        } => {
-            let inner: Vec<String> = fields
-                .iter()
-                .map(|(k, v)| format!("{k}: {}", format_value(v)))
-                .collect();
-            if class_name.is_empty() {
-                format!("{{{}}}", inner.join(", "))
-            } else {
-                format!("{class_name} {{{}}}", inner.join(", "))
-            }
-        }
-        BexExternalValue::Variant { variant_name, .. } => variant_name.clone(),
-        BexExternalValue::Union { value, .. } => format_value(value),
-        BexExternalValue::Uint8Array(bytes) => format!("<bytes:{}>", bytes.len()),
-        _ => format!("{value:?}"),
-    }
+    value.render_readable()
 }

--- a/baml_language/crates/baml_tests/tests/errors.rs
+++ b/baml_language/crates/baml_tests/tests/errors.rs
@@ -32,6 +32,6 @@ function main() -> int {
       File "test.baml", line 11, in user.one
       File "test.baml", line 7, in user.two
       File "test.baml", line 3, in user.three
-    uncaught throw: String("boom")
+    uncaught throw: "boom"
     "#);
 }

--- a/baml_language/crates/baml_tests/tests/exceptions.rs
+++ b/baml_language/crates/baml_tests/tests/exceptions.rs
@@ -124,7 +124,7 @@ function main() -> int {
       File "test.baml", line 12, in user.main
       File "test.baml", line 8, in user.outer
       File "test.baml", line 3, in user.inner
-    uncaught throw: String("from_closure")
+    uncaught throw: "from_closure"
     "#);
 }
 
@@ -152,8 +152,38 @@ function main() -> int {
       File "test.baml", line 11, in user.main
       File "test.baml", line 7, in user.caller
       File "test.baml", line 3, in user.divider
-    uncaught throw: Instance { class_name: "baml.panics.DivisionByZero", type_args: [], fields: {"dividend": Int(42)} }
+    uncaught throw: baml.panics.DivisionByZero {dividend: 42}
     "#);
+}
+
+/// B-623 regression: an uncaught `throw` of an error instance must surface the
+/// value's readable rendering, not the Rust `Debug` shape (`Instance { class_name,
+/// type_args, fields }`, `QualifiedTypeName`, `TyAttr`).
+#[tokio::test]
+async fn uncaught_throw_renders_readable_error_not_debug() {
+    let output = baml_test!(
+        r#"
+function main() -> void {
+  throw baml.errors.Io { message: "boom" }
+}
+"#
+    );
+
+    let err = output.result.unwrap_err();
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains(r#"uncaught throw: baml.errors.Io {message: "boom"}"#),
+        "expected readable render, got: {rendered}"
+    );
+    // Must not leak Rust `Debug` internals.
+    for leak in [
+        "Instance {",
+        "QualifiedTypeName",
+        "TyAttr",
+        "String(\"boom\")",
+    ] {
+        assert!(!rendered.contains(leak), "leaked `{leak}` in: {rendered}");
+    }
 }
 
 // ============================================================================

--- a/baml_language/crates/baml_tests/tests/http.rs
+++ b/baml_language/crates/baml_tests/tests/http.rs
@@ -332,6 +332,6 @@ async fn http_response_text_consumed() {
     insta::assert_snapshot!(output.result.unwrap_err().to_string(), @r#"
     Traceback (most recent call last):
       File "test.baml", line 5, in user.main
-    uncaught throw: Instance { class_name: "baml.errors.Io", type_args: [], fields: {"message": String("Response body has already been consumed")} }
+    uncaught throw: baml.errors.Io {message: "Response body has already been consumed"}
     "#);
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -506,7 +506,7 @@ fn format_unhandled_throw(value: &BexExternalValue, trace: &[bex_vm::StackFrame]
             loc.function_name.as_str(),
         )
     }));
-    write!(out, "uncaught throw: {value:?}").unwrap();
+    write!(out, "uncaught throw: {}", value.render_readable()).unwrap();
     out
 }
 

--- a/baml_language/crates/bex_external_types/src/bex_external_value.rs
+++ b/baml_language/crates/bex_external_types/src/bex_external_value.rs
@@ -495,6 +495,67 @@ impl BexExternalValue {
     pub fn is_host_value(&self) -> bool {
         matches!(self, Self::HostValue(_))
     }
+
+    /// Human-readable, structural rendering of this value — the form `baml run`
+    /// prints in debug mode and the form the CLI surfaces for an uncaught
+    /// `throw`.
+    ///
+    /// This is deliberately distinct from the [`Debug`](std::fmt::Debug) impl,
+    /// which leaks Rust-internal shapes: a thrown
+    /// `baml.errors.Io { message: "boom" }` renders here as
+    /// `baml.errors.Io { message: "boom" }` rather than
+    /// `Instance { class_name: "baml.errors.Io", type_args: [], fields: {..} }`,
+    /// and a generic instance's `type_args` are omitted entirely instead of
+    /// dumping `Class(QualifiedTypeName { .. }, [], TyAttr { .. })`.
+    ///
+    /// It is a pure structural pretty-printer, not the VM's `baml.ToString`
+    /// dispatch: it runs without a live VM (e.g. after the VM has unwound on an
+    /// uncaught throw), so it cannot honor user `to_string` overrides.
+    pub fn render_readable(&self) -> String {
+        match self {
+            BexExternalValue::Null => "null".to_string(),
+            BexExternalValue::Int(i) => i.to_string(),
+            BexExternalValue::Bigint(i) => i.to_string(),
+            BexExternalValue::Float(f) => {
+                let s = f.to_string();
+                if s.contains('.') || !f.is_finite() {
+                    s
+                } else {
+                    format!("{s}.0")
+                }
+            }
+            BexExternalValue::Bool(b) => b.to_string(),
+            BexExternalValue::String(s) => format!("{s:?}"),
+            BexExternalValue::Array { items, .. } => {
+                let inner: Vec<String> = items.iter().map(Self::render_readable).collect();
+                format!("[{}]", inner.join(", "))
+            }
+            BexExternalValue::Map { entries, .. } => {
+                let inner: Vec<String> = entries
+                    .iter()
+                    .map(|(k, v)| format!("{k:?}: {}", v.render_readable()))
+                    .collect();
+                format!("{{{}}}", inner.join(", "))
+            }
+            BexExternalValue::Instance {
+                class_name, fields, ..
+            } => {
+                let inner: Vec<String> = fields
+                    .iter()
+                    .map(|(k, v)| format!("{k}: {}", v.render_readable()))
+                    .collect();
+                if class_name.is_empty() {
+                    format!("{{{}}}", inner.join(", "))
+                } else {
+                    format!("{class_name} {{{}}}", inner.join(", "))
+                }
+            }
+            BexExternalValue::Variant { variant_name, .. } => variant_name.clone(),
+            BexExternalValue::Union { value, .. } => value.render_readable(),
+            BexExternalValue::Uint8Array(bytes) => format!("<bytes:{}>", bytes.len()),
+            _ => format!("{self:?}"),
+        }
+    }
 }
 
 impl From<i64> for BexExternalValue {
@@ -722,4 +783,61 @@ pub fn try_convert_rust_data(
         return Some(BexExternalValue::HostValue(typed));
     }
     None
+}
+
+#[cfg(test)]
+mod render_readable_tests {
+    use super::*;
+
+    /// A thrown error instance renders as `Class { field: value }`, not the
+    /// Rust `Debug` shape `Instance { class_name: .., type_args: [], fields: .. }`.
+    /// This is the exact B-623 repro.
+    #[test]
+    fn instance_renders_class_and_fields_not_debug() {
+        let value = BexExternalValue::instance(
+            "baml.errors.Io",
+            IndexMap::from([("message", BexExternalValue::from("boom"))]),
+        );
+        assert_eq!(
+            value.render_readable(),
+            r#"baml.errors.Io {message: "boom"}"#
+        );
+    }
+
+    /// A generic error instance carrying a `Class(..)` in its `type_args` — the
+    /// shape that used to dump `Class(QualifiedTypeName { .. }, [], TyAttr { .. })`
+    /// under `Debug` — renders readably with the `type_args` omitted and no Rust
+    /// internals leaked.
+    #[test]
+    fn generic_instance_omits_type_args_and_never_leaks_debug() {
+        let inner = BexExternalValue::instance(
+            "baml.errors.Io",
+            IndexMap::from([("message", BexExternalValue::from("boom"))]),
+        );
+        let value = BexExternalValue::instance_generic(
+            "baml.future.AllFailed",
+            vec![RuntimeTy::class("baml.errors.Io")],
+            IndexMap::from([(
+                "errors",
+                BexExternalValue::Array {
+                    element_type: RuntimeTy::class("baml.errors.Io"),
+                    items: vec![inner],
+                },
+            )]),
+        );
+
+        let rendered = value.render_readable();
+        assert!(
+            rendered.starts_with("baml.future.AllFailed {"),
+            "unexpected render: {rendered}"
+        );
+        assert!(
+            rendered.contains(r#"errors: [baml.errors.Io {message: "boom"}]"#),
+            "unexpected render: {rendered}"
+        );
+        // The bug: `Debug` leaks Rust-internal shapes. The readable form must not.
+        for leak in ["Instance {", "QualifiedTypeName", "TyAttr", "Class("] {
+            assert!(!rendered.contains(leak), "leaked `{leak}` in: {rendered}");
+        }
+    }
 }


### PR DESCRIPTION
## What

Render an uncaught `throw` value using a readable structural rendering instead of Rust `Debug`.

Fixes **B-623**.

## Why

When a `throw` propagated to the top (uncaught), the CLI printed the thrown value via `{:?}` (Debug), leaking Rust/compiler internals instead of a readable form.

**Before:**
```
$ baml run -e 'throw baml.errors.Io { message: "boom" }'
uncaught throw: Instance { class_name: "baml.errors.Io", type_args: [], fields: {"message": String("boom")} }
```
Generic errors leaked even worse internals (`type_args: [Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "Io" }, [], TyAttr { … })]`).

**After:**
```
$ baml run -e 'throw baml.errors.Io { message: "boom" }'
uncaught throw: baml.errors.Io {message: "boom"}
```

## How

- The uncaught-throw print site (`bex_engine::format_unhandled_throw`) formatted the thrown `BexExternalValue` with `{:?}`. It now goes through a canonical structural renderer.
- Added `BexExternalValue::render_readable()` in `bex_external_types` — the exact human-readable structural pretty-printer `baml run` already uses for its debug output. That logic previously lived as `baml_exec::format_value`; it now delegates to the shared method so `baml run` output and a leaked `throw` render identically (single source of truth).
- A generic instance's `type_args` are omitted from the rendering (the renderer only walks `class_name` + `fields`), so `QualifiedTypeName` / `TyAttr` can no longer leak.
- Pure rendering change: throw semantics and the process exit code are unchanged.

## How tested

- New unit tests in `bex_external_types`: an `Io` instance renders as `baml.errors.Io {message: "boom"}`; a generic instance carrying a `Class(..)` in its `type_args` renders readably and asserts no `Instance {` / `QualifiedTypeName` / `TyAttr` / `Class(` leak.
- New end-to-end regression test in `baml_tests` for `throw baml.errors.Io { message: "boom" }`.
- Updated 4 existing inline snapshots (`errors.rs`, `exceptions.rs` x2, `http.rs`) to the readable form.
- Verified the CLI repro by hand.
- Local: `cargo nextest run` set (4221 passed), `cargo test -p baml_tests` (26 passed), `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error and value displays now use a cleaner, human-readable format with type annotations.
  * Uncaught throws now show readable class-style output instead of internal debug details.

* **Bug Fixes**
  * Improved exception and HTTP error messages to be more concise and consistent.
  * Prevented internal implementation details from appearing in thrown error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->