### PR TITLE
chore: make size-gate work for forks

### DIFF
--- a/.github/workflows/docs.reusable.yaml
+++ b/.github/workflows/docs.reusable.yaml
@@ -65,9 +65,10 @@ jobs:
 
       - name: Comment URL in PR
         if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v3.0.1
+        uses: marocchino/sticky-pull-request-comment@v3.0.5
         with:
-          file-path: preview_url.txt
+          header: docs-preview
+          path: preview_url.txt
 
       - name: Extract docs URL
         id: docs_url
@@ -174,11 +175,20 @@ jobs:
         run: |
           pnpm vercel deploy --target $TARGET_ENV --prebuilt --token=${{ secrets.VERCEL_TOKEN_SAM }} | tee preview_url.txt
 
+      # sticky-pull-request-comment resolves `path` with @actions/glob, which
+      # rejects `..` segments — and this job runs in ../sage-backend, outside
+      # the workspace. Stage the file into the workspace so the action can
+      # read it.
+      - name: Stage preview URL for PR comment
+        if: github.event_name == 'pull_request'
+        run: cp preview_url.txt "$GITHUB_WORKSPACE/backend_preview_url.txt"
+
       - name: Comment URL in PR
         if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v3.0.1
+        uses: marocchino/sticky-pull-request-comment@v3.0.5
         with:
-          file-path: ../sage-backend/preview_url.txt
+          header: backend-preview
+          path: backend_preview_url.txt
 
       - name: Extract backend URL
         id: backend_url

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -36,16 +36,16 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
 
-# Individual size-gate jobs are intentionally never allowed to fail.
+# Individual measure-baml-size jobs are intentionally never allowed to fail.
 # Each platform job has `continue-on-error: true` so a violation, runner
 # death, or build hiccup does not fail the calling workflow. The
-# size-gate-report job aggregates all available reports and is the one
+# enforce-baml-size job aggregates all available reports and is the one
 # place where a real failure (policy violation or a missing platform
 # report) can block CI.
 
 jobs:
   size-gate-linux:
-    name: "size-gate (linux)"
+    name: "measure-baml-size (linux)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     continue-on-error: true
@@ -131,7 +131,7 @@ jobs:
           if-no-files-found: ignore
 
   size-gate-macos:
-    name: "size-gate (macos)"
+    name: "measure-baml-size (macos)"
     runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 20
     continue-on-error: true
@@ -217,7 +217,7 @@ jobs:
           if-no-files-found: ignore
 
   size-gate-windows:
-    name: "size-gate (windows)"
+    name: "measure-baml-size (windows)"
     runs-on: blacksmith-8vcpu-windows-2025
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
@@ -325,7 +325,7 @@ jobs:
           if-no-files-found: ignore
 
   size-gate-wasm:
-    name: "size-gate (wasm)"
+    name: "measure-baml-size (wasm)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     continue-on-error: true
@@ -413,7 +413,7 @@ jobs:
           if-no-files-found: ignore
 
   size-gate-report:
-    name: "size-gate (report)"
+    name: "enforce-baml-size"
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: always()
     needs: [size-gate-linux, size-gate-macos, size-gate-windows, size-gate-wasm]
@@ -540,13 +540,9 @@ jobs:
             printf '%s\n' "${missing[@]}" > missing-platforms.txt
           fi
 
-      - name: "Post PR comment"
-        if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v3.0.1
-        with:
-          file-path: unified-report.md
-          comment-tag: size-gate
-
+      # Print the report BEFORE attempting the PR comment: on fork PRs the
+      # token is read-only and the comment post fails, so stdout + the
+      # summary tab must not depend on it.
       - name: "Print report + write job summary"
         run: |
           # Print to the workflow console log (so the status is visible in
@@ -554,6 +550,17 @@ jobs:
           cat unified-report.md
           # ...and to the run's summary tab.
           cat unified-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Best effort: fork PRs run with a read-only GITHUB_TOKEN
+      # (pull-requests: read), so posting the comment fails there. The
+      # report is still visible in the step above and the summary tab.
+      - name: "Post PR comment (best effort)"
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v3.0.5
+        with:
+          header: size-gate
+          path: unified-report.md
 
       - name: "Fail if any platform is missing or any check failed"
         env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Documentation and backend preview links now use sticky pull request comments, updating a single existing comment instead of creating duplicates.
  * Size validation workflow messaging was clarified, with per-platform measurement and an enforcement step that block CI when policy violations or missing reports are detected.
  * Unified report output is shown before any pull request comment attempt, and non-critical comment-posting failures are treated as best-effort (won’t interrupt size validation results).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->