### PR TITLE
Use `RealizedTy` in runtime

### DIFF
--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -1731,7 +1731,7 @@ fn emit_result_conversion_ok(out: &mut String, b: &NativeBuiltin, indent: &str) 
         .unwrap();
         writeln!(
             out,
-            "{indent}Ok(Value::object(vm.alloc_array(baml_type::RuntimeTy::string(), result_values)))"
+            "{indent}Ok(Value::object(vm.alloc_array(baml_type::RealizedTy::string(), result_values)))"
         )
         .unwrap();
         return;
@@ -1811,11 +1811,11 @@ fn reads_multiple_containers(b: &NativeBuiltin) -> bool {
     receiver_containers + param_containers >= 2
 }
 
-/// Emit a Rust expression that constructs the `baml_type::RuntimeTy` describing
+/// Emit a Rust expression that constructs the `baml_type::RealizedTy` describing
 /// `ty` at VM runtime, used to tag `vm.alloc_array` / `vm.alloc_map`
 /// allocations with their declared element/key/value types.
 ///
-/// - Leaf primitives map to their exact `RuntimeTy` constructor.
+/// - Leaf primitives map to their exact `RealizedTy` constructor.
 /// - A **generic parameter** resolves to the call's instantiated type argument,
 ///   read from `vm.current_call_type_args()` at the parameter's declaration
 ///   index (the call-instruction handler records the leading `LoadType`s there,
@@ -1823,34 +1823,34 @@ fn reads_multiple_containers(b: &NativeBuiltin) -> bool {
 ///   conversions: the native body makes no nested call that could overwrite the
 ///   pending args before the result is built.
 /// - **Media / named / `$rust_type`** positions map to their concrete
-///   `RuntimeTy`.
+///   `RealizedTy`.
 ///
 /// `unknown` appears only when a generic name is absent from `generics` or its
 /// type argument was not supplied at the call — never as a lazy fallback for a
 /// type that is statically recoverable.
 fn runtime_ty_expr(ty: &BamlType, generics: &[String]) -> String {
     match ty {
-        BamlType::String => "baml_type::RuntimeTy::string()".to_string(),
-        BamlType::Int => "baml_type::RuntimeTy::int()".to_string(),
-        BamlType::Bigint => "baml_type::RuntimeTy::bigint()".to_string(),
-        BamlType::Float => "baml_type::RuntimeTy::float()".to_string(),
-        BamlType::Bool => "baml_type::RuntimeTy::bool()".to_string(),
-        BamlType::Null => "baml_type::RuntimeTy::null()".to_string(),
-        BamlType::Uint8Array => "baml_type::RuntimeTy::uint8array()".to_string(),
+        BamlType::String => "baml_type::RealizedTy::string()".to_string(),
+        BamlType::Int => "baml_type::RealizedTy::int()".to_string(),
+        BamlType::Bigint => "baml_type::RealizedTy::bigint()".to_string(),
+        BamlType::Float => "baml_type::RealizedTy::float()".to_string(),
+        BamlType::Bool => "baml_type::RealizedTy::bool()".to_string(),
+        BamlType::Null => "baml_type::RealizedTy::null()".to_string(),
+        BamlType::Uint8Array => "baml_type::RealizedTy::uint8array()".to_string(),
         BamlType::List(inner) => {
             format!(
-                "baml_type::RuntimeTy::list({})",
+                "baml_type::RealizedTy::list({})",
                 runtime_ty_expr(inner, generics)
             )
         }
         BamlType::Map(key, value) => format!(
-            "baml_type::RuntimeTy::map({}, {})",
+            "baml_type::RealizedTy::map({}, {})",
             runtime_ty_expr(key, generics),
             runtime_ty_expr(value, generics)
         ),
         BamlType::Optional(inner) => {
             format!(
-                "baml_type::RuntimeTy::optional({})",
+                "baml_type::RealizedTy::optional({})",
                 runtime_ty_expr(inner, generics)
             )
         }
@@ -1863,16 +1863,16 @@ fn runtime_ty_expr(ty: &BamlType, generics: &[String]) -> String {
             // best-effort tag, not a correctness invariant worth a hard panic.
             Some(idx) => format!(
                 "vm.current_call_type_args().get({idx}).cloned()\
-                    .unwrap_or_else(baml_type::RuntimeTy::unknown)"
+                    .unwrap_or_else(baml_type::RealizedTy::unknown)"
             ),
             None => format!("compile_error!(\"unknown type arg `{name}`\")"),
         },
         BamlType::Media(kind) => format!(
-            "baml_type::RuntimeTy::Media({}, baml_type::TyAttr::default())",
+            "baml_type::RealizedTy::Media({}, baml_type::TyAttr::default())",
             media_kind_path(kind)
         ),
         BamlType::RustType => {
-            "baml_type::RuntimeTy::RustType { attr: baml_type::TyAttr::default() }".to_string()
+            "baml_type::RealizedTy::RustType { attr: baml_type::TyAttr::default() }".to_string()
         }
         // `Named` is a lossy catch-all: the type parser discards a class's
         // generic arguments (`Box<int>` → `Named("Box")`) and also funnels
@@ -1881,7 +1881,7 @@ fn runtime_ty_expr(ty: &BamlType, generics: &[String]) -> String {
         // drop generics and fabricate a class for the placeholder names, so this
         // static-`BamlType` path cannot recover a named type — the complete type
         // lives only on the runtime value's stored `element_ty`.
-        BamlType::Named(_) => "baml_type::RuntimeTy::unknown()".to_string(),
+        BamlType::Named(_) => "baml_type::RealizedTy::unknown()".to_string(),
     }
 }
 

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -2024,26 +2024,33 @@ fn compute_function_metadata_from_item_tree(
         );
     }
     // Inside an interface's own method signature, `Self` is the rigid type variable
-    // bound by that interface — register the bound so a `Self.Item` projection
+    // bound by that interface. Resolve that declaring interface as an `Interface`
+    // constraint (its qualified name plus its own generic params as rigid type
+    // vars) once: it is both `Self`'s registered bound — so a `Self.Item` projection
     // determines its declaring interface through `Self`'s bound closure (the same
-    // recipe as TIR's signature realization).
-    if let Some(iface_data) = enclosing_interface
-        && let Some(def) = pkg_items.lookup_type(&pkg_info.namespace_path, &iface_data.name)
-        && matches!(
-            def,
-            baml_compiler2_hir::contributions::Definition::Interface(_)
-        )
-    {
-        let qtn = baml_compiler2_tir::lower_type_expr::qualify_def(db, def, &iface_data.name);
-        let args = iface_data
-            .generic_params
-            .iter()
-            .map(|p| baml_compiler2_tir::ty::Ty::TypeVar(p.clone(), baml_type::TyAttr::default()))
-            .collect();
-        scope_bounds.insert(
-            Name::new("Self"),
-            vec![baml_type::Interface::new(qtn, args, Vec::new())],
-        );
+    // recipe as TIR's signature realization) — and the qualifier of each
+    // `Self.<assoc>` projection built below.
+    let self_declaring_interface: Option<baml_type::Interface> =
+        enclosing_interface.and_then(|iface_data| {
+            let def = pkg_items.lookup_type(&pkg_info.namespace_path, &iface_data.name)?;
+            if !matches!(
+                def,
+                baml_compiler2_hir::contributions::Definition::Interface(_)
+            ) {
+                return None;
+            }
+            let qtn = baml_compiler2_tir::lower_type_expr::qualify_def(db, def, &iface_data.name);
+            let args = iface_data
+                .generic_params
+                .iter()
+                .map(|p| {
+                    baml_compiler2_tir::ty::Ty::TypeVar(p.clone(), baml_type::TyAttr::default())
+                })
+                .collect();
+            Some(baml_type::Interface::new(qtn, args, Vec::new()))
+        });
+    if let Some(iface) = &self_declaring_interface {
+        scope_bounds.insert(Name::new("Self"), vec![iface.clone()]);
     }
 
     // A method declared inside an interface resolves its associated types
@@ -2079,7 +2086,11 @@ fn compute_function_metadata_from_item_tree(
                         assoc.name.clone(),
                         baml_compiler2_tir::ty::Ty::AssociatedTypeProjection {
                             base: Box::new(self_var()),
-                            interface: None,
+                            // The declaring interface resolved above; we are in the
+                            // `Some(iface_data)` arm, so it is present.
+                            interface: Box::new(self_declaring_interface.clone().unwrap_or_else(
+                                || unreachable!("interface method has a declaring interface"),
+                            )),
                             member: assoc.name.clone(),
                             attr: baml_type::TyAttr::default(),
                         },

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 use baml_base::{Name, Span};
 pub use baml_compiler2_ast::BuiltinKind;
-use baml_type::{RuntimeTy, TyTemplate};
+use baml_type::{RealizedTy, RuntimeTy, TyTemplate};
 
 // ============================================================================
 // Optimization Level
@@ -880,8 +880,9 @@ pub enum Constant {
     GenericFunction {
         /// The base generic function.
         item: ItemRef,
-        /// The concrete type arguments (fully resolved, no type parameters).
-        type_args: Vec<RuntimeTy>,
+        /// The concrete type arguments — fully realized (no type parameters),
+        /// exactly what the runtime `Object::GenericFunction` carries.
+        type_args: Vec<RealizedTy>,
     },
     /// An enum variant value.
     EnumVariant {

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -812,22 +812,20 @@ pub fn tir2_to_template(
             // consumer to resolve. Never an error, never erased.
             .unwrap_or_else(|| TyTemplate::AssociatedTypeProjection {
                 base: Box::new(tir2_to_template(base, resolved, generic_params)),
-                interface: interface.as_ref().map(|iface| {
-                    Box::new(baml_type::TyTemplateInterface {
-                        name: iface.name.clone(),
-                        generics: iface
-                            .generics
-                            .iter()
-                            .map(|g| tir2_to_template(g, resolved, generic_params))
-                            .collect(),
-                        associated_types: iface
-                            .associated_types
-                            .iter()
-                            .map(|(name, ty)| {
-                                (name.clone(), tir2_to_template(ty, resolved, generic_params))
-                            })
-                            .collect(),
-                    })
+                interface: Box::new(baml_type::TyTemplateInterface {
+                    name: interface.name.clone(),
+                    generics: interface
+                        .generics
+                        .iter()
+                        .map(|g| tir2_to_template(g, resolved, generic_params))
+                        .collect(),
+                    associated_types: interface
+                        .associated_types
+                        .iter()
+                        .map(|(name, ty)| {
+                            (name.clone(), tir2_to_template(ty, resolved, generic_params))
+                        })
+                        .collect(),
                 }),
                 member: member.clone(),
                 attr: TyAttr::default(),
@@ -3263,9 +3261,9 @@ impl<'db> LoweringContext<'db> {
                 // associated-type bindings); erase compiler-only types within them
                 // too, matching the `Tir2Ty::Interface` arm above. (The field is an
                 // `Interface` after the interface-object refactor, not a `Ty`.)
-                interface: interface.map(|iface| {
-                    Box::new(iface.map_tys(|ty| Self::erase_compiler_only_ty(ty.clone())))
-                }),
+                interface: Box::new(
+                    interface.map_tys(|ty| Self::erase_compiler_only_ty(ty.clone())),
+                ),
                 member,
                 attr,
             },
@@ -10643,7 +10641,7 @@ impl<'db> LoweringContext<'db> {
     fn resolve_projection_bound(&self, ty: &Tir2Ty) -> Option<Tir2Ty> {
         use baml_type::normalize::TypeContext;
         let Tir2Ty::AssociatedTypeProjection {
-            interface: Some(iface),
+            interface: iface,
             member,
             ..
         } = ty

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -832,13 +832,21 @@ pub fn tir2_to_template(
             }),
         // FIXME(typevar-templates): `Self` is the one type variable that may
         // legitimately survive to a template (it is a real, if unresolved,
-        // reference to the concrete implementor type). It maps to `Wildcard` as
-        // a temporary bandaid — correct for a top-level `x is Self` (emits
-        // `false`), but it OVER-MATCHES in a nested position (`Foo<Self>`), where
-        // the guard treats `Wildcard` as "any". Give `Self` a real frame slot so
-        // it lowers to a `TypeArgRef` (interface default-method / class-body
-        // work) and delete this arm.
-        Tir2Ty::TypeVar(name, _) if name == "Self" => TyTemplate::Wildcard,
+        // reference to the concrete implementor type). It has no frame slot in
+        // the current calling model, so a materialization position demotes it
+        // to the realized top type `unknown` — the same honest reflection an
+        // unspecialized generic slot gets (the out-of-range `TypeArgRef` rule
+        // in `TyTemplate::substitute`), decided and documented here at compile
+        // time rather than smuggled through a `Wildcard` hole for the runtime
+        // to erase (a hole has no concrete form, so `substitute` rejects it as
+        // an internal error). Dispatch-guard positions never reach this arm:
+        // `tir2_to_dispatch_guard_template` intercepts every `TypeVar` before
+        // delegating here, and there `Self` stays a `Wildcard` hole (matching
+        // "any" — over-matching in nested positions like `Foo<Self>`). Give
+        // `Self` a real frame slot so it lowers to a `TypeArgRef` (interface
+        // default-method / class-body work), fix the guard over-match with the
+        // same slot, and delete this arm.
+        Tir2Ty::TypeVar(name, _) if name == "Self" => realized_leaf_template(&RuntimeTy::unknown()),
         Tir2Ty::TypeVar(name, _) => {
             let Some(n) = generic_params.iter().position(|p| p == name) else {
                 // A non-`Self` type variable with no frame position is a defect:

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -6417,7 +6417,7 @@ impl<'db> LoweringContext<'db> {
         // generic param, then substitute `class_type_args` so a field
         // declared as `T` resolves to the concrete receiver-side binding.
         let template = tir2_to_template(&tir_ty, self.resolved_aliases, &class_data.generic_params);
-        template.substitute(class_type_args)
+        template.substitute_symbolic(class_type_args)
     }
 
     fn lower_item_ref(&mut self, expr_id: AstExprId, def: Definition<'db>, dest: Place) {
@@ -9087,8 +9087,15 @@ impl LoweringContext<'_> {
         let templates = self.generic_apply_type_arg_templates(type_args);
         if templates.iter().all(TyTemplate::is_fully_concrete) {
             // Concrete args → pooled, interned compile-time constant
-            // (pointer-stable identity).
-            let concrete: Vec<RuntimeTy> = templates.iter().map(|t| t.substitute(&[])).collect();
+            // (pointer-stable identity). Each template is fully concrete, so it
+            // narrows directly to a `RealizedTy` — the value the runtime carries.
+            let concrete: Vec<RealizedTy> = templates
+                .iter()
+                .map(|t| {
+                    RealizedTy::try_from(t)
+                        .unwrap_or_else(|e| unreachable!("checked fully concrete: {e}"))
+                })
+                .collect();
             self.builder.assign(
                 dest,
                 Rvalue::Use(Operand::Constant(Constant::GenericFunction {

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -590,8 +590,9 @@ impl baml_type::normalize::TypeContext for TypeInferenceBuilder<'_> {
         base: &Ty,
         interface: &baml_type::Interface,
         member: &Name,
+        fuel: u32,
     ) -> baml_type::normalize::ProjectionStep {
-        self.as_global().project(base, interface, member)
+        self.as_global().project(base, interface, member, fuel)
     }
 }
 

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -8359,11 +8359,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 base, interface, ..
             } => {
                 Self::ty_contains_unknown_like(base, count_builtin)
-                    || interface.as_ref().is_some_and(|interface| {
-                        interface
-                            .tys()
-                            .any(|t| Self::ty_contains_unknown_like(t, count_builtin))
-                    })
+                    || interface
+                        .tys()
+                        .any(|t| Self::ty_contains_unknown_like(t, count_builtin))
             }
             Ty::List(elem, _) | Ty::EvolvingList(elem, _) => {
                 Self::ty_contains_unknown_like(elem, count_builtin)
@@ -10827,7 +10825,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
             Ty::AssociatedTypeProjection {
-                interface: Some(projection_iface),
+                interface: projection_iface,
                 member: assoc,
                 ..
             } if member.as_str() != "from_json" => {

--- a/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
@@ -109,7 +109,7 @@ pub(crate) fn lower_projection(
             } else {
                 Ty::AssociatedTypeProjection {
                     base: Box::new(base),
-                    interface: Some(Box::new(interface)),
+                    interface: Box::new(interface),
                     member,
                     attr: TyAttr::default(),
                 }
@@ -280,20 +280,15 @@ fn determine_interface(
             interface: inner_interface,
             member: inner_member,
             ..
-        } => {
-            let inner_interface = inner_interface.as_ref().unwrap_or_else(|| {
-                unreachable!("a symbolic projection base always carries its determined interface")
-            });
-            determine_chained(
-                ctx,
-                &base,
-                inner_base,
-                inner_interface,
-                inner_member,
-                explicit,
-                member,
-            )
-        }
+        } => determine_chained(
+            ctx,
+            &base,
+            inner_base,
+            inner_interface,
+            inner_member,
+            explicit,
+            member,
+        ),
         // Already-errored bases — and the unfilled `_` inference hole, which the
         // fill machinery resolves or diagnoses — propagate without a fresh diagnostic.
         Ty::Error { .. } | Ty::Unknown { .. } | Ty::BuiltinUnknown { .. } | Ty::Infer { .. } => {
@@ -608,7 +603,7 @@ fn associated_type_bound_interface(
             .map(|(_, pin)| pin.clone())
             .unwrap_or_else(|| Ty::AssociatedTypeProjection {
                 base: Box::new(self_ty.clone()),
-                interface: Some(Box::new(realized.clone())),
+                interface: Box::new(realized.clone()),
                 member: assoc.name.clone(),
                 attr: TyAttr::default(),
             });

--- a/baml_language/crates/baml_compiler2_tir/src/exhaustiveness.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/exhaustiveness.rs
@@ -289,10 +289,8 @@ fn write_ty_identity(out: &mut String, ty: &Ty) {
         } => {
             out.push_str("Assoc<");
             write_ty_identity(out, base);
-            if let Some(interface) = interface {
-                out.push_str(" as ");
-                write_ty_identity(out, &interface.to_ty());
-            }
+            out.push_str(" as ");
+            write_ty_identity(out, &interface.to_ty());
             let _ = write!(out, ".{member}>");
         }
         Ty::Int { .. } => out.push_str("P:Int"),

--- a/baml_language/crates/baml_compiler2_tir/src/generics.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/generics.rs
@@ -81,9 +81,7 @@ pub fn substitute_ty(ty: &Ty, bindings: &FxHashMap<Name, Ty>) -> Ty {
             attr,
         } => Ty::AssociatedTypeProjection {
             base: Box::new(substitute_ty(base, bindings)),
-            interface: interface
-                .as_ref()
-                .map(|interface| Box::new(interface.map_tys(|t| substitute_ty(t, bindings)))),
+            interface: Box::new(interface.map_tys(|t| substitute_ty(t, bindings))),
             member: member.clone(),
             attr: attr.clone(),
         },
@@ -175,12 +173,7 @@ pub fn contains_typevar(ty: &Ty) -> bool {
         Ty::TypeVar(_, _) => true,
         Ty::AssociatedTypeProjection {
             base, interface, ..
-        } => {
-            contains_typevar(base)
-                || interface
-                    .as_ref()
-                    .is_some_and(|interface| interface.tys().any(contains_typevar))
-        }
+        } => contains_typevar(base) || interface.tys().any(contains_typevar),
         Ty::List(inner, _) | Ty::EvolvingList(inner, _) => contains_typevar(inner),
         Ty::Map {
             key: k, value: v, ..
@@ -325,9 +318,7 @@ pub fn contains_typevar_where(ty: &Ty, pred: &dyn Fn(&Name) -> bool) -> bool {
             base, interface, ..
         } => {
             contains_typevar_where(base, pred)
-                || interface.as_ref().is_some_and(|interface| {
-                    interface.tys().any(|t| contains_typevar_where(t, pred))
-                })
+                || interface.tys().any(|t| contains_typevar_where(t, pred))
         }
         _ => false,
     }
@@ -420,9 +411,7 @@ pub fn erase_typevars_where(ty: &Ty, pred: &dyn Fn(&Name) -> bool) -> Ty {
             attr,
         } => Ty::AssociatedTypeProjection {
             base: Box::new(erase_typevars_where(base, pred)),
-            interface: interface
-                .as_ref()
-                .map(|interface| Box::new(interface.map_tys(|t| erase_typevars_where(t, pred)))),
+            interface: Box::new(interface.map_tys(|t| erase_typevars_where(t, pred))),
             member: member.clone(),
             attr: attr.clone(),
         },
@@ -489,9 +478,7 @@ pub fn erase_unresolved_typevars(
             attr,
         } => Ty::AssociatedTypeProjection {
             base: Box::new(erase_unresolved_typevars(base, diagnostics)),
-            interface: interface.as_ref().map(|interface| {
-                Box::new(interface.map_tys(|t| erase_unresolved_typevars(t, diagnostics)))
-            }),
+            interface: Box::new(interface.map_tys(|t| erase_unresolved_typevars(t, diagnostics))),
             member: member.clone(),
             attr: attr.clone(),
         },
@@ -603,9 +590,7 @@ pub fn erase_typevars_matching(ty: &Ty, should_erase: &impl Fn(&Name) -> bool) -
             attr,
         } => Ty::AssociatedTypeProjection {
             base: Box::new(erase_typevars_matching(base, should_erase)),
-            interface: interface.as_ref().map(|interface| {
-                Box::new(interface.map_tys(|t| erase_typevars_matching(t, should_erase)))
-            }),
+            interface: Box::new(interface.map_tys(|t| erase_typevars_matching(t, should_erase))),
             member: member.clone(),
             attr: attr.clone(),
         },

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
@@ -95,14 +95,8 @@ pub(crate) fn normalized_arg_implements_bound(
         Ty::Unknown { .. } | Ty::Error { .. } => return true,
         Ty::TypeVar(name, _) => ctx.type_var_bound(name),
         Ty::AssociatedTypeProjection {
-            interface: Some(iface),
-            member,
-            ..
-        } => ctx.associated_type_bound(iface, member.clone()),
-        // Never determined — errored upstream; don't cascade.
-        Ty::AssociatedTypeProjection {
-            interface: None, ..
-        } => return true,
+            interface, member, ..
+        } => ctx.associated_type_bound(interface, member.clone()),
         // A concrete argument implements the bound directly through its impls.
         _ => return ctx.implements_interface(arg, bound),
     };

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -431,12 +431,7 @@ fn var_under_union(name: &Name, ty: &Ty) -> bool {
             | Ty::Future(k, v, _) => occurs(name, k, in_union) || occurs(name, v, in_union),
             Ty::AssociatedTypeProjection {
                 base, interface, ..
-            } => {
-                occurs(name, base, in_union)
-                    || interface
-                        .as_ref()
-                        .is_some_and(|i| i.tys().any(|t| occurs(name, t, in_union)))
-            }
+            } => occurs(name, base, in_union) || interface.tys().any(|t| occurs(name, t, in_union)),
             Ty::Function {
                 params,
                 ret,
@@ -543,9 +538,7 @@ fn nf(ty: &Ty, enum_variants: EnumVariants) -> Ty {
             attr,
         } => Ty::AssociatedTypeProjection {
             base: Box::new(nf(base, enum_variants)),
-            interface: interface
-                .as_ref()
-                .map(|i| Box::new(i.map_tys(|t| nf(t, enum_variants)))),
+            interface: Box::new(interface.map_tys(|t| nf(t, enum_variants))),
             member: member.clone(),
             attr: attr.clone(),
         },
@@ -1373,9 +1366,7 @@ fn occurs_in(n: &Name, t: &Ty, vars: &[Name], bindings: &TypeBindings) -> bool {
             base, interface, ..
         } => {
             occurs_in(n, base, vars, bindings)
-                || interface
-                    .as_ref()
-                    .is_some_and(|i| i.tys().any(|t| occurs_in(n, t, vars, bindings)))
+                || interface.tys().any(|t| occurs_in(n, t, vars, bindings))
         }
         Ty::Function {
             params,
@@ -1810,7 +1801,11 @@ mod tests {
         // not `Unknown` (which is only for search-budget exhaustion).
         let proj = Ty::AssociatedTypeProjection {
             base: Box::new(Ty::type_var("T")),
-            interface: None,
+            interface: Box::new(
+                interface("Iter", vec![])
+                    .as_interface()
+                    .expect("interface() builds an existential"),
+            ),
             member: Name::new("Item"),
             attr: TyAttr::default(),
         };

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -1615,9 +1615,7 @@ fn collect_ty_packages(ty: &Ty, out: &mut Vec<Name>) {
             base, interface, ..
         } => {
             collect_ty_packages(base, out);
-            if let Some(iface) = interface {
-                collect_interface_packages(iface, out);
-            }
+            collect_interface_packages(interface, out);
         }
         // No qualified name: primitives, literals, type variables, and sentinels.
         Ty::Int { .. }

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -1329,14 +1329,7 @@ mod tests {
                 interface, member, ..
             } => {
                 assert_eq!(member.as_str(), "Item");
-                assert_eq!(
-                    interface
-                        .expect("interface determined")
-                        .name
-                        .name()
-                        .as_str(),
-                    "Iterator"
-                );
+                assert_eq!(interface.name.name().as_str(), "Iterator");
             }
             other => panic!("expected a symbolic Self.Item projection, got {other:?}"),
         }
@@ -1453,7 +1446,7 @@ mod tests {
         );
         let projection = Ty::AssociatedTypeProjection {
             base: Box::new(Ty::TypeVar(Name::new("Self"), TyAttr::default())),
-            interface: Some(Box::new(foo)),
+            interface: Box::new(foo),
             member: Name::new("Assoc"),
             attr: TyAttr::default(),
         };
@@ -1497,7 +1490,7 @@ mod tests {
             base: Box::new(Ty::Int {
                 attr: TyAttr::default(),
             }),
-            interface: Some(Box::new(foo)),
+            interface: Box::new(foo),
             member: Name::new("Assoc"),
             attr: TyAttr::default(),
         };
@@ -1925,15 +1918,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(**base, string_ty, "base must be the realized argument");
-                assert_eq!(
-                    interface
-                        .as_ref()
-                        .expect("interface determined")
-                        .name
-                        .name()
-                        .as_str(),
-                    "HasItem"
-                );
+                assert_eq!(interface.as_ref().name.name().as_str(), "HasItem");
                 assert_eq!(member.as_str(), "Item");
             }
             other => panic!("expected a symbolic T.Item projection, got {other:?}"),
@@ -2808,14 +2793,7 @@ mod tests {
                 interface, member, ..
             } => {
                 assert_eq!(member.as_str(), "X");
-                assert_eq!(
-                    interface
-                        .expect("interface determined")
-                        .name
-                        .name()
-                        .as_str(),
-                    "Base"
-                );
+                assert_eq!(interface.name.name().as_str(), "Base");
             }
             other => panic!("expected a symbolic projection through Base, got {other:?}"),
         }
@@ -2836,14 +2814,7 @@ mod tests {
                 ..
             } => {
                 assert!(matches!(*base, Ty::TypeVar(ref n, _) if n.as_str() == "T"));
-                assert_eq!(
-                    interface
-                        .expect("interface determined")
-                        .name
-                        .name()
-                        .as_str(),
-                    "HasItem"
-                );
+                assert_eq!(interface.name.name().as_str(), "HasItem");
                 assert_eq!(member.as_str(), "Item");
             }
             other => panic!("expected a symbolic T.Item projection, got {other:?}"),
@@ -2912,14 +2883,7 @@ mod tests {
                     matches!(*base, Ty::AssociatedTypeProjection { ref member, .. } if member.as_str() == "A"),
                     "outer projection's base is the inner `T.A` projection",
                 );
-                assert_eq!(
-                    interface
-                        .expect("interface determined")
-                        .name
-                        .name()
-                        .as_str(),
-                    "Inner"
-                );
+                assert_eq!(interface.name.name().as_str(), "Inner");
                 assert_eq!(member.as_str(), "B");
             }
             other => panic!("expected a symbolic T.A.B projection, got {other:?}"),
@@ -2972,14 +2936,7 @@ mod tests {
             Ty::AssociatedTypeProjection {
                 interface, member, ..
             } => {
-                assert_eq!(
-                    interface
-                        .expect("interface determined")
-                        .name
-                        .name()
-                        .as_str(),
-                    "L3"
-                );
+                assert_eq!(interface.name.name().as_str(), "L3");
                 assert_eq!(member.as_str(), "C");
             }
             other => panic!("expected a symbolic T.A.B.C projection, got {other:?}"),
@@ -3005,7 +2962,7 @@ mod tests {
             panic!("expected a symbolic T.A.B projection, got {ty:?}");
         };
         assert_eq!(member.as_str(), "B");
-        let interface = interface.as_ref().expect("interface determined");
+        let interface = interface.as_ref();
         assert_eq!(interface.name.name().as_str(), "Inner");
         // `Inner`'s sole argument must be the symbolic `T.C` projection, not `TypeVar("C")`.
         match interface.generics.as_slice() {
@@ -3040,7 +2997,7 @@ mod tests {
             panic!("expected a symbolic T.A.X projection, got {ty:?}");
         };
         assert_eq!(member.as_str(), "X");
-        let interface = interface.as_ref().expect("interface determined");
+        let interface = interface.as_ref();
         assert_eq!(interface.name.name().as_str(), "J");
         // `J`'s arg is the finite symbolic `T.B` projection; B's own `K<A>` bound is not opened.
         match interface.generics.as_slice() {

--- a/baml_language/crates/baml_compiler2_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/normalize.rs
@@ -111,7 +111,7 @@ enum StructuralTy {
     /// Symbolic associated type projection — opaque unless already resolved.
     AssociatedTypeProjection {
         base: Box<StructuralTy>,
-        interface: Option<Box<StructuralTy>>,
+        interface: Box<StructuralTy>,
         member: Name,
     },
     // Special
@@ -152,7 +152,7 @@ impl StructuralTy {
                 member,
             } => StructuralTy::AssociatedTypeProjection {
                 base: Box::new(base.canonicalize()),
-                interface: interface.map(|interface| Box::new(interface.canonicalize())),
+                interface: Box::new(interface.canonicalize()),
                 member,
             },
             StructuralTy::List(inner) => StructuralTy::List(Box::new(inner.canonicalize())),
@@ -505,9 +505,7 @@ fn substitute(
             member,
         } => StructuralTy::AssociatedTypeProjection {
             base: Box::new(substitute(base, var, replacement)),
-            interface: interface
-                .as_ref()
-                .map(|interface| Box::new(substitute(interface, var, replacement))),
+            interface: Box::new(substitute(interface, var, replacement)),
             member: member.clone(),
         },
         StructuralTy::Mu { var: v, body } if v != var => StructuralTy::Mu {
@@ -657,14 +655,12 @@ fn normalize_impl(
             ..
         } => StructuralTy::AssociatedTypeProjection {
             base: Box::new(normalize_impl(base, aliases, recursive, expanding)),
-            interface: interface.as_ref().map(|interface| {
-                Box::new(normalize_impl(
-                    &interface.to_ty(),
-                    aliases,
-                    recursive,
-                    expanding,
-                ))
-            }),
+            interface: Box::new(normalize_impl(
+                &interface.to_ty(),
+                aliases,
+                recursive,
+                expanding,
+            )),
             member: member.clone(),
         },
         // `$rust_type` — opaque Rust-managed state. Treated as Unknown
@@ -744,11 +740,9 @@ fn ty_has_cycle(
             base, interface, ..
         } => {
             ty_has_cycle(base, aliases, visited, stack)
-                || interface.as_ref().is_some_and(|interface| {
-                    interface
-                        .tys()
-                        .any(|t| ty_has_cycle(t, aliases, visited, stack))
-                })
+                || interface
+                    .tys()
+                    .any(|t| ty_has_cycle(t, aliases, visited, stack))
         }
         Ty::Function {
             params,
@@ -909,10 +903,8 @@ fn extract_type_alias_deps(
                 base, interface, ..
             } => {
                 visit(base, aliases, non_structural, structural, in_structural);
-                if let Some(interface) = interface {
-                    for ty in interface.tys() {
-                        visit(ty, aliases, non_structural, structural, in_structural);
-                    }
+                for ty in interface.tys() {
+                    visit(ty, aliases, non_structural, structural, in_structural);
                 }
             }
             Ty::Function {

--- a/baml_language/crates/baml_compiler2_tir/src/type_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/type_context.rs
@@ -92,6 +92,10 @@ impl baml_type::normalize::TypeContext for GlobalTypeContext<'_, '_> {
         base: &Ty,
         interface: &baml_type::Interface,
         member: &Name,
+        // Single-step reducer: each arm returns one `Reduced`/`Opaque` result, and
+        // the caller (`NormalTy::from_ty`) decrements its own fuel across the chain,
+        // so there is no self-recursion here to bound.
+        _fuel: u32,
     ) -> baml_type::normalize::ProjectionStep {
         use baml_type::normalize::ProjectionStep;
         // The qualifier already pins the member — that pin *is* the projection.

--- a/baml_language/crates/baml_tests/snapshots/baml_src/inferred_generic_type_args.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/inferred_generic_type_args.snap
@@ -301,7 +301,7 @@ function inferred_generic_type_args.ProbeB.TypeProbe.seen(self: inferred_generic
 
 function inferred_generic_type_args.SelfEcho.nested_self_type(self: inferred_generic_type_args.SelfEcho) -> string {
     load_var self
-    load_type _
+    load_type unknown
     alloc_array 1
     call user.inferred_generic_type_args.echo_type
     return

--- a/baml_language/crates/baml_type/src/family.rs
+++ b/baml_language/crates/baml_type/src/family.rs
@@ -249,8 +249,12 @@ ty_family! {
         #[axis(projection)]
         AssociatedTypeProjection {
             base: Box<Ty>,
-            /// TODO: Should not be an `Option`; fix once the TIR is able to determine correctly.
-            interface: Option<Box<Interface>>,
+            /// The declaring interface of this projection — always known: the TIR
+            /// resolves `(base as I).member` to its interface `I` (or lowers to
+            /// `Ty::Error` when it cannot be determined), so a resolved projection
+            /// never lacks its qualifier. This is what lets a realized-base
+            /// projection reduce to the impl's binding at substitution time.
+            interface: Box<Interface>,
             member: Name,
             attr: TyAttr,
         } = 26,

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -42,6 +42,7 @@ pub use family::*;
 pub use names::*;
 pub use primitive::*;
 pub use runtime_ty::*;
+pub use template::SubstituteError;
 
 /// Upper bound on the bit-length of a `bigint` value we are willing to
 /// materialize at runtime. ~268 million bits ≈ 80 million decimal digits ≈ 32

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -913,16 +913,12 @@ impl Ty {
                 member,
                 ..
             } => {
-                if let Some(interface) = interface {
-                    format!(
-                        "({} as {}).{}",
-                        base.render_with(s),
-                        interface.to_ty().render_with(s),
-                        member
-                    )
-                } else {
-                    format!("{}.{}", base.render_with(s), member)
-                }
+                format!(
+                    "({} as {}).{}",
+                    base.render_with(s),
+                    interface.to_ty().render_with(s),
+                    member
+                )
             }
             Ty::Never { .. } => "never".to_string(),
             Ty::Void { .. } => "void".to_string(),
@@ -1124,10 +1120,7 @@ impl fmt::Display for Ty {
                 interface,
                 member,
                 ..
-            } => match interface {
-                Some(iface) => write!(f, "({base} as {}).{member}", iface.to_ty()),
-                None => write!(f, "{base}.{member}"),
-            },
+            } => write!(f, "({base} as {}).{member}", interface.to_ty()),
             Ty::Never { .. } => write!(f, "never"),
             Ty::Unknown { .. } => write!(f, "unknown"),
             Ty::Error { .. } => write!(f, "<error>"),
@@ -1209,7 +1202,7 @@ mod tests {
             Ty::TypeVar(Name::new("T"), TyAttr::default()),
             Ty::AssociatedTypeProjection {
                 base: boxed(Ty::TypeVar(Name::new("T"), TyAttr::default())),
-                interface: None,
+                interface: Box::new(Interface::new(qtn("Iterator"), vec![], vec![])),
                 member: Name::new("Item"),
                 attr: TyAttr::default(),
             },
@@ -1325,7 +1318,7 @@ mod tests {
             Ty::TypeVar(Name::new("T"), TyAttr::default()),
             Ty::AssociatedTypeProjection {
                 base: boxed(Ty::TypeVar(Name::new("T"), TyAttr::default())),
-                interface: None,
+                interface: Box::new(Interface::new(qtn("Iterator"), vec![], vec![])),
                 member: Name::new("Item"),
                 attr: TyAttr::default(),
             },

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -41,12 +41,15 @@ use crate::{
 // CONTEXT
 // ═══════════════════════════════════════════════════════════════════════════
 
-/// Starting fuel for projection reduction in one `from_ty` walk: the maximum
-/// length of a reduction chain (`(A as I).X` → `(B as J).Y` → …) before a
-/// projection is left opaque. Generous for any real program; bounds a cyclic
-/// `type A = (C as I).B` / `type B = (C as J).A` (itself a declaration-level error
-/// caught elsewhere) so normalization terminates instead of recursing forever.
-const PROJECTION_REDUCTION_FUEL: u32 = 256;
+/// Starting fuel for projection reduction: the maximum length of a reduction
+/// chain (`(A as I).X` → `(B as J).Y` → …) before a projection is left opaque (the
+/// canonical algebra) or its realization fails (the runtime). Generous for any
+/// real program; bounds a cyclic `type A = (C as I).B` / `type B = (C as J).A`
+/// (itself a declaration-level error caught elsewhere) so both the `from_ty` walk
+/// here and the runtime `TyTemplate::substitute` reduction terminate instead of
+/// recursing forever. Shared by both paths so the single limit shrinks in one
+/// place once declaration-level cycle rejection lands.
+pub(crate) const PROJECTION_REDUCTION_FUEL: u32 = 256;
 
 /// The result of reducing an associated-type projection `(base as I).member`
 /// through [`TypeContext::project`].
@@ -162,7 +165,15 @@ pub trait TypeContext {
     /// dead symbolic type with no error, a silent soundness hole (same class as
     /// [`associated_type_bound`](Self::associated_type_bound)). A context over
     /// already-realized values (the runtime) returns `Opaque` explicitly.
-    fn project(&self, base: &Ty, interface: &Interface, member: &Name) -> ProjectionStep;
+    ///
+    /// `fuel` is the remaining projection-reduction budget. A context that itself
+    /// drives the reduction recursion — the runtime, whose `project` realizes the
+    /// impl binding through `TyTemplate::substitute` and can re-enter `project` —
+    /// threads it on so a cyclic associated-type binding terminates. A single-step
+    /// reducer whose recursion is instead bounded by its caller (the canonical
+    /// `from_ty` walk, which decrements its own fuel) ignores it.
+    fn project(&self, base: &Ty, interface: &Interface, member: &Name, fuel: u32)
+    -> ProjectionStep;
 
     // ── type algebra (defaulted; the canonical implementation) ──────────────
     //
@@ -777,7 +788,8 @@ impl NormalTy {
                 // is assignable from its realization. The qualifier always names the
                 // impl; fuel guards a cyclic reduction.
                 if fuel > 0
-                    && let ProjectionStep::Reduced(reduced) = ctx.project(base, interface, member)
+                    && let ProjectionStep::Reduced(reduced) =
+                        ctx.project(base, interface, member, fuel)
                 {
                     return Self::from_ty(&reduced, ctx, expanding, fuel - 1);
                 }

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -628,7 +628,11 @@ enum NormalTy {
     Future(Box<NormalTy>, Box<NormalTy>),
     AssociatedTypeProjection {
         base: Box<NormalTy>,
-        interface: Option<Box<NormalTy>>,
+        /// The declaring interface (a normalized `NormalTy::Interface`), always
+        /// present — mirrors the non-optional `Ty::AssociatedTypeProjection`
+        /// qualifier it is built from, and is what makes a realized-base
+        /// projection reducible via [`TypeContext::project`].
+        interface: Box<NormalTy>,
         member: Name,
     },
     // Recursion
@@ -770,27 +774,18 @@ impl NormalTy {
                 // *is* the type the impl binds (like `1 + 1` *is* `2`). Reduce it to
                 // that whenever the context can determine it — the reduced type
                 // becomes the canonical form, so the projection compares equal to /
-                // is assignable from its realization. Only a `Some(interface)`
-                // projection is reducible (the qualifier names the impl); fuel guards
-                // a cyclic reduction.
-                if let Some(iface) = interface
-                    && fuel > 0
-                    && let ProjectionStep::Reduced(reduced) = ctx.project(base, iface, member)
+                // is assignable from its realization. The qualifier always names the
+                // impl; fuel guards a cyclic reduction.
+                if fuel > 0
+                    && let ProjectionStep::Reduced(reduced) = ctx.project(base, interface, member)
                 {
                     return Self::from_ty(&reduced, ctx, expanding, fuel - 1);
                 }
-                // Not reducible — symbolic base, an unresolved `(T as ?).M` qualifier,
-                // or exhausted fuel: an opaque leaf, equal only to a
-                // structurally-identical projection. The two spellings `(T as ?).M`
-                // and `(T as I).M` of the same associated type are deliberately NOT
-                // equated here; the TIR must resolve the interface to `Some(I)` before
-                // an equivalence/subtype check relies on it (pinned by
-                // `projection_with_unresolved_interface_is_opaque`).
+                // Not reducible — symbolic base or exhausted fuel: an opaque leaf,
+                // equal only to a structurally-identical projection.
                 NormalTy::AssociatedTypeProjection {
                     base: Box::new(Self::from_ty(base, ctx, expanding, fuel)),
-                    interface: interface
-                        .as_ref()
-                        .map(|i| Box::new(Self::from_ty(&i.to_ty(), ctx, expanding, fuel))),
+                    interface: Box::new(Self::from_ty(&interface.to_ty(), ctx, expanding, fuel)),
                     member: member.clone(),
                 }
             }
@@ -862,10 +857,7 @@ impl NormalTy {
             }
             NormalTy::AssociatedTypeProjection {
                 base, interface, ..
-            } => {
-                base.mentions_rec_var(var)
-                    || interface.as_ref().is_some_and(|i| i.mentions_rec_var(var))
-            }
+            } => base.mentions_rec_var(var) || interface.mentions_rec_var(var),
             NormalTy::Int
             | NormalTy::Bigint
             | NormalTy::Float
@@ -927,7 +919,7 @@ impl NormalTy {
                 member,
             } => NormalTy::AssociatedTypeProjection {
                 base: Box::new(base.canonicalize(ctx)),
-                interface: interface.map(|i| Box::new(i.canonicalize(ctx))),
+                interface: Box::new(interface.canonicalize(ctx)),
                 member,
             },
             NormalTy::Function {
@@ -1022,7 +1014,7 @@ impl NormalTy {
         let (member, value) = pin;
         let NormalTy::AssociatedTypeProjection {
             base,
-            interface: Some(iface),
+            interface: iface,
             member: proj_member,
         } = value
         else {
@@ -1139,16 +1131,14 @@ impl NormalTy {
 
             // A still-symbolic associated-type projection is a subtype of `sup` if
             // any of its associated type's declared bounds is — the projection
-            // analogue of the `TypeVar` rule above. Fires only when the projection
-            // carries a resolved interface; an unresolved one (`interface: None`)
-            // stays opaque (equal only to itself, via reflexivity). A realized-base
-            // projection is intended to be resolved to a concrete type by an
-            // upstream pre-pass before reaching here. Must precede the interface
-            // arms below, which would otherwise ask `implements_interface` about a
-            // non-concrete projection.
+            // analogue of the `TypeVar` rule above. The projection always carries
+            // its declaring interface; a realized-base projection is intended to be
+            // resolved to a concrete type by an upstream pre-pass before reaching
+            // here. Must precede the interface arms below, which would otherwise ask
+            // `implements_interface` about a non-concrete projection.
             (
                 NormalTy::AssociatedTypeProjection {
-                    interface: Some(iface),
+                    interface: iface,
                     member,
                     ..
                 },
@@ -1311,7 +1301,13 @@ impl NormalTy {
                 member,
             } => Ty::AssociatedTypeProjection {
                 base: Box::new(base.into_ty()),
-                interface: interface.and_then(|i| i.into_interface()).map(Box::new),
+                // The projection's qualifier is always a normalized interface, so
+                // it round-trips back to an `Interface` here.
+                interface: Box::new(
+                    interface
+                        .into_interface()
+                        .unwrap_or_else(|| unreachable!("projection qualifier is an interface")),
+                ),
                 member,
                 attr,
             },
@@ -1544,9 +1540,7 @@ impl NormalTy {
                 member,
             } => NormalTy::AssociatedTypeProjection {
                 base: Box::new(base.substitute(var, replacement)),
-                interface: interface
-                    .as_ref()
-                    .map(|i| Box::new(i.substitute(var, replacement))),
+                interface: Box::new(interface.substitute(var, replacement)),
                 member: member.clone(),
             },
             // A nested μ binding the same name shadows it; do not substitute inside.

--- a/baml_language/crates/baml_type/src/normalize/tests.rs
+++ b/baml_language/crates/baml_type/src/normalize/tests.rs
@@ -93,7 +93,13 @@ impl TypeContext for Ctx {
             .collect()
     }
 
-    fn project(&self, base: &Ty, interface: &Interface, member: &Name) -> ProjectionStep {
+    fn project(
+        &self,
+        base: &Ty,
+        interface: &Interface,
+        member: &Name,
+        _fuel: u32,
+    ) -> ProjectionStep {
         self.projections
             .iter()
             .find(|(b, i, m, _)| b == base && i == &interface.name && m == member)

--- a/baml_language/crates/baml_type/src/normalize/tests.rs
+++ b/baml_language/crates/baml_type/src/normalize/tests.rs
@@ -135,7 +135,7 @@ fn typevar(s: &str) -> Ty {
 fn projection(base: Ty, iface_name: &str, member: &str) -> Ty {
     Ty::AssociatedTypeProjection {
         base: Box::new(base),
-        interface: Some(Box::new(Interface::new(qtn(iface_name), vec![], vec![]))),
+        interface: Box::new(Interface::new(qtn(iface_name), vec![], vec![])),
         member: Name::new(member),
         attr: TyAttr::default(),
     }
@@ -598,13 +598,17 @@ fn symbolic_associated_type_projection_subtypes_via_its_bound() {
     );
     ctx.requires.push((qtn("Summarizable"), qtn("Displayable")));
 
-    let proj = |interface: Option<Interface>| Ty::AssociatedTypeProjection {
+    let proj = |interface: Interface| Ty::AssociatedTypeProjection {
         base: Box::new(typevar("T")),
-        interface: interface.map(Box::new),
+        interface: Box::new(interface),
         member: Name::new("Item"),
         attr: TyAttr::default(),
     };
-    let iter_proj = proj(iface("Iter").as_interface());
+    let iter_proj = proj(
+        iface("Iter")
+            .as_interface()
+            .expect("iface() builds an interface existential"),
+    );
 
     assert!(is_subtype(&iter_proj, &iface("Summarizable"), &ctx));
     // …including transitively through the bound's `requires`.
@@ -613,43 +617,6 @@ fn symbolic_associated_type_projection_subtypes_via_its_bound() {
     assert!(!is_subtype(&iter_proj, &iface("Unrelated"), &ctx));
     // Reflexivity still holds (the projection is equal to itself).
     assert!(is_subtype(&iter_proj, &iter_proj, &ctx));
-    // An unresolved-interface projection is opaque — no bound to reason through.
-    assert!(!is_subtype(&proj(None), &iface("Summarizable"), &ctx));
-}
-
-#[test]
-fn projection_with_unresolved_interface_is_opaque() {
-    // A projection whose interface the TIR has not yet determined (`interface:
-    // None`) canonicalizes opaquely: it equals only a structurally-identical
-    // projection. In particular the two spellings of the *same* associated type —
-    // `(T as ?).Item` (unresolved) and `(T as Iter).Item` (resolved) — are NOT
-    // equated by this algebra, unlike the TIR's legacy
-    // `projection_views_equivalent`. This is the known gap (review item L3): it is
-    // resolved upstream by the TIR determining the interface (filling `Some(I)`,
-    // per `Ty::AssociatedTypeProjection`'s field TODO) BEFORE equivalence is flipped
-    // onto this algebra. If that flip lands while `None` can still occur, a real
-    // `(T as ?).M` vs `(T as I).M` comparison would give a false negative — this
-    // test pins the current opaque behavior so the gap can't be crossed silently.
-    let ctx = Ctx::default();
-    let proj =
-        |base: &str, interface: Option<Interface>, member: &str| Ty::AssociatedTypeProjection {
-            base: Box::new(typevar(base)),
-            interface: interface.map(Box::new),
-            member: Name::new(member),
-            attr: TyAttr::default(),
-        };
-    let unresolved = proj("T", None, "Item");
-    let resolved = proj("T", iface("Iter").as_interface(), "Item");
-
-    // Opaque: each spelling equals only itself.
-    assert!(equivalent(&unresolved, &unresolved, &ctx));
-    assert!(equivalent(&resolved, &resolved, &ctx));
-    // The gap: unresolved and resolved spellings of the same projection are not
-    // equated structurally (the legacy view-equivalence would equate them).
-    assert!(!equivalent(&unresolved, &resolved, &ctx));
-    // Distinct member / base are never equated.
-    assert!(!equivalent(&unresolved, &proj("T", None, "Other"), &ctx));
-    assert!(!equivalent(&unresolved, &proj("U", None, "Item"), &ctx));
 }
 
 // ── aliases & recursion ──────────────────────────────────────────────────--

--- a/baml_language/crates/baml_type/src/realized_ty.rs
+++ b/baml_language/crates/baml_type/src/realized_ty.rs
@@ -7,7 +7,7 @@
 //! deeply excludes the `typevar`-axis variants (`TypeVar`,
 //! `AssociatedTypeProjection`) and rejects them by name.
 
-use crate::{RealizedTy, TyAttr};
+use crate::{Name, RealizedTy, TyAttr, TypeName};
 
 impl RealizedTy {
     // --- Primitive constructors (default TyAttr) ---
@@ -19,9 +19,30 @@ impl RealizedTy {
         }
     }
 
+    /// `bigint` with default attributes.
+    pub fn bigint() -> Self {
+        RealizedTy::Bigint {
+            attr: TyAttr::default(),
+        }
+    }
+
+    /// `float` with default attributes.
+    pub fn float() -> Self {
+        RealizedTy::Float {
+            attr: TyAttr::default(),
+        }
+    }
+
     /// `string` with default attributes.
     pub fn string() -> Self {
         RealizedTy::String {
+            attr: TyAttr::default(),
+        }
+    }
+
+    /// `bool` with default attributes.
+    pub fn bool() -> Self {
+        RealizedTy::Bool {
             attr: TyAttr::default(),
         }
     }
@@ -33,10 +54,129 @@ impl RealizedTy {
         }
     }
 
+    /// `uint8array` with default attributes.
+    pub fn uint8array() -> Self {
+        RealizedTy::Uint8Array {
+            attr: TyAttr::default(),
+        }
+    }
+
     /// `unknown` (the top type) with default attributes.
     pub fn unknown() -> Self {
         RealizedTy::BuiltinUnknown {
             attr: TyAttr::default(),
+        }
+    }
+
+    // --- Compound constructors (default TyAttr) ---
+
+    /// `T[]` (list) with default attributes.
+    pub fn list(inner: RealizedTy) -> Self {
+        RealizedTy::List(Box::new(inner), TyAttr::default())
+    }
+
+    /// `map<K, V>` with default attributes.
+    pub fn map(key: RealizedTy, value: RealizedTy) -> Self {
+        RealizedTy::Map {
+            key: Box::new(key),
+            value: Box::new(value),
+            attr: TyAttr::default(),
+        }
+    }
+
+    /// `A | B | ...` (union) with default attributes.
+    pub fn union(members: impl IntoIterator<Item = RealizedTy>) -> Self {
+        RealizedTy::Union(members.into_iter().collect(), TyAttr::default())
+    }
+
+    /// `T?` (optional) — sugar for `T | null`, flattened and idempotent.
+    /// Mirrors [`crate::RuntimeTy::optional`].
+    pub fn optional(inner: RealizedTy) -> Self {
+        match inner {
+            RealizedTy::Union(mut members, attr) => {
+                if !members.iter().any(RealizedTy::is_null) {
+                    members.push(RealizedTy::null());
+                }
+                RealizedTy::Union(members, attr)
+            }
+            n @ RealizedTy::Null { .. } => n,
+            other => RealizedTy::Union(vec![other, RealizedTy::null()], TyAttr::default()),
+        }
+    }
+
+    /// `Class(name)` with default attributes (local module path), no type args.
+    pub fn class(name: &str) -> Self {
+        RealizedTy::Class(TypeName::local(name.into()), Vec::new(), TyAttr::default())
+    }
+
+    /// `Class(name, args)` — a parametric class instantiation.
+    pub fn class_with_args(name: TypeName, args: Vec<RealizedTy>) -> Self {
+        RealizedTy::Class(name, args, TyAttr::default())
+    }
+
+    /// `Class(name)` under the implicit `user` package, no type args.
+    pub fn user_class(name: &str) -> Self {
+        RealizedTy::Class(
+            TypeName::local(Name::new(name)),
+            Vec::new(),
+            TyAttr::default(),
+        )
+    }
+
+    /// `Class(name, args)` under the implicit `user` package.
+    pub fn user_class_with_args(name: &str, args: Vec<RealizedTy>) -> Self {
+        RealizedTy::Class(TypeName::local(Name::new(name)), args, TyAttr::default())
+    }
+
+    /// Opaque resource handle type (file, socket, HTTP response body).
+    pub fn resource() -> Self {
+        RealizedTy::Resource {
+            attr: TyAttr::default(),
+        }
+    }
+
+    /// Opaque structured prompt tree type for LLM calls.
+    pub fn prompt_ast() -> Self {
+        RealizedTy::PromptAst {
+            attr: TyAttr::default(),
+        }
+    }
+
+    /// Meta-type — a runtime value that wraps a [`RealizedTy`].
+    pub fn type_type() -> Self {
+        RealizedTy::Type {
+            attr: TyAttr::default(),
+        }
+    }
+
+    /// True if this is exactly the `null` type.
+    pub fn is_null(&self) -> bool {
+        matches!(self, RealizedTy::Null { .. })
+    }
+
+    /// True if this is a union that includes `null` — i.e. an optional type.
+    /// Mirrors [`crate::RuntimeTy::is_nullable_union`].
+    pub fn is_nullable_union(&self) -> bool {
+        matches!(self, RealizedTy::Union(members, _) if members.iter().any(RealizedTy::is_null))
+    }
+
+    /// Remove `null` from a nullable union, collapsing the result. Mirrors
+    /// [`crate::RuntimeTy::strip_null`].
+    pub fn strip_null(&self) -> RealizedTy {
+        match self {
+            RealizedTy::Union(members, attr) => {
+                let non_null: Vec<RealizedTy> =
+                    members.iter().filter(|m| !m.is_null()).cloned().collect();
+                match non_null.len() {
+                    0 => self.clone(),
+                    1 => non_null
+                        .into_iter()
+                        .next()
+                        .unwrap_or_else(|| unreachable!("len checked")),
+                    _ => RealizedTy::Union(non_null, attr.clone()),
+                }
+            }
+            _ => self.clone(),
         }
     }
 }

--- a/baml_language/crates/baml_type/src/realized_ty.rs
+++ b/baml_language/crates/baml_type/src/realized_ty.rs
@@ -135,11 +135,11 @@ mod tests {
         // it has no realized form — the conversion rejects it at the top level.
         let ty = Ty::AssociatedTypeProjection {
             base: Box::new(Ty::TypeVar(Name::new("T"), def())),
-            interface: Some(Box::new(Interface {
+            interface: Box::new(Interface {
                 name: qtn("Iterator"),
                 generics: vec![],
                 associated_types: vec![],
-            })),
+            }),
             member: Name::new("Item"),
             attr: def(),
         };

--- a/baml_language/crates/baml_type/src/runtime_ty.rs
+++ b/baml_language/crates/baml_type/src/runtime_ty.rs
@@ -406,10 +406,7 @@ pub fn lower_to_runtime(ty: &Ty, resolved: &ResolvedAliases) -> Result<RuntimeTy
             attr,
         } => RuntimeTy::AssociatedTypeProjection {
             base: Box::new(lower_to_runtime(base, resolved)?),
-            interface: interface
-                .as_ref()
-                .map(|i| lower_interface_to_runtime(i, resolved).map(Box::new))
-                .transpose()?,
+            interface: Box::new(lower_interface_to_runtime(interface, resolved)?),
             member: member.clone(),
             attr: attr.clone(),
         },
@@ -539,11 +536,11 @@ mod tests {
     fn round_trip_associated_type_projection() {
         let ty = Ty::AssociatedTypeProjection {
             base: Box::new(Ty::TypeVar(Name::new("T"), def())),
-            interface: Some(Box::new(Interface {
+            interface: Box::new(Interface {
                 name: qtn("Iterator"),
                 generics: vec![],
                 associated_types: vec![],
-            })),
+            }),
             member: Name::new("Item"),
             attr: def(),
         };

--- a/baml_language/crates/baml_type/src/template.rs
+++ b/baml_language/crates/baml_type/src/template.rs
@@ -31,9 +31,65 @@
 use std::fmt;
 
 use crate::{
-    Name, RealizedTy, RuntimeFunctionParamTy, RuntimeInterface, RuntimeTy, TyAttr, TyTemplate,
-    TyTemplateInterface, TypeName,
+    Interface, Name, RealizedFunctionParamTy, RealizedTy, RuntimeFunctionParamTy, RuntimeInterface,
+    RuntimeTy, Ty, TyAttr, TyTemplate, TyTemplateInterface, TypeName,
+    normalize::{ProjectionStep, TypeContext},
 };
+
+/// Why a [`TyTemplate::substitute`] failed to fully realize a template against a
+/// frame's realized type arguments.
+///
+/// Substitution at runtime must produce a fully realized [`RealizedTy`] — every
+/// frame reference filled, every projection reduced — or fail loudly. It never
+/// erases an unresolved position to `unknown` (which would silently break the
+/// value's compile-time type contract). Each variant is a broken invariant the VM
+/// surfaces as an internal error, not a user-facing type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubstituteError {
+    /// A `Wildcard` (dispatch-guard hole) reached materialization. A hole matches
+    /// any type at its position; it has no single concrete form to substitute to.
+    Wildcard,
+    /// An associated-type projection `(base as I).member` over a *realized* base
+    /// could not be reduced to a concrete type — no impl binding was found. The
+    /// compiler proves the impl exists for any realized base, so this is a broken
+    /// invariant at runtime rather than a legitimate outcome.
+    UnreducibleProjection {
+        /// The associated-type member that failed to reduce.
+        member: Name,
+    },
+    /// A projection reduced, but to a type that still contained a non-realized
+    /// position (named by `variant`). A realized base should reduce to a realized
+    /// witness, so this too is a broken invariant.
+    ProjectionNotRealized {
+        /// The associated-type member whose reduction was not realized.
+        member: Name,
+        /// The offending non-realized variant encountered in the reduced type.
+        variant: &'static str,
+    },
+}
+
+impl fmt::Display for SubstituteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Wildcard => write!(
+                f,
+                "a wildcard hole cannot be materialized to a concrete type"
+            ),
+            Self::UnreducibleProjection { member } => {
+                write!(
+                    f,
+                    "associated-type projection `.{member}` could not be reduced"
+                )
+            }
+            Self::ProjectionNotRealized { member, variant } => write!(
+                f,
+                "associated-type projection `.{member}` reduced to a non-realized `{variant}`"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SubstituteError {}
 
 impl TyTemplate {
     // --- Ergonomic constructors (default TyAttr) ---
@@ -71,99 +127,138 @@ impl TyTemplate {
         TyTemplate::Interface(name, args, associated_bindings, TyAttr::default())
     }
 
-    /// Walk the template once, substituting each `TypeArgRef(n)` with
-    /// `type_args[n]`.
+    /// Materialize this template against a frame's fully realized `type_args`,
+    /// producing a [`RealizedTy`] — every `TypeArgRef(n)` replaced by
+    /// `type_args[n]`, every associated-type projection reduced through `ctx` to
+    /// its impl binding.
     ///
-    /// If `n` is out of range (e.g. when a generic function is called from a
-    /// non-generic context that didn't supply type arguments), the substitution
-    /// falls back to `RuntimeTy::unknown()` rather than panicking. This handles
-    /// stdlib paths where `T`/`S` are declared in the function signature for
-    /// type-checking purposes but the corresponding Rust sys-op implementation
-    /// doesn't use the type-arg slot.
-    pub fn substitute(&self, type_args: &[RuntimeTy]) -> RuntimeTy {
+    /// Runtime type arguments are always realized (a generic call binds each
+    /// parameter to a concrete type), so a template that occurs at a
+    /// materialization site — a `LoadType`, a generic-function value, an instance's
+    /// class type args — realizes fully or fails. It never erases an unfilled
+    /// position to `unknown`; an out-of-range reference, a `Wildcard` hole (which
+    /// belongs only in dispatch guards, never in materialization), or an
+    /// unreducible projection is a broken invariant returned as a
+    /// [`SubstituteError`] for the VM to surface as an internal error.
+    ///
+    /// A projection reduces because its qualifier is always known (the interface is
+    /// non-optional) and its base realizes here, so `ctx.project` — the same impl
+    /// consultation the canonical algebra uses — determines the concrete witness.
+    pub fn substitute<C: TypeContext>(
+        &self,
+        type_args: &[RealizedTy],
+        ctx: &C,
+    ) -> Result<RealizedTy, SubstituteError> {
         match self {
             // ── Template-only leaves ──────────────────────────────────────────
-            Self::TypeArgRef(n) | Self::TypeArgRefOrWildcard(n) => type_args
+            // A frame reference materializes to its bound type argument. An
+            // *unbound* slot (the frame supplied no arg at this index) is a
+            // generic parameter that was never specialized at runtime — e.g. an
+            // `unknown`-typed value flowing into `string.from<T>` →
+            // `reflect.type_of<T>()`. Its honest realized reflection is the top
+            // type `unknown`: a concrete `RealizedTy`, not a leaked type variable,
+            // so this is not the typevar-erasure the migration eliminates. (The
+            // `TypeArgRefOrWildcard` bandaid resolves identically.)
+            Self::TypeArgRef(n) | Self::TypeArgRefOrWildcard(n) => Ok(type_args
                 .get(*n as usize)
                 .cloned()
-                .unwrap_or_else(RuntimeTy::unknown),
-            // A wildcard never reaches `LoadType` materialization; if it ever
-            // does, fall back to `unknown` rather than panicking.
-            Self::Wildcard => RuntimeTy::unknown(),
+                .unwrap_or_else(RealizedTy::unknown)),
+            // A wildcard is a dispatch-guard hole; it has no single concrete form.
+            Self::Wildcard => Err(SubstituteError::Wildcard),
 
-            // ── Composites: recurse, resolving nested template refs ───────────
-            Self::List(inner, attr) => {
-                RuntimeTy::List(Box::new(inner.substitute(type_args)), attr.clone())
-            }
-            Self::Map { key, value, attr } => RuntimeTy::Map {
-                key: Box::new(key.substitute(type_args)),
-                value: Box::new(value.substitute(type_args)),
+            // ── Composites: recurse, propagating failures ─────────────────────
+            Self::List(inner, attr) => Ok(RealizedTy::List(
+                Box::new(inner.substitute(type_args, ctx)?),
+                attr.clone(),
+            )),
+            Self::Map { key, value, attr } => Ok(RealizedTy::Map {
+                key: Box::new(key.substitute(type_args, ctx)?),
+                value: Box::new(value.substitute(type_args, ctx)?),
                 attr: attr.clone(),
-            },
-            Self::Union(parts, attr) => RuntimeTy::Union(
-                parts.iter().map(|p| p.substitute(type_args)).collect(),
+            }),
+            Self::Union(parts, attr) => Ok(RealizedTy::Union(
+                parts
+                    .iter()
+                    .map(|p| p.substitute(type_args, ctx))
+                    .collect::<Result<_, _>>()?,
                 attr.clone(),
-            ),
-            Self::Class(name, args, attr) => RuntimeTy::Class(
+            )),
+            Self::Class(name, args, attr) => Ok(RealizedTy::Class(
                 name.clone(),
-                args.iter().map(|a| a.substitute(type_args)).collect(),
+                args.iter()
+                    .map(|a| a.substitute(type_args, ctx))
+                    .collect::<Result<_, _>>()?,
                 attr.clone(),
-            ),
-            Self::Interface(name, args, associated_bindings, attr) => RuntimeTy::Interface(
+            )),
+            Self::Interface(name, args, associated_bindings, attr) => Ok(RealizedTy::Interface(
                 name.clone(),
-                args.iter().map(|a| a.substitute(type_args)).collect(),
+                args.iter()
+                    .map(|a| a.substitute(type_args, ctx))
+                    .collect::<Result<_, _>>()?,
                 associated_bindings
                     .iter()
-                    .map(|(name, ty)| (name.clone(), ty.substitute(type_args)))
-                    .collect(),
+                    .map(|(name, ty)| Ok((name.clone(), ty.substitute(type_args, ctx)?)))
+                    .collect::<Result<_, _>>()?,
                 attr.clone(),
-            ),
+            )),
             Self::Function {
                 params,
                 ret,
                 throws,
                 attr,
-            } => RuntimeTy::Function {
+            } => Ok(RealizedTy::Function {
                 params: params
                     .iter()
-                    .map(|p| RuntimeFunctionParamTy {
-                        name: p.name.clone(),
-                        ty: p.ty.substitute(type_args),
-                        mode: p.mode,
+                    .map(|p| {
+                        Ok(RealizedFunctionParamTy {
+                            name: p.name.clone(),
+                            ty: p.ty.substitute(type_args, ctx)?,
+                            mode: p.mode,
+                        })
                     })
-                    .collect(),
-                ret: Box::new(ret.substitute(type_args)),
-                throws: Box::new(throws.substitute(type_args)),
+                    .collect::<Result<_, _>>()?,
+                ret: Box::new(ret.substitute(type_args, ctx)?),
+                throws: Box::new(throws.substitute(type_args, ctx)?),
                 attr: attr.clone(),
-            },
-            Self::Future(value, error, attr) => RuntimeTy::Future(
-                Box::new(value.substitute(type_args)),
-                Box::new(error.substitute(type_args)),
+            }),
+            Self::Future(value, error, attr) => Ok(RealizedTy::Future(
+                Box::new(value.substitute(type_args, ctx)?),
+                Box::new(error.substitute(type_args, ctx)?),
                 attr.clone(),
-            ),
-            // The projection stays symbolic — only its base/interface positions
-            // realize. Resolving it to the witness type needs impl knowledge the
-            // substitution environment doesn't carry.
+            )),
+            // Realize the base, then reduce the projection to the impl's binding.
+            // The qualifier is always known and the base is realized here, so a
+            // realized-base projection reduces to exactly one concrete witness;
+            // anything else is a broken invariant, never a symbolic leaf.
             Self::AssociatedTypeProjection {
                 base,
                 interface,
                 member,
-                attr,
-            } => RuntimeTy::AssociatedTypeProjection {
-                base: Box::new(base.substitute(type_args)),
-                interface: Box::new(interface.substitute(type_args)),
-                member: member.clone(),
-                attr: attr.clone(),
-            },
+                ..
+            } => {
+                let base = base.substitute(type_args, ctx)?;
+                let interface = interface.substitute(type_args, ctx)?;
+                match ctx.project(base.as_ty(), &interface, member) {
+                    ProjectionStep::Reduced(reduced) => {
+                        RealizedTy::try_from(&reduced).map_err(|e| {
+                            SubstituteError::ProjectionNotRealized {
+                                member: member.clone(),
+                                variant: e.variant,
+                            }
+                        })
+                    }
+                    ProjectionStep::Opaque => Err(SubstituteError::UnreducibleProjection {
+                        member: member.clone(),
+                    }),
+                }
+            }
 
             // ── Realized leaf ─────────────────────────────────────────────────
             // No template refs and no nested type positions: it narrows to a
-            // `RealizedTy` (proving realizedness) which widens to `RuntimeTy` by
-            // transmute. A composite variant is handled above, so a narrowing
-            // failure here would be a missing arm — surfaced loudly.
-            other => RealizedTy::try_from(other.clone())
-                .unwrap_or_else(|e| unreachable!("realized-leaf template narrowing failed: {e}"))
-                .into(),
+            // `RealizedTy` directly. A composite variant is handled above, so a
+            // narrowing failure here would be a missing arm — surfaced loudly.
+            other => Ok(RealizedTy::try_from(other.clone())
+                .unwrap_or_else(|e| unreachable!("realized-leaf template narrowing failed: {e}"))),
         }
     }
 
@@ -238,21 +333,135 @@ impl TyTemplate {
             | Self::Never { .. } => false,
         }
     }
+
+    /// Compile-time counterpart to [`Self::substitute`]: resolve each
+    /// `TypeArgRef(n)` against `type_args` but leave every unresolved position
+    /// *symbolic*. An associated projection stays a projection; a `Wildcard` or
+    /// out-of-range reference falls back to `unknown`. Used by compile-time type
+    /// computation (e.g. a class field's type given the receiver's class args),
+    /// where the args may themselves be symbolic — an unspecialized generic — so
+    /// the result is a `RuntimeTy` that can still carry type variables, unlike the
+    /// runtime [`Self::substitute`], which realizes fully or fails.
+    #[expect(deprecated, reason = "TypeArgRefOrWildcard is a live template variant")]
+    pub fn substitute_symbolic(&self, type_args: &[RuntimeTy]) -> RuntimeTy {
+        match self {
+            Self::TypeArgRef(n) | Self::TypeArgRefOrWildcard(n) => type_args
+                .get(*n as usize)
+                .cloned()
+                .unwrap_or_else(RuntimeTy::unknown),
+            Self::Wildcard => RuntimeTy::unknown(),
+            Self::List(inner, attr) => {
+                RuntimeTy::List(Box::new(inner.substitute_symbolic(type_args)), attr.clone())
+            }
+            Self::Map { key, value, attr } => RuntimeTy::Map {
+                key: Box::new(key.substitute_symbolic(type_args)),
+                value: Box::new(value.substitute_symbolic(type_args)),
+                attr: attr.clone(),
+            },
+            Self::Union(parts, attr) => RuntimeTy::Union(
+                parts
+                    .iter()
+                    .map(|p| p.substitute_symbolic(type_args))
+                    .collect(),
+                attr.clone(),
+            ),
+            Self::Class(name, args, attr) => RuntimeTy::Class(
+                name.clone(),
+                args.iter()
+                    .map(|a| a.substitute_symbolic(type_args))
+                    .collect(),
+                attr.clone(),
+            ),
+            Self::Interface(name, args, associated_bindings, attr) => RuntimeTy::Interface(
+                name.clone(),
+                args.iter()
+                    .map(|a| a.substitute_symbolic(type_args))
+                    .collect(),
+                associated_bindings
+                    .iter()
+                    .map(|(name, ty)| (name.clone(), ty.substitute_symbolic(type_args)))
+                    .collect(),
+                attr.clone(),
+            ),
+            Self::Function {
+                params,
+                ret,
+                throws,
+                attr,
+            } => RuntimeTy::Function {
+                params: params
+                    .iter()
+                    .map(|p| RuntimeFunctionParamTy {
+                        name: p.name.clone(),
+                        ty: p.ty.substitute_symbolic(type_args),
+                        mode: p.mode,
+                    })
+                    .collect(),
+                ret: Box::new(ret.substitute_symbolic(type_args)),
+                throws: Box::new(throws.substitute_symbolic(type_args)),
+                attr: attr.clone(),
+            },
+            Self::Future(value, error, attr) => RuntimeTy::Future(
+                Box::new(value.substitute_symbolic(type_args)),
+                Box::new(error.substitute_symbolic(type_args)),
+                attr.clone(),
+            ),
+            Self::AssociatedTypeProjection {
+                base,
+                interface,
+                member,
+                attr,
+            } => RuntimeTy::AssociatedTypeProjection {
+                base: Box::new(base.substitute_symbolic(type_args)),
+                interface: Box::new(interface.substitute_symbolic(type_args)),
+                member: member.clone(),
+                attr: attr.clone(),
+            },
+            // A realized leaf narrows to `RealizedTy` then widens to `RuntimeTy`.
+            other => RealizedTy::try_from(other.clone())
+                .unwrap_or_else(|e| unreachable!("realized-leaf template narrowing failed: {e}"))
+                .into(),
+        }
+    }
 }
 
 impl TyTemplateInterface {
     /// Substitute frame type args through the interface's generic and
-    /// associated-binding positions (see [`TyTemplate::substitute`]).
-    fn substitute(&self, type_args: &[RuntimeTy]) -> RuntimeInterface {
+    /// associated-binding positions, producing the realized [`Interface`]
+    /// constraint used to reduce the enclosing projection (see
+    /// [`TyTemplate::substitute`]). Each realized position widens into `Ty` for the
+    /// [`Interface`] the projection query consumes.
+    fn substitute<C: TypeContext>(
+        &self,
+        type_args: &[RealizedTy],
+        ctx: &C,
+    ) -> Result<Interface, SubstituteError> {
+        Ok(Interface::new(
+            self.name.clone(),
+            self.generics
+                .iter()
+                .map(|g| g.substitute(type_args, ctx).map(Ty::from))
+                .collect::<Result<_, _>>()?,
+            self.associated_types
+                .iter()
+                .map(|(name, ty)| Ok((name.clone(), Ty::from(ty.substitute(type_args, ctx)?))))
+                .collect::<Result<_, _>>()?,
+        ))
+    }
+
+    /// Compile-time counterpart to [`Self::substitute`] (see
+    /// [`TyTemplate::substitute_symbolic`]): resolve frame refs but leave
+    /// unresolved positions symbolic, producing a `RuntimeInterface`.
+    fn substitute_symbolic(&self, type_args: &[RuntimeTy]) -> RuntimeInterface {
         RuntimeInterface::new(
             self.name.clone(),
             self.generics
                 .iter()
-                .map(|g| g.substitute(type_args))
+                .map(|g| g.substitute_symbolic(type_args))
                 .collect(),
             self.associated_types
                 .iter()
-                .map(|(name, ty)| (name.clone(), ty.substitute(type_args)))
+                .map(|(name, ty)| (name.clone(), ty.substitute_symbolic(type_args)))
                 .collect(),
         )
     }
@@ -361,19 +570,61 @@ impl TyTemplate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Interface, QualifiedTypeName, RuntimeTy};
+
+    /// A context-free [`TypeContext`]: these substitution tests exercise frame-ref
+    /// resolution and realization, not projection reduction, so every query fails
+    /// safe (no aliases, memberships, bounds, or reducible projections).
+    struct NoCtx;
+    impl TypeContext for NoCtx {
+        fn alias_def(&self, _: &QualifiedTypeName) -> Option<Ty> {
+            None
+        }
+        fn implements_interface(&self, _: &Ty, _: &Interface) -> bool {
+            false
+        }
+        fn type_var_bound(&self, _: &Name) -> Vec<Interface> {
+            Vec::new()
+        }
+        fn interface_requires(&self, _: &Interface, _: &Interface) -> bool {
+            false
+        }
+        fn enum_variants(&self, _: &QualifiedTypeName) -> Option<Vec<Name>> {
+            None
+        }
+        fn associated_type_bound(&self, _: &Interface, _: Name) -> Vec<Interface> {
+            Vec::new()
+        }
+        fn project(&self, _: &Ty, _: &Interface, _: &Name) -> ProjectionStep {
+            ProjectionStep::Opaque
+        }
+    }
+
+    /// Build a `RealizedTy` frame argument from a `RuntimeTy` constructor.
+    fn r(ty: RuntimeTy) -> RealizedTy {
+        RealizedTy::try_from(ty).expect("test arg is realized")
+    }
+
+    /// Materialize against a frame, upcasting the realized result to `RuntimeTy`
+    /// so it can be compared with `RuntimeTy`'s ergonomic constructors.
+    fn sub(tmpl: &TyTemplate, args: &[RealizedTy]) -> RuntimeTy {
+        RuntimeTy::from(
+            tmpl.substitute(args, &NoCtx)
+                .expect("substitution realizes"),
+        )
+    }
 
     #[test]
     fn concrete_template_substitutes_to_itself() {
         let tmpl = TyTemplate::from(RealizedTy::int());
-        assert_eq!(tmpl.substitute(&[]), RuntimeTy::int());
+        assert_eq!(sub(&tmpl, &[]), RuntimeTy::int());
         assert!(tmpl.is_fully_concrete());
     }
 
     #[test]
     fn type_arg_ref_substitutes_correctly() {
         let tmpl = TyTemplate::TypeArgRef(0);
-        let ty = tmpl.substitute(&[RuntimeTy::string()]);
-        assert_eq!(ty, RuntimeTy::string());
+        assert_eq!(sub(&tmpl, &[r(RuntimeTy::string())]), RuntimeTy::string());
         assert!(!tmpl.is_fully_concrete());
     }
 
@@ -381,8 +632,10 @@ mod tests {
     fn array_of_type_arg_ref() {
         // list<#0> with type_args=[int] → int[]
         let tmpl = TyTemplate::list(TyTemplate::TypeArgRef(0));
-        let ty = tmpl.substitute(&[RuntimeTy::int()]);
-        assert_eq!(ty, RuntimeTy::list(RuntimeTy::int()));
+        assert_eq!(
+            sub(&tmpl, &[r(RuntimeTy::int())]),
+            RuntimeTy::list(RuntimeTy::int())
+        );
         assert!(!tmpl.is_fully_concrete());
     }
 
@@ -393,9 +646,28 @@ mod tests {
             TyTemplate::TypeArgRef(0),
             TyTemplate::from(RealizedTy::null()),
         ]);
-        let ty = tmpl.substitute(&[RuntimeTy::string()]);
-        assert_eq!(ty, RuntimeTy::optional(RuntimeTy::string()));
+        assert_eq!(
+            sub(&tmpl, &[r(RuntimeTy::string())]),
+            RuntimeTy::optional(RuntimeTy::string())
+        );
         assert!(!tmpl.is_fully_concrete());
+    }
+
+    #[test]
+    fn out_of_range_type_arg_ref_is_unknown() {
+        // A frame ref with no matching arg is an unspecialized generic parameter;
+        // its honest realized reflection is the top type `unknown` (a concrete
+        // `RealizedTy`, not a leaked type variable).
+        let tmpl = TyTemplate::TypeArgRef(0);
+        assert_eq!(tmpl.substitute(&[], &NoCtx), Ok(RealizedTy::unknown()));
+    }
+
+    #[test]
+    fn wildcard_cannot_be_materialized() {
+        assert_eq!(
+            TyTemplate::Wildcard.substitute(&[r(RuntimeTy::int())], &NoCtx),
+            Err(SubstituteError::Wildcard)
+        );
     }
 
     #[test]
@@ -411,9 +683,8 @@ mod tests {
             TyTemplate::from(RealizedTy::string()),
         ]);
         assert!(tmpl.is_fully_concrete());
-        let ty = tmpl.substitute(&[]);
         assert_eq!(
-            ty,
+            sub(&tmpl, &[]),
             RuntimeTy::union([RuntimeTy::int(), RuntimeTy::string()])
         );
     }
@@ -434,9 +705,8 @@ mod tests {
             vec![TyTemplate::TypeArgRef(0)],
         );
         let user = RuntimeTy::user_class("User");
-        let result = tmpl.substitute(std::slice::from_ref(&user));
         assert_eq!(
-            result,
+            sub(&tmpl, &[r(user.clone())]),
             RuntimeTy::class_with_args(TypeName::local(crate::Name::new("Container")), vec![user])
         );
         assert!(!tmpl.is_fully_concrete());
@@ -446,9 +716,8 @@ mod tests {
     fn class_no_args_is_fully_concrete() {
         let tmpl = TyTemplate::class(TypeName::local(crate::Name::new("User")), vec![]);
         assert!(tmpl.is_fully_concrete());
-        let result = tmpl.substitute(&[]);
         assert_eq!(
-            result,
+            sub(&tmpl, &[]),
             RuntimeTy::Class(
                 TypeName::local(crate::Name::new("User")),
                 vec![],

--- a/baml_language/crates/baml_type/src/template.rs
+++ b/baml_language/crates/baml_type/src/template.rs
@@ -151,9 +151,7 @@ impl TyTemplate {
                 attr,
             } => RuntimeTy::AssociatedTypeProjection {
                 base: Box::new(base.substitute(type_args)),
-                interface: interface
-                    .as_ref()
-                    .map(|iface| Box::new(iface.substitute(type_args))),
+                interface: Box::new(interface.substitute(type_args)),
                 member: member.clone(),
                 attr: attr.clone(),
             },
@@ -212,13 +210,11 @@ impl TyTemplate {
                 base, interface, ..
             } => {
                 base.contains_wildcard()
-                    || interface.as_ref().is_some_and(|iface| {
-                        iface.generics.iter().any(Self::contains_wildcard)
-                            || iface
-                                .associated_types
-                                .iter()
-                                .any(|(_, ty)| ty.contains_wildcard())
-                    })
+                    || interface.generics.iter().any(Self::contains_wildcard)
+                    || interface
+                        .associated_types
+                        .iter()
+                        .any(|(_, ty)| ty.contains_wildcard())
             }
             // Realized leaves carry no nested type positions.
             Self::Int { .. }
@@ -342,16 +338,14 @@ impl TyTemplate {
                 attr,
             } => Ty::AssociatedTypeProjection {
                 base: Box::new(base.to_display_ty()),
-                interface: interface.as_ref().map(|iface| {
-                    Box::new(crate::Interface {
-                        name: iface.name.clone(),
-                        generics: iface.generics.iter().map(Self::to_display_ty).collect(),
-                        associated_types: iface
-                            .associated_types
-                            .iter()
-                            .map(|(n, t)| (n.clone(), t.to_display_ty()))
-                            .collect(),
-                    })
+                interface: Box::new(crate::Interface {
+                    name: interface.name.clone(),
+                    generics: interface.generics.iter().map(Self::to_display_ty).collect(),
+                    associated_types: interface
+                        .associated_types
+                        .iter()
+                        .map(|(n, t)| (n.clone(), t.to_display_ty()))
+                        .collect(),
                 }),
                 member: member.clone(),
                 attr: attr.clone(),

--- a/baml_language/crates/baml_type/src/template.rs
+++ b/baml_language/crates/baml_type/src/template.rs
@@ -66,6 +66,16 @@ pub enum SubstituteError {
         /// The offending non-realized variant encountered in the reduced type.
         variant: &'static str,
     },
+    /// A projection-reduction chain exceeded the fuel budget — a cyclic or
+    /// pathologically deep associated-type binding whose reduction re-enters
+    /// itself (`type X = (_ as I).Y` reducing back through `X`). The compiler is
+    /// expected to reject such cycles at declaration, so hitting this runtime
+    /// backstop is a broken invariant rather than a legitimate outcome; it stops
+    /// the recursion instead of overflowing the stack.
+    ProjectionFuelExhausted {
+        /// The associated-type member whose reduction chain did not terminate.
+        member: Name,
+    },
 }
 
 impl fmt::Display for SubstituteError {
@@ -84,6 +94,10 @@ impl fmt::Display for SubstituteError {
             Self::ProjectionNotRealized { member, variant } => write!(
                 f,
                 "associated-type projection `.{member}` reduced to a non-realized `{variant}`"
+            ),
+            Self::ProjectionFuelExhausted { member } => write!(
+                f,
+                "associated-type projection `.{member}` did not terminate within the reduction budget"
             ),
         }
     }
@@ -149,6 +163,26 @@ impl TyTemplate {
         type_args: &[RealizedTy],
         ctx: &C,
     ) -> Result<RealizedTy, SubstituteError> {
+        self.substitute_with_fuel(type_args, ctx, crate::normalize::PROJECTION_REDUCTION_FUEL)
+    }
+
+    /// [`Self::substitute`] with an explicit projection-reduction budget.
+    ///
+    /// `fuel` bounds the associated-type reduction chain: each projection reduced
+    /// through `ctx.project` (which realizes the impl binding by re-entering this
+    /// method) spends one unit, so a cyclic binding — `type X = (_ as I).Y`
+    /// reducing back through `X` — terminates with
+    /// [`SubstituteError::ProjectionFuelExhausted`] instead of overflowing the
+    /// stack. This is the runtime twin of the canonical algebra's fuel guard in
+    /// `normalize`'s `from_ty` walk. The public [`Self::substitute`] seeds the full
+    /// `PROJECTION_REDUCTION_FUEL` budget; `ctx.project` threads the remainder back
+    /// in for the binding it realizes.
+    pub fn substitute_with_fuel<C: TypeContext>(
+        &self,
+        type_args: &[RealizedTy],
+        ctx: &C,
+        fuel: u32,
+    ) -> Result<RealizedTy, SubstituteError> {
         match self {
             // ── Template-only leaves ──────────────────────────────────────────
             // A frame reference materializes to its bound type argument. An
@@ -168,36 +202,38 @@ impl TyTemplate {
 
             // ── Composites: recurse, propagating failures ─────────────────────
             Self::List(inner, attr) => Ok(RealizedTy::List(
-                Box::new(inner.substitute(type_args, ctx)?),
+                Box::new(inner.substitute_with_fuel(type_args, ctx, fuel)?),
                 attr.clone(),
             )),
             Self::Map { key, value, attr } => Ok(RealizedTy::Map {
-                key: Box::new(key.substitute(type_args, ctx)?),
-                value: Box::new(value.substitute(type_args, ctx)?),
+                key: Box::new(key.substitute_with_fuel(type_args, ctx, fuel)?),
+                value: Box::new(value.substitute_with_fuel(type_args, ctx, fuel)?),
                 attr: attr.clone(),
             }),
             Self::Union(parts, attr) => Ok(RealizedTy::Union(
                 parts
                     .iter()
-                    .map(|p| p.substitute(type_args, ctx))
+                    .map(|p| p.substitute_with_fuel(type_args, ctx, fuel))
                     .collect::<Result<_, _>>()?,
                 attr.clone(),
             )),
             Self::Class(name, args, attr) => Ok(RealizedTy::Class(
                 name.clone(),
                 args.iter()
-                    .map(|a| a.substitute(type_args, ctx))
+                    .map(|a| a.substitute_with_fuel(type_args, ctx, fuel))
                     .collect::<Result<_, _>>()?,
                 attr.clone(),
             )),
             Self::Interface(name, args, associated_bindings, attr) => Ok(RealizedTy::Interface(
                 name.clone(),
                 args.iter()
-                    .map(|a| a.substitute(type_args, ctx))
+                    .map(|a| a.substitute_with_fuel(type_args, ctx, fuel))
                     .collect::<Result<_, _>>()?,
                 associated_bindings
                     .iter()
-                    .map(|(name, ty)| Ok((name.clone(), ty.substitute(type_args, ctx)?)))
+                    .map(|(name, ty)| {
+                        Ok((name.clone(), ty.substitute_with_fuel(type_args, ctx, fuel)?))
+                    })
                     .collect::<Result<_, _>>()?,
                 attr.clone(),
             )),
@@ -212,18 +248,18 @@ impl TyTemplate {
                     .map(|p| {
                         Ok(RealizedFunctionParamTy {
                             name: p.name.clone(),
-                            ty: p.ty.substitute(type_args, ctx)?,
+                            ty: p.ty.substitute_with_fuel(type_args, ctx, fuel)?,
                             mode: p.mode,
                         })
                     })
                     .collect::<Result<_, _>>()?,
-                ret: Box::new(ret.substitute(type_args, ctx)?),
-                throws: Box::new(throws.substitute(type_args, ctx)?),
+                ret: Box::new(ret.substitute_with_fuel(type_args, ctx, fuel)?),
+                throws: Box::new(throws.substitute_with_fuel(type_args, ctx, fuel)?),
                 attr: attr.clone(),
             }),
             Self::Future(value, error, attr) => Ok(RealizedTy::Future(
-                Box::new(value.substitute(type_args, ctx)?),
-                Box::new(error.substitute(type_args, ctx)?),
+                Box::new(value.substitute_with_fuel(type_args, ctx, fuel)?),
+                Box::new(error.substitute_with_fuel(type_args, ctx, fuel)?),
                 attr.clone(),
             )),
             // Realize the base, then reduce the projection to the impl's binding.
@@ -236,9 +272,18 @@ impl TyTemplate {
                 member,
                 ..
             } => {
-                let base = base.substitute(type_args, ctx)?;
-                let interface = interface.substitute(type_args, ctx)?;
-                match ctx.project(base.as_ty(), &interface, member) {
+                let base = base.substitute_with_fuel(type_args, ctx, fuel)?;
+                let interface = interface.substitute(type_args, ctx, fuel)?;
+                // Spend one unit on *this* reduction before consulting `ctx.project`,
+                // which realizes the impl binding by re-entering `substitute` and can
+                // reach another projection. A cyclic binding would otherwise recurse
+                // forever; the backstop mirrors the canonical algebra's `from_ty`.
+                let Some(fuel) = fuel.checked_sub(1) else {
+                    return Err(SubstituteError::ProjectionFuelExhausted {
+                        member: member.clone(),
+                    });
+                };
+                match ctx.project(base.as_ty(), &interface, member, fuel) {
                     ProjectionStep::Reduced(reduced) => {
                         RealizedTy::try_from(&reduced).map_err(|e| {
                             SubstituteError::ProjectionNotRealized {
@@ -435,16 +480,22 @@ impl TyTemplateInterface {
         &self,
         type_args: &[RealizedTy],
         ctx: &C,
+        fuel: u32,
     ) -> Result<Interface, SubstituteError> {
         Ok(Interface::new(
             self.name.clone(),
             self.generics
                 .iter()
-                .map(|g| g.substitute(type_args, ctx).map(Ty::from))
+                .map(|g| g.substitute_with_fuel(type_args, ctx, fuel).map(Ty::from))
                 .collect::<Result<_, _>>()?,
             self.associated_types
                 .iter()
-                .map(|(name, ty)| Ok((name.clone(), Ty::from(ty.substitute(type_args, ctx)?))))
+                .map(|(name, ty)| {
+                    Ok((
+                        name.clone(),
+                        Ty::from(ty.substitute_with_fuel(type_args, ctx, fuel)?),
+                    ))
+                })
                 .collect::<Result<_, _>>()?,
         ))
     }
@@ -595,7 +646,7 @@ mod tests {
         fn associated_type_bound(&self, _: &Interface, _: Name) -> Vec<Interface> {
             Vec::new()
         }
-        fn project(&self, _: &Ty, _: &Interface, _: &Name) -> ProjectionStep {
+        fn project(&self, _: &Ty, _: &Interface, _: &Name, _fuel: u32) -> ProjectionStep {
             ProjectionStep::Opaque
         }
     }
@@ -667,6 +718,82 @@ mod tests {
         assert_eq!(
             TyTemplate::Wildcard.substitute(&[r(RuntimeTy::int())], &NoCtx),
             Err(SubstituteError::Wildcard)
+        );
+    }
+
+    /// `(#0 as Cyclic).member` — a projection whose base is a realized frame ref.
+    fn cyclic_projection(member: crate::Name) -> TyTemplate {
+        TyTemplate::AssociatedTypeProjection {
+            base: Box::new(TyTemplate::TypeArgRef(0)),
+            interface: Box::new(TyTemplateInterface {
+                name: TypeName::local(crate::Name::new("Cyclic")),
+                generics: vec![],
+                associated_types: vec![],
+            }),
+            member,
+            attr: TyAttr::default(),
+        }
+    }
+
+    /// A context whose every projection reduces by realizing *the same* projection
+    /// again — a cyclic associated-type binding. Without the fuel backstop this
+    /// recurses forever; with it, the chain exhausts its budget and fails.
+    struct CyclicCtx;
+    impl TypeContext for CyclicCtx {
+        fn alias_def(&self, _: &QualifiedTypeName) -> Option<Ty> {
+            None
+        }
+        fn implements_interface(&self, _: &Ty, _: &Interface) -> bool {
+            false
+        }
+        fn type_var_bound(&self, _: &Name) -> Vec<Interface> {
+            Vec::new()
+        }
+        fn interface_requires(&self, _: &Interface, _: &Interface) -> bool {
+            false
+        }
+        fn enum_variants(&self, _: &QualifiedTypeName) -> Option<Vec<Name>> {
+            None
+        }
+        fn associated_type_bound(&self, _: &Interface, _: Name) -> Vec<Interface> {
+            Vec::new()
+        }
+        fn project(&self, _: &Ty, _: &Interface, member: &Name, fuel: u32) -> ProjectionStep {
+            // The binding for `member` is the same projection, so realizing it
+            // re-enters `project`. The threaded `fuel` bounds the cycle; an
+            // exhausted budget surfaces as a substitution error (→ `Opaque`).
+            match cyclic_projection(member.clone()).substitute_with_fuel(
+                &[RealizedTy::unknown()],
+                self,
+                fuel,
+            ) {
+                Ok(reduced) => ProjectionStep::Reduced(reduced.into()),
+                Err(_) => ProjectionStep::Opaque,
+            }
+        }
+    }
+
+    #[test]
+    fn projection_fuel_guard_fires_at_zero() {
+        // With no remaining budget a projection cannot even attempt its reduction.
+        let proj = cyclic_projection(crate::Name::new("Item"));
+        assert_eq!(
+            proj.substitute_with_fuel(&[RealizedTy::unknown()], &CyclicCtx, 0),
+            Err(SubstituteError::ProjectionFuelExhausted {
+                member: crate::Name::new("Item"),
+            })
+        );
+    }
+
+    #[test]
+    fn cyclic_projection_terminates_instead_of_overflowing() {
+        // A cyclic associated-type binding would realize to itself forever without
+        // the backstop; with it, the chain exhausts its fuel and fails rather than
+        // overflowing the stack.
+        let proj = cyclic_projection(crate::Name::new("Item"));
+        assert!(
+            proj.substitute_with_fuel(&[RealizedTy::unknown()], &CyclicCtx, 16)
+                .is_err()
         );
     }
 

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -12,6 +12,22 @@ use bex_vm::BexVm;
 
 use crate::{BexEngine, EngineError};
 
+/// Narrow a host-supplied [`RuntimeTy`] to the [`baml_type::RealizedTy`] the VM
+/// heap stores for a value's type (an array's element type, a map's key/value
+/// types, an instance's class type args, a reflected `type` value, a host
+/// callable's signature).
+///
+/// A runtime value always carries a fully realized type, so a host that supplies
+/// a non-realized type — an unfilled type variable or an associated-type
+/// projection, the only positions [`RuntimeTy`] admits that
+/// [`baml_type::RealizedTy`] does not — is an FFI contract violation. It is
+/// surfaced loudly as an [`EngineError::TypeMismatch`] rather than erased.
+fn realize_host_ty(ty: RuntimeTy) -> Result<baml_type::RealizedTy, EngineError> {
+    baml_type::RealizedTy::try_from(ty).map_err(|e| EngineError::TypeMismatch {
+        message: format!("host-supplied type is not realized: {e}"),
+    })
+}
+
 // ============================================================================
 // VM Value to External Conversion
 // ============================================================================
@@ -148,7 +164,11 @@ impl BexEngine {
                     let handle = self.heap.create_handle(ptr);
                     let ty = RuntimeTy::Class(
                         class.name.clone(),
-                        instance.class_type_args.to_vec(),
+                        instance
+                            .class_type_args
+                            .iter()
+                            .map(baml_type::RuntimeTy::from)
+                            .collect(),
                         baml_type::TyAttr::default(),
                     );
                     return Ok(BexExternalValue::Adt(BexExternalAdt::TaggedHeapHandle {
@@ -174,9 +194,13 @@ impl BexEngine {
                         .zip(instance.fields.iter())
                         .map(|(class_field, slot)| {
                             let value = slot.load();
-                            let field_type = class_field
-                                .field_template
-                                .substitute(&instance.class_type_args);
+                            let field_type = class_field.field_template.substitute_symbolic(
+                                &instance
+                                    .class_type_args
+                                    .iter()
+                                    .map(baml_type::RuntimeTy::from)
+                                    .collect::<Vec<_>>(),
+                            );
                             Ok((
                                 class_field.name.clone(),
                                 self.convert_vm_value_to_external_with_type(
@@ -190,7 +214,11 @@ impl BexEngine {
 
                 Ok(BexExternalValue::Instance {
                     class_name: class.name.to_string(),
-                    type_args: instance.class_type_args.to_vec(),
+                    type_args: instance
+                        .class_type_args
+                        .iter()
+                        .map(baml_type::RuntimeTy::from)
+                        .collect(),
                     fields: fields?,
                 })
             }
@@ -247,7 +275,9 @@ impl BexEngine {
             }),
             Object::Bigint(bi) => Ok(BexExternalValue::Bigint((**bi).clone())),
             Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
-            Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type((**ty).clone()))),
+            Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(
+                (**ty).clone().into(),
+            ))),
             Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.to_vec())),
             Object::RustData(arc) => Ok(bex_external_types::try_convert_rust_data(arc)
                 .unwrap_or_else(|| BexExternalValue::RustData(arc.clone()))),
@@ -662,6 +692,7 @@ impl BexEngine {
                 element_type,
                 items,
             } => {
+                let element_ty = realize_host_ty(element_type)?;
                 let values = items
                     .into_iter()
                     .map(|v| self.convert_external_to_vm_value(holder, v))
@@ -670,7 +701,7 @@ impl BexEngine {
                     holder
                         .holder_mut()
                         .tlab_mut()
-                        .alloc_array(element_type, values),
+                        .alloc_array(element_ty, values),
                 )
             }
             BexExternalValue::Map {
@@ -678,6 +709,8 @@ impl BexEngine {
                 value_type,
                 entries,
             } => {
+                let key_ty = realize_host_ty(key_type)?;
+                let value_ty = realize_host_ty(value_type)?;
                 let values = entries
                     .into_iter()
                     .map(|(k, v)| {
@@ -689,7 +722,7 @@ impl BexEngine {
                     holder
                         .holder_mut()
                         .tlab_mut()
-                        .alloc_map(key_type, value_type, values),
+                        .alloc_map(key_ty, value_ty, values),
                 )
             }
             BexExternalValue::Uint8Array(bytes) => {
@@ -748,11 +781,15 @@ impl BexEngine {
                         Some(&class_field.field_type),
                     )?);
                 }
+                let realized_type_args = type_args
+                    .into_iter()
+                    .map(realize_host_ty)
+                    .collect::<Result<Box<[_]>, _>>()?;
                 Value::object(
                     holder
                         .holder_mut()
                         .tlab_mut()
-                        .alloc_instance_with_type_args(*class_ptr, type_args, values),
+                        .alloc_instance_with_type_args(*class_ptr, realized_type_args, values),
                 )
             }
             BexExternalValue::Variant {
@@ -793,6 +830,7 @@ impl BexEngine {
                 Value::object(holder.holder_mut().tlab_mut().alloc_collector(c))
             }
             BexExternalValue::Adt(BexExternalAdt::Type(ty)) => {
+                let ty = realize_host_ty(ty)?;
                 Value::object(holder.holder_mut().tlab_mut().alloc_type(ty))
             }
             BexExternalValue::Adt(BexExternalAdt::PromptAst(_)) => {
@@ -909,15 +947,27 @@ impl BexEngine {
                     }
                     other => other,
                 };
+                // The VM heap stores the callable's signature as `RealizedTy`
+                // (`HostClosure`'s fields). A bound host callable's declared
+                // function type is realized here; a non-realized position (an
+                // unfilled type variable) is a contract violation surfaced as a
+                // type mismatch rather than erased.
+                let realized_params = params
+                    .iter()
+                    .map(baml_type::RealizedFunctionParamTy::try_from)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| EngineError::TypeMismatch {
+                        message: format!("host callable parameter type is not realized: {e}"),
+                    })?;
                 let host_closure = bex_vm_types::HostClosure {
                     handle: arc,
-                    ret_ty: Box::new(ret),
-                    throws_ty: Box::new(normalized_throws),
+                    ret_ty: Box::new(realize_host_ty(ret)?),
+                    throws_ty: Box::new(realize_host_ty(normalized_throws)?),
                     arity: params.len(),
                     // Capture the declared params (names + optionality) so the VM
                     // can split the call args into positional + supplied-optional
                     // (by name) on dispatch, for the per-bridge argument reshape.
-                    params: Box::new(params.clone()),
+                    params: Box::new(realized_params),
                 };
                 Value::object(
                     holder
@@ -2117,7 +2167,9 @@ impl BexEngine {
                     };
                     for class_field in &class.fields {
                         if let Some(field_value) = fields.get(&class_field.name) {
-                            let field_ty = class_field.field_template.substitute(expected_args);
+                            let field_ty = class_field
+                                .field_template
+                                .substitute_symbolic(expected_args);
                             self.validate_host_return_schema(field_value, &field_ty)?;
                         }
                         // Missing fields are reported by
@@ -2252,7 +2304,11 @@ fn find_matching_union_member(value: Value, members: &[RuntimeTy]) -> Option<&Ru
                             matches!(m, RuntimeTy::Class(tn, expected_args, _)
                                 if *tn == class.name
                                 && (expected_args.is_empty()
-                                    || expected_args[..] == inst.class_type_args[..]))
+                                    || (expected_args.len() == inst.class_type_args.len()
+                                        && expected_args
+                                            .iter()
+                                            .zip(inst.class_type_args.iter())
+                                            .all(|(e, a)| e == a.as_runtime_ty()))))
                         })
                     } else {
                         None
@@ -2389,7 +2445,11 @@ pub(crate) fn vm_arg_to_external(vm: &BexVm, value: Value) -> BexExternalValue {
 
                     BexExternalValue::Instance {
                         class_name,
-                        type_args: instance.class_type_args.to_vec(),
+                        type_args: instance
+                            .class_type_args
+                            .iter()
+                            .map(baml_type::RuntimeTy::from)
+                            .collect(),
                         fields,
                     }
                 }

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -1390,13 +1390,13 @@ fn template_max_type_arg_ref(t: &baml_type::TyTemplate) -> Option<u32> {
             base, interface, ..
         } => template_max_type_arg_ref(base)
             .into_iter()
-            .chain(interface.iter().flat_map(|iface| {
-                iface
+            .chain(
+                interface
                     .generics
                     .iter()
-                    .chain(iface.associated_types.iter().map(|(_, t)| t))
-                    .filter_map(template_max_type_arg_ref)
-            }))
+                    .chain(interface.associated_types.iter().map(|(_, t)| t))
+                    .filter_map(template_max_type_arg_ref),
+            )
             .max(),
         // Realized leaves and `Wildcard` carry no frame ref.
         _ => None,

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -317,6 +317,50 @@ impl FutureManagerGuard<'_> {
         Ok(())
     }
 
+    /// Settle `id` to `InternalError` from the spawn task's terminal
+    /// engine-error path, where the child thread (and its heap permit) are
+    /// already gone.
+    ///
+    /// Tolerant counterpart to [`Self::internal_error_future`]: that helper
+    /// runs on the still-live child thread, where a non-`Pending` future is an
+    /// invariant violation worth asserting. Here the thread died on an
+    /// arbitrary engine-error escape path, so the future may legitimately
+    /// already be settled (the error can strike after a successful settle) —
+    /// an already-settled or unknown future is left as-is and the error only
+    /// logged. Like `internal_error_future`, the `active_futures` entry is
+    /// retained so a later `Await` resumes against the same heap object and
+    /// surfaces the original [`EngineError`] instead of parking forever.
+    pub fn settle_spawn_engine_error(&mut self, id: FutureId, err: EngineError) {
+        let Some(entry) = self.holder().active_futures.get(&id) else {
+            tracing::error!(
+                ?id,
+                ?err,
+                "spawn thread terminated with an engine error but its future \
+                 is not active; error dropped"
+            );
+            return;
+        };
+        // SAFETY: caller holds the heap permit via `self.proof`.
+        let fut = match unsafe { entry.future_ref() } {
+            Ok(fut) => fut,
+            Err(handle_err) => {
+                tracing::error!(
+                    ?id,
+                    ?err,
+                    ?handle_err,
+                    "spawn thread terminated with an engine error but its \
+                     future handle is unreadable; error dropped"
+                );
+                return;
+            }
+        };
+        // A lost CAS means the future already reached a terminal state (a
+        // settle that preceded the error, or a concurrent `f.cancel()`);
+        // that state is the one the awaiter observes, and it is already a
+        // wake-up — no parked parent is left behind either way.
+        let _ = fut.settle_internal_error(Box::new(err));
+    }
+
     /// Remove and return the heap `Future` for `id` if it's still
     /// `Pending`. Returns `Ok(None)` if the future has already been
     /// settled out-of-band (e.g. via BAML's `f.cancel()` which transitions

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -843,7 +843,8 @@ fn host_call_type_arg(
     // the await a moving GC may relocate/collect this `Object::Type` and the raw
     // pointer would dangle. The caller clones the `RuntimeTy` out before awaiting.
     match unsafe { ptr.get() } {
-        Object::Type(ty) => Ok((**ty).clone()),
+        // `Object::Type` stores a realized type; widen it to the boundary `RuntimeTy`.
+        Object::Type(ty) => Ok((**ty).clone().into()),
         _ => Err(bad_slot()),
     }
 }
@@ -987,7 +988,11 @@ fn value_runtime_baml_ty(value: Value, _proof: bex_heap::PermitProof<'_>) -> Opt
                     };
                     Some(RuntimeTy::Class(
                         class.name.clone(),
-                        instance.class_type_args.to_vec(),
+                        instance
+                            .class_type_args
+                            .iter()
+                            .map(baml_type::RuntimeTy::from)
+                            .collect(),
                         TyAttr::default(),
                     ))
                 }
@@ -2555,6 +2560,22 @@ impl BexEngine {
         // against the callee's generic params. An empty map seeds nothing
         // (non-generic callee) or all-unbound slots (generic callee with no
         // bindings).
+        // The runtime frame holds realized type args; narrow the host-supplied
+        // bindings at this FFI boundary, rejecting a non-realized binding rather
+        // than erasing it.
+        let type_args = type_args
+            .into_iter()
+            .map(|(name, ty)| match baml_type::RealizedTy::try_from(&ty) {
+                Ok(realized) => Ok((name, realized)),
+                Err(e) => Err(EngineError::VmInternalError(
+                    bex_vm::errors::VmInternalError::TypeSubstitution {
+                        message: format!(
+                            "host entry-point type argument `{name}` is not realized: {e}"
+                        ),
+                    },
+                )),
+            })
+            .collect::<Result<indexmap::IndexMap<_, _>, _>>()?;
         thread
             .vm
             .set_entry_point_with_type_args(entry_ptr, &vm_args, type_args);
@@ -2800,7 +2821,11 @@ impl BexEngine {
             if let Some(RuntimeTy::Class(_, declared_args, _)) = param_types.first() {
                 let mut bindings = indexmap::IndexMap::new();
                 for (declared, concrete) in declared_args.iter().zip(seed_type_args.iter()) {
-                    crate::conversion::collect_type_var_bindings(declared, concrete, &mut bindings);
+                    crate::conversion::collect_type_var_bindings(
+                        declared,
+                        concrete.as_runtime_ty(),
+                        &mut bindings,
+                    );
                 }
                 return_type = crate::conversion::substitute_type_vars(&return_type, &bindings);
             }
@@ -2855,6 +2880,10 @@ impl BexEngine {
         // pairing each with the callee's generic-param name. A lambda has no
         // declared param names, so fall back to the index as a key; the named
         // lowering then emits the unnamed bindings in order.
+        // The seed args are realized (a value's captured/class type args); widen
+        // them into the `RuntimeTy` the host `type_args` channel carries. They are
+        // re-narrowed to `RealizedTy` at the `set_entry_point_with_type_args`
+        // boundary inside `run_entry_point`.
         let seed_type_args: indexmap::IndexMap<String, RuntimeTy> = seed_type_args
             .into_iter()
             .enumerate()
@@ -2864,7 +2893,7 @@ impl BexEngine {
                         .get(i)
                         .cloned()
                         .unwrap_or_else(|| i.to_string()),
-                    ty,
+                    RuntimeTy::from(ty),
                 )
             })
             .collect();

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -4111,6 +4111,28 @@ impl BexEngine {
                         ?future_id,
                         "spawn thread terminated with engine error"
                     );
+                    // The event loop settles the future itself on the VM-error
+                    // paths (`InternalError` / `TracedInternalError` /
+                    // unhandled-throw arms), but an `EngineError` escaping
+                    // through any other `?` in the loop arrives here with the
+                    // future still `Pending` — and an unsettled future parks
+                    // every awaiter forever (the parent, its parent, …). This
+                    // arm is the single choke point that restores the
+                    // propagation chain: settle the future with the engine
+                    // error so the awaiter re-raises it, *its* terminal path
+                    // settles the next future up, and the root surfaces the
+                    // original error to the host. The thread's own permit died
+                    // with the event loop, so settle under a fresh rootless
+                    // permit (`()` roots nothing; the future entry itself
+                    // roots the heap object).
+                    let admin = engine.heap_permit_manager.new_permit(()).await;
+                    let active = admin.acquire().await;
+                    engine
+                        .futures
+                        .acquire(active.proof())
+                        .await
+                        .settle_spawn_engine_error(future_id, err);
+                    child_cancel.cancel();
                 }
             }
         };

--- a/baml_language/crates/bex_engine/src/trace_heap.rs
+++ b/baml_language/crates/bex_engine/src/trace_heap.rs
@@ -321,7 +321,11 @@ impl TraceSnapshotBuilder {
                         .collect();
                     self.alloc(TraceValue::Instance {
                         type_name: class.name.to_string(),
-                        type_args: instance.class_type_args.to_vec(),
+                        type_args: instance
+                            .class_type_args
+                            .iter()
+                            .map(baml_type::RuntimeTy::from)
+                            .collect(),
                         fields,
                     })
                 } else {
@@ -617,10 +621,10 @@ mod tests {
             .await;
         let array_ptr = permit
             .tlab_mut()
-            .alloc_array(baml_type::RuntimeTy::unknown(), vec![]);
+            .alloc_array(baml_type::RealizedTy::unknown(), vec![]);
         unsafe {
             *array_ptr.get_mut() = Object::Array(bex_vm_types::types::Array::new(
-                baml_type::RuntimeTy::unknown(),
+                baml_type::RealizedTy::unknown(),
                 vec![Value::int(1), Value::object(array_ptr)],
             ));
         }

--- a/baml_language/crates/bex_engine/src/trace_value_encode.rs
+++ b/baml_language/crates/bex_engine/src/trace_value_encode.rs
@@ -662,13 +662,12 @@ fn runtime_ty_to_variant(ty: &RuntimeTy) -> BamlTyVariant {
             ..
         } => BamlTyVariant::AssociatedTypeProjection(BamlTyAssociatedTypeProjection {
             base: Some(Box::new(runtime_ty_to_proto_ty(base))),
-            interface: interface.as_deref().map(|interface| {
-                Box::new(interface_to_proto_ty(
-                    &interface.name,
-                    &interface.generics,
-                    &interface.associated_types,
-                ))
-            }),
+            // Always present on the Rust side; the wire field stays optional.
+            interface: Some(Box::new(interface_to_proto_ty(
+                &interface.name,
+                &interface.generics,
+                &interface.associated_types,
+            ))),
             member: member.as_str().to_string(),
         }),
         RuntimeTy::BuiltinUnknown { .. } => BamlTyVariant::Unknown(BamlTyUnknown {}),

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -572,7 +572,8 @@ impl<'a> BexValue<'a> {
                     actual: obj.to_string(),
                 });
             };
-            Ok((**ty).clone())
+            // `Object::Type` stores a realized type; widen it into `RuntimeTy`.
+            Ok((**ty).clone().into())
         }
 
         match self {
@@ -826,7 +827,13 @@ fn convert_object(
                 .collect::<Result<_, _>>()?;
             Ok(BexExternalValue::Instance {
                 class_name: class.name.to_string(),
-                type_args: instance.class_type_args.to_vec(),
+                // Instances store realized class type args; widen them into the
+                // `RuntimeTy` the external boundary carries.
+                type_args: instance
+                    .class_type_args
+                    .iter()
+                    .map(baml_type::RuntimeTy::from)
+                    .collect(),
                 fields,
             })
         }
@@ -851,7 +858,9 @@ fn convert_object(
             })
         }
         Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
-        Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type((**ty).clone()))),
+        Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(
+            (**ty).clone().into(),
+        ))),
         Object::Bigint(bi) => Ok(BexExternalValue::Bigint((**bi).clone())),
         Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.to_vec())),
         Object::RustData(data) => Ok(bex_external_types::try_convert_rust_data(data)

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -1323,7 +1323,7 @@ mod tests {
         // Instance has 3 fields but class expects 1 — should panic on verify
         let _bad_instance = tlab.alloc(Object::Instance(bex_vm_types::types::Instance::new(
             class_ptr,
-            vec![],
+            Box::new([]),
             vec![Value::int(1), Value::int(2), Value::int(3)],
         )));
 
@@ -1368,7 +1368,7 @@ mod tests {
 
         // Allocate an array that references the string
         let arr = tlab.alloc_array(
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::unknown(),
             vec![Value::object(str_obj)],
         );
 
@@ -1528,8 +1528,8 @@ mod tests {
         let mut map = indexmap::IndexMap::new();
         map.insert(bex_str::BexStr::from("key"), Value::object(str_obj));
         let map_obj = tlab.alloc_map(
-            baml_type::RuntimeTy::string(),
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::string(),
+            baml_type::RealizedTy::unknown(),
             map,
         );
 
@@ -1653,20 +1653,20 @@ mod tests {
         let leaf_str = tlab.alloc_string("leaf".to_string());
 
         let inner_array = tlab.alloc_array(
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::unknown(),
             vec![Value::object(leaf_str)],
         );
 
         let mut map = indexmap::IndexMap::new();
         map.insert(bex_str::BexStr::from("nested"), Value::object(inner_array));
         let middle_map = tlab.alloc_map(
-            baml_type::RuntimeTy::string(),
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::string(),
+            baml_type::RealizedTy::unknown(),
             map,
         );
 
         let outer_array = tlab.alloc_array(
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::unknown(),
             vec![Value::object(middle_map)],
         );
 
@@ -2250,7 +2250,7 @@ mod tests {
     fn test_gc_leaf_type_preserved() {
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
-        let ptr = tlab.alloc(Object::Type(Box::new(baml_type::RuntimeTy::Int {
+        let ptr = tlab.alloc(Object::Type(Box::new(baml_type::RealizedTy::Int {
             attr: baml_type::TyAttr::default(),
         })));
 
@@ -2258,7 +2258,7 @@ mod tests {
         let Object::Type(ty) = (unsafe { new_roots[0].get() }) else {
             panic!("not type")
         };
-        assert!(matches!(**ty, baml_type::RuntimeTy::Int { .. }));
+        assert!(matches!(**ty, baml_type::RealizedTy::Int { .. }));
     }
 
     #[test]
@@ -2266,10 +2266,10 @@ mod tests {
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
-        let arr = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![]);
+        let arr = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![]);
         let map = tlab.alloc_map(
-            baml_type::RuntimeTy::string(),
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::string(),
+            baml_type::RealizedTy::unknown(),
             indexmap::IndexMap::new(),
         );
 
@@ -2298,9 +2298,9 @@ mod tests {
 
         // D -> C -> B -> A (leaf string wrapped in nested arrays)
         let a = tlab.alloc_string("a".to_string());
-        let b = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(a)]);
-        let c = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(b)]);
-        let d = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(c)]);
+        let b = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![Value::object(a)]);
+        let c = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![Value::object(b)]);
+        let d = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![Value::object(c)]);
 
         let (stats, new_roots, _) = unsafe { heap.collect_garbage(&[d]) };
         assert_eq!(stats.live_count, 4);
@@ -2338,7 +2338,7 @@ mod tests {
         let children: Vec<Value> = (0..5)
             .map(|i| Value::object(tlab.alloc_string(format!("child_{i}"))))
             .collect();
-        let parent = tlab.alloc_array(baml_type::RuntimeTy::unknown(), children);
+        let parent = tlab.alloc_array(baml_type::RealizedTy::unknown(), children);
 
         // Also allocate explicit garbage
         let _garbage = tlab.alloc_string("garbage".to_string());
@@ -2355,10 +2355,14 @@ mod tests {
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
         let shared = tlab.alloc_string("shared".to_string());
-        let parent_a =
-            tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(shared)]);
-        let parent_b =
-            tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(shared)]);
+        let parent_a = tlab.alloc_array(
+            baml_type::RealizedTy::unknown(),
+            vec![Value::object(shared)],
+        );
+        let parent_b = tlab.alloc_array(
+            baml_type::RealizedTy::unknown(),
+            vec![Value::object(shared)],
+        );
 
         let (stats, new_roots, _) = unsafe { heap.collect_garbage(&[parent_a, parent_b]) };
         // 2 parents + 1 shared child (not 4 — shared object copied only once)
@@ -2391,10 +2395,10 @@ mod tests {
 
         // root -> [B, C], B -> [D], C -> [D]
         let d = tlab.alloc_string("diamond_bottom".to_string());
-        let b = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(d)]);
-        let c = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(d)]);
+        let b = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![Value::object(d)]);
+        let c = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![Value::object(d)]);
         let root = tlab.alloc_array(
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::unknown(),
             vec![Value::object(b), Value::object(c)],
         );
 
@@ -2437,14 +2441,14 @@ mod tests {
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
         // Create A (array placeholder) and B (cell pointing to A), then patch A -> B
-        let a = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![]); // placeholder, will be patched
+        let a = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![]); // placeholder, will be patched
         let b = tlab.alloc(Object::Cell(bex_vm_types::types::Cell::new(Value::object(
             a,
         ))));
         // Patch A to reference B, forming a cycle
         unsafe {
             *a.get_mut() = Object::Array(bex_vm_types::types::Array::new(
-                baml_type::RuntimeTy::unknown(),
+                baml_type::RealizedTy::unknown(),
                 vec![Value::object(b)],
             ));
         }
@@ -2478,12 +2482,12 @@ mod tests {
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
         // Island: three mutually-referencing objects, none reachable from roots
-        let x = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![]); // placeholder
-        let y = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(x)]);
-        let z = tlab.alloc_array(baml_type::RuntimeTy::unknown(), vec![Value::object(y)]);
+        let x = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![]); // placeholder
+        let y = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![Value::object(x)]);
+        let z = tlab.alloc_array(baml_type::RealizedTy::unknown(), vec![Value::object(y)]);
         unsafe {
             *x.get_mut() = Object::Array(bex_vm_types::types::Array::new(
-                baml_type::RuntimeTy::unknown(),
+                baml_type::RealizedTy::unknown(),
                 vec![Value::object(z)],
             ));
         }
@@ -2506,7 +2510,7 @@ mod tests {
         let mut current = tlab.alloc_string("leaf".to_string());
         for _ in 0..99 {
             current = tlab.alloc_array(
-                baml_type::RuntimeTy::unknown(),
+                baml_type::RealizedTy::unknown(),
                 vec![Value::object(current)],
             );
         }
@@ -2612,7 +2616,7 @@ mod tests {
 
         // --- Container: Object::Array ---
         let array_container = tlab.alloc_array(
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::unknown(),
             vec![Value::object(leaf_for_array)],
         );
 
@@ -2620,8 +2624,8 @@ mod tests {
         let mut map_data = indexmap::IndexMap::new();
         map_data.insert(bex_str::BexStr::from("k"), Value::object(leaf_for_map));
         let map_container = tlab.alloc_map(
-            baml_type::RuntimeTy::string(),
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::string(),
+            baml_type::RealizedTy::unknown(),
             map_data,
         );
 
@@ -2658,7 +2662,7 @@ mod tests {
         })));
         let instance_container = tlab.alloc(Object::Instance(Instance::new(
             class_ptr,
-            vec![],
+            Box::new([]),
             vec![Value::object(leaf_string)],
         )));
 

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -67,7 +67,7 @@ impl TlabChunk {
 ///
 /// // Fast allocation - just bumps pointer
 /// let ptr1 = tlab.alloc_string("hello".to_string());
-/// let ptr2 = tlab.alloc_array(baml_type::RuntimeTy::int(), vec![Value::int(1), Value::int(2)]);
+/// let ptr2 = tlab.alloc_array(baml_type::RealizedTy::int(), vec![Value::int(1), Value::int(2)]);
 ///
 /// // When chunk exhausted, refill gets a new region
 /// for _ in 0..2000 {
@@ -173,7 +173,11 @@ impl Tlab {
 
     /// Allocate an array object whose elements have static type `element_ty`.
     #[inline]
-    pub fn alloc_array(&mut self, element_ty: baml_type::RuntimeTy, values: Vec<Value>) -> HeapPtr {
+    pub fn alloc_array(
+        &mut self,
+        element_ty: baml_type::RealizedTy,
+        values: Vec<Value>,
+    ) -> HeapPtr {
         self.alloc(Object::Array(Array::new(element_ty, values)))
     }
 
@@ -181,8 +185,8 @@ impl Tlab {
     #[inline]
     pub fn alloc_map(
         &mut self,
-        key_ty: baml_type::RuntimeTy,
-        value_ty: baml_type::RuntimeTy,
+        key_ty: baml_type::RealizedTy,
+        value_ty: baml_type::RealizedTy,
         values: IndexMap<bex_str::BexStr, Value>,
     ) -> HeapPtr {
         self.alloc(Object::Map(Map::new(key_ty, value_ty, values)))
@@ -191,7 +195,7 @@ impl Tlab {
     /// Allocate a non-generic instance object (empty class type args).
     #[inline]
     pub fn alloc_instance(&mut self, class: HeapPtr, fields: Vec<Value>) -> HeapPtr {
-        self.alloc_instance_with_type_args(class, vec![], fields)
+        self.alloc_instance_with_type_args(class, Box::new([]), fields)
     }
 
     /// Allocate an instance object carrying its concrete class type args (De
@@ -201,7 +205,7 @@ impl Tlab {
     pub fn alloc_instance_with_type_args(
         &mut self,
         class: HeapPtr,
-        type_args: Vec<baml_type::RuntimeTy>,
+        type_args: Box<[baml_type::RealizedTy]>,
         fields: Vec<Value>,
     ) -> HeapPtr {
         self.alloc(Object::Instance(Instance::new(class, type_args, fields)))
@@ -240,7 +244,7 @@ impl Tlab {
 
     /// Allocate a type descriptor object on the heap.
     #[inline]
-    pub fn alloc_type(&mut self, ty: baml_type::RuntimeTy) -> HeapPtr {
+    pub fn alloc_type(&mut self, ty: baml_type::RealizedTy) -> HeapPtr {
         self.alloc(Object::Type(Box::new(ty)))
     }
 
@@ -349,14 +353,14 @@ pub trait TlabHolder {
         self.tlab_mut().alloc_string(s)
     }
 
-    fn alloc_array(&mut self, element_ty: baml_type::RuntimeTy, values: Vec<Value>) -> HeapPtr {
+    fn alloc_array(&mut self, element_ty: baml_type::RealizedTy, values: Vec<Value>) -> HeapPtr {
         self.tlab_mut().alloc_array(element_ty, values)
     }
 
     fn alloc_map(
         &mut self,
-        key_ty: baml_type::RuntimeTy,
-        value_ty: baml_type::RuntimeTy,
+        key_ty: baml_type::RealizedTy,
+        value_ty: baml_type::RealizedTy,
         values: IndexMap<bex_str::BexStr, Value>,
     ) -> HeapPtr {
         self.tlab_mut().alloc_map(key_ty, value_ty, values)
@@ -386,7 +390,7 @@ pub trait TlabHolder {
         self.tlab_mut().alloc_collector(collector)
     }
 
-    fn alloc_type(&mut self, ty: baml_type::RuntimeTy) -> HeapPtr {
+    fn alloc_type(&mut self, ty: baml_type::RealizedTy) -> HeapPtr {
         self.tlab_mut().alloc_type(ty)
     }
 
@@ -542,7 +546,7 @@ mod tests {
         let mut tlab = Tlab::new(heap);
 
         let values = vec![Value::int(1), Value::int(2), Value::int(3)];
-        let ptr = tlab.alloc_array(baml_type::RuntimeTy::int(), values);
+        let ptr = tlab.alloc_array(baml_type::RealizedTy::int(), values);
 
         unsafe {
             match ptr.get() {
@@ -563,8 +567,8 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert(bex_str::BexStr::from("key"), Value::int(42));
         let ptr = tlab.alloc_map(
-            baml_type::RuntimeTy::string(),
-            baml_type::RuntimeTy::int(),
+            baml_type::RealizedTy::string(),
+            baml_type::RealizedTy::int(),
             map,
         );
 

--- a/baml_language/crates/bex_heap/tests/generational.rs
+++ b/baml_language/crates/bex_heap/tests/generational.rs
@@ -414,7 +414,7 @@ fn test_mark_card_for_gen2_object() {
 
     // Create an object and promote to Gen2 via major GC
     let arr = tlab.alloc_array(
-        baml_type::RuntimeTy::int(),
+        baml_type::RealizedTy::int(),
         vec![bex_vm_types::Value::int(0)],
     );
     let (_, roots, _) =
@@ -445,7 +445,7 @@ fn test_dirty_card_roots_keep_gen0_alive_during_minor_gc() {
 
     // Step 1: Create an array and promote to Gen2
     let arr = tlab.alloc_array(
-        baml_type::RuntimeTy::unknown(),
+        baml_type::RealizedTy::unknown(),
         vec![bex_vm_types::Value::NULL],
     );
     let (_, roots1, _) =
@@ -504,7 +504,7 @@ fn test_clean_card_does_not_root_gen0_objects() {
 
     // Promote an array to Gen2 (no cross-gen references, no dirty cards)
     let arr = tlab.alloc_array(
-        baml_type::RuntimeTy::int(),
+        baml_type::RealizedTy::int(),
         vec![bex_vm_types::Value::int(99)],
     );
     let (_, roots1, _) =
@@ -538,7 +538,7 @@ fn test_stale_dirty_card_does_not_root_unrelated_gen0_object() {
 
     // Promote an array with no object references into Gen2.
     let arr = tlab.alloc_array(
-        baml_type::RuntimeTy::unknown(),
+        baml_type::RealizedTy::unknown(),
         vec![bex_vm_types::Value::NULL],
     );
     let (_, roots1, _) =
@@ -598,7 +598,7 @@ fn test_critical_gen2_stale_pointer_after_minor_gc() {
 
     // Step 1: Allocate a Gen0 array and promote it to Gen2 via major GC.
     let container = tlab.alloc_array(
-        baml_type::RuntimeTy::unknown(),
+        baml_type::RealizedTy::unknown(),
         vec![bex_vm_types::Value::NULL],
     );
     let (_, roots1, _) =
@@ -662,7 +662,7 @@ fn test_critical_gen2_chain_through_gen0_after_minor_gc() {
 
     // Step 1: Promote an array container to Gen2.
     let container = tlab.alloc_array(
-        baml_type::RuntimeTy::unknown(),
+        baml_type::RealizedTy::unknown(),
         vec![bex_vm_types::Value::NULL],
     );
     let (_, roots1, _) =
@@ -674,7 +674,7 @@ fn test_critical_gen2_chain_through_gen0_after_minor_gc() {
     // Step 2: Build a Gen0 chain: inner_leaf <- wrapper_array
     let inner_leaf = tlab.alloc_string("inner_leaf".to_string());
     let wrapper = tlab.alloc_array(
-        baml_type::RuntimeTy::unknown(),
+        baml_type::RealizedTy::unknown(),
         vec![bex_vm_types::Value::object(inner_leaf)],
     );
     assert_eq!(heap.generation_of(inner_leaf), Generation::Gen0);
@@ -843,7 +843,7 @@ fn test_gen1_container_acquires_young_ref_survives_minor_gc_chain() {
 
     // T0: Allocate container A in Gen0 with a placeholder slot.
     let a_g0 = tlab.alloc_array(
-        baml_type::RuntimeTy::unknown(),
+        baml_type::RealizedTy::unknown(),
         vec![bex_vm_types::Value::NULL],
     );
     assert_eq!(heap.generation_of(a_g0), Generation::Gen0);

--- a/baml_language/crates/bex_vm/src/package_baml/array.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/array.rs
@@ -87,14 +87,14 @@ fn forward_ptr(ptr: &mut HeapPtr, forwarding: &HashMap<HeapPtr, HeapPtr>) {
 /// `.first()` — that is the receiver's `T` — it is the first of the method's two
 /// own generics, i.e. the second-to-last arg. Counting from the back makes it
 /// correct whether or not the prepend fired (e.g. an `unknown`-typed receiver).
-fn map_result_element_ty(vm: &BexVm) -> baml_type::RuntimeTy {
+fn map_result_element_ty(vm: &BexVm) -> baml_type::RealizedTy {
     let type_args = vm.current_call_type_args();
     type_args
         .len()
         .checked_sub(2)
         .and_then(|u_index| type_args.get(u_index))
         .cloned()
-        .unwrap_or_else(baml_type::RuntimeTy::unknown)
+        .unwrap_or_else(baml_type::RealizedTy::unknown)
 }
 
 /// Extract the callback `HeapPtr` from a `Value` carrying a heap
@@ -413,7 +413,7 @@ struct MapContinuation {
     results: Vec<Value>,
     /// Result element type — the closure's return type `U` from
     /// `map<U, E>(self, f: (T) -> U) -> U[]`, captured at dispatch time.
-    element_ty: baml_type::RuntimeTy,
+    element_ty: baml_type::RealizedTy,
 }
 
 impl Continuation for MapContinuation {
@@ -447,7 +447,7 @@ struct FilterContinuation {
     results: Vec<Value>,
     /// The receiver array's element type `T`, captured at dispatch — `filter`
     /// preserves it (`T[] -> T[]`).
-    element_ty: baml_type::RuntimeTy,
+    element_ty: baml_type::RealizedTy,
 }
 
 impl Continuation for FilterContinuation {
@@ -663,7 +663,7 @@ struct FlatMapContinuation {
     results: Vec<Value>,
     /// Result element type — the closure's element return type `U` from
     /// `flat_map<U, E>(self, f: (T) -> U[]) -> U[]`, captured at dispatch time.
-    element_ty: baml_type::RuntimeTy,
+    element_ty: baml_type::RealizedTy,
 }
 
 impl Continuation for FlatMapContinuation {

--- a/baml_language/crates/bex_vm/src/package_baml/csv.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/csv.rs
@@ -1329,8 +1329,8 @@ fn class_key(qtn: &baml_type::TypeName) -> String {
     qtn.render_dotted(false)
 }
 
-fn classify_cell_ty(ty: &baml_type::RuntimeTy) -> Result<CellTy, String> {
-    use baml_type::RuntimeTy;
+fn classify_cell_ty(ty: &baml_type::RealizedTy) -> Result<CellTy, String> {
+    use baml_type::RealizedTy;
     let nullable = ty.is_nullable_union();
     let base = if nullable {
         ty.strip_null()
@@ -1338,15 +1338,17 @@ fn classify_cell_ty(ty: &baml_type::RuntimeTy) -> Result<CellTy, String> {
         ty.clone()
     };
     let target = match &base {
-        RuntimeTy::String { .. } => Target::Str,
-        RuntimeTy::Int { .. } => Target::Int,
-        RuntimeTy::Bigint { .. } => Target::Bigint,
-        RuntimeTy::Float { .. } => Target::Float,
-        RuntimeTy::Bool { .. } => Target::Bool,
-        RuntimeTy::Enum(qtn, _) => Target::Enum(qtn.clone()),
-        RuntimeTy::Class(qtn, _, _) if class_key(qtn) == INSTANT_FQN => Target::Instant,
-        RuntimeTy::Class(qtn, _, _) if class_key(qtn) == PLAINDATE_FQN => Target::PlainDate,
-        RuntimeTy::Class(qtn, _, _) if class_key(qtn) == PLAINDATETIME_FQN => Target::PlainDateTime,
+        RealizedTy::String { .. } => Target::Str,
+        RealizedTy::Int { .. } => Target::Int,
+        RealizedTy::Bigint { .. } => Target::Bigint,
+        RealizedTy::Float { .. } => Target::Float,
+        RealizedTy::Bool { .. } => Target::Bool,
+        RealizedTy::Enum(qtn, _) => Target::Enum(qtn.clone()),
+        RealizedTy::Class(qtn, _, _) if class_key(qtn) == INSTANT_FQN => Target::Instant,
+        RealizedTy::Class(qtn, _, _) if class_key(qtn) == PLAINDATE_FQN => Target::PlainDate,
+        RealizedTy::Class(qtn, _, _) if class_key(qtn) == PLAINDATETIME_FQN => {
+            Target::PlainDateTime
+        }
         other => return Err(format!("type `{other}` is not cell-decodable")),
     };
     Ok(CellTy { target, nullable })
@@ -1501,10 +1503,10 @@ fn record_arc(vm: &BexVm, rec: Value) -> Result<Arc<RecordData>, VmRustFnError> 
 fn decode_record_to_instance(
     vm: &mut BexVm,
     rd: &RecordData,
-    ty: &baml_type::RuntimeTy,
+    ty: &baml_type::RealizedTy,
 ) -> Result<Value, DecodeFail> {
-    use baml_type::RuntimeTy;
-    let RuntimeTy::Class(qtn, type_args, _) = ty else {
+    use baml_type::RealizedTy;
+    let RealizedTy::Class(qtn, type_args, _) = ty else {
         return Err(DecodeFail::Info(ErrInfo::new(
             Kind::Options,
             format!("decode target `{ty}` is not a class; CSV decodes into flat classes"),
@@ -1529,7 +1531,7 @@ fn decode_record_to_instance(
 
     let mut field_values = Vec::with_capacity(class_fields.len());
     for (fi, cf) in class_fields.iter().enumerate() {
-        let field_ty = cf.field_template.substitute(type_args);
+        let field_ty = vm.realize_field_ty(&cf.field_template, type_args);
         let cell_ty = classify_cell_ty(&field_ty).map_err(|msg| {
             DecodeFail::Info(ErrInfo::new(
                 Kind::Options,
@@ -1632,11 +1634,15 @@ fn decode_record_to_instance(
     }
 
     Ok(Value::object(vm.tlab.alloc(Object::Instance(
-        Instance::new(class_ptr, type_args.clone(), field_values),
+        Instance::new(
+            class_ptr,
+            type_args.clone().into_boxed_slice(),
+            field_values,
+        ),
     ))))
 }
 
-fn current_type_arg(vm: &mut BexVm, who: &str) -> Result<baml_type::RuntimeTy, VmRustFnError> {
+fn current_type_arg(vm: &mut BexVm, who: &str) -> Result<baml_type::RealizedTy, VmRustFnError> {
     // `.first()` is the method's own first generic only because `CsvRecord` is
     // non-generic, so MIR's receiver-class-type-arg prepend (which would push
     // class args ahead of the method's) contributes nothing here. A generic
@@ -1654,7 +1660,7 @@ fn cell_to_optional(
     vm: &mut BexVm,
     rd: &RecordData,
     col: Option<usize>,
-    ty: &baml_type::RuntimeTy,
+    ty: &baml_type::RealizedTy,
 ) -> Result<Option<Value>, VmRustFnError> {
     let cell_ty = match classify_cell_ty(ty) {
         Ok(c) => c,
@@ -2026,7 +2032,7 @@ fn md_escape(text: &str) -> String {
     out
 }
 
-fn md_value_text(vm: &mut BexVm, v: Value, field_ty: Option<&baml_type::RuntimeTy>) -> String {
+fn md_value_text(vm: &mut BexVm, v: Value, field_ty: Option<&baml_type::RealizedTy>) -> String {
     // Prompt text is not meant to round-trip: non-finite floats render as-is.
     if let ValueKind::Object(ptr) = v.kind() {
         if let Object::Float(f) = vm.get_object(ptr) {
@@ -2161,7 +2167,7 @@ impl BamlClassCsvCsvReader for PackageBamlImpl {
                             .map(|n| Value::object(vm.alloc_string(n)))
                             .collect();
                         // CSV header names are always strings.
-                        Value::object(vm.alloc_array(baml_type::RuntimeTy::string(), items))
+                        Value::object(vm.alloc_array(baml_type::RealizedTy::string(), items))
                     }
                 };
                 Ok(copy::csv::CsvHeaders { names: names_value }.to_value(vm))
@@ -2417,9 +2423,9 @@ impl BamlNamespaceCsv for PackageBamlImpl {
     }
 
     fn _validate_columns(vm: &mut BexVm, r: &Value) -> Result<(), VmRustFnError> {
-        use baml_type::RuntimeTy;
+        use baml_type::RealizedTy;
         let ty = current_type_arg(vm, "baml.csv.rows")?;
-        let RuntimeTy::Class(qtn, type_args, _) = &ty else {
+        let RealizedTy::Class(qtn, type_args, _) = &ty else {
             let info = ErrInfo::new(
                 Kind::Options,
                 format!("rows target `{ty}` is not a class; CSV decodes into flat classes"),
@@ -2444,7 +2450,7 @@ impl BamlNamespaceCsv for PackageBamlImpl {
         let header = lock(&st).header.clone();
 
         for cf in &class_fields {
-            let field_ty = cf.field_template.substitute(type_args);
+            let field_ty = vm.realize_field_ty(&cf.field_template, type_args);
             let cell_ty = match classify_cell_ty(&field_ty) {
                 Ok(c) => c,
                 Err(msg) => {
@@ -2618,19 +2624,24 @@ impl BamlNamespaceCsv for PackageBamlImpl {
     }
 
     fn _to_markdown(vm: &mut BexVm, rows: &[Value], max_rows: i64) -> bex_str::BexStr {
-        use baml_type::RuntimeTy;
+        use baml_type::RealizedTy;
         let ty = vm.current_call_type_args().first().cloned();
         let max = usize::try_from(max_rows).unwrap_or(0);
 
         // Header names + field types from T (or the first row's class).
         let class_info = match &ty {
-            Some(RuntimeTy::Class(qtn, type_args, _)) => {
+            Some(RealizedTy::Class(qtn, type_args, _)) => {
                 vm.lookup_type(qtn)
                     .and_then(|ptr| match vm.get_object(ptr) {
                         Object::Class(c) => Some(
                             c.fields
                                 .iter()
-                                .map(|f| (f.name.clone(), f.field_template.substitute(type_args)))
+                                .map(|f| {
+                                    (
+                                        f.name.clone(),
+                                        vm.realize_field_ty(&f.field_template, type_args),
+                                    )
+                                })
                                 .collect::<Vec<_>>(),
                         ),
                         _ => None,

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use baml_type::{MediaKind, RuntimeTy, TypeName};
+use baml_type::{MediaKind, RealizedTy, TypeName};
 
 /// FQN of the recursive `json` type alias declared in `baml.json`.
 /// Mirrors `baml_base::qualified_name::BAML_JSON_JSON`; inlined here to
@@ -25,10 +25,10 @@ const BAML_JSON_JSON: &str = "baml.json.json";
 
 /// The runtime type of an untyped `json` value: the recursive `baml.json.json`
 /// alias (`null | bool | int | float | string | json[] | map<string, json>`).
-/// Recursive aliases stay opaque in `RuntimeTy`, so this is the most precise
+/// Recursive aliases stay opaque in `RealizedTy`, so this is the most precise
 /// element/value type available for containers parsed from untyped JSON.
-pub(super) fn json_alias_ty() -> RuntimeTy {
-    RuntimeTy::TypeAlias(
+pub(super) fn json_alias_ty() -> RealizedTy {
+    RealizedTy::TypeAlias(
         TypeName::from_dotted_path(BAML_JSON_JSON),
         baml_type::TyAttr::default(),
     )
@@ -49,8 +49,8 @@ where
     r
 }
 
-/// Build the runtime registration key for a `RuntimeTy::Class(qtn, ...)` /
-/// `RuntimeTy::Enum(qtn, _)` lookup against `BexVm::resolved_class_names`.
+/// Build the runtime registration key for a `RealizedTy::Class(qtn, ...)` /
+/// `RealizedTy::Enum(qtn, _)` lookup against `BexVm::resolved_class_names`.
 ///
 /// Compiler-side `display_name` strips the `user.` prefix from
 /// user-defined types for nicer diagnostic strings, but
@@ -650,7 +650,7 @@ pub fn serde_to_value(vm: &mut BexVm, v: &serde_json::Value) -> Value {
                 .collect();
             // Untyped JSON object: string keys, `json` values.
             Value::object(vm.tlab.alloc(Object::Map(Map::new(
-                RuntimeTy::string(),
+                RealizedTy::string(),
                 json_alias_ty(),
                 entries,
             ))))
@@ -660,7 +660,7 @@ pub fn serde_to_value(vm: &mut BexVm, v: &serde_json::Value) -> Value {
 
 /// Convert a VM `Value` into a `serde_json::Value`, ignoring declared types.
 ///
-/// Used for `RuntimeTy::TypeAlias(BAML_JSON_JSON)` and for class fields whose runtime
+/// Used for `RealizedTy::TypeAlias(BAML_JSON_JSON)` and for class fields whose runtime
 /// field type is intentionally untyped or unavailable.
 pub fn value_to_serde(vm: &BexVm, v: Value) -> serde_json::Value {
     use bex_vm_types::ValueKind;
@@ -691,7 +691,7 @@ pub fn value_to_serde(vm: &BexVm, v: Value) -> serde_json::Value {
             // typed (`ty_value_to_serde`) and structural (`render_to_serde`)
             // walkers. This is reached when a variant flows through an arm that
             // delegates to the untyped converter — e.g. `ty_value_to_serde`'s
-            // `RuntimeTy::Union` arm for a field typed `E | ...` (including the
+            // `RealizedTy::Union` arm for a field typed `E | ...` (including the
             // optional enum `E?` == `E | null`). Without this, such fields
             // serialized as `null` (B-728).
             Object::Variant(var) => {
@@ -731,7 +731,7 @@ pub fn value_to_serde(vm: &BexVm, v: Value) -> serde_json::Value {
 
 // ─── Typed JSON serialize ────────────────────────────────────────────────────
 
-/// Serialize a VM `Value` to a JSON string driven by the runtime `RuntimeTy`.
+/// Serialize a VM `Value` to a JSON string driven by the runtime `RealizedTy`.
 ///
 /// Walks the value matching the shape of `ty`.  Throws
 /// `JsonSerializationError` for non-representable types (`uint8array`,
@@ -739,7 +739,7 @@ pub fn value_to_serde(vm: &BexVm, v: Value) -> serde_json::Value {
 pub fn json_to_string_typed(
     vm: &mut BexVm,
     v: Value,
-    ty: &RuntimeTy,
+    ty: &RealizedTy,
 ) -> Result<String, VmRustFnError> {
     let mut path = String::new();
     let json_val = ty_value_to_serde(vm, v, ty, &mut path)?;
@@ -762,21 +762,21 @@ pub fn json_to_string_typed(
 fn ty_value_to_serde(
     vm: &mut BexVm,
     value: Value,
-    ty: &RuntimeTy,
+    ty: &RealizedTy,
     path: &mut String,
 ) -> Result<serde_json::Value, VmRustFnError> {
     match ty {
         // Primitive shapes: emit the value directly through value_to_serde,
         // which is total for scalar values.
-        RuntimeTy::Null { .. } => Ok(serde_json::Value::Null),
-        RuntimeTy::Int { .. }
-        | RuntimeTy::Float { .. }
-        | RuntimeTy::Bool { .. }
-        | RuntimeTy::String { .. } => Ok(value_to_serde(vm, value)),
-        RuntimeTy::Bigint { .. } => Ok(value_to_serde(vm, value)),
-        RuntimeTy::Literal(_, _, _) => Ok(value_to_serde(vm, value)),
+        RealizedTy::Null { .. } => Ok(serde_json::Value::Null),
+        RealizedTy::Int { .. }
+        | RealizedTy::Float { .. }
+        | RealizedTy::Bool { .. }
+        | RealizedTy::String { .. } => Ok(value_to_serde(vm, value)),
+        RealizedTy::Bigint { .. } => Ok(value_to_serde(vm, value)),
+        RealizedTy::Literal(_, _, _) => Ok(value_to_serde(vm, value)),
 
-        RuntimeTy::List(elem, _) => {
+        RealizedTy::List(elem, _) => {
             let items = match value.as_object_ptr() {
                 Some(ptr) => match vm.get_object(ptr) {
                     Object::Array(arr) => arr.to_vec(),
@@ -794,7 +794,7 @@ fn ty_value_to_serde(
             Ok(serde_json::Value::Array(out))
         }
 
-        RuntimeTy::Map { value: vty, .. } => {
+        RealizedTy::Map { value: vty, .. } => {
             let entries = match value.as_object_ptr() {
                 Some(ptr) => match vm.get_object(ptr) {
                     Object::Map(m) => m.to_index_map(),
@@ -812,20 +812,20 @@ fn ty_value_to_serde(
             Ok(serde_json::Value::Object(out))
         }
 
-        RuntimeTy::TypeAlias(name, _) if name.display_name().as_str() == BAML_JSON_JSON => {
+        RealizedTy::TypeAlias(name, _) if name.display_name().as_str() == BAML_JSON_JSON => {
             Ok(value_to_serde(vm, value))
         }
 
-        RuntimeTy::TypeAlias(_, _) => {
+        RealizedTy::TypeAlias(_, _) => {
             // Unknown / cross-package recursive aliases: fall back to untyped.
             Ok(value_to_serde(vm, value))
         }
 
-        RuntimeTy::Class(qtn, _type_args, _) | RuntimeTy::Interface(qtn, _type_args, _, _) => {
+        RealizedTy::Class(qtn, _type_args, _) | RealizedTy::Interface(qtn, _type_args, _, _) => {
             serialize_class_instance(vm, value, qtn, path)
         }
 
-        RuntimeTy::Enum(_, _) => match value.as_object_ptr() {
+        RealizedTy::Enum(_, _) => match value.as_object_ptr() {
             Some(ptr) => match vm.get_object(ptr) {
                 Object::Variant(var) => {
                     let enm_ptr = var.enm;
@@ -848,24 +848,24 @@ fn ty_value_to_serde(
             None => Err(raise_serialize(vm, "expected enum variant", path, "enum")),
         },
 
-        RuntimeTy::EnumVariant(_, name, _) => Ok(serde_json::Value::String(name.to_string())),
+        RealizedTy::EnumVariant(_, name, _) => Ok(serde_json::Value::String(name.to_string())),
 
-        RuntimeTy::Media(kind, _) => serialize_media(vm, value, *kind, path),
+        RealizedTy::Media(kind, _) => serialize_media(vm, value, *kind, path),
 
-        RuntimeTy::Uint8Array { .. } => Err(raise_serialize(
+        RealizedTy::Uint8Array { .. } => Err(raise_serialize(
             vm,
             "uint8array requires explicit encoding (use to_base64() or to_hex())",
             path,
             "uint8array",
         )),
 
-        RuntimeTy::Union(_, _) => {
+        RealizedTy::Union(_, _) => {
             // Tagged structurally — dispatch on the runtime Value shape rather
             // than trying each member. Matches json-alias union semantics.
             Ok(value_to_serde(vm, value))
         }
 
-        RuntimeTy::Resource { .. } | RuntimeTy::PromptAst { .. } => Err(raise_serialize(
+        RealizedTy::Resource { .. } | RealizedTy::PromptAst { .. } => Err(raise_serialize(
             vm,
             "cannot serialize opaque type",
             path,
@@ -873,25 +873,25 @@ fn ty_value_to_serde(
         )),
 
         // Compiler-only / non-representable variants.
-        RuntimeTy::Function { .. } => Err(raise_serialize(
+        RealizedTy::Function { .. } => Err(raise_serialize(
             vm,
             "cannot serialize function values",
             path,
             "function",
         )),
-        RuntimeTy::Future(_, _, _) => Err(raise_serialize(
+        RealizedTy::Future(_, _, _) => Err(raise_serialize(
             vm,
             "cannot serialize future values",
             path,
             "future",
         )),
-        RuntimeTy::BuiltinUnknown { .. } => Err(raise_serialize(
+        RealizedTy::BuiltinUnknown { .. } => Err(raise_serialize(
             vm,
             "cannot serialize unknown type",
             path,
             "unknown",
         )),
-        RuntimeTy::Void { .. } => {
+        RealizedTy::Void { .. } => {
             // `void` has no declared JSON shape to validate against here.
             // Use structural serialization of the produced value.
             // Instantiated generic class fields normally use `field_template`
@@ -900,18 +900,16 @@ fn ty_value_to_serde(
         }
 
         // Type-level and opaque types carry no serializable runtime value:
-        // reflection types (`TypeVar`, `AssociatedTypeProjection`, `Type`),
-        // opaque Rust state (`RustType`), and the bottom type (`Never`).
-        RuntimeTy::TypeVar(_, _)
-        | RuntimeTy::AssociatedTypeProjection { .. }
-        | RuntimeTy::Never { .. }
-        | RuntimeTy::RustType { .. }
-        | RuntimeTy::Type { .. } => Err(raise_serialize(
-            vm,
-            "cannot serialize compiler-only type",
-            path,
-            "compiler_only",
-        )),
+        // reflection types (`Type`), opaque Rust state (`RustType`), and the
+        // bottom type (`Never`).
+        RealizedTy::Never { .. } | RealizedTy::RustType { .. } | RealizedTy::Type { .. } => {
+            Err(raise_serialize(
+                vm,
+                "cannot serialize compiler-only type",
+                path,
+                "compiler_only",
+            ))
+        }
     }
 }
 
@@ -920,7 +918,7 @@ fn ty_value_to_serde(
 ///
 /// Special-cases media classes (`baml.media.Pdf`/`Audio`/`Video`/`Image`)
 /// which are stored as `Object::Instance` with a `_data: Object::RustData`
-/// field.  Detected by class FQN; a leading `RuntimeTy::Media(_)` would have
+/// field.  Detected by class FQN; a leading `RealizedTy::Media(_)` would have
 /// already routed through `serialize_media`.
 fn serialize_class_instance(
     vm: &mut BexVm,
@@ -988,7 +986,7 @@ fn serialize_class_instance(
         // Substitute class-level type-args into the field's template so
         // generic positions (`item: T` in `Container<T>`) resolve to the
         // concrete type carried on `Instance::class_type_args`.
-        let field_ty = cf.field_template.substitute(&class_type_args);
+        let field_ty = vm.realize_field_ty(&cf.field_template, &class_type_args);
         let field_json = with_path_segment(path, format_args!(".{}", cf.name), |p| {
             ty_value_to_serde(vm, field_value, &field_ty, p)
         })?;
@@ -1067,14 +1065,14 @@ fn read_media_value(vm: &BexVm, value: Value) -> Option<Arc<baml_builtins2::Medi
 // ─── Typed JSON deserialize ──────────────────────────────────────────────────
 
 /// Parse a JSON string and coerce it to a VM `Value` of the given runtime
-/// `RuntimeTy`.
+/// `RealizedTy`.
 ///
 /// Throws `JsonParseError` for invalid JSON and `JsonDecodeError` when the
 /// parsed JSON does not match the target type.
 pub fn json_from_string_typed(
     vm: &mut BexVm,
     s: &str,
-    ty: &RuntimeTy,
+    ty: &RealizedTy,
 ) -> Result<Value, VmRustFnError> {
     let parsed: serde_json::Value = serde_json::from_str(s).map_err(|e| {
         let msg = e.to_string();
@@ -1092,21 +1090,21 @@ pub fn json_from_string_typed(
 fn ty_serde_to_value(
     vm: &mut BexVm,
     json: &serde_json::Value,
-    ty: &RuntimeTy,
+    ty: &RealizedTy,
     path: &mut String,
 ) -> Result<Value, VmRustFnError> {
     match ty {
-        RuntimeTy::Null { .. } => match json {
+        RealizedTy::Null { .. } => match json {
             serde_json::Value::Null => Ok(Value::NULL),
             _ => Err(raise_decode(vm, "expected null", path)),
         },
 
-        RuntimeTy::Bool { .. } => match json {
+        RealizedTy::Bool { .. } => match json {
             serde_json::Value::Bool(b) => Ok(Value::bool(*b)),
             _ => Err(raise_decode(vm, "expected boolean", path)),
         },
 
-        RuntimeTy::Int { .. } => match json {
+        RealizedTy::Int { .. } => match json {
             serde_json::Value::Number(n) => n.as_i64().and_then(Value::try_int).ok_or_else(|| {
                 raise_decode(
                     vm,
@@ -1118,13 +1116,13 @@ fn ty_serde_to_value(
         },
 
         // Bigint JSON decoding is not yet implemented (Phase 9+).
-        RuntimeTy::Bigint { .. } => Err(raise_decode(
+        RealizedTy::Bigint { .. } => Err(raise_decode(
             vm,
             "bigint JSON decoding not yet implemented",
             path,
         )),
 
-        RuntimeTy::Float { .. } => match json {
+        RealizedTy::Float { .. } => match json {
             serde_json::Value::Number(n) => {
                 if let Some(f) = n.as_f64() {
                     Ok(Value::object(vm.alloc_float(f)))
@@ -1135,12 +1133,12 @@ fn ty_serde_to_value(
             _ => Err(raise_decode(vm, "expected number", path)),
         },
 
-        RuntimeTy::String { .. } => match json {
+        RealizedTy::String { .. } => match json {
             serde_json::Value::String(s) => Ok(Value::object(vm.alloc_string(s.clone()))),
             _ => Err(raise_decode(vm, "expected string", path)),
         },
 
-        RuntimeTy::List(elem, _) => match json {
+        RealizedTy::List(elem, _) => match json {
             serde_json::Value::Array(arr) => {
                 let mut items = Vec::with_capacity(arr.len());
                 for (i, item) in arr.iter().enumerate() {
@@ -1157,7 +1155,7 @@ fn ty_serde_to_value(
             _ => Err(raise_decode(vm, "expected array", path)),
         },
 
-        RuntimeTy::Map { value: vty, .. } => match json {
+        RealizedTy::Map { value: vty, .. } => match json {
             serde_json::Value::Object(map) => {
                 let mut entries: IndexMap<bex_vm_types::BexStr, Value> =
                     IndexMap::with_capacity(map.len());
@@ -1169,7 +1167,7 @@ fn ty_serde_to_value(
                 }
                 // BAML maps are always string-keyed at runtime.
                 Ok(Value::object(vm.tlab.alloc(Object::Map(Map::new(
-                    RuntimeTy::string(),
+                    RealizedTy::string(),
                     (**vty).clone(),
                     entries,
                 )))))
@@ -1177,32 +1175,32 @@ fn ty_serde_to_value(
             _ => Err(raise_decode(vm, "expected object", path)),
         },
 
-        RuntimeTy::TypeAlias(name, _) if name.display_name().as_str() == BAML_JSON_JSON => {
+        RealizedTy::TypeAlias(name, _) if name.display_name().as_str() == BAML_JSON_JSON => {
             Ok(serde_to_value(vm, json))
         }
 
-        RuntimeTy::TypeAlias(_, _) => {
+        RealizedTy::TypeAlias(_, _) => {
             // Unknown / cross-package recursive aliases: fall back to untyped.
             Ok(serde_to_value(vm, json))
         }
 
-        RuntimeTy::Class(qtn, type_args, _) => {
+        RealizedTy::Class(qtn, type_args, _) => {
             if let Some(kind) = media_kind_from_fqn(qtn.display_name().as_str()) {
                 return deserialize_media(vm, json, kind, qtn, path);
             }
             deserialize_class_instance(vm, json, qtn, type_args, path)
         }
 
-        RuntimeTy::Interface(qtn, type_args, _, _) => {
+        RealizedTy::Interface(qtn, type_args, _, _) => {
             deserialize_class_instance(vm, json, qtn, type_args, path)
         }
 
-        RuntimeTy::Enum(qtn, _) => match json {
+        RealizedTy::Enum(qtn, _) => match json {
             serde_json::Value::String(s) => deserialize_enum_variant(vm, qtn, s, path),
             _ => Err(raise_decode(vm, "expected enum variant string", path)),
         },
 
-        RuntimeTy::EnumVariant(qtn, name, _) => match json {
+        RealizedTy::EnumVariant(qtn, name, _) => match json {
             serde_json::Value::String(s) if s == name.as_str() => {
                 deserialize_enum_variant(vm, qtn, s, path)
             }
@@ -1213,15 +1211,15 @@ fn ty_serde_to_value(
             )),
         },
 
-        RuntimeTy::Media(kind, _) => deserialize_media_by_kind(vm, json, *kind, path),
+        RealizedTy::Media(kind, _) => deserialize_media_by_kind(vm, json, *kind, path),
 
-        RuntimeTy::Uint8Array { .. } => Err(raise_decode(
+        RealizedTy::Uint8Array { .. } => Err(raise_decode(
             vm,
             "uint8array requires explicit encoding (use from_base64() or from_hex())",
             path,
         )),
 
-        RuntimeTy::Union(members, _) => {
+        RealizedTy::Union(members, _) => {
             // Try each member structurally; first match wins.
             for member in members {
                 let mut tmp_path = path.clone();
@@ -1232,7 +1230,7 @@ fn ty_serde_to_value(
             Err(raise_decode(vm, "no union member matched", path))
         }
 
-        RuntimeTy::Literal(lit, _, _) => match (lit, json) {
+        RealizedTy::Literal(lit, _, _) => match (lit, json) {
             (baml_type::Literal::Bool(b), serde_json::Value::Bool(jb)) if b == jb => {
                 Ok(Value::bool(*jb))
             }
@@ -1264,14 +1262,14 @@ fn ty_serde_to_value(
             _ => Err(raise_decode(vm, "literal mismatch", path)),
         },
 
-        RuntimeTy::Resource { .. } | RuntimeTy::PromptAst { .. } => {
+        RealizedTy::Resource { .. } | RealizedTy::PromptAst { .. } => {
             Err(raise_decode(vm, "cannot deserialize opaque type", path))
         }
 
-        RuntimeTy::Function { .. }
-        | RuntimeTy::Future(_, _, _)
-        | RuntimeTy::BuiltinUnknown { .. }
-        | RuntimeTy::Void { .. } => {
+        RealizedTy::Function { .. }
+        | RealizedTy::Future(_, _, _)
+        | RealizedTy::BuiltinUnknown { .. }
+        | RealizedTy::Void { .. } => {
             // These variants do not provide a concrete JSON schema to validate
             // against here. Preserve structural JSON conversion for values
             // whose shape is already JSON-representable.
@@ -1279,13 +1277,11 @@ fn ty_serde_to_value(
         }
 
         // Type-level and opaque types are not valid decode targets: reflection
-        // types (`TypeVar`, `AssociatedTypeProjection`, `Type`), opaque Rust
-        // state (`RustType`), and the bottom type (`Never`).
-        RuntimeTy::TypeVar(_, _)
-        | RuntimeTy::AssociatedTypeProjection { .. }
-        | RuntimeTy::Never { .. }
-        | RuntimeTy::RustType { .. }
-        | RuntimeTy::Type { .. } => Err(raise_decode(vm, "cannot decode compiler-only type", path)),
+        // types (`Type`), opaque Rust state (`RustType`), and the bottom type
+        // (`Never`).
+        RealizedTy::Never { .. } | RealizedTy::RustType { .. } | RealizedTy::Type { .. } => {
+            Err(raise_decode(vm, "cannot decode compiler-only type", path))
+        }
     }
 }
 
@@ -1293,7 +1289,7 @@ fn deserialize_class_instance(
     vm: &mut BexVm,
     json: &serde_json::Value,
     qtn: &TypeName,
-    type_args: &[RuntimeTy],
+    type_args: &[RealizedTy],
     path: &mut String,
 ) -> Result<Value, VmRustFnError> {
     let map = match json {
@@ -1326,7 +1322,7 @@ fn deserialize_class_instance(
         // Substitute class-level type-args into the field's template so a
         // `Container<User>::item` field decodes against `User` rather than
         // erased runtime metadata.
-        let field_ty = cf.field_template.substitute(type_args);
+        let field_ty = vm.realize_field_ty(&cf.field_template, type_args);
         let v = with_path_segment(path, format_args!(".{}", cf.name), |p| {
             let field_json_owned;
             let field_json: &serde_json::Value = if let Some(v) = map.get(cf.name.as_str()) {
@@ -1348,7 +1344,7 @@ fn deserialize_class_instance(
     }
 
     Ok(Value::object(vm.tlab.alloc(Object::Instance(
-        Instance::new(class_ptr, type_args.to_vec(), field_values),
+        Instance::new(class_ptr, type_args.into(), field_values),
     ))))
 }
 
@@ -1454,7 +1450,7 @@ fn deserialize_media(
 /// `serde_json::Value` and running `ty_serde_to_value`. Used by
 /// [`json_to_dispatch`] for leaf types (primitives, enums, media, literals)
 /// that can never carry a `baml.FromJson` override.
-fn structural_decode_value(vm: &mut BexVm, j: Value, ty: &RuntimeTy) -> NativeCallResult {
+fn structural_decode_value(vm: &mut BexVm, j: Value, ty: &RealizedTy) -> NativeCallResult {
     let serde = value_to_serde(vm, j);
     let mut path = String::new();
     match ty_serde_to_value(vm, &serde, ty, &mut path) {
@@ -1513,18 +1509,18 @@ pub(super) fn json_to_shim(vm: &mut BexVm, j: Value) -> NativeCallResult {
 ///   target wins; otherwise decode per-field via [`class_from_json_start`];
 /// - everything else (primitives, enums, media, literals, type-aliases): a
 ///   structural decode (no overrides possible).
-fn json_to_dispatch(vm: &mut BexVm, j: Value, ty: &RuntimeTy) -> NativeCallResult {
+fn json_to_dispatch(vm: &mut BexVm, j: Value, ty: &RealizedTy) -> NativeCallResult {
     match ty {
-        RuntimeTy::Union(members, _) if members.iter().any(RuntimeTy::is_null) => {
+        RealizedTy::Union(members, _) if members.iter().any(RealizedTy::is_null) => {
             if j.is_null() {
                 NativeCallResult::Done(Value::NULL)
             } else {
                 json_to_dispatch(vm, j, &ty.strip_null())
             }
         }
-        RuntimeTy::List(elem, _) => list_from_json_start(vm, j, elem),
-        RuntimeTy::Map { value: vty, .. } => map_from_json_start(vm, j, vty),
-        RuntimeTy::Class(qtn, type_args, _) | RuntimeTy::Interface(qtn, type_args, _, _)
+        RealizedTy::List(elem, _) => list_from_json_start(vm, j, elem),
+        RealizedTy::Map { value: vty, .. } => map_from_json_start(vm, j, vty),
+        RealizedTy::Class(qtn, type_args, _) | RealizedTy::Interface(qtn, type_args, _, _)
             if media_kind_from_fqn(qtn.display_name().as_str()).is_none() =>
         {
             match try_yield_interface_from_json(vm, j, ty) {
@@ -1547,7 +1543,7 @@ fn class_from_json_start(
     vm: &mut BexVm,
     j: Value,
     qtn: &TypeName,
-    type_args: &[RuntimeTy],
+    type_args: &[RealizedTy],
 ) -> NativeCallResult {
     let map: IndexMap<bex_vm_types::BexStr, Value> = match j.as_object_ptr() {
         Some(p) => match vm.get_object(p) {
@@ -1589,9 +1585,9 @@ fn class_from_json_start(
         }
     };
     // Resolve each field's json value + its (type-arg-substituted) field type.
-    let mut fields: Vec<(Value, RuntimeTy)> = Vec::with_capacity(class_fields.len());
+    let mut fields: Vec<(Value, RealizedTy)> = Vec::with_capacity(class_fields.len());
     for cf in &class_fields {
-        let field_ty = cf.field_template.substitute(type_args);
+        let field_ty = vm.realize_field_ty(&cf.field_template, type_args);
         let field_json = match map.get(cf.name.as_str()) {
             Some(v) => *v,
             // Optional (`T?` == `T | null`) fields may be absent → null.
@@ -1615,8 +1611,8 @@ fn class_from_json_start(
 fn class_drive(
     vm: &mut BexVm,
     class_ptr: HeapPtr,
-    class_type_args: Vec<RuntimeTy>,
-    fields: Vec<(Value, RuntimeTy)>,
+    class_type_args: Vec<RealizedTy>,
+    fields: Vec<(Value, RealizedTy)>,
     mut results: Vec<Value>,
     mut idx: usize,
 ) -> NativeCallResult {
@@ -1651,15 +1647,15 @@ fn class_drive(
         };
     }
     NativeCallResult::Done(Value::object(vm.tlab.alloc(Object::Instance(
-        Instance::new(class_ptr, class_type_args, results),
+        Instance::new(class_ptr, class_type_args.into(), results),
     ))))
 }
 
 /// Resumes [`class_drive`] after one field's `baml.json.to` decode returns.
 struct ClassFromJsonCont {
     class_ptr: HeapPtr,
-    class_type_args: Vec<RuntimeTy>,
-    fields: Vec<(Value, RuntimeTy)>,
+    class_type_args: Vec<RealizedTy>,
+    fields: Vec<(Value, RealizedTy)>,
     results: Vec<Value>,
     idx: usize,
 }
@@ -1721,10 +1717,10 @@ impl Continuation for ClassFromJsonCont {
 fn try_yield_interface_from_json(
     vm: &mut BexVm,
     j: Value,
-    ty: &RuntimeTy,
+    ty: &RealizedTy,
 ) -> Option<NativeCallResult> {
     let (qtn, type_args) = match ty {
-        RuntimeTy::Class(qtn, type_args, _) | RuntimeTy::Interface(qtn, type_args, _, _) => {
+        RealizedTy::Class(qtn, type_args, _) | RealizedTy::Interface(qtn, type_args, _, _) => {
             (qtn, type_args)
         }
         _ => return None,
@@ -1744,7 +1740,7 @@ fn try_yield_interface_from_json(
 
 // ── List dispatch ─────────────────────────────────────────────────────────────
 
-fn list_from_json_start(vm: &mut BexVm, j: Value, elem_ty: &RuntimeTy) -> NativeCallResult {
+fn list_from_json_start(vm: &mut BexVm, j: Value, elem_ty: &RealizedTy) -> NativeCallResult {
     let array = match j.as_object_ptr() {
         Some(p) => match vm.get_object(p) {
             Object::Array(a) => a.to_vec(),
@@ -1765,7 +1761,7 @@ fn list_from_json_start(vm: &mut BexVm, j: Value, elem_ty: &RuntimeTy) -> Native
 fn list_drive(
     vm: &mut BexVm,
     array: Vec<Value>,
-    elem_ty: RuntimeTy,
+    elem_ty: RealizedTy,
     mut results: Vec<Value>,
     mut idx: usize,
 ) -> NativeCallResult {
@@ -1815,13 +1811,13 @@ fn list_drive(
 /// True for class/interface/list/map (after peeling an optional wrapper); false
 /// for leaf types (primitives, enums, media, literals) — which decode
 /// structurally and can never carry an override.
-fn needs_driver_decode(ty: &RuntimeTy) -> bool {
+fn needs_driver_decode(ty: &RealizedTy) -> bool {
     matches!(
         peel_optional(ty),
-        RuntimeTy::Class(..)
-            | RuntimeTy::Interface(..)
-            | RuntimeTy::List(..)
-            | RuntimeTy::Map { .. }
+        RealizedTy::Class(..)
+            | RealizedTy::Interface(..)
+            | RealizedTy::List(..)
+            | RealizedTy::Map { .. }
     )
 }
 
@@ -1837,7 +1833,7 @@ fn missing_to_driver() -> NativeCallResult {
 
 struct ListFromJsonCont {
     array: Vec<Value>,
-    elem_ty: RuntimeTy,
+    elem_ty: RealizedTy,
     results: Vec<Value>,
     idx: usize,
 }
@@ -1870,7 +1866,7 @@ impl Continuation for ListFromJsonCont {
 
 // ── Map dispatch ──────────────────────────────────────────────────────────────
 
-fn map_from_json_start(vm: &mut BexVm, j: Value, val_ty: &RuntimeTy) -> NativeCallResult {
+fn map_from_json_start(vm: &mut BexVm, j: Value, val_ty: &RealizedTy) -> NativeCallResult {
     let entries: Vec<(bex_vm_types::BexStr, Value)> = match j.as_object_ptr() {
         Some(p) => match vm.get_object(p) {
             Object::Map(m) => m.lock().iter().map(|(k, v)| (k.clone(), *v)).collect(),
@@ -1888,7 +1884,7 @@ fn map_from_json_start(vm: &mut BexVm, j: Value, val_ty: &RuntimeTy) -> NativeCa
 fn map_drive(
     vm: &mut BexVm,
     entries: Vec<(bex_vm_types::BexStr, Value)>,
-    val_ty: RuntimeTy,
+    val_ty: RealizedTy,
     mut results: IndexMap<bex_vm_types::BexStr, Value>,
     mut idx: usize,
 ) -> NativeCallResult {
@@ -1927,7 +1923,7 @@ fn map_drive(
     }
     // Type-directed: string keys, decode value type carried from `val_ty`.
     let map_val = Value::object(vm.tlab.alloc(Object::Map(Map::new(
-        RuntimeTy::string(),
+        RealizedTy::string(),
         val_ty,
         results,
     ))));
@@ -1936,7 +1932,7 @@ fn map_drive(
 
 struct MapFromJsonCont {
     entries: Vec<(bex_vm_types::BexStr, Value)>,
-    val_ty: RuntimeTy,
+    val_ty: RealizedTy,
     results: IndexMap<bex_vm_types::BexStr, Value>,
     idx: usize,
 }
@@ -1985,7 +1981,7 @@ impl Continuation for MapFromJsonCont {
 /// If `ty` is a nullable union (`T | null`) and `v` is `Value::Null`, returns
 /// `Some(Null)`. Otherwise `None` — caller should dispatch on the inner
 /// (non-null) type.
-fn optional_null_short_circuit(v: Value, ty: &RuntimeTy) -> Option<Value> {
+fn optional_null_short_circuit(v: Value, ty: &RealizedTy) -> Option<Value> {
     if ty.is_nullable_union() && v.is_null() {
         Some(Value::NULL)
     } else {
@@ -1996,9 +1992,9 @@ fn optional_null_short_circuit(v: Value, ty: &RuntimeTy) -> Option<Value> {
 /// Strip the outer nullable-union wrapper, if any. Used by the list/map walker
 /// so that `T | null` element types still dispatch through `C.from_json` for
 /// the non-null member.
-fn peel_optional(ty: &RuntimeTy) -> &RuntimeTy {
-    if let RuntimeTy::Union(members, _) = ty {
-        if members.iter().any(RuntimeTy::is_null) {
+fn peel_optional(ty: &RealizedTy) -> &RealizedTy {
+    if let RealizedTy::Union(members, _) = ty {
+        if members.iter().any(RealizedTy::is_null) {
             if let Some(inner) = members.iter().find(|m| !m.is_null()) {
                 if members.iter().filter(|m| !m.is_null()).count() == 1 {
                     return inner;
@@ -2012,7 +2008,7 @@ fn peel_optional(ty: &RuntimeTy) -> &RuntimeTy {
 /// Synchronous (no-yield) decode of `v` as `ty`. For class-with-override
 /// elements the caller must use the yield path; this helper structurally
 /// decodes everything else.
-fn decode_value_sync(vm: &mut BexVm, v: Value, ty: &RuntimeTy) -> Result<Value, VmRustFnError> {
+fn decode_value_sync(vm: &mut BexVm, v: Value, ty: &RealizedTy) -> Result<Value, VmRustFnError> {
     let serde = value_to_serde(vm, v);
     let mut path = String::new();
     ty_serde_to_value(vm, &serde, ty, &mut path)

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -83,7 +83,7 @@ pub enum NativeCallResult {
     YieldToCall {
         callee: HeapPtr,
         args: Vec<Value>,
-        type_args: Vec<baml_type::RuntimeTy>,
+        type_args: Vec<baml_type::RealizedTy>,
         continuation: Box<dyn Continuation>,
     },
 }
@@ -138,7 +138,7 @@ impl Continuation for PassThroughContinuation {
 /// builtins take it in place of `&[Value]` with no body changes.
 pub struct ArrayView<'a> {
     /// The receiver array's declared element type (`T` of `T[]`).
-    pub ty: &'a baml_type::RuntimeTy,
+    pub ty: &'a baml_type::RealizedTy,
     /// The receiver array's elements.
     pub data: &'a [Value],
 }
@@ -159,9 +159,9 @@ impl std::ops::Deref for ArrayView<'_> {
 /// it in place of `&IndexMap<BexStr, Value>` with no body changes.
 pub struct MapView<'a> {
     /// The receiver map's declared key type (`K` of `map<K, V>`).
-    pub key_ty: &'a baml_type::RuntimeTy,
+    pub key_ty: &'a baml_type::RealizedTy,
     /// The receiver map's declared value type (`V` of `map<K, V>`).
-    pub value_ty: &'a baml_type::RuntimeTy,
+    pub value_ty: &'a baml_type::RealizedTy,
     /// The receiver map's entries.
     pub data: &'a indexmap::IndexMap<bex_str::BexStr, Value>,
 }

--- a/baml_language/crates/bex_vm/src/package_baml/ops.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/ops.rs
@@ -19,7 +19,7 @@ use std::{
     sync::Arc,
 };
 
-use baml_type::{Name, RuntimeTy, TyAttr, TypeName};
+use baml_type::{Name, RealizedTy, TyAttr, TypeName};
 use bex_str::BexStr;
 use bex_vm_types::{
     HeapPtr, ValueKind,
@@ -171,7 +171,7 @@ enum Cmp {
     Yield {
         callee: HeapPtr,
         args: Vec<Value>,
-        type_args: Vec<RuntimeTy>,
+        type_args: Vec<RealizedTy>,
     },
 }
 
@@ -557,15 +557,15 @@ impl Continuation for EqualsDriver {
     }
 }
 
-/// The concrete runtime `RuntimeTy` of the class instance or enum value at `ptr` — `Class` with
+/// The concrete runtime `RealizedTy` of the class instance or enum value at `ptr` — `Class` with
 /// its `class_type_args` (so a generic instance resolves at the right args), or `Enum`.
 /// `None` for any other object kind (only instances/enums implement `Equals`).
-fn value_concrete_ty(vm: &BexVm, ptr: HeapPtr) -> Option<RuntimeTy> {
+fn value_concrete_ty(vm: &BexVm, ptr: HeapPtr) -> Option<RealizedTy> {
     match vm.get_object(ptr) {
         Object::Instance(inst) => {
             let (class_ptr, type_args) = (inst.class, inst.class_type_args.to_vec());
             match vm.get_object(class_ptr) {
-                Object::Class(class) => Some(RuntimeTy::Class(
+                Object::Class(class) => Some(RealizedTy::Class(
                     class.name.clone(),
                     type_args,
                     TyAttr::default(),
@@ -574,7 +574,7 @@ fn value_concrete_ty(vm: &BexVm, ptr: HeapPtr) -> Option<RuntimeTy> {
             }
         }
         Object::Variant(v) => match vm.get_object(v.enm) {
-            Object::Enum(e) => Some(RuntimeTy::Enum(e.name.clone(), TyAttr::default())),
+            Object::Enum(e) => Some(RealizedTy::Enum(e.name.clone(), TyAttr::default())),
             _ => None,
         },
         _ => None,
@@ -585,7 +585,7 @@ fn value_concrete_ty(vm: &BexVm, ptr: HeapPtr) -> Option<RuntimeTy> {
 /// `None` when the type has no `Equals` impl (→ the structural/identity fallback). The
 /// concrete type carries any `class_type_args`, so a generic/blanket impl
 /// (`implement<T> Equals for Box<T>`) resolves at the right `T`.
-fn resolve_equals_eq(vm: &BexVm, concrete: &RuntimeTy) -> Option<(HeapPtr, Vec<RuntimeTy>)> {
+fn resolve_equals_eq(vm: &BexVm, concrete: &RealizedTy) -> Option<(HeapPtr, Vec<RealizedTy>)> {
     // `Equals` is non-generic — no interface args to select on; off the resolved
     // rule, `eq` is the concrete method (the impl's own, or the merged default),
     // invoked with its frame realized against the impl's bound type args.
@@ -594,7 +594,14 @@ fn resolve_equals_eq(vm: &BexVm, concrete: &RuntimeTy) -> Option<(HeapPtr, Vec<R
     // `fqn` is the resolved callee's heap pointer (the impl method or merged
     // default), baked at emit time — invoke it directly.
     let callee = method.fqn;
-    Some((callee, resolve::realize_frame(&method.frame, &bound_args)))
+    // The resolved impl's frame realizes fully against its bound args (every
+    // projection reduced through the impl registry). A failure is a broken
+    // compiler/VM invariant rather than a runtime possibility, so surface it
+    // instead of silently dropping the custom `eq`.
+    let type_args = resolve::realize_frame(vm, &method.frame, &bound_args).unwrap_or_else(|e| {
+        unreachable!("Equals impl frame did not realize against bound args: {e}")
+    });
+    Some((callee, type_args))
 }
 
 /// The `baml.ops.Equals` interface name.

--- a/baml_language/crates/bex_vm/src/package_baml/resolve.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/resolve.rs
@@ -7,21 +7,20 @@
 //! impl applies (the caller decides the fallback).
 //!
 //! This mirrors the compiler's selection (`match_ty_pattern` + bound validation
-//! in `baml_compiler2_tir::interfaces`), run on `baml_type::RuntimeTy`: unify the rule's
+//! in `baml_compiler2_tir::interfaces`), run on `baml_type::RealizedTy`: unify the rule's
 //! `for_ty_pattern` against the concrete type (binding the impl's generic
 //! params), then discharge each param's declared bound as a nested obligation.
 
 use std::borrow::Cow;
 
-use baml_type::{
-    Literal, MediaKind, Name, RealizedTy, RuntimeInterface, RuntimeTy, TyAttr, TyTemplate, TypeName,
-};
+use baml_type::{Literal, MediaKind, Name, RealizedTy, TyAttr, TyTemplate, TypeName};
 use bex_vm_types::{
     HeapPtr,
+    errors::VmInternalError,
     types::{Object, Package, RuntimeImplRule},
 };
 
-use crate::BexVm;
+use crate::{BexVm, type_context::RuntimeTypeContext};
 
 /// Dereference a package pointer to its [`Package`]. The runtime `vm.packages`
 /// index only ever holds `Object::Package` pointers.
@@ -59,17 +58,22 @@ fn collect_package_rules<'a>(
 /// reach this.
 const MAX_OBLIGATION_DEPTH: usize = 128;
 
-/// An in-progress membership goal — does `RuntimeTy` implement the interface `TypeName`
+/// An in-progress membership goal — does `RealizedTy` implement the interface `TypeName`
 /// at these args / associated bindings? Tracked on a stack so a goal that
 /// recurses back to itself (an inductive cycle, with no concrete-impl base case)
 /// is detected and rejected rather than spun on until the depth backstop.
-type Obligation = (RuntimeTy, TypeName, Vec<RuntimeTy>, Vec<(Name, RuntimeTy)>);
+type Obligation = (
+    RealizedTy,
+    TypeName,
+    Vec<RealizedTy>,
+    Vec<(Name, RealizedTy)>,
+);
 
 /// The package that owns `ty`, if any. Primitives/containers have none — their
 /// impls live in the interface's package (orphan rule).
-fn type_package(ty: &RuntimeTy) -> Option<&Name> {
+fn type_package(ty: &RealizedTy) -> Option<&Name> {
     match ty {
-        RuntimeTy::Class(tn, ..) | RuntimeTy::Enum(tn, ..) | RuntimeTy::Interface(tn, ..) => {
+        RealizedTy::Class(tn, ..) | RealizedTy::Enum(tn, ..) | RealizedTy::Interface(tn, ..) => {
             Some(tn.package())
         }
         _ => None,
@@ -83,20 +87,20 @@ fn type_package(ty: &RuntimeTy) -> Option<&Name> {
 /// types; every other type passes through untouched. Only the top level is
 /// normalized — nested type args keep their literal form so invariance holds
 /// (`Box<1>` is not `Box<int>`).
-fn concrete_base(ty: &RuntimeTy) -> Cow<'_, RuntimeTy> {
+fn concrete_base(ty: &RealizedTy) -> Cow<'_, RealizedTy> {
     match ty {
         // Persist the type's attr onto the base (consistent with the enum-variant
         // arm below), so a literal carrying a non-default attr normalizes to its
         // base with that attr intact rather than silently dropping it.
-        RuntimeTy::Literal(lit, _, attr) => Cow::Owned(match lit {
-            Literal::Int(_) => RuntimeTy::Int { attr: attr.clone() },
-            Literal::Bigint(_) => RuntimeTy::Bigint { attr: attr.clone() },
-            Literal::Float(_) => RuntimeTy::Float { attr: attr.clone() },
-            Literal::String(_) => RuntimeTy::String { attr: attr.clone() },
-            Literal::Bool(_) => RuntimeTy::Bool { attr: attr.clone() },
+        RealizedTy::Literal(lit, _, attr) => Cow::Owned(match lit {
+            Literal::Int(_) => RealizedTy::Int { attr: attr.clone() },
+            Literal::Bigint(_) => RealizedTy::Bigint { attr: attr.clone() },
+            Literal::Float(_) => RealizedTy::Float { attr: attr.clone() },
+            Literal::String(_) => RealizedTy::String { attr: attr.clone() },
+            Literal::Bool(_) => RealizedTy::Bool { attr: attr.clone() },
         }),
-        RuntimeTy::EnumVariant(name, _, attr) => {
-            Cow::Owned(RuntimeTy::Enum(name.clone(), attr.clone()))
+        RealizedTy::EnumVariant(name, _, attr) => {
+            Cow::Owned(RealizedTy::Enum(name.clone(), attr.clone()))
         }
         _ => Cow::Borrowed(ty),
     }
@@ -110,7 +114,7 @@ fn concrete_base(ty: &RuntimeTy) -> Cow<'_, RuntimeTy> {
 /// it never changes an existing pair's answer.
 fn candidate_rules<'a>(
     vm: &'a BexVm,
-    concrete_ty: &RuntimeTy,
+    concrete_ty: &RealizedTy,
     iface: &TypeName,
 ) -> Vec<&'a RuntimeImplRule> {
     let base = concrete_base(concrete_ty);
@@ -163,20 +167,20 @@ fn candidate_rules<'a>(
 /// no-match case.
 pub(crate) fn resolve_implements_rule<'a>(
     vm: &'a BexVm,
-    concrete_ty: &RuntimeTy,
+    concrete_ty: &RealizedTy,
     iface: &TypeName,
-    iface_args: &[RuntimeTy],
-) -> Option<(&'a RuntimeImplRule, Vec<RuntimeTy>)> {
-    let mut fallback: Option<(&'a RuntimeImplRule, Vec<RuntimeTy>)> = None;
+    iface_args: &[RealizedTy],
+) -> Option<(&'a RuntimeImplRule, Vec<RealizedTy>)> {
+    let mut fallback: Option<(&'a RuntimeImplRule, Vec<RealizedTy>)> = None;
     for rule in candidate_rules(vm, concrete_ty, iface) {
         let Some(type_args) = rule_applies(vm, rule, concrete_ty, &mut Vec::new()) else {
             continue;
         };
         // Select on the interface's input args only (associated types are outputs).
-        let rule_args: Vec<RuntimeTy> = rule
+        let rule_args: Vec<RealizedTy> = rule
             .interface_args
             .iter()
-            .map(|t| substitute_checked(t, &type_args))
+            .map(|t| substitute_checked(vm, t, &type_args))
             .collect();
         if iface_args.is_empty() || ty_args_equivalent(&rule_args, iface_args) {
             return Some((rule, type_args));
@@ -191,10 +195,24 @@ pub(crate) fn resolve_implements_rule<'a>(
 /// (from [`resolve_implements_rule`]). The result is the `frame.type_args` to
 /// seed the resolved callee with: the impl's own generics for an impl method, or
 /// the interface's args + associated types for an inherited default.
-pub(crate) fn realize_frame(template: &[TyTemplate], bound_args: &[RuntimeTy]) -> Vec<RuntimeTy> {
+pub(crate) fn realize_frame(
+    vm: &BexVm,
+    template: &[TyTemplate],
+    bound_args: &[RealizedTy],
+) -> Result<Vec<RealizedTy>, VmInternalError> {
+    // Materialization boundary: seeding a bytecode frame's realized type args.
+    // The impl's frame templates realize fully against the (realized) bound args —
+    // every projection reduced through the impl registry — or it is an internal
+    // error, never a silent `unknown`.
+    let ctx = RuntimeTypeContext::new(vm);
     template
         .iter()
-        .map(|t| substitute_checked(t, bound_args))
+        .map(|t| {
+            t.substitute(bound_args, &ctx)
+                .map_err(|e| VmInternalError::TypeSubstitution {
+                    message: e.to_string(),
+                })
+        })
         .collect()
 }
 
@@ -207,10 +225,10 @@ pub(crate) fn realize_frame(template: &[TyTemplate], bound_args: &[RuntimeTy]) -
 /// bounded impl's nested obligations.
 pub(crate) fn type_implements(
     vm: &BexVm,
-    concrete_ty: &RuntimeTy,
+    concrete_ty: &RealizedTy,
     iface: &TypeName,
-    requested_args: &[RuntimeTy],
-    requested_assoc: &[(Name, RuntimeTy)],
+    requested_args: &[RealizedTy],
+    requested_assoc: &[(Name, RealizedTy)],
 ) -> bool {
     prove(
         vm,
@@ -229,10 +247,10 @@ pub(crate) fn type_implements(
 /// repeating) is likewise rejected.
 fn prove(
     vm: &BexVm,
-    concrete_ty: &RuntimeTy,
+    concrete_ty: &RealizedTy,
     iface: &TypeName,
-    requested_args: &[RuntimeTy],
-    requested_assoc: &[(Name, RuntimeTy)],
+    requested_args: &[RealizedTy],
+    requested_assoc: &[(Name, RealizedTy)],
     stack: &mut Vec<Obligation>,
 ) -> bool {
     // Key on the normalized (literal/enum-variant → base) type so `1` and `int`
@@ -251,7 +269,7 @@ fn prove(
         .into_iter()
         .any(|rule| {
             rule_applies(vm, rule, concrete_ty, stack).is_some_and(|bindings| {
-                interface_request_matches(rule, &bindings, requested_args, requested_assoc)
+                interface_request_matches(vm, rule, &bindings, requested_args, requested_assoc)
             })
         });
     stack.pop();
@@ -263,18 +281,18 @@ fn prove(
 fn rule_applies(
     vm: &BexVm,
     rule: &RuntimeImplRule,
-    concrete_ty: &RuntimeTy,
+    concrete_ty: &RealizedTy,
     stack: &mut Vec<Obligation>,
-) -> Option<Vec<RuntimeTy>> {
+) -> Option<Vec<RealizedTy>> {
     let base = concrete_base(concrete_ty);
     let concrete_ty = &*base;
-    let mut bindings: Vec<Option<RuntimeTy>> = vec![None; rule.generic_param_bounds.len()];
+    let mut bindings: Vec<Option<RealizedTy>> = vec![None; rule.generic_param_bounds.len()];
     if !match_template(&rule.for_ty_pattern, concrete_ty, &mut bindings) {
         return None;
     }
     // The for-type pattern must constrain every generic param — a param the
     // pattern never mentions could not be inferred from the receiver.
-    let type_args: Vec<RuntimeTy> = bindings.into_iter().collect::<Option<_>>()?;
+    let type_args: Vec<RealizedTy> = bindings.into_iter().collect::<Option<_>>()?;
 
     // Bounds as nested obligations (rustc winnowing): every interface in a param's
     // bound set must be implemented by that param's bound type arg, at the bound's
@@ -284,15 +302,15 @@ fn rule_applies(
             // The bound's args/assoc may reference the impl's params (`T extends
             // Container<U>`), so substitute them with the bindings, then require
             // the arg to implement the interface at that exact instantiation.
-            let req_args: Vec<RuntimeTy> = bound
+            let req_args: Vec<RealizedTy> = bound
                 .args
                 .iter()
-                .map(|t| substitute_checked(t, &type_args))
+                .map(|t| substitute_checked(vm, t, &type_args))
                 .collect();
-            let req_assoc: Vec<(Name, RuntimeTy)> = bound
+            let req_assoc: Vec<(Name, RealizedTy)> = bound
                 .assoc
                 .iter()
-                .map(|(n, t)| (n.clone(), substitute_checked(t, &type_args)))
+                .map(|(n, t)| (n.clone(), substitute_checked(vm, t, &type_args)))
                 .collect();
             // An interface-existential type arg satisfies a bound that names the
             // same interface directly: the type checker only forms `Iterable<Item
@@ -336,13 +354,13 @@ fn rule_applies(
 /// *implement* an interface, so this must not be folded into `prove` /
 /// `type_implements` (reflection relies on `Iterable` not implementing itself).
 fn interface_existential_satisfies_bound(
-    concrete_ty: &RuntimeTy,
+    concrete_ty: &RealizedTy,
     iface: &TypeName,
-    requested_args: &[RuntimeTy],
-    requested_assoc: &[(Name, RuntimeTy)],
+    requested_args: &[RealizedTy],
+    requested_assoc: &[(Name, RealizedTy)],
 ) -> bool {
     let base = concrete_base(concrete_ty);
-    let RuntimeTy::Interface(ex_qtn, ex_args, ex_assoc, _) = base.as_ref() else {
+    let RealizedTy::Interface(ex_qtn, ex_args, ex_assoc, _) = base.as_ref() else {
         return false;
     };
     ex_qtn == iface
@@ -350,19 +368,19 @@ fn interface_existential_satisfies_bound(
         && associated_bindings_equivalent(ex_assoc, requested_assoc)
 }
 
-/// Unify a `TyTemplate` pattern against a concrete `RuntimeTy`, binding each
+/// Unify a `TyTemplate` pattern against a concrete `RealizedTy`, binding each
 /// `TypeArgRef(n)` into `bindings[n]`. A repeated param must bind consistently.
 fn match_template(
     pattern: &TyTemplate,
-    concrete: &RuntimeTy,
-    bindings: &mut [Option<RuntimeTy>],
+    concrete: &RealizedTy,
+    bindings: &mut [Option<RealizedTy>],
 ) -> bool {
     // A fully-realized pattern carries no frame refs or holes: compare it to
     // the concrete type semantically (union-order-insensitive, matching the
     // type checker). The flattened successor to the old `Concrete(t)` arm —
     // `ty_equivalent` falls back to structural `==` for non-union leaves.
     if let Ok(realized) = <&RealizedTy>::try_from(pattern) {
-        return ty_equivalent(realized.as_runtime_ty(), concrete);
+        return ty_equivalent(realized, concrete);
     }
 
     match pattern {
@@ -383,11 +401,11 @@ fn match_template(
             }
         }
         TyTemplate::List(inner, _) => match concrete {
-            RuntimeTy::List(elem, _) => match_template(inner, elem, bindings),
+            RealizedTy::List(elem, _) => match_template(inner, elem, bindings),
             _ => false,
         },
         TyTemplate::Map { key, value, .. } => match concrete {
-            RuntimeTy::Map {
+            RealizedTy::Map {
                 key: ckey,
                 value: cvalue,
                 ..
@@ -395,11 +413,11 @@ fn match_template(
             _ => false,
         },
         TyTemplate::Class(name, args, _) => match concrete {
-            RuntimeTy::Class(cname, cargs, _) => name == cname && all_match(args, cargs, bindings),
+            RealizedTy::Class(cname, cargs, _) => name == cname && all_match(args, cargs, bindings),
             _ => false,
         },
         TyTemplate::Interface(name, args, assoc, _) => match concrete {
-            RuntimeTy::Interface(cname, cargs, cassoc, _) => {
+            RealizedTy::Interface(cname, cargs, cassoc, _) => {
                 // Each *concrete* binding must match a same-named pattern binding, found
                 // order-insensitively; extra pattern bindings don't constrain. This
                 // direction mirrors the compiler's selection matcher
@@ -431,7 +449,7 @@ fn match_template(
             throws,
             ..
         } => match concrete {
-            RuntimeTy::Function {
+            RealizedTy::Function {
                 params: cparams,
                 ret: cret,
                 throws: cthrows,
@@ -449,7 +467,7 @@ fn match_template(
             _ => false,
         },
         TyTemplate::Future(value, error, _) => match concrete {
-            RuntimeTy::Future(cvalue, cerror, _) => {
+            RealizedTy::Future(cvalue, cerror, _) => {
                 match_template(value, cvalue, bindings) && match_template(error, cerror, bindings)
             }
             _ => false,
@@ -458,7 +476,7 @@ fn match_template(
         // distinct concrete member, with type-var bindings consistent across the
         // chosen pairing (so `Box<T | int>` matches a value `Box<int | string>`).
         TyTemplate::Union(parts, _) => match concrete {
-            RuntimeTy::Union(cparts, _) => match_union(parts, cparts, bindings),
+            RealizedTy::Union(cparts, _) => match_union(parts, cparts, bindings),
             _ => false,
         },
         // Realized leaves are handled by the fast path above.
@@ -469,8 +487,8 @@ fn match_template(
 /// Pairwise-unify positional template args against concrete args (same arity).
 fn all_match(
     patterns: &[TyTemplate],
-    concretes: &[RuntimeTy],
-    bindings: &mut [Option<RuntimeTy>],
+    concretes: &[RealizedTy],
+    bindings: &mut [Option<RealizedTy>],
 ) -> bool {
     patterns.len() == concretes.len()
         && patterns
@@ -486,8 +504,8 @@ fn all_match(
 /// (e.g. `[T, int]` against `[int, string]` must pick `T = string`, not `T = int`).
 fn match_union(
     patterns: &[TyTemplate],
-    concretes: &[RuntimeTy],
-    bindings: &mut [Option<RuntimeTy>],
+    concretes: &[RealizedTy],
+    bindings: &mut [Option<RealizedTy>],
 ) -> bool {
     if patterns.len() != concretes.len() {
         return false;
@@ -502,9 +520,9 @@ fn match_union(
 
 fn match_union_rec(
     patterns: &[TyTemplate],
-    concretes: &[RuntimeTy],
+    concretes: &[RealizedTy],
     used: &mut [bool],
-    bindings: &mut [Option<RuntimeTy>],
+    bindings: &mut [Option<RealizedTy>],
 ) -> bool {
     let Some((first, rest)) = patterns.split_first() else {
         return true;
@@ -531,20 +549,21 @@ fn match_union_rec(
 /// request. The rule's interface args / bindings are concretised with the
 /// `for_ty_pattern` bindings, then compared; an empty request matches any.
 fn interface_request_matches(
+    vm: &BexVm,
     rule: &RuntimeImplRule,
-    bindings: &[RuntimeTy],
-    requested_args: &[RuntimeTy],
-    requested_assoc: &[(Name, RuntimeTy)],
+    bindings: &[RealizedTy],
+    requested_args: &[RealizedTy],
+    requested_assoc: &[(Name, RealizedTy)],
 ) -> bool {
-    let rule_args: Vec<RuntimeTy> = rule
+    let rule_args: Vec<RealizedTy> = rule
         .interface_args
         .iter()
-        .map(|t| substitute_checked(t, bindings))
+        .map(|t| substitute_checked(vm, t, bindings))
         .collect();
-    let rule_assoc: Vec<(Name, RuntimeTy)> = rule
+    let rule_assoc: Vec<(Name, RealizedTy)> = rule
         .interface_assoc
         .iter()
-        .map(|(n, t)| (n.clone(), substitute_checked(t, bindings)))
+        .map(|(n, t)| (n.clone(), substitute_checked(vm, t, bindings)))
         .collect();
     (requested_args.is_empty() || ty_args_equivalent(&rule_args, requested_args))
         && associated_bindings_equivalent(&rule_assoc, requested_assoc)
@@ -556,7 +575,7 @@ fn interface_request_matches(
 /// semantically irrelevant — the type checker treats `int | string` and
 /// `string | int` as identical). Falls back to structural `==` for non-union
 /// leaves.
-pub(super) fn ty_args_equivalent(a: &[RuntimeTy], b: &[RuntimeTy]) -> bool {
+pub(super) fn ty_args_equivalent(a: &[RealizedTy], b: &[RealizedTy]) -> bool {
     a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| ty_equivalent(x, y))
 }
 
@@ -567,14 +586,14 @@ pub(super) fn ty_args_equivalent(a: &[RuntimeTy], b: &[RuntimeTy]) -> bool {
 /// constructor. Every variant that carries a nested type recurses here; bare leaves
 /// (primitives, enums, opaque handles, sentinels) and mismatched-constructor pairs fall
 /// to structural `==`, which is exact for them.
-pub(super) fn ty_equivalent(a: &RuntimeTy, b: &RuntimeTy) -> bool {
+pub(super) fn ty_equivalent(a: &RealizedTy, b: &RealizedTy) -> bool {
     match (a, b) {
         // Order-insensitive comparison of union members via a one-to-one matching:
         // each `a` member must pair with a *distinct* equivalent `b` member. A
         // plain `all(|x| any(|y| ...))` would wrongly accept `int | int` as
         // equivalent to `int | string` (both left members match the single `int`
         // on the right), so consume each matched member.
-        (RuntimeTy::Union(am, _), RuntimeTy::Union(bm, _)) => {
+        (RealizedTy::Union(am, _), RealizedTy::Union(bm, _)) => {
             if am.len() != bm.len() {
                 return false;
             }
@@ -591,53 +610,39 @@ pub(super) fn ty_equivalent(a: &RuntimeTy, b: &RuntimeTy) -> bool {
             true
         }
         // Recurse into nested generic instantiations (`Box<Slot<int | string>>`).
-        (RuntimeTy::Class(an, aa, _), RuntimeTy::Class(bn, ba, _)) => {
+        (RealizedTy::Class(an, aa, _), RealizedTy::Class(bn, ba, _)) => {
             an == bn && ty_args_equivalent(aa, ba)
         }
-        (RuntimeTy::Interface(an, aa, ab, _), RuntimeTy::Interface(bn, ba, bb, _)) => {
+        (RealizedTy::Interface(an, aa, ab, _), RealizedTy::Interface(bn, ba, bb, _)) => {
             an == bn && ty_args_equivalent(aa, ba) && associated_bindings_exactly_equivalent(ab, bb)
         }
         // Recurse through container wrappers so a union nested inside them is still
         // compared order-insensitively (`Box<(int | string)?>` ==
         // `Box<(string | int)?>`); otherwise the wrapper would fall to the
         // structural `==` below and defeat the union-set comparison.
-        (RuntimeTy::List(ai, _), RuntimeTy::List(bi, _)) => ty_equivalent(ai, bi),
+        (RealizedTy::List(ai, _), RealizedTy::List(bi, _)) => ty_equivalent(ai, bi),
         (
-            RuntimeTy::Map {
+            RealizedTy::Map {
                 key: ak, value: av, ..
             },
-            RuntimeTy::Map {
+            RealizedTy::Map {
                 key: bk, value: bv, ..
             },
         ) => ty_equivalent(ak, bk) && ty_equivalent(av, bv),
         // The remaining nested-type-bearing constructors, so a union buried in a future,
         // function signature, or associated projection is still compared
         // order-insensitively rather than falling to the order-sensitive `==` below.
-        (RuntimeTy::Future(av, ae, _), RuntimeTy::Future(bv, be, _)) => {
+        (RealizedTy::Future(av, ae, _), RealizedTy::Future(bv, be, _)) => {
             ty_equivalent(av, bv) && ty_equivalent(ae, be)
         }
         (
-            RuntimeTy::AssociatedTypeProjection {
-                base: abase,
-                interface: aiface,
-                member: amember,
-                ..
-            },
-            RuntimeTy::AssociatedTypeProjection {
-                base: bbase,
-                interface: biface,
-                member: bmember,
-                ..
-            },
-        ) => amember == bmember && ty_equivalent(abase, bbase) && iface_equivalent(aiface, biface),
-        (
-            RuntimeTy::Function {
+            RealizedTy::Function {
                 params: ap,
                 ret: aret,
                 throws: athrows,
                 ..
             },
-            RuntimeTy::Function {
+            RealizedTy::Function {
                 params: bp,
                 ret: bret,
                 throws: bthrows,
@@ -655,19 +660,9 @@ pub(super) fn ty_equivalent(a: &RuntimeTy, b: &RuntimeTy) -> bool {
     }
 }
 
-/// Equivalence of two optional interface *constraints* (the `as I` annotation of
-/// an associated-type projection), mirroring the `RuntimeTy::Interface` arm of
-/// [`ty_equivalent`]: same name, equivalent generic arguments, and exactly
-/// equivalent associated-type bindings.
-fn iface_equivalent(x: &RuntimeInterface, y: &RuntimeInterface) -> bool {
-    x.name == y.name
-        && ty_args_equivalent(&x.generics, &y.generics)
-        && associated_bindings_exactly_equivalent(&x.associated_types, &y.associated_types)
-}
-
 pub(super) fn associated_bindings_equivalent(
-    impl_bindings: &[(Name, RuntimeTy)],
-    requested_bindings: &[(Name, RuntimeTy)],
+    impl_bindings: &[(Name, RealizedTy)],
+    requested_bindings: &[(Name, RealizedTy)],
 ) -> bool {
     requested_bindings.is_empty()
         || requested_bindings
@@ -680,8 +675,8 @@ pub(super) fn associated_bindings_equivalent(
 }
 
 fn associated_bindings_exactly_equivalent(
-    a: &[(Name, RuntimeTy)],
-    b: &[(Name, RuntimeTy)],
+    a: &[(Name, RealizedTy)],
+    b: &[(Name, RealizedTy)],
 ) -> bool {
     a.len() == b.len()
         && associated_bindings_equivalent(a, b)
@@ -691,7 +686,7 @@ fn associated_bindings_exactly_equivalent(
 /// One implementor of an interface: the concrete implementor type plus the
 /// interface args / associated bindings that impl pins (empty = "matches any
 /// instantiation", for blanket impls and typevar-bearing dimensions).
-type ImplementorEntry = (RuntimeTy, Vec<RuntimeTy>, Vec<(Name, RuntimeTy)>);
+type ImplementorEntry = (RealizedTy, Vec<RealizedTy>, Vec<(Name, RealizedTy)>);
 
 /// The concrete types that nominally implement `iface`, each paired with the
 /// interface instantiation its impl fixes — the inverse of [`type_implements`].
@@ -719,7 +714,7 @@ pub(super) fn implementor_entries(vm: &BexVm, iface: &TypeName) -> Vec<Implement
                     // Blanket impl: its bounds decide membership; every concrete
                     // type satisfying them is an implementor, at the interface
                     // instantiation the blanket pins (typevar dimensions erased).
-                    let (args, assoc) = pinned_interface_instantiation(rule);
+                    let (args, assoc) = pinned_interface_instantiation(vm, rule);
                     for ty in concrete_types(vm) {
                         if rule_applies(vm, rule, &ty, &mut Vec::new()).is_some() {
                             push_unique(&mut out, (ty, args.clone(), assoc.clone()));
@@ -731,13 +726,13 @@ pub(super) fn implementor_entries(vm: &BexVm, iface: &TypeName) -> Vec<Implement
                 other if <&RealizedTy>::try_from(other).is_ok() => {
                     let realized = <&RealizedTy>::try_from(other)
                         .unwrap_or_else(|_| unreachable!("guarded by the `is_ok` above"));
-                    let (args, assoc) = pinned_interface_instantiation(rule);
-                    push_unique(&mut out, (realized.as_runtime_ty().clone(), args, assoc));
+                    let (args, assoc) = pinned_interface_instantiation(vm, rule);
+                    push_unique(&mut out, (realized.clone(), args, assoc));
                 }
                 // A generic class for-type (`Foo<T>`) is reported by its base.
                 TyTemplate::Class(name, _, _) => {
-                    let (args, assoc) = pinned_interface_instantiation(rule);
-                    let base = RuntimeTy::Class(name.clone(), Vec::new(), TyAttr::default());
+                    let (args, assoc) = pinned_interface_instantiation(vm, rule);
+                    let base = RealizedTy::Class(name.clone(), Vec::new(), TyAttr::default());
                     push_unique(&mut out, (base, args, assoc));
                 }
                 _ => {}
@@ -753,14 +748,15 @@ pub(super) fn implementor_entries(vm: &BexVm, iface: &TypeName) -> Vec<Implement
 /// generic class is reported by its base, so a per-instantiation arg can't be
 /// named — empty then matches any requested instantiation).
 fn pinned_interface_instantiation(
+    vm: &BexVm,
     rule: &RuntimeImplRule,
-) -> (Vec<RuntimeTy>, Vec<(Name, RuntimeTy)>) {
+) -> (Vec<RealizedTy>, Vec<(Name, RealizedTy)>) {
     let args = if rule.interface_args.iter().any(template_has_type_arg_ref) {
         Vec::new()
     } else {
         rule.interface_args
             .iter()
-            .map(|t| substitute_checked(t, &[]))
+            .map(|t| substitute_checked(vm, t, &[]))
             .collect()
     };
     let assoc = if rule
@@ -772,26 +768,28 @@ fn pinned_interface_instantiation(
     } else {
         rule.interface_assoc
             .iter()
-            .map(|(n, t)| (n.clone(), substitute_checked(t, &[])))
+            .map(|(n, t)| (n.clone(), substitute_checked(vm, t, &[])))
             .collect()
     };
     (args, assoc)
 }
 
-/// [`TyTemplate::substitute`], asserting in debug builds that every `TypeArgRef`
-/// is in range. The resolver always substitutes a *complete* env (one binding per
-/// impl generic param), so an out-of-range index means a malformed rule —
-/// `substitute` would silently yield `unknown`, which could then make distinct
-/// types compare equal (`unknown == unknown`). Release builds keep the graceful
-/// fallback. (We can't assert inside `substitute` itself: stdlib sys-op paths
-/// rely on its out-of-range → `unknown` behavior.)
-fn substitute_checked(template: &TyTemplate, env: &[RuntimeTy]) -> RuntimeTy {
+/// Realize an impl rule's interface-arg [`TyTemplate`] against a *complete* env
+/// (one binding per impl generic param) for the resolver's own arg *comparison* —
+/// not value materialization. A debug assert catches an out-of-range `TypeArgRef`
+/// (a malformed rule); in release, a substitution failure falls back to the top
+/// type, keeping selection conservative without aborting the query. (Value
+/// materialization uses [`realize_frame`], which is strict.)
+fn substitute_checked(vm: &BexVm, template: &TyTemplate, env: &[RealizedTy]) -> RealizedTy {
     debug_assert!(
         max_type_arg_ref(template).is_none_or(|n| (n as usize) < env.len()),
         "impl rule references a type arg out of range for an env of {}",
         env.len(),
     );
-    template.substitute(env)
+    let ctx = RuntimeTypeContext::new(vm);
+    template
+        .substitute(env, &ctx)
+        .unwrap_or_else(|_| RealizedTy::unknown())
 }
 
 /// The largest `TypeArgRef` de Bruijn index anywhere in `t`, if any.
@@ -883,23 +881,23 @@ fn template_has_type_arg_ref(t: &TyTemplate) -> bool {
     }
 }
 
-/// Every loaded concrete type — classes, enums, and the primitives — as a `RuntimeTy` at
+/// Every loaded concrete type — classes, enums, and the primitives — as a `RealizedTy` at
 /// its base (no type args). The candidate set a blanket impl's bounds are checked
 /// against: a blanket `for T` can be satisfied by any concrete type, not just
 /// classes. (`all_class_and_enum_ptrs` covers both classes and enums across every
 /// loaded package.) `$stream` companions are filtered later by
 /// `push_unique`.
-fn concrete_types(vm: &BexVm) -> Vec<RuntimeTy> {
-    let mut types: Vec<RuntimeTy> = vm
+fn concrete_types(vm: &BexVm) -> Vec<RealizedTy> {
+    let mut types: Vec<RealizedTy> = vm
         .all_class_and_enum_ptrs()
         .filter_map(|ptr| match vm.get_object(ptr) {
-            Object::Class(class) => Some(RuntimeTy::Class(
+            Object::Class(class) => Some(RealizedTy::Class(
                 class.name.clone(),
                 Vec::new(),
                 TyAttr::default(),
             )),
             Object::Enum(enum_def) => {
-                Some(RuntimeTy::Enum(enum_def.name.clone(), TyAttr::default()))
+                Some(RealizedTy::Enum(enum_def.name.clone(), TyAttr::default()))
             }
             _ => None,
         })
@@ -912,34 +910,34 @@ fn concrete_types(vm: &BexVm) -> Vec<RuntimeTy> {
     // Parameterized subjects (`List`/`Map`) and non-value types are intentionally omitted:
     // their instantiations can't be enumerated.
     types.extend([
-        RuntimeTy::Int {
+        RealizedTy::Int {
             attr: TyAttr::default(),
         },
-        RuntimeTy::Bigint {
+        RealizedTy::Bigint {
             attr: TyAttr::default(),
         },
-        RuntimeTy::Float {
+        RealizedTy::Float {
             attr: TyAttr::default(),
         },
-        RuntimeTy::String {
+        RealizedTy::String {
             attr: TyAttr::default(),
         },
-        RuntimeTy::Bool {
+        RealizedTy::Bool {
             attr: TyAttr::default(),
         },
-        RuntimeTy::Null {
+        RealizedTy::Null {
             attr: TyAttr::default(),
         },
-        RuntimeTy::Uint8Array {
+        RealizedTy::Uint8Array {
             attr: TyAttr::default(),
         },
-        RuntimeTy::Type {
+        RealizedTy::Type {
             attr: TyAttr::default(),
         },
-        RuntimeTy::Resource {
+        RealizedTy::Resource {
             attr: TyAttr::default(),
         },
-        RuntimeTy::PromptAst {
+        RealizedTy::PromptAst {
             attr: TyAttr::default(),
         },
     ]);
@@ -952,7 +950,7 @@ fn concrete_types(vm: &BexVm) -> Vec<RuntimeTy> {
             MediaKind::Pdf,
             MediaKind::Generic,
         ]
-        .map(|kind| RuntimeTy::Media(kind, TyAttr::default())),
+        .map(|kind| RealizedTy::Media(kind, TyAttr::default())),
     );
     types
 }
@@ -968,9 +966,9 @@ fn push_unique(out: &mut Vec<ImplementorEntry>, entry: ImplementorEntry) {
 }
 
 /// Whether `ty` is an internal `…$stream` companion type.
-fn is_stream_companion(ty: &RuntimeTy) -> bool {
+fn is_stream_companion(ty: &RealizedTy) -> bool {
     match ty {
-        RuntimeTy::Class(tn, ..) | RuntimeTy::Enum(tn, ..) => tn.name().ends_with("$stream"),
+        RealizedTy::Class(tn, ..) | RealizedTy::Enum(tn, ..) => tn.name().ends_with("$stream"),
         _ => false,
     }
 }
@@ -990,15 +988,15 @@ mod tests {
     // resolver, where the literal-/attr-sensitivity would otherwise be untested.)
     #[test]
     fn concrete_literal_pattern_matches_only_the_literal() {
-        let one = RuntimeTy::Literal(Literal::Int(1), Freshness::Regular, TyAttr::default());
+        let one = RealizedTy::Literal(Literal::Int(1), Freshness::Regular, TyAttr::default());
         let pattern = TyTemplate::from(RealizedTy::Literal(
             Literal::Int(1),
             Freshness::Regular,
             TyAttr::default(),
         ));
-        let mut binds: Vec<Option<RuntimeTy>> = Vec::new();
+        let mut binds: Vec<Option<RealizedTy>> = Vec::new();
         assert!(match_template(&pattern, &one, &mut binds));
-        assert!(!match_template(&pattern, &RuntimeTy::int(), &mut binds));
+        assert!(!match_template(&pattern, &RealizedTy::int(), &mut binds));
     }
 
     #[test]
@@ -1009,20 +1007,20 @@ mod tests {
         // such nested unions order-sensitively (only `Class`/`List`/`Map`/`Interface`
         // recursed). Built with explicit member order so the two genuinely differ.
         let attr = || TyAttr::default();
-        let never = || RuntimeTy::Never { attr: attr() };
-        let str_ty = || RuntimeTy::String { attr: attr() };
-        let int_string = RuntimeTy::Union(vec![RuntimeTy::int(), str_ty()], attr());
-        let string_int = RuntimeTy::Union(vec![str_ty(), RuntimeTy::int()], attr());
+        let never = || RealizedTy::Never { attr: attr() };
+        let str_ty = || RealizedTy::String { attr: attr() };
+        let int_string = RealizedTy::Union(vec![RealizedTy::int(), str_ty()], attr());
+        let string_int = RealizedTy::Union(vec![str_ty(), RealizedTy::int()], attr());
 
-        let a = RuntimeTy::Future(Box::new(int_string), Box::new(never()), attr());
-        let b = RuntimeTy::Future(Box::new(string_int), Box::new(never()), attr());
+        let a = RealizedTy::Future(Box::new(int_string), Box::new(never()), attr());
+        let b = RealizedTy::Future(Box::new(string_int), Box::new(never()), attr());
         assert!(
             ty_equivalent(&a, &b),
             "Future<int | string> ≡ Future<string | int>"
         );
 
         // A genuinely different value type is still distinguished.
-        let c = RuntimeTy::Future(Box::new(RuntimeTy::int()), Box::new(never()), attr());
+        let c = RealizedTy::Future(Box::new(RealizedTy::int()), Box::new(never()), attr());
         assert!(!ty_equivalent(&a, &c));
     }
 }

--- a/baml_language/crates/bex_vm/src/package_baml/resolve.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/resolve.rs
@@ -629,11 +629,7 @@ pub(super) fn ty_equivalent(a: &RuntimeTy, b: &RuntimeTy) -> bool {
                 member: bmember,
                 ..
             },
-        ) => {
-            amember == bmember
-                && ty_equivalent(abase, bbase)
-                && opt_iface_equivalent(aiface.as_deref(), biface.as_deref())
-        }
+        ) => amember == bmember && ty_equivalent(abase, bbase) && iface_equivalent(aiface, biface),
         (
             RuntimeTy::Function {
                 params: ap,
@@ -663,16 +659,10 @@ pub(super) fn ty_equivalent(a: &RuntimeTy, b: &RuntimeTy) -> bool {
 /// an associated-type projection), mirroring the `RuntimeTy::Interface` arm of
 /// [`ty_equivalent`]: same name, equivalent generic arguments, and exactly
 /// equivalent associated-type bindings.
-fn opt_iface_equivalent(a: Option<&RuntimeInterface>, b: Option<&RuntimeInterface>) -> bool {
-    match (a, b) {
-        (Some(x), Some(y)) => {
-            x.name == y.name
-                && ty_args_equivalent(&x.generics, &y.generics)
-                && associated_bindings_exactly_equivalent(&x.associated_types, &y.associated_types)
-        }
-        (None, None) => true,
-        (Some(_), None) | (None, Some(_)) => false,
-    }
+fn iface_equivalent(x: &RuntimeInterface, y: &RuntimeInterface) -> bool {
+    x.name == y.name
+        && ty_args_equivalent(&x.generics, &y.generics)
+        && associated_bindings_exactly_equivalent(&x.associated_types, &y.associated_types)
 }
 
 pub(super) fn associated_bindings_equivalent(
@@ -835,14 +825,18 @@ fn max_type_arg_ref(t: &TyTemplate) -> Option<u32> {
             base, interface, ..
         } => max_type_arg_ref(base)
             .into_iter()
-            .chain(interface.iter().flat_map(|iface| {
-                iface.generics.iter().filter_map(max_type_arg_ref).chain(
-                    iface
-                        .associated_types
-                        .iter()
-                        .filter_map(|(_, t)| max_type_arg_ref(t)),
-                )
-            }))
+            .chain(
+                interface
+                    .generics
+                    .iter()
+                    .filter_map(max_type_arg_ref)
+                    .chain(
+                        interface
+                            .associated_types
+                            .iter()
+                            .filter_map(|(_, t)| max_type_arg_ref(t)),
+                    ),
+            )
             .max(),
         // Realized leaves and `Wildcard` carry no frame ref.
         _ => None,
@@ -878,13 +872,11 @@ fn template_has_type_arg_ref(t: &TyTemplate) -> bool {
             base, interface, ..
         } => {
             template_has_type_arg_ref(base)
-                || interface.as_ref().is_some_and(|iface| {
-                    iface.generics.iter().any(template_has_type_arg_ref)
-                        || iface
-                            .associated_types
-                            .iter()
-                            .any(|(_, t)| template_has_type_arg_ref(t))
-                })
+                || interface.generics.iter().any(template_has_type_arg_ref)
+                || interface
+                    .associated_types
+                    .iter()
+                    .any(|(_, t)| template_has_type_arg_ref(t))
         }
         // Realized leaves and `Wildcard` carry no frame ref.
         _ => false,

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -651,7 +651,7 @@ fn deep_copy_value_recursive(
                 Object::Instance(instance) => {
                     let placeholder_ptr = vm.tlab.alloc(Object::Instance(Instance::new(
                         instance.class,
-                        instance.class_type_args.to_vec(),
+                        instance.class_type_args.to_vec().into_boxed_slice(),
                         Vec::new(),
                     )));
                     copied_objects.insert(ptr, placeholder_ptr);
@@ -663,7 +663,7 @@ fn deep_copy_value_recursive(
 
                     let new_instance = Instance::new(
                         instance.class,
-                        instance.class_type_args.to_vec(),
+                        instance.class_type_args.to_vec().into_boxed_slice(),
                         new_fields,
                     );
                     // no GC write barrier because it is all in gen0

--- a/baml_language/crates/bex_vm/src/package_baml/toml.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/toml.rs
@@ -68,7 +68,7 @@ fn convert_toml_value(vm: &mut BexVm, value: ::toml::Value) -> Result<Value, VmR
             // TOML table values decode into the `json` algebra (string keys),
             // so the value type is the recursive `json` union.
             let map = Value::object(vm.alloc_map(
-                baml_type::RuntimeTy::string(),
+                baml_type::RealizedTy::string(),
                 super::json::json_alias_ty(),
                 map,
             ));

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -1,10 +1,10 @@
-use bex_vm_types::types::{InterfaceImplementorEntry, Object, Value};
+use bex_vm_types::types::{Object, Value};
 
 use super::{BamlClassTypeValue, PackageBamlImpl, resolve};
 use crate::BexVm;
 
 impl BamlClassTypeValue for PackageBamlImpl {
-    /// Returns the `RuntimeTy`'s display name.  Includes namespaces and (for
+    /// Returns the `RealizedTy`'s display name.  Includes namespaces and (for
     /// non-`user` packages) the package prefix, so two distinct types never
     /// collide on this string — package names are unique within a workspace,
     /// so eliding the implicit `user.` prefix is unambiguous.
@@ -84,31 +84,39 @@ impl BamlClassTypeValue for PackageBamlImpl {
     }
 }
 
-/// The concrete `RuntimeTy` wrapped by a `type` value (class, enum, interface,
+/// The concrete `RealizedTy` wrapped by a `type` value (class, enum, interface,
 /// primitive, container, …), or `None` if `value` isn't a `type`.
-fn type_value_ty(vm: &BexVm, value: Value) -> Option<baml_type::RuntimeTy> {
+fn type_value_ty(vm: &BexVm, value: Value) -> Option<baml_type::RealizedTy> {
     match vm.get_object(value.as_object_ptr()?) {
         Object::Type(ty) => Some(ty.as_ref().clone()),
         _ => None,
     }
 }
 
+/// A realized interface instantiation as reflected off a value: the type's
+/// qualified name, its realized generic arguments, and its associated bindings.
+type RealizedTypeInstantiation = (
+    baml_type::TypeName,
+    Vec<baml_type::RealizedTy>,
+    Vec<(baml_type::Name, baml_type::RealizedTy)>,
+);
+
 /// Returns the type's base name plus its generic arguments (e.g.
 /// `[string]` for `Box<string>`). Used by reflection to discriminate generic
 /// interface instantiations.
-fn ty_name_args_and_assoc(vm: &BexVm, value: Value) -> Option<InterfaceImplementorEntry> {
+fn ty_name_args_and_assoc(vm: &BexVm, value: Value) -> Option<RealizedTypeInstantiation> {
     let ptr = value.as_object_ptr()?;
     let Object::Type(ty) = vm.get_object(ptr) else {
         return None;
     };
     match ty.as_ref() {
-        baml_type::RuntimeTy::Class(name, args, _) => {
+        baml_type::RealizedTy::Class(name, args, _) => {
             Some((name.clone(), args.clone(), Vec::new()))
         }
-        baml_type::RuntimeTy::Interface(name, args, associated_bindings, _) => {
+        baml_type::RealizedTy::Interface(name, args, associated_bindings, _) => {
             Some((name.clone(), args.clone(), associated_bindings.clone()))
         }
-        baml_type::RuntimeTy::Enum(name, _) => Some((name.clone(), Vec::new(), Vec::new())),
+        baml_type::RealizedTy::Enum(name, _) => Some((name.clone(), Vec::new(), Vec::new())),
         other => primitive_type_name(other).map(|name| (name, Vec::new(), Vec::new())),
     }
 }
@@ -119,14 +127,14 @@ fn ty_name_args_and_assoc(vm: &BexVm, value: Value) -> Option<InterfaceImplement
 /// structural — the registry bakes their for-types as `Concrete(RuntimeTy::Int { .. })`
 /// etc. (`baml_compiler2_mir`'s `tir2_to_template`), matched by `resolve::match_template`
 /// — so this is a reflection key, never compared against a baked pattern.
-fn primitive_type_name(ty: &baml_type::RuntimeTy) -> Option<baml_type::TypeName> {
+fn primitive_type_name(ty: &baml_type::RealizedTy) -> Option<baml_type::TypeName> {
     let name = match ty {
-        baml_type::RuntimeTy::Int { .. } => "int",
-        baml_type::RuntimeTy::Bigint { .. } => "bigint",
-        baml_type::RuntimeTy::Float { .. } => "float",
-        baml_type::RuntimeTy::String { .. } => "string",
-        baml_type::RuntimeTy::Bool { .. } => "bool",
-        baml_type::RuntimeTy::Null { .. } => "null",
+        baml_type::RealizedTy::Int { .. } => "int",
+        baml_type::RealizedTy::Bigint { .. } => "bigint",
+        baml_type::RealizedTy::Float { .. } => "float",
+        baml_type::RealizedTy::String { .. } => "string",
+        baml_type::RealizedTy::Bool { .. } => "bool",
+        baml_type::RealizedTy::Null { .. } => "null",
         _ => return None,
     };
     Some(baml_type::QualifiedTypeName::local(baml_type::Name::new(

--- a/baml_language/crates/bex_vm/src/package_baml/yaml.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/yaml.rs
@@ -66,7 +66,7 @@ fn convert_yaml_value(vm: &mut BexVm, value: serde_yaml::Value) -> Result<Value,
             }
             // `baml.json.json` maps: string keys, `json` values.
             Ok(Value::object(vm.alloc_map(
-                baml_type::RuntimeTy::string(),
+                baml_type::RealizedTy::string(),
                 super::json::json_alias_ty(),
                 entries,
             )))

--- a/baml_language/crates/bex_vm/src/type_context.rs
+++ b/baml_language/crates/bex_vm/src/type_context.rs
@@ -118,6 +118,7 @@ impl TypeContext for RuntimeTypeContext<'_> {
         base: &Ty,
         interface: &Interface,
         member: &Name,
+        fuel: u32,
     ) -> baml_type::normalize::ProjectionStep {
         use baml_type::normalize::ProjectionStep;
         // Reduce `(base as I).member` to the impl's binding when the base is a
@@ -150,8 +151,10 @@ impl TypeContext for RuntimeTypeContext<'_> {
             return ProjectionStep::Opaque;
         };
         // Realize the binding against the impl's bound args; widen back into `Ty`
-        // for the canonical algebra.
-        match template.substitute(&bound_args, self) {
+        // for the canonical algebra. `fuel` is threaded on so a cyclic
+        // associated-type binding — whose realization re-enters `project` — is
+        // bounded rather than recursing forever (the runtime twin of `from_ty`).
+        match template.substitute_with_fuel(&bound_args, self, fuel) {
             Ok(reduced) => ProjectionStep::Reduced(reduced.into()),
             Err(_) => ProjectionStep::Opaque,
         }

--- a/baml_language/crates/bex_vm/src/type_context.rs
+++ b/baml_language/crates/bex_vm/src/type_context.rs
@@ -22,7 +22,7 @@
 //! a proven-exhaustive match — see the List/Map-invariance sequencing constraint;
 //! the matcher's callers gate structural tests accordingly).
 
-use baml_type::{Interface, Name, QualifiedTypeName, RuntimeTy, Ty, normalize::TypeContext};
+use baml_type::{Interface, Name, QualifiedTypeName, RealizedTy, Ty, normalize::TypeContext};
 use bex_vm_types::types::Object;
 
 use crate::BexVm;
@@ -48,16 +48,17 @@ impl TypeContext for RuntimeTypeContext<'_> {
     }
 
     fn implements_interface(&self, concrete: &Ty, interface: &Interface) -> bool {
-        // Narrow the algebra's `Ty` operands to `RuntimeTy` and delegate to the
-        // open-world resolver. A narrowing failure (a compiler-only variant that
-        // cannot exist at runtime) fails safe: no membership is claimed.
-        let Ok(concrete) = RuntimeTy::try_from(concrete) else {
+        // Narrow the algebra's `Ty` operands to the runtime's `RealizedTy` and
+        // delegate to the open-world resolver. A narrowing failure (a non-realized
+        // variant that cannot exist as a runtime value) fails safe: no membership
+        // is claimed.
+        let Ok(concrete) = RealizedTy::try_from(concrete) else {
             return false;
         };
         let Ok(args) = interface
             .generics
             .iter()
-            .map(RuntimeTy::try_from)
+            .map(RealizedTy::try_from)
             .collect::<Result<Vec<_>, _>>()
         else {
             return false;
@@ -65,7 +66,7 @@ impl TypeContext for RuntimeTypeContext<'_> {
         let Ok(assoc) = interface
             .associated_types
             .iter()
-            .map(|(name, ty)| RuntimeTy::try_from(ty).map(|ty| (name.clone(), ty)))
+            .map(|(name, ty)| RealizedTy::try_from(ty).map(|ty| (name.clone(), ty)))
             .collect::<Result<Vec<_>, _>>()
         else {
             return false;
@@ -114,13 +115,45 @@ impl TypeContext for RuntimeTypeContext<'_> {
 
     fn project(
         &self,
-        _base: &Ty,
-        _interface: &Interface,
-        _member: &Name,
+        base: &Ty,
+        interface: &Interface,
+        member: &Name,
     ) -> baml_type::normalize::ProjectionStep {
-        // Explicitly opaque: for the same reason as `associated_type_bound` — a
-        // realized runtime value never carries a symbolic `(_ as I).member`
-        // projection for the algebra to reduce.
-        baml_type::normalize::ProjectionStep::Opaque
+        use baml_type::normalize::ProjectionStep;
+        // Reduce `(base as I).member` to the impl's binding when the base is a
+        // realized runtime type — the runtime twin of the compiler's projection
+        // reduction. A symbolic (non-realized) base, an interface arg that is not
+        // realized, no applicable impl, or a binding that does not itself realize
+        // all leave the projection opaque (equal only to itself), never a wrong
+        // reduction.
+        let Ok(base) = RealizedTy::try_from(base) else {
+            return ProjectionStep::Opaque;
+        };
+        let Ok(iface_args) = interface
+            .generics
+            .iter()
+            .map(RealizedTy::try_from)
+            .collect::<Result<Vec<_>, _>>()
+        else {
+            return ProjectionStep::Opaque;
+        };
+        // Select the applicable impl and read its associated-type binding template.
+        let Some((rule, bound_args)) = crate::package_baml::resolve_implements_rule(
+            self.vm,
+            &base,
+            &interface.name,
+            &iface_args,
+        ) else {
+            return ProjectionStep::Opaque;
+        };
+        let Some((_, template)) = rule.interface_assoc.iter().find(|(n, _)| n == member) else {
+            return ProjectionStep::Opaque;
+        };
+        // Realize the binding against the impl's bound args; widen back into `Ty`
+        // for the canonical algebra.
+        match template.substitute(&bound_args, self) {
+            Ok(reduced) => ProjectionStep::Reduced(reduced.into()),
+            Err(_) => ProjectionStep::Opaque,
+        }
     }
 }

--- a/baml_language/crates/bex_vm/src/type_match.rs
+++ b/baml_language/crates/bex_vm/src/type_match.rs
@@ -33,7 +33,7 @@
 //! Dormant until MIR/emit routes structural type tests through
 //! `ConstValue::Type` — the sole caller today is a unit-tested `IsType` arm.
 
-use baml_type::{RuntimeTy, Ty, TyTemplate, normalize};
+use baml_type::{RealizedTy, Ty, TyTemplate, normalize};
 use bex_vm_types::Value;
 
 use crate::{BexVm, type_context::RuntimeTypeContext};
@@ -69,7 +69,7 @@ pub(crate) fn value_matches_template(
     vm: &BexVm,
     value: Value,
     template: &TyTemplate,
-    frame_type_args: &[RuntimeTy],
+    frame_type_args: &[RealizedTy],
 ) -> bool {
     // A value with no concrete BAML type (function/closure/future/…) is a member
     // of no structural type test.
@@ -100,13 +100,17 @@ pub(crate) fn value_matches_template(
 fn template_relates<C: normalize::TypeContext>(
     ctx: &C,
     template: &TyTemplate,
-    frame_type_args: &[RuntimeTy],
+    frame_type_args: &[RealizedTy],
     actual: &Ty,
     variance: Variance,
 ) -> bool {
     if !template.contains_wildcard() {
-        // Resolve frame references and let the canonical algebra do the work.
-        let expected = template.substitute(frame_type_args);
+        // Resolve frame references (and reduce any projection) into a realized
+        // type, then let the canonical algebra do the work. A template that does
+        // not realize against the frame's realized args matches nothing.
+        let Ok(expected) = template.substitute(frame_type_args, ctx) else {
+            return false;
+        };
         return relate(ctx, actual, expected.as_ty(), variance);
     }
 
@@ -258,11 +262,17 @@ mod tests {
     }
 
     /// `template_relates` over the empty context, covariant at the top level.
+    /// The frame args are written as `RuntimeTy` for test ergonomics and narrowed
+    /// to the realized frame the matcher takes (they are all concrete here).
     fn matches(template: &TyTemplate, frame: &[RuntimeTy], actual: &RuntimeTy) -> bool {
+        let frame: Vec<RealizedTy> = frame
+            .iter()
+            .map(|t| RealizedTy::try_from(t).expect("test frame arg is realized"))
+            .collect();
         template_relates(
             &EmptyCtx,
             template,
-            frame,
+            &frame,
             actual.as_ty(),
             Variance::Covariant,
         )

--- a/baml_language/crates/bex_vm/src/type_match.rs
+++ b/baml_language/crates/bex_vm/src/type_match.rs
@@ -255,6 +255,7 @@ mod tests {
             _: &baml_type::Ty,
             _: &Interface,
             _: &Name,
+            _fuel: u32,
         ) -> baml_type::normalize::ProjectionStep {
             // Context-free: no impls to reduce through; projections stay opaque.
             baml_type::normalize::ProjectionStep::Opaque

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -21,44 +21,45 @@ use smallvec::SmallVec;
 
 fn guard_template_matches(
     template: &baml_type::TyTemplate,
-    frame_type_args: &[baml_type::RuntimeTy],
-    actual: &baml_type::RuntimeTy,
+    frame_type_args: &[baml_type::RealizedTy],
+    actual: &baml_type::RealizedTy,
 ) -> bool {
-    use baml_type::{RealizedTy, RuntimeTy, TyTemplate};
+    use baml_type::{RealizedTy, TyTemplate};
 
     // A fully-realized template carries no frame refs or holes: compare it to
     // the actual arg by exact structural equality (the invariant-position rule
     // for reified type args). This is the flattened successor to the old
     // `Concrete(expected) => expected == actual` arm.
     if let Ok(realized) = <&RealizedTy>::try_from(template) {
-        return realized.as_runtime_ty() == actual;
+        return realized == actual;
     }
 
     match template {
         TyTemplate::Wildcard => true,
         #[expect(deprecated)]
         TyTemplate::TypeArgRefOrWildcard(n) => match frame_type_args.get(*n as usize) {
-            Some(RuntimeTy::BuiltinUnknown { .. }) | None => true,
-            Some(expected) => actual.is_subtype_of(expected),
+            Some(RealizedTy::BuiltinUnknown { .. }) | None => true,
+            // The context-free subtype fork lives on `RuntimeTy`; upcast only to
+            // consult it.
+            Some(expected) => actual
+                .as_runtime_ty()
+                .is_subtype_of(expected.as_runtime_ty()),
         },
-        TyTemplate::TypeArgRef(n) => {
-            frame_type_args
-                .get(*n as usize)
-                .cloned()
-                .unwrap_or_else(RuntimeTy::unknown)
-                == *actual
-        }
+        TyTemplate::TypeArgRef(n) => frame_type_args.get(*n as usize).map_or_else(
+            || RealizedTy::unknown() == *actual,
+            |expected| expected == actual,
+        ),
         TyTemplate::List(inner, _) => {
-            matches!(actual, RuntimeTy::List(actual_inner, _) if guard_template_matches(inner, frame_type_args, actual_inner))
+            matches!(actual, RealizedTy::List(actual_inner, _) if guard_template_matches(inner, frame_type_args, actual_inner))
         }
         TyTemplate::Map { key, value, .. } => {
-            matches!(actual, RuntimeTy::Map { key: actual_key, value: actual_value, .. } if guard_template_matches(key, frame_type_args, actual_key) && guard_template_matches(value, frame_type_args, actual_value))
+            matches!(actual, RealizedTy::Map { key: actual_key, value: actual_value, .. } if guard_template_matches(key, frame_type_args, actual_key) && guard_template_matches(value, frame_type_args, actual_value))
         }
         TyTemplate::Class(name, args, _) => {
-            matches!(actual, RuntimeTy::Class(actual_name, actual_args, _) if name == actual_name && args.len() == actual_args.len() && args.iter().zip(actual_args).all(|(template, actual)| guard_template_matches(template, frame_type_args, actual)))
+            matches!(actual, RealizedTy::Class(actual_name, actual_args, _) if name == actual_name && args.len() == actual_args.len() && args.iter().zip(actual_args).all(|(template, actual)| guard_template_matches(template, frame_type_args, actual)))
         }
         TyTemplate::Interface(name, args, assoc, _) => {
-            matches!(actual, RuntimeTy::Interface(actual_name, actual_args, actual_assoc, _) if name == actual_name
+            matches!(actual, RealizedTy::Interface(actual_name, actual_args, actual_assoc, _) if name == actual_name
             && args.len() == actual_args.len()
             && args.iter().zip(actual_args).all(|(template, actual)| guard_template_matches(template, frame_type_args, actual))
             && assoc.iter().all(|(name, template)| {
@@ -69,7 +70,7 @@ fn guard_template_matches(
             }))
         }
         TyTemplate::Union(parts, _) => match actual {
-            RuntimeTy::Union(actual_parts, _) => actual_parts.iter().all(|actual_part| {
+            RealizedTy::Union(actual_parts, _) => actual_parts.iter().all(|actual_part| {
                 parts
                     .iter()
                     .any(|part| guard_template_matches(part, frame_type_args, actual_part))
@@ -84,7 +85,7 @@ fn guard_template_matches(
             throws,
             ..
         } => {
-            matches!(actual, RuntimeTy::Function { params: actual_params, ret: actual_ret, throws: actual_throws, .. }
+            matches!(actual, RealizedTy::Function { params: actual_params, ret: actual_ret, throws: actual_throws, .. }
                 if params.len() == actual_params.len()
                 && params.iter().zip(actual_params).all(|(param, actual_param)| {
                     param.mode == actual_param.mode
@@ -94,7 +95,7 @@ fn guard_template_matches(
                 && guard_template_matches(throws, frame_type_args, actual_throws))
         }
         TyTemplate::Future(value, error, _) => {
-            matches!(actual, RuntimeTy::Future(actual_value, actual_error, _)
+            matches!(actual, RealizedTy::Future(actual_value, actual_error, _)
                 if guard_template_matches(value, frame_type_args, actual_value)
                 && guard_template_matches(error, frame_type_args, actual_error))
         }
@@ -118,12 +119,12 @@ fn guard_template_matches(
 /// fallback, matching the host's De Bruijn send order.
 fn lower_named_type_args(
     param_names: &[String],
-    type_args: IndexMap<String, baml_type::RuntimeTy>,
-) -> Vec<baml_type::RuntimeTy> {
+    type_args: IndexMap<String, baml_type::RealizedTy>,
+) -> Vec<baml_type::RealizedTy> {
     if param_names.is_empty() {
         return type_args.into_iter().map(|(_, ty)| ty).collect();
     }
-    let mut positional = vec![baml_type::RuntimeTy::unknown(); param_names.len()];
+    let mut positional = vec![baml_type::RealizedTy::unknown(); param_names.len()];
     for (name, ty) in type_args {
         if let Some(idx) = param_names.iter().position(|p| *p == name) {
             positional[idx] = ty;
@@ -184,6 +185,7 @@ use crate::{
     errors::{StackFrame, VmBamlError, VmError, VmInternalError, VmPanic, VmRustFnError},
     indexable::{EvalStack, EvalStackTrait},
     package_baml::{NativeCallResult, NativeFunction},
+    type_context::RuntimeTypeContext,
     types::ObjectTrait,
 };
 
@@ -281,7 +283,12 @@ pub struct BytecodeFrame {
     /// Populated by the `Call { ntypeargs }` instruction when the callee is
     /// generic.  Empty for non-generic calls.  Used by the `LoadType`
     /// instruction to substitute `TypeArgRef(n)` leaves in a `TyTemplate`.
-    pub type_args: Vec<baml_type::RuntimeTy>,
+    ///
+    /// Realized by construction: a generic call binds each parameter to a
+    /// concrete type, seeded from the callee's realized `Object` type args
+    /// (`GenericFunction`/`BoundMethod`/`Closure`/`Instance`), so a `LoadType`
+    /// substitutes them into a fully realized type.
+    pub type_args: Vec<baml_type::RealizedTy>,
     /// Byte offset of the most recently dispatched opcode (compact path).
     /// In the legacy path this mirrors `instruction_ptr - 1` and is kept
     /// up-to-date before each `step()` call.
@@ -353,7 +360,7 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::atomic::AtomicBool;
 
-    use baml_type::{Name, RuntimeTy, TyAttr, TyTemplate, TypeName};
+    use baml_type::{Name, RealizedTy, RuntimeTy, TyAttr, TyTemplate, TypeName};
     use bex_heap::{BexHeap, CollectionLevel, Tlab};
     use bex_vm_types::{
         EarlyYieldCheck, FunctionCaptureProps, FunctionKind, GlobalPool, HeapPtr, Object,
@@ -575,10 +582,10 @@ mod tests {
     fn guard_template_type_arg_ref_or_wildcard_honors_subtyping() {
         use super::guard_template_matches;
 
-        let shape = RuntimeTy::class("Shape");
-        let sq = RuntimeTy::class("Sq");
+        let shape = RealizedTy::class("Shape");
+        let sq = RealizedTy::class("Sq");
         // The reified frame `T` from the B-634 repro: the un-subsumed join.
-        let widened_t = RuntimeTy::union([shape.clone(), sq.clone()]);
+        let widened_t = RealizedTy::union([shape.clone(), sq.clone()]);
 
         // Under-match fix: the value's actual arg (`Shape`) is a member of the
         // widened frame `T` (`Shape | Sq`), so the subtype-or-wildcard template
@@ -621,7 +628,7 @@ mod tests {
 
         // An unconcretized (all-`unknown`) frame slot matches any instance.
         assert!(
-            guard_template_matches(&subtype_template, &[RuntimeTy::unknown()], &shape),
+            guard_template_matches(&subtype_template, &[RealizedTy::unknown()], &shape),
             "an unknown frame slot must match any runtime arg"
         );
     }
@@ -638,8 +645,8 @@ mod tests {
             foo.clone(),
             vec![TyTemplate::from(baml_type::RealizedTy::int())],
         );
-        let foo_int_value = RuntimeTy::class_with_args(foo.clone(), vec![RuntimeTy::int()]);
-        let foo_string_value = RuntimeTy::class_with_args(foo, vec![RuntimeTy::string()]);
+        let foo_int_value = RealizedTy::class_with_args(foo.clone(), vec![RealizedTy::int()]);
+        let foo_string_value = RealizedTy::class_with_args(foo, vec![RealizedTy::string()]);
 
         assert!(
             guard_template_matches(&foo_int_template, &[], &foo_int_value),
@@ -923,7 +930,7 @@ pub struct BexVm {
     /// Saved/restored across nested `Call` instructions; native handlers that
     /// re-enter the VM (via `YieldToCall`) therefore see their own type-args
     /// even if the inner callback uses different ones.
-    pending_call_type_args: Vec<baml_type::RuntimeTy>,
+    pending_call_type_args: Vec<baml_type::RealizedTy>,
 }
 
 /// VM execution state.
@@ -1391,7 +1398,7 @@ impl BexVm {
     ///
     /// Returns an empty slice for calls with `ntypeargs == 0` and from outside
     /// any call dispatch context.
-    pub fn current_call_type_args(&self) -> &[baml_type::RuntimeTy] {
+    pub fn current_call_type_args(&self) -> &[baml_type::RealizedTy] {
         &self.pending_call_type_args
     }
 
@@ -1623,14 +1630,14 @@ impl BexVm {
     /// `unknown`. The generated array-receiver glue calls this to build the
     /// [`ArrayView`](crate::package_baml::ArrayView) it hands a builtin, so a
     /// type-preserving builtin (e.g. `filter`) can tag its result array.
-    pub fn array_element_ty(&self, value: &Value) -> baml_type::RuntimeTy {
+    pub fn array_element_ty(&self, value: &Value) -> baml_type::RealizedTy {
         value
             .as_object_ptr()
             .and_then(|ptr| match self.get_object(ptr) {
                 Object::Array(arr) => Some((*arr.element_ty).clone()),
                 _ => None,
             })
-            .unwrap_or_else(baml_type::RuntimeTy::unknown)
+            .unwrap_or_else(baml_type::RealizedTy::unknown)
     }
 
     /// The declared key type of `value` when it is an `Object::Map`, else
@@ -1638,27 +1645,49 @@ impl BexVm {
     /// [`Self::map_value_ty`]) to build the
     /// [`MapView`](crate::package_baml::MapView) it hands a builtin, so a
     /// type-preserving builtin can tag its result map.
-    pub fn map_key_ty(&self, value: &Value) -> baml_type::RuntimeTy {
+    pub fn map_key_ty(&self, value: &Value) -> baml_type::RealizedTy {
         value
             .as_object_ptr()
             .and_then(|ptr| match self.get_object(ptr) {
                 Object::Map(map) => Some((*map.key_ty).clone()),
                 _ => None,
             })
-            .unwrap_or_else(baml_type::RuntimeTy::unknown)
+            .unwrap_or_else(baml_type::RealizedTy::unknown)
     }
 
     /// The declared value type of `value` when it is an `Object::Map`, else
     /// `unknown`. The map analogue of [`Self::array_element_ty`]; see
     /// [`Self::map_key_ty`].
-    pub fn map_value_ty(&self, value: &Value) -> baml_type::RuntimeTy {
+    pub fn map_value_ty(&self, value: &Value) -> baml_type::RealizedTy {
         value
             .as_object_ptr()
             .and_then(|ptr| match self.get_object(ptr) {
                 Object::Map(map) => Some((*map.value_ty).clone()),
                 _ => None,
             })
-            .unwrap_or_else(baml_type::RuntimeTy::unknown)
+            .unwrap_or_else(baml_type::RealizedTy::unknown)
+    }
+
+    /// Realize a class field's type template against an instance's realized class
+    /// type args, reducing any associated projection through the impl registry.
+    ///
+    /// A field template references only the class's own generic params (each bound
+    /// to a realized arg here) and the fields have concrete declared types, so this
+    /// always realizes; a substitution failure is a broken compiler/VM invariant,
+    /// surfaced as a panic rather than a silent `unknown`.
+    pub(crate) fn realize_field_ty(
+        &self,
+        template: &baml_type::TyTemplate,
+        class_type_args: &[baml_type::RealizedTy],
+    ) -> baml_type::RealizedTy {
+        let ctx = RuntimeTypeContext::new(self);
+        template
+            .substitute(class_type_args, &ctx)
+            .unwrap_or_else(|e| {
+                unreachable!(
+                    "class field type template did not realize against realized class args: {e}"
+                )
+            })
     }
 
     /// Read an object from the heap via `HeapPtr`.
@@ -1934,15 +1963,14 @@ impl BexVm {
                     ) {
                         ConcreteRealizedTy::Media(kind, TyAttr::default())
                     } else {
-                        // A generic instance's stored `class_type_args` are realized
-                        // at construction (`Box<int>` ⇒ `T = int`); narrow each into
-                        // the `ConcreteRealizedTy::Class` argument list.
-                        let type_args = inst
-                            .class_type_args
-                            .iter()
-                            .map(realized_arg)
-                            .collect::<Option<Vec<_>>>()?;
-                        ConcreteRealizedTy::Class(class.name.clone(), type_args, TyAttr::default())
+                        // A generic instance's stored `class_type_args` are already
+                        // realized (`Box<int>` ⇒ `T = int`), so they are exactly the
+                        // `ConcreteRealizedTy::Class` argument list.
+                        ConcreteRealizedTy::Class(
+                            class.name.clone(),
+                            inst.class_type_args.to_vec(),
+                            TyAttr::default(),
+                        )
                     }
                 }
                 other => unreachable!(
@@ -1964,13 +1992,12 @@ impl BexVm {
             },
             // Arrays/maps carry their element/key/value types, so the faithful
             // `list<T>` / `map<K, V>` is reconstructed from the value itself.
-            Object::Array(arr) => ConcreteRealizedTy::List(
-                Box::new(realized_arg(&arr.element_ty)?),
-                TyAttr::default(),
-            ),
+            Object::Array(arr) => {
+                ConcreteRealizedTy::List(Box::new((*arr.element_ty).clone()), TyAttr::default())
+            }
             Object::Map(map) => ConcreteRealizedTy::Map {
-                key: Box::new(realized_arg(&map.key_ty)?),
-                value: Box::new(realized_arg(&map.value_ty)?),
+                key: Box::new((*map.key_ty).clone()),
+                value: Box::new((*map.value_ty).clone()),
                 attr: TyAttr::default(),
             },
             // A cell is a transparent capture/mutable-binding slot, not a value
@@ -2002,19 +2029,10 @@ impl BexVm {
                 }
             }
             Object::HostClosure(hc) => ConcreteRealizedTy::Function {
-                params: hc
-                    .params
-                    .iter()
-                    .map(|p| {
-                        Some(baml_type::RealizedFunctionParamTy {
-                            name: p.name.clone(),
-                            ty: realized_arg(&p.ty)?,
-                            mode: p.mode,
-                        })
-                    })
-                    .collect::<Option<Vec<_>>>()?,
-                ret: Box::new(realized_arg(&hc.ret_ty)?),
-                throws: Box::new(realized_arg(&hc.throws_ty)?),
+                // The host-closure signature is already stored as realized types.
+                params: (*hc.params).clone(),
+                ret: Box::new((*hc.ret_ty).clone()),
+                throws: Box::new((*hc.throws_ty).clone()),
                 attr: TyAttr::default(),
             },
             // BUG: a `BoundMethod` is a callable value and *should* reconstruct
@@ -2241,7 +2259,7 @@ impl BexVm {
         // inherited positional slots — so fall back to the index as a key; the
         // named lowering then emits the unnamed bindings in order.
         let param_names = self.entry_point_generic_param_names(function);
-        let type_args: IndexMap<String, baml_type::RuntimeTy> = positional
+        let type_args: IndexMap<String, baml_type::RealizedTy> = positional
             .into_iter()
             .enumerate()
             .map(|(i, ty)| {
@@ -2276,7 +2294,7 @@ impl BexVm {
         &mut self,
         function: HeapPtr,
         args: &[Value],
-        type_args: IndexMap<String, baml_type::RuntimeTy>,
+        type_args: IndexMap<String, baml_type::RealizedTy>,
     ) {
         debug_assert!(
             matches!(
@@ -2398,7 +2416,7 @@ impl BexVm {
         &mut self,
         function: HeapPtr,
         args: &[Value],
-        type_args: Vec<baml_type::RuntimeTy>,
+        type_args: Vec<baml_type::RealizedTy>,
         callable_kind: FunctionKind,
     ) {
         let callee_global = self
@@ -3109,9 +3127,11 @@ impl BexVm {
 
     pub(crate) fn alloc_error_value(&mut self, class: ErrorClass, fields: Vec<Value>) -> Value {
         let class_ptr = self.error_class_ptrs[class as usize];
-        let instance_ptr =
-            self.tlab
-                .alloc(Object::Instance(Instance::new(class_ptr, vec![], fields)));
+        let instance_ptr = self.tlab.alloc(Object::Instance(Instance::new(
+            class_ptr,
+            Box::new([]),
+            fields,
+        )));
         Value::object(instance_ptr)
     }
 
@@ -3137,7 +3157,7 @@ impl BexVm {
         // element type.
         let frames_array = Value::object(
             self.tlab
-                .alloc_array(baml_type::RuntimeTy::unknown(), frames),
+                .alloc_array(baml_type::RealizedTy::unknown(), frames),
         );
         self.alloc_error_value(ErrorClass::StackTrace, vec![frames_array])
     }
@@ -3346,9 +3366,11 @@ impl BexVm {
     /// Allocate a `baml.panics.*` class instance using pre-resolved pointers.
     pub fn alloc_panic_value(&mut self, class: PanicClass, fields: Vec<Value>) -> Value {
         let class_ptr = self.panic_class_ptrs[class as usize];
-        let instance_ptr =
-            self.tlab
-                .alloc(Object::Instance(Instance::new(class_ptr, vec![], fields)));
+        let instance_ptr = self.tlab.alloc(Object::Instance(Instance::new(
+            class_ptr,
+            Box::new([]),
+            fields,
+        )));
         Value::object(instance_ptr)
     }
 
@@ -3758,7 +3780,7 @@ impl BexVm {
     pub(crate) fn bound_method_curried_type_args(
         &self,
         receiver: Value,
-    ) -> Box<[baml_type::RuntimeTy]> {
+    ) -> Box<[baml_type::RealizedTy]> {
         match receiver.as_object_ptr() {
             Some(ptr) => match self.get_object(ptr) {
                 Object::Instance(inst) => inst.class_type_args.clone(),
@@ -4171,14 +4193,14 @@ impl BexVm {
         // a host callable accepts arbitrary argument types.
         let positional_ptr = self
             .tlab
-            .alloc_array(baml_type::RuntimeTy::unknown(), positional);
+            .alloc_array(baml_type::RealizedTy::unknown(), positional);
         let optional_ptr = self.tlab.alloc_map(
-            baml_type::RuntimeTy::string(),
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::string(),
+            baml_type::RealizedTy::unknown(),
             optional,
         );
         let args_array_ptr = self.tlab.alloc_array(
-            baml_type::RuntimeTy::unknown(),
+            baml_type::RealizedTy::unknown(),
             vec![Value::object(positional_ptr), Value::object(optional_ptr)],
         );
         let ret_ty_ptr = self.tlab.alloc(Object::Type(Box::new(ret_ty)));
@@ -4231,8 +4253,8 @@ impl BexVm {
         // BytecodeFrame after it is created.
         let (is_host, closure_type_args, bound_method_class_type_args): (
             bool,
-            Box<[baml_type::RuntimeTy]>,
-            Box<[baml_type::RuntimeTy]>,
+            Box<[baml_type::RealizedTy]>,
+            Box<[baml_type::RealizedTy]>,
         ) = match self.get_object(callee_ptr) {
             Object::HostClosure(_) => (true, Box::new([]), Box::new([])),
             Object::Closure(c) => (false, c.captured_type_args.clone(), Box::new([])),
@@ -4270,7 +4292,7 @@ impl BexVm {
         // (reflect.type_of<T>, json natives) resolve T at runtime. (The
         // Closure/BoundMethod type args are classified in the consolidated match
         // above; GenericFunction is specific to generic instantiation values.)
-        let gf_type_args: Box<[baml_type::RuntimeTy]> = match self.get_object(callee_ptr) {
+        let gf_type_args: Box<[baml_type::RealizedTy]> = match self.get_object(callee_ptr) {
             Object::GenericFunction(gf) => gf.type_args.clone(),
             _ => Box::new([]),
         };
@@ -4398,7 +4420,7 @@ impl BexVm {
                 // `gf_type_args`; a closure-wrapped value
                 // (`let g = baml.json.from_string; let f = g<User>`) carries them
                 // on the closure's `captured_type_args`. Use whichever is set.
-                let native_type_args: &[baml_type::RuntimeTy] = if !gf_type_args.is_empty() {
+                let native_type_args: &[baml_type::RealizedTy] = if !gf_type_args.is_empty() {
                     &gf_type_args
                 } else {
                     &closure_type_args
@@ -4774,7 +4796,7 @@ impl BexVm {
         };
 
         Ok(Value::object(self.tlab.alloc(Object::Instance(
-            Instance::new(class_ptr, class_type_args, fields),
+            Instance::new(class_ptr, class_type_args.into(), fields),
         ))))
     }
 
@@ -5780,7 +5802,7 @@ impl BexVm {
 
                     // Pop class-level type args from the stack (sitting below any
                     // field init instructions that follow).
-                    let class_type_args: Vec<baml_type::RuntimeTy> = if ntypeargs > 0 {
+                    let class_type_args: Vec<baml_type::RealizedTy> = if ntypeargs > 0 {
                         let base = self
                             .stack
                             .len()
@@ -5816,7 +5838,7 @@ impl BexVm {
                         self.tlab
                             .alloc(Object::Instance(bex_vm_types::types::Instance::new(
                                 class_ptr,
-                                class_type_args,
+                                class_type_args.into(),
                                 fields,
                             )));
                     self.stack.push(Value::object(instance_ptr));
@@ -6005,7 +6027,7 @@ impl BexVm {
 
                     // Pop `ntypeargs` Object::Type values from the stack into a Vec<RuntimeTy>.
                     // These sit below the regular value args on the stack.
-                    let type_args: Vec<baml_type::RuntimeTy> = if ntypeargs > 0 {
+                    let type_args: Vec<baml_type::RealizedTy> = if ntypeargs > 0 {
                         let total_needed = arg_count + ntypeargs;
                         let base = self
                             .stack
@@ -6093,7 +6115,7 @@ impl BexVm {
                             // interfaces carry none and resolve by name + `Self`.
                             // Associated types are outputs, not part of the key.
                             Object::Type(ty) => match ty.as_ref() {
-                                baml_type::RuntimeTy::Interface(qtn, args, _assoc, _attr) => {
+                                baml_type::RealizedTy::Interface(qtn, args, _assoc, _attr) => {
                                     (qtn.clone(), args.clone())
                                 }
                                 other => unreachable!(
@@ -6110,7 +6132,7 @@ impl BexVm {
                     // Extract the `ntypeargs` method-level type args (sitting below
                     // the value args, as in `Call`) and remove them, leaving the
                     // `nargs` value args (receiver first).
-                    let method_type_args: Vec<baml_type::RuntimeTy> = if ntypeargs > 0 {
+                    let method_type_args: Vec<baml_type::RealizedTy> = if ntypeargs > 0 {
                         let total_needed = nargs + ntypeargs;
                         let base = self
                             .stack
@@ -6146,9 +6168,8 @@ impl BexVm {
                     // agrees. The rule borrows `self`; scope it so the borrow ends
                     // before the `&mut self` call below.
                     let receiver = self.stack[StackIndex::from_raw(args_offset)];
-                    // The resolver operates on the loose `RuntimeTy`; widen back
-                    // from the value's concrete-realized type.
-                    let self_ty = baml_type::RuntimeTy::from(
+                    // `Self` is the receiver value's realized concrete type.
+                    let self_ty = baml_type::RealizedTy::from(
                         self.value_concrete_ty(receiver).unwrap_or_else(|| {
                             unreachable!(
                                 "value of kind {:?} cannot be a virtual-call receiver",
@@ -6182,7 +6203,7 @@ impl BexVm {
                         // default), then the method-level type args — matching the
                         // callee's De Bruijn layout `[owner… ++ method…]`.
                         let mut frame =
-                            crate::package_baml::realize_frame(&method.frame, &bound_args);
+                            crate::package_baml::realize_frame(self, &method.frame, &bound_args)?;
                         frame.extend(method_type_args);
                         (callee, frame)
                     };
@@ -6787,7 +6808,7 @@ impl BexVm {
                     captures.reverse();
 
                     // Pop type args (pushed before the captures).
-                    let captured_type_args: Vec<baml_type::RuntimeTy> = if ntypeargs > 0 {
+                    let captured_type_args: Vec<baml_type::RealizedTy> = if ntypeargs > 0 {
                         let mut type_args = Vec::with_capacity(ntypeargs);
                         for _ in 0..ntypeargs {
                             let v = self.stack.ensure_pop();
@@ -6823,13 +6844,15 @@ impl BexVm {
                         }
                     };
 
-                    let ty = {
-                        // A fully-realized template narrows to `RealizedTy` (a
-                        // single validation walk) and widens to `RuntimeTy` by
-                        // transmute — no substitution environment needed.
-                        // Otherwise resolve its frame refs.
+                    let ty: baml_type::RealizedTy = {
+                        // A fully-realized template narrows to `RealizedTy` in a
+                        // single validation walk — no substitution environment
+                        // needed. Otherwise resolve its frame refs (and reduce any
+                        // projection) against the frame's realized type args; the
+                        // result must be realized or it is an internal error, never
+                        // a `unknown` erasure.
                         if let Ok(realized) = <&baml_type::RealizedTy>::try_from(&template) {
-                            baml_type::RuntimeTy::from(realized)
+                            realized.clone()
                         } else {
                             let frame_type_args =
                                 if let Frame::Bytecode(bf) = &self.frames[*frame_idx] {
@@ -6837,7 +6860,12 @@ impl BexVm {
                                 } else {
                                     vec![]
                                 };
-                            template.substitute(&frame_type_args)
+                            let ctx = RuntimeTypeContext::new(self);
+                            template.substitute(&frame_type_args, &ctx).map_err(|e| {
+                                VmInternalError::TypeSubstitution {
+                                    message: e.to_string(),
+                                }
+                            })?
                         }
                     };
 
@@ -6886,7 +6914,7 @@ impl BexVm {
                         let iface_ptr = self.as_object_ptr(iface_value, ObjectType::Type)?;
                         match self.get_object(iface_ptr) {
                             Object::Type(ty) => match ty.as_ref() {
-                                baml_type::RuntimeTy::Interface(qtn, args, _assoc, _attr) => {
+                                baml_type::RealizedTy::Interface(qtn, args, _assoc, _attr) => {
                                     (qtn.clone(), args.clone())
                                 }
                                 other => unreachable!(
@@ -6903,7 +6931,7 @@ impl BexVm {
                     // The method-level type args (a generic interface method's own
                     // generics, specialized at the reference site) sit below the
                     // interface type; they append to the resolved impl frame.
-                    let mut method_type_args: Vec<baml_type::RuntimeTy> =
+                    let mut method_type_args: Vec<baml_type::RealizedTy> =
                         Vec::with_capacity(ntypeargs);
                     for _ in 0..ntypeargs {
                         let v = self.stack.ensure_pop();
@@ -6915,9 +6943,8 @@ impl BexVm {
                     }
                     method_type_args.reverse();
                     let receiver = self.stack.ensure_pop();
-                    // The resolver operates on the loose `RuntimeTy`; widen back
-                    // from the value's concrete-realized type.
-                    let self_ty = baml_type::RuntimeTy::from(
+                    // `Self` is the receiver value's realized concrete type.
+                    let self_ty = baml_type::RealizedTy::from(
                         self.value_concrete_ty(receiver).unwrap_or_else(|| {
                             unreachable!(
                                 "value of kind {:?} cannot be a virtual bound-method receiver",
@@ -6943,7 +6970,7 @@ impl BexVm {
                             }
                         })?;
                         let mut frame =
-                            crate::package_baml::realize_frame(&method.frame, &bound_args);
+                            crate::package_baml::realize_frame(self, &method.frame, &bound_args)?;
                         frame.extend(method_type_args);
                         (method.fqn, frame)
                     };
@@ -6963,7 +6990,7 @@ impl BexVm {
                     let ntypeargs = { read_u16_unchecked(code, pc) as usize };
                     // Pop the `ntypeargs` `Object::Type` values (resolved against
                     // the current frame by the preceding LoadType instructions).
-                    let mut type_args: Vec<baml_type::RuntimeTy> = Vec::with_capacity(ntypeargs);
+                    let mut type_args: Vec<baml_type::RealizedTy> = Vec::with_capacity(ntypeargs);
                     for _ in 0..ntypeargs {
                         let v = self.stack.ensure_pop();
                         let ptr = self.as_object_ptr(v, ObjectType::Type)?;
@@ -6992,7 +7019,7 @@ impl BexVm {
                     // The callable value was pushed last (top of stack); the
                     // resolved `Object::Type` args sit beneath it.
                     let callable = self.stack.ensure_pop();
-                    let mut type_args: Vec<baml_type::RuntimeTy> = Vec::with_capacity(ntypeargs);
+                    let mut type_args: Vec<baml_type::RealizedTy> = Vec::with_capacity(ntypeargs);
                     for _ in 0..ntypeargs {
                         let v = self.stack.ensure_pop();
                         let ptr = self.as_object_ptr(v, ObjectType::Type)?;
@@ -7020,7 +7047,7 @@ impl BexVm {
                     // `T` at runtime, and — unlike closure-wrapping it — never
                     // crashes. (`GenericFunction` does not reach here: TIR rejects
                     // type args on an already-specialized value.)
-                    let wrap: Option<(HeapPtr, Vec<Value>, Vec<baml_type::RuntimeTy>)> =
+                    let wrap: Option<(HeapPtr, Vec<Value>, Vec<baml_type::RealizedTy>)> =
                         match self.get_object(callable_ptr) {
                             Object::Function(_) => Some((callable_ptr, Vec::new(), Vec::new())),
                             Object::Closure(c) => Some((

--- a/baml_language/crates/bex_vm/tests/load_type.rs
+++ b/baml_language/crates/bex_vm/tests/load_type.rs
@@ -13,7 +13,7 @@
 use std::sync::{Arc, atomic::AtomicBool};
 
 use baml_project::testing::compile_source;
-use baml_type::{RuntimeTy, TyTemplate};
+use baml_type::{RealizedTy, RuntimeTy, TyTemplate};
 use bex_vm::{BexVm, VmExecState};
 use bex_vm_types::{
     ConstValue, FunctionCaptureProps, GlobalIndex, Instruction, Object, ObjectIndex, Value,
@@ -131,8 +131,8 @@ fn load_type_concrete_int() {
     match vm.get_object(ptr) {
         Object::Type(ty) => assert_eq!(
             **ty,
-            RuntimeTy::int(),
-            "LoadType(int) should materialise RuntimeTy::int"
+            RealizedTy::int(),
+            "LoadType(int) should materialise RealizedTy::int"
         ),
         other => panic!("expected Object::Type, got {other:?}"),
     }
@@ -174,8 +174,8 @@ fn load_type_concrete_string_different_from_int() {
         other => panic!("expected Object::Type for string, got {other:?}"),
     };
 
-    assert_eq!(int_ty, RuntimeTy::int());
-    assert_eq!(str_ty, RuntimeTy::string());
+    assert_eq!(int_ty, RealizedTy::int());
+    assert_eq!(str_ty, RealizedTy::string());
     assert_ne!(
         int_ty, str_ty,
         "int and string LoadType payloads must differ"
@@ -215,7 +215,7 @@ fn load_type_type_arg_ref_substitutes_from_frame() {
         use bex_vm::Frame;
         let frame = vm.frames.last_mut().expect("entry frame must exist");
         if let Frame::Bytecode(bf) = frame {
-            bf.type_args = vec![RuntimeTy::string()];
+            bf.type_args = vec![RealizedTy::string()];
         } else {
             panic!("entry frame should be Bytecode");
         }
@@ -229,7 +229,7 @@ fn load_type_type_arg_ref_substitutes_from_frame() {
         }
     };
 
-    // The result must be an Object::Type wrapping RuntimeTy::string()
+    // The result must be an Object::Type wrapping RealizedTy::string()
     let Some(ptr) = result.as_object_ptr() else {
         panic!("expected Object, got {result:?}");
     };
@@ -238,7 +238,7 @@ fn load_type_type_arg_ref_substitutes_from_frame() {
         Object::Type(ty) => {
             assert_eq!(
                 **ty,
-                RuntimeTy::string(),
+                RealizedTy::string(),
                 "TypeArgRef(0) should resolve to string"
             );
         }
@@ -276,7 +276,7 @@ fn load_type_array_of_type_arg_ref() {
         use bex_vm::Frame;
         let frame = vm.frames.last_mut().expect("entry frame must exist");
         if let Frame::Bytecode(bf) = frame {
-            bf.type_args = vec![RuntimeTy::int()];
+            bf.type_args = vec![RealizedTy::int()];
         } else {
             panic!("entry frame should be Bytecode");
         }
@@ -298,7 +298,7 @@ fn load_type_array_of_type_arg_ref() {
         Object::Type(ty) => {
             assert_eq!(
                 **ty,
-                RuntimeTy::list(RuntimeTy::int()),
+                RealizedTy::list(RealizedTy::int()),
                 "Array(TypeArgRef(0)) with int → int[]"
             );
         }
@@ -383,8 +383,8 @@ fn call_ntypeargs_threads_type_arg_into_callee() {
         Object::Type(ty) => {
             assert_eq!(
                 **ty,
-                RuntimeTy::string(),
-                "inner function should receive RuntimeTy::string() via type arg"
+                RealizedTy::string(),
+                "inner function should receive RealizedTy::string() via type arg"
             );
         }
         other => panic!("expected Object::Type, got {other:?}"),

--- a/baml_language/crates/bex_vm/tests/method_class_type_args.rs
+++ b/baml_language/crates/bex_vm/tests/method_class_type_args.rs
@@ -12,7 +12,7 @@
 use std::sync::{Arc, atomic::AtomicBool};
 
 use baml_project::testing::compile_source;
-use baml_type::{Name, RuntimeTy, TyAttr, TyTemplate, TypeName};
+use baml_type::{Name, RealizedTy, RuntimeTy, TyAttr, TyTemplate, TypeName};
 use bex_vm::{BexVm, VmExecState};
 use bex_vm_types::{
     ConstValue, FunctionCaptureProps, Instruction, Object, ObjectIndex, Value,
@@ -139,8 +139,8 @@ fn alloc_instance_ntypeargs_stores_class_type_args() {
         Object::Instance(inst) => {
             assert_eq!(
                 inst.class_type_args.to_vec(),
-                vec![RuntimeTy::int()],
-                "Instance::class_type_args should equal [RuntimeTy::int()]"
+                vec![RealizedTy::int()],
+                "Instance::class_type_args should equal [RealizedTy::int()]"
             );
         }
         other => panic!("expected Object::Instance, got {other:?}"),
@@ -225,7 +225,7 @@ fn method_frame_type_args_seeded_with_class_type_args() {
         use bex_vm::Frame;
         let frame = vm.frames.last_mut().expect("entry frame");
         if let Frame::Bytecode(bf) = frame {
-            bf.type_args = vec![RuntimeTy::int()]; // receiver.class_type_args = [int]
+            bf.type_args = vec![RealizedTy::int()]; // receiver.class_type_args = [int]
         } else {
             panic!("entry frame should be Bytecode");
         }
@@ -246,7 +246,7 @@ fn method_frame_type_args_seeded_with_class_type_args() {
         Object::Type(ty) => {
             assert_eq!(
                 **ty,
-                RuntimeTy::int(),
+                RealizedTy::int(),
                 "TypeArgRef(0) with class_type_args=[int] should yield int"
             );
         }
@@ -277,7 +277,7 @@ fn method_frame_type_args_seeded_string() {
         use bex_vm::Frame;
         let frame = vm.frames.last_mut().expect("entry frame");
         if let Frame::Bytecode(bf) = frame {
-            bf.type_args = vec![RuntimeTy::string()];
+            bf.type_args = vec![RealizedTy::string()];
         }
     }
 
@@ -296,7 +296,7 @@ fn method_frame_type_args_seeded_string() {
         Object::Type(ty) => {
             assert_eq!(
                 **ty,
-                RuntimeTy::string(),
+                RealizedTy::string(),
                 "TypeArgRef(0) with class_type_args=[string] should yield string"
             );
         }
@@ -326,7 +326,7 @@ function f() -> string[] {
         .expect("map result should be an array object");
     match vm.get_object(ptr) {
         Object::Array(arr) => assert!(
-            matches!(&*arr.element_ty, RuntimeTy::String { .. }),
+            matches!(&*arr.element_ty, RealizedTy::String { .. }),
             "map result element_ty should be `string` (closure return `U`), not `{:?}` \
              (the receiver `T`)",
             arr.element_ty

--- a/baml_language/crates/bex_vm_types/src/errors.rs
+++ b/baml_language/crates/bex_vm_types/src/errors.rs
@@ -285,6 +285,16 @@ pub enum VmInternalError {
     /// compiler/VM inconsistency, not a user-reachable condition.
     #[error("virtual call could not resolve interface method `{method}`")]
     UnresolvedVirtualCall { method: String },
+
+    /// A `LoadType` (or other materialization) could not fully realize a
+    /// `TyTemplate` against the frame's realized type arguments — a frame
+    /// reference out of range, a `Wildcard` hole reaching a materialization
+    /// position, or an associated-type projection that did not reduce. Runtime
+    /// type arguments are realized, so the compiler guarantees such templates
+    /// realize; a failure here is a compiler/VM inconsistency, surfaced loudly
+    /// rather than erased to `unknown`.
+    #[error("could not realize type template: {message}")]
+    TypeSubstitution { message: String },
 }
 
 /// Any kind of virtual machine error.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -616,7 +616,7 @@ mod tests {
     fn instance_field_helpers_load_and_store_checked_slots() {
         let instance = Instance::new(
             HeapPtr::null(),
-            vec![],
+            Box::new([]),
             vec![Value::int(10), Value::int(20)],
         );
 
@@ -633,7 +633,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "index out of bounds")]
     fn instance_load_field_panics_for_invalid_slot() {
-        let instance = Instance::new(HeapPtr::null(), vec![], vec![Value::int(10)]);
+        let instance = Instance::new(HeapPtr::null(), Box::new([]), vec![Value::int(10)]);
 
         let _ = instance.load_field(1);
     }

--- a/baml_language/crates/bex_vm_types/src/types/class.rs
+++ b/baml_language/crates/bex_vm_types/src/types/class.rs
@@ -7,8 +7,6 @@ use crate::{AtomicValueSlot, CleanupLatch, HeapPtr, Value};
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct ClassField {
     pub name: String,
-    /// Resolved field type with `TypeVar`s erased to `RuntimeTy::BuiltinUnknown`.
-    ///
     /// Used by paths that don't care about parametric class type-args
     /// (codegen, `sys_ops` walking, output-format rendering).  For typed
     /// runtime walking against an `Instance::class_type_args` binding, use
@@ -82,7 +80,7 @@ pub struct Instance {
     /// Boxed (immutable after construction) rather than a `Vec` so `Instance`
     /// stays within `Object`'s 64-byte budget once the `cleaned` latch is added
     /// — matching the existing `Box<[RuntimeTy]>` convention for type-arg lists.
-    pub class_type_args: Box<[baml_type::RuntimeTy]>,
+    pub class_type_args: Box<[baml_type::RealizedTy]>,
 
     /// Fields are accessed by index. No string lookups. Each slot is atomic so
     /// racing field reads/writes across `spawn` fibers cannot become a Rust
@@ -99,12 +97,12 @@ pub struct Instance {
 impl Instance {
     pub fn new(
         class: HeapPtr,
-        class_type_args: Vec<baml_type::RuntimeTy>,
+        class_type_args: Box<[baml_type::RealizedTy]>,
         fields: Vec<Value>,
     ) -> Self {
         Self {
             class,
-            class_type_args: class_type_args.into(),
+            class_type_args,
             fields: fields.into_iter().map(AtomicValueSlot::new).collect(),
             cleaned: CleanupLatch::new(false),
         }

--- a/baml_language/crates/bex_vm_types/src/types/containers.rs
+++ b/baml_language/crates/bex_vm_types/src/types/containers.rs
@@ -187,13 +187,13 @@ impl<T> std::ops::DerefMut for LockedWriteGuard<'_, T> {
 
 #[derive(Clone, Debug)]
 pub struct Array {
-    pub element_ty: Box<baml_type::RuntimeTy>,
+    pub element_ty: Box<baml_type::RealizedTy>,
     pub data: ArrayContainer,
 }
 
 impl Array {
     /// Build an array of `element_ty` from its backing values.
-    pub fn new(element_ty: baml_type::RuntimeTy, data: Vec<Value>) -> Self {
+    pub fn new(element_ty: baml_type::RealizedTy, data: Vec<Value>) -> Self {
         Self {
             element_ty: Box::new(element_ty),
             data: ArrayContainer::new(data),
@@ -270,8 +270,8 @@ pub type Uint8ArrayWriteGuard<'a> = LockedWriteGuard<'a, Vec<u8>>;
 
 #[derive(Clone, Debug)]
 pub struct Map {
-    pub key_ty: Box<baml_type::RuntimeTy>,
-    pub value_ty: Box<baml_type::RuntimeTy>,
+    pub key_ty: Box<baml_type::RealizedTy>,
+    pub value_ty: Box<baml_type::RealizedTy>,
     pub data: MapContainer,
 }
 /// Heap-mutable map container. Pairs a boxed `IndexMap<BexStr, Value>` with
@@ -295,8 +295,8 @@ impl MapReadGuard<'_> {
 impl Map {
     /// Build a map of `key_ty`/`value_ty` from its backing entries.
     pub fn new(
-        key_ty: baml_type::RuntimeTy,
-        value_ty: baml_type::RuntimeTy,
+        key_ty: baml_type::RealizedTy,
+        value_ty: baml_type::RealizedTy,
         data: IndexMap<bex_str::BexStr, Value>,
     ) -> Self {
         Self {

--- a/baml_language/crates/bex_vm_types/src/types/function.rs
+++ b/baml_language/crates/bex_vm_types/src/types/function.rs
@@ -320,7 +320,7 @@ pub struct Closure {
     /// before the cell captures.  These become `frame.type_args` when the
     /// closure is invoked, so that `LoadType(TypeArgRef(N))` inside the
     /// closure body resolves correctly.
-    pub captured_type_args: Box<[baml_type::RuntimeTy]>,
+    pub captured_type_args: Box<[baml_type::RealizedTy]>,
 }
 
 /// A method bound to a specific receiver instance.
@@ -357,7 +357,7 @@ pub struct BoundMethod {
     /// type variable, but the upstream fix that stops typevars leaking into
     /// value positions is still in flight, so all three stay `RuntimeTy` and
     /// narrow to `RealizedTy` together once it lands.
-    pub type_args: Box<[baml_type::RuntimeTy]>,
+    pub type_args: Box<[baml_type::RealizedTy]>,
 }
 
 /// A generic function instantiation carrying concrete type arguments.
@@ -373,7 +373,7 @@ pub struct GenericFunction {
     /// via the global table, mirroring `MakeBoundMethod`).
     pub function: crate::GlobalIndex,
     /// Concrete type arguments to seed into `frame.type_args` when called.
-    pub type_args: Box<[baml_type::RuntimeTy]>,
+    pub type_args: Box<[baml_type::RealizedTy]>,
 }
 
 /// A host-language callable bound to a BAML function type.
@@ -394,7 +394,7 @@ pub struct HostClosure {
     /// The declared return type of the host-callable, threaded through
     /// `SysOp::BamlHostCallHostValue` as `type_arg_0` so the sysop impl
     /// can validate the host's returned value against the BAML signature.
-    pub ret_ty: Box<baml_type::RuntimeTy>,
+    pub ret_ty: Box<baml_type::RealizedTy>,
     /// The declared error/throws contract of the host-callable (`E` in
     /// `call_host_value<T, E>`), threaded through
     /// `SysOp::BamlHostCallHostValue` as `type_arg_1`. A host throw is
@@ -404,7 +404,7 @@ pub struct HostClosure {
     /// accepts any thrown value — the "unknown" fallback. Concrete throws
     /// (e.g. `throws ParseError`) pass through unchanged so the contract
     /// check can reject off-type throws as `HostContractViolation`.
-    pub throws_ty: Box<baml_type::RuntimeTy>,
+    pub throws_ty: Box<baml_type::RealizedTy>,
     /// Number of value arguments the host callable expects.
     ///
     /// `CallIndirect` reads this to drain the right number of operand slots
@@ -418,7 +418,7 @@ pub struct HostClosure {
     /// optionals, omitted ones dropped), so each bridge can apply its calling
     /// convention (e.g. TypeScript's trailing `$opts`) without the callee type
     /// on the wire. `Box`-ed to keep `Object` within its size budget.
-    pub params: Box<Vec<baml_type::RuntimeFunctionParamTy>>,
+    pub params: Box<Vec<baml_type::RealizedFunctionParamTy>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]

--- a/baml_language/crates/bex_vm_types/src/types/object.rs
+++ b/baml_language/crates/bex_vm_types/src/types/object.rs
@@ -121,8 +121,8 @@ pub enum Object {
     /// Collector object (opaque handle to `bex_events::Collector`).
     Collector(CollectorRef),
 
-    /// A type descriptor value — wraps a `baml_type::RuntimeTy`.
-    Type(Box<baml_type::RuntimeTy>),
+    /// A type descriptor value — wraps a `baml_type::RealizedTy`.
+    Type(Box<baml_type::RealizedTy>),
 
     #[cfg(feature = "heap_debug")]
     Sentinel(crate::types::SentinelKind),
@@ -191,16 +191,16 @@ enum ObjectWire {
         num_bigint::BigInt,
     ),
     Uint8Array(Vec<u8>),
-    Array(Box<baml_type::RuntimeTy>, Vec<Value>),
+    Array(Box<baml_type::RealizedTy>, Vec<Value>),
     Map(
-        Box<baml_type::RuntimeTy>,
-        Box<baml_type::RuntimeTy>,
+        Box<baml_type::RealizedTy>,
+        Box<baml_type::RealizedTy>,
         IndexMap<String, Value>,
     ),
     Float(f64),
     Future(crate::Future),
     UnscheduledFuture(UnscheduledFuture),
-    Type(Box<baml_type::RuntimeTy>),
+    Type(Box<baml_type::RealizedTy>),
 }
 
 impl BorshSerialize for Object {

--- a/baml_language/crates/bridge_ctypes/src/ty_decode.rs
+++ b/baml_language/crates/bridge_ctypes/src/ty_decode.rs
@@ -146,20 +146,26 @@ pub fn proto_ty_to_runtime_ty(ty: &BamlTy) -> Result<RuntimeTy, CtypesError> {
             base: Box::new(opt_to_runtime_ty(p.base.as_deref())?),
             // The projection's interface constraint is wired as a `Ty` and must
             // decode to an interface existential, from which the constraint
-            // (`RuntimeInterface`) is recovered.
-            interface: match p.interface.as_deref() {
-                Some(ty) => match proto_ty_to_runtime_ty(ty)? {
-                    RuntimeTy::Interface(name, generics, associated_types, _) => Some(Box::new(
-                        RuntimeInterface::new(name, generics, associated_types),
-                    )),
+            // (`RuntimeInterface`) is recovered. A projection always carries its
+            // declaring interface, so an absent wire field is a malformed message —
+            // reject it rather than fabricate an unqualified projection.
+            interface: {
+                let ty = p.interface.as_deref().ok_or_else(|| {
+                    CtypesError::InternalError(
+                        "AssociatedTypeProjection.interface is required".to_string(),
+                    )
+                })?;
+                match proto_ty_to_runtime_ty(ty)? {
+                    RuntimeTy::Interface(name, generics, associated_types, _) => {
+                        Box::new(RuntimeInterface::new(name, generics, associated_types))
+                    }
                     _ => {
                         return Err(CtypesError::InternalError(
                             "AssociatedTypeProjection.interface did not decode to an interface type"
                                 .to_string(),
                         ));
                     }
-                },
-                None => None,
+                }
             },
             member: Name::new(&p.member),
             attr: TyAttr::default(),

--- a/baml_language/crates/bridge_ctypes/src/ty_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/ty_encode.rs
@@ -171,15 +171,15 @@ fn runtime_ty_to_variant(ty: &RuntimeTy) -> TyVariant {
             ..
         } => TyVariant::AssociatedTypeProjection(Box::new(BamlTyAssociatedTypeProjection {
             base: Some(Box::new(runtime_ty_to_proto_ty(base))),
-            interface: interface.as_deref().map(|iface| {
-                Box::new(BamlTy {
-                    ty: Some(TyVariant::Interface(interface_to_proto(
-                        &iface.name,
-                        &iface.generics,
-                        &iface.associated_types,
-                    ))),
-                })
-            }),
+            // Always present on the Rust side; the wire field stays optional for
+            // backward compatibility but a projection always encodes its interface.
+            interface: Some(Box::new(BamlTy {
+                ty: Some(TyVariant::Interface(interface_to_proto(
+                    &interface.name,
+                    &interface.generics,
+                    &interface.associated_types,
+                ))),
+            })),
             member: member.as_str().to_string(),
         })),
 
@@ -278,18 +278,22 @@ mod tests {
         // `BamlTy::Interface`, decoded back into a `RuntimeInterface`).
         assert_roundtrip(&RuntimeTy::AssociatedTypeProjection {
             base: Box::new(RuntimeTy::int()),
-            interface: Some(Box::new(RuntimeInterface {
+            interface: Box::new(RuntimeInterface {
                 name: TypeName::from_dotted_path("user.Iterator"),
                 generics: vec![RuntimeTy::int()],
                 associated_types: vec![(Name::new("Item"), RuntimeTy::string())],
-            })),
+            }),
             member: Name::new("Item"),
             attr: TyAttr::default(),
         });
-        // Projection with no constraint (`interface: None`).
+        // A projection through an unparameterized interface.
         assert_roundtrip(&RuntimeTy::AssociatedTypeProjection {
             base: Box::new(RuntimeTy::string()),
-            interface: None,
+            interface: Box::new(RuntimeInterface {
+                name: TypeName::from_dotted_path("user.HasOutput"),
+                generics: vec![],
+                associated_types: vec![],
+            }),
             member: Name::new("Output"),
             attr: TyAttr::default(),
         });


### PR DESCRIPTION
Representation tightening to prevent invariant violations:
- The interface in associated type projection types (`I` in `(C as I).Assoc`) is no longer optional: it must either be written explicitly or inferred by the TIR.
- The runtime now uses `RealizedTy` anywhere that typevars are invalid, including function call frames and instances' generic params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of generic and associated types across compilation and runtime execution.
  * Fixed type-aware JSON, CSV, YAML, TOML, and array operations for complex type arguments.
  * Improved interface method resolution and associated-type projection behavior.
  * Prevented spawned tasks from remaining indefinitely pending when internal errors occur.

* **Reliability**
  * Added clearer error reporting when type substitutions cannot be completed.
  * Improved validation of type information crossing runtime and host boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->