### PR TITLE
feat(output-format): add TOON output format

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1285,7 +1285,7 @@ dependencies = [
  "supports-color",
  "tempfile",
  "test-log",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -1618,7 +1618,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3238,7 +3238,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
  "tokio",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -3287,7 +3287,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
  "url",
 ]
@@ -4314,7 +4314,8 @@ dependencies = [
  "serde_json",
  "strsim",
  "test-log",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
+ "toon-format",
  "unicode-normalization",
  "uuid",
  "wasm-bindgen-test",
@@ -4425,7 +4426,7 @@ dependencies = [
  "shellexpand",
  "similar",
  "simple-logging",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower 0.5.2",
@@ -5191,7 +5192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "ucd-trie",
 ]
 
@@ -5831,7 +5832,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.28",
  "socket2",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5852,7 +5853,7 @@ dependencies = [
  "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6027,7 +6028,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6558,10 +6559,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -6588,10 +6590,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6611,15 +6622,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.9.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -6862,7 +6874,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -7150,11 +7162,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -7170,9 +7182,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7477,6 +7489,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toon-format"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7670,7 +7694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ef1b7a6d914a34127ed8e1fa927eb7088903787bcded4fa3eef8f85ee1568be"
 dependencies = [
  "indexmap 2.9.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "ts-rs-macros",
 ]
 
@@ -7725,7 +7749,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -7737,7 +7761,7 @@ checksum = "fa0f2333ec5a49706b6f29896d0e4cdba1665d2bf2d752d0c4f130634935d42f"
 dependencies = [
  "arrayvec 0.7.6",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -8756,3 +8780,9 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -154,6 +154,7 @@ syn = { version = "2.0", features = ["full", "parsing", "extra-traits"] }
 test-log = "0.2.16"
 textwrap = "0.16.0"
 thiserror = "2.0.12"
+toon-format = { version = "0.5.0", default-features = false }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 time = { version = "0.3.36", features = ["formatting"] }

--- a/engine/baml-lib/jinja-runtime/src/lib.rs
+++ b/engine/baml-lib/jinja-runtime/src/lib.rs
@@ -1103,6 +1103,49 @@ mod render_tests {
     }
 
     #[test]
+    fn render_output_format_as_toon() -> anyhow::Result<()> {
+        setup_logging();
+
+        let ir = make_test_ir(
+            "
+            class C {
+
+            }
+            ",
+        )?;
+
+        let rendered = render_prompt(
+            "{{ ctx.output_format(format='toon') }}",
+            &BamlValue::Map(BamlMap::default()),
+            RenderContext {
+                client: RenderContext_Client {
+                    name: "gpt4".to_string(),
+                    provider: "openai".to_string(),
+                    default_role: "system".to_string(),
+                    allowed_roles: vec!["system".to_string()],
+                    remap_role: HashMap::new(),
+                    options: IndexMap::new(),
+                },
+                output_format: OutputFormatContent::new_array(),
+                tags: HashMap::new(),
+            },
+            &[],
+            &ir,
+            &HashMap::new(),
+        )?;
+
+        assert_eq!(
+            rendered,
+            RenderedPrompt::Completion(
+                "Answer with a TOON array using this schema. Replace N with the actual array length:\n[N]: string"
+                    .to_string()
+            )
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn render_output_format_prefix_unspecified() -> anyhow::Result<()> {
         setup_logging();
 

--- a/engine/baml-lib/jinja-runtime/src/output_format/mod.rs
+++ b/engine/baml-lib/jinja-runtime/src/output_format/mod.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use minijinja::{value::Kwargs, ErrorKind, Value};
 use strum::VariantNames;
-use types::HoistClasses;
+use types::{HoistClasses, OutputFormatMode};
 
 use self::types::OutputFormatContent;
 use crate::{types::RenderOptions, RenderContext};
@@ -209,10 +209,41 @@ impl minijinja::value::Object for OutputFormat {
             None
         };
 
+        let format = if kwargs.has("format") {
+            match kwargs
+                .get::<String>("format")
+                .map(|s| OutputFormatMode::from_str(s.as_str()))
+            {
+                Ok(Ok(format)) => Some(format),
+                Ok(Err(e)) => {
+                    return Err(Error::new(
+                        ErrorKind::SyntaxError,
+                        format!(
+                            "Invalid value for format (expected one of {}): {}",
+                            OutputFormatMode::VARIANTS.join(", "),
+                            e
+                        ),
+                    ))
+                }
+                Err(e) => {
+                    return Err(Error::new(
+                        ErrorKind::SyntaxError,
+                        format!(
+                            "Invalid value for format (expected one of {}): {}",
+                            OutputFormatMode::VARIANTS.join(", "),
+                            e
+                        ),
+                    ))
+                }
+            }
+        } else {
+            None
+        };
+
         let Ok(_) = kwargs.assert_all_used() else {
             return Err(Error::new(
                 ErrorKind::TooManyArguments,
-                "output_format() got an unexpected keyword argument (only 'prefix', 'always_hoist_enums', 'enum_value_prefix', 'or_splitter', 'hoisted_class_prefix', 'hoist_classes', 'map_style', 'quote_class_fields', and 'render_null_as' are allowed)",
+                "output_format() got an unexpected keyword argument (only 'prefix', 'always_hoist_enums', 'enum_value_prefix', 'or_splitter', 'hoisted_class_prefix', 'hoist_classes', 'map_style', 'quote_class_fields', 'render_null_as', and 'format' are allowed)",
             ));
         };
 
@@ -226,6 +257,7 @@ impl minijinja::value::Object for OutputFormat {
             hoist_classes,
             quote_class_fields,
             render_null_as,
+            format,
         ))?;
 
         match content {

--- a/engine/baml-lib/jinja-runtime/src/output_format/types.rs
+++ b/engine/baml-lib/jinja-runtime/src/output_format/types.rs
@@ -207,6 +207,16 @@ pub(crate) enum MapStyle {
     ObjectLiteral,
 }
 
+#[derive(Clone, Copy, Default, strum::EnumString, strum::VariantNames)]
+pub(crate) enum OutputFormatMode {
+    #[default]
+    #[strum(serialize = "json")]
+    Json,
+
+    #[strum(serialize = "toon")]
+    Toon,
+}
+
 /// Hoist classes setting.
 ///
 /// Recursive classes are always hoisted.
@@ -233,6 +243,7 @@ pub struct RenderOptions {
     map_style: MapStyle,
     quote_class_fields: bool,
     render_null_as: RenderSetting<String>,
+    format: OutputFormatMode,
 }
 
 impl Default for RenderOptions {
@@ -247,6 +258,7 @@ impl Default for RenderOptions {
             map_style: MapStyle::TypeParameters,
             quote_class_fields: false,
             render_null_as: RenderSetting::Auto,
+            format: OutputFormatMode::Json,
         }
     }
 }
@@ -272,6 +284,7 @@ impl RenderOptions {
         hoist_classes: Option<HoistClasses>,
         quote_class_fields: Option<bool>,
         render_null_as: Option<Option<String>>,
+        format: Option<OutputFormatMode>,
     ) -> Self {
         Self {
             prefix: prefix.map_or(RenderSetting::Auto, |p| {
@@ -292,6 +305,7 @@ impl RenderOptions {
             render_null_as: render_null_as
                 .flatten()
                 .map_or(RenderSetting::Auto, RenderSetting::Always),
+            format: format.unwrap_or_default(),
         }
     }
 
@@ -363,6 +377,7 @@ struct ClassFieldRender {
     name: String,
     r#type: String,
     description: Option<String>,
+    toon_nested: bool,
 }
 
 impl std::fmt::Display for ClassRender {
@@ -401,6 +416,62 @@ impl std::fmt::Display for ClassRender {
             }
         }
         write!(f, "}}")
+    }
+}
+
+fn render_toon_key(key: &str) -> String {
+    let mut chars = key.chars();
+    let valid = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.'));
+
+    if valid {
+        key.to_string()
+    } else {
+        serde_json::to_string(key).expect("serializing a string cannot fail")
+    }
+}
+
+impl ClassRender {
+    fn render_toon(&self) -> String {
+        let mut result = String::new();
+
+        if let Some(description) = self.description.as_deref().map(str::trim) {
+            if !description.is_empty() {
+                for line in description.lines() {
+                    result.push_str(&format!("// {line}\n"));
+                }
+                result.push('\n');
+            }
+        }
+
+        for value in &self.values {
+            if let Some(description) = &value.description {
+                for line in description.lines() {
+                    result.push_str(&format!("// {line}\n"));
+                }
+            }
+
+            let key = render_toon_key(&value.name);
+            if let Some(array_schema) = value.r#type.strip_prefix("[N]") {
+                result.push_str(&key);
+                result.push_str("[N]");
+                result.push_str(array_schema);
+                result.push('\n');
+            } else if value.toon_nested || value.r#type.contains('\n') {
+                result.push_str(&format!("{key}:\n"));
+                for line in value.r#type.lines() {
+                    result.push_str("  ");
+                    result.push_str(line);
+                    result.push('\n');
+                }
+            } else {
+                result.push_str(&format!("{key}: {}\n", value.r#type));
+            }
+        }
+
+        result.trim_end().to_string()
     }
 }
 
@@ -486,7 +557,14 @@ impl OutputFormatContent {
                         "\n"
                     };
 
-                    Some(format!("Answer in JSON using this {type_prefix}:{end}"))
+                    Some(match options.format {
+                        OutputFormatMode::Json => {
+                            format!("Answer in JSON using this {type_prefix}:{end}")
+                        }
+                        OutputFormatMode::Toon => format!(
+                            "Answer in TOON using this {type_prefix}. Replace every N in an array header with the actual array length:{end}"
+                        ),
+                    })
                 }
                 TypeIR::RecursiveTypeAlias { .. } => {
                     let type_prefix = match &options.hoisted_class_prefix {
@@ -494,27 +572,67 @@ impl OutputFormatContent {
                         _ => RenderOptions::DEFAULT_TYPE_PREFIX_IN_RENDER_MESSAGE,
                     };
 
-                    Some(format!("Answer in JSON using this {type_prefix}: "))
+                    Some(match options.format {
+                        OutputFormatMode::Json => {
+                            format!("Answer in JSON using this {type_prefix}: ")
+                        }
+                        OutputFormatMode::Toon => format!(
+                            "Answer in TOON using this {type_prefix}. Replace every N in an array header with the actual array length: "
+                        ),
+                    })
                 }
-                TypeIR::List(_, _) => Some(String::from(
-                    "Answer with a JSON Array using this schema:\n",
-                )),
+                TypeIR::List(_, _) => Some(match options.format {
+                    OutputFormatMode::Json => {
+                        String::from("Answer with a JSON Array using this schema:\n")
+                    }
+                    OutputFormatMode::Toon => String::from(
+                        "Answer with a TOON array using this schema. Replace N with the actual array length:\n",
+                    ),
+                }),
                 TypeIR::Union(items, _) => match items.view() {
                     UnionTypeViewGeneric::Null => Some(format!(
                         "Answer ONLY with {}:\n",
                         output_format_content.render_null_type(options)
                     )),
                     UnionTypeViewGeneric::Optional(_) => {
-                        Some(String::from("Answer in JSON using this schema:\n"))
+                        Some(match options.format {
+                            OutputFormatMode::Json => {
+                                String::from("Answer in JSON using this schema:\n")
+                            }
+                            OutputFormatMode::Toon => {
+                                String::from("Answer in TOON using this schema:\n")
+                            }
+                        })
                     }
                     UnionTypeViewGeneric::OneOf(_) => {
-                        Some(String::from("Answer in JSON using any of these schemas:\n"))
+                        Some(match options.format {
+                            OutputFormatMode::Json => {
+                                String::from("Answer in JSON using any of these schemas:\n")
+                            }
+                            OutputFormatMode::Toon => {
+                                String::from("Answer in TOON using any of these schemas:\n")
+                            }
+                        })
                     }
                     UnionTypeViewGeneric::OneOfOptional(_) => {
-                        Some(String::from("Answer in JSON using any of these schemas:\n"))
+                        Some(match options.format {
+                            OutputFormatMode::Json => {
+                                String::from("Answer in JSON using any of these schemas:\n")
+                            }
+                            OutputFormatMode::Toon => {
+                                String::from("Answer in TOON using any of these schemas:\n")
+                            }
+                        })
                     }
                 },
-                TypeIR::Map(_, _, _) => Some(String::from("Answer in JSON using this schema:\n")),
+                TypeIR::Map(_, _, _) => Some(match options.format {
+                    OutputFormatMode::Json => {
+                        String::from("Answer in JSON using this schema:\n")
+                    }
+                    OutputFormatMode::Toon => {
+                        String::from("Answer in TOON using this schema:\n")
+                    }
+                }),
                 TypeIR::Tuple(_, _) => None,
                 TypeIR::Arrow(_, _) => None, // TODO: Error? Arrow shouldn't appear here.
                 TypeIR::Top(_) => panic!(
@@ -532,6 +650,19 @@ impl OutputFormatContent {
     }
 
     fn enum_to_string(&self, enm: &Enum, options: &RenderOptions) -> String {
+        if matches!(options.format, OutputFormatMode::Toon) {
+            return format!(
+                "{}[{}]: {}",
+                render_toon_key(enm.name.rendered_name()),
+                enm.values.len(),
+                enm.values
+                    .iter()
+                    .map(|(name, _)| name.rendered_name())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+        }
+
         EnumRender {
             name: enm.name.rendered_name().to_string(),
             delimiter: "----".into(),
@@ -731,7 +862,7 @@ impl OutputFormatContent {
                     ));
                 };
 
-                ClassRender {
+                let class = ClassRender {
                     name: class.name.rendered_name().to_string(),
                     description: class.description.clone(),
                     values: class
@@ -741,6 +872,10 @@ impl OutputFormatContent {
                             Ok(ClassFieldRender {
                                 name: name.rendered_name().to_string(),
                                 description: description.clone(),
+                                toon_nested: matches!(
+                                    field_type,
+                                    TypeIR::Class { .. } | TypeIR::Map(_, _, _)
+                                ),
                                 r#type: self.render_possibly_hoisted_type(
                                     options, field_type, render_ctx,
                                 )?,
@@ -748,8 +883,12 @@ impl OutputFormatContent {
                         })
                         .collect::<Result<_, minijinja::Error>>()?,
                     quote_fields: options.quote_class_fields,
+                };
+
+                match options.format {
+                    OutputFormatMode::Json => class.to_string(),
+                    OutputFormatMode::Toon => class.render_toon(),
                 }
-                .to_string()
             }
             TypeIR::RecursiveTypeAlias { name, .. } => name.to_owned(),
             TypeIR::List(inner, _) => {
@@ -765,7 +904,23 @@ impl OutputFormatContent {
 
                 let inner_str = self.render_possibly_hoisted_type(options, inner, render_ctx)?;
 
-                if !is_hoisted
+                if matches!(options.format, OutputFormatMode::Toon) {
+                    if inner_str.contains('\n') {
+                        let mut lines = inner_str.lines();
+                        let first = lines.next().unwrap_or_default();
+                        let rest = lines
+                            .map(|line| format!("    {line}"))
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        if rest.is_empty() {
+                            format!("[N]:\n  - {first}")
+                        } else {
+                            format!("[N]:\n  - {first}\n{rest}")
+                        }
+                    } else {
+                        format!("[N]: {inner_str}")
+                    }
+                } else if !is_hoisted
                     && match inner.as_ref() {
                         TypeIR::Primitive(_, _) => false,
                         TypeIR::Enum { .. } => inner_str.len() > 15,
@@ -794,12 +949,22 @@ impl OutputFormatContent {
                     "Tuple type is not supported in outputs",
                 ))
             }
-            TypeIR::Map(key_type, value_type, _) => MapRender {
-                style: &options.map_style,
-                key_type: self.render_possibly_hoisted_type(options, key_type, render_ctx)?,
-                value_type: self.render_possibly_hoisted_type(options, value_type, render_ctx)?,
+            TypeIR::Map(key_type, value_type, _) => {
+                let key_type = self.render_possibly_hoisted_type(options, key_type, render_ctx)?;
+                let value_type =
+                    self.render_possibly_hoisted_type(options, value_type, render_ctx)?;
+                match options.format {
+                    OutputFormatMode::Json => MapRender {
+                        style: &options.map_style,
+                        key_type,
+                        value_type,
+                    }
+                    .to_string(),
+                    OutputFormatMode::Toon => {
+                        format!("<key ({key_type})>: {value_type}")
+                    }
+                }
             }
-            .to_string(),
             TypeIR::Arrow(_, _) => {
                 return Err(minijinja::Error::new(
                     minijinja::ErrorKind::BadSerialization,
@@ -964,11 +1129,22 @@ impl OutputFormatContent {
                 (Vec::new(), schema)
             };
 
-            let class_def = match &options.hoisted_class_prefix {
-                RenderSetting::Always(prefix) if !prefix.is_empty() => {
-                    format!("{prefix} {class_name} {schema_body}")
-                }
-                _ => format!("{class_name} {schema_body}"),
+            let class_def = match options.format {
+                OutputFormatMode::Toon => format!(
+                    "{}:\n{}",
+                    render_toon_key(class_name),
+                    schema_body
+                        .lines()
+                        .map(|line| format!("  {line}"))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                ),
+                OutputFormatMode::Json => match &options.hoisted_class_prefix {
+                    RenderSetting::Always(prefix) if !prefix.is_empty() => {
+                        format!("{prefix} {class_name} {schema_body}")
+                    }
+                    _ => format!("{class_name} {schema_body}"),
+                },
             };
 
             // Prepend description if present
@@ -1124,6 +1300,7 @@ mod tests {
                 None,
                 None,
                 Some(Some("omit".to_string())),
+                None,
             ))
             .unwrap();
         assert_eq!(rendered, Some("string or omit".into()));
@@ -1143,6 +1320,7 @@ mod tests {
                 None,
                 None,
                 Some(Some("omit".to_string())),
+                None,
             ))
             .unwrap()
             .unwrap();
@@ -1161,6 +1339,115 @@ mod tests {
         assert_eq!(
             rendered,
             Some("Answer with a JSON Array using this schema:\nstring[]".to_string())
+        );
+    }
+
+    #[test]
+    fn render_toon_array() {
+        let content = OutputFormatContent::new_array();
+        let rendered = content
+            .render(RenderOptions {
+                format: OutputFormatMode::Toon,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            rendered,
+            Some(
+                "Answer with a TOON array using this schema. Replace N with the actual array length:\n[N]: string"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn render_toon_class_with_nested_types() {
+        let enums = vec![Enum {
+            name: Name::new("Status".to_string()),
+            values: vec![
+                (Name::new("ACTIVE".to_string()), None),
+                (Name::new("PAUSED".to_string()), None),
+            ],
+            constraints: Vec::new(),
+        }];
+        let classes = vec![
+            Class {
+                name: Name::new("Address".to_string()),
+                description: None,
+                namespace: baml_types::StreamingMode::NonStreaming,
+                fields: vec![(Name::new("city".to_string()), TypeIR::string(), None, false)],
+                constraints: Vec::new(),
+                streaming_behavior: Default::default(),
+            },
+            Class {
+                name: Name::new("Profile".to_string()),
+                description: None,
+                namespace: baml_types::StreamingMode::NonStreaming,
+                fields: vec![
+                    (
+                        Name::new("status".to_string()),
+                        TypeIR::r#enum("Status"),
+                        None,
+                        false,
+                    ),
+                    (
+                        Name::new("tags".to_string()),
+                        TypeIR::list(TypeIR::string()),
+                        None,
+                        false,
+                    ),
+                    (
+                        Name::new("metadata".to_string()),
+                        TypeIR::map(TypeIR::string(), TypeIR::int()),
+                        None,
+                        false,
+                    ),
+                    (
+                        Name::new("address".to_string()),
+                        TypeIR::class("Address"),
+                        None,
+                        false,
+                    ),
+                    (
+                        Name::new("nickname".to_string()),
+                        TypeIR::optional(TypeIR::string()),
+                        None,
+                        false,
+                    ),
+                    (
+                        Name::new("identifier".to_string()),
+                        TypeIR::union(vec![TypeIR::int(), TypeIR::string()]),
+                        None,
+                        false,
+                    ),
+                ],
+                constraints: Vec::new(),
+                streaming_behavior: Default::default(),
+            },
+        ];
+
+        let rendered = OutputFormatContent::target(TypeIR::class("Profile"))
+            .enums(enums)
+            .classes(classes)
+            .build()
+            .render(RenderOptions {
+                format: OutputFormatMode::Toon,
+                ..Default::default()
+            })
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            rendered,
+            r#"Answer in TOON using this schema. Replace every N in an array header with the actual array length:
+status: 'ACTIVE' or 'PAUSED'
+tags[N]: string
+metadata:
+  <key (string)>: int
+address:
+  city: string
+nickname: string or null
+identifier: int or string"#
         );
     }
 
@@ -3559,6 +3846,7 @@ Answer in JSON using this schema: Ret"#
             None,       // hoist_classes
             None,       // quote_class_fields
             None,       // render_null_as
+            None,       // format
         );
 
         let rendered = content.render(options).unwrap().unwrap();

--- a/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
@@ -312,6 +312,18 @@ fn test_output_format() {
     );
 
     assert_eq!(
+        assert_evaluates_to!("ctx.output_format(format='toon')", &types),
+        Type::String
+    );
+
+    assert_eq!(
+        assert_fails_to!("ctx.output_format(format='yaml')", &types),
+        vec![
+            "Function 'baml::OutputFormat' expects argument 'format' to be of type (none | literal[\"json\"] | literal[\"toon\"]), but got literal[\"yaml\"]"
+        ]
+    );
+
+    assert_eq!(
         assert_fails_to!(
             "ctx.output_format(prefix='1', always_hoist_enums=1)",
             &types

--- a/engine/baml-lib/jinja/src/evaluate_type/types.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/types.rs
@@ -393,6 +393,14 @@ impl PredefinedTypes {
                                 "render_null_as".into(),
                                 Type::merge(vec![Type::String, Type::None]),
                             ),
+                            (
+                                "format".into(),
+                                Type::merge(vec![
+                                    Type::None,
+                                    Type::Literal(LiteralValue::String(String::from("json"))),
+                                    Type::Literal(LiteralValue::String(String::from("toon"))),
+                                ]),
+                            ),
                         ],
                     ),
                 ),

--- a/engine/baml-lib/jsonish/Cargo.toml
+++ b/engine/baml-lib/jsonish/Cargo.toml
@@ -36,6 +36,7 @@ test-log.workspace = true
 regex.workspace = true
 thiserror = "2.0.9"
 unicode-normalization = "0.1.24"
+toon-format.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["v4", "js"] }

--- a/engine/baml-lib/jsonish/src/jsonish/mod.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/mod.rs
@@ -1,5 +1,6 @@
 mod parser;
 mod value;
 
+pub(crate) use parser::parse_toon;
 pub use parser::{parse, ParseOptions};
 pub use value::{Fixes, Value};

--- a/engine/baml-lib/jsonish/src/jsonish/parser/mod.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/mod.rs
@@ -2,8 +2,10 @@ mod entry;
 mod fixing_parser;
 mod markdown_parser;
 mod multi_json_parser;
+mod toon_parser;
 
 pub use entry::parse;
+pub(crate) use toon_parser::parse as parse_toon;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseOptions {

--- a/engine/baml-lib/jsonish/src/jsonish/parser/toon_parser.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/toon_parser.rs
@@ -1,0 +1,279 @@
+use std::collections::HashSet;
+
+use toon_format::{decode, DecodeOptions};
+
+use crate::jsonish::Value;
+
+/// Decode structured TOON candidates before falling back to JSON repair.
+///
+/// LLMs often prepend a short explanation, so in addition to the complete
+/// response we try suffixes beginning at a TOON object field or array header.
+/// Primitive-only responses are already handled well by JSONish and are not
+/// considered here, which avoids interpreting arbitrary prose as TOON.
+pub(crate) fn parse(input: &str) -> Option<Vec<Value>> {
+    let lines = input.lines().collect::<Vec<_>>();
+    let mut candidates = Vec::<String>::new();
+
+    if let Some(index) = find_toon_start(&lines) {
+        candidates.push(lines[index..].join("\n"));
+    }
+
+    candidates.extend(fenced_toon_blocks(input).into_iter().map(str::to_string));
+
+    let options = DecodeOptions::new().with_strict(false);
+    let mut seen = HashSet::new();
+    let values = candidates
+        .into_iter()
+        .map(|candidate| dedent(&candidate))
+        .map(|candidate| repair_inline_array_lengths(&candidate))
+        .filter_map(|candidate| decode::<serde_json::Value>(&candidate, &options).ok())
+        .filter(|value| value.is_object() || value.is_array())
+        .filter_map(|value| serde_json::from_value::<Value>(value).ok())
+        .filter(|value| seen.insert(value.clone()))
+        .collect::<Vec<_>>();
+
+    (!values.is_empty()).then_some(values)
+}
+
+fn find_toon_start(lines: &[&str]) -> Option<usize> {
+    let mut start = None;
+    for (index, line) in lines.iter().enumerate() {
+        let line = line.trim();
+        if line.starts_with('{') || (line.starts_with('[') && !looks_like_toon_header(line)) {
+            return None;
+        }
+        if start.is_none() && looks_like_toon(line) {
+            start = Some(index);
+        }
+    }
+
+    start
+}
+
+fn dedent(input: &str) -> String {
+    let indent = input
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start_matches(' ').len())
+        .min()
+        .unwrap_or(0);
+
+    input
+        .lines()
+        .map(|line| line.get(indent..).unwrap_or(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn repair_inline_array_lengths(input: &str) -> String {
+    input
+        .lines()
+        .map(|line| {
+            let Some(open) = line.find('[') else {
+                return line.to_string();
+            };
+            let Some(relative_close) = line[open + 1..].find("]: ") else {
+                return line.to_string();
+            };
+            let close = open + 1 + relative_close;
+            let header = &line[open + 1..close];
+            let (length, delimiter) = match header.chars().last() {
+                Some('|') => (&header[..header.len() - 1], '|'),
+                Some('\t') => (&header[..header.len() - 1], '\t'),
+                _ => (header, ','),
+            };
+            if length.is_empty() || !length.chars().all(|c| c.is_ascii_digit()) {
+                return line.to_string();
+            }
+
+            let values = &line[close + 3..];
+            if values.is_empty() {
+                return line.to_string();
+            }
+            let actual = count_delimited_values(values, delimiter);
+            let delimiter_marker = match delimiter {
+                ',' => "",
+                '|' => "|",
+                '\t' => "\t",
+                _ => unreachable!("TOON only supports comma, pipe, and tab delimiters"),
+            };
+            format!(
+                "{}[{}{}]{}",
+                &line[..open],
+                actual,
+                delimiter_marker,
+                &line[close + 1..]
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn count_delimited_values(values: &str, delimiter: char) -> usize {
+    let mut count = 1;
+    let mut quoted = false;
+    let mut escaped = false;
+
+    for ch in values.chars() {
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' && quoted {
+            escaped = true;
+        } else if ch == '"' {
+            quoted = !quoted;
+        } else if ch == delimiter && !quoted {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+fn looks_like_toon(line: &str) -> bool {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('{') {
+        return false;
+    }
+
+    if looks_like_toon_header(line) {
+        return true;
+    }
+
+    line.split_once(':')
+        .is_some_and(|(key, _)| is_valid_toon_key(key.trim()))
+}
+
+fn looks_like_toon_header(line: &str) -> bool {
+    let Some((header, _)) = line.split_once(':') else {
+        return false;
+    };
+    let Some(open) = header.find('[') else {
+        return false;
+    };
+    let Some(relative_close) = header[open + 1..].find(']') else {
+        return false;
+    };
+    let close = open + 1 + relative_close;
+    let key = header[..open].trim();
+    if !key.is_empty() && !is_valid_toon_key(key) {
+        return false;
+    }
+
+    let length = header[open + 1..close].trim_end_matches(['|', '\t']);
+    if length.is_empty() || !length.chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+
+    let fields = header[close + 1..].trim();
+    fields.is_empty() || (fields.starts_with('{') && fields.ends_with('}'))
+}
+
+fn is_valid_toon_key(key: &str) -> bool {
+    if key.starts_with('"') && key.ends_with('"') && key.len() >= 2 {
+        return true;
+    }
+
+    let mut chars = key.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.'))
+}
+
+fn fenced_toon_blocks(input: &str) -> Vec<&str> {
+    let mut blocks = Vec::new();
+    let mut offset = 0;
+
+    while let Some(open) = input[offset..].find("```") {
+        let after_open = offset + open + 3;
+        let Some(line_end) = input[after_open..].find('\n') else {
+            break;
+        };
+        let tag = input[after_open..after_open + line_end].trim();
+        let content_start = after_open + line_end + 1;
+        let Some(close) = input[content_start..].find("```") else {
+            break;
+        };
+        let content_end = content_start + close;
+
+        if tag.is_empty() || tag.eq_ignore_ascii_case("toon") {
+            blocks.push(input[content_start..content_end].trim());
+        }
+        offset = content_end + 3;
+    }
+
+    blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use baml_types::CompletionState;
+
+    use super::*;
+
+    #[test]
+    fn parses_toon_after_preamble() {
+        let values = parse("Here is the result:\nname: Ada\ntags[2]: math,code").unwrap();
+        assert!(values.iter().any(|value| matches!(
+            value,
+            Value::Object(fields, _) if *fields == vec![
+                ("name".into(), Value::String("Ada".into(), CompletionState::Complete)),
+                ("tags".into(), Value::Array(
+                    vec![
+                        Value::String("math".into(), CompletionState::Complete),
+                        Value::String("code".into(), CompletionState::Complete),
+                    ],
+                    CompletionState::Complete,
+                )),
+            ]
+        )));
+    }
+
+    #[test]
+    fn recovers_from_an_incorrect_array_length() {
+        let values = parse("items[3]: one,two").unwrap();
+        assert!(values.iter().any(|value| matches!(
+            value,
+            Value::Object(fields, _) if
+                matches!(&fields[0].1, Value::Array(items, _) if items.len() == 2))));
+    }
+
+    #[test]
+    fn ignores_plain_prose() {
+        assert!(parse("This is only prose.").is_none());
+    }
+
+    #[test]
+    fn parses_globally_indented_toon() {
+        let values = parse("  name: Ada\n  metadata:\n    active: true").unwrap();
+        assert!(values.iter().any(|value| matches!(
+            value,
+            Value::Object(fields, _) if fields.iter().any(|(key, _)| key == "name")
+        )));
+    }
+
+    #[test]
+    fn recognizes_keyed_and_root_array_headers() {
+        assert!(looks_like_toon("people[2]{name,age}:"));
+        assert!(looks_like_toon("[2]: one,two"));
+        assert!(!looks_like_toon("not a key: value"));
+    }
+
+    #[test]
+    fn does_not_scan_inside_json() {
+        assert!(parse("{\n  \"name\": \"Ada\"\n}").is_none());
+        assert!(parse("Result:\n{\n  \"name\": \"Ada\"\n}").is_none());
+    }
+
+    #[test]
+    fn repairs_only_inline_array_lengths() {
+        assert_eq!(
+            repair_inline_array_lengths("items[4]: one,\"two,three\",four"),
+            "items[3]: one,\"two,three\",four"
+        );
+        assert_eq!(
+            repair_inline_array_lengths("items[2]{name,age}:\n  Ada,36"),
+            "items[2]{name,age}:\n  Ada,36"
+        );
+    }
+}

--- a/engine/baml-lib/jsonish/src/jsonish/parser/toon_parser.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/toon_parser.rs
@@ -184,17 +184,16 @@ fn fenced_toon_blocks(input: &str) -> Vec<&str> {
     let mut blocks = Vec::new();
     let mut offset = 0;
 
-    while let Some(open) = input[offset..].find("```") {
-        let after_open = offset + open + 3;
+    while let Some(open) = find_line_start_fence(input, offset) {
+        let after_open = open + 3;
         let Some(line_end) = input[after_open..].find('\n') else {
             break;
         };
         let tag = input[after_open..after_open + line_end].trim();
         let content_start = after_open + line_end + 1;
-        let Some(close) = input[content_start..].find("```") else {
+        let Some(content_end) = find_line_start_fence(input, content_start) else {
             break;
         };
-        let content_end = content_start + close;
 
         if tag.is_empty() || tag.eq_ignore_ascii_case("toon") {
             blocks.push(input[content_start..content_end].trim());
@@ -203,6 +202,18 @@ fn fenced_toon_blocks(input: &str) -> Vec<&str> {
     }
 
     blocks
+}
+
+fn find_line_start_fence(input: &str, offset: usize) -> Option<usize> {
+    input[offset..]
+        .match_indices("```")
+        .map(|(index, _)| offset + index)
+        .find(|&index| {
+            let line_start = input[..index]
+                .rfind('\n')
+                .map_or(0, |line_end| line_end + 1);
+            input[line_start..index].chars().all(char::is_whitespace)
+        })
 }
 
 #[cfg(test)]
@@ -275,5 +286,12 @@ mod tests {
             repair_inline_array_lengths("items[2]{name,age}:\n  Ada,36"),
             "items[2]{name,age}:\n  Ada,36"
         );
+    }
+
+    #[test]
+    fn ignores_inline_backticks_when_pairing_fenced_toon_blocks() {
+        let blocks = fenced_toon_blocks("A stray ``` in prose.\n  ```toon\n  name: Ada\n  ```\n");
+
+        assert_eq!(blocks, vec!["name: Ada"]);
     }
 }

--- a/engine/baml-lib/jsonish/src/lib.rs
+++ b/engine/baml-lib/jsonish/src/lib.rs
@@ -237,11 +237,21 @@ pub fn from_str(
     }
 
     // When the schema is just a string, i should really just return the raw_string w/o parsing it.
-    let value = jsonish::parse(
+    let mut value = jsonish::parse(
         raw_string,
         jsonish::ParseOptions::default(),
         raw_string_is_done,
     )?;
+
+    if let Some(toon_values) = jsonish::parse_toon(raw_string) {
+        let mut candidates = match value {
+            Value::AnyOf(candidates, _) => candidates,
+            value => vec![value],
+        };
+        candidates.extend(toon_values);
+        candidates.dedup();
+        value = Value::AnyOf(candidates, raw_string.to_string());
+    }
 
     // Pick the schema that is the most specific.
     log::debug!("Parsed JSONish (step 1 of parsing) {raw_string_is_done}: {value:#?}");

--- a/engine/baml-lib/jsonish/src/lib.rs
+++ b/engine/baml-lib/jsonish/src/lib.rs
@@ -4,7 +4,7 @@ pub mod tests;
 use anyhow::Result;
 use indexmap::IndexMap;
 pub mod deserializer;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 pub mod jsonish;
 
 use baml_types::{
@@ -249,7 +249,7 @@ pub fn from_str(
             value => vec![value],
         };
         candidates.extend(toon_values);
-        candidates.dedup();
+        deduplicate_candidates(&mut candidates);
         value = Value::AnyOf(candidates, raw_string.to_string());
     }
 
@@ -290,6 +290,25 @@ pub fn from_str(
     // parsed_value.clear_flags();
 
     Ok(parsed_value)
+}
+
+fn deduplicate_candidates(candidates: &mut Vec<Value>) {
+    let mut seen = HashSet::new();
+    candidates.retain(|candidate| seen.insert(candidate.clone()));
+}
+
+#[cfg(test)]
+mod toon_candidate_tests {
+    use super::*;
+
+    #[test]
+    fn deduplicates_all_candidates_in_first_seen_order() {
+        let mut candidates = vec![Value::Boolean(true), Value::Null, Value::Boolean(true)];
+
+        deduplicate_candidates(&mut candidates);
+
+        assert_eq!(candidates, vec![Value::Boolean(true), Value::Null]);
+    }
 }
 
 impl ResponseBamlValue {

--- a/engine/baml-lib/jsonish/src/tests/mod.rs
+++ b/engine/baml-lib/jsonish/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod test_literals;
 mod test_maps;
 mod test_partials;
 mod test_streaming;
+mod test_toon;
 mod test_unions;
 
 use std::{

--- a/engine/baml-lib/jsonish/src/tests/test_toon.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_toon.rs
@@ -1,0 +1,89 @@
+use super::*;
+
+const TOON_TYPES: &str = r#"
+enum Status {
+  ACTIVE
+  PAUSED
+}
+
+class Address {
+  city string
+}
+
+class Result {
+  name string
+  status Status
+  tags string[]
+  metadata map<string, int>
+  address Address?
+  identifier string | int
+}
+
+class People {
+  people Person[]
+}
+
+class Person {
+  name string
+  age int
+}
+"#;
+
+test_deserializer!(
+    parses_toon_class_with_enum_list_map_optional_and_union,
+    TOON_TYPES,
+    r#"name: Ada
+status: ACTIVE
+tags[2]: math,code
+metadata:
+  score: 10
+address:
+  city: London
+identifier: 42"#,
+    TypeIR::class("Result"),
+    {
+        "name": "Ada",
+        "status": "ACTIVE",
+        "tags": ["math", "code"],
+        "metadata": { "score": 10 },
+        "address": { "city": "London" },
+        "identifier": 42
+    }
+);
+
+test_deserializer!(
+    parses_toon_tabular_class_list,
+    TOON_TYPES,
+    r#"people[2]{name,age}:
+  Ada,36
+  Grace,37"#,
+    TypeIR::class("People"),
+    {
+        "people": [
+            { "name": "Ada", "age": 36 },
+            { "name": "Grace", "age": 37 }
+        ]
+    }
+);
+
+test_deserializer!(
+    parses_toon_after_preamble_and_recovers_bad_length,
+    TOON_TYPES,
+    r#"Here is the requested result:
+name: Ada
+status: PAUSED
+tags[3]: math,code
+metadata:
+  score: 10
+address: null
+identifier: baml"#,
+    TypeIR::class("Result"),
+    {
+        "name": "Ada",
+        "status": "PAUSED",
+        "tags": ["math", "code"],
+        "metadata": { "score": 10 },
+        "address": null,
+        "identifier": "baml"
+    }
+);

--- a/fern/03-reference/baml/prompt-syntax/output-format.mdx
+++ b/fern/03-reference/baml/prompt-syntax/output-format.mdx
@@ -3,7 +3,7 @@ title: ctx.output_format
 ---
 
 
-`{{ ctx.output_format }}` is used within a prompt template (or in any template_string) to print out the function's output schema into the prompt. It describes to the LLM how to generate a structure BAML can parse (usually JSON).
+`{{ ctx.output_format }}` is used within a prompt template (or in any template_string) to print out the function's output schema into the prompt. It describes to the LLM how to generate a structure BAML can parse. JSON is the default, and TOON is also supported.
 
 Here's an example of a function with `{{ ctx.output_format }}`, and how it gets rendered by BAML before sending it to the LLM.
 
@@ -57,6 +57,32 @@ Answer in JSON using this schema:
 ```
 
 Here's the parameters:
+<ParamField path="format" type="'json' | 'toon'">
+
+**Default: `"json"`**
+
+Controls the serialization format requested from the model. Use TOON
+([Token-Oriented Object Notation](https://toonformat.dev)) for a more compact,
+token-efficient response:
+
+```baml
+{{ ctx.output_format(format="toon") }}
+```
+
+For example, a class containing a list renders a TOON-shaped schema like this:
+
+```text
+Answer in TOON using this schema. Replace every N in an array header with the actual array length:
+name: string
+tags[N]: string
+```
+
+The model must replace `N` with the number of array items in its response. BAML
+decodes the TOON response and applies the same schema-aware parsing and coercion
+used for JSON responses.
+
+</ParamField>
+
 <ParamField path="prefix" type="string">
 The prefix instruction to use before printing out the schema. 
 


### PR DESCRIPTION
## Issue Reference
- [x] This PR addresses #2666

@aaronvg mentioned on #2666 that you're looking for contributors to drive TOON support through, and asked for a spec of how BAML types serialize into the format in the prompt. This is a first pass at that. Happy to adjust the surface (client option vs. `ctx.output_format(...)` argument, spec details) based on what fits the design you had in mind.

## Changes
Adds TOON ([Token-Oriented Object Notation](https://toonformat.dev)) as a selectable output format:

- `{{ ctx.output_format(format="toon") }}` renders TOON-shaped schema instructions instead of JSON. `format` defaults to `"json"`, so existing prompts are unchanged.
- The `format` argument is validated at compile time in the jinja type checker (only `"json"` / `"toon"` accepted).
- Response parsing decodes TOON via the official `toon-format` crate and feeds it through the same schema-aligned (`jsonish`) coercion used for JSON, so preambles, indentation, tabular arrays, and recoverable array-length mismatches are all handled.
- Builds on the existing `toon` input Jinja filter (#2720) — this adds the output/parse side.

Rendering lives in `engine/baml-lib/jinja-runtime/src/output_format/`; parsing in `engine/baml-lib/jsonish/` (new `toon_parser.rs`). Docs updated in `fern/03-reference/baml/prompt-syntax/output-format.mdx`.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

Added round-trip tests covering class/enum/list/map/optional/union, TOON after a model preamble, and recoverable bad array lengths. Local runs:
- `jsonish`: 493 tests pass (incl. 10 new `test_toon` cases)
- `internal-baml-jinja`: 119 pass, `internal-baml-jinja-types`: 43 pass
- `cargo fmt --check`, `git diff --check`, and current-branch `baml check` all clean

## Screenshots

Simulated demo of the prompt-side contrast (JSON vs TOON schema for the same type) and the parse-back to a typed value:

![TOON output format demo](https://files.catbox.moe/06l220.gif)

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Adds one dependency (`toon-format` 0.5.0). The branch is a couple of commits behind current `canary`; I can rebase before merge. AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TOON as a supported option for `ctx.output_format` via a new `format` parameter.
  * Enabled schema and prompt rendering in TOON mode, including arrays, maps, enums, and nested classes.
  * Added TOON-aware response parsing and decoding, including recovery from preambles and formatting variations.
  * Extended validation to recognize `format="json"` and `format="toon"`.
* **Bug Fixes**
  * Improved TOON candidate extraction and array-length recovery.
* **Documentation**
  * Updated output-format documentation with TOON guidance.
* **Tests**
  * Added coverage for TOON rendering, parsing, decoding, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->