### PR TITLE
fix(bridge-python): accept ints where we expect floats

### DIFF
--- a/baml_language/crates/baml_tests/tests/floats.rs
+++ b/baml_language/crates/baml_tests/tests/floats.rs
@@ -19,3 +19,110 @@ async fn float_abs_negative_zero() {
     assert_eq!(n, 0.0);
     assert!(n.is_sign_positive());
 }
+
+// ─── FFI-boundary int → float coercion ────────────────────────────────────────
+
+/// Unwrap the `Union { value, .. }` envelope a union-typed return carries.
+fn union_payload<E: std::fmt::Debug>(result: &Result<BexExternalValue, E>) -> &BexExternalValue {
+    match result {
+        Ok(BexExternalValue::Union { value, .. }) => value,
+        other => panic!("expected Ok(Union), got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_int_to_float_coercion() {
+    // Host encoders are value-shaped, not schema-shaped (Python `7` and JS
+    // integral `Number`s arrive as `Int`), so a declared `float` slot must
+    // widen a host `Int` at the call boundary. The type system itself does
+    // not relate `int` and `float`, so this is not expressible from a BAML
+    // call site — it stays a Rust test like the bigint boundary tests.
+    const BAML: &str = r#"
+        function DoubleOrEcho(x: float | string) -> float | string {
+            if (x is float) { x * 2.0 } else { x }
+        }
+    "#;
+
+    // A host int lands on the union's float member and arrives as a genuine
+    // VM float — the body's `* 2.0` would fault on an int operand.
+    let from_int = baml_test!(
+        baml: BAML,
+        entry: "DoubleOrEcho",
+        args: { "x" => BexExternalValue::Int(7) },
+    );
+    assert_eq!(
+        union_payload(&from_int.result),
+        &BexExternalValue::Float(14.0)
+    );
+
+    // The string member is untouched by the numeric routing and echoes back.
+    let from_string = baml_test!(
+        baml: BAML,
+        entry: "DoubleOrEcho",
+        args: { "x" => BexExternalValue::String("hi".into()) },
+    );
+    assert_eq!(
+        union_payload(&from_string.result),
+        &BexExternalValue::String("hi".into())
+    );
+}
+
+// ─── Numeric-union member selection for a host int ────────────────────────────
+//
+// A host int arriving at a numeric union picks the best member, not the first
+// declared one: an exact `int` member wins outright, and between `bigint` and
+// `float` the lossless `bigint` (exact for every i64) beats the lossy `float`
+// (rounds above 2^53). Each entry function reports the member the value
+// actually landed on by matching on the member types.
+
+/// Build a `WhichMember(x: <union>) -> string` snippet that reports which
+/// union member `x` inhabits at runtime, with one match arm per member.
+fn which_member_src(union: &str) -> String {
+    let arms: String = union
+        .split('|')
+        .map(str::trim)
+        .map(|member| format!("                let v: {member} => \"{member}\",\n"))
+        .collect();
+    format!(
+        r#"
+        function WhichMember(x: {union}) -> string {{
+            match (x) {{
+{arms}            }}
+        }}
+    "#
+    )
+}
+
+/// Call `WhichMember` with a host `Int(7)` and return the reported member name.
+async fn member_for_host_int(union: &str) -> String {
+    let output = baml_test!(
+        baml: &which_member_src(union),
+        entry: "WhichMember",
+        args: { "x" => BexExternalValue::Int(7) },
+    );
+    match output.result {
+        Ok(BexExternalValue::String(s)) => s.as_str().to_owned(),
+        other => panic!("expected Ok(String), got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_int_into_int_float_bigint_union_prefers_int() {
+    assert_eq!(member_for_host_int("int | float | bigint").await, "int");
+}
+
+#[tokio::test]
+async fn test_int_into_float_bigint_int_union_prefers_int_regardless_of_order() {
+    assert_eq!(member_for_host_int("float | bigint | int").await, "int");
+}
+
+#[tokio::test]
+async fn test_int_into_bigint_float_union_prefers_bigint() {
+    assert_eq!(member_for_host_int("bigint | float").await, "bigint");
+}
+
+#[tokio::test]
+async fn test_int_into_float_bigint_union_prefers_bigint_regardless_of_order() {
+    // `float` is declared first — the lossless `bigint` must still win.
+    assert_eq!(member_for_host_int("float | bigint").await, "bigint");
+}

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -2550,10 +2550,10 @@ fn union_class_arm(ty: &RuntimeTy) -> Option<&RuntimeTy> {
 /// Handles int↔bigint conversion at the FFI boundary. These conversions exist
 /// **only** at the host boundary — the type system is purely structural and
 /// does not relate `int` and `bigint` (see
-/// `baml_compiler2_tir::normalize::is_subtype_of`). `int → bigint` widens
-/// unconditionally; `bigint → int` succeeds when the value fits in i64,
-/// erroring on overflow rather than silently truncating. Also performs optional
-/// unwrap and numeric-singleton union routing.
+/// `baml_compiler2_tir::normalize::is_subtype_of`). `int → bigint` and
+/// `int → float` widen unconditionally; `bigint → int` succeeds when the value
+/// fits in i64, erroring on overflow rather than silently truncating. Unions
+/// delegate to member coercion.
 ///
 /// Class / enum naming is intentionally *not* rewritten here — the
 /// engine-side FQN (e.g. `user.lorem.MyLorem`) is the authoritative
@@ -2572,8 +2572,8 @@ pub(crate) fn coerce_return_to_declared_type(
 /// These conversions exist only at the FFI boundary. The compile-time subtype
 /// relation (`baml_compiler2_tir::normalize::is_subtype_of`,
 /// `baml_type::RuntimeTy::is_subtype_of`) is purely structural and does **not** widen
-/// `int` to `bigint`; the arms below add that widening (plus a checked
-/// `bigint → int` narrowing) only when crossing the host boundary.
+/// `int` to `bigint` or `float`; the arms below add those widenings (plus a
+/// checked `bigint → int` narrowing) only when crossing the host boundary.
 fn coerce_numeric_to_declared_type(
     value: BexExternalValue,
     ty: &RuntimeTy,
@@ -2598,39 +2598,53 @@ fn coerce_numeric_to_declared_type(
                 message: format!("bigint value {bi} does not fit in i64"),
             }),
 
-        // Union with exactly one of {Int, Bigint}: route to that member.
-        // Nullable numeric unions (`int | null`) flow through here too — a
-        // `Null` value coerced against the chosen numeric member falls to the
-        // catch-all `(v, _) => Ok(v)` and is preserved.
-        // Unions containing both are left alone; `find_matching_union_member`
-        // picks by value shape at the VM boundary.
+        // Int → Float widening (FFI boundary only — `int` is not a subtype of
+        // `float` in the type system). Hosts whose encoders are value-shaped
+        // rather than schema-shaped emit integral numbers as ints (Python `7`,
+        // JS `Number.isInteger`), so a `float` slot must accept them; without
+        // this arm the int rides through unconverted and a declared `-> float`
+        // hands the host back an int.
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "deliberate host-language `float(int)` semantics — may round above 2^53"
+        )]
+        (
+            BexExternalValue::Int(i),
+            RuntimeTy::Float { .. } | RuntimeTy::Literal(Literal::Float(_), _, _),
+        ) => Ok(BexExternalValue::Float(i as f64)),
+
+        // Union: delegate to member coercion. A value that already inhabits
+        // some member is left alone (an `Int` against `int | float` stays
+        // `Int`; `Null` against `int | null` is preserved). Otherwise the
+        // first member the value coerces into wins — a host int lands on the
+        // `bigint` member of `bigint | null` or the `float` member of
+        // `float?`. A member coercion error (bigint → int overflow)
+        // propagates rather than silently falling through.
         (v, RuntimeTy::Union(members, _)) => {
-            let has_int = members.iter().any(|m| {
-                matches!(
-                    m,
-                    RuntimeTy::Int { .. } | RuntimeTy::Literal(Literal::Int(_), _, _)
-                )
-            });
-            let has_bigint = members.iter().any(|m| {
-                matches!(
-                    m,
-                    RuntimeTy::Bigint { .. } | RuntimeTy::Literal(Literal::Bigint(_), _, _)
-                )
-            });
-            if has_int == has_bigint {
-                Ok(v)
-            } else if let Some(target) = members.iter().find(|m| {
-                matches!(
-                    m,
-                    RuntimeTy::Int { .. }
-                        | RuntimeTy::Bigint { .. }
-                        | RuntimeTy::Literal(Literal::Int(_) | Literal::Bigint(_), _, _)
-                )
-            }) {
-                coerce_numeric_to_declared_type(v, target)
-            } else {
-                Ok(v)
+            if members.iter().any(|m| value_matches_type(&v, m)) {
+                return Ok(v);
             }
+            // A host int prefers the lossless target: `bigint` (exact for
+            // every i64) beats `float` (rounds above 2^53) regardless of
+            // member declaration order. An exact `int` member was already
+            // taken by the match check above. The partition is stable, so
+            // declaration order still breaks ties within each group.
+            let prefer_bigint = matches!(&v, BexExternalValue::Int(_));
+            let (bigint_members, other_members): (Vec<&RuntimeTy>, Vec<&RuntimeTy>) =
+                members.iter().partition(|m| {
+                    prefer_bigint
+                        && matches!(
+                            m,
+                            RuntimeTy::Bigint { .. } | RuntimeTy::Literal(Literal::Bigint(_), _, _)
+                        )
+                });
+            for member in bigint_members.into_iter().chain(other_members) {
+                let coerced = coerce_numeric_to_declared_type(v.clone(), member)?;
+                if value_matches_type(&coerced, member) {
+                    return Ok(coerced);
+                }
+            }
+            Ok(v)
         }
 
         (v, _) => Ok(v),

--- a/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_primitives.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_primitives.py
@@ -52,6 +52,16 @@ def test_round_trip_float():
     assert round_trip_float(x=2.5) == 2.5
 
 
+def test_round_trip_float_accepts_int():
+    # A Python int into a float param widens at the FFI boundary (the wire
+    # encoder is value-shaped, so `7` arrives Rust-side as an int). The
+    # declared `-> float` must hand back a genuine float, not the int riding
+    # through unconverted.
+    result = round_trip_float(x=7)
+    assert isinstance(result, float)
+    assert result == 7.0
+
+
 def test_round_trip_string():
     assert round_trip_string(x="hi") == "hi"
 
@@ -78,3 +88,20 @@ def test_round_trip_primitives():
         uint8array_field=b"ab",
     )
     assert round_trip_primitives(p=p) == p
+
+
+def test_round_trip_primitives_float_field_accepts_int():
+    # An int into a float *field* is coerced by pydantic at construction, so
+    # it reaches the wire as a float already — pin that contract alongside the
+    # param-level widening above.
+    p = Primitives(
+        int_field=1,
+        float_field=2,
+        string_field="s",
+        bool_field=True,
+        null_field=None,
+        uint8array_field=b"ab",
+    )
+    assert isinstance(p.float_field, float)
+    result = round_trip_primitives(p=p)
+    assert result.float_field == 2.0

--- a/baml_language/sdks/python/uv.lock
+++ b/baml_language/sdks/python/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "baml-bridge"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "protobuf" },


### PR DESCRIPTION
Fixes B-817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFI numeric coercion by widening `int` to `float` when a `float` is expected.
  * Reworked union coercion so values are routed to the best-matching union member, with correct float typing and consistent member-precedence behavior (including `int`/`bigint` and `float` interactions).

* **Tests**
  * Added regression coverage for `float` widening and union member selection at the FFI boundary.
  * Added Python round-trip tests verifying integer inputs decode as genuine floats.

* **Documentation**
  * Clarified coercion and narrowing/widening rules across the FFI boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->