### PR TITLE
docs: make gemini model refs up to date

### DIFF
--- a/fern/01-guide/04-baml-basics/concurrent-calls.mdx
+++ b/fern/01-guide/04-baml-basics/concurrent-calls.mdx
@@ -450,7 +450,7 @@ async function fastestProviderWins(message: string) {
 
   const geminiRegistry = new ClientRegistry()
   geminiRegistry.addLlmClient('Gemini', 'vertex-ai', {
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3.5-flash',
     location: 'us-central1',
     credentials: process.env.GOOGLE_APPLICATION_CREDENTIALS
   })
@@ -517,7 +517,7 @@ async def fastest_provider_wins(message: str):
     
     gemini_registry = ClientRegistry()
     gemini_registry.add_llm_client('Gemini', 'vertex-ai', {
-        'model': 'gemini-2.5-flash',
+        'model': 'gemini-3.5-flash',
         'location': 'us-central1',
         'credentials': os.environ.get('GOOGLE_APPLICATION_CREDENTIALS_CONTENT')
     })
@@ -614,7 +614,7 @@ func fastestProviderWins(message string) (interface{}, error) {
     
     geminiRegistry, _ := b.NewClientRegistry()
     geminiRegistry.AddLlmClient("Gemini", "vertex-ai", map[string]interface{}{
-        "model": "gemini-2.5-flash",
+        "model": "gemini-3.5-flash",
         "location": "us-central1",
         "credentials": os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"),
     })

--- a/fern/01-guide/04-baml-basics/multi-modal.mdx
+++ b/fern/01-guide/04-baml-basics/multi-modal.mdx
@@ -473,7 +473,7 @@ When using Google AI with images stored in GCS:
 client<llm> GeminiWithGCS {
   provider google-ai
   options {
-    model "gemini-1.5-pro"
+    model "gemini-3.1-pro-preview"
     api_key env.GOOGLE_API_KEY
     media_url_handler {
       image "send_base64_unless_google_url"  // Preserve gs:// URLs, convert others

--- a/fern/01-guide/05-baml-advanced/modular-api.mdx
+++ b/fern/01-guide/05-baml-advanced/modular-api.mdx
@@ -418,7 +418,7 @@ Remember that the client is defined in the BAML function (or you can use the
 
 ```baml BAML {2}
 function ExtractResume(resume: string) -> Resume {
-  client "google-ai/gemini-2.5-flash"
+  client "google-ai/gemini-3.5-flash"
   // Prompt here...
 }
 ```
@@ -440,7 +440,7 @@ async def run():
 
   # Use the gemini library to send the request.
   res = await client.aio.models.generate_content(
-    model="gemini-2.5-flash",
+    model="gemini-3.5-flash",
     contents=body["contents"],
     config={
       "safety_settings": [body["safetySettings"]] # REST API uses camelCase
@@ -461,7 +461,7 @@ import { b } from 'baml_client'
 async function run() {
   // Initialize the Gemini client.
   const client = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY!)
-  const model = client.getGenerativeModel({ model: "gemini-2.5-flash" })
+  const model = client.getGenerativeModel({ model: "gemini-3.5-flash" })
 
   // Get the HTTP request object.
   const req = await b.request.ExtractResume("John Doe | Software Engineer | BSc in CS")

--- a/fern/01-guide/09-comparisons/ai-sdk.mdx
+++ b/fern/01-guide/09-comparisons/ai-sdk.mdx
@@ -140,7 +140,7 @@ function getModel(provider: string) {
   switch(provider) {
     case 'openai': return openai('gpt-4o');
     case 'anthropic': return anthropic('claude-3-opus-20240229');
-    case 'google': return google('gemini-pro');
+    case 'google': return google('gemini-3.1-pro-preview');
     // Don't forget to handle errors...
   }
 }
@@ -288,9 +288,9 @@ client<llm> Claude {
 }
 
 client<llm> Gemini {
-  provider google
+  provider google-ai
   options {
-    model "gemini-pro"
+    model "gemini-3.1-pro-preview"
   }
 }
 

--- a/fern/03-reference/baml/clients/providers/google-ai.mdx
+++ b/fern/03-reference/baml/clients/providers/google-ai.mdx
@@ -18,7 +18,7 @@ Example:
 client<llm> MyClient {
   provider google-ai
   options {
-    model "gemini-2.5-flash"
+    model "gemini-3.5-flash"
   }
 }
 ```
@@ -45,16 +45,17 @@ You can use this to modify the `headers` and `base_url` for example.
 <ParamField
   path="model"
   type="string"
+  required
 >
-  The model to use. **Default: `gemini-2.5-flash`**
+  The model to use.
 
   We don't have any checks for this field, you can pass any string you wish.
 
 | Model | Use Case | Context | Key Features |
 |-------|----------|---------|--------------|
-| **gemini-2.5-pro** | Complex tasks, coding, STEM | 1M | Adaptive thinking, multimodal |
-| **gemini-2.5-flash** | Production apps, balanced performance | 1M | Best price/performance |
-| **gemini-2.5-flash-lite** | High-volume, cost-sensitive | 1M | Lowest cost, fastest |
+| **gemini-3.1-pro-preview** | Complex tasks, coding, STEM | 1M | Adaptive thinking, multimodal |
+| **gemini-3.5-flash** | Production apps, balanced performance | 1M | Best price/performance |
+| **gemini-3.1-flash-lite** | High-volume, cost-sensitive | 1M | Lowest cost, fastest |
 
 See the [Google Model Docs](https://ai.google.dev/gemini-api/docs/models/gemini) for the latest models.
 </ParamField>
@@ -71,7 +72,7 @@ Example:
 client<llm> MyClient {
   provider google-ai
   options {
-    model "gemini-2.5-flash"
+    model "gemini-3.5-flash"
     headers {
       "X-My-Header" "my-value"
     }

--- a/fern/03-reference/baml/clients/providers/openrouter.mdx
+++ b/fern/03-reference/baml/clients/providers/openrouter.mdx
@@ -39,7 +39,7 @@ The `openrouter` provider extends [`openai-generic`](openai-generic) with OpenRo
 | `openai/gpt-4o-mini` | Fast, cost-effective |
 | `anthropic/claude-3.5-sonnet` | Claude 3.5 Sonnet |
 | `anthropic/claude-3-haiku` | Fast Claude variant |
-| `google/gemini-2.0-flash-001` | Gemini 2.0 Flash |
+| `google/gemini-3.5-flash` | Gemini 3.5 Flash |
 | `meta-llama/llama-3.1-70b-instruct` | Llama 3.1 70B |
 
 OpenRouter supports model variants for routing preferences (e.g., `:nitro` for high-throughput):

--- a/fern/03-reference/baml/clients/providers/vertex.mdx
+++ b/fern/03-reference/baml/clients/providers/vertex.mdx
@@ -12,7 +12,7 @@ Example using a Vertex API Key (Express Mode):
 client<llm> MyClient {
   provider vertex-ai
   options {
-    model gemini-2.5-pro
+    model gemini-3.1-pro-preview
     location us-central1 // or "global"
     project_id my-project-id
     query_params {
@@ -41,7 +41,7 @@ When using a Vertex API Key, set the `key` query parameter and specify your `pro
 client<llm> VertexApiKeyClient {
   provider vertex-ai
   options {
-    model gemini-2.5-pro
+    model gemini-3.1-pro-preview
     location us-central1 // you can also use "global"
     project_id my-project-id
     query_params {
@@ -71,7 +71,7 @@ credentials](https://cloud.google.com/docs/authentication/application-default-cr
 client<llm> MyClient {
   provider vertex-ai
   options {
-    model gemini-2.5-pro
+    model gemini-3.1-pro-preview
     location us-central1
     project_id my-project-id
     // we will by default try to use this form of authentication.
@@ -190,7 +190,7 @@ Try setting `location: global` in your client options:
 client<llm> MyClient {
   provider vertex-ai
   options {
-    model gemini-2.5-pro
+    model gemini-3.1-pro-preview
     location global
     project_id my-project-id
   }
@@ -282,7 +282,7 @@ visible on-screen when the user navigates to #credentials_content, due to how Fe
     client<llm> Vertex {
       provider vertex-ai
       options {
-        model gemini-2.5-pro
+        model gemini-3.1-pro-preview
         location us-central1
         // credentials can be a block string containing service account credentials in JSON format
         credentials #"
@@ -313,7 +313,7 @@ visible on-screen when the user navigates to #credentials_content, due to how Fe
   client<llm> Vertex {
     provider vertex-ai
     options {
-      model gemini-2.5-pro
+      model gemini-3.1-pro-preview
       location us-central1
       credentials "path/to/credentials.json"
     }
@@ -326,7 +326,7 @@ visible on-screen when the user navigates to #credentials_content, due to how Fe
     client<llm> Vertex {
       provider vertex-ai
       options {
-        model gemini-2.5-pro
+        model gemini-3.1-pro-preview
         location us-central1
         // credentials can be a block string containing service account credentials in JSON format
         credentials {
@@ -369,7 +369,7 @@ visible on-screen when the user navigates to #credentials_content, due to how Fe
     client<llm> Vertex {
       provider vertex-ai
       options {
-        model gemini-2.5-pro
+        model gemini-3.1-pro-preview
         location us-central1
         // credentials_content is a block string containing service account credentials in JSON format
         credentials_content #"
@@ -405,9 +405,9 @@ visible on-screen when the user navigates to #credentials_content, due to how Fe
 
 | Model | Input(s) | Optimized for |
 | --- | ---  | --- |
-| `gemini-2.5-pro`  | Audio, images, videos, and text | Complex reasoning tasks such as code and text generation, text editing, problem solving, data extraction and generation |
-| `gemini-2.5-flash`  | Audio, images, videos, and text | Fast and versatile performance across a diverse variety of tasks |
-| `gemini-1.0-pro` | Text | Natural language tasks, multi-turn text and code chat, and code generation |
+| `gemini-3.1-pro-preview`  | Audio, images, videos, and text | Complex reasoning tasks such as code and text generation, text editing, problem solving, data extraction and generation |
+| `gemini-3.5-flash`  | Audio, images, videos, and text | Fast and versatile performance across a diverse variety of tasks |
+| `gemini-3.1-flash-lite` | Audio, images, videos, and text | High-volume, cost-sensitive and low-latency tasks |
 
 See the [Google Model Docs](https://ai.google.dev/gemini-api/docs/models/gemini) for the latest models.
 </ParamField>
@@ -420,7 +420,7 @@ Example:
 client<llm> MyClient {
   provider vertex-ai
   options {
-    model gemini-2.5-pro
+    model gemini-3.1-pro-preview
     project_id my-project-id
     location us-central1
     // Additional headers
@@ -440,7 +440,7 @@ Example (use a Vertex API Key with Express Mode):
 client<llm> MyClient {
   provider vertex-ai
   options {
-    model gemini-2.5-pro
+    model gemini-3.1-pro-preview
     project_id my-project-id
     location us-central1
     query_params {
@@ -481,7 +481,7 @@ Consult the specific provider's documentation for more information.
 client<llm> MyClient {
   provider vertex-ai
   options {
-    model gemini-2.5-pro
+    model gemini-3.1-pro-preview
     project_id my-project-id
     location us-central1
 
@@ -504,7 +504,7 @@ client<llm> MyClient {
 client<llm> MyClient {
   provider vertex-ai
   options {
-    model gemini-2.5-pro
+    model gemini-3.1-pro-preview
     project_id my-project-id
     location us-central1
 
@@ -524,7 +524,7 @@ client<llm> MyClient {
   client<llm> GeminiThinking {
     provider vertex-ai
     options {
-      model gemini-2.5-pro
+      model gemini-3.1-pro-preview
       project_id my-project-id
       location us-central1
       generationConfig {

--- a/fern/03-reference/baml_client/client-option.mdx
+++ b/fern/03-reference/baml_client/client-option.mdx
@@ -186,7 +186,7 @@ The `client` value can be:
    - `"openai/gpt-4o-mini"` - OpenAI models
    - `"anthropic/claude-sonnet-4-20250514"` - Anthropic models
    - `"openrouter/meta-llama/llama-3.1-70b-instruct"` - OpenRouter models
-   - `"google-ai/gemini-2.0-flash"` - Google AI models
+   - `"google-ai/gemini-3.5-flash"` - Google AI models
 
 2. **Client defined in `.baml` files** - Reference by name (e.g., `"MyCustomClient"`)
 

--- a/fern/03-reference/baml_client/pdf.mdx
+++ b/fern/03-reference/baml_client/pdf.mdx
@@ -438,7 +438,7 @@ client<llm> AnthropicClient {
 client<llm> VertexClient {
   provider vertex-ai
   options {
-    model "gemini-1.5-pro"
+    model "gemini-3.1-pro-preview"
     project "your-project"
     location "us-central1"
     media_url_handler {
@@ -451,7 +451,7 @@ client<llm> VertexClient {
 client<llm> GoogleAIClient {
   provider google-ai
   options {
-    model "gemini-1.5-pro"
+    model "gemini-3.1-pro-preview"
     api_key env.GOOGLE_API_KEY
     media_url_handler {
       pdf "send_base64_unless_google_url"  // Keep gs:// URLs, convert others


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Gemini model examples across guides and reference documentation to use current Gemini 3 models.
  * Refreshed Google AI and Vertex AI model option tables, examples, and configuration guidance.
  * Updated OpenRouter and client-name examples to reference newer Gemini models.
  * Clarified that the Google AI model option is required and documented supported model choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->