### PR TITLE
fix(compiler): bitwise NOT (~) was a silent identity (B-766)

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -1277,6 +1277,11 @@ impl LoweringContext {
         let mut op = None;
         let mut operand = None;
         let mut double_op = false;
+        // Set when the prefix operator is `~` (bitwise NOT). Desugared below
+        // into `-x - 1` (two's-complement complement) rather than a dedicated
+        // `UnaryOp` variant, so it reuses the existing, correct `Neg`/`Sub`
+        // type rules and VM opcodes without a new operator in the pipeline.
+        let mut bit_not = false;
         // Value of an `INTEGER_LITERAL` token seen *directly* in this
         // `UNARY_EXPR` (not via a child node like a parenthesized expr).
         let mut direct_int_lit: Option<i64> = None;
@@ -1290,6 +1295,7 @@ impl LoweringContext {
                     let span = token.text_range();
                     match token.kind() {
                         SyntaxKind::NOT => op = Some(UnaryOp::Not),
+                        SyntaxKind::TILDE => bit_not = true,
                         SyntaxKind::MINUS => op = Some(UnaryOp::Neg),
                         SyntaxKind::MINUS_MINUS => {
                             op = Some(UnaryOp::Neg);
@@ -1331,6 +1337,35 @@ impl LoweringContext {
         }
 
         let expr = operand.unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.span_range()));
+
+        // Bitwise NOT: desugar `~x` into `-x - 1`. Two's-complement complement
+        // is `~x == -x - 1`, correct for every BAML int (63-bit signed) whose
+        // negation is representable. Lowering to existing `Neg`/`Sub` keeps `~`
+        // out of the type checker and VM as a distinct operator while producing
+        // the correct value; the operand is evaluated exactly once. The lone
+        // corner is `~INT_MIN`: its result (`INT_MAX`) is representable, but the
+        // intermediate `-INT_MIN` overflows the range, so it throws/errors like
+        // any other `-INT_MIN` — an inherent limitation of negating INT_MIN
+        // here, not a silent wrong answer (the bug this fix removes).
+        if bit_not {
+            let span = node.span_range();
+            let neg = self.alloc_expr(
+                Expr::Unary {
+                    op: UnaryOp::Neg,
+                    expr,
+                },
+                span,
+            );
+            let one = self.alloc_expr(Expr::Literal(Literal::Int(1)), span);
+            return self.alloc_expr(
+                Expr::Binary {
+                    op: BinaryOp::Sub,
+                    lhs: neg,
+                    rhs: one,
+                },
+                span,
+            );
+        }
 
         let Some(op) = op else {
             return expr;

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -1349,6 +1349,14 @@ impl LoweringContext {
         // here, not a silent wrong answer (the bug this fix removes).
         if bit_not {
             let span = node.span_range();
+            // Every node built here is compiler-generated: the user wrote `~`,
+            // which desugars away entirely, so — unlike the backtick/tagged
+            // desugarings, whose outer `Template` still maps 1:1 to user syntax
+            // — no surviving node corresponds to the source. Mark all of them
+            // synthetic (so tooling like inlay hints skips them) and restore the
+            // flag afterward. Only the operand `x`, lowered above, is user code
+            // and keeps its real, non-synthetic id.
+            let prev_synth = std::mem::replace(&mut self.synthesizing, true);
             let neg = self.alloc_expr(
                 Expr::Unary {
                     op: UnaryOp::Neg,
@@ -1357,7 +1365,7 @@ impl LoweringContext {
                 span,
             );
             let one = self.alloc_expr(Expr::Literal(Literal::Int(1)), span);
-            return self.alloc_expr(
+            let result = self.alloc_expr(
                 Expr::Binary {
                     op: BinaryOp::Sub,
                     lhs: neg,
@@ -1365,6 +1373,8 @@ impl LoweringContext {
                 },
                 span,
             );
+            self.synthesizing = prev_synth;
+            return result;
         }
 
         let Some(op) = op else {

--- a/baml_language/crates/baml_tests/baml_src/ns_operators/operators.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_operators/operators.baml
@@ -54,6 +54,15 @@ test "shift_right" {
     assert.is_true(baml.deep_equals(10 >> 3, 1))
 }
 
+// Bitwise NOT (`~`) is two's-complement complement: `~x == -x - 1`. Regression
+// for B-766, where `~` silently lowered to the identity (`~x == x`).
+test "bitwise_not" {
+    assert.is_true(baml.deep_equals(~0, -1))
+    assert.is_true(baml.deep_equals(~1, -2))
+    assert.is_true(baml.deep_equals(~255, -256))
+    assert.is_true(baml.deep_equals(~(-1), 0))
+}
+
 // ─── Unary ───────────────────────────────────────────────────────────────────
 
 test "unary_negate" {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/operators.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/operators.snap
@@ -63,158 +63,164 @@ function operators.$init_test_ns_operators_operators(registry: testing.TestColle
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "unary_negate"
+    load_const "bitwise_not"
     make_closure .<lambda($init_test_ns_operators_operators, 10)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "unary_not"
+    load_const "unary_negate"
     make_closure .<lambda($init_test_ns_operators_operators, 11)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "negative_int_in_let"
+    load_const "unary_not"
     make_closure .<lambda($init_test_ns_operators_operators, 12)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "negative_int_arithmetic"
+    load_const "negative_int_in_let"
     make_closure .<lambda($init_test_ns_operators_operators, 13)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "negative_int_comparison"
+    load_const "negative_int_arithmetic"
     make_closure .<lambda($init_test_ns_operators_operators, 14)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "negative_float_in_let"
+    load_const "negative_int_comparison"
     make_closure .<lambda($init_test_ns_operators_operators, 15)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "double_negation"
+    load_const "negative_float_in_let"
     make_closure .<lambda($init_test_ns_operators_operators, 16)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "double_negation_variable"
+    load_const "double_negation"
     make_closure .<lambda($init_test_ns_operators_operators, 17)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "equal"
+    load_const "double_negation_variable"
     make_closure .<lambda($init_test_ns_operators_operators, 18)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "not_equal"
+    load_const "equal"
     make_closure .<lambda($init_test_ns_operators_operators, 19)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "greater_than"
+    load_const "not_equal"
     make_closure .<lambda($init_test_ns_operators_operators, 20)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "greater_than_or_equal"
+    load_const "greater_than"
     make_closure .<lambda($init_test_ns_operators_operators, 21)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "less_than"
+    load_const "greater_than_or_equal"
     make_closure .<lambda($init_test_ns_operators_operators, 22)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "less_than_or_equal"
+    load_const "less_than"
     make_closure .<lambda($init_test_ns_operators_operators, 23)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "logical_and"
+    load_const "less_than_or_equal"
     make_closure .<lambda($init_test_ns_operators_operators, 24)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "logical_or"
+    load_const "logical_and"
     make_closure .<lambda($init_test_ns_operators_operators, 25)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "short_circuit_and"
+    load_const "logical_or"
     make_closure .<lambda($init_test_ns_operators_operators, 26)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "short_circuit_or"
+    load_const "short_circuit_and"
     make_closure .<lambda($init_test_ns_operators_operators, 27)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "assign_add"
+    load_const "short_circuit_or"
     make_closure .<lambda($init_test_ns_operators_operators, 28)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "assign_subtract"
+    load_const "assign_add"
     make_closure .<lambda($init_test_ns_operators_operators, 29)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "assign_multiply"
+    load_const "assign_subtract"
     make_closure .<lambda($init_test_ns_operators_operators, 30)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "assign_divide"
+    load_const "assign_multiply"
     make_closure .<lambda($init_test_ns_operators_operators, 31)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "assign_modulo"
+    load_const "assign_divide"
     make_closure .<lambda($init_test_ns_operators_operators, 32)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "assign_bitwise_and"
+    load_const "assign_modulo"
     make_closure .<lambda($init_test_ns_operators_operators, 33)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "assign_bitwise_or"
+    load_const "assign_bitwise_and"
     make_closure .<lambda($init_test_ns_operators_operators, 34)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1
     load_var registry
-    load_const "assign_bitwise_xor"
+    load_const "assign_bitwise_or"
     make_closure .<lambda($init_test_ns_operators_operators, 35)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "assign_bitwise_xor"
+    make_closure .<lambda($init_test_ns_operators_operators, 36)>, 0
     load_const null
     call testing.TestCollector.register_test
     pop 1


### PR DESCRIPTION
## B-766 — `~` (bitwise NOT) silently returned the operand unchanged

### Bug
The `~` prefix operator compiled and ran with **no diagnostic** but was an identity function (`~x == x`):

| expr | before | expected |
|------|--------|----------|
| `~0` | `0` | `-1` |
| `~1` | `1` | `-2` |
| `~255` | `255` | `-256` |
| `~(-1)` | `-1` | `0` |

The other bitwise ops (`& | ^ << >>`) were already correct.

### Root cause
`~` (`Tilde`) had **no match arm** in `lower_unary_expr` (`baml_compiler2_ast/src/lower_expr_body.rs`). The token fell through to `_ => {}`, so no `UnaryOp` was recorded and the function returned the operand expression unchanged — the operator was silently dropped during CST→AST lowering, before it ever reached the type checker, MIR, or VM. (So this was never a wrong opcode in the VM; the op simply vanished at lowering.)

### Fix
Desugar `~x` into `-x - 1` (two's-complement complement) in AST lowering, reusing the already-correct `Neg` and `Sub`. This:
- keeps the change entirely in the AST-lowering layer — **no TIR / type-system changes**, no new operator threaded through MIR/VM;
- evaluates the operand exactly once (no double side effects);
- is correct for `int` and `bigint`.

Verified via `baml-cli run -e`: `~0→-1`, `~1→-2`, `~255→-256`, `~(-1)→0`, `~(~5)→5`, `~INT_MAX→INT_MIN`. Non-int operands now give clean type errors (`~true`, `~"hi"`) instead of a silent identity.

### Known corner: `~INT_MIN`
`~INT_MIN` mathematically equals `INT_MAX` (which is representable), but the intermediate `-INT_MIN` overflows BAML's 63-bit range, so it errors — exactly like plain `-(INT_MIN)`, which already errors in BAML today. This is an inherent limitation of negating INT_MIN in a 63-bit signed system, **not** a silent wrong answer (which is the bug this removes). Making `~INT_MIN` fully correct would require a dedicated VM bit-complement opcode plus a TIR type rule for a distinct `~` operator, which is out of this ticket's scope (VM/operator correctness fix; TIR owned by another engineer).

### Regression test
`crates/baml_tests/baml_src/ns_operators/operators.baml` gains a `bitwise_not` test with the exact ticket vectors (`~0==-1`, `~1==-2`, `~255==-256`, `~(-1)==0`). Regenerated the `operators` bytecode snapshot — only that namespace shifted (new test lambda + renumbered later lambdas); no `__baml_std__` churn.

### Secondary (skipped) — `~` in `baml describe Int`
The `int.baml` builtin doc only documents arithmetic operators; there is no bitwise-operators section to append `~` to, and that file lives in `baml_builtins2/baml_std`, which regenerates `__baml_std__` snapshots (the churn / sibling-contamination zone flagged for this machine). Skipped per the ticket's "skip if it widens the change" guidance.

### Local CI (0 failures)
- `cargo nextest run --all-features -E 'not package(baml_tests) and not package(/^sdk_test_/) and not binary(=pack_e2e)'` → 4245 passed
- `cargo test -p baml_tests` → all binaries passed
- `cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `~` bitwise NOT operator in expressions.

* **Bug Fixes**
  * `~` now follows standard two’s-complement behavior (e.g., `~0 = -1`, `~1 = -2`, `~255 = -256`, `~(-1) = 0`), including edge-case correctness.

* **Tests**
  * Added a dedicated `bitwise_not` test block covering multiple cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->