### PR TITLE
fix(engine): defer fire-and-forget spawn error surfacing to thread termination

### DIFF
--- a/baml_language/crates/baml_tests/baml_src/ns_spawn_throws/spawn_throws.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_spawn_throws/spawn_throws.baml
@@ -94,3 +94,22 @@ function racing_successful_spawn_returns_cleanly_fn() -> int {
 test "racing_successful_spawn_returns_cleanly" {
     assert.is_true(baml.deep_equals(racing_successful_spawn_returns_cleanly_fn(), 7))
 }
+
+// Regression: an errored spawn that IS awaited-and-caught must not be pre-empted
+// by an intervening await of an UNRELATED future. `f` throws and enqueues its
+// fire-and-forget error; the `sleep` in `g` guarantees `f` has thrown by the
+// time we `await g`. A per-await drain of that unrelated await used to surface
+// `f`'s error as an uncaught throw before `(await f) catch` could install its
+// handler. Fire-and-forget surfacing must instead defer to thread termination,
+// where "never awaited" is certain — leaving `await f` free to route the error
+// into the `catch`, which returns 99.
+function caught_not_preempted_by_unrelated_await_fn() -> int {
+    let f = spawn { boom_io_x() };
+    let g = spawn { baml.sys.sleep(baml.time.Duration.from_milliseconds(50n)); 7 };
+    let _ = await g;
+    (await f) catch (e) { baml.errors.Io => 99 }
+}
+
+test "caught_not_preempted_by_unrelated_await" {
+    assert.is_true(baml.deep_equals(caught_not_preempted_by_unrelated_await_fn(), 99))
+}

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -4057,8 +4057,12 @@ impl BexEngine {
     /// awaited the future routed through `future_ready`, which takes the
     /// stash entry) are skipped — that error was delivered at the await,
     /// where a `catch` could handle it, and must not re-surface here.
-    /// Returns `None` once the queue is empty. Used by the parent's await
-    /// drain (pre- and post-) for BEP-034 fire-and-forget propagation.
+    /// Returns `None` once the queue is empty. Called only where "never
+    /// awaited" is certain: the root's end-of-run drain and a child thread's
+    /// own `Complete` drain. The `Await` arm does NOT drain here — it only
+    /// trims the awaited future's own entry via
+    /// `vm_thread_consume_pending_child_error_for`, letting that future's
+    /// error flow through `await`/`catch` instead of being surfaced.
     async fn drain_one_pending_child_error(
         &self,
         thread: &mut bex_heap::ActiveHeapPermit<BexThread>,

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -4343,6 +4343,26 @@ impl BexEngine {
                     // registry and return SettledChild. The awaiter's
                     // next `Await` instruction picks up `FutureRead::Ready`.
                     if let Some(future_id) = thread.vm_thread_settles_future() {
+                        // A child thread has no "end of run", so this is where
+                        // "never awaited" becomes certain for ITS own spawned
+                        // children. Surface any still-unobserved grandchild
+                        // error before fulfilling: settle this future `Errored`
+                        // (propagating up via the parent's fire-and-forget
+                        // queue) instead of `Fulfilled`. The root path handles
+                        // its own errors in the end-of-run drain below; this
+                        // mirrors that for intermediate threads and closes the
+                        // gap where a child that errored a grandchild and
+                        // completed WITHOUT ever awaiting would drop the error
+                        // silently.
+                        if let Some(err) = self.drain_one_pending_child_error(&mut thread).await? {
+                            self.prof_drain_open_calls(
+                                &mut thread.vm,
+                                bex_events::prof::record::FunctionEndStatus::Errored,
+                            );
+                            self.settle_child_errored(&mut thread, future_id, err)
+                                .await?;
+                            return Ok(ThreadOutcome::SettledChild(ChildSettleKind::Errored));
+                        }
                         let mut guard = self.futures.acquire(thread.proof()).await;
                         guard.fulfill_future(future_id, value)?;
                         return Ok(ThreadOutcome::SettledChild(ChildSettleKind::Fulfilled));
@@ -4923,43 +4943,25 @@ impl BexEngine {
                         }
                         AwaitOutcome::Done(r) => r?,
                     }
-                    // Post-await drain: surface fire-and-forget child errors
-                    // that nobody observed. This is the ONLY drain point — it
-                    // runs after the awaited future settled, by which time a
-                    // legitimate consumer (a sibling `await`, a combinator's
-                    // internal awaits) has consumed any deferred error it was
-                    // going to handle, leaving the stash entry absent and the
-                    // drain skipping it.
-                    //
-                    // Carve-out: the entry for the future we are awaiting must
-                    // not be drained here — its deferred error flows through
+                    // Post-await: trim the awaited future's now-dead queue
+                    // entry. Its deferred error (if any) flowed through
                     // `future_ready` → `FutureRead::Error` → `VmError::Thrown`,
-                    // which user `catch` clauses can handle. Without this, an
-                    // `(await f) catch (e) { … }` where `f` errored would have
-                    // its error pre-empted as an `UnhandledThrow`. Keyed by
-                    // `future_id`: stable across GC moves and producer settles.
+                    // where user `catch` clauses handle it; the stale
+                    // `(future_id, ptr)` queue entry must not linger and be
+                    // re-surfaced as fire-and-forget at thread termination.
+                    // Keyed by `future_id`: stable across GC moves and producer
+                    // settles.
+                    //
+                    // We deliberately do NOT surface OTHER pending child errors
+                    // here. A per-await drain cannot tell a future that will be
+                    // awaited later (`let f = spawn{…}; await g; await f catch
+                    // …`) from one that is genuinely never awaited, so draining
+                    // here stole `f`'s error out from under its `catch` whenever
+                    // the parent awaited an unrelated future first. Fire-and-
+                    // forget surfacing now happens only where "never awaited" is
+                    // certain: the root's end-of-run drain (below) and a child
+                    // thread's own `Complete` drain.
                     thread.vm_thread_consume_pending_child_error_for(future_id);
-                    if let Some(value) = self.drain_one_pending_child_error(&mut thread).await? {
-                        // This terminates the thread WITHOUT unwinding the
-                        // VM (it is parked at its Await opcode with every
-                        // frame open) — drain the open calls like the
-                        // cancel blocks do, with Errored: an unobserved
-                        // child error killed this thread.
-                        self.prof_drain_open_calls(
-                            &mut thread.vm,
-                            bex_events::prof::record::FunctionEndStatus::Errored,
-                        );
-                        if let Some(our_future_id) = thread.vm_thread_settles_future() {
-                            self.settle_child_errored(&mut thread, our_future_id, value)
-                                .await?;
-                            return Ok(ThreadOutcome::SettledChild(ChildSettleKind::Errored));
-                        }
-                        let external = self.vm_value_to_owned(thread.proof(), value);
-                        return Err(EngineError::UnhandledThrow {
-                            value: Box::new(external),
-                            trace: Vec::new(),
-                        });
-                    }
                 }
 
                 // BEP-034 `baml.future.__await_any`: park until the FIRST of

--- a/baml_language/crates/bex_engine/tests/fire_and_forget.rs
+++ b/baml_language/crates/bex_engine/tests/fire_and_forget.rs
@@ -1,10 +1,15 @@
-//! BEP-034 fire-and-forget error propagation.
+//! Fire-and-forget error propagation.
 //!
-//! A spawned child's unhandled throw surfaces at the spawner's next `await`
-//! — but ONLY if no other task observed (awaited) the future first. An error
-//! consumed by an awaiter (where a `catch` can handle it) must not re-surface
-//! at the spawner. The engine implements this by DEFERRING the error settle
-//! (see `FutureManagerGuard::defer_error` / `future_ready`).
+//! A spawned child's unhandled throw must surface if no task ever awaits the
+//! future, but must NOT surface if the future is awaited (where a `catch` can
+//! handle it). The engine implements this by DEFERRING the error settle (see
+//! `FutureManagerGuard::defer_error` / `future_ready`): an awaiter consumes the
+//! deferred error through `future_ready`, while a genuinely-never-awaited error
+//! is surfaced only where "never awaited" is certain — the owning thread's
+//! termination (root end-of-run, or a child thread's own completion). Surfacing
+//! is NOT done at every intervening `await`, since that cannot distinguish a
+//! future awaited later from one never awaited, and would pre-empt the former's
+//! `catch`.
 
 mod common;
 
@@ -105,4 +110,52 @@ async fn unobserved_child_error_still_surfaces_at_spawner() {
         }
         other => panic!("expected UnhandledThrow(\"boom\"), got {other:?}"),
     }
+}
+
+/// Regression: an errored future that IS awaited-and-caught must not be
+/// pre-empted by an intervening `await` of an UNRELATED future. `f` throws
+/// and enqueues its fire-and-forget error; `g`'s sleep guarantees `f` has
+/// thrown by the time we `await g`. Surfacing the error at that unrelated
+/// await stole it from under `(await f) catch` and escaped as an uncaught
+/// throw. With surfacing deferred to termination, `await f` routes the error
+/// into the `catch`, which returns 99.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn caught_error_not_preempted_by_unrelated_await() {
+    let source = r#"
+        function bad() -> int throws string { throw "boom" }
+        function slow() -> int { baml.sys.sleep(baml.time.Duration.from_milliseconds(50n)); 7 }
+        function main() -> int {
+            let f = spawn { bad() };
+            let g = spawn { slow() };
+            let _ = await g;
+            (await f) catch (e) { let e => 99 }
+        }
+    "#;
+    assert_eq!(run_main(source).await.unwrap(), BexExternalValue::Int(99));
+}
+
+/// Regression for the intermediate-thread drain: a child thread `t` that
+/// spawns its OWN child `gc` which throws, never awaits it, and then
+/// completes must still surface `gc`'s error rather than dropping it. A
+/// child thread has no end-of-run, so the surfacing happens at `t`'s own
+/// completion, propagating up so `main`'s `await t` observes it and catches.
+/// `t`'s sleep lets `gc` throw and enqueue on `t`'s fire-and-forget queue
+/// before `t` completes, so the completion drain deterministically finds it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn intermediate_thread_surfaces_never_awaited_grandchild_error() {
+    let source = r#"
+        function gc_bad() -> int throws string { throw "gc boom" }
+        function t_body() -> int {
+            spawn { gc_bad() };
+            baml.sys.sleep(baml.time.Duration.from_milliseconds(50n));
+            42
+        }
+        function main() -> int {
+            let t = spawn { t_body() };
+            (await t) catch (e) { let e => -1 }
+        }
+    "#;
+    // `t`'s body reaches 42, but its never-awaited grandchild error surfaces at
+    // `t`'s completion (settling `t` Errored), so `main`'s `await t` catches it.
+    assert_eq!(run_main(source).await.unwrap(), BexExternalValue::Int(-1));
 }

--- a/baml_language/crates/bex_engine/tests/prof_gate.rs
+++ b/baml_language/crates/bex_engine/tests/prof_gate.rs
@@ -2286,15 +2286,19 @@ async fn spawned_child_cancellation_ends_child_cancelled() {
     );
 }
 
-/// An UNOBSERVED fire-and-forget child error (BEP-034) surfaces at the
-/// spawner's next await and terminates the parent thread *without*
-/// unwinding its VM — the parent is parked at the Await opcode with every
-/// frame open. The §7 decision 2 drain (Errored flavor) closes those
-/// frames, so full balance holds. Found by the post-decision adversarial
-/// review: before the fix this was the one remaining systematic
-/// frame-strander (the awaited-future error path in
-/// `spawned_child_error_ends_child_errored` below unwinds VM-side and
-/// never hit it).
+/// An UNOBSERVED fire-and-forget child error (`spawn { uce_bad() }` whose
+/// handle is discarded and never awaited) surfaces at the spawner's END OF
+/// RUN, not at an intervening await of an unrelated future. The root
+/// function itself runs to completion and returns normally — its frame
+/// ends `Ok` — and the end-of-run drain then surfaces the never-awaited
+/// child error as an `UnhandledThrow`, so the *run* ends `Errored` even
+/// though `main` did not. Deferring surfacing to end-of-run (rather than
+/// draining at every await) is what keeps an errored-but-later-awaited
+/// future from being pre-empted before its `catch` installs; the trade-off
+/// is that a genuinely-dropped error surfaces at termination instead of at
+/// the next await. Full frame balance still holds: the child's thrower
+/// unwinds VM-side (`user.uce_bad` ends `Errored`) and the root's frames
+/// close normally via VM completion.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn unobserved_child_error_drains_parent_frames() {
     let _guard = test_lock().await;
@@ -2321,8 +2325,9 @@ async fn unobserved_child_error_drains_parent_frames() {
     let statuses = end_statuses_by_fqn(&header, &events);
     assert_eq!(
         statuses.get("user.main"),
-        Some(&vec![pb::FunctionEndStatus::Errored as i32]),
-        "the drain closes the parent's open root frame Errored: {statuses:?}"
+        Some(&vec![pb::FunctionEndStatus::Ok as i32]),
+        "the root function completes normally; the never-awaited error \
+         surfaces afterward at the end-of-run drain: {statuses:?}"
     );
     assert_eq!(
         statuses.get("user.uce_bad"),


### PR DESCRIPTION
## Problem

A throw from a `spawn`ed future could escape **uncaught** past the `catch` on its `await`, under concurrency/load (Fixes B-405; surfaced as the flaky `methods_on_errored_future` CI failure).

A spawned child's thrown error is *deferred* (parked in `deferred_errors` plus an entry on the parent's fire-and-forget queue) rather than settled directly, so an awaiter can route it into a `catch` via `future_ready`. The **post-await drain** surfaced any pending child error as an `UnhandledThrow` after *every* await, with a carve-out protecting only the future *currently* being awaited.

That drain cannot distinguish a future that will be awaited later from one that is never awaited. When the parent awaits an unrelated future first:

```baml
let f = spawn { fail_io() };   // throws, enqueues fire-and-forget error
let g = spawn { slow_ok() };
let _ = await g;               // post-await drain steals f's error here...
(await f) catch (e) { ... }    // ...before this catch can install
```

the drain after `await g` consumed `f`'s deferred error and surfaced it uncaught, before `(await f) catch` installed its handler. Under CI load the ordering raced and the `Io` throw escaped the `catch`.

## Deterministic repro

`f` throws immediately; `g`'s 50ms sleep guarantees `f` has thrown and enqueued by the time the parent drains after `await g`. On `canary` this deterministically escaped as `uncaught throw: baml.errors.Io {message: "x"}`; with a 0ms `g` it was flaky (matching the original "only under load" report). With this change it returns cleanly.

## Fix

Surface fire-and-forget errors only where "never awaited" is certain:

- **Root** — the existing end-of-run drain (after waiting for outstanding spawns). Unchanged.
- **Child thread** — a new drain at its own `Complete`, settling the future `Errored` and propagating up, since a child thread has no end-of-run. This also closes a latent gap where a child that errored a never-awaited grandchild and then completed dropped that error silently.

The per-await surfacing is removed; the awaited future's stale queue entry is still trimmed so it is not re-surfaced at termination. An errored-and-awaited future's error now always flows through `await`/`catch`.

### Behavioral note

A genuinely never-awaited spawn error now surfaces at thread termination instead of "at the spawner's next await." No test pinned the intermediate timing; the run still ends with the same `UnhandledThrow`. The profiling test was updated to the new model: the root function completes `Ok` and the background error surfaces at end-of-run, so the *run* ends `Errored`.

### Known limitation (pre-existing, out of scope)

A *racing* never-awaited grandchild (an intermediate thread that completes before its own child's task has thrown) is still dropped, because an intermediate thread does not wait for its outstanding children the way the root does. This predates the change and is a separate follow-up.

## Tests

- BAML: `caught_not_preempted_by_unrelated_await` (ns_spawn_throws)
- Engine: `caught_error_not_preempted_by_unrelated_await`, `intermediate_thread_surfaces_never_awaited_grandchild_error`
- Full `bex_engine` (fire_and_forget, combinators, cancellation, host_value_callable, prof_gate) and `baml_tests` spawn/future/cancel suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined “fire-and-forget” error handling so background task errors are surfaced only when they’re guaranteed to be never awaited.
  * Ensured an awaited-and-caught task error isn’t preempted by intervening awaits of unrelated futures.
  * Preserved deterministic error propagation for errors from never-awaited nested tasks.

* **Tests**
  * Added regression coverage for these error-handling scenarios, including expected profiling/drain outcomes.
  * Updated profiling expectations for an end-of-run drain behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->