### PR TITLE
fix(grammar): stage untracked files when committing to the grammar mirror

### DIFF
--- a/.github/workflows/sync-grammar-mirror.yml
+++ b/.github/workflows/sync-grammar-mirror.yml
@@ -117,9 +117,12 @@ jobs:
 
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/textmate_baml -o IdentitiesOnly=yes"
           cd /tmp/mirror-repo
+          # -A, not commit -a: newly assembled files (dist/, package.json, the
+          # publish workflow) are untracked in the mirror and -a would drop them.
+          git add -A
           git -c user.name="github-actions[bot]" \
               -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-              commit -am "Sync from BoundaryML/baml@${SOURCE_SHA} (v${next})"
+              commit -m "Sync from BoundaryML/baml@${SOURCE_SHA} (v${next})"
           git push origin main
           echo "version=${next}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
The first sync-grammar-mirror run pushed only the modified README and grammar to BoundaryML/textMate-baml: `git commit -am` stages tracked files only, and every newly assembled file (package.json, dist/, language-configuration.json, the mirror's publish workflow) was untracked, so they were silently dropped. Stage with `git add -A` before committing.

Verified against the mirror: its sync commit (`891dd38`) contains only `README.md`, `grammars/baml.tmLanguage.json`, and the jinja deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated mirror updates to ensure all generated and newly added files are included in release commits.
  * Prevented incomplete mirror updates caused by untracked assembled files being omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->