### PR TITLE
test: pin OPENAI_API_KEY defaulting for declared vs runtime-constructed clients

### DIFF
--- a/baml_language/crates/baml_tests/tests/env.rs
+++ b/baml_language/crates/baml_tests/tests/env.rs
@@ -76,3 +76,81 @@ async fn env_sugar_existing_var() {
         Ok(BexExternalValue::String("sugar_value".to_string().into()))
     );
 }
+
+// ─── Client `api_key` env defaulting ──────────────────────────────────────────
+//
+// The `OPENAI_API_KEY` default is applied at exactly two construction sites —
+// compile-time lowering of `client<llm>` declarations and the runtime
+// `"openai/model"` shorthand — NOT by the openai provider itself. A
+// `PrimitiveClient` constructed as a plain object at runtime therefore builds
+// an *unauthenticated* request even with `OPENAI_API_KEY` set. The two tests
+// below pin both sides of that contrast.
+
+/// Extract the headers map from a `main() -> map<string, string>` run.
+fn result_headers(
+    result: Result<BexExternalValue, impl std::fmt::Debug>,
+) -> indexmap::IndexMap<String, BexExternalValue> {
+    match result {
+        Ok(BexExternalValue::Map { entries, .. }) => entries,
+        other => panic!("expected Ok(Map), got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn declared_openai_client_defaults_api_key_from_env() {
+    unsafe { std::env::set_var("OPENAI_API_KEY", "sk-from-env") };
+    let output = baml_test!(
+        r#"
+            client<llm> EnvClient {
+                provider openai
+                options {
+                    model "gpt-4o"
+                }
+            }
+
+            function Greet(name: string) -> string {
+                client EnvClient
+                prompt `Hello ${name}!`
+            }
+
+            function main() -> map<string, string> {
+                Greet$build_request("World").headers
+            }
+        "#
+    );
+    let headers = result_headers(output.result);
+    assert_eq!(
+        headers.get("authorization"),
+        Some(&BexExternalValue::String("Bearer sk-from-env".into())),
+        "a declared client<llm> with no api_key defaults it from OPENAI_API_KEY"
+    );
+}
+
+#[tokio::test]
+async fn runtime_constructed_primitive_client_does_not_read_openai_api_key_env() {
+    unsafe { std::env::set_var("OPENAI_API_KEY", "sk-from-env") };
+    let output = baml_test!(
+        r#"
+            function main() -> map<string, string> {
+                let pc = baml.llm.PrimitiveClient {
+                    name: "runtime-openai",
+                    provider: "openai",
+                    options: baml.llm.PrimitiveClientOptions {
+                        model: "gpt-4o",
+                        headers: {},
+                        query_params: {},
+                        request_body: {},
+                    },
+                };
+                let prompt = baml.llm.assemble_prompt_ast(["Say hi"], []);
+                pc.build_request(prompt, reflect.type_of<string>()).headers
+            }
+        "#
+    );
+    let headers = result_headers(output.result);
+    assert!(
+        !headers.contains_key("authorization"),
+        "surprise: a runtime-constructed PrimitiveClient gets NO api_key env \
+         default, so the request goes out without authorization; got: {headers:?}"
+    );
+}


### PR DESCRIPTION
## What

Two `baml_tests` in `crates/baml_tests/tests/env.rs` pinning where the `OPENAI_API_KEY` default does — and does not — apply:

- **`declared_openai_client_defaults_api_key_from_env`**: a declared `client<llm>` with no `api_key` picks up `OPENAI_API_KEY` — `Fn$build_request()` emits `authorization: Bearer <key>`. (The compiler bakes `baml.env.get("OPENAI_API_KEY")` into the client's generated constructor during lowering, `lower_cst.rs` §2b / B-489.)
- **`runtime_constructed_primitive_client_does_not_read_openai_api_key_env`**: a `PrimitiveClient` constructed as a plain object at runtime and driven through `.build_request()` produces **no** `authorization` header even with `OPENAI_API_KEY` set — the request builds successfully but goes out unauthenticated.

## Why

The env-var default is applied at exactly two construction sites — compile-time lowering of `client<llm>` declarations, and the runtime `"openai/model"` shorthand (`from_shorthand` in `sys_ops`) — not by the openai provider itself. `apply_provider_defaults` on the runtime-construction path fills `base_url`/roles but deliberately never `api_key` (env access needs the async `RuntimeIo`, which that sync path doesn't have).

That gap is surprising, so these tests document the current behavior. If a future change closes the gap (e.g. an env default inside the `build_request` sys-op), the second test is the one to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)