### PR TITLE
chore(lsp): review follow-ups — per-file codecs, memoization tests, doc fixes

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
+ "salsa",
  "syn 2.0.117",
  "text-size",
  "walkdir",

--- a/baml_language/TEST_INSTRUCTIONS.md
+++ b/baml_language/TEST_INSTRUCTIONS.md
@@ -71,6 +71,9 @@ UPDATE_EXPECT=1 cargo test --package baml_lsp2_actions_tests
 ### 7. Verify all tests pass
 
 ```bash
+# Library unit tests — always run these when Rust code changes
+cargo test --lib
+
 # Run all tests (can skip slow parser_stress with --skip parser_stress)
 cargo test --package baml_tests -- --skip parser_stress
 cargo test --package baml_lsp2_actions_tests
@@ -108,13 +111,13 @@ cargo insta review
 - **Type checking**: `crates/baml_compiler2_tir/src/builder.rs`
 
 
-DO NOT EDIT the diagnostics manually in baml_lsp2_actions_tests. Use update_expect=1
+DO NOT EDIT the diagnostics manually in baml_lsp2_actions_tests. Use UPDATE_EXPECT=1
 
 Find the base-case that makes syntax fail and add that to baml_test with a good name and good folder organization.
 
 A good place to start when given a diagnostic failure or some parser issue is to look at the snapshot test (create one if missing) and checking the .snap files for CST/HIR etc.
 
-BEFORE you run these lsp tests with update_expect, make sure to just run without it and figure out if the new results are what you expect.
+BEFORE you run these lsp tests with UPDATE_EXPECT, make sure to just run without it and figure out if the new results are what you expect.
 
 Just because the existing file may say 'no diagnostics expected' doesn't mean it is correct by the way. We haven't finished implementing all diagnostics. You have to see if we added some other comments elsewhere in the file to see what we should sort of expect, or just inspect the behavior manually.
 

--- a/baml_language/crates/baml_lsp2_actions_tests/Cargo.toml
+++ b/baml_language/crates/baml_lsp2_actions_tests/Cargo.toml
@@ -25,3 +25,6 @@ walkdir = { workspace = true }
 
 [package.metadata.ci]
 wasm_support = false
+
+[dev-dependencies]
+salsa = { workspace = true }

--- a/baml_language/crates/baml_lsp2_actions_tests/src/lib.rs
+++ b/baml_language/crates/baml_lsp2_actions_tests/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod memoization;
 pub mod parser;
 pub mod runner;
 pub mod updater;

--- a/baml_language/crates/baml_lsp2_actions_tests/src/memoization.rs
+++ b/baml_language/crates/baml_lsp2_actions_tests/src/memoization.rs
@@ -1,0 +1,114 @@
+//! Pins the B1 memoization contract: `file_annotations` and
+//! `semantic_tokens` are Salsa tracked queries, so an unchanged file never
+//! recomputes them and a source edit invalidates them. Assertions count
+//! `WillExecute` events rather than inspecting results, so implementation
+//! rewrites of either query keep these tests meaningful.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use baml_lsp2_actions::{annotations::file_annotations, tokens::semantic_tokens};
+use baml_project::ProjectDatabase;
+
+type EventLog = Arc<Mutex<Vec<salsa::Event>>>;
+
+const SOURCE_V1: &str = r#"
+function Echo(value: int) -> int {
+    value
+}
+
+function Main() -> int {
+    let result = Echo(1)
+    result
+}
+"#;
+
+const SOURCE_V2: &str = r#"
+function Echo(value: string) -> string {
+    value
+}
+
+function Main() -> string {
+    let result = Echo("changed")
+    result
+}
+"#;
+
+fn test_db() -> (ProjectDatabase, EventLog, PathBuf) {
+    let events = EventLog::default();
+    let callback_events = Arc::clone(&events);
+    let mut db = ProjectDatabase::new_with_event_callback(Box::new(move |event| {
+        callback_events
+            .lock()
+            .expect("event log mutex poisoned")
+            .push(event);
+    }));
+    db.set_project_root(Path::new("/test"));
+    let path = PathBuf::from("/test/main.baml");
+    db.add_or_update_file(&path, SOURCE_V1);
+    (db, events, path)
+}
+
+fn clear_events(events: &EventLog) {
+    events.lock().expect("event log mutex poisoned").clear();
+}
+
+fn query_execution_count(db: &ProjectDatabase, events: &EventLog, query_name: &str) -> usize {
+    events
+        .lock()
+        .expect("event log mutex poisoned")
+        .iter()
+        .filter(|event| {
+            let salsa::EventKind::WillExecute { database_key } = &event.kind else {
+                return false;
+            };
+            let name =
+                (db as &dyn salsa::Database).ingredient_debug_name(database_key.ingredient_index());
+            name == query_name || name.ends_with(&format!("::{query_name}"))
+        })
+        .count()
+}
+
+#[test]
+fn file_annotations_are_memoized_and_invalidated_by_source_edits() {
+    let (mut db, events, path) = test_db();
+    let file = db.get_file(&path).expect("test file should exist");
+
+    clear_events(&events);
+    let cold = file_annotations(&db, file).clone();
+    assert_eq!(query_execution_count(&db, &events, "file_annotations"), 1);
+
+    clear_events(&events);
+    let warm = file_annotations(&db, file).clone();
+    assert_eq!(warm, cold);
+    assert_eq!(query_execution_count(&db, &events, "file_annotations"), 0);
+
+    db.add_or_update_file(&path, SOURCE_V2);
+    clear_events(&events);
+    let changed = file_annotations(&db, file).clone();
+    assert_ne!(changed, cold);
+    assert_eq!(query_execution_count(&db, &events, "file_annotations"), 1);
+}
+
+#[test]
+fn semantic_tokens_are_memoized_and_invalidated_by_source_edits() {
+    let (mut db, events, path) = test_db();
+    let file = db.get_file(&path).expect("test file should exist");
+
+    clear_events(&events);
+    let cold = semantic_tokens(&db, file).clone();
+    assert_eq!(query_execution_count(&db, &events, "semantic_tokens"), 1);
+
+    clear_events(&events);
+    let warm = semantic_tokens(&db, file).clone();
+    assert_eq!(warm, cold);
+    assert_eq!(query_execution_count(&db, &events, "semantic_tokens"), 0);
+
+    db.add_or_update_file(&path, SOURCE_V2);
+    clear_events(&events);
+    let changed = semantic_tokens(&db, file).clone();
+    assert_ne!(changed, cold);
+    assert_eq!(query_execution_count(&db, &events, "semantic_tokens"), 1);
+}

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -592,13 +592,19 @@ impl BexLspRequest for BexMulitProject {
                 // Use compiler2 usages_at — returns Vec<Location> (file + TextRange).
                 let usages = baml_lsp2_actions::usages_at(db, source_file, offset);
 
+                // Building a codec scans the whole target file for its line
+                // table; many usages land in the same file, so build one
+                // codec per distinct file, not per result.
+                let mut codecs = std::collections::HashMap::new();
                 usages
                     .into_iter()
                     .filter_map(|loc| {
                         let file_id = loc.file.file_id(db);
                         let path = db.file_id_to_path(file_id)?;
                         let target_uri = wasm_helpers::from_file_path(path).ok()?;
-                        let target_codec = PositionCodec::new(loc.file.text(db), encoding);
+                        let target_codec = codecs
+                            .entry(file_id)
+                            .or_insert_with(|| PositionCodec::new(loc.file.text(db), encoding));
                         let range = target_codec.byte_range_to_lsp(loc.range);
                         Some(lsp_types::Location {
                             uri: target_uri,
@@ -679,6 +685,10 @@ impl BexLspRequest for BexMulitProject {
             let source_files = lsp_db.get_source_files();
             let results = baml_lsp2_actions::search_symbols(lsp_db, &source_files, query);
 
+            // One codec per distinct file: a broad query matches many
+            // symbols in the same file, and codec construction scans the
+            // whole file for its line table.
+            let mut codecs = std::collections::HashMap::new();
             for sym in results {
                 let file_id = sym.file.file_id(lsp_db);
                 let Some(path) = lsp_db.file_id_to_path(file_id) else {
@@ -687,7 +697,9 @@ impl BexLspRequest for BexMulitProject {
                 let Ok(uri) = wasm_helpers::from_file_path(path) else {
                     continue;
                 };
-                let codec = PositionCodec::new(sym.file.text(lsp_db), encoding);
+                let codec = codecs
+                    .entry(file_id)
+                    .or_insert_with(|| PositionCodec::new(sym.file.text(lsp_db), encoding));
                 let range = codec.byte_range_to_lsp(sym.name_span);
 
                 symbols.push(lsp_types::WorkspaceSymbol {


### PR DESCRIPTION
Stacked on #4000 (retargets to canary when it merges). Batches the four small items deferred from the #4000 review cycle so the approved, CI-green main PR stayed untouched.

1. **Per-file `PositionCodec` in `references` and `workspace/symbol`** — CodeRabbit's one valid Major on #4000: codec construction scans the entire target file to build its line table, and both handlers built one per *result*; a symbol with N usages in one file did N identical scans. Now one codec per distinct file via a lazy map inside each handler (the same pattern `document_symbol` already used).
2. **Memoization contract tests** (ported from the alternate implementation's test suite): `file_annotations` and `semantic_tokens` execute exactly once cold, zero times warm, and once again after a source edit — asserted by counting salsa `WillExecute` events, so future implementation rewrites (including the #3867 re-land) keep the tests meaningful. This also formally answers the stale "bypasses Salsa memoization" review claim on #3969 by pinning the invariant.
3. **`TEST_INSTRUCTIONS.md`**: the "Verify all tests pass" section now includes `cargo test --lib` (previously the documented flow skipped the workspace unit tests entirely — where all of #4000's new tests live), and two case-sensitive `UPDATE_EXPECT` references fixed (lowercase `update_expect=1` is a silent no-op for expect-test).

Validation: `bex_project` 45/45, `baml_lsp2_actions_tests` 377/377 (incl. the 2 new memoization tests), clippy `-D warnings` clean, wasm check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEMxti5WQ8bCgJUuX9AQvo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness for “Find References” and workspace symbol searches, especially when results span multiple locations in the same file.

* **Bug Fixes**
  * Strengthened language-server behavior verification to ensure cached results are reused correctly and refreshed after source changes.

* **Documentation**
  * Clarified testing guidance for Rust changes and language-server snapshot updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->