### PR TITLE
feat(cffi): export bytecode runtime initializer

### DIFF
--- a/baml_language/crates/bridge_cffi/src/ffi/runtime.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/runtime.rs
@@ -2,7 +2,10 @@
 
 use std::{collections::HashMap, ffi::CStr};
 
-use crate::{Buffer, initialize_runtime, panic::ffi_safe_ptr};
+use crate::{
+    Buffer, initialize_runtime,
+    initialize_runtime_from_bytecode as initialize_runtime_from_bytecode_impl, panic::ffi_safe_ptr,
+};
 
 /// Returns the BAML version as a Buffer containing raw UTF-8 bytes.
 /// Caller must free with free_buffer().
@@ -52,6 +55,43 @@ pub extern "C" fn create_baml_runtime(
     })
 }
 
+/// Initialize the process-global BAML runtime from serialized bytecode.
+///
+/// An empty returned buffer means success. On failure, the buffer contains a
+/// UTF-8 error message. The caller owns every returned buffer and must release
+/// it with [`crate::free_buffer`].
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[unsafe(no_mangle)]
+pub extern "C" fn initialize_runtime_from_bytecode(bytecode: *const u8, length: usize) -> Buffer {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if bytecode.is_null() && length != 0 {
+            return Err("bytecode pointer is null but length is nonzero".to_string());
+        }
+
+        let bytecode = if length == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(bytecode, length) }
+        };
+        initialize_runtime_from_bytecode_impl(bytecode)
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }));
+
+    match result {
+        Ok(Ok(())) => Buffer::from(Vec::new()),
+        Ok(Err(error)) => Buffer::from(error.into_bytes()),
+        Err(panic_info) => {
+            let message = panic_info
+                .downcast_ref::<&str>()
+                .map(|message| (*message).to_string())
+                .or_else(|| panic_info.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".to_string());
+            Buffer::from(format!("panic while initializing BAML bytecode: {message}").into_bytes())
+        }
+    }
+}
+
 /// Destroy the BAML runtime.
 /// This is a no-op since the global engine persists for the process lifetime.
 #[unsafe(no_mangle)]
@@ -67,4 +107,20 @@ pub extern "C" fn invoke_runtime_cli(_args: *const *const libc::c_char) -> libc:
     // TODO: Implement CLI invocation if needed
     eprintln!("invoke_runtime_cli not implemented in bridge_cffi");
     1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytecode_initializer_rejects_null_pointer_with_nonzero_length() {
+        let buffer = initialize_runtime_from_bytecode(std::ptr::null(), 1);
+        let message = unsafe { std::slice::from_raw_parts(buffer.ptr.cast::<u8>(), buffer.len) };
+        assert_eq!(
+            std::str::from_utf8(message).unwrap(),
+            "bytecode pointer is null but length is nonzero"
+        );
+        crate::free_buffer(buffer);
+    }
 }


### PR DESCRIPTION
## Summary

- expose initialize_runtime_from_bytecode through the stable C ABI for non-Rust language bridges
- delegate runtime construction to the existing canonical Rust initializer used by Python and Node
- return an empty owned Buffer on success and a UTF-8 error Buffer on failure
- catch panics at the ABI boundary and reject null pointers paired with nonzero lengths

## Why

Python and Node can call the canonical Rust API directly through their Rust native extensions. Bridges implemented outside Rust, beginning with Go, need an unmanaged pointer-and-length entry point. This provides that shared entry point without duplicating runtime initialization logic.

## Verification

- cargo test -p bridge_cffi --lib: 11 passed
- cargo clippy -p bridge_cffi --lib -- -D warnings
- confirmed the initialize_runtime_from_bytecode symbol is exported by libbridge_cffi.dylib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for initializing the runtime directly from bytecode.
  * Initialization errors are returned as readable messages instead of causing application crashes.
  * Invalid bytecode input is detected and reported clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->