### PR TITLE
fix(vm): prune stale Watch graph roots before GC

### DIFF
--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -5357,6 +5357,10 @@ impl BexVm {
     /// is the VM's lifetime backstop for non-local exits (for example, a native
     /// panic unwinding the frame before its explicit `Unwatch` executes).
     fn unregister_frame_watches(&mut self, locals_offset: StackIndex) {
+        if self.watched_vars.is_empty() {
+            return;
+        }
+
         let locals_offset = locals_offset.raw();
         let frame_watches: Vec<StackIndex> = self
             .watched_vars
@@ -5365,11 +5369,15 @@ impl BexVm {
             .filter(|index| index.raw() >= locals_offset)
             .collect();
 
-        for local_var_index in frame_watches {
-            self.watched_vars.remove(&local_var_index);
-            self.watch
-                .unregister_root(NodeId::LocalVar(local_var_index));
+        if frame_watches.is_empty() {
+            return;
         }
+
+        for &local_var_index in &frame_watches {
+            self.watched_vars.remove(&local_var_index);
+        }
+        self.watch
+            .unregister_roots(frame_watches.into_iter().map(NodeId::LocalVar));
     }
 
     /// Load the function object for the given frame.

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -586,6 +586,39 @@ mod tests {
     }
 
     #[test]
+    fn init_spread_without_watch_does_not_populate_watch_graph() {
+        let mut vm = test_vm(vec![test_class(1)]);
+        let class_ptr = vm.idx_to_ptr(ObjectIndex::from_raw(0));
+        let old_value = vm.tlab.alloc_string("old".to_string());
+        let new_value = vm.tlab.alloc_string("new".to_string());
+        let source_ptr = vm.tlab.alloc(Object::Instance(Instance::new(
+            class_ptr,
+            Vec::new(),
+            vec![Value::object(new_value)],
+        )));
+        let dest_ptr = vm.tlab.alloc(Object::Instance(Instance::new(
+            class_ptr,
+            Vec::new(),
+            vec![Value::object(old_value)],
+        )));
+
+        let result = vm
+            .init_spread(
+                Value::object(dest_ptr),
+                Value::object(source_ptr),
+                &FieldCopySet {
+                    fields: vec![FieldCopy { source: 0, dest: 0 }],
+                },
+            )
+            .expect("spread should succeed");
+
+        assert!(result.is_none());
+        let mut watch_roots = Vec::new();
+        vm.watch.collect_roots(&mut watch_roots);
+        assert!(watch_roots.is_empty());
+    }
+
+    #[test]
     fn trampoline_function_survives_gc_while_frame_is_active() {
         let (mut vm, native_ptr) = vm_with_native_entry();
 
@@ -2623,6 +2656,8 @@ impl BexVm {
         // stack and call stack should be empty.
         self.stack.clear();
         self.frames.clear();
+        self.watched_vars.clear();
+        self.watch = Watch::new();
         self.pending_call_captures.clear();
         self.seen_throw_values.clear();
         self.thrown_value_causes.clear();
@@ -3938,6 +3973,7 @@ impl BexVm {
             let popped = self.frames.pop().expect("frame stack is not empty");
             match popped {
                 Frame::Bytecode(bf) => {
+                    self.unregister_frame_watches(bf.locals_offset);
                     self.stack.drain(bf.locals_offset..);
                     // Unwound frames close with the unwind status (Errored /
                     // Cancelled / Exited by thrown class); native frames emit
@@ -5244,6 +5280,22 @@ impl BexVm {
         old_value: Value,
         new_value: Value,
     ) {
+        let Some(snapshot) = self.snapshot_watched_node(watched_node) else {
+            return;
+        };
+        self.finish_watched_node_update(watched_node, path, old_value, new_value, snapshot);
+    }
+
+    /// Copies the roots affected by `watched_node` before a mutation occurs.
+    ///
+    /// Array and map element stores must release their object lock before
+    /// walking/deep-copying the graph, so they take this snapshot before the
+    /// atomic locked mutation and finish the topology update afterward.
+    fn snapshot_watched_node(&mut self, watched_node: NodeId) -> Option<(Vec<NodeId>, Vec<Value>)> {
+        if !self.watch.is_watched(watched_node) {
+            return None;
+        }
+
         // Deep-copy previous root values so the notification filter can diff
         // old vs new. Two-pass because `baml_deep_copy` needs `&mut self`,
         // which conflicts with borrowing `self.watch` for root_state.
@@ -5257,6 +5309,17 @@ impl BexVm {
             }
         }
 
+        Some((roots, old_roots_copies))
+    }
+
+    fn finish_watched_node_update(
+        &mut self,
+        watched_node: NodeId,
+        path: watch::Path,
+        old_value: Value,
+        new_value: Value,
+        (roots, old_roots_copies): (Vec<NodeId>, Vec<Value>),
+    ) {
         self.update_watched_node_dependencies(watched_node, path, old_value, new_value);
 
         for (&root, old_value) in roots.iter().zip(old_roots_copies) {
@@ -5273,6 +5336,10 @@ impl BexVm {
         old_value: Value,
         new_value: Value,
     ) {
+        if !self.watch.is_watched(watched_node) {
+            return;
+        }
+
         if let Some(old) = old_value.as_object_ptr() {
             self.watch
                 .unlink_edge(watched_node, path.clone(), NodeId::HeapObject(old));
@@ -5280,6 +5347,28 @@ impl BexVm {
 
         if let Some(new) = new_value.as_object_ptr() {
             watch::track_watch_dependencies(&mut self.watch, watched_node, path, new);
+        }
+    }
+
+    /// Removes Watch roots owned by the bytecode frame whose locals begin at
+    /// `locals_offset`.
+    ///
+    /// MIR normally emits `Unwatch` before a watched local leaves scope. This
+    /// is the VM's lifetime backstop for non-local exits (for example, a native
+    /// panic unwinding the frame before its explicit `Unwatch` executes).
+    fn unregister_frame_watches(&mut self, locals_offset: StackIndex) {
+        let locals_offset = locals_offset.raw();
+        let frame_watches: Vec<StackIndex> = self
+            .watched_vars
+            .keys()
+            .copied()
+            .filter(|index| index.raw() >= locals_offset)
+            .collect();
+
+        for local_var_index in frame_watches {
+            self.watched_vars.remove(&local_var_index);
+            self.watch
+                .unregister_root(NodeId::LocalVar(local_var_index));
         }
     }
 
@@ -6629,14 +6718,6 @@ impl BexVm {
                     if self.watched_vars.remove(&local_var_index).is_some() {
                         let var_node = NodeId::LocalVar(local_var_index);
                         self.watch.unregister_root(var_node);
-                        let value = self.stack[local_var_index];
-                        if let Some(object_index) = value.as_object_ptr() {
-                            self.watch.unlink_edge(
-                                var_node,
-                                watch::Path::Binding,
-                                NodeId::HeapObject(object_index),
-                            );
-                        }
                     }
                     if self.early_yield.should_early_yield() {
                         return Ok(Some(VmExecState::EarlyYield));
@@ -7032,6 +7113,7 @@ impl BexVm {
                         capture_mask,
                         result,
                     );
+                    self.unregister_frame_watches(locals_offset);
                     self.stack.drain(locals_offset..);
                     self.stack.push(result);
                     self.frames.pop();
@@ -7915,12 +7997,11 @@ impl BexVm {
                     };
                     let new_value_u8: Option<u8> =
                         new_value.as_int().map(|v| (v.cast_unsigned() & 0xFF) as u8);
+                    let watched_node = NodeId::HeapObject(array_object_index);
+                    let watch_snapshot = self.snapshot_watched_node(watched_node);
                     // Acquire the array's write lock for bounds-check + old
-                    // read + new write atomically. Guard drops at end of
-                    // inner scope before any `&mut self` ops. A negative index
-                    // counts from the end; the resolved offset flows out for the
-                    // watch path below, while an out-of-range index reports the
-                    // original index in the panic.
+                    // read + new write atomically. The Watch snapshot above is
+                    // taken before the mutation without holding this lock.
                     let store_result: Result<(Value, usize), (i64, usize)> = {
                         match self.get_object(array_object_index) {
                             Object::Array(arr) => {
@@ -7974,13 +8055,15 @@ impl BexVm {
                             )));
                         }
                     };
-                    let watched_node = NodeId::HeapObject(array_object_index);
-                    self.update_watched_node(
-                        watched_node,
-                        watch::Path::ArrayIndex(index),
-                        old_value,
-                        new_value,
-                    );
+                    if let Some(snapshot) = watch_snapshot {
+                        self.finish_watched_node_update(
+                            watched_node,
+                            watch::Path::ArrayIndex(index),
+                            old_value,
+                            new_value,
+                            snapshot,
+                        );
+                    }
                     self.heap.write_barrier(array_object_index, new_value);
                     let notifications = self.process_notifications(watched_node)?;
                     if !notifications.is_empty() {
@@ -7997,8 +8080,11 @@ impl BexVm {
                     let key_index = self.as_object_ptr(key_value, ObjectType::String)?;
                     let key = self.get_object(key_index).as_string()?.clone();
                     let map_index = self.as_object_ptr(map_value, ObjectType::Map)?;
-                    // Take the map's write lock for capture-old + insert-new
-                    // atomically. Guard drops before any `&mut self` ops.
+                    let watched_node = NodeId::HeapObject(map_index);
+                    let watch_snapshot = self.snapshot_watched_node(watched_node);
+                    // Keep capture-old + insert-new atomic. The Watch snapshot
+                    // above is taken before the mutation without holding this
+                    // lock.
                     let store_result: Result<Value, ObjectType> = {
                         match self.get_object(map_index) {
                             Object::Map(map) => {
@@ -8020,13 +8106,15 @@ impl BexVm {
                             .into());
                         }
                     };
-                    let watched_node = NodeId::HeapObject(map_index);
-                    self.update_watched_node(
-                        watched_node,
-                        watch::Path::MapKey(key.to_string()),
-                        old_value,
-                        new_value,
-                    );
+                    if let Some(snapshot) = watch_snapshot {
+                        self.finish_watched_node_update(
+                            watched_node,
+                            watch::Path::MapKey(key.to_string()),
+                            old_value,
+                            new_value,
+                            snapshot,
+                        );
+                    }
                     self.heap.write_barrier(map_index, new_value);
                     let notifications = self.process_notifications(watched_node)?;
                     if !notifications.is_empty() {

--- a/baml_language/crates/bex_vm/src/watch.rs
+++ b/baml_language/crates/bex_vm/src/watch.rs
@@ -391,8 +391,22 @@ impl Watch {
     /// teardown operation: callers do not need to unlink the root's binding
     /// separately.
     pub fn unregister_root(&mut self, root: NodeId) {
-        self.roots.remove(&root);
-        self.rebuild_reachability_and_prune();
+        self.unregister_roots([root]);
+    }
+
+    /// Unregisters multiple emittable roots with a single graph rebuild.
+    ///
+    /// Frame teardown can remove several watched locals at once. Removing all
+    /// of their root states before recomputing avoids rebuilding the same
+    /// surviving graph once per local.
+    pub fn unregister_roots(&mut self, roots: impl IntoIterator<Item = NodeId>) {
+        let mut removed_any = false;
+        for root in roots {
+            removed_any |= self.roots.remove(&root).is_some();
+        }
+        if removed_any {
+            self.rebuild_reachability_and_prune();
+        }
     }
 
     /// Unlinks parent.path -> child from the graph.
@@ -982,6 +996,44 @@ mod tests {
         assert_graph_invariants(&watch);
 
         watch.unregister_root(root_b);
+        assert!(watch.children.is_empty());
+        assert!(watch.parents.is_empty());
+        assert!(watch.reachable_from_root.is_empty());
+        assert!(watch.roots_reaching_node.is_empty());
+    }
+
+    #[test]
+    fn unregister_roots_batches_shared_graph_teardown() {
+        let mut watch = Watch::new();
+        let root_a = NodeId::LocalVar(StackIndex::from_raw(0));
+        let root_b = NodeId::LocalVar(StackIndex::from_raw(1));
+        let root_c = NodeId::LocalVar(StackIndex::from_raw(2));
+        let class_ptr = leaf();
+        let shared = leaf();
+        let parent_a = instance(class_ptr, vec![Value::object(shared)]);
+        let parent_b = instance(class_ptr, vec![Value::object(shared)]);
+        let parent_c = instance(class_ptr, vec![Value::object(shared)]);
+
+        for (root, parent) in [(root_a, parent_a), (root_b, parent_b), (root_c, parent_c)] {
+            watch.register_root(root, test_root_state());
+            track_watch_dependencies(&mut watch, root, Path::Binding, parent);
+        }
+
+        watch.unregister_roots([root_a, root_b]);
+
+        assert!(!watch.is_watched(root_a));
+        assert!(!watch.is_watched(root_b));
+        assert!(!watch.is_watched(NodeId::HeapObject(parent_a)));
+        assert!(!watch.is_watched(NodeId::HeapObject(parent_b)));
+        assert!(watch.is_watched(root_c));
+        assert!(watch.is_watched(NodeId::HeapObject(parent_c)));
+        assert_eq!(
+            watch.copy_roots_reaching(NodeId::HeapObject(shared)),
+            vec![root_c]
+        );
+        assert_graph_invariants(&watch);
+
+        watch.unregister_roots([root_c]);
         assert!(watch.children.is_empty());
         assert!(watch.parents.is_empty());
         assert!(watch.reachable_from_root.is_empty());

--- a/baml_language/crates/bex_vm/src/watch.rs
+++ b/baml_language/crates/bex_vm/src/watch.rs
@@ -201,7 +201,8 @@ pub enum Path {
     MapKey(String),
 }
 
-/// The emit dependency graph with incremental reachability maintenance.
+/// The emit dependency graph with incremental linking and complete
+/// recomputation after destructive topology changes.
 ///
 /// Public API consists of this set of operations:
 ///
@@ -308,6 +309,60 @@ impl Watch {
         visited
     }
 
+    /// Recomputes reachability from every active root and drops structural
+    /// graph entries that no active root can reach.
+    ///
+    /// Destructive topology changes cannot be updated locally in the general
+    /// case: cycles and shared descendants mean that removing one edge (or one
+    /// root) may leave a node reachable through another path. Rebuilding the
+    /// indexes from the remaining roots keeps these invariants in one place:
+    ///
+    /// - `children` contains only edges whose endpoints are actively watched;
+    /// - `parents` is the exact reverse of `children`;
+    /// - `reachable_from_root` and `roots_reaching_node` are exact inverses.
+    fn rebuild_reachability_and_prune(&mut self) {
+        if self.roots.is_empty() {
+            self.children.clear();
+            self.parents.clear();
+            self.reachable_from_root.clear();
+            self.roots_reaching_node.clear();
+            return;
+        }
+
+        let mut reachable_from_root = HashMap::with_capacity(self.roots.len());
+        let mut roots_reaching_node: HashMap<NodeId, HashSet<NodeId>> = HashMap::new();
+
+        for &root in self.roots.keys() {
+            let reachable = self.breadth_first_search_from(root);
+            for &node in &reachable {
+                roots_reaching_node.entry(node).or_default().insert(root);
+            }
+            reachable_from_root.insert(root, reachable);
+        }
+
+        let live_nodes: HashSet<NodeId> = roots_reaching_node.keys().copied().collect();
+        self.children.retain(|parent, edges| {
+            if !live_nodes.contains(parent) {
+                return false;
+            }
+            edges.retain(|(_, child)| live_nodes.contains(child));
+            !edges.is_empty()
+        });
+
+        self.parents.clear();
+        for (&parent, edges) in &self.children {
+            for (path, child) in edges {
+                self.parents
+                    .entry(*child)
+                    .or_default()
+                    .insert((parent, path.clone()));
+            }
+        }
+
+        self.reachable_from_root = reachable_from_root;
+        self.roots_reaching_node = roots_reaching_node;
+    }
+
     /// Registers a new emittable root at the given node.
     ///
     /// Triggers a BFS graph traversal starting at `root`.
@@ -331,73 +386,27 @@ impl Watch {
 
     /// Unregisters an emittable root (e.g., when it goes out of scope).
     ///
-    /// Scans all reachable nodes from root and updates cached indexes. It does
-    /// not fully traverse the graph starting at `root`.
+    /// Recomputes reachability from the remaining roots and removes graph
+    /// entries that are no longer watched. This is deliberately a complete
+    /// teardown operation: callers do not need to unlink the root's binding
+    /// separately.
     pub fn unregister_root(&mut self, root: NodeId) {
-        // Remove from active roots
         self.roots.remove(&root);
-
-        // Clean up reachability cache
-        if let Some(reachable) = self.reachable_from_root.remove(&root) {
-            for node in reachable {
-                if let Some(roots) = self.roots_reaching_node.get_mut(&node) {
-                    roots.remove(&root);
-                    if roots.is_empty() {
-                        self.roots_reaching_node.remove(&node);
-                    }
-                }
-            }
-        }
+        self.rebuild_reachability_and_prune();
     }
 
     /// Unlinks parent.path -> child from the graph.
     ///
-    /// Updates reachability incrementally for all affected roots.
+    /// Recomputes reachability from all active roots after removing the edge.
     pub fn unlink_edge(&mut self, parent: NodeId, path: Path, child: NodeId) {
         if let Some(edges) = self.children.get_mut(&parent) {
-            edges.remove(&(path.clone(), child));
+            edges.remove(&(path, child));
             if edges.is_empty() {
                 self.children.remove(&parent);
             }
         }
 
-        if let Some(edges) = self.parents.get_mut(&child) {
-            edges.remove(&(parent, path));
-            if edges.is_empty() {
-                self.parents.remove(&child);
-            }
-        }
-
-        // For each root that reaches the child, recompute reachability and
-        // remove unreachable nodes.
-        let roots_reaching = self.copy_roots_reaching(child);
-
-        for root in roots_reaching {
-            let still_reachable = self.breadth_first_search_from(root);
-
-            // Swap in the new reachable set, taking ownership of the old one
-            // without cloning.
-            let old_reachable = self
-                .reachable_from_root
-                .insert(root, still_reachable)
-                .unwrap_or_default();
-
-            let still_reachable = &self.reachable_from_root[&root];
-
-            // Update inverse index: remove root from nodes no longer reachable.
-            // If a node becomes unreachable from ALL roots, prune its graph
-            // edges to avoid stale entries (and dangling HeapPtrs after GC).
-            for node in old_reachable.difference(still_reachable) {
-                if let Some(roots) = self.roots_reaching_node.get_mut(node) {
-                    roots.remove(&root);
-                    if roots.is_empty() {
-                        self.roots_reaching_node.remove(node);
-                        self.children.remove(node);
-                        self.parents.remove(node);
-                    }
-                }
-            }
-        }
+        self.rebuild_reachability_and_prune();
     }
 
     /// Watched root state.
@@ -440,13 +449,16 @@ impl Watch {
 ///
 /// Free function to avoid borrow checker issues when calling from `BexVm`.
 pub fn track_watch_dependencies(watch: &mut Watch, parent: NodeId, path: Path, child_ptr: HeapPtr) {
+    // Collect roots reaching parent so we can propagate reachability.
+    let roots = watch.copy_roots_reaching(parent);
+    if roots.is_empty() {
+        return;
+    }
+
     let child = NodeId::HeapObject(child_ptr);
 
     // Add the top-level edge (e.g. root --Binding--> object).
     watch.add_edge(parent, path, child);
-
-    // Collect roots reaching parent so we can propagate reachability.
-    let roots = watch.copy_roots_reaching(parent);
 
     // Walk the heap from child, building edges and propagating reachability.
     let mut queue = VecDeque::new();
@@ -646,7 +658,7 @@ impl RootHaver for Watch {
     /// `debug_assert!(remap_was_traced(...))` calls below verify the
     /// invariant on every patched node.
     fn forward_roots(&mut self, forwarding: &HashMap<HeapPtr, HeapPtr>) {
-        if forwarding.is_empty() || self.roots.is_empty() {
+        if forwarding.is_empty() {
             return;
         }
 
@@ -703,18 +715,56 @@ impl RootHaver for Watch {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use bex_heap::{BexHeap, Tlab};
     use bex_vm_types::types::Instance;
 
     use super::*;
 
     fn test_root_state() -> RootState {
+        test_root_state_with_value(Value::int(0))
+    }
+
+    fn test_root_state_with_value(value: Value) -> RootState {
         RootState {
-            value: Value::int(0),
+            value,
             last_assigned: None,
             last_notified: None,
             channel: "Test".to_string(),
             filter: WatchFilter::Default,
         }
+    }
+
+    fn assert_graph_invariants(watch: &Watch) {
+        let mut expected_parents: HashMap<NodeId, HashSet<(NodeId, Path)>> = HashMap::new();
+        for (&parent, edges) in &watch.children {
+            assert!(
+                watch.roots_reaching_node.contains_key(&parent),
+                "unwatched parent retained in graph: {parent:?}"
+            );
+            for (path, child) in edges {
+                assert!(
+                    watch.roots_reaching_node.contains_key(child),
+                    "unwatched child retained in graph: {child:?}"
+                );
+                expected_parents
+                    .entry(*child)
+                    .or_default()
+                    .insert((parent, path.clone()));
+            }
+        }
+        assert_eq!(watch.parents, expected_parents);
+
+        let mut expected_inverse: HashMap<NodeId, HashSet<NodeId>> = HashMap::new();
+        for &root in watch.roots.keys() {
+            let reachable = watch.breadth_first_search_from(root);
+            assert_eq!(watch.reachable_from_root.get(&root), Some(&reachable));
+            for node in reachable {
+                expected_inverse.entry(node).or_default().insert(root);
+            }
+        }
+        assert_eq!(watch.roots_reaching_node, expected_inverse);
     }
 
     /// Allocates an `Object` on the heap via `Box` and returns a `HeapPtr`.
@@ -752,6 +802,24 @@ mod tests {
 
         assert!(watch.roots.contains_key(&var));
         assert_eq!(watch.copy_roots_reaching(var).len(), 1);
+        assert_graph_invariants(&watch);
+    }
+
+    #[test]
+    fn tracking_dependencies_for_unwatched_parent_is_a_noop() {
+        let mut watch = Watch::new();
+        let parent = NodeId::LocalVar(StackIndex::from_raw(0));
+        let child = leaf();
+
+        track_watch_dependencies(&mut watch, parent, Path::Binding, child);
+
+        assert!(watch.children.is_empty());
+        assert!(watch.parents.is_empty());
+        assert!(watch.reachable_from_root.is_empty());
+        assert!(watch.roots_reaching_node.is_empty());
+        let mut gc_roots = Vec::new();
+        watch.collect_roots(&mut gc_roots);
+        assert!(gc_roots.is_empty());
     }
 
     #[test]
@@ -779,6 +847,7 @@ mod tests {
             watch.copy_roots_reaching(NodeId::HeapObject(obj_ptr)).len(),
             0
         );
+        assert_graph_invariants(&watch);
     }
 
     #[test]
@@ -810,6 +879,9 @@ mod tests {
         // Neither should be covered
         assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(a)).len(), 0);
         assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(b)).len(), 0);
+        assert!(watch.children.is_empty());
+        assert!(watch.parents.is_empty());
+        assert_graph_invariants(&watch);
     }
 
     #[test]
@@ -843,6 +915,7 @@ mod tests {
         assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj1)).len(), 1);
         assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj2)).len(), 0);
         assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj3)).len(), 0);
+        assert_graph_invariants(&watch);
     }
 
     #[test]
@@ -878,6 +951,89 @@ mod tests {
             watch.copy_roots_reaching(NodeId::HeapObject(obj_ptr)).len(),
             0
         );
+        assert_graph_invariants(&watch);
+    }
+
+    #[test]
+    fn unregister_root_prunes_shared_graph_without_damaging_remaining_root() {
+        let mut watch = Watch::new();
+        let root_a = NodeId::LocalVar(StackIndex::from_raw(0));
+        let root_b = NodeId::LocalVar(StackIndex::from_raw(1));
+        let class_ptr = leaf();
+        let shared = leaf();
+        let parent_a = instance(class_ptr, vec![Value::object(shared)]);
+        let parent_b = instance(class_ptr, vec![Value::object(shared)]);
+
+        watch.register_root(root_a, test_root_state());
+        watch.register_root(root_b, test_root_state());
+        track_watch_dependencies(&mut watch, root_a, Path::Binding, parent_a);
+        track_watch_dependencies(&mut watch, root_b, Path::Binding, parent_b);
+
+        watch.unregister_root(root_a);
+
+        assert!(!watch.is_watched(root_a));
+        assert!(!watch.is_watched(NodeId::HeapObject(parent_a)));
+        assert!(watch.is_watched(root_b));
+        assert!(watch.is_watched(NodeId::HeapObject(parent_b)));
+        assert_eq!(
+            watch.copy_roots_reaching(NodeId::HeapObject(shared)),
+            vec![root_b]
+        );
+        assert_graph_invariants(&watch);
+
+        watch.unregister_root(root_b);
+        assert!(watch.children.is_empty());
+        assert!(watch.parents.is_empty());
+        assert!(watch.reachable_from_root.is_empty());
+        assert!(watch.roots_reaching_node.is_empty());
+    }
+
+    #[test]
+    fn unlink_diamond_preserves_shared_descendant_through_alternate_path() {
+        let mut watch = Watch::new();
+        let root = NodeId::LocalVar(StackIndex::from_raw(0));
+        let class_ptr = leaf();
+        let shared = leaf();
+        let left = instance(class_ptr, vec![Value::object(shared)]);
+        let right = instance(class_ptr, vec![Value::object(shared)]);
+        let diamond = instance(class_ptr, vec![Value::object(left), Value::object(right)]);
+
+        watch.register_root(root, test_root_state());
+        track_watch_dependencies(&mut watch, root, Path::Binding, diamond);
+        watch.unlink_edge(
+            NodeId::HeapObject(diamond),
+            Path::InstanceField(0),
+            NodeId::HeapObject(left),
+        );
+
+        assert!(!watch.is_watched(NodeId::HeapObject(left)));
+        assert!(watch.is_watched(NodeId::HeapObject(right)));
+        assert!(watch.is_watched(NodeId::HeapObject(shared)));
+        assert_eq!(
+            watch.copy_roots_reaching(NodeId::HeapObject(shared)),
+            vec![root]
+        );
+        assert_graph_invariants(&watch);
+    }
+
+    #[test]
+    fn unregister_then_unlink_is_idempotent_and_leaves_no_gc_roots() {
+        let mut watch = Watch::new();
+        let root = NodeId::LocalVar(StackIndex::from_raw(0));
+        let child = leaf();
+
+        watch.register_root(root, test_root_state_with_value(Value::object(child)));
+        track_watch_dependencies(&mut watch, root, Path::Binding, child);
+
+        // This is the historical VM teardown order. `unregister_root` is now
+        // complete, so the redundant unlink must be a harmless no-op.
+        watch.unregister_root(root);
+        watch.unlink_edge(root, Path::Binding, NodeId::HeapObject(child));
+
+        assert_graph_invariants(&watch);
+        let mut gc_roots = Vec::new();
+        watch.collect_roots(&mut gc_roots);
+        assert!(gc_roots.is_empty());
     }
 
     /// Regression test: every `HeapPtr` that `forward_roots` would patch
@@ -933,6 +1089,124 @@ mod tests {
                 roots.contains(&needed),
                 "collect_roots missing pointer that forward_roots would patch: {needed:?}"
             );
+        }
+    }
+    #[test]
+    fn forward_roots_defensively_remaps_a_synthetic_orphaned_graph() {
+        let mut watch = Watch::new();
+        let root = NodeId::LocalVar(StackIndex::from_raw(0));
+        let old_child = leaf();
+        let new_child = leaf();
+
+        // Public operations preserve the active-reachability invariant. Build
+        // an orphan directly to keep the GC forwarding code defensive if a
+        // future mutation path violates that invariant.
+        watch.add_edge(root, Path::Binding, NodeId::HeapObject(old_child));
+
+        assert!(watch.roots.is_empty());
+        let mut before = Vec::new();
+        watch.collect_roots(&mut before);
+        assert!(before.contains(&old_child));
+
+        watch.forward_roots(&HashMap::from([(old_child, new_child)]));
+
+        let mut after = Vec::new();
+        watch.collect_roots(&mut after);
+        assert!(!after.contains(&old_child));
+        assert!(after.contains(&new_child));
+    }
+
+    #[test]
+    fn active_watch_survives_gc_then_releases_object_on_unregister() {
+        let heap = BexHeap::new(vec![]);
+        let mut tlab = Tlab::new(Arc::clone(&heap));
+        let mut watch = Watch::new();
+        let root = NodeId::LocalVar(StackIndex::from_raw(0));
+        let object = tlab.alloc_string("watched".to_string());
+
+        watch.register_root(root, test_root_state_with_value(Value::object(object)));
+        track_watch_dependencies(&mut watch, root, Path::Binding, object);
+
+        let mut gc_roots = Vec::new();
+        watch.collect_roots(&mut gc_roots);
+        let (first_stats, _, forwarding) = unsafe { heap.collect_garbage(&gc_roots) };
+        tlab.invalidate();
+        assert_eq!(first_stats.live_count, 1);
+        watch.forward_roots(&forwarding);
+        assert_graph_invariants(&watch);
+
+        watch.unregister_root(root);
+        let mut after_unregister = Vec::new();
+        watch.collect_roots(&mut after_unregister);
+        assert!(after_unregister.is_empty());
+
+        let (second_stats, _, _) = unsafe { heap.collect_garbage(&after_unregister) };
+        tlab.invalidate();
+        assert_eq!(second_stats.live_count, 0);
+        assert_eq!(second_stats.collected_count, 1);
+    }
+
+    #[test]
+    fn repeated_watch_teardown_does_not_retain_heap_objects() {
+        const ITERATIONS: usize = 1_000;
+
+        let heap = BexHeap::new(vec![]);
+        let mut tlab = Tlab::new(Arc::clone(&heap));
+        let mut watch = Watch::new();
+        let root = NodeId::LocalVar(StackIndex::from_raw(0));
+
+        for i in 0..ITERATIONS {
+            let object = tlab.alloc_string(format!("temporary-{i}"));
+            watch.register_root(root, test_root_state_with_value(Value::object(object)));
+            track_watch_dependencies(&mut watch, root, Path::Binding, object);
+            watch.unregister_root(root);
+        }
+
+        assert_graph_invariants(&watch);
+        let mut gc_roots = Vec::new();
+        watch.collect_roots(&mut gc_roots);
+        assert!(gc_roots.is_empty(), "Watch retained {gc_roots:?}");
+
+        let (stats, _, _) = unsafe { heap.collect_garbage(&gc_roots) };
+        tlab.invalidate();
+        assert_eq!(stats.live_count, 0);
+        assert!(
+            stats.collected_count >= ITERATIONS,
+            "expected at least {ITERATIONS} temporary objects to be collected, got {}",
+            stats.collected_count
+        );
+    }
+
+    #[test]
+    fn repeated_gc_forward_and_unwatch_cycles_do_not_retain_objects() {
+        const CYCLES: usize = 100;
+
+        let heap = BexHeap::new(vec![]);
+        let mut tlab = Tlab::new(Arc::clone(&heap));
+        let mut watch = Watch::new();
+        let root = NodeId::LocalVar(StackIndex::from_raw(0));
+
+        for i in 0..CYCLES {
+            let object = tlab.alloc_string(format!("cycle-{i}"));
+            watch.register_root(root, test_root_state_with_value(Value::object(object)));
+            track_watch_dependencies(&mut watch, root, Path::Binding, object);
+
+            let mut active_roots = Vec::new();
+            watch.collect_roots(&mut active_roots);
+            let (active_stats, _, forwarding) = unsafe { heap.collect_garbage(&active_roots) };
+            tlab.invalidate();
+            assert_eq!(active_stats.live_count, 1, "active cycle {i}");
+            watch.forward_roots(&forwarding);
+            assert_graph_invariants(&watch);
+
+            watch.unregister_root(root);
+            let mut released_roots = Vec::new();
+            watch.collect_roots(&mut released_roots);
+            assert!(released_roots.is_empty(), "released cycle {i}");
+            let (released_stats, _, _) = unsafe { heap.collect_garbage(&released_roots) };
+            tlab.invalidate();
+            assert_eq!(released_stats.live_count, 0, "released cycle {i}");
+            assert_graph_invariants(&watch);
         }
     }
 }

--- a/baml_language/crates/bex_vm/tests/watch_gc.rs
+++ b/baml_language/crates/bex_vm/tests/watch_gc.rs
@@ -1,0 +1,168 @@
+//! VM-level regressions for Watch graph lifetime and GC roots.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::sync::{Arc, atomic::AtomicBool};
+
+use baml_project::testing::compile_source;
+use bex_vm::{BexVm, VmExecState};
+use bex_vm_types::RootHaver;
+
+const MAX_EXEC_CALLS: usize = 256;
+
+fn run_to_completion(source: &str) -> (BexVm, usize) {
+    let program = compile_source(source);
+    let entry_index = program
+        .function_index("user.main")
+        .expect("user.main not found");
+    let mut vm =
+        BexVm::from_program(program, Arc::new(AtomicBool::new(false))).expect("from_program");
+    let entry_ptr = vm.heap.compile_time_ptr(entry_index);
+    vm.set_entry_point(entry_ptr, &[]);
+
+    let mut notification_count = 0;
+    for _ in 0..MAX_EXEC_CALLS {
+        match vm.exec().expect("exec") {
+            VmExecState::Complete(_) => return (vm, notification_count),
+            VmExecState::Notify(_) => notification_count += 1,
+            VmExecState::EarlyYield => {}
+            other => panic!("unexpected VM state: {other:?}"),
+        }
+    }
+    panic!("VM did not complete within {MAX_EXEC_CALLS} exec() calls");
+}
+
+fn watch_gc_roots(vm: &BexVm) -> Vec<bex_vm_types::HeapPtr> {
+    let mut roots = Vec::new();
+    vm.watch.collect_roots(&mut roots);
+    roots
+}
+
+fn assert_no_watch_roots(source: &str) {
+    let (vm, notification_count) = run_to_completion(source);
+    assert_eq!(notification_count, 0);
+    assert!(
+        watch_gc_roots(&vm).is_empty(),
+        "BAML without `watch` must not retain objects through Watch"
+    );
+}
+
+#[test]
+fn ordinary_field_mutation_does_not_populate_watch() {
+    assert_no_watch_roots(
+        r#"
+        class Box { value: string }
+
+        function main() -> int {
+            let box = Box { value: "before" }
+            box.value = "after"
+            0
+        }
+        "#,
+    );
+}
+
+#[test]
+fn ordinary_array_mutation_does_not_populate_watch() {
+    assert_no_watch_roots(
+        r#"
+        function main() -> int {
+            let array = ["before"]
+            array[0] = "after"
+            0
+        }
+        "#,
+    );
+}
+
+#[test]
+fn ordinary_map_mutation_does_not_populate_watch() {
+    assert_no_watch_roots(
+        r#"
+        function main() -> int {
+            let map = {"key": "before"}
+            map["key"] = "after"
+            0
+        }
+        "#,
+    );
+}
+
+#[test]
+fn function_scope_unwatch_releases_the_entire_object_graph() {
+    let (vm, notification_count) = run_to_completion(
+        r#"
+        class Inner { value: string }
+        class Outer { inner: Inner }
+
+        function main() -> int {
+            watch let outer = Outer { inner: Inner { value: "before" } }
+            outer.inner.value = "after"
+            0
+        }
+        "#,
+    );
+
+    assert_eq!(notification_count, 1);
+    assert!(
+        watch_gc_roots(&vm).is_empty(),
+        "Unwatch at function exit must release all structural Watch roots"
+    );
+}
+
+#[test]
+fn watched_array_map_and_uint8array_assignments_notify_before_teardown() {
+    for source in [
+        r#"
+        function main() -> int {
+            watch let array = ["before"]
+            array[0] = "after"
+            0
+        }
+        "#,
+        r#"
+        function main() -> int {
+            watch let map = {"key": "before"}
+            map["key"] = "after"
+            0
+        }
+        "#,
+        r#"
+        function main() -> int {
+            watch let bytes = b"abc"
+            bytes[0] = 122
+            0
+        }
+        "#,
+    ] {
+        let (vm, notification_count) = run_to_completion(source);
+        assert_eq!(notification_count, 1, "source did not notify:\n{source}");
+        assert!(watch_gc_roots(&vm).is_empty());
+    }
+}
+
+#[test]
+fn native_panic_unwind_unregisters_callee_watch_roots() {
+    let (vm, notification_count) = run_to_completion(
+        r#"
+        class Box { value: string }
+
+        function watched_then_panics() -> int {
+            watch let box = Box { value: "temporary" }
+            baml.sys.panic("boom")
+        }
+
+        function main() -> int {
+            watched_then_panics() catch (e) {
+                baml.panics.UserPanic => 42
+            }
+        }
+        "#,
+    );
+
+    assert_eq!(notification_count, 0);
+    assert!(
+        watch_gc_roots(&vm).is_empty(),
+        "unwound callee left stale Watch roots"
+    );
+}


### PR DESCRIPTION
## Summary

Fix Watch graph lifetime bookkeeping so ordinary object mutations cannot create hidden GC roots, teardown removes disconnected graph state, watched mutations snapshot before changing the value, and exception unwinds release frame-owned watches.

## Root cause

A normal field, array, map, or spread update entered Watch dependency tracking even when no BAML variable used watch let.

Before:

    ordinary mutation
          |
          v
    track_watch_dependencies
          |
          v
    add structural edge first
          |
          +---- no reaching watch root ----> return
                                                |
                                                v
                                  orphan HeapPtr remains in
                                  Watch children / parents
                                                |
                                                v
                                  GC collect_roots retains it
                                                |
                         Watch::forward_roots returned early
                         when the active roots map was empty
                                                |
                                                v
                                  stale from-space pointer
                                                |
                                                v
                                  parallel execution SIGSEGV

A second teardown problem amplified this: unregister_root removed the reachability indexes before the VM unlinked the binding edge. Once disconnected from the active root, the old pruning path could no longer discover and remove the orphan graph. Reverse edges could also survive shared branches and cycles.

## Fix

- Return before adding a dependency edge when no active watched root reaches the parent.
- Recompute reachability from every active root after destructive graph operations.
- Prune unreachable children and parents, then rebuild the reverse index exactly from the surviving forward graph.
- Clear all structural graph state when the last root is unregistered.
- Keep GC root collection and forwarding symmetric as a defense-in-depth invariant.
- Unregister frame-owned watches on normal return and exception unwind.
- Snapshot watched array and map roots before mutation while preserving the original atomic locked write.
- Reset watch bookkeeping during VM finalization.

After:

    ordinary mutation + no active watch root
          |
          v
       no-op

    unregister or unlink
          |
          v
    recompute from active roots
          |
          v
    prune unreachable graph
          |
          v
    rebuild reverse edges
          |
          v
    collect_roots <==> forward_roots stay symmetric

## Tests

Added invariant and regression coverage for:

- unwatched field, array, map, and spread mutations
- shared branches, diamonds, and cycles
- unregister then unlink idempotence
- defensive forwarding of a synthetic orphan
- active roots surviving GC and release after unregister
- 1,000 teardown allocations without retention
- 100 interleaved GC, forward, unwatch, and GC cycles
- function return and native panic unwind cleanup
- array, map, and uint8array notification ordering

Validation:

- cargo nextest run -p bex_vm: 90 passed
- cargo nextest run -p bex_heap -p bex_vm -p baml_tests: 3,054 passed
- cargo nextest run --workspace: 7,155 passed, 44 skipped
- uvx prek --all-files: all hooks passed
- live parallel provider integration run: no SIGSEGV or signal termination; 52 passed and 11 existing functional or environment-dependent scenarios failed

## Scope

This PR contains only three bex_vm files. It does not include provider or BEPv2 scenario changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core VM watch/GC interaction and exception unwind paths; incorrect pruning or teardown could drop notifications or retain memory, and the prior bug caused production SIGSEGVs.
> 
> **Overview**
> Fixes **Watch** dependency bookkeeping so ordinary mutations and teardown cannot leave hidden GC roots or stale heap pointers (including parallel **SIGSEGV** regressions).
> 
> **Watch graph:** `track_watch_dependencies` now **no-ops** when no active root reaches the parent. **Unregister**, **unlink**, and batched **`unregister_roots`** no longer patch reachability incrementally; they **`rebuild_reachability_and_prune`** from surviving roots so shared branches, diamonds, and cycles stay consistent. **`Unwatch`** drops the redundant binding **unlink** (unregister is complete). **`forward_roots`** still runs when the roots map is empty so orphaned graph nodes can be remapped defensively.
> 
> **VM lifecycle:** **`finalize`** clears **`watched_vars`** and resets **`Watch`**. **`unregister_frame_watches`** runs on normal return and exception unwind as a backstop when **`Unwatch`** does not run. Array/map stores take a **pre-lock** watch snapshot and finish topology updates after the atomic write.
> 
> **Tests:** Unit/VM regressions for unwatched mutations, GC retention, frame/panic cleanup, and a new **`watch_gc`** integration suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5dbd2e03632158c9fa18880a339b9752fa7c64f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atomic handling of watch-graph updates for container element mutations, ensuring consistent dependency/topology changes.
  * Tightened watch-root cleanup when frames exit normally or during panic unwinding.
  * Corrected watch unwatch/unregister behavior so unwatched values aren’t retained.
* **Tests**
  * Added regression tests covering watch GC-root lifetime, container updates, invariant graph consistency, and no-op behavior when there are no active watch roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->