### PR TITLE
Test + I/O timeouts and the end-of-run engine wedge fix

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_http/http.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_http/http.baml
@@ -108,11 +108,13 @@ class SseStream {
 }
 
 /// Converts an optional timeout into the nanosecond count carried across the
-/// sys-op boundary. `null` (no deadline) becomes `0n`, which the native layer
-/// treats as unbounded. Modeled on Rust's `Option<Duration>`.
+/// sys-op boundary. `null` becomes the DEFAULT deadline (5 minutes) — a plain
+/// `http.send(request)` can no longer wedge a program forever on a stalled
+/// socket. Pass an explicit `Duration` for a longer (or shorter) deadline;
+/// there is deliberately no "unbounded" spelling.
 function _timeout_nanos(timeout: root.time.Duration?) -> bigint throws never {
   match (timeout) {
-    null => 0n,
+    null => 300000000000n, // 5 minutes
     let t: root.time.Duration => t.to_nanoseconds(),
   }
 }
@@ -120,7 +122,7 @@ function _timeout_nanos(timeout: root.time.Duration?) -> bigint throws never {
 /// Sends a GET request to `url` and returns the response.
 ///
 /// `timeout` is the total deadline for the request (connection + response
-/// headers + body). `null` (the default) imposes no deadline. On expiry this
+/// headers + body). `null` (the default) means 5 minutes. On expiry this
 /// throws `root.errors.Timeout`.
 function fetch(url: string, timeout: root.time.Duration? = null) -> Response throws root.errors.Io | root.errors.Timeout {
   // Thin wrapper resolving the default: `$rust_io_function` sys-ops don't fill
@@ -135,7 +137,7 @@ function _fetch(url: string, timeout_nanos: bigint) -> Response throws root.erro
 /// Sends an HTTP request and returns the response.
 ///
 /// `timeout` is the total deadline for the request, as in `fetch`. `null` (the
-/// default) imposes no deadline.
+/// default) means 5 minutes.
 function send(request: Request, timeout: root.time.Duration? = null) -> Response throws root.errors.Io | root.errors.Timeout {
   _send(request, _timeout_nanos(timeout))
 }

--- a/baml_language/crates/baml_builtins2/baml_std/testing/registry.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/testing/registry.baml
@@ -378,25 +378,48 @@ function run_children_parallel(children: TestSetChild[]) -> TestSetReport {
 }
 
 // Run a single test with error handling and optional runner middleware.
+// Every test races against a deadline (default 5 minutes; override with the
+// BAML_TEST_TIMEOUT_MS env var): a hung test — a stalled network read, a
+// deadlocked await — becomes a FAIL with a "timed out" message instead of
+// hanging the whole run. `baml.future.race` cancels the losers when one
+// side settles (BEP-034), so a timed-out body is actively cancelled and a
+// finished test's leftover timer doesn't linger.
 function run_test(body: TestBody, runner: TestRunner?) -> TestReport {
   let base_run: TestReportThunk = () -> TestReport {
     let start = baml.sys.now_ms()
-    let result = {
-      body()
-      RunReport { outcome: "pass", duration_ms: 0, message: null }
-    } catch_all (e) {
-      let p: baml.panics.UserPanic => {
-        RunReport { outcome: "fail", duration_ms: 0, message: p.message }
-      },
-      let p: baml.panics.AssertionFailed => {
-        RunReport { outcome: "fail", duration_ms: 0, message: p.message }
-      },
-      baml.panics.Panic => {
-        RunReport { outcome: "fail", duration_ms: 0, message: null }
-      },
-      _ => {
-        RunReport { outcome: "fail", duration_ms: 0, message: null }
+    let timeout_ms = match (baml.env.get("BAML_TEST_TIMEOUT_MS") catch (e) { _ => null }) {
+      let t: string => int.parse(t) catch (e) { _ => 300000 },
+      _ => 300000,
+    };
+    let work: baml.future.Future<RunReport, null> = spawn {
+      {
+        body()
+        RunReport { outcome: "pass", duration_ms: 0, message: null }
+      } catch_all (e) {
+        let p: baml.panics.UserPanic => {
+          RunReport { outcome: "fail", duration_ms: 0, message: p.message }
+        },
+        let p: baml.panics.AssertionFailed => {
+          RunReport { outcome: "fail", duration_ms: 0, message: p.message }
+        },
+        baml.panics.Panic => {
+          RunReport { outcome: "fail", duration_ms: 0, message: null }
+        },
+        _ => {
+          RunReport { outcome: "fail", duration_ms: 0, message: null }
+        }
       }
+    }
+    let timer: baml.future.Future<RunReport, null> = spawn {
+      baml.sys.sleep(baml.time.Duration.from_milliseconds(timeout_ms)) catch (e) { _ => null }
+      RunReport {
+        outcome: "fail",
+        duration_ms: 0,
+        message: "test timed out after " + timeout_ms.to_string() + "ms (override with BAML_TEST_TIMEOUT_MS)",
+      }
+    }
+    let result = (await baml.future.race([work, timer])) catch_all (e) {
+      _ => RunReport { outcome: "fail", duration_ms: 0, message: "test task failed unexpectedly" }
     }
     TestReport {
       outcome: result.outcome,

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -258,6 +258,36 @@ impl FutureManagerGuard<'_> {
         Ok(())
     }
 
+    /// Settle `id` to `InternalError` **only if it is still `Pending`**, a no-op
+    /// otherwise. Unlike [`Self::internal_error_future`] this tolerates an
+    /// already-settled future (e.g. a racing `f.cancel()`) without asserting.
+    ///
+    /// Used by `spawn_thread_inner` when a spawned child's event loop bubbled an
+    /// `EngineError` out WITHOUT settling its own future — the child awaited a
+    /// future that produced an `InternalError`, and `AwaitOutcome::Done(r) => r?`
+    /// propagated the error past every `settle_child_*`. Left `Pending`, the
+    /// child's `ready` wake never fires, so its awaiter parks forever and the
+    /// stall cascades up to the root's B-650 end-of-run wait, wedging shutdown.
+    /// Settling here fires the `ready` wake and routes the error through
+    /// `future_ready`, so the awaiter resumes and re-propagates it — the same
+    /// deterministic surfacing a non-spawned `Await` gets.
+    pub fn settle_internal_error_if_pending(
+        &mut self,
+        id: FutureId,
+        err: EngineError,
+    ) -> Result<(), EngineError> {
+        let Some(entry) = self.holder().active_futures.get(&id) else {
+            // Already settled and cleaned up out-of-band — nothing to do.
+            return Ok(());
+        };
+        // SAFETY: caller holds the heap permit via `self.proof`.
+        let fut = unsafe { entry.future_ref() }?;
+        if matches!(fut.read(), FutureRead::Pending(_)) {
+            self.internal_error_future(id, err)?;
+        }
+        Ok(())
+    }
+
     /// Sets the future to `InternalError` and notifies the waiter.
     ///
     /// Unlike the other terminal-transition helpers, this does **not** remove
@@ -496,6 +526,7 @@ impl FutureManagerGuard<'_> {
             })
             .collect()
     }
+
 }
 impl TlabHolder for FutureManagerGuard<'_> {
     fn tlab(&self) -> &Tlab {

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3365,6 +3365,29 @@ impl BexEngine {
         Ok(())
     }
 
+    /// Settle a spawned child's still-`Pending` future after its event loop
+    /// bubbled an [`EngineError`] out of `run_thread_event_loop` (the `Err` /
+    /// invariant-violating `RootValue` arms in [`Self::spawn_thread_inner`]).
+    ///
+    /// The child task has already fully unwound here — its `ActiveHeapPermit`
+    /// was consumed by (and dropped inside) `run_thread_event_loop` — so we own
+    /// no permit. Acquire a fresh COLD permit (the `active_future_count`
+    /// pattern) purely to reach the `FutureManager`, and settle the future as an
+    /// internal error IF it is still `Pending` (tolerating a racing cancel).
+    /// This fires the `ready` wake and routes the error to any awaiter, so the
+    /// await chain resumes instead of parking forever and wedging shutdown.
+    async fn settle_spawn_engine_error(self: &Arc<Self>, future_id: FutureId, err: EngineError) {
+        let active = self.heap_permit_manager.new_permit(()).await.acquire().await;
+        let mut guard = self.futures.acquire(active.proof()).await;
+        if let Err(settle_err) = guard.settle_internal_error_if_pending(future_id, err) {
+            tracing::error!(
+                ?settle_err,
+                ?future_id,
+                "failed to settle a spawned child's leaked future after an engine error"
+            );
+        }
+    }
+
     /// Transition the child future settled by `thread` to `Error(value)`,
     /// fire its cancel token, and push our settled future ptr onto our
     /// parent's fire-and-forget error queue per BEP-034 — without this,
@@ -4027,11 +4050,35 @@ impl BexEngine {
                 // The abnormal arms close any spans the event loop left open
                 // before the thread ends — the ring EndThread (emitted by the
                 // run_thread_event_loop wrapper) must never strand open spans.
+                //
+                // Both arms MUST also settle the child's heap `Future`. A child
+                // event loop reaches here with its future still `Pending`: the
+                // normal terminal transitions (`Complete`/throw/cancel) return
+                // `Ok(SettledChild)` after settling, so `Ok(RootValue)` is an
+                // invariant violation and `Err` is an `EngineError` that bubbled
+                // out past every `settle_child_*` (notably the InternalError
+                // reproduced by the live testset: a child awaited a future that
+                // produced an `InternalError`, and `AwaitOutcome::Done(r) => r?`
+                // propagated it here). Left `Pending`, the child's `ready` wake
+                // never fires, its awaiter parks forever, and the stall cascades
+                // to the root's B-650 end-of-run wait — the engine never observes
+                // quiescence and `baml test` wedges after finishing all work.
+                // Settling as an internal error fires the wake and re-propagates
+                // the error deterministically up the await chain.
                 Ok(ThreadOutcome::RootValue(_)) => {
                     tracing::error!(
                         ?future_id,
                         "spawn thread returned a root value instead of settling its future"
                     );
+                    engine
+                        .settle_spawn_engine_error(
+                            future_id,
+                            EngineError::Other(
+                                "spawn thread returned a root value instead of settling its future"
+                                    .to_string(),
+                            ),
+                        )
+                        .await;
                 }
                 Err(err) => {
                     tracing::error!(
@@ -4039,6 +4086,7 @@ impl BexEngine {
                         ?future_id,
                         "spawn thread terminated with engine error"
                     );
+                    engine.settle_spawn_engine_error(future_id, err).await;
                 }
             }
         };

--- a/baml_language/crates/bex_engine/tests/host_value_callable.rs
+++ b/baml_language/crates/bex_engine/tests/host_value_callable.rs
@@ -1496,3 +1496,90 @@ async fn host_callable_with_generic_return_is_rejected() {
     );
     drop(arc);
 }
+
+// ============================================================================
+// Regression: a spawned child that AWAITS a future which settles to an
+// `InternalError` must not leak its own future as `Pending` forever.
+// ============================================================================
+
+// Root cause (engine-shutdown wedge, reproduced from the live `baml test`
+// sweep): when a spawned awaiter is PARKED on a future and that future settles
+// to `InternalError`, the engine's `Await`/`AwaitAny` arm resolves the
+// awaiter's `SetOnce` wait with an `Err(EngineError)` and propagates it via
+// `AwaitOutcome::Done(r) => r?`. That bubbles the error out of
+// `run_thread_event_loop` WITHOUT any `settle_child_*` running, so
+// `spawn_thread_inner` used to only *log* it — leaving the awaiter's heap
+// `Future` `Pending`. Its `ready` wake never fires, so ITS awaiter (and,
+// transitively, the root's B-650 end-of-run wait) parks forever: the VM did all
+// its work but the engine never observes quiescence and the process wedges.
+//
+// The live trigger was a VM `TracedVmInternalError` surfaced on live data (its
+// `Display` renders with a Python-style `Traceback (most recent call last):`
+// header — BAML's own internal-error formatter, not an actual Python
+// exception). Here we seed the SAME leak deterministically and offline with a
+// host-bridge fault (`FakeReturn::BridgeFailure`), which the engine surfaces as
+// an uncatchable `EngineError::VmInternalError { BridgeFailure }` — a permanent
+// host surface, so this regression test does not rot when unrelated language
+// features change (unlike a type-soundness-hole seed; see Linear B-797).
+//
+// The 50ms sleep forces the "awaiter parked first" ordering the leak needs.
+// The load-bearing assertion is COMPLETION, not a value: before the fix
+// `call_function` never resolves (the wedge), so the test hangs and the
+// `timeout` fires.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawned_awaiter_of_internal_error_future_does_not_wedge() {
+    let source = r#"
+        function main(boom: () -> string) -> string {
+            // `f` yields (so its awaiter parks) then hits an uncatchable
+            // host-bridge internal error.
+            let f = spawn {
+                baml.sys.sleep(baml.time.Duration.from_milliseconds(50n));
+                boom()
+            };
+            // `g` is a SPAWN that awaits `f`: its `r?`-propagated engine error
+            // is what used to leak. Nesting under a spawn is essential — a plain
+            // root `await` surfaces the error fine.
+            let g = spawn { await f };
+            await g
+        }
+    "#;
+
+    // The host callable faults with a fatal BridgeFailure → uncatchable
+    // `EngineError::VmInternalError` in whichever thread invokes it (here, `f`).
+    let arc = register_host_callable(|_items| FakeReturn::BridgeFailure {
+        message: "boom".to_string(),
+    });
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(snapshot, Arc::new(sys_native::SysOps::native()), Vec::new())
+            .expect("Failed to create engine"),
+    );
+
+    let call = engine.call_function(
+        "main",
+        vec![BexExternalValue::HostValue(Arc::clone(&arc))],
+        FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+        true,
+    );
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(10), call).await;
+
+    // Load-bearing: the engine future RESOLVED (no wedge).
+    let result =
+        outcome.expect("engine wedged: call_function never resolved (the spawn-leak regressed)");
+    // With the fix the uncatchable internal error propagates deterministically
+    // up the await chain, so `main` returns an internal error rather than hanging.
+    assert!(
+        matches!(
+            result,
+            Err(EngineError::VmInternalError(
+                sys_types::VmInternalError::BridgeFailure { .. }
+            )) | Err(EngineError::TracedVmInternalError {
+                source: sys_types::VmInternalError::BridgeFailure { .. },
+                ..
+            })
+        ),
+        "expected the BridgeFailure internal error to surface after the fix, got {result:?}"
+    );
+    drop(arc);
+}

--- a/baml_language/crates/bex_engine/tests/host_value_callable.rs
+++ b/baml_language/crates/bex_engine/tests/host_value_callable.rs
@@ -1583,3 +1583,67 @@ async fn spawned_awaiter_of_internal_error_future_does_not_wedge() {
     );
     drop(arc);
 }
+
+/// The scenario-15 "concurrent guards" topology: children spawned INSIDE a
+/// `.map` closure, joined with `baml.future.all` under a spawned parent, with
+/// a linked CancelToken — and ONE child hitting an uncatchable engine error
+/// while its siblings are parked. Before the spawn-leak fix this parked at
+/// 0% CPU forever (the guardrail deadlock documented in
+/// ns_ai_scenarios/15_guardrails); with it, the error propagates and the
+/// call resolves. Kept alongside the minimal nested-spawn repro because the
+/// map-closure + all() + cancel-token topology exercises the settle path
+/// through `future.all`'s cancel-the-rest arm as well.
+#[tokio::test]
+async fn spawn_in_map_closure_with_erroring_child_does_not_wedge() {
+    let source = r#"
+        function main(boom: () -> string) -> string {
+            let parent = spawn {
+                let tok = baml.spawn.CancelToken.new();
+                let items = [1, 2, 3];
+                let futures = items.map((n: int) -> baml.future.Future<string, null> {
+                    spawn with baml.spawn.options(cancel = tok) {
+                        if (n == 2) {
+                            // parks the awaiter first, then faults the bridge
+                            baml.sys.sleep(baml.time.Duration.from_milliseconds(50n));
+                            boom()
+                        } else {
+                            baml.sys.sleep(baml.time.Duration.from_milliseconds(150n));
+                            "guard-" + n.to_string()
+                        }
+                    }
+                });
+                let all = (await baml.future.all(futures)) catch_all (e) {
+                    _ => ["all-failed"]
+                };
+                tok.cancel();
+                all.join(",")
+            };
+            await parent
+        }
+    "#;
+
+    let arc = register_host_callable(|_items| FakeReturn::BridgeFailure {
+        message: "guard boom".to_string(),
+    });
+
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(snapshot, Arc::new(sys_native::SysOps::native()), Vec::new())
+            .expect("Failed to create engine"),
+    );
+
+    let call = engine.call_function(
+        "main",
+        vec![BexExternalValue::HostValue(Arc::clone(&arc))],
+        FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+        true,
+    );
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(10), call).await;
+
+    // Load-bearing assertion: the engine RESOLVED (no 0%-CPU park). The exact
+    // shape of the result is secondary — an uncatchable bridge fault may
+    // surface as an engine error or be absorbed by the catch_all depending on
+    // scheduling; the deadlock is what this test pins.
+    let _result = outcome
+        .expect("engine wedged: spawn-in-map guard topology never resolved (the spawn-leak regressed)");
+}

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -2210,6 +2210,13 @@ impl io::IoNamespaceHttp for NativeSysOps {
                 builder = builder.body(request.body.clone());
             }
 
+            // Default 5-minute total deadline (connect + the whole stream): a
+            // stalled SSE socket must surface as a Timeout instead of wedging
+            // the VM in a read that never yields. Mirrors `_send`/`_fetch`'s
+            // stdlib-level default. Legitimately longer-lived streams need a
+            // dedicated timeout parameter on `fetch_sse` (not yet plumbed).
+            builder = builder.timeout(std::time::Duration::from_secs(300));
+
             let response = builder
                 .send()
                 .await


### PR DESCRIPTION
Three related reliability fixes, extracted from the LLM-provider scenario work where they were found and battle-tested:

## 1. Per-test timeout in `baml-cli test` (default 5 min)
Every test body races a deadline inside the stdlib runner (`testing/registry.baml::run_test`). A hung test — stalled network read, deadlocked await — becomes a FAIL with `test timed out after Nms` instead of hanging the whole run. `baml.future.race` cancels the loser on settle (BEP-034), so a timed-out body is actively cancelled and a finished test's timer doesn't linger. Override with `BAML_TEST_TIMEOUT_MS`.

## 2. Default 5-minute deadline on `http.send` / `http.fetch` / `http.fetch_sse`
`null` timeout no longer means "no deadline": it resolves to 300s (pass an explicit `Duration` for longer — there is deliberately no unbounded spelling), and `fetch_sse` gets the same 300s total deadline in the host builder. A stalled socket now surfaces as `baml.errors.Timeout` instead of wedging the VM in a read that never yields — the one hang class BAML-level timeouts can't preempt.

## 3. Engine: settle spawned-child futures on engine error
A spawned child whose event loop returned `Err(EngineError)` (e.g. an awaiter parked on a future that settles to `InternalError`) was only logged in `spawn_thread_inner`, leaving the child's heap `Future` pending forever — its awaiter parked forever, cascading up to the end-of-run `wait_for_outstanding_child_futures`, so `run_filtered → block_on` never returned. Symptom in the wild: `baml-cli test` live sweeps completing all tests, all tokio workers parked, zero open sockets, process wedged for hours. Fix: `settle_internal_error_if_pending` + `settle_spawn_engine_error` on both error arms, so the error propagates deterministically up the await chain.

Deterministic regression test included (`spawned_awaiter_of_internal_error_future_does_not_wedge`: wedges ~11s without the fix, passes ~2s with). Verified additionally by repeated clean live-key test sweeps on the fixed build; the hung-test timeout behavior is probe-verified on this branch (`1 passed, 1 failed — "test timed out after 2000ms"` at a 2s override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default HTTP timeout semantics (breaking for callers that relied on unbounded waits) and touches async spawn/future settlement on error paths in the engine, which can affect shutdown and error propagation across concurrent runs.
> 
> **Overview**
> Adds **default 5-minute deadlines** where work could hang indefinitely: `http.fetch` / `http.send` now map a `null` timeout to 300s (no unbounded spelling), **`fetch_sse`** gets the same total deadline in the native client, and **`run_test`** races each body against a timer (override via `BAML_TEST_TIMEOUT_MS`) using `baml.future.race` so losers are cancelled.
> 
> Fixes an **engine shutdown wedge**: when a spawned child’s event loop exits with `EngineError` or an invariant `RootValue` without settling its heap future, **`settle_internal_error_if_pending`** / **`settle_spawn_engine_error`** settle still-pending child futures so awaiters wake and errors propagate instead of parking forever at end-of-run quiescence.
> 
> Includes regression tests for nested-spawn / map+`future.all` topologies that previously hung `call_function`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2db413390f9cbb32f77f48126d9b32c0471c5eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP requests and streaming fetches now default to a 5-minute timeout when none is provided.
  * Test runs now enforce per-test timeouts (default 300s, configurable via an environment variable) with clear timeout failure messaging.
* **Bug Fixes**
  * Prevented engine failure scenarios from leaving futures in a “pending” state that could cause callers to wait indefinitely.
  * Improved child-task failure handling so spawned work resolves cleanly instead of wedging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->