### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -40,13 +40,13 @@ policy.max_delta_pct = 3.0
 # engine/compiler/sdkgen generics support, +499 KB / +3.2% vs the prior
 # 15.59 MB baseline).
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 17_052_433
+max_file_bytes = 17_480_864
 # Linux x86_64: baseline 21.51 MB file.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 22_176_914
+max_file_bytes = 22_747_163
 # Windows x86_64: baseline 18.11 MB file.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 18_657_997
+max_file_bytes = 19_098_870
 
 [artifacts.packed-program]
 kind = "pack"
@@ -54,13 +54,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 12.01 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 12_472_693
+max_file_bytes = 12_593_524
 # Linux x86_64: baseline 15.62 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 16_090_067
+max_file_bytes = 16_305_593
 # Windows x86_64: baseline 13.00 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 13_397_777
+max_file_bytes = 13_505_727
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -84,4 +84,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.06 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_180_730
+max_gzip_bytes = 4_262_473

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-27T09:59:43Z"
-git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
+recorded_at = "2026-07-14T09:58:35Z"
+git_sha = "4146a2afc4d11a7fd274b1ade60efe868a6ac829"
 
 [artifacts.baml-cli]
-file_bytes = 16555760
-stripped_bytes = 16555792
-gzip_bytes = 7995187
+file_bytes = 16971712
+stripped_bytes = 16971744
+gzip_bytes = 8191659
 
 [artifacts.packed-program]
-file_bytes = 12109410
-gzip_bytes = 5741271
+file_bytes = 12226722
+gzip_bytes = 5884693

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-06-27T09:59:43Z"
-git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
+recorded_at = "2026-07-14T09:58:35Z"
+git_sha = "4146a2afc4d11a7fd274b1ade60efe868a6ac829"
 
 [artifacts.bridge_wasm]
-file_bytes = 14320322
-gzip_bytes = 4058961
+file_bytes = 14601922
+gzip_bytes = 4138323

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-27T09:59:43Z"
-git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
+recorded_at = "2026-07-14T09:58:35Z"
+git_sha = "4146a2afc4d11a7fd274b1ade60efe868a6ac829"
 
 [artifacts.baml-cli]
-file_bytes = 18114560
-stripped_bytes = 18114560
-gzip_bytes = 8210454
+file_bytes = 18542592
+stripped_bytes = 18542592
+gzip_bytes = 8402923
 
 [artifacts.packed-program]
-file_bytes = 13007550
-gzip_bytes = 5840978
+file_bytes = 13112356
+gzip_bytes = 5965731

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-06-27T09:59:43Z"
-git_sha = "18e49eefcbac896307c61050a78fb595d7fc79f4"
+recorded_at = "2026-07-14T09:58:35Z"
+git_sha = "4146a2afc4d11a7fd274b1ade60efe868a6ac829"
 
 [artifacts.baml-cli]
-file_bytes = 21530984
-stripped_bytes = 21530976
-gzip_bytes = 9200478
+file_bytes = 22084624
+stripped_bytes = 22084616
+gzip_bytes = 9439970
 
 [artifacts.packed-program]
-file_bytes = 15621424
-gzip_bytes = 6576288
+file_bytes = 15830672
+gzip_bytes = 6727114


### PR DESCRIPTION
Adopted from CI run [`4146a2afc4d11a7fd274b1ade60efe868a6ac829`](https://github.com/BoundaryML/baml/actions/runs/29317861389).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 22.1 MB | 9.4 MB | **file** | 21.5 MB | +553.6 KB (+2.6%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 15.8 MB | 6.7 MB | **file** | 15.6 MB | +209.2 KB (+1.3%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 17.0 MB | 8.2 MB | **file** | 16.6 MB | +416.0 KB (+2.5%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 12.2 MB | 5.9 MB | **file** | 12.1 MB | +117.3 KB (+1.0%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 14.6 MB | 🔒 4.1 MB | **gzip** | 4.1 MB | +79.4 KB (+2.0%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 18.5 MB | 8.4 MB | **file** | 18.1 MB | +428.0 KB (+2.4%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 13.1 MB | 6.0 MB | **file** | 13.0 MB | +104.8 KB (+0.8%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact size thresholds for Linux, Windows, macOS, and WebAssembly builds.
  * Refreshed recorded build metadata and size measurements across supported platforms.
  * Adjusted WebAssembly compressed-size limits to reflect current build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->