### PR TITLE
Clarify deferred playground folder collapse

### DIFF
--- a/typescript2/app-vscode-webview/src/FunctionSidebar.interaction.test.tsx
+++ b/typescript2/app-vscode-webview/src/FunctionSidebar.interaction.test.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FunctionSidebar } from '../../pkg-playground/src/FunctionSidebar';
+
+const collapsePendingMessage =
+  'Will collapse when this folder is no longer kept open automatically';
+
+describe('FunctionSidebar folder disclosure', () => {
+  it('shows a pending indicator before collapsing after navigation leaves the folder', () => {
+    render(<SidebarHarness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Functions (2)' }));
+    const folder = screen.getByRole('button', { name: 'demo (1)' });
+    expect(folder).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(folder);
+
+    expect(folder).toHaveAttribute('aria-expanded', 'true');
+    expect(folder).toHaveAttribute('data-collapse-pending', 'true');
+    expect(screen.getByText(collapsePendingMessage)).toBeInTheDocument();
+    expect(folder.querySelector('svg')).toHaveClass('text-vsc-accent');
+    expect(folder.querySelector('svg')).not.toHaveClass('rotate-90');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Main' }));
+
+    expect(folder).toHaveAttribute('aria-expanded', 'false');
+    expect(folder).not.toHaveAttribute('data-collapse-pending');
+  });
+
+  it('cancels pending collapse when the forced-open folder is clicked again', () => {
+    render(<SidebarHarness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Functions (2)' }));
+    const folder = screen.getByRole('button', { name: 'demo (1)' });
+
+    fireEvent.click(folder);
+    expect(folder).toHaveAttribute('data-collapse-pending', 'true');
+
+    fireEvent.click(folder);
+    expect(folder).not.toHaveAttribute('data-collapse-pending');
+    expect(folder.querySelector('svg')).toHaveClass('rotate-90');
+    expect(folder.querySelector('svg')).not.toHaveClass('text-vsc-accent');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Main' }));
+    expect(folder).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+function SidebarHarness() {
+  const [selectedFn, setSelectedFn] = useState<string | null>('demo.Foo');
+
+  return (
+    <FunctionSidebar
+      functions={[
+        { name: 'Main', kind: 'expr', origin: 'userDefined' },
+        { name: 'demo.Foo', kind: 'expr', origin: 'userDefined' },
+      ]}
+      showInternalFunctions={false}
+      internalFunctionCount={0}
+      selectedFn={selectedFn}
+      onSelectFn={setSelectedFn}
+      onRefreshTests={vi.fn()}
+    />
+  );
+}

--- a/typescript2/app-vscode-webview/src/FunctionSidebar.interaction.test.tsx
+++ b/typescript2/app-vscode-webview/src/FunctionSidebar.interaction.test.tsx
@@ -20,6 +20,7 @@ describe('FunctionSidebar folder disclosure', () => {
     expect(folder).toHaveAttribute('aria-expanded', 'true');
     expect(folder).toHaveAttribute('data-collapse-pending', 'true');
     expect(screen.getByText(collapsePendingMessage)).toBeInTheDocument();
+    expect(folder.querySelector('svg')).toHaveClass('shrink-0');
     expect(folder.querySelector('svg')).toHaveClass('text-vsc-accent');
     expect(folder.querySelector('svg')).not.toHaveClass('rotate-90');
 

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -242,21 +242,36 @@ function FunctionTreeNode({
 
   if (node.type === 'folder') {
     const forcedOpen = forcedOpenFolderKeys.has(node.key);
-    const open = forcedOpen || (openFolderKeys[node.key] ?? false);
+    const requestedOpen = openFolderKeys[node.key];
+    const collapsePending = forcedOpen && requestedOpen === false;
+    const open = forcedOpen || (requestedOpen ?? false);
+    const collapsePendingMessage =
+      'Will collapse when this folder is no longer kept open automatically';
     return (
       <Collapsible
         open={open}
-        onOpenChange={(nextOpen) => onFolderOpenChange(node.key, nextOpen)}
+        onOpenChange={(nextOpen) =>
+          onFolderOpenChange(
+            node.key,
+            collapsePending && !nextOpen ? true : nextOpen,
+          )
+        }
       >
         <CollapsibleTrigger
           className="flex items-center gap-1 w-full pr-2 py-0.5 cursor-pointer text-[10px] font-vsc-mono text-vsc-text-muted hover:bg-vsc-hover"
           style={{ paddingLeft: indent }}
-          title={node.path.join('.')}
+          title={
+            collapsePending
+              ? `${node.path.join('.')} — ${collapsePendingMessage}`
+              : node.path.join('.')
+          }
+          data-collapse-pending={collapsePending || undefined}
         >
           <ChevronRight
             className={cn(
-              'h-3 w-3 text-vsc-text-faint transition-transform',
-              open && 'rotate-90',
+              'h-3 w-3 transition-transform',
+              collapsePending ? 'text-vsc-accent' : 'text-vsc-text-faint',
+              open && !collapsePending && 'rotate-90',
             )}
           />
           <Folder className="h-3.5 w-3.5 shrink-0 text-vsc-text-faint" />
@@ -266,6 +281,9 @@ function FunctionTreeNode({
           <span className="text-vsc-text-faint ml-1">
             ({node.functionCount})
           </span>
+          {collapsePending && (
+            <span className="sr-only">{collapsePendingMessage}</span>
+          )}
         </CollapsibleTrigger>
         <CollapsibleContent>
           {node.children.map((child) => (

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -269,7 +269,7 @@ function FunctionTreeNode({
         >
           <ChevronRight
             className={cn(
-              'h-3 w-3 transition-transform',
+              'h-3 w-3 shrink-0 transition-transform',
               collapsePending ? 'text-vsc-accent' : 'text-vsc-text-faint',
               open && !collapsePending && 'rotate-90',
             )}


### PR DESCRIPTION
## Summary
- preserve the selected namespace’s forced-open behavior while recording an explicit deferred-collapse preference
- show a blue right-facing chevron, tooltip, and screen-reader status when collapse is queued
- allow a second click to cancel the queued collapse and keep the folder open
- add interaction coverage for both navigating-away collapse and cancellation

## Why
The playground already kept the selected function’s namespace visible and remembered a click to collapse it after navigation left that namespace. Because the folder remained visibly open, the click appeared to do nothing. This makes the deferred state visible without hiding the active function.

## Validation
- `prek run --stage pre-commit --files typescript2/pkg-playground/src/FunctionSidebar.tsx typescript2/app-vscode-webview/src/FunctionSidebar.interaction.test.tsx`
- installed pre-commit hook during `git commit`
- `pnpm --filter app-vscode-webview exec vitest run --project unit src/FunctionSidebar.interaction.test.tsx`
- `pnpm --filter @b/pkg-playground exec vitest run src/FunctionSidebar.test.ts`
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter app-vscode-webview build`
- `cargo build -p baml_cli --bin baml-cli`
- manual browser verification against the source-built playground

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved folder disclosure behavior when folders must remain temporarily open.
  * Added clear visual, tooltip, and accessibility feedback when a folder is scheduled to collapse.
  * Users can cancel a pending collapse by reopening the folder.

* **Tests**
  * Added coverage for pending-collapse behavior and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->