### PR TITLE
Fix playground cURL previews for legacy tests

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -1798,9 +1798,40 @@ pub struct ConfigItemDef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TestDef {
     pub name: Name,
-    pub config_items: Vec<ConfigItemDef>,
+    /// Functions targeted by this legacy config-block test.
+    pub function_refs: Vec<Name>,
+    /// Statically declared test arguments.
+    pub args: Vec<(Name, TestArgValue)>,
     pub span: TextRange,
     pub name_span: TextRange,
+}
+
+/// A JSON-compatible value declared in a legacy test's `args` block.
+///
+/// Floats are stored as bit patterns so the AST remains `Eq`, which is
+/// required by the incremental compiler's early-cutoff comparisons.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TestArgValue {
+    Null,
+    Int(i64),
+    FloatBits(u64),
+    Bool(bool),
+    String(std::string::String),
+    Array(Vec<TestArgValue>),
+    Map(Vec<(std::string::String, TestArgValue)>),
+}
+
+impl TestArgValue {
+    pub fn float(value: f64) -> Self {
+        Self::FloatBits(value.to_bits())
+    }
+
+    pub fn as_float(&self) -> Option<f64> {
+        match self {
+            Self::FloatBits(bits) => Some(f64::from_bits(*bits)),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -15,12 +15,12 @@ use rowan::ast::AstNode;
 use crate::{
     DeclarativeMeta, LoweringDiagnostic,
     ast::{
-        AssociatedTypeBindingDef, AssociatedTypeDef, AstSourceMap, BuiltinKind, CallArg,
-        ConfigItemDef, EnumDef, Expr, ExprBody, ExprId, FieldDef, FunctionBodyDef, FunctionDef,
-        FunctionDefaults, ImplementsBlockDef, ImplementsForDef, InterfaceDef,
-        InterfaceFieldLinkDef, Interpolation, Item, LetDef, LetOrigin, LlmBodyDef, MethodSigDef,
-        Param, RawAttribute, RawAttributeArg, RawPrompt, TemplateStringDef, TestDef, TypeAliasDef,
-        TypeExpr, TypeExprKind, VariantDef,
+        AssociatedTypeBindingDef, AssociatedTypeDef, AstSourceMap, BuiltinKind, CallArg, EnumDef,
+        Expr, ExprBody, ExprId, FieldDef, FunctionBodyDef, FunctionDef, FunctionDefaults,
+        ImplementsBlockDef, ImplementsForDef, InterfaceDef, InterfaceFieldLinkDef, Interpolation,
+        Item, LetDef, LetOrigin, LlmBodyDef, MethodSigDef, Param, RawAttribute, RawAttributeArg,
+        RawPrompt, TemplateStringDef, TestArgValue, TestDef, TypeAliasDef, TypeExpr, TypeExprKind,
+        VariantDef,
     },
     companions::expand_companions,
     lower_expr_body, lower_type_expr,
@@ -1829,17 +1829,112 @@ fn lower_test(node: &SyntaxNode, diags: &mut Vec<LoweringDiagnostic>) -> Option<
     };
 
     let test_name = name_token.text().to_string();
-    let config_items = test
-        .config_block()
-        .map(|cb| lower_config_block(&cb, "test", &test_name, diags))
+    let config_block = test.config_block();
+    if let Some(block) = &config_block {
+        for item in block.items() {
+            if item.key().is_none() {
+                diags.push(LoweringDiagnostic::MissingConfigKey {
+                    block_kind: "test",
+                    block_name: test_name.clone(),
+                    span: item.syntax().span_range(),
+                });
+            }
+        }
+    }
+    let function_refs = test
+        .function_reference_names()
+        .into_iter()
+        .map(Name::new)
+        .collect();
+    let args = config_block
+        .as_ref()
+        .and_then(|block| block.items().find(|item| item.matches_key("args")))
+        .and_then(|item| item.nested_block())
+        .map(|block| lower_test_arg_map(&block))
         .unwrap_or_default();
 
     Some(TestDef {
         name: Name::new(&test_name),
-        config_items,
+        function_refs,
+        args,
         span: node.span_range(),
         name_span: name_token.text_range(),
     })
+}
+
+fn lower_test_arg_map(block: &ast::ConfigBlock) -> Vec<(Name, TestArgValue)> {
+    block
+        .items()
+        .filter_map(|item| {
+            let key = item.key()?;
+            Some((Name::new(key.text()), lower_test_arg_item(&item)))
+        })
+        .collect()
+}
+
+fn lower_test_arg_item(item: &ast::ConfigItem) -> TestArgValue {
+    if let Some(block) = item.nested_block() {
+        return TestArgValue::Map(
+            lower_test_arg_map(&block)
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value))
+                .collect(),
+        );
+    }
+
+    item.config_value_node()
+        .map(|value| lower_test_arg_config_value(&value))
+        .unwrap_or(TestArgValue::Null)
+}
+
+fn lower_test_arg_config_value(value: &SyntaxNode) -> TestArgValue {
+    if let Some(array) = value
+        .children()
+        .find(|child| child.kind() == SyntaxKind::ARRAY_LITERAL)
+    {
+        return TestArgValue::Array(
+            array
+                .children()
+                .filter_map(|element| match element.kind() {
+                    SyntaxKind::CONFIG_VALUE => Some(lower_test_arg_config_value(&element)),
+                    SyntaxKind::CONFIG_BLOCK => ast::ConfigBlock::cast(element).map(|block| {
+                        TestArgValue::Map(
+                            lower_test_arg_map(&block)
+                                .into_iter()
+                                .map(|(key, value)| (key.to_string(), value))
+                                .collect(),
+                        )
+                    }),
+                    _ => None,
+                })
+                .collect(),
+        );
+    }
+
+    let raw = value.text().to_string();
+    if let Some(string) = crate::parse_string_attr_value(raw.trim()) {
+        return TestArgValue::String(string);
+    }
+
+    let text = ast::ConfigValue::cast(value.clone())
+        .and_then(|config_value| config_value.scalar_text())
+        .unwrap_or_default();
+
+    match text.as_str() {
+        "null" => return TestArgValue::Null,
+        "true" => return TestArgValue::Bool(true),
+        "false" => return TestArgValue::Bool(false),
+        _ => {}
+    }
+
+    if let Ok(value) = text.parse::<i64>() {
+        return TestArgValue::Int(value);
+    }
+    if let Ok(value) = text.parse::<f64>() {
+        return TestArgValue::float(value);
+    }
+
+    TestArgValue::String(text)
 }
 
 /// Extract the name expression element from a `TEST_EXPR_DEF` or `TESTSET_DEF` node.
@@ -3034,32 +3129,6 @@ fn validate_client_options(
             span,
         });
     }
-}
-
-fn lower_config_block(
-    cb: &ast::ConfigBlock,
-    block_kind: &'static str,
-    block_name: &str,
-    diags: &mut Vec<LoweringDiagnostic>,
-) -> Vec<ConfigItemDef> {
-    cb.items()
-        .filter_map(|item| {
-            let Some(key_token) = item.key() else {
-                diags.push(LoweringDiagnostic::MissingConfigKey {
-                    block_kind,
-                    block_name: block_name.to_string(),
-                    span: item.syntax().span_range(),
-                });
-                return None;
-            };
-            let value = item.value_str().unwrap_or_default();
-            Some(ConfigItemDef {
-                key: Name::new(key_token.text()),
-                value,
-                span: item.syntax().span_range(),
-            })
-        })
-        .collect()
 }
 
 /// Lower variant-level attributes from an `EnumVariant` node.

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -1872,14 +1872,18 @@ fn lower_test_arg_map(block: &ast::ConfigBlock) -> Vec<(Name, TestArgValue)> {
         .collect()
 }
 
+fn lower_test_arg_map_as_value(block: &ast::ConfigBlock) -> TestArgValue {
+    TestArgValue::Map(
+        lower_test_arg_map(block)
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect(),
+    )
+}
+
 fn lower_test_arg_item(item: &ast::ConfigItem) -> TestArgValue {
     if let Some(block) = item.nested_block() {
-        return TestArgValue::Map(
-            lower_test_arg_map(&block)
-                .into_iter()
-                .map(|(key, value)| (key.to_string(), value))
-                .collect(),
-        );
+        return lower_test_arg_map_as_value(&block);
     }
 
     item.config_value_node()
@@ -1897,14 +1901,8 @@ fn lower_test_arg_config_value(value: &SyntaxNode) -> TestArgValue {
                 .children()
                 .filter_map(|element| match element.kind() {
                     SyntaxKind::CONFIG_VALUE => Some(lower_test_arg_config_value(&element)),
-                    SyntaxKind::CONFIG_BLOCK => ast::ConfigBlock::cast(element).map(|block| {
-                        TestArgValue::Map(
-                            lower_test_arg_map(&block)
-                                .into_iter()
-                                .map(|(key, value)| (key.to_string(), value))
-                                .collect(),
-                        )
-                    }),
+                    SyntaxKind::CONFIG_BLOCK => ast::ConfigBlock::cast(element)
+                        .map(|block| lower_test_arg_map_as_value(&block)),
                     _ => None,
                 })
                 .collect(),

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree.rs
@@ -320,33 +320,7 @@ pub struct Client {
     pub round_robin_start: Option<usize>,
 }
 
-/// A test argument value stored in the `ItemTree`.
-///
-/// Floats are stored as bit patterns (via `f64::to_bits`) to allow `Eq` and `Hash`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TestArgValue {
-    Null,
-    Int(i64),
-    /// Float stored as raw bits (`f64::to_bits(value)`).
-    FloatBits(u64),
-    Bool(bool),
-    String(String),
-    Array(Vec<TestArgValue>),
-    Map(Vec<(String, TestArgValue)>),
-}
-
-impl TestArgValue {
-    pub fn float(v: f64) -> Self {
-        Self::FloatBits(v.to_bits())
-    }
-
-    pub fn as_float(&self) -> Option<f64> {
-        match self {
-            Self::FloatBits(bits) => Some(f64::from_bits(*bits)),
-            _ => None,
-        }
-    }
-}
+pub use baml_compiler2_ast::ast::TestArgValue;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Test {
@@ -803,27 +777,12 @@ impl ItemTree {
 
     pub fn alloc_test(&mut self, t: &ast::TestDef) -> LocalItemId<TestMarker> {
         let id = self.alloc_id(ItemKind::Test, &t.name);
-        // Extract function_refs from config_items (key "functions" or "function")
-        let function_refs = t
-            .config_items
-            .iter()
-            .filter(|item| item.key.as_str() == "functions" || item.key.as_str() == "function")
-            .flat_map(|item| {
-                // Values may be comma-separated or a single name
-                item.value
-                    .split(',')
-                    .map(|s| Name::new(s.trim().trim_matches('"')))
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-        // Args come from config_items with key "args" — store raw; complex parsing skipped
-        let args = Vec::new();
         self.tests.insert(
             id,
             Test {
                 name: t.name.clone(),
-                function_refs,
-                args,
+                function_refs: t.function_refs.clone(),
+                args: t.args.clone(),
             },
         );
         id

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -2736,7 +2736,7 @@ impl TestDef {
         self.syntax
             .descendants()
             .filter_map(ConfigItem::cast)
-            .find(|item| item.matches_key("functions"))
+            .find(|item| item.matches_key("functions") || item.matches_key("function"))
             .and_then(|item| {
                 // Find the CONFIG_VALUE child (excludes attributes which are siblings)
                 item.syntax()
@@ -2751,6 +2751,38 @@ impl TestDef {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    /// Get complete function references from the legacy `function(s)` config.
+    ///
+    /// Unlike [`Self::function_names`], this preserves qualified references
+    /// such as `workflows.Classify` as one value.
+    pub fn function_reference_names(&self) -> Vec<String> {
+        let Some(value) = self
+            .syntax
+            .descendants()
+            .filter_map(ConfigItem::cast)
+            .find(|item| item.matches_key("functions") || item.matches_key("function"))
+            .and_then(|item| item.config_value_node())
+        else {
+            return Vec::new();
+        };
+
+        let Some(text) = ConfigValue::cast(value).and_then(|value| value.scalar_text()) else {
+            return Vec::new();
+        };
+        let contents = text
+            .strip_prefix('[')
+            .and_then(|value| value.strip_suffix(']'))
+            .unwrap_or(&text);
+
+        contents
+            .split(',')
+            .map(str::trim)
+            .map(|name| name.trim_matches('"'))
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .collect()
     }
 
     /// Get the config block.

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -2711,6 +2711,13 @@ impl ConfigValue {
 }
 
 impl TestDef {
+    fn function_config_item(&self) -> Option<ConfigItem> {
+        self.syntax
+            .descendants()
+            .filter_map(ConfigItem::cast)
+            .find(|item| item.matches_key("functions") || item.matches_key("function"))
+    }
+
     /// Get the test name.
     pub fn name(&self) -> Option<SyntaxToken> {
         self.syntax
@@ -2733,10 +2740,7 @@ impl TestDef {
     pub fn function_names(&self) -> Vec<SyntaxToken> {
         // Look for a ConfigItem with key "functions" and extract all function names.
         // The function names are inside a CONFIG_VALUE child node, not in attributes.
-        self.syntax
-            .descendants()
-            .filter_map(ConfigItem::cast)
-            .find(|item| item.matches_key("functions") || item.matches_key("function"))
+        self.function_config_item()
             .and_then(|item| {
                 // Find the CONFIG_VALUE child (excludes attributes which are siblings)
                 item.syntax()
@@ -2759,10 +2763,7 @@ impl TestDef {
     /// such as `workflows.Classify` as one value.
     pub fn function_reference_names(&self) -> Vec<String> {
         let Some(value) = self
-            .syntax
-            .descendants()
-            .filter_map(ConfigItem::cast)
-            .find(|item| item.matches_key("functions") || item.matches_key("function"))
+            .function_config_item()
             .and_then(|item| item.config_value_node())
         else {
             return Vec::new();

--- a/baml_language/crates/baml_project/src/symbols.rs
+++ b/baml_language/crates/baml_project/src/symbols.rs
@@ -95,7 +95,9 @@ impl From<baml_compiler2_ast::ast::FunctionOrigin> for FunctionOrigin {
 #[derive(Debug, Clone)]
 pub struct TestSymbol {
     pub name: String,
-    /// The first function this test targets.
+    /// One function targeted by this test. Tests that target multiple
+    /// functions produce one symbol per function so preview selection is
+    /// unambiguous.
     pub function_name: String,
     /// Test args serialized as a JSON string.
     pub args_json: String,
@@ -205,32 +207,64 @@ pub fn list_tests_with_metadata(db: &ProjectDatabase) -> Vec<TestSymbol> {
     let pkg_id = PackageId::new(db, Name::new("user"));
     let pkg = package_items(db, pkg_id);
     let mut result = Vec::new();
-    for ns_items in pkg.namespaces.values() {
+    for (namespace_path, ns_items) in &pkg.namespaces {
         for (name, defn) in &ns_items.values {
             if let Definition::Test(test_loc) = defn {
                 let item_tree = file_item_tree(db, test_loc.file(db));
                 let test = &item_tree[test_loc.id(db)];
 
-                // function_refs contains the function names this test targets
-                let function_name = test
-                    .function_refs
-                    .first()
-                    .map(std::string::ToString::to_string)
-                    .unwrap_or_default();
-
-                // args parsing is skipped in canary's alloc_test — always empty for now
-                let args_json = "{}".to_string();
-
-                result.push(TestSymbol {
-                    name: name.to_string(),
-                    function_name,
-                    args_json,
-                });
+                let args_json = serialize_test_args(&test.args);
+                result.extend(test.function_refs.iter().map(|function_name| {
+                    let function_name = ns_items
+                        .values
+                        .get(function_name)
+                        .filter(|definition| definition.kind() == DefinitionKind::Function)
+                        .map(|_| playground_function_name(namespace_path, function_name))
+                        .unwrap_or_else(|| function_name.to_string());
+                    TestSymbol {
+                        name: name.to_string(),
+                        function_name,
+                        args_json: args_json.clone(),
+                    }
+                }));
             }
         }
     }
-    result.sort_by(|a, b| a.name.cmp(&b.name));
+    result.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then_with(|| a.function_name.cmp(&b.function_name))
+    });
     result
+}
+
+fn serialize_test_args(args: &[(Name, baml_compiler2_hir::item_tree::TestArgValue)]) -> String {
+    let object = args
+        .iter()
+        .map(|(name, value)| (name.to_string(), test_arg_to_json(value)))
+        .collect();
+    serde_json::to_string(&serde_json::Value::Object(object)).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn test_arg_to_json(value: &baml_compiler2_hir::item_tree::TestArgValue) -> serde_json::Value {
+    use baml_compiler2_hir::item_tree::TestArgValue;
+
+    match value {
+        TestArgValue::Null => serde_json::Value::Null,
+        TestArgValue::Int(value) => serde_json::Value::from(*value),
+        TestArgValue::FloatBits(bits) => serde_json::Value::from(f64::from_bits(*bits)),
+        TestArgValue::Bool(value) => serde_json::Value::from(*value),
+        TestArgValue::String(value) => serde_json::Value::from(value.clone()),
+        TestArgValue::Array(items) => {
+            serde_json::Value::Array(items.iter().map(test_arg_to_json).collect())
+        }
+        TestArgValue::Map(entries) => serde_json::Value::Object(
+            entries
+                .iter()
+                .map(|(key, value)| (key.clone(), test_arg_to_json(value)))
+                .collect(),
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -273,5 +307,134 @@ mod tests {
                 "demo.inner.InnerFunc".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn playground_test_metadata_preserves_typed_nested_args() {
+        let mut db = make_db();
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/main.baml"),
+            r##"
+function Preview(
+  text: string,
+  raw_text: string,
+  count: int,
+  ratio: float,
+  enabled: bool,
+  missing: string?,
+  tags: unknown[],
+  payload: map<string, unknown>,
+) -> string {
+  text
+}
+
+test PreviewCase {
+  functions [Preview]
+  args {
+    text "hello world\nnext"
+    raw_text #"raw value with spaces"#
+    count -2
+    ratio 1.5
+    enabled true
+    missing null
+    tags ["a", 3, false]
+    payload {
+      nested "value"
+    }
+  }
+}
+"##,
+        );
+
+        let tests = list_tests_with_metadata(&db);
+        assert_eq!(tests.len(), 1);
+        assert_eq!(tests[0].name, "PreviewCase");
+        assert_eq!(tests[0].function_name, "Preview");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&tests[0].args_json).unwrap(),
+            serde_json::json!({
+                "text": "hello world\nnext",
+                "raw_text": "raw value with spaces",
+                "count": -2,
+                "ratio": 1.5,
+                "enabled": true,
+                "missing": null,
+                "tags": ["a", 3, false],
+                "payload": { "nested": "value" },
+            }),
+        );
+    }
+
+    #[test]
+    fn playground_test_metadata_expands_multi_function_tests() {
+        let mut db = make_db();
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/main.baml"),
+            r#"
+function Alpha(value: string) -> string { value }
+function Beta(value: string) -> string { value }
+
+test SharedCase {
+  functions [Alpha, Beta]
+  args { value "same" }
+}
+"#,
+        );
+
+        let tests = list_tests_with_metadata(&db);
+        assert_eq!(
+            tests
+                .iter()
+                .map(|test| (test.name.as_str(), test.function_name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("SharedCase", "Alpha"), ("SharedCase", "Beta")],
+        );
+        assert!(
+            tests
+                .iter()
+                .all(|test| test.args_json == r#"{"value":"same"}"#)
+        );
+    }
+
+    #[test]
+    fn playground_test_metadata_qualifies_local_namespace_function() {
+        let mut db = make_db();
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/ns_demo/main.baml"),
+            r#"
+function Preview(value: string) -> string { value }
+
+test PreviewCase {
+  functions [Preview]
+  args { value "namespaced" }
+}
+"#,
+        );
+
+        let tests = list_tests_with_metadata(&db);
+        assert_eq!(tests.len(), 1);
+        assert_eq!(tests[0].function_name, "demo.Preview");
+    }
+
+    #[test]
+    fn playground_test_metadata_preserves_cross_namespace_function_reference() {
+        let mut db = make_db();
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/ns_demo/preview.baml"),
+            "function Preview(value: string) -> string { value }",
+        );
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/main.baml"),
+            r#"
+test PreviewCase {
+  functions [demo.Preview]
+  args { value "namespaced" }
+}
+"#,
+        );
+
+        let tests = list_tests_with_metadata(&db);
+        assert_eq!(tests.len(), 1);
+        assert_eq!(tests[0].function_name, "demo.Preview");
     }
 }

--- a/baml_language/crates/bex_project/src/bex_lsp/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/mod.rs
@@ -121,6 +121,14 @@ pub struct LlmCapabilities {
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TestInfo {
+    pub name: String,
+    pub function_name: String,
+    pub args_json: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProjectDiagnostic {
     pub severity: &'static str,
     pub message: String,
@@ -131,6 +139,8 @@ pub struct ProjectDiagnostic {
 pub struct ProjectUpdate {
     pub is_bex_current: bool,
     pub functions: Vec<FunctionInfo>,
+    /// Statically declared legacy test cases that can seed function previews.
+    pub tests: Vec<TestInfo>,
     /// Shared type table for `FunctionInfo.params` refs: every named type
     /// referenced from any function's schema, defined exactly once and keyed
     /// by canonical dotted FQN. `None` (omitted on the wire) means the binary

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
@@ -738,10 +738,19 @@ impl BexMulitProject {
                 params: f.params,
             })
             .collect();
+        let tests = baml_project::list_tests_with_metadata(db)
+            .into_iter()
+            .map(|test| crate::bex_lsp::TestInfo {
+                name: test.name,
+                function_name: test.function_name,
+                args_json: test.args_json,
+            })
+            .collect();
 
         crate::bex_lsp::ProjectUpdate {
             is_bex_current,
             functions,
+            tests,
             types: Some(listing.types),
             diagnostics,
         }

--- a/baml_language/crates/bridge_wasm/src/wasm_playground.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_playground.rs
@@ -199,9 +199,19 @@ pub struct ProjectDiagnostic {
 #[derive(Tsify, Serialize)]
 #[tsify(into_wasm_abi)]
 #[serde(rename_all = "camelCase")]
+pub struct TestInfo {
+    pub name: String,
+    pub function_name: String,
+    pub args_json: String,
+}
+
+#[derive(Tsify, Serialize)]
+#[tsify(into_wasm_abi)]
+#[serde(rename_all = "camelCase")]
 pub struct ProjectUpdate {
     pub is_bex_current: bool,
     pub functions: Vec<FunctionInfo>,
+    pub tests: Vec<TestInfo>,
     /// Shared type table for `FunctionInfo.params` refs; `None` = binary
     /// predates the args form. Must match `bex_project::ProjectUpdate`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -354,6 +364,15 @@ impl From<bex_project::PlaygroundNotification> for PlaygroundNotification {
                                     client_name: c.client_name,
                                 }),
                                 params: f.params.map(|ps| ps.into_iter().map(Into::into).collect()),
+                            })
+                            .collect(),
+                        tests: update
+                            .tests
+                            .into_iter()
+                            .map(|test| TestInfo {
+                                name: test.name,
+                                function_name: test.function_name,
+                                args_json: test.args_json,
                             })
                             .collect(),
                         types: update.types.map(|types| {

--- a/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
@@ -176,6 +176,75 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
   });
 });
 
+describe('ExecutionPanel test previews', () => {
+  it('hydrates function args when a legacy test is selected without running it', async () => {
+    const port = new FakeRuntimePort();
+
+    render(<ExecutionPanel port={port} />);
+
+    act(() => {
+      port.emit({
+        type: 'playgroundNotification',
+        notification: { type: 'listProjects', projects: ['project'] },
+      });
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'updateProject',
+          project: 'project',
+          update: {
+            isBexCurrent: true,
+            functions: [
+              {
+                name: 'ClassifySentiment',
+                kind: 'llm',
+                origin: 'userDefined',
+                capabilities: {
+                  renderPrompt: true,
+                  buildRequest: true,
+                  clientName: 'Gpt5',
+                },
+                params: [
+                  {
+                    name: 'text',
+                    hasDefault: false,
+                    schema: { type: 'string' },
+                  },
+                ],
+              },
+            ],
+            tests: [
+              {
+                name: 'HappySentiment',
+                functionName: 'ClassifySentiment',
+                argsJson: '{"text":"I absolutely love this feature"}',
+              },
+            ],
+            diagnostics: [],
+          },
+        },
+      });
+    });
+
+    fireEvent.click(
+      await screen.findByTitle(
+        'Use HappySentiment args for ClassifySentiment',
+      ),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'raw' }));
+
+    const rawInput = await screen.findByPlaceholderText('{"key": "value"}');
+    expect(JSON.parse((rawInput as HTMLInputElement).value)).toEqual({
+      text: 'I absolutely love this feature',
+    });
+    expect(
+      screen.getByText('ClassifySentiment()'),
+    ).toBeInTheDocument();
+    expect(port.sent.some((message) => message.type === 'startRun')).toBe(false);
+    expect(port.sent.some((message) => message.type === 'startTestRun')).toBe(false);
+  });
+});
+
 describe('ExecutionPanel args form', () => {
   it('renders the args form from param schemas and serializes edits into argsJson', async () => {
     const port = new FakeRuntimePort();

--- a/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
@@ -4,6 +4,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   ExecutionPanel,
   type ControlFlowGraph,
+  type ProjectUpdate,
   type RuntimePort,
   type Run,
   type WorkerInMessage,
@@ -177,8 +178,39 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
 });
 
 describe('ExecutionPanel test previews', () => {
-  it('hydrates function args when a legacy test is selected without running it', async () => {
+  it('hydrates legacy test args without running and releases selection on navigation', async () => {
     const port = new FakeRuntimePort();
+    const projectUpdate: ProjectUpdate = {
+      isBexCurrent: true,
+      functions: [
+        {
+          name: 'ClassifySentiment',
+          kind: 'llm',
+          origin: 'userDefined',
+          capabilities: {
+            renderPrompt: true,
+            buildRequest: true,
+            clientName: 'Gpt5',
+          },
+          params: [
+            {
+              name: 'text',
+              hasDefault: false,
+              schema: { type: 'string' },
+            },
+          ],
+        },
+        { name: 'OtherFunction', kind: 'expr', origin: 'userDefined' },
+      ],
+      tests: [
+        {
+          name: 'HappySentiment',
+          functionName: 'ClassifySentiment',
+          argsJson: '{"text":"I absolutely love this feature"}',
+        },
+      ],
+      diagnostics: [],
+    };
 
     render(<ExecutionPanel port={port} />);
 
@@ -192,36 +224,7 @@ describe('ExecutionPanel test previews', () => {
         notification: {
           type: 'updateProject',
           project: 'project',
-          update: {
-            isBexCurrent: true,
-            functions: [
-              {
-                name: 'ClassifySentiment',
-                kind: 'llm',
-                origin: 'userDefined',
-                capabilities: {
-                  renderPrompt: true,
-                  buildRequest: true,
-                  clientName: 'Gpt5',
-                },
-                params: [
-                  {
-                    name: 'text',
-                    hasDefault: false,
-                    schema: { type: 'string' },
-                  },
-                ],
-              },
-            ],
-            tests: [
-              {
-                name: 'HappySentiment',
-                functionName: 'ClassifySentiment',
-                argsJson: '{"text":"I absolutely love this feature"}',
-              },
-            ],
-            diagnostics: [],
-          },
+          update: projectUpdate,
         },
       });
     });
@@ -242,6 +245,38 @@ describe('ExecutionPanel test previews', () => {
     ).toBeInTheDocument();
     expect(port.sent.some((message) => message.type === 'startRun')).toBe(false);
     expect(port.sent.some((message) => message.type === 'startTestRun')).toBe(false);
+
+    act(() => {
+      port.emit({
+        type: 'cursorContext',
+        context: {
+          functionName: 'OtherFunction',
+          isWorkflow: false,
+          workflowMemberships: [],
+          sourceExprId: null,
+          testName: null,
+        },
+      });
+    });
+    expect(await screen.findByText('OtherFunction()')).toBeInTheDocument();
+
+    act(() => {
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'updateProject',
+          project: 'project',
+          update: {
+            ...projectUpdate,
+            tests: projectUpdate.tests?.map((test) => ({
+              ...test,
+              argsJson: '{"text":"source edit"}',
+            })),
+          },
+        },
+      });
+    });
+    expect(await screen.findByText('OtherFunction()')).toBeInTheDocument();
   });
 });
 

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -35,19 +35,20 @@ import { ErrorDisplay } from './components/ErrorDisplay';
 import { MetadataBadges } from './components/MetadataBadges';
 import { PromptStats } from './components/PromptStats';
 import type { RuntimePort } from './runtime-port';
-import type {
-  ControlFlowGraph,
-  CursorContext,
-  DiagnosticEntry,
-  FetchLogEntry,
-  FunctionInfo,
-  ProjectUpdate,
-  TestInfo,
-  Run,
-  BoundaryId,
-  RunStatus,
-  SourceNavigationTarget,
-  WorkerOutMessage,
+import {
+  previewTestKey,
+  type ControlFlowGraph,
+  type CursorContext,
+  type DiagnosticEntry,
+  type FetchLogEntry,
+  type FunctionInfo,
+  type ProjectUpdate,
+  type TestInfo,
+  type Run,
+  type BoundaryId,
+  type RunStatus,
+  type SourceNavigationTarget,
+  type WorkerOutMessage,
 } from './worker-protocol';
 import type { ResultRendererProps } from './result-renderers';
 import { ArgsForm } from './ArgsForm';
@@ -173,10 +174,6 @@ function testTargetMatches(candidate: string, target: string): boolean {
     candidate.endsWith(`/${target}`) ||
     candidate.split('/').pop() === target
   );
-}
-
-function previewTestKey(test: TestInfo): string {
-  return `${test.functionName}\u0000${test.name}`;
 }
 
 function isExpandedTestSet(def: SerializedTestDef): def is SerializedTestSet {
@@ -1163,6 +1160,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     // that owns the call so the top-level workflow remains the primary view.
     if (isCallSite) {
       if (sourceExprFunctionName !== currentFn) {
+        setSelectedPreviewTestKey(null);
         setSelectedFn(sourceExprFunctionName);
         setViewingCollection(false);
         setViewingTestRun(false);
@@ -1194,6 +1192,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       if (root !== currentFn) {
         pendingHighlightRef.current =
           target != null ? { fn: root, nodeId: target } : null;
+        setSelectedPreviewTestKey(null);
         setSelectedFn(root);
         setViewingCollection(false);
         setViewingTestRun(false);
@@ -1210,6 +1209,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     }
     // Not part of any workflow — show the function's own graph.
     if (ctx.functionName !== currentFn) {
+      setSelectedPreviewTestKey(null);
       setSelectedFn(ctx.functionName);
       setViewingCollection(false);
       setViewingTestRun(false);
@@ -1279,11 +1279,13 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
               setSelectedProject(n.project);
               if (n.functionName) {
                 setWorkflowContext(null);
+                setSelectedPreviewTestKey(null);
                 setSelectedFn(n.functionName);
                 setViewingCollection(false);
                 setViewingTestRun(false);
               } else if (n.testName || n.testsetName) {
                 setWorkflowContext(null);
+                setSelectedPreviewTestKey(null);
                 setSelectedFn(null);
                 setViewingCollection(false);
                 setViewingTestRun(true);
@@ -2445,6 +2447,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
               findCallSiteNode(wf, hop);
             pendingHighlightRef.current =
               target != null ? { fn: wf, nodeId: target } : null;
+            setSelectedPreviewTestKey(null);
             setSelectedFn(wf);
             setHighlightedNodeId(null);
           }}

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -42,6 +42,7 @@ import type {
   FetchLogEntry,
   FunctionInfo,
   ProjectUpdate,
+  TestInfo,
   Run,
   BoundaryId,
   RunStatus,
@@ -172,6 +173,10 @@ function testTargetMatches(candidate: string, target: string): boolean {
     candidate.endsWith(`/${target}`) ||
     candidate.split('/').pop() === target
   );
+}
+
+function previewTestKey(test: TestInfo): string {
+  return `${test.functionName}\u0000${test.name}`;
 }
 
 function isExpandedTestSet(def: SerializedTestDef): def is SerializedTestSet {
@@ -756,6 +761,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     useState<PendingTestTarget | null>(null);
 
   const [selectedFn, setSelectedFn] = useState<string | null>(null);
+  const [selectedPreviewTestKey, setSelectedPreviewTestKey] = useState<
+    string | null
+  >(null);
   const [showInternalFunctions, setShowInternalFunctions] = useState(false);
   const [argsJson, setArgsJson] = useState(initialArgsJson ?? '{}');
   // Args editor mode. 'form' renders the schema-driven ArgsForm when the
@@ -1679,6 +1687,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   // `typedArgsByFnRef` — an edit that misses either silently desyncs them.
   const updateArgsJson = useCallback(
     (next: string) => {
+      setSelectedPreviewTestKey(null);
       setArgsJson(next);
       if (selectedFn) typedArgsByFnRef.current[selectedFn] = next;
     },
@@ -2027,6 +2036,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     : undefined;
   const isLoadingProject = selectedProject != null && currentUpdate == null;
   const functions: FunctionInfo[] = currentUpdate?.functions ?? [];
+  const previewTests = currentUpdate?.tests ?? [];
   const internalFunctionCount = functions.filter(isInternalFunction).length;
   const visibleFunctions = showInternalFunctions
     ? functions
@@ -2038,6 +2048,34 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   const selectedFnInfo = visibleFunctions.find((f) => f.name === selectedFn);
   const canPreviewPrompt = selectedFnInfo?.capabilities?.renderPrompt ?? false;
   const canPreviewCurl = selectedFnInfo?.capabilities?.buildRequest ?? false;
+
+  const handleSelectPreviewTest = useCallback((test: TestInfo) => {
+    const key = previewTestKey(test);
+    typedArgsByFnRef.current[test.functionName] = test.argsJson;
+    setArgsJson(test.argsJson);
+    setSelectedPreviewTestKey(key);
+    setSelectedFn(test.functionName);
+    setViewingCollection(false);
+    setViewingTestRun(false);
+    setHighlightedNodeId(null);
+    setWorkflowContext(null);
+  }, []);
+
+  // Keep a selected preview case synchronized with source edits. If the test
+  // is deleted, retain the current function/args as an ordinary manual draft.
+  useEffect(() => {
+    if (!selectedPreviewTestKey) return;
+    const test = previewTests.find(
+      (candidate) => previewTestKey(candidate) === selectedPreviewTestKey,
+    );
+    if (!test) {
+      setSelectedPreviewTestKey(null);
+      return;
+    }
+    typedArgsByFnRef.current[test.functionName] = test.argsJson;
+    setArgsJson(test.argsJson);
+    setSelectedFn(test.functionName);
+  }, [previewTests, selectedPreviewTestKey]);
 
   // ── Args form wiring ─────────────────────────────────────────────────────
   // `undefined` = no schema shipped (old engine / extraction miss) → raw-only.
@@ -2750,8 +2788,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   internalFunctionCount={internalFunctionCount}
                   isLoadingProject={isLoadingProject}
                   testTree={testTree}
+                  previewTests={previewTests}
+                  selectedPreviewTestKey={selectedPreviewTestKey}
+                  onSelectPreviewTest={handleSelectPreviewTest}
                   selectedFn={selectedFn}
                   onSelectFn={(fn) => {
+                    setSelectedPreviewTestKey(null);
                     setViewingCollection(false);
                     setViewingTestRun(false);
                     setHighlightedNodeId(null);

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -27,7 +27,11 @@ import type {
   SerializedTestDef,
   SerializedTestSet,
 } from './serialized-test-tree';
-import type { FunctionInfo, TestInfo } from './worker-protocol';
+import {
+  previewTestKey,
+  type FunctionInfo,
+  type TestInfo,
+} from './worker-protocol';
 
 // ---------------------------------------------------------------------------
 // TestTreeNode — recursive tree renderer for SerializedTestDef items
@@ -484,7 +488,7 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
               )}
 
               {previewTests.map((test) => {
-                const key = `${test.functionName}\u0000${test.name}`;
+                const key = previewTestKey(test);
                 const duplicateName = (previewNameCounts.get(test.name) ?? 0) > 1;
                 return (
                   <button

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -27,7 +27,7 @@ import type {
   SerializedTestDef,
   SerializedTestSet,
 } from './serialized-test-tree';
-import type { FunctionInfo } from './worker-protocol';
+import type { FunctionInfo, TestInfo } from './worker-protocol';
 
 // ---------------------------------------------------------------------------
 // TestTreeNode — recursive tree renderer for SerializedTestDef items
@@ -193,6 +193,9 @@ export interface FunctionSidebarProps {
   internalFunctionCount: number;
   isLoadingProject?: boolean;
   testTree?: SerializedTestDef[] | null;
+  previewTests?: TestInfo[];
+  selectedPreviewTestKey?: string | null;
+  onSelectPreviewTest?: (test: TestInfo) => void;
   selectedFn: string | null;
   onSelectFn: (name: string | null) => void;
   onRefreshTests: () => void;
@@ -315,6 +318,9 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
   internalFunctionCount,
   isLoadingProject = false,
   testTree,
+  previewTests = [],
+  selectedPreviewTestKey,
+  onSelectPreviewTest,
   selectedFn,
   onSelectFn,
   onRefreshTests,
@@ -347,6 +353,13 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
   };
 
   const treeItems = testTree ?? [];
+  const previewNameCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const test of previewTests) {
+      counts.set(test.name, (counts.get(test.name) ?? 0) + 1);
+    }
+    return counts;
+  }, [previewTests]);
   let emptyFunctionMessage = 'No matches';
   if (isLoadingProject) {
     emptyFunctionMessage = 'Loading project...';
@@ -458,17 +471,46 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
             </div>
 
             <CollapsibleContent>
-              {!testTree && (
+              {!testTree && previewTests.length === 0 && (
                 <div className="px-4 py-2 text-[10px] text-vsc-text-faint italic">
                   No test data yet
                 </div>
               )}
 
-              {testTree && treeItems.length === 0 && (
+              {testTree && treeItems.length === 0 && previewTests.length === 0 && (
                 <div className="px-4 py-2 text-[10px] text-vsc-text-faint italic">
                   No tests found
                 </div>
               )}
+
+              {previewTests.map((test) => {
+                const key = `${test.functionName}\u0000${test.name}`;
+                const duplicateName = (previewNameCounts.get(test.name) ?? 0) > 1;
+                return (
+                  <button
+                    type="button"
+                    key={key}
+                    className={cn(
+                      'flex items-center gap-1.5 w-full pr-2 py-0.5 text-[10px] font-vsc-mono text-left',
+                      selectedPreviewTestKey === key
+                        ? 'bg-vsc-accent/15 text-vsc-text font-semibold'
+                        : 'text-vsc-text-muted hover:bg-vsc-hover',
+                    )}
+                    style={{ paddingLeft: 8 }}
+                    onClick={() => onSelectPreviewTest?.(test)}
+                    title={`Use ${test.name} args for ${test.functionName}`}
+                  >
+                    <FlaskConical size={12} className="text-vsc-text-faint shrink-0" />
+                    <span className="truncate text-[11px]">
+                      {test.name}
+                      {duplicateName ? ` → ${test.functionName}` : ''}
+                    </span>
+                    <span className="ml-auto text-[9px] text-vsc-text-faint shrink-0">
+                      preview
+                    </span>
+                  </button>
+                );
+              })}
 
               {treeItems.map((def, i) => (
                 <TestTreeNode

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -128,9 +128,18 @@ export interface FunctionInfo {
   params?: ParamSchema[];
 }
 
+/** A statically declared legacy test that can seed function previews. */
+export interface TestInfo {
+  name: string;
+  functionName: string;
+  argsJson: string;
+}
+
 export interface ProjectUpdate {
   isBexCurrent: boolean;
   functions: FunctionInfo[];
+  /** Omitted by older runtimes; the UI treats that as no previewable tests. */
+  tests?: TestInfo[];
   /** Shared type table for `FunctionInfo.params` refs. `undefined` = binary
    *  predates the args form (refs, if any, degrade to raw JSON); may be an
    *  empty object when no function references named types. */

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -135,6 +135,13 @@ export interface TestInfo {
   argsJson: string;
 }
 
+/** Stable identity shared by preview selection state and sidebar rows. */
+export function previewTestKey(
+  test: Pick<TestInfo, 'functionName' | 'name'>,
+): string {
+  return `${test.functionName}\u0000${test.name}`;
+}
+
 export interface ProjectUpdate {
   isBexCurrent: boolean;
   functions: FunctionInfo[];


### PR DESCRIPTION
## Summary

- preserve legacy test function targets and typed argument values through compiler lowering
- include previewable test metadata in native and WASM playground project updates
- render legacy tests as selectable preview cases that hydrate the target function and arguments without starting a run
- keep selected previews synchronized with source edits and support multi-function and namespaced targets

## Root cause

During the compiler2 playground migration, legacy test declarations retained their function references but discarded the nested `args` block when building the item tree. Project updates also exposed functions but not test metadata. As a result, the test sidebar could only offer execution-oriented testset nodes, while Prompt and cURL previews continued to use the manually selected function arguments.

## User impact

Selecting a legacy test now seeds the playground with that test's declared arguments. Prompt and cURL previews immediately reflect the selected case, and selection itself does not execute the function or test. Runtime-collected testsets continue to use the existing run flow.

Fixes [B-719](https://linear.app/boundaryml2/issue/B-719/playground-view-curl-didnt-appear-to-work-with-testsets).

## Validation

- `cargo test -p baml_project playground_test_metadata -- --nocapture`
- `cargo test -p baml_tests test_old_and_new -- --nocapture`
- `cargo clippy -p baml_compiler2_ast -p baml_compiler2_hir -p baml_project -p bex_project -p bridge_wasm --all-targets -- -D warnings`
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter app-vscode-webview typecheck`
- `pnpm --filter app-vscode-webview test:unit:run -- src/ExecutionPanel.strict-mode.test.tsx`
- live playground verification with the B-719 fixture: selecting `HappySentiment` produced a cURL body containing the exact declared text and did not start a run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for previewing legacy tests in the playground sidebar, including nested arguments, multi-function targets, duplicate test names, and live updates.
  * Project updates now include test metadata (test name, target function, and serialized args) and ExecutionPanel can load a selected preview’s args without starting execution.
* **Bug Fixes**
  * Improved handling of legacy `function`/`functions` formats and added diagnostics for missing required test config keys.
* **Tests**
  * Added coverage for preview selection and args JSON hydration behavior in the execution panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->