### PR TITLE
fix(vm): serialize enum variants as their name in union/optional json fields (B-728)

### DIFF
--- a/baml_language/crates/baml_tests/tests/to_json_interface.rs
+++ b/baml_language/crates/baml_tests/tests/to_json_interface.rs
@@ -256,3 +256,65 @@ async fn enum_renders_as_variant_name() {
     let out = expect_json(&program("enum Color { Red  Green  Blue }", "Color.Green")).await;
     assert_eq!(out, r#""Green""#);
 }
+
+// ─── B-728: enum & string-literal-union fields in the value→JSON dispatch ──────
+//
+// A class field of `enum` type or a string-literal union (`"X" | "Y"`) must
+// serialize to a plain JSON string — the variant name / the string — through
+// both the structural `baml.json.from` / `.to_json()` path and the typed
+// `baml.json.to_string<T>` path. The regression these lock in: a field whose
+// declared type is a *union containing an enum* (including the optional enum
+// `E?` == `E | null`) serialized as `null` through the typed walker, whose
+// `RuntimeTy::Union` arm delegates to the untyped `value_to_serde`, which
+// mapped enum variants to `null` instead of the variant-name string.
+
+#[tokio::test]
+async fn enum_field_serializes_as_variant_name() {
+    // Primary ticket case: `class C { e E }` round-trips through `.to_json()`.
+    let out = expect_json(&program("enum E { A  B }  class C { e E }", "C { e: E.A }")).await;
+    assert_eq!(out, r#"{"e":"A"}"#);
+}
+
+#[tokio::test]
+async fn string_literal_union_field_serializes_as_string() {
+    // Primary ticket case: a `"X" | "Y"` field round-trips through `.to_json()`
+    // as the plain string.
+    let out = expect_json(&program(r#"class D { f "X" | "Y" }"#, r#"D { f: "X" }"#)).await;
+    assert_eq!(out, r#"{"f":"X"}"#);
+}
+
+#[tokio::test]
+async fn optional_enum_field_serializes_via_typed_to_string() {
+    // Regression: `E?` == `E | null` is a union, so the typed `to_string<T>`
+    // walker rendered it via the untyped converter, which produced `null` for
+    // the enum variant. It must be the variant name.
+    let out = expect_json(
+        r#"
+        enum E { A  B }
+        class OptEnum { e E? }
+        function main() -> string {
+            return baml.json.to_string(OptEnum { e: E.A })
+        }
+        "#,
+    )
+    .await;
+    assert_eq!(out, r#"{"e":"A"}"#);
+}
+
+#[tokio::test]
+async fn enum_union_field_serializes_via_typed_to_string() {
+    // Regression: a field typed as a union of two enums (`E | F`) serialized the
+    // held variant as `null` through the typed walker. It must be the name.
+    let out = expect_json(
+        r#"
+        enum E { A  B }
+        enum F { X  Y }
+        class EnumUnion { v E | F }
+        function main() -> string {
+            return baml.json.to_string(EnumUnion { v: F.Y })
+        }
+        "#,
+    )
+    .await;
+    assert_eq!(out, r#"{"v":"Y"}"#);
+}

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -687,13 +687,30 @@ pub fn value_to_serde(vm: &BexVm, v: Value) -> serde_json::Value {
                 serde_json::Value::Object(entries)
             }
             Object::Bigint(bi) => serde_json::Value::String(bi.to_string()),
+            // An enum variant renders as its variant-name string, matching the
+            // typed (`ty_value_to_serde`) and structural (`render_to_serde`)
+            // walkers. This is reached when a variant flows through an arm that
+            // delegates to the untyped converter — e.g. `ty_value_to_serde`'s
+            // `RuntimeTy::Union` arm for a field typed `E | ...` (including the
+            // optional enum `E?` == `E | null`). Without this, such fields
+            // serialized as `null` (B-728).
+            Object::Variant(var) => {
+                let (enm, index) = (var.enm, var.index);
+                match vm.get_object(enm) {
+                    Object::Enum(e) => e
+                        .variants
+                        .get(index)
+                        .map(|v| serde_json::Value::String(v.name.clone()))
+                        .unwrap_or(serde_json::Value::Null),
+                    _ => serde_json::Value::Null,
+                }
+            }
             Object::Instance(_)
             | Object::Class(_)
             | Object::Enum(_)
             | Object::Interface(_)
             | Object::Package(_)
             | Object::ImplRule(_)
-            | Object::Variant(_)
             | Object::Function(_)
             | Object::Future(_)
             | Object::UnscheduledFuture(_)


### PR DESCRIPTION
## B-728 — enum & string-literal-union fields fail `to_json()` / `--output-format json`

### What was wrong
A class field whose declared type is a **union containing an enum** — most commonly the optional enum `E?` (which desugars to `E | null`), but also `E | F` — serialized to `null` when rendered through the typed serializer `baml.json.to_string<T>`:

```baml
enum E { A B }
class OptEnum { e E? }
baml.json.to_string(OptEnum { e: E.A })   // => {"e":null}   (should be {"e":"A"})
```

### Root cause
`ty_value_to_serde`'s `RuntimeTy::Union` arm dispatches structurally on the runtime value by delegating to the untyped converter `value_to_serde`. That converter lumped `Object::Variant` into the catch-all arm that returns `serde_json::Value::Null`, so any enum variant reaching it (via a union/optional field) was dropped to `null`.

The structural walker `render_to_serde` (which backs `.to_json()` / `baml.json.from` and `--output-format json` via `baml.json.serialize`) already renders variants correctly — this is why bare `enum` fields and `"X" | "Y"` string-literal-union fields serialize fine. The gap was only in the untyped converter used by the typed `to_string<T>` path and the `RuntimeTy::Union` / `Void` / `TypeAlias` delegations.

### Fix
Render an enum variant as its variant-name string in `value_to_serde`, matching the typed (`ty_value_to_serde`) and structural (`render_to_serde`) walkers. This is the minimal change to the value→JSON conversion; it only affects the previously-`null` variant case, so no existing behavior changes.

### Tests
Adds four regression tests in `to_json_interface.rs`:
- `enum_field_serializes_as_variant_name` — `class C { e E }` via `.to_json()` → `{"e":"A"}`
- `string_literal_union_field_serializes_as_string` — `class D { f "X" | "Y" }` → `{"f":"X"}`
- `optional_enum_field_serializes_via_typed_to_string` — `E?` field via `to_string<T>` → `{"e":"A"}` (fails on `main`, produced `{"e":null}`)
- `enum_union_field_serializes_via_typed_to_string` — `E | F` field via `to_string<T>` → `{"v":"Y"}` (fails on `main`)

### Local CI
- `cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/) and not binary(=pack_e2e)'` → 4245 passed
- `cargo test -p baml_tests` → 0 failed
- `cargo fmt --check` clean · `cargo clippy --all-targets --all-features -- -D warnings` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enum fields and string-literal union fields now serialize as plain JSON strings in both structural JSON conversion and typed JSON output.
  * Optional enums and unions of enums now produce the expected string values instead of empty or null output.
  * Variant values are now preserved as their variant names during JSON conversion when supported, improving consistency across JSON paths.
* **Tests**
  * Added regression coverage for enum, literal union, optional enum, and enum-union serialization cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->