### PR TITLE
fix(graph): resolve root-qualified namespaced function calls

### DIFF
--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -508,6 +508,10 @@ impl ProjectDatabase {
         self.ast_control_flow_graph_impl(function_name, &mut ctx)
     }
 
+    fn normalize_graph_function_name(function_name: &str) -> &str {
+        function_name.strip_prefix("root.").unwrap_or(function_name)
+    }
+
     fn ast_control_flow_graph_impl(
         &self,
         function_name: &str,
@@ -517,6 +521,7 @@ impl ProjectDatabase {
             build_control_flow_graph_from_ast, build_llm_control_flow_graph,
         };
 
+        let function_name = Self::normalize_graph_function_name(function_name);
         if !ctx.expanding.insert(function_name.to_string()) {
             return None;
         }
@@ -746,7 +751,10 @@ impl ProjectDatabase {
                 .map(AsRef::<str>::as_ref)
                 .collect::<Vec<_>>()
                 .join(".");
-            calls.push((expr_id.into_raw().into_u32(), callee_name));
+            calls.push((
+                expr_id.into_raw().into_u32(),
+                Self::normalize_graph_function_name(&callee_name).to_string(),
+            ));
         }
         calls
     }
@@ -2018,6 +2026,59 @@ function Workflow(input: string) -> string {
         assert!(
             prepared.nodes.contains_key(&call_node.id),
             "LLM call must always render"
+        );
+    }
+
+    #[test]
+    fn test_root_qualified_llm_call_is_resolved_and_rendered() {
+        use baml_compiler2_visualization::control_flow::{
+            NodeType, prepare_control_flow_graph_for_visualization,
+        };
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/ns_task_routing/choose_task.baml"),
+            r##"
+function ChooseTask(input: string) -> string {
+    client GPT4
+    prompt #"Choose a task for {{ input }}"#
+}
+"##,
+        );
+        db.add_or_update_file(
+            std::path::Path::new("/tmp/ns_voice_turn/workflow.baml"),
+            r#"
+function VoiceTurn(input: string) -> string {
+    root.task_routing.ChooseTask(input)
+}
+"#,
+        );
+
+        assert!(
+            db.ast_control_flow_graph("root.voice_turn.VoiceTurn")
+                .is_some(),
+            "absolute root-qualified graph lookup should resolve the namespaced workflow"
+        );
+
+        let graph = db
+            .ast_control_flow_graph("voice_turn.VoiceTurn")
+            .expect("expected graph for namespaced VoiceTurn workflow");
+        let call_node = graph
+            .nodes
+            .values()
+            .find(|node| node.label == "root.task_routing.ChooseTask(input)")
+            .expect("caller graph should contain the absolute namespaced call");
+        assert!(
+            matches!(call_node.node_type, NodeType::LlmFunction),
+            "absolute namespaced LLM call should resolve as LlmFunction, got {:?}",
+            call_node.node_type
+        );
+
+        let prepared = prepare_control_flow_graph_for_visualization(&graph);
+        assert!(
+            prepared.nodes.contains_key(&call_node.id),
+            "absolute namespaced LLM call must survive visualization pruning"
         );
     }
 


### PR DESCRIPTION
## Author Comment

I found a bug with namespaces where referencing them with root results in graph view breaking. Fixed it by adding a single helper function that matches the name shape with what the downstream code consuming it expects by stripping the leading "root." from the name.

## Codex Summary

Cross-namespace BAML calls use root-qualified paths such as `root.task_routing.ChooseTask(...)`. These calls compile and run correctly, but the graph analyzer retained the leading `root.` while its function resolver expected the playground-qualified name `task_routing.ChooseTask`.

The lookup therefore failed to recognize the callee as an LLM function. Graph preparation intentionally preserves LLM calls while pruning ordinary helper calls without `//#` headers. Consequently, the misclassified call was removed and affected workflows could appear as only a root node.

This change removes one leading `root.` before graph lookup. The normalization applies both to requested graph entry points and to callees extracted from the AST. It is limited to static graph analysis and does not change runtime name resolution or displayed source labels.

The regression test verifies that:

- A root-qualified namespaced workflow can be used as a graph entry point.
- A cross-namespace `root.*` call resolves as `NodeType::LlmFunction`.
- The LLM call survives visualization pruning without a `//#` header.

Tested with:

```text
cargo test -p baml_project test_root_qualified_llm_call_is_resolved_and_rendered --lib
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow calls using root-qualified names so they resolve correctly.
  * Ensured namespaced language-model functions remain visible in workflow visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->