### PR TITLE
perf(compiler2): ~32x faster cold compile — remove redundant work, memoize package-invariant queries

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "indicatif",
  "insta",
  "libsui",
+ "mimalloc",
  "object 0.36.3",
  "regex",
  "reqwest",
@@ -833,6 +834,7 @@ dependencies = [
  "baml_compiler2_ppir",
  "baml_compiler2_tir",
  "baml_type",
+ "baml_workspace",
  "indexmap",
  "num-bigint",
  "rustc-hash 2.1.2",
@@ -853,6 +855,22 @@ dependencies = [
  "salsa",
  "smol_str 0.3.6",
  "text-size",
+]
+
+[[package]]
+name = "baml_compiler2_profile"
+version = "0.0.0-beta"
+dependencies = [
+ "anyhow",
+ "baml_compiler2_tir",
+ "baml_compiler_diagnostics",
+ "baml_project",
+ "baml_workspace",
+ "clap",
+ "mimalloc",
+ "salsa",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -988,6 +1006,7 @@ dependencies = [
  "baml_compiler_diagnostics",
  "baml_compiler_parser",
  "baml_compiler_syntax",
+ "baml_type",
  "baml_workspace",
  "bitflags 2.11.1",
  "indexmap",
@@ -4237,6 +4256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,6 +4514,15 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -858,22 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "baml_compiler2_profile"
-version = "0.0.0-beta"
-dependencies = [
- "anyhow",
- "baml_compiler2_tir",
- "baml_compiler_diagnostics",
- "baml_project",
- "baml_workspace",
- "clap",
- "mimalloc",
- "salsa",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "baml_compiler2_tir"
 version = "0.1.0"
 dependencies = [
@@ -7675,6 +7659,22 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tools_compile_profile"
+version = "0.0.0-beta"
+dependencies = [
+ "anyhow",
+ "baml_compiler2_tir",
+ "baml_compiler_diagnostics",
+ "baml_project",
+ "baml_workspace",
+ "clap",
+ "mimalloc",
+ "salsa",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "tools_onionskin"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -202,6 +202,7 @@ bytecount = "0.6"
 reqwest = { version = "0.13.1", default-features = false, features = [
   "stream",
 ] }
+mimalloc = { version = "0.1.52" }
 rowan = { version = "0.16" }
 rustls = { version = "0.23.37", default-features = false }
 rustls-pemfile = "2"

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -42,6 +42,7 @@ flate2 = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
 libsui = { workspace = true }
+mimalloc = { workspace = true }
 object = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking", "json", "rustls" ] }

--- a/baml_language/crates/baml_cli/src/main.rs
+++ b/baml_language/crates/baml_cli/src/main.rs
@@ -5,6 +5,13 @@
 
 use std::io::Write as _;
 
+/// The compiler workload is dominated by small short-lived allocations
+/// (`Ty` trees, `Vec`s, `SmolStr`s): macOS system malloc measured ~35% of
+/// single-threaded cold-compile CPU. mimalloc cuts cold `baml check` /
+/// `baml build` wall time by ~40%.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     // TODO: baml_log is disabled for now
     // baml_log::init()?;

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// A reference to an environment variable found in source code (`env.VAR_NAME`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvVarRef {
     /// The variable name (e.g., `"OPENAI_API_KEY"`).
     pub name: String,

--- a/baml_language/crates/baml_compiler2_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/lib.rs
@@ -88,6 +88,58 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
     files
 }
 
+// ── file_ast ──────────────────────────────────────────────────────────────────
+
+/// The CST → AST lowering output for one file: top-level items plus the
+/// lowering diagnostics and `env.*` references produced along the way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileAst {
+    pub items: Vec<baml_compiler2_ast::Item>,
+    pub diagnostics: Vec<baml_compiler2_ast::LoweringDiagnostic>,
+    pub env_var_refs: Vec<baml_compiler2_ast::EnvVarRef>,
+}
+
+// Safety: `FileAst` holds only plain (non-`'db`) data. Manual `Update` impl
+// uses `PartialEq` for Salsa early-cutoff, mirroring `ResolvedClassFields`.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for FileAst {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// CST → AST lowering for one file, computed once and shared.
+///
+/// Salsa-tracked because *six* different consumers need a file's AST items
+/// (both `file_semantic_index` queries, `ppir_expansion_items`, the two
+/// project-wide expansion-map collectors, and the LSP check pass). Before
+/// this query existed each of them re-lowered the syntax tree from scratch —
+/// ~31% of cold-compile CPU on the test corpus was repeated CST traversal.
+/// See `crates/baml_compiler2_profile/README.md`.
+#[salsa::tracked(returns(ref))]
+pub fn file_ast(db: &dyn Db, file: SourceFile) -> FileAst {
+    let tree = baml_compiler_parser::syntax_tree(db, file);
+    let path = file.path(db);
+    let (items, diagnostics, env_var_refs) =
+        baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
+    FileAst {
+        items,
+        diagnostics,
+        env_var_refs,
+    }
+}
+
 // ── file_semantic_index ───────────────────────────────────────────────────────
 
 /// Coarse per-file query — always re-runs on file change (`no_eq`).
@@ -98,15 +150,13 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
 pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
-    let (items, lowering_diags, env_var_refs) =
-        baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
+    let ast = file_ast(db, file);
 
     let builder = SemanticIndexBuilder::new(db, file);
     builder
-        .with_lowering_diagnostics(lowering_diags)
-        .with_env_var_refs(env_var_refs)
-        .build(&items, file_range)
+        .with_lowering_diagnostics(ast.diagnostics.clone())
+        .with_env_var_refs(ast.env_var_refs.clone())
+        .build(&ast.items, file_range)
 }
 
 // ── Projection helpers ────────────────────────────────────────────────────────

--- a/baml_language/crates/baml_compiler2_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/lib.rs
@@ -126,7 +126,7 @@ unsafe impl salsa::Update for FileAst {
 /// project-wide expansion-map collectors, and the LSP check pass). Before
 /// this query existed each of them re-lowered the syntax tree from scratch —
 /// ~31% of cold-compile CPU on the test corpus was repeated CST traversal.
-/// See `crates/baml_compiler2_profile/README.md`.
+/// See `crates/tools_compile_profile/README.md`.
 #[salsa::tracked(returns(ref))]
 pub fn file_ast(db: &dyn Db, file: SourceFile) -> FileAst {
     let tree = baml_compiler_parser::syntax_tree(db, file);

--- a/baml_language/crates/baml_compiler2_mir/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_mir/Cargo.toml
@@ -13,6 +13,7 @@ baml_compiler2_hir = { workspace = true }
 baml_compiler2_ppir = { workspace = true }
 baml_compiler2_tir = { workspace = true }
 baml_type = { workspace = true }
+baml_workspace = { workspace = true }
 indexmap = { workspace = true }
 num-bigint = { workspace = true }
 rustc-hash = { workspace = true }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -86,7 +86,7 @@ pub fn resolved_aliases_for_package(
 fn interface_tir_type_args_match_preserving_typevars(
     impl_iface_args: &[Tir2Ty],
     iface_type_args: &[Tir2Ty],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &baml_type::ResolvedAliases,
 ) -> bool {
     impl_iface_args.len() == iface_type_args.len()
         && impl_iface_args
@@ -108,7 +108,7 @@ fn interface_tir_type_args_match_preserving_typevars(
 fn tir_type_satisfies_dispatch_request(
     actual: &Tir2Ty,
     requested: &Tir2Ty,
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &baml_type::ResolvedAliases,
 ) -> bool {
     if baml_compiler2_tir::normalize::is_same_normalized_type(actual, requested, aliases) {
         return true;
@@ -228,7 +228,7 @@ fn bind_interface_class_type_arg(
     name: &Name,
     actual: &Tir2Ty,
     bindings: &mut FxHashMap<Name, Tir2Ty>,
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &baml_type::ResolvedAliases,
 ) -> bool {
     match bindings.get(name) {
         Some(existing) => {
@@ -245,7 +245,7 @@ fn infer_interface_class_bindings(
     formal: &Tir2Ty,
     actual: &Tir2Ty,
     class_params: &[Name],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &baml_type::ResolvedAliases,
     bindings: &mut FxHashMap<Name, Tir2Ty>,
     // Associated-type bindings tolerate an unpinnable typevar union
     // (`Error = E | E2` vs a normalized request) by leaving the params
@@ -476,7 +476,7 @@ fn interface_class_guard_for_args(
     requested_iface_args: &[Tir2Ty],
     requested_iface_assoc: &[(Name, Tir2Ty)],
     class_params: &[Name],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &baml_type::ResolvedAliases,
 ) -> Option<InterfaceClassGuard> {
     // An *uninstantiated* request (no type args) matches any implementor
     // instantiation — e.g. `self: Container` inside a generic interface's
@@ -592,7 +592,7 @@ fn type_satisfies_bound(
     db: &dyn crate::Db,
     actual: &Tir2Ty,
     bound: &Tir2Ty,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &baml_type::ResolvedAliases,
     default_pkg: &baml_base::Name,
     depth: u32,
 ) -> bool {
@@ -655,7 +655,7 @@ fn package_class_qtns(db: &dyn crate::Db, pkg_name: &Name) -> Vec<QualifiedTypeN
 fn with_global_ctx<R>(
     db: &dyn baml_compiler2_tir::Db,
     pkg_id: baml_compiler2_hir::package::PackageId<'_>,
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
+    aliases: &baml_type::ResolvedAliases,
     bounds: &FxHashMap<Name, Tir2Ty>,
     f: impl FnOnce(&baml_compiler2_tir::type_context::GlobalTypeContext<'_, '_>) -> R,
 ) -> R {
@@ -1525,7 +1525,7 @@ use baml_compiler2_tir::{
     inference::infer_scope_types,
     resolve::{ResolvedName, resolve_name_at_in_scope},
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 type ClassFieldIndices = IndexMap<TypeName, IndexMap<String, usize>>;
 type ClassFieldTypes = IndexMap<TypeName, IndexMap<String, RuntimeTy>>;
@@ -1648,6 +1648,12 @@ struct PackageLoweringData {
     enum_variants: EnumVariantIndices,
     interface_implementors: ImplementorsByInterface,
     resolved_aliases: ResolvedAliases,
+    /// Every method name any in-scope interface (own package + dependency
+    /// closure) declares, required or default. Fast pre-filter for
+    /// [`LoweringContext::dispatch_target_for_concrete`]: a member name absent
+    /// here can never dispatch through an interface impl, so the (hot) impl
+    /// enumeration is skipped for the overwhelmingly common plain-method case.
+    interface_method_names: FxHashSet<Name>,
 }
 
 /// # Safety
@@ -1672,6 +1678,73 @@ unsafe impl salsa::Update for PackageLoweringData {
             true
         }
     }
+}
+
+/// Project-wide class → runtime type-tag assignment.
+///
+/// Wrapper struct so the map can be the output of a Salsa-tracked query
+/// (needs a manual [`salsa::Update`] impl, mirroring `PackageLoweringData`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct ClassTypeTags(IndexMap<TypeName, i64>);
+
+// Safety: `ClassTypeTags` holds only plain (non-`'db`) data. Manual `Update`
+// impl uses `PartialEq` for Salsa early-cutoff.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for ClassTypeTags {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// Build `class_type_tags` by iterating `compiler2_all_files` in the same order as the
+/// emitter (`generate_project_bytecode` in `baml_compiler2_emit`). This guarantees that
+/// the integer type tags stored in Switch arms exactly match the `class.type_tag` values
+/// assigned to runtime Class objects.
+///
+/// Salsa-tracked: the map is a pure function of the project, but it was
+/// rebuilt (walking every file's item tree) inside every `LoweringContext`
+/// construction — once per function lowered, ~13% of cold CPU on the test
+/// corpus. See `crates/baml_compiler2_profile/README.md`.
+#[salsa::tracked(returns(ref))]
+fn class_type_tags_for_project(
+    db: &dyn crate::Db,
+    project: baml_workspace::Project,
+) -> ClassTypeTags {
+    let _ = project; // key: recompute when the project's file set changes
+    let all_files = compiler2_all_files(db);
+    let mut class_type_tags: IndexMap<TypeName, i64> = IndexMap::new();
+    let mut class_type_tag_counter = 0i64;
+
+    for file in &all_files {
+        let item_tree = file_item_tree(db, *file);
+        let pkg_info = file_package(db, *file);
+
+        for class_data in item_tree.classes.values() {
+            let class_qtn = QualifiedTypeName::new(
+                pkg_info.package.clone(),
+                pkg_info.namespace_path.clone(),
+                class_data.name.clone(),
+            );
+            let type_tag = baml_type::typetag::CLASS_BASE + class_type_tag_counter;
+            class_type_tag_counter += 1;
+            // Use entry to avoid overwriting if the same class appears via multiple paths
+            // (e.g., both FQ and short names). First encounter wins — consistent with emit.rs.
+            class_type_tags.entry(class_qtn).or_insert(type_tag);
+        }
+    }
+
+    ClassTypeTags(class_type_tags)
 }
 
 /// Build the package-invariant [`PackageLoweringData`] once per package,
@@ -1722,12 +1795,39 @@ fn package_lowering_data<'db>(
         );
     }
 
+    let mut interface_method_names = FxHashSet::default();
+    let mut all_pkgs = vec![pkg_id];
+    all_pkgs.extend(baml_compiler2_hir::package::package_dependency_closure(
+        db, pkg_id,
+    ));
+    for pkg in all_pkgs {
+        let items = package_items(db, pkg);
+        for ns in items.namespaces.values() {
+            for def in ns.types.values() {
+                let Definition::Interface(iface_loc) = def else {
+                    continue;
+                };
+                let itree = file_item_tree(db, iface_loc.file(db));
+                let Some(iface_data) = itree.interfaces.get(&iface_loc.id(db)) else {
+                    continue;
+                };
+                for sig in &iface_data.required_methods {
+                    interface_method_names.insert(sig.name.clone());
+                }
+                for &fn_id in &iface_data.default_methods {
+                    interface_method_names.insert(itree[fn_id].name.clone());
+                }
+            }
+        }
+    }
+
     PackageLoweringData {
         class_fields,
         class_field_types,
         enum_variants,
         interface_implementors,
         resolved_aliases,
+        interface_method_names,
     }
 }
 
@@ -1839,8 +1939,9 @@ struct LoweringContext<'db> {
     class_field_types: &'db ClassFieldTypes,
     enum_variants: &'db EnumVariantIndices,
     /// Pre-computed type tags for class types, used by `SwitchKind::TypeTag`
-    /// for union-type switch optimization (ported from MIR 1).
-    class_type_tags: IndexMap<TypeName, i64>,
+    /// for union-type switch optimization (ported from MIR 1). Borrowed from
+    /// the project-keyed `class_type_tags_for_project` query.
+    class_type_tags: &'db IndexMap<TypeName, i64>,
     /// BEP-044: for every interface, the list of classes that implement it
     /// (directly or transitively through interface `requires`). Lets the field-access
     /// and method-call lowering paths emit a type-tag switch over the
@@ -1854,6 +1955,10 @@ struct LoweringContext<'db> {
     // Borrowed from `package_lowering_data` (shared across every function in
     // the package) rather than cloned per context.
     resolved_aliases: &'db ResolvedAliases,
+
+    /// All method names declared by in-scope interfaces — see
+    /// [`PackageLoweringData::interface_method_names`].
+    interface_method_names: &'db FxHashSet<Name>,
 
     watched_locals_stack: Vec<Local>,
 
@@ -2194,7 +2299,7 @@ impl<'db> LoweringContext<'db> {
 
     /// Populate `class_fields` and `enum_variants` from a single package's items.
     ///
-    /// Note: `class_type_tags` is built separately via `build_class_type_tags` to ensure
+    /// Note: `class_type_tags` is built separately via `class_type_tags_for_project` to ensure
     /// the same file-iteration order as the emitter (`generate_project_bytecode`).
     fn populate_from_package(
         db: &'db dyn crate::Db,
@@ -2453,7 +2558,7 @@ impl<'db> LoweringContext<'db> {
                                 db,
                                 &actual,
                                 &bound_ty,
-                                &resolved_aliases.aliases,
+                                resolved_aliases,
                                 &pkg_info.package,
                                 BLANKET_BOUND_DEPTH,
                             ) {
@@ -2473,41 +2578,6 @@ impl<'db> LoweringContext<'db> {
                 }
             }
         }
-    }
-
-    /// Build `class_type_tags` by iterating `compiler2_all_files` in the same order as the
-    /// emitter (`generate_project_bytecode` in `baml_compiler2_emit`). This guarantees that
-    /// the integer type tags stored in Switch arms exactly match the `class.type_tag` values
-    /// assigned to runtime Class objects.
-    fn build_class_type_tags(db: &'db dyn crate::Db) -> IndexMap<TypeName, i64> {
-        let all_files = compiler2_all_files(db);
-        let mut class_type_tags: IndexMap<TypeName, i64> = IndexMap::new();
-        let mut class_type_tag_counter = 0i64;
-
-        for file in &all_files {
-            let item_tree = file_item_tree(db, *file);
-            let pkg_info = file_package(db, *file);
-
-            // Build module_path: [package] ++ namespace_path
-            let mut module_path: Vec<Name> = vec![pkg_info.package.clone()];
-            module_path.extend(pkg_info.namespace_path.iter().cloned());
-
-            for class_data in item_tree.classes.values() {
-                let class_qtn = QualifiedTypeName::new(
-                    pkg_info.package.clone(),
-                    pkg_info.namespace_path.clone(),
-                    class_data.name.clone(),
-                );
-                let tn = class_qtn.clone();
-                let type_tag = baml_type::typetag::CLASS_BASE + class_type_tag_counter;
-                class_type_tag_counter += 1;
-                // Use entry to avoid overwriting if the same class appears via multiple paths
-                // (e.g., both FQ and short names). First encounter wins — consistent with emit.rs.
-                class_type_tags.entry(tn).or_insert(type_tag);
-            }
-        }
-
-        class_type_tags
     }
 
     fn new(
@@ -2688,7 +2758,7 @@ impl<'db> LoweringContext<'db> {
 
         // Build class_type_tags using the same file-iteration order as the emitter,
         // so that switch arms get the same integer tags as runtime class.type_tag fields.
-        let class_type_tags = Self::build_class_type_tags(db);
+        let class_type_tags = &class_type_tags_for_project(db, db.project()).0;
 
         // --- Determine arity from function signature ---
         let sig = baml_compiler2_ppir::function_signature(db, func_loc);
@@ -2748,6 +2818,7 @@ impl<'db> LoweringContext<'db> {
             transitive_captures_needed: Vec::new(),
             tagged_body_param_bindings: HashMap::new(),
             resolved_aliases: &pkg_data.resolved_aliases,
+            interface_method_names: &pkg_data.interface_method_names,
             watched_locals_stack: Vec::new(),
             defer_stack: Vec::new(),
             synthetic_name_counts: HashMap::new(),
@@ -2805,7 +2876,7 @@ impl<'db> LoweringContext<'db> {
 
         // Build class_type_tags using the same file-iteration order as the emitter,
         // so that switch arms get the same integer tags as runtime class.type_tag fields.
-        let class_type_tags = Self::build_class_type_tags(db);
+        let class_type_tags = &class_type_tags_for_project(db, db.project()).0;
 
         LoweringContext {
             db,
@@ -2834,6 +2905,7 @@ impl<'db> LoweringContext<'db> {
             class_type_tags,
             interface_implementors: &pkg_data.interface_implementors,
             resolved_aliases: &pkg_data.resolved_aliases,
+            interface_method_names: &pkg_data.interface_method_names,
             watched_locals_stack: Vec::new(),
             defer_stack: Vec::new(),
             synthetic_name_counts: HashMap::new(),
@@ -3574,14 +3646,14 @@ impl<'db> LoweringContext<'db> {
         let gctx = baml_compiler2_tir::type_context::GlobalTypeContext {
             db: self.db,
             res_ctx,
-            aliases: &self.resolved_aliases.aliases,
+            aliases: self.resolved_aliases,
             bounds: &bounds,
         };
         baml_compiler2_tir::interfaces::impls_for_type(
             self.db,
             pkg_id,
             recv,
-            &self.resolved_aliases.aliases,
+            self.resolved_aliases,
             |a, b| baml_type::normalize::is_subtype(a, b, &gctx),
         )
     }
@@ -3612,6 +3684,13 @@ impl<'db> LoweringContext<'db> {
                 | Tir2Ty::Map { .. }
                 | Tir2Ty::Future(..)
         ) {
+            return None;
+        }
+        // Fast pre-filter: a name no in-scope interface declares can never
+        // dispatch through an impl. Skips the per-call impl enumeration
+        // (`l1_impls_for_recv` probes every impl block's pattern against the
+        // receiver) for plain method calls and field accesses.
+        if !self.interface_method_names.contains(method) {
             return None;
         }
         for resolved in self.l1_impls_for_recv(recv_ty) {
@@ -10707,7 +10786,7 @@ impl<'db> LoweringContext<'db> {
         with_global_ctx(
             self.db,
             self.package_id(),
-            &self.resolved_aliases.aliases,
+            self.resolved_aliases,
             &self.generic_param_bounds,
             |ctx| baml_type::normalize::normalize(ty, ctx),
         )
@@ -10729,7 +10808,7 @@ impl<'db> LoweringContext<'db> {
         with_global_ctx(
             self.db,
             self.package_id(),
-            &self.resolved_aliases.aliases,
+            self.resolved_aliases,
             &self.generic_param_bounds,
             |ctx| {
                 ctx.associated_type_bound(iface, member.clone())
@@ -10951,7 +11030,7 @@ impl<'db> LoweringContext<'db> {
                             requested_args,
                             requested_assoc,
                             &class_data.generic_params,
-                            &self.resolved_aliases.aliases,
+                            self.resolved_aliases,
                         ) else {
                             continue;
                         };
@@ -11030,7 +11109,7 @@ impl<'db> LoweringContext<'db> {
                         requested_args,
                         requested_assoc,
                         &class_data.generic_params,
-                        &self.resolved_aliases.aliases,
+                        self.resolved_aliases,
                     ) else {
                         continue;
                     };
@@ -14624,7 +14703,7 @@ mod tests {
 
     #[test]
     fn interface_tir_type_args_match_preserves_type_var_identity() {
-        let aliases = HashMap::new();
+        let aliases = baml_type::ResolvedAliases::default();
 
         assert!(interface_tir_type_args_match_preserving_typevars(
             &[type_var("L"), type_var("R")],
@@ -14640,7 +14719,7 @@ mod tests {
 
     #[test]
     fn interface_class_guard_checks_assoc_when_request_omits_generic_args() {
-        let aliases = HashMap::new();
+        let aliases = baml_type::ResolvedAliases::default();
         let impl_args = vec![primitive(&PrimitiveType::String)];
         let requested_args = Vec::new();
         let requested_assoc = vec![(Name::new("Value"), primitive(&PrimitiveType::Int))];

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1715,7 +1715,7 @@ unsafe impl salsa::Update for ClassTypeTags {
 /// Salsa-tracked: the map is a pure function of the project, but it was
 /// rebuilt (walking every file's item tree) inside every `LoweringContext`
 /// construction — once per function lowered, ~13% of cold CPU on the test
-/// corpus. See `crates/baml_compiler2_profile/README.md`.
+/// corpus. See `crates/tools_compile_profile/README.md`.
 #[salsa::tracked(returns(ref))]
 fn class_type_tags_for_project(
     db: &dyn crate::Db,

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -54,9 +54,8 @@ pub fn collect_block_attrs(
     let mut result = FxHashMap::default();
     for file in project.files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, *file);
-        let cst = baml_compiler_parser::syntax_tree(db, *file);
-        let (items, _, _) = ast::lower_file(&cst);
-        for item in &items {
+        let items = &baml_compiler2_hir::file_ast(db, *file).items;
+        for item in items {
             let (name, item_attrs) = match item {
                 ast::Item::Class(c) => (&c.name, &c.attributes),
                 ast::Item::Enum(e) => (&e.name, &e.attributes),
@@ -85,9 +84,8 @@ pub fn collect_alias_bodies(
     let mut result = FxHashMap::default();
     for file in project.files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, *file);
-        let cst = baml_compiler_parser::syntax_tree(db, *file);
-        let (items, _, _) = ast::lower_file(&cst);
-        for item in &items {
+        let items = &baml_compiler2_hir::file_ast(db, *file).items;
+        for item in items {
             if let ast::Item::TypeAlias(a) = item {
                 let ty = a.type_expr.as_ref().map(PpirTy::from_type_expr).unwrap_or(
                     PpirTy::CannotBeStreamed {
@@ -191,8 +189,7 @@ fn make_raw_attr_no_args(name: &str) -> ast::RawAttribute {
 /// Compute synthetic `*$stream` AST items for a single file in one pass.
 #[salsa::tracked]
 pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems<'_> {
-    let cst = baml_compiler_parser::syntax_tree(db, file);
-    let (items, _, _) = ast::lower_file(&cst);
+    let items = &baml_compiler2_hir::file_ast(db, file).items;
 
     // Get HIR classification for the file's package (original types only)
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
@@ -215,7 +212,7 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
     let mut seen_class_names = FxHashSet::default();
     let mut seen_alias_names = FxHashSet::default();
 
-    for item in &items {
+    for item in items {
         match item {
             ast::Item::Class(c) => {
                 if c.name.ends_with("$stream") {
@@ -578,13 +575,26 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
 // -- Canonical queries (original + *$stream) ----------------------------------
 
 /// Canonical semantic index: original AST items + PPIR synthetic *$stream items.
+///
+/// When a file has no synthetic items, the post-expansion index is byte-for-byte
+/// the pre-expansion one, so this delegates to HIR's already-computed index
+/// instead of rebuilding scopes/bindings/contributions a second time.
+pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> &FileSemanticIndex<'_> {
+    let expansion = ppir_expansion_items(db, file);
+    if expansion.items(db).is_empty() {
+        return baml_compiler2_hir::file_semantic_index(db, file);
+    }
+    file_semantic_index_expanded(db, file)
+}
+
+/// The merged (original + *$stream) index for files that actually have
+/// synthetic items. Callers must go through [`file_semantic_index`].
 #[salsa::tracked(returns(ref), no_eq)]
-pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
+fn file_semantic_index_expanded(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
-    let (mut items, lowering_diags, env_var_refs) =
-        ast::lower_file_with_path(&tree, Some(path.as_path()));
+    let ast_result = baml_compiler2_hir::file_ast(db, file);
+    let mut items = ast_result.items.clone();
 
     // Merge synthetic *$stream items
     let expansion = ppir_expansion_items(db, file);
@@ -592,8 +602,8 @@ pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'
 
     // Re-run HIR builder on merged items
     baml_compiler2_hir::SemanticIndexBuilder::new(db, file)
-        .with_lowering_diagnostics(lowering_diags)
-        .with_env_var_refs(env_var_refs)
+        .with_lowering_diagnostics(ast_result.diagnostics.clone())
+        .with_env_var_refs(ast_result.env_var_refs.clone())
         .build(&items, file_range)
 }
 
@@ -616,6 +626,11 @@ pub fn file_item_tree(db: &dyn Db, file: SourceFile) -> Arc<ItemTree> {
 ///
 /// TIR should call this instead of `baml_compiler2_hir::body::function_body`
 /// so that PPIR-synthesized functions (like `$parse_stream`) are found.
+///
+/// Salsa-tracked (mirroring HIR's `function_body`): MIR lowering fetches the
+/// callee's body at every direct-call site, and the untracked version cloned
+/// the entire `ExprBody` arena out of the item tree each time.
+#[salsa::tracked]
 pub fn function_body<'db>(
     db: &'db dyn Db,
     function: baml_compiler2_hir::loc::FunctionLoc<'db>,

--- a/baml_language/crates/baml_compiler2_profile/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_profile/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "baml_compiler2_profile"
+version = { workspace = true }
+publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+description = "Standalone profiling harness for the BAML compiler pipeline (parse → HIR → PPIR → TIR → MIR → emit)."
+
+[[bin]]
+name = "baml_compiler2_profile"
+path = "src/main.rs"
+
+[dependencies]
+baml_compiler2_tir = { workspace = true }
+baml_compiler_diagnostics = { workspace = true }
+baml_project = { workspace = true }
+baml_workspace = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true, features = [ "derive" ] }
+mimalloc = { workspace = true }
+salsa = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[lints.clippy]
+print_stdout = "allow"
+print_stderr = "allow"
+
+[package.metadata.ci]
+wasm_support = false

--- a/baml_language/crates/baml_compiler2_profile/README.md
+++ b/baml_language/crates/baml_compiler2_profile/README.md
@@ -1,0 +1,260 @@
+# baml_compiler2_profile
+
+Standalone profiling harness for the BAML compiler pipeline.
+
+This is the tool to reach for when someone says **"`baml check` is slow on
+my project"**. It runs the same pipeline `baml check` runs
+(parse → HIR → PPIR → TIR → MIR → emit), and produces:
+
+- Wall-clock time split between `db build`, `check` (diagnostics), and
+  `emit` (bytecode)
+- Salsa query execution counts, cache hits, and blocked-on counts
+- Per-phase aggregate (which pipeline stage is doing the most query work)
+- Top-N most executed queries
+- A "suspect" table of queries that fire many times but rarely hit cache
+
+The tool is intentionally black-box: it uses only `salsa::Event`
+callbacks, so it needs no changes in the compiler under test. You can run
+it against any past commit as long as `baml_project` still exists.
+
+## When to use it
+
+- To answer **"which pipeline stage is eating my compile time?"** — read
+  the "Query events by phase" section.
+- To answer **"which specific query is executed a suspiciously high
+  number of times?"** — read the "Top queries by executions" section.
+- To answer **"is there work I could have cached but didn't?"** — read
+  the "Suspect: high exec, low cache hit" section.
+- For a **line-level CPU flamegraph** of what's actually hot inside a
+  slow query, wrap this binary with `samply` (see below).
+
+## What it is *not*
+
+- Not a per-query self-time measurement. Salsa doesn't emit a
+  `DidExecute` event, so it's impossible to bracket a query body from the
+  outside. For self-time, use `samply` (which samples the actual thread
+  stacks).
+- Not a monitor for the LSP path. It runs `check + get_bytecode` from a
+  fresh database, which mirrors CLI `baml check`, not the incremental
+  editor path.
+
+## Cache mode: cold by default
+
+Every measured run is **cold** by default: a fresh `ProjectDatabase` is
+built per run, so Salsa's memoization cache starts empty. This mirrors
+`baml check` from the CLI — one process, one db, no re-use. `cache
+hits: 0` in the report is *expected*, not a bug.
+
+There is no other cache to disable. Cargo's build cache is unrelated
+(that only affects compiling Rust; the profiler binary is already built
+before it runs). Inside the pipeline, the only in-process cache is
+Salsa's memoization, and this tool defeats it structurally by building a
+new database per run.
+
+To also measure the flip side — "if Salsa's cache *were* effective
+across `baml check` invocations, how much would it save?" — pass
+`--warm-runs N`. After each cold run, the tool invokes `check` +
+`get_bytecode` `N` more times against the *same* database (no input
+mutation). Warm invocations exercise the cache exclusively.
+
+The cold-vs-warm table then makes three failure modes visible:
+
+1. **Warm re-executes queries.** Something is being invalidated even
+   though inputs haven't changed → caching gap inside a tracked query.
+2. **Warm executes 0 queries but still spends real wall-clock time.**
+   That work lives outside any Salsa query. Salsa can't cache it — the
+   wrapper (`db.check()` / `db.get_bytecode()`) is doing per-invocation
+   materialization / walking / cloning. **This is what we see on the
+   test corpus today for `emit`: cold 13.6s, warm 12.1s.**
+3. **Warm total ≈ 0.** Salsa is fully caching this workload; nothing
+   further to chase in the caching layer.
+
+## Usage
+
+```bash
+# Build once
+cargo build --release -p baml_compiler2_profile
+
+# Point at any directory that contains .baml files or a baml_src/ dir
+./target/release/baml_compiler2_profile /path/to/baml/project
+
+# Cold + warm re-runs on the same db — measures Salsa's cache effect
+./target/release/baml_compiler2_profile --warm-runs 2 /path/to/project
+
+# JSON output (diff two runs, feed a spreadsheet, etc.)
+./target/release/baml_compiler2_profile --json /path/to/project > run.json
+
+# Multiple cold-cache runs for variance measurement
+./target/release/baml_compiler2_profile --repeat 5 /path/to/project
+
+# Just measure `check`, skip bytecode (matches what `baml check` does
+# when there are diagnostic errors)
+./target/release/baml_compiler2_profile --check-only /path/to/project
+
+# Compact one-liner for logs / dashboards
+./target/release/baml_compiler2_profile --summary-line /path/to/project | tail -1
+```
+
+## Combining with `samply` for a real CPU flamegraph
+
+The event-based stats above tell you **how often** each query runs. To
+find **which lines inside a query are hot**, sample the process:
+
+```bash
+# Build with symbols; the workspace `release` profile already keeps them
+cargo build --release -p baml_compiler2_profile
+
+# Record and open in the web UI (macOS)
+samply record ./target/release/baml_compiler2_profile /path/to/project
+
+# On Linux
+samply record ./target/release/baml_compiler2_profile /path/to/project
+```
+
+`samply` opens a browser UI with an inverted call tree, a top function
+list, and a flamegraph — read those views alongside the query counts
+from this tool. The two together answer:
+
+- "which queries do the most work?" (this tool)
+- "which lines inside those queries are hot?" (samply)
+
+## Interpreting the report
+
+Sample output for the built-in test corpus (~78 files, 25k lines) as it
+looked **before the July 2026 optimization pass** (see the audit section
+below — the same corpus now compiles in ~0.5s):
+
+```
+--- Wall clock (representative run) ---
+  db build (inputs)         0.002 s
+  check                     8.107 s
+  emit (bytecode)          13.245 s
+  TOTAL                    21.354 s
+
+--- Query events by phase ---
+  phase          executions   cache hits      hit %
+  tir                 19016            0      0.00%
+  hir                  6697            0      0.00%
+  parser                132            0      0.00%
+  ppir                  132            0      0.00%
+  lexer                 132            0      0.00%
+
+--- Top queries by executions ---
+  exec     hits     blocked  hit%      query
+  15863    0        0        0.0    % infer_scope_types
+  2304     0        0        0.0    % function_in_scope_generic_param_bounds
+  2298     0        0        0.0    % function_body
+  2172     0        0        0.0    % callable_throws
+  ...
+```
+
+Reading this:
+
+- **`hits` is 0 everywhere.** That's expected on a cold `baml check` —
+  we build a fresh database, so nothing is in the cache. If you want to
+  measure the incremental path (LSP), you'd need to run twice against
+  the same db (not what this tool models). For CLI `baml check`, cold
+  hits are the realistic case.
+- **`tir` is 19k / 26k = 72% of all query work.** Most of the compile is
+  scope-level type inference.
+- **`infer_scope_types` alone fires 15k times.** This is per-scope (a
+  scope is a function body / block / lambda / match arm). On this
+  workload that's ~200 scopes/file. Whether that's excessive depends on
+  the code shape.
+- **`emit` takes more wall-clock time than `check`** on this workload.
+  That's an outlier worth checking with `samply` because there aren't
+  many emit-level Salsa queries — most of emit's cost is in the
+  bytecode walker itself.
+
+## The July 2026 cold-compile audit
+
+This section documents the audit this tool was built for, both as a
+record of *why* the compiler's hot paths look the way they do now and as
+a worked example of the methodology. Several `// See
+crates/baml_compiler2_profile/README.md` comments in the compiler point
+here.
+
+**Result: cold `check` + `emit` on the test corpus (78 files, 25,838
+lines) went from 16.0s to ~0.50s — a ~32× single-threaded improvement.**
+End-to-end CLI `baml check` wall time went from ~17s to ~0.55s on the
+same corpus. No parallelism was added; every win was removing redundant
+work, memoizing package/project-invariant computation as Salsa queries,
+or cutting allocation churn.
+
+### Methodology
+
+1. Run this tool for query execution counts. Any query that executes
+   more times than there are "natural" keys for it (files, scopes,
+   packages) is doing duplicate work.
+2. Wrap the tool with `samply` for a CPU profile. Self-time
+   concentrated in `clone`/`drop`/`malloc` means the *representation*
+   is the problem, not any single call site.
+3. Fix the biggest thing, re-measure, repeat. Every change below was
+   individually measured on the same corpus; numbers are cold-cache
+   medians of 5 runs.
+
+### What we found and fixed, in order
+
+| # | Change | Cold time after | Notes |
+|---|--------|-----------------|-------|
+| 0 | Baseline | 16.0s | `check` 8.1s, `emit` 13.2s in the worst measurement |
+| 1 | Hoist recursive-alias analysis into `ResolvedAliases` | 4.0s | `find_recursive_aliases` (a whole-alias-graph DFS) ran on **every** `is_subtype_of` / `is_same_normalized_type` call — 18k times. It now runs once per package; callers pass `&ResolvedAliases` (aliases + precomputed recursive set) end-to-end. |
+| 2 | `package_resolved_aliases` + `package_impl_locs` as tracked queries | 2.7s | The alias map and impl-block list were rebuilt (full clone of every alias `Ty` + project walk) inside every `infer_scope_types` execution — ~16k times. |
+| 3 | `file_ast` tracked query (CST → AST once per file) | 1.9s | Six consumers (HIR + PPIR semantic indexes, `ppir_expansion_items`, two project-wide expansion-map collectors, LSP check) each re-lowered the syntax tree from scratch: ~31% of cold CPU was repeated CST traversal. |
+| 4 | `class_type_tags_for_project` tracked query | 1.5s | The project-wide class → type-tag map was rebuilt (walking every file's item tree) once per *function* lowered in MIR, ~13% of cold CPU. |
+| 5 | Skip diagnostics collection for builtin stdlib files | 1.5s | The builtin stdlib shipped with the compiler was eagerly type-checked on every `baml check` (a fixed ~70ms floor even for a 1-line project) and can never produce an actionable diagnostic. Builtin scopes user code touches are still inferred lazily. |
+| 6 | mimalloc as global allocator (CLI + this tool) | 0.87s | macOS system malloc was ~35% of remaining CPU — the workload is dominated by small, short-lived `Ty`/`Vec`/`SmolStr` allocations. This is mitigation, not cure; see "future work" below. |
+| 7 | Subtype-check fast paths (`baml_type::normalize`) | 0.76s | Reflexivity short-circuit, and co-inductive assumption bookkeeping (deep clone + full-tree hash of the pair) restricted to the *expanding* arms (μ-types, type vars, projections) — the only arms through which a cycle can regress. Millions of purely structural steps skip it. |
+| 8 | `heads_definitely_differ` filter in `is_same_normalized_type` | 0.66s | MIR impl dispatch probes every candidate impl pattern against the receiver; the common case is a miss between types with different nominal heads, decidable without the two allocation-heavy normalization walks. |
+| 9 | PPIR `file_semantic_index` delegates to HIR's when a file has no `$stream` expansions | 0.63s | The post-expansion index is byte-for-byte the pre-expansion one for such files; it was rebuilt anyway. |
+| 10 | `callee_generics_for_func` tracked query | 0.58s | Every call site re-derived the callee's declared generic params and re-lowered its bound type exprs (~10% of cold CPU). |
+| 11 | Nested-lambda inference projection | 0.56s | Every lambda body was type-inferred **twice**: inline while inferring the enclosing function, then again from scratch by the standalone `ScopeKind::Lambda` query. The inline pass now captures the lambda's complete tables (`NestedLambdaInference`, moved not cloned) and the Lambda query projects them. This also fixed a user-visible bug: diagnostics inside lambdas were reported twice. |
+| 12 | Interface-method-name pre-filter in MIR dispatch | 0.53s | `dispatch_target_for_concrete` enumerated every impl block in the package closure for every method call *and field access*. A per-package set of all interface-declared method names rejects the common plain-method case in one hash lookup (`is_same_normalized_type` calls: 952k → 275k). |
+| 13 | `ppir::function_body` tracked | 0.50s | MIR fetches the callee's body at every direct-call site; the untracked version cloned the entire `ExprBody` arena out of the item tree each time. |
+
+Two further fixes affected the CLI path rather than the pipeline:
+
+- **Diagnostic rendering built ariadne's line index per diagnostic.**
+  `render_diagnostics` constructed a fresh `SourceCache` — a line index
+  over *every file in the project* — for each diagnostic. On a corpus
+  with 79 warnings that was 34% of `baml check` wall time. The cache is
+  now built once per batch. (CLI: 0.94s → 0.55s.)
+- **Salsa cycle recovery moved with the query head.** Converting
+  `package_resolved_aliases` into a tracked query moved a legitimate
+  dependency cycle (aliases whose RHS is an associated-type projection
+  resolve through `infer_scope_types`, which consults the alias map)
+  onto a query without `cycle_initial`. It now seeds fixpoint iteration
+  with the empty alias environment, mirroring `infer_scope_types`.
+
+### What's deliberately NOT here
+
+- **No parallelism.** All wins are single-threaded; parallel check/emit
+  remains available as a future multiplier.
+- **No on-disk cache.** Verified: the compiler has no bytecode/query
+  cache on disk. Every `baml check` is a cold in-process Salsa run.
+
+### Known remaining costs (future work)
+
+- **Allocation churn is mitigated, not fixed.** ~25% of remaining
+  self-time is `malloc`/`free`/`memmove`/`clone`/`drop` of `Ty` trees,
+  which have deep value semantics (`Vec<Ty>`/`Box<Ty>` children,
+  inline `QualifiedTypeName`s). The foundational fix is hash-consing /
+  interning (`Ty` as a copyable handle; equality as integer compare),
+  staged as: intern `QualifiedTypeName` → intern `Ty` behind smart
+  constructors → arena the `NormalTy` normalization temporaries.
+- **Files with `$stream` expansions build their semantic index twice**
+  (pre-expansion HIR + post-expansion PPIR) — 79 of 132 corpus files;
+  worth ~30–50ms.
+
+## Adding a new query to the phase breakdown
+
+Salsa's `Ingredient::debug_name()` returns just the function name (e.g.
+`"file_semantic_index"`) with no crate qualification, so we can't group
+by crate. When you add a new `#[salsa::tracked]` function to the
+compiler, add its name to `phase_for_query` in `src/main.rs` so it lands
+in the right phase bucket instead of `"other"`.
+
+Same-named queries from different crates (e.g. HIR and PPIR both expose
+`file_semantic_index`) are disambiguated in the report by their
+`IngredientIndex` — the report shows them on separate lines with a
+`[IngredientIndex(N)]` suffix.

--- a/baml_language/crates/baml_compiler2_profile/src/main.rs
+++ b/baml_language/crates/baml_compiler2_profile/src/main.rs
@@ -1,0 +1,1113 @@
+//! `baml_compiler2_profile`: A standalone profiling harness for the BAML compiler.
+//!
+//! This tool loads a BAML project, runs the full compiler pipeline
+//! (parse → HIR → PPIR → TIR → MIR → emit) end-to-end, and reports:
+//!
+//! - Wall-clock time for each pipeline phase
+//! - Per-Salsa-query execution counts (how many times each cached query
+//!   actually ran its body)
+//! - Per-Salsa-query cache hits (how many times it returned a memoized value)
+//! - Aggregate stats grouped by crate prefix
+//! - Top-N most executed queries
+//! - Top-N queries with lowest cache-hit rate (candidates for redundant work)
+//!
+//! Design goals:
+//! - Fast to run and re-run against any BAML project
+//! - No changes to the compiler under test — pure black-box instrumentation
+//!   via `salsa::Event` callbacks
+//! - Works with external CPU samplers (`samply`, `Instruments`) for
+//!   flamegraph analysis of hot Rust code inside individual queries
+//!
+//! ## Cache mode
+//!
+//! Every measured run is **cold** by default: a fresh `ProjectDatabase`
+//! is built per run, so Salsa's memoization cache starts empty. This
+//! matches how `baml check` is invoked from the CLI (one process, one
+//! db). If you want to also measure the effect of Salsa's cache, pass
+//! `--warm-runs N` — after each cold run we invoke `check` +
+//! `get_bytecode` `N` more times against the *same* db, so those extra
+//! invocations exercise the cache exclusively.
+//!
+//! ## Usage
+//!
+//! ```text
+//! # Human-readable report (cold-only)
+//! cargo run --release -p baml_compiler2_profile -- /path/to/baml/project
+//!
+//! # Cold run followed by 2 warm re-runs on the same db (measures cache)
+//! cargo run --release -p baml_compiler2_profile -- --warm-runs 2 /path/to/project
+//!
+//! # JSON output for programmatic diffing
+//! cargo run --release -p baml_compiler2_profile -- --json /path/to/project
+//!
+//! # Repeat N times (useful for measuring cold-cache variance)
+//! cargo run --release -p baml_compiler2_profile -- --repeat 3 /path/to/project
+//!
+//! # Skip bytecode generation (measure just `check`, not `check + emit`)
+//! cargo run --release -p baml_compiler2_profile -- --check-only /path/to/project
+//!
+//! # Combine with a CPU sampler for a flamegraph
+//! cargo build --release -p baml_compiler2_profile
+//! samply record ./target/release/baml_compiler2_profile /path/to/project
+//! ```
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use baml_compiler_diagnostics::Severity;
+
+/// The compiler's workload is dominated by small short-lived allocations
+/// (`Ty` trees, `Vec`s, `SmolStr`s): macOS system malloc was ~35% of
+/// single-threaded cold-compile CPU in `samply` profiles. mimalloc cuts
+/// that overhead substantially.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+use baml_project::ProjectDatabase;
+use baml_workspace::discover_baml_files;
+use clap::Parser;
+use salsa::{Database, Event, EventKind};
+
+/// Profile a full BAML compile pipeline against a project on disk.
+#[derive(Parser, Debug)]
+#[command(
+    name = "baml_compiler2_profile",
+    about = "Profile a full BAML compile (parse → HIR → PPIR → TIR → MIR → emit) end-to-end."
+)]
+struct Args {
+    /// Path to a BAML project (containing `baml_src/` or `baml.toml`) OR
+    /// to a directory of `.baml` files. If a `baml_src/` subdirectory is
+    /// present under the given path, its contents are loaded; otherwise
+    /// the given directory is walked recursively for `.baml` files.
+    project: PathBuf,
+
+    /// Emit machine-readable JSON instead of the human-readable report.
+    #[arg(long)]
+    json: bool,
+
+    /// Repeat the compile N times back-to-back with a fresh database each
+    /// time. Useful for measuring cold-cache variance. The report shows the
+    /// median run when N > 1.
+    #[arg(long, default_value_t = 1)]
+    repeat: usize,
+
+    /// After each cold run, additionally invoke `check` + `get_bytecode` N
+    /// more times against the *same* database (no input mutation between
+    /// invocations). Every event Salsa fires on these calls is a hit
+    /// against its memoization cache, so this measures cache
+    /// effectiveness. A warm run that still executes many queries is
+    /// evidence of a caching gap.
+    #[arg(long, default_value_t = 0)]
+    warm_runs: usize,
+
+    /// Only run diagnostics collection (`check`), skip bytecode generation
+    /// (`emit`). Approximates what `baml check` does when it exits early on
+    /// diagnostic errors.
+    #[arg(long)]
+    check_only: bool,
+
+    /// Show this many entries in each top-N table.
+    #[arg(long, default_value_t = 30)]
+    top_n: usize,
+
+    /// Additionally emit a compact "phase summary" line at the very end,
+    /// suitable for grepping/telemetry across many runs.
+    #[arg(long)]
+    summary_line: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    if !args.project.exists() {
+        anyhow::bail!("path does not exist: {}", args.project.display());
+    }
+
+    let (root, source_paths) = discover_project_sources(&args.project)?;
+    if source_paths.is_empty() {
+        anyhow::bail!(
+            "no .baml files discovered under {}. Point --project at a directory containing \
+             `baml_src/` or `.baml` files.",
+            args.project.display()
+        );
+    }
+
+    let sources = read_sources(&source_paths)?;
+    let total_bytes: usize = sources.iter().map(|(_, text)| text.len()).sum();
+    let total_lines: usize = sources
+        .iter()
+        .map(|(_, text)| text.matches('\n').count() + 1)
+        .sum();
+
+    eprintln!("[baml_compiler2_profile] project: {}", root.display());
+    eprintln!(
+        "[baml_compiler2_profile] {} files, {} lines, {} bytes",
+        sources.len(),
+        total_lines,
+        total_bytes,
+    );
+    if args.repeat > 1 {
+        eprintln!("[baml_compiler2_profile] running {} times", args.repeat);
+    }
+
+    let cold_runs = args.repeat.max(1);
+    let mut runs: Vec<RunReport> = Vec::with_capacity(cold_runs * (1 + args.warm_runs));
+    for i in 0..cold_runs {
+        eprintln!(
+            "[baml_compiler2_profile] cold run {}/{} (fresh database, empty Salsa cache)",
+            i + 1,
+            cold_runs
+        );
+        // `run_cold_plus_warm` builds a fresh db (cold), invokes the
+        // pipeline once, then invokes it `warm_runs` more times against
+        // the *same* db — each of those additional invocations reuses
+        // Salsa's cache, so its query counts show cache effectiveness.
+        let reports = run_cold_plus_warm(&root, &sources, args.check_only, args.warm_runs)?;
+        for r in &reports {
+            eprintln!(
+                "[baml_compiler2_profile]   [{}] total: {:.3}s  (check {:.3}s, emit {:.3}s, exec {} queries, hit {})",
+                r.mode.label(),
+                r.total.as_secs_f64(),
+                r.check.as_secs_f64(),
+                r.emit.as_secs_f64(),
+                total_executions(&r.queries),
+                total_cache_hits(&r.queries),
+            );
+        }
+        runs.extend(reports);
+    }
+
+    // Pick a representative *cold* run: median by total time. Warm runs
+    // are usually near-zero and would dominate the "min" bucket if we
+    // mixed them together, hiding the real cold-start cost.
+    let mut cold_only: Vec<&RunReport> = runs.iter().filter(|r| r.mode.is_cold()).collect();
+    cold_only.sort_by_key(|r| r.total);
+    let representative = cold_only[cold_only.len() / 2];
+
+    if args.json {
+        print_json(
+            representative,
+            &runs,
+            total_bytes,
+            total_lines,
+            sources.len(),
+        );
+    } else {
+        print_human(
+            representative,
+            &runs,
+            total_bytes,
+            total_lines,
+            sources.len(),
+            args.top_n,
+        );
+    }
+
+    if args.summary_line {
+        print_summary_line(representative, sources.len(), total_lines, total_bytes);
+    }
+
+    Ok(())
+}
+
+/// Discover the project root and its `.baml` source paths.
+///
+/// If `path/baml_src` exists, we walk that subtree. Otherwise we walk the
+/// path itself. We don't try to parse `baml.toml` — this tool is
+/// deliberately permissive so it can be pointed at any directory of BAML
+/// files (including test fixtures that don't have a manifest).
+fn discover_project_sources(path: &Path) -> Result<(PathBuf, Vec<PathBuf>)> {
+    let canonical = std::fs::canonicalize(path)
+        .with_context(|| format!("failed to canonicalize {}", path.display()))?;
+    let walk_root = if canonical.join("baml_src").is_dir() {
+        canonical.join("baml_src")
+    } else {
+        canonical.clone()
+    };
+    let files = discover_baml_files(&walk_root);
+    Ok((canonical, files))
+}
+
+fn read_sources(paths: &[PathBuf]) -> Result<Vec<(PathBuf, String)>> {
+    let mut out = Vec::with_capacity(paths.len());
+    for path in paths {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        out.push((path.clone(), text));
+    }
+    Ok(out)
+}
+
+/// Whether a `RunReport` corresponds to a cold-cache pipeline
+/// invocation (fresh db) or a warm-cache one (re-invoked on the same db
+/// without any input changes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RunMode {
+    /// Fresh `ProjectDatabase`; Salsa memoization cache starts empty.
+    /// Mirrors CLI `baml check` which spawns a new process per run.
+    Cold,
+    /// `n`-th (1-based) re-invocation of the pipeline on the same
+    /// database from a previous cold run, with no input mutation in
+    /// between. Every query resolve here should be a cache hit if
+    /// memoization is doing its job.
+    Warm { index: usize },
+}
+
+impl RunMode {
+    fn is_cold(self) -> bool {
+        matches!(self, RunMode::Cold)
+    }
+    fn label(self) -> String {
+        match self {
+            RunMode::Cold => "cold".to_string(),
+            RunMode::Warm { index } => format!("warm#{index}"),
+        }
+    }
+}
+
+/// Redundant-work counters for TIR normalization/subtyping hot path.
+///
+/// Captured from `baml_compiler2_tir::normalize::PROF_*` before/after
+/// each invocation. These count how many times key entry points fire
+/// during one compile — the flamegraph told us they dominate ~78% of
+/// CPU, this quantifies exactly how much repeated work they represent.
+///
+/// The pattern to look for: `is_same_normalized_type ≪ find_recursive_aliases`
+/// means we recompute the recursive-alias set on every call, which is a
+/// pure function of the alias map (constant per package). Similarly
+/// `has_cycle ≫ number-of-aliases` means the alias DFS is invoked
+/// with far more entry points than there are aliases in the program.
+#[derive(Debug, Default, Clone, Copy, serde::Serialize)]
+struct TirAuditCounters {
+    is_same_normalized_type: u64,
+    is_subtype_of: u64,
+    find_recursive_aliases: u64,
+    has_cycle: u64,
+    normalize: u64,
+}
+
+impl TirAuditCounters {
+    fn snapshot() -> Self {
+        use std::sync::atomic::Ordering;
+
+        use baml_compiler2_tir::normalize as n;
+        Self {
+            is_same_normalized_type: n::PROF_IS_SAME_NORMALIZED_TYPE_CALLS.load(Ordering::Relaxed),
+            is_subtype_of: n::PROF_IS_SUBTYPE_OF_CALLS.load(Ordering::Relaxed),
+            find_recursive_aliases: n::PROF_FIND_RECURSIVE_ALIASES_CALLS.load(Ordering::Relaxed),
+            has_cycle: n::PROF_HAS_CYCLE_CALLS.load(Ordering::Relaxed),
+            normalize: n::PROF_NORMALIZE_CALLS.load(Ordering::Relaxed),
+        }
+    }
+    fn reset() {
+        baml_compiler2_tir::normalize::perf_audit_reset();
+    }
+}
+
+/// A single compile run's measurements.
+#[derive(Debug)]
+struct RunReport {
+    /// Cold (fresh db) or warm (re-invoked on same db).
+    mode: RunMode,
+    /// Time to build the database and add all files as Salsa inputs.
+    /// Zero for warm runs (the db already exists).
+    db_build: Duration,
+    /// Time to run `db.check()` (all diagnostics).
+    check: Duration,
+    /// Time to run `db.get_bytecode()` (parse → MIR → emit). Zero when
+    /// `--check-only` was passed OR when `check()` surfaced errors and
+    /// bytecode generation was skipped.
+    emit: Duration,
+    /// Total wall clock (`db_build + check + emit`).
+    total: Duration,
+    /// Number of error-severity diagnostics produced by `check()`.
+    error_count: usize,
+    /// Number of warning-severity diagnostics produced by `check()`.
+    warning_count: usize,
+    /// Whether `get_bytecode()` was called (i.e., not `--check-only` and
+    /// no errors from `check`).
+    emit_attempted: bool,
+    /// Number of times Salsa reported a fixpoint cycle iteration during
+    /// the run. Rare; large numbers hint at a query that's oscillating.
+    cycle_iterations: u64,
+    /// Per-query stats resolved to human-readable names, sorted by
+    /// `executed` descending. Deterministic across runs.
+    queries: Vec<QueryRow>,
+    /// TIR normalization audit counters (redundant-work quantifier).
+    tir_audit: TirAuditCounters,
+}
+
+/// One row in the per-query event table.
+#[derive(Debug, Clone, serde::Serialize)]
+struct QueryRow {
+    /// The Salsa ingredient's debug name, e.g.
+    /// `baml_compiler2_hir::file_semantic_index::file_semantic_index`. This
+    /// is Salsa's own `Ingredient::debug_name`, so it always matches what
+    /// Salsa's tracing prints.
+    name: String,
+    /// Times Salsa actually ran the query's body (cache miss / stale
+    /// input). This is the "real work" number.
+    executed: u64,
+    /// Times Salsa was able to reuse a memoized value (cache hit).
+    cache_hits: u64,
+    /// Times we blocked waiting for another thread to compute the same
+    /// query. Non-zero here means the compile is trying to be parallel.
+    blocked: u64,
+}
+
+fn total_executions(rows: &[QueryRow]) -> u64 {
+    rows.iter().map(|r| r.executed).sum()
+}
+
+fn total_cache_hits(rows: &[QueryRow]) -> u64 {
+    rows.iter().map(|r| r.cache_hits).sum()
+}
+
+/// Raw per-ingredient counters accumulated on the Salsa event callback.
+/// Kept name-free (`IngredientIndex` only) so the callback stays allocation-
+/// free on the hot path — name resolution happens once at report time.
+#[derive(Default, Debug)]
+struct RawStats {
+    /// Map from `IngredientIndex` → (executed, cache_hits, blocked). The
+    /// `IngredientIndex` newtype is `Hash + Eq + Copy`, so it's a fine
+    /// HashMap key without any conversion.
+    counters: HashMap<salsa::IngredientIndex, RawCounters>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct RawCounters {
+    executed: u64,
+    cache_hits: u64,
+    blocked: u64,
+}
+
+/// Build a fresh instrumented database, then invoke the compile pipeline
+/// `1 + warm_runs` times: once cold (empty cache) and then `warm_runs`
+/// more times against the *same* database (no input mutation between
+/// invocations, so every resolve should be a Salsa cache hit).
+///
+/// The Salsa event callback is installed once on the database and
+/// remains active for all invocations. Between invocations we snapshot
+/// and clear the per-ingredient counters so each `RunReport` describes
+/// only its own invocation's events.
+fn run_cold_plus_warm(
+    root: &Path,
+    sources: &[(PathBuf, String)],
+    check_only: bool,
+    warm_runs: usize,
+) -> Result<Vec<RunReport>> {
+    let stats: Arc<Mutex<RawStats>> = Arc::new(Mutex::new(RawStats::default()));
+    // Cycle events don't need per-query breakdown — a single counter is
+    // enough. Keeping it as an `AtomicU64` avoids competing with the
+    // per-event mutex for the (very rare) cycle path.
+    let cycle_iters = Arc::new(AtomicU64::new(0));
+
+    let stats_cb = Arc::clone(&stats);
+    let cycles_cb = Arc::clone(&cycle_iters);
+    let callback: baml_project::EventCallback = Box::new(move |event: Event| {
+        // We deliberately do NOT resolve query names inside the callback.
+        // Salsa's `ingredient_debug_name` allocates a `Cow<str>` per call;
+        // doing that on every event would swamp the very compile-time
+        // signal we're trying to capture. Instead we accumulate into an
+        // `IngredientIndex`-keyed map and resolve names once at report
+        // time (after the run completes).
+        match event.kind {
+            EventKind::WillExecute { database_key } => {
+                let idx = database_key.ingredient_index();
+                let mut guard = stats_cb.lock().unwrap();
+                guard.counters.entry(idx).or_default().executed += 1;
+            }
+            EventKind::DidValidateMemoizedValue { database_key } => {
+                let idx = database_key.ingredient_index();
+                let mut guard = stats_cb.lock().unwrap();
+                guard.counters.entry(idx).or_default().cache_hits += 1;
+            }
+            EventKind::WillBlockOn { database_key, .. } => {
+                let idx = database_key.ingredient_index();
+                let mut guard = stats_cb.lock().unwrap();
+                guard.counters.entry(idx).or_default().blocked += 1;
+            }
+            EventKind::WillIterateCycle { .. } => {
+                cycles_cb.fetch_add(1, Ordering::Relaxed);
+            }
+            _ => {}
+        }
+    });
+
+    let build_start = Instant::now();
+    let mut db = ProjectDatabase::new_with_event_callback(callback);
+    db.set_project_root(root);
+    for (path, text) in sources {
+        db.add_or_update_file(path, text);
+    }
+    let db_build = build_start.elapsed();
+    // Cold-run counter snapshot baseline is empty — anything the callback
+    // recorded during `set_project_root` / `add_or_update_file` (there
+    // shouldn't be any query executions yet, but be defensive) gets
+    // dropped so we only report events from `check`/`emit`.
+    *stats.lock().unwrap() = RawStats::default();
+    let cold_cycles_before = cycle_iters.load(Ordering::Relaxed);
+
+    let mut reports = Vec::with_capacity(1 + warm_runs);
+
+    let cold = invoke_pipeline(
+        &mut db,
+        &stats,
+        &cycle_iters,
+        cold_cycles_before,
+        check_only,
+        RunMode::Cold,
+        db_build,
+    )?;
+    let cold_had_errors = cold.error_count > 0;
+    reports.push(cold);
+
+    // Warm re-runs share the db. We don't rebuild inputs; Salsa should
+    // resolve everything from its cache. If `check_only` was set, we
+    // reuse it. If cold had errors, we still exercise the warm path
+    // (the caller may want to see whether reruns are also fast even in
+    // that case — they should be).
+    for i in 1..=warm_runs {
+        let cycles_before = cycle_iters.load(Ordering::Relaxed);
+        let warm = invoke_pipeline(
+            &mut db,
+            &stats,
+            &cycle_iters,
+            cycles_before,
+            check_only || cold_had_errors,
+            RunMode::Warm { index: i },
+            Duration::ZERO,
+        )?;
+        reports.push(warm);
+    }
+
+    Ok(reports)
+}
+
+/// Invoke `check` + optionally `get_bytecode` on an already-built db,
+/// snapshotting and clearing the per-ingredient counters so this run's
+/// `RunReport` describes only its own events. The caller supplies
+/// `db_build_time` (nonzero only on cold runs).
+fn invoke_pipeline(
+    db: &mut ProjectDatabase,
+    stats: &Mutex<RawStats>,
+    cycle_iters: &AtomicU64,
+    cycles_before: u64,
+    check_only: bool,
+    mode: RunMode,
+    db_build_time: Duration,
+) -> Result<RunReport> {
+    // Zero out redundant-work counters so this run's numbers describe
+    // only what happens between now and the end of `get_bytecode`.
+    TirAuditCounters::reset();
+
+    let check_start = Instant::now();
+    let check_result = db.check();
+    let check = check_start.elapsed();
+
+    let error_count = check_result
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .count();
+    let warning_count = check_result
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Warning)
+        .count();
+    drop(check_result); // release large HashMaps early
+
+    let (emit, emit_attempted) = if check_only {
+        (Duration::ZERO, false)
+    } else if error_count > 0 {
+        // Matches the CLI: `check` errors abort the pipeline before
+        // bytecode generation.
+        eprintln!(
+            "[baml_compiler2_profile]   [{}] skipping emit: {error_count} error(s) reported by check",
+            mode.label()
+        );
+        (Duration::ZERO, false)
+    } else {
+        let emit_start = Instant::now();
+        db.get_bytecode()
+            .map_err(|e| anyhow::anyhow!("bytecode generation failed: {e:?}"))?;
+        (emit_start.elapsed(), true)
+    };
+
+    // Snapshot and clear the per-run counters. This is what makes
+    // per-invocation warm-run reporting possible: each report describes
+    // only the events fired during its own `check` + `get_bytecode`.
+    // Safe because after those calls return, no more Salsa events can
+    // arrive on this thread until the next invocation.
+    let raw = std::mem::take(&mut *stats.lock().unwrap());
+    let queries = resolve_query_names(db, &raw);
+
+    let cycles_after = cycle_iters.load(Ordering::Relaxed);
+    let tir_audit = TirAuditCounters::snapshot();
+    let total = db_build_time + check + emit;
+
+    Ok(RunReport {
+        mode,
+        db_build: db_build_time,
+        check,
+        emit,
+        total,
+        error_count,
+        warning_count,
+        emit_attempted,
+        cycle_iterations: cycles_after - cycles_before,
+        queries,
+        tir_audit,
+    })
+}
+
+/// Look up each ingredient index's debug name and produce a sorted
+/// `QueryRow` list. Sort order: `executed desc, name asc` — deterministic
+/// so JSON output is diff-friendly across runs.
+///
+/// Salsa's `Ingredient::debug_name` returns just the function name (e.g.
+/// `"file_semantic_index"`), not a qualified path. Different crates can
+/// register queries with the same name (e.g. HIR and PPIR both expose
+/// `file_semantic_index`) and they will collide in the report. We
+/// disambiguate by appending the ingredient index whenever the same name
+/// is emitted by more than one ingredient — enough for the reader to
+/// tell them apart in the report and keep counts correct.
+fn resolve_query_names(db: &ProjectDatabase, raw: &RawStats) -> Vec<QueryRow> {
+    let mut name_by_idx: HashMap<salsa::IngredientIndex, String> = raw
+        .counters
+        .keys()
+        .map(|idx| {
+            (
+                *idx,
+                (db as &dyn Database)
+                    .ingredient_debug_name(*idx)
+                    .to_string(),
+            )
+        })
+        .collect();
+
+    // Detect name collisions: multiple ingredient indices share the same
+    // debug name. Suffix the collisions so the report shows each row on
+    // its own line with a stable-per-index label.
+    let mut count_by_name: HashMap<String, usize> = HashMap::new();
+    for name in name_by_idx.values() {
+        *count_by_name.entry(name.clone()).or_default() += 1;
+    }
+    for (idx, name) in &mut name_by_idx {
+        if count_by_name.get(name).copied().unwrap_or(0) > 1 {
+            // Ingredient index is a `u32`-newtype but its accessor is
+            // pub(crate); its `Debug` prints as `IngredientIndex(N)`,
+            // which is what we surface to the report.
+            *name = format!("{name} [{idx:?}]");
+        }
+    }
+
+    let mut rows: Vec<QueryRow> = raw
+        .counters
+        .iter()
+        .map(|(idx, c)| QueryRow {
+            name: name_by_idx
+                .remove(idx)
+                .unwrap_or_else(|| format!("{idx:?}")),
+            executed: c.executed,
+            cache_hits: c.cache_hits,
+            blocked: c.blocked,
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.executed
+            .cmp(&a.executed)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    rows
+}
+
+// ── Reporting ────────────────────────────────────────────────────────────
+
+/// Group a query into a coarse pipeline phase.
+///
+/// Salsa's `debug_name` returns just the function name (e.g.
+/// `"file_semantic_index"`) with no crate qualification, so we can't rely
+/// on `contains("baml_compiler2_hir")` etc. Instead we map by *known
+/// query function name* — the list is small (~40 unique queries at last
+/// count) so a hardcoded mapping is manageable and gives an accurate
+/// phase breakdown.
+///
+/// If you add a new tracked query to the compiler and want it grouped,
+/// add its name here.
+fn phase_for_query(name: &str) -> &'static str {
+    // Strip our own disambiguation suffix `" [IngredientIndex(N)]"` if
+    // present so both collision variants map to the same phase.
+    let base = name.split(" [").next().unwrap_or(name);
+    match base {
+        // Lexer / parser / syntax
+        "lex_file" => "lexer",
+        "parse_result" | "parse_errors" | "syntax_tree" => "parser",
+
+        // HIR (baml_compiler2_hir)
+        "file_semantic_index"
+        | "file_item_tree"
+        | "file_package"
+        | "namespace_items"
+        | "package_items"
+        | "function_signature"
+        | "function_body"
+        | "function_parameter_defaults"
+        | "function_in_scope_generic_param_bounds"
+        | "class_generic_param_bounds"
+        | "compiler2_all_files" => "hir",
+
+        // PPIR (baml_compiler2_ppir)
+        "ppir_expansion_items" => "ppir",
+
+        // TIR (baml_compiler2_tir)
+        "infer_scope_types"
+        | "resolve_class_fields"
+        | "resolve_type_alias"
+        | "resolve_name_at"
+        | "callable_throws"
+        | "impl_data"
+        | "impl_data_source_map"
+        | "validate_impl_signatures"
+        | "package_coherence_diagnostics"
+        | "package_resolution_context" => "tir",
+
+        // MIR (baml_compiler2_mir)
+        "lower_function" | "lower_let_body" => "mir",
+
+        // Emit (baml_compiler2_emit)
+        "generate_project_bytecode" => "emit",
+
+        _ => "other",
+    }
+}
+
+fn print_human(
+    report: &RunReport,
+    all_runs: &[RunReport],
+    bytes: usize,
+    lines: usize,
+    files: usize,
+    top_n: usize,
+) {
+    println!();
+    println!("=== BAML compile profile ===");
+    println!(
+        "workload: {} files, {} lines, {} bytes",
+        files, lines, bytes
+    );
+    // Explicit cache-mode line — makes it impossible to misread the
+    // report as a warm/incremental measurement when it isn't.
+    let cold_count = all_runs.iter().filter(|r| r.mode.is_cold()).count();
+    let warm_count = all_runs.iter().filter(|r| !r.mode.is_cold()).count();
+    println!(
+        "cache mode: cold (fresh Salsa db per run){}",
+        if warm_count > 0 {
+            format!(
+                " + {} warm re-run(s) per cold run, on the same db",
+                warm_count / cold_count.max(1)
+            )
+        } else {
+            String::new()
+        },
+    );
+
+    // Wall-clock breakdown
+    println!();
+    println!(
+        "--- Wall clock (representative COLD run, {} cold + {} warm invocation(s) total) ---",
+        cold_count, warm_count,
+    );
+    println!(
+        "  {:<20} {:>10.3} s",
+        "db build (inputs)",
+        report.db_build.as_secs_f64()
+    );
+    println!("  {:<20} {:>10.3} s", "check", report.check.as_secs_f64());
+    if report.emit_attempted {
+        println!(
+            "  {:<20} {:>10.3} s",
+            "emit (bytecode)",
+            report.emit.as_secs_f64()
+        );
+    } else {
+        println!(
+            "  {:<20} {:>10}   (skipped: {})",
+            "emit (bytecode)",
+            "-",
+            if report.error_count > 0 {
+                "check reported errors"
+            } else {
+                "--check-only"
+            }
+        );
+    }
+    println!("  {:<20} {:>10.3} s", "TOTAL", report.total.as_secs_f64());
+
+    if report.error_count + report.warning_count > 0 {
+        println!(
+            "  diagnostics: {} error(s), {} warning(s)",
+            report.error_count, report.warning_count
+        );
+    }
+
+    // Cold-only variance table (only shown when there are ≥2 cold runs).
+    let cold_runs: Vec<&RunReport> = all_runs.iter().filter(|r| r.mode.is_cold()).collect();
+    if cold_runs.len() > 1 {
+        let min = cold_runs
+            .iter()
+            .map(|r| r.total.as_secs_f64())
+            .fold(f64::INFINITY, f64::min);
+        let max = cold_runs
+            .iter()
+            .map(|r| r.total.as_secs_f64())
+            .fold(f64::NEG_INFINITY, f64::max);
+        let mean =
+            cold_runs.iter().map(|r| r.total.as_secs_f64()).sum::<f64>() / cold_runs.len() as f64;
+        println!();
+        println!("--- Cold-run variance across {} runs ---", cold_runs.len());
+        println!(
+            "  total: min {:.3}s  median {:.3}s  mean {:.3}s  max {:.3}s",
+            min,
+            report.total.as_secs_f64(),
+            mean,
+            max
+        );
+    }
+
+    // Cold vs warm comparison — the point of `--warm-runs`. If warm
+    // totals are near zero, Salsa's cache is doing what it should. If
+    // warm totals still spend real time in `check` or `emit`, we have a
+    // caching gap: a tracked query is being re-executed even though its
+    // inputs didn't change.
+    if warm_count > 0 {
+        println!();
+        println!("--- Cold vs warm (per-invocation, same-db reruns) ---");
+        println!(
+            "  {:<10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+            "mode", "total_s", "check_s", "emit_s", "exec", "hits"
+        );
+        for r in all_runs {
+            println!(
+                "  {:<10} {:>10.3} {:>10.3} {:>10.3} {:>10} {:>10}",
+                r.mode.label(),
+                r.total.as_secs_f64(),
+                r.check.as_secs_f64(),
+                r.emit.as_secs_f64(),
+                total_executions(&r.queries),
+                total_cache_hits(&r.queries),
+            );
+        }
+        // Cross-check: three distinct failure modes to call out.
+        //
+        //  1) Warm runs *re-execute* queries: caching gap inside Salsa
+        //     (input keys aren't stable, or the query isn't tracked).
+        //  2) Warm runs execute nothing but still spend real time:
+        //     work is happening OUTSIDE any Salsa query — the wrapper
+        //     is doing materialization / walking / cloning on every
+        //     call. Salsa's cache can't help this; the fix is to
+        //     memoize (or move) the work.
+        //  3) Warm total ≈ 0: everything is cached, no lead.
+        let warm_reports: Vec<&RunReport> = all_runs.iter().filter(|r| !r.mode.is_cold()).collect();
+        let worst_warm_exec = warm_reports
+            .iter()
+            .map(|r| total_executions(&r.queries))
+            .max()
+            .unwrap_or(0);
+        let worst_warm_check = warm_reports
+            .iter()
+            .map(|r| r.check.as_secs_f64())
+            .fold(0.0_f64, f64::max);
+        let worst_warm_emit = warm_reports
+            .iter()
+            .map(|r| r.emit.as_secs_f64())
+            .fold(0.0_f64, f64::max);
+        println!();
+        if worst_warm_exec > 0 {
+            println!(
+                "  ⚠ warm runs re-executed up to {worst_warm_exec} queries. Any query still \
+                 firing on a warm run is a caching gap — its inputs are stable but it isn't \
+                 being memoized (or its key is unstable across calls)."
+            );
+        }
+        // Threshold: 100ms of warm wall-time in a phase with 0 exec
+        // is enough to be worth investigating. Below that it's likely
+        // just Salsa's revision-check bookkeeping.
+        if worst_warm_exec == 0 && (worst_warm_check > 0.1 || worst_warm_emit > 0.1) {
+            println!(
+                "  ⚠ warm runs executed 0 queries but still spent significant wall time \
+                 (check={:.3}s, emit={:.3}s). That work lives OUTSIDE any Salsa tracked \
+                 query, so Salsa's cache cannot help it. Look at what `db.check()` and \
+                 `db.get_bytecode()` do between their tracked-query calls — the wrapper is \
+                 doing per-invocation work (materialization, walking, cloning, printing).",
+                worst_warm_check, worst_warm_emit
+            );
+        }
+        if worst_warm_exec == 0 && worst_warm_check <= 0.1 && worst_warm_emit <= 0.1 {
+            println!(
+                "  ✓ warm runs are fully cached (0 executions, ≤100ms of wall time in every \
+                 phase). Salsa is doing its job on this workload."
+            );
+        }
+    }
+
+    // Aggregate query stats
+    let resolved = report.queries.as_slice();
+    let total_exec: u64 = resolved.iter().map(|r| r.executed).sum();
+    let total_hits: u64 = resolved.iter().map(|r| r.cache_hits).sum();
+    let total_blocks: u64 = resolved.iter().map(|r| r.blocked).sum();
+    let total_events = total_exec + total_hits;
+    let hit_rate = if total_events == 0 {
+        0.0
+    } else {
+        total_hits as f64 / total_events as f64 * 100.0
+    };
+
+    // TIR redundant-work audit — see `TirAuditCounters` docstring.
+    let a = report.tir_audit;
+    println!();
+    println!("--- TIR normalization audit (representative COLD run) ---");
+    println!(
+        "  {:<32} {:>12}",
+        "is_same_normalized_type calls", a.is_same_normalized_type
+    );
+    println!("  {:<32} {:>12}", "is_subtype_of calls", a.is_subtype_of);
+    println!(
+        "  {:<32} {:>12}",
+        "find_recursive_aliases calls", a.find_recursive_aliases
+    );
+    println!("  {:<32} {:>12}", "has_cycle calls", a.has_cycle);
+    println!("  {:<32} {:>12}", "normalize calls", a.normalize);
+    // Derived ratios: if `find_recursive_aliases` is called ~once per
+    // `is_same_normalized_type + is_subtype_of`, we know each entry
+    // point unconditionally re-computes the recursive-alias DFS. That
+    // DFS is a pure function of the alias map (constant per package),
+    // so those calls are all redundant work.
+    let entries = a.is_same_normalized_type + a.is_subtype_of;
+    if entries > 0 && a.find_recursive_aliases >= entries {
+        let ratio = a.find_recursive_aliases as f64 / entries as f64;
+        println!(
+            "  ⚠ find_recursive_aliases fires {:.2}× per (is_same_normalized_type + is_subtype_of).",
+            ratio
+        );
+        println!(
+            "    The recursive-alias set is a pure function of `aliases` (constant per package)."
+        );
+        println!(
+            "    Every extra call is a full DFS over the alias graph. All of it is duplicate work."
+        );
+    }
+    if a.has_cycle > 0 && a.find_recursive_aliases > 0 {
+        let per_call = a.has_cycle as f64 / a.find_recursive_aliases as f64;
+        println!(
+            "  info: has_cycle fires {:.1}× per find_recursive_aliases call — matches ~aliases count",
+            per_call
+        );
+    }
+
+    println!();
+    println!("--- Query events (aggregate) ---");
+    println!("  executions:  {:>12}", total_exec);
+    println!(
+        "  cache hits:  {:>12}   ({:.2}% of resolves)",
+        total_hits, hit_rate
+    );
+    println!("  blocked on:  {:>12}", total_blocks);
+    println!("  cycle iters: {:>12}", report.cycle_iterations);
+    println!("  unique queries: {:>9}", resolved.len());
+
+    // Per-phase aggregate
+    let mut phase_totals: HashMap<&'static str, (u64, u64)> = HashMap::new();
+    for row in resolved {
+        let phase = phase_for_query(&row.name);
+        let entry = phase_totals.entry(phase).or_default();
+        entry.0 += row.executed;
+        entry.1 += row.cache_hits;
+    }
+    let mut phase_rows: Vec<_> = phase_totals.into_iter().collect();
+    phase_rows.sort_by(|a, b| b.1.0.cmp(&a.1.0));
+    println!();
+    println!("--- Query events by phase ---");
+    println!(
+        "  {:<12} {:>12} {:>12} {:>10}",
+        "phase", "executions", "cache hits", "hit %"
+    );
+    for (phase, (exec, hits)) in &phase_rows {
+        let total = exec + hits;
+        let pct = if total == 0 {
+            0.0
+        } else {
+            *hits as f64 / total as f64 * 100.0
+        };
+        println!("  {:<12} {:>12} {:>12} {:>9.2}%", phase, exec, hits, pct);
+    }
+
+    // Top-N by executions
+    println!();
+    println!(
+        "--- Top {} queries by executions (uncached work) ---",
+        top_n
+    );
+    println!(
+        "  {:<8} {:<8} {:<8} {:<8}  query",
+        "exec", "hits", "blocked", "hit%"
+    );
+    for row in resolved.iter().take(top_n) {
+        let total = row.executed + row.cache_hits;
+        let pct = if total == 0 {
+            0.0
+        } else {
+            row.cache_hits as f64 / total as f64 * 100.0
+        };
+        println!(
+            "  {:<8} {:<8} {:<8} {:<7.1}% {}",
+            row.executed, row.cache_hits, row.blocked, pct, row.name
+        );
+    }
+
+    // Top-N by (exec + hits): most-touched queries. High counts here mean
+    // the query is on the hot path; combined with a low hit% these are
+    // candidates for redundant work.
+    let mut by_touches: Vec<&QueryRow> = resolved.iter().collect();
+    by_touches.sort_by(|a, b| {
+        (b.executed + b.cache_hits)
+            .cmp(&(a.executed + a.cache_hits))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    println!();
+    println!("--- Top {} queries by total calls (exec + hits) ---", top_n);
+    println!(
+        "  {:<10} {:<8} {:<8} {:<8}  query",
+        "calls", "exec", "hits", "hit%"
+    );
+    for row in by_touches.iter().take(top_n) {
+        let calls = row.executed + row.cache_hits;
+        let pct = if calls == 0 {
+            0.0
+        } else {
+            row.cache_hits as f64 / calls as f64 * 100.0
+        };
+        println!(
+            "  {:<10} {:<8} {:<8} {:<7.1}% {}",
+            calls, row.executed, row.cache_hits, pct, row.name
+        );
+    }
+
+    // Queries where execution >> cache_hits: suspicious.
+    // Filter out queries with tiny counts (< 100) to keep the noise down —
+    // for those it doesn't matter whether they're cached.
+    let mut suspect: Vec<&QueryRow> = resolved
+        .iter()
+        .filter(|r| r.executed >= 100 && r.executed >= r.cache_hits * 2)
+        .collect();
+    suspect.sort_by(|a, b| b.executed.cmp(&a.executed));
+    println!();
+    println!("--- Suspect: high exec, low cache hit (exec ≥ 100, exec ≥ 2× hits) ---");
+    if suspect.is_empty() {
+        println!("  (none)");
+    } else {
+        println!("  {:<8} {:<8} {:<8}  query", "exec", "hits", "hit%");
+        for row in suspect.iter().take(top_n) {
+            let total = row.executed + row.cache_hits;
+            let pct = if total == 0 {
+                0.0
+            } else {
+                row.cache_hits as f64 / total as f64 * 100.0
+            };
+            println!(
+                "  {:<8} {:<8} {:<7.1}% {}",
+                row.executed, row.cache_hits, pct, row.name
+            );
+        }
+    }
+
+    println!();
+    println!("Tips:");
+    println!("  * For a CPU flamegraph, wrap this binary with a sampler:");
+    println!("      samply record ./target/release/baml_compiler2_profile <project>");
+    println!("  * The 'suspect' table above is a first place to look for repeated");
+    println!("    work — a query that fires many times but is rarely a cache hit");
+    println!("    is either recomputing per-call, or keyed too finely.");
+    println!();
+}
+
+fn print_json(
+    report: &RunReport,
+    all_runs: &[RunReport],
+    bytes: usize,
+    lines: usize,
+    files: usize,
+) {
+    #[derive(serde::Serialize)]
+    struct Out<'a> {
+        files: usize,
+        lines: usize,
+        bytes: usize,
+        representative: RunOut<'a>,
+        all_runs: Vec<RunOut<'a>>,
+    }
+    #[derive(serde::Serialize)]
+    struct RunOut<'a> {
+        /// "cold" or "warm#N" — see `RunMode`.
+        mode: String,
+        total_seconds: f64,
+        db_build_seconds: f64,
+        check_seconds: f64,
+        emit_seconds: f64,
+        emit_attempted: bool,
+        error_count: usize,
+        warning_count: usize,
+        total_executions: u64,
+        total_cache_hits: u64,
+        cycle_iterations: u64,
+        queries: &'a [QueryRow],
+        tir_audit: TirAuditCounters,
+    }
+    fn to_out(r: &RunReport) -> RunOut<'_> {
+        RunOut {
+            mode: r.mode.label(),
+            total_seconds: r.total.as_secs_f64(),
+            db_build_seconds: r.db_build.as_secs_f64(),
+            check_seconds: r.check.as_secs_f64(),
+            emit_seconds: r.emit.as_secs_f64(),
+            emit_attempted: r.emit_attempted,
+            error_count: r.error_count,
+            warning_count: r.warning_count,
+            total_executions: total_executions(&r.queries),
+            total_cache_hits: total_cache_hits(&r.queries),
+            cycle_iterations: r.cycle_iterations,
+            queries: r.queries.as_slice(),
+            tir_audit: r.tir_audit,
+        }
+    }
+    let out = Out {
+        files,
+        lines,
+        bytes,
+        representative: to_out(report),
+        all_runs: all_runs.iter().map(to_out).collect(),
+    };
+    println!("{}", serde_json::to_string_pretty(&out).unwrap());
+}
+
+fn print_summary_line(report: &RunReport, files: usize, lines: usize, bytes: usize) {
+    println!(
+        "SUMMARY files={} lines={} bytes={} total_s={:.3} check_s={:.3} emit_s={:.3} exec={} hits={} unique={}",
+        files,
+        lines,
+        bytes,
+        report.total.as_secs_f64(),
+        report.check.as_secs_f64(),
+        report.emit.as_secs_f64(),
+        total_executions(&report.queries),
+        total_cache_hits(&report.queries),
+        report.queries.len(),
+    );
+}

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -752,7 +752,7 @@ pub struct TypeInferenceBuilder<'db> {
     /// `package_resolved_aliases` value (not rebuilt per scope) so
     /// `is_same_normalized_type` and `is_subtype_of` reuse the
     /// precomputed `recursive` set instead of re-DFS'ing the alias
-    /// graph on every call. See `crates/baml_compiler2_profile/README.md`
+    /// graph on every call. See `crates/tools_compile_profile/README.md`
     /// for the audit that surfaced the redundant work this fixes.
     aliases: &'db baml_type::ResolvedAliases,
     /// Namespace path for the file being analyzed (e.g. `["env"]` for `baml/env.baml`).

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -13,7 +13,7 @@
 //! NOT recurse into it — lambda bodies are separate scopes with their own
 //! `infer_scope_types` Salsa query.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
 use baml_base::{Name, SourceFile};
 use baml_compiler2_ast::{
@@ -135,6 +135,91 @@ fn function_generic_param_bounds_exprs(
 ) -> Vec<Option<TypeExpr>> {
     let item_tree = baml_compiler2_ppir::file_item_tree(db, func_loc.file(db));
     item_tree[func_loc.id(db)].generic_param_bounds.clone()
+}
+
+/// Per-callee generic-parameter facts consumed at every call site:
+/// the enclosing class's generic params (empty for free functions), the
+/// callee's user-declared params, their lowered interface bounds, and the
+/// callee's name for diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct CalleeGenerics {
+    pub(crate) class_params: Vec<Name>,
+    pub(crate) user_params: Vec<Name>,
+    pub(crate) user_bounds: Vec<Option<Ty>>,
+    pub(crate) name: Name,
+}
+
+// Safety: `CalleeGenerics` holds only plain (non-`'db`) data. Manual `Update`
+// impl uses `PartialEq` for Salsa early-cutoff.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for CalleeGenerics {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: `old_pointer` is valid, aligned, and Salsa-owned.
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// The declared generic params and lowered bounds of a callable, memoized per
+/// function. Every call site used to redo this from scratch — an item-tree
+/// scan for the enclosing class plus a re-lowering of the bound type
+/// expressions — which showed up as ~10% of cold compile time.
+#[salsa::tracked(returns(ref))]
+pub(crate) fn callee_generics_for_func<'db>(
+    db: &'db dyn crate::Db,
+    func_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
+) -> CalleeGenerics {
+    let sig = baml_compiler2_ppir::elaborated_function_signature(db, func_loc);
+    // The enclosing class's generic params (`[]` for a free function). These
+    // are always in scope when lowering the method's *bounds* — a bound may
+    // reference a class generic (`<U extends Eq<C>>` on a method of
+    // `class Box<C>`) regardless of how the class args are supplied — so they
+    // must be visible or `C` would resolve to `unknown`.
+    let file = func_loc.file(db);
+    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
+    let class_params: Vec<Name> = item_tree
+        .classes
+        .values()
+        .find(|class_data| class_data.methods.contains(&func_loc.id(db)))
+        .map(|class_data| class_data.generic_params.clone())
+        .unwrap_or_default();
+
+    // Lower the user generic params' interface bounds in the callee's own
+    // package/namespace, with the class params in scope (see above). The
+    // bounds were already validated at the declaration site, so discard
+    // re-lowering diagnostics here.
+    let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
+    let pkg_id = PackageId::new(db, pkg_info.package.clone());
+    let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
+    let mut bound_scope = class_params.clone();
+    bound_scope.extend(sig.user_generic_params.iter().cloned());
+    let mut diags = Vec::new();
+    let user_bounds = lower_generic_param_bounds(
+        db,
+        &function_generic_param_bounds_exprs(db, func_loc),
+        pkg_items,
+        &pkg_info.namespace_path,
+        &bound_scope,
+        None,
+        &mut diags,
+    );
+
+    CalleeGenerics {
+        class_params,
+        user_params: sig.user_generic_params.clone(),
+        user_bounds,
+        name: sig.name.clone(),
+    }
 }
 
 pub(crate) fn lower_generic_param_bounds(
@@ -544,7 +629,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         GlobalTypeContext {
             db: self.context.db(),
             res_ctx: self.res_ctx,
-            aliases: &self.aliases,
+            aliases: self.aliases,
             bounds: &self.generic_param_bounds,
         }
     }
@@ -662,9 +747,14 @@ pub struct TypeInferenceBuilder<'db> {
     scope: ScopeId<'db>,
     /// Declared return type for the function (used to check return statements).
     declared_return_ty: Option<Ty>,
-    /// Resolved type alias map: alias qualified name → expanded Ty.
-    /// Used by the normalizer for structural subtype checking.
-    aliases: HashMap<crate::ty::QualifiedTypeName, Ty>,
+    /// Resolved type alias environment: alias map + precomputed
+    /// recursive-alias set. Held by reference to the Salsa-cached
+    /// `package_resolved_aliases` value (not rebuilt per scope) so
+    /// `is_same_normalized_type` and `is_subtype_of` reuse the
+    /// precomputed `recursive` set instead of re-DFS'ing the alias
+    /// graph on every call. See `crates/baml_compiler2_profile/README.md`
+    /// for the audit that surfaced the redundant work this fixes.
+    aliases: &'db baml_type::ResolvedAliases,
     /// Namespace path for the file being analyzed (e.g. `["env"]` for `baml/env.baml`).
     ns_context: Vec<Name>,
     /// BEP-044: when this body is the override of an interface method
@@ -773,6 +863,15 @@ pub struct TypeInferenceBuilder<'db> {
     /// to the owning Function/Let scope) lets that standalone inference seed
     /// them — see `infer_scope_types`'s `ScopeKind::Lambda` arm.
     pub template_body_params: FxHashMap<FileScopeId, Vec<FunctionParamTy>>,
+    /// Accumulates each nested lambda's full inline-inference tables, keyed by
+    /// the lambda's `FileScopeId`. Captured at the end of `infer_lambda_body`
+    /// before parent state is restored. Like `nested_lambda_types`, NOT
+    /// saved/restored by `infer_lambda_body`, so entries for arbitrarily
+    /// nested lambdas bubble up to the owning Function/Let scope, where the
+    /// standalone `ScopeKind::Lambda` query projects them out instead of
+    /// re-inferring the body.
+    pub nested_lambda_inference:
+        FxHashMap<FileScopeId, crate::inference::NestedLambdaInference<'db>>,
     /// Diagnostic-only concrete escaping throws for lambda expressions in the
     /// current scope. Used to explain callback forwarding without affecting
     /// call instantiation or throws checking semantics.
@@ -966,7 +1065,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         res_ctx: &'db PackageResolutionContext<'db>,
         package_id: PackageId<'db>,
         scope: ScopeId<'db>,
-        aliases: HashMap<crate::ty::QualifiedTypeName, Ty>,
+        aliases: &'db baml_type::ResolvedAliases,
     ) -> Self {
         let db = context.db();
         let package_items = &res_ctx.own_items;
@@ -1010,6 +1109,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             function_coercions: FxHashMap::default(),
             default_parameter_inference: crate::inference::DefaultParameterInference::empty(),
             nested_lambda_types: FxHashMap::default(),
+            nested_lambda_inference: FxHashMap::default(),
             template_body_params: FxHashMap::default(),
             lambda_effective_throws: FxHashMap::default(),
             is_auto_derived_body: false,
@@ -1130,6 +1230,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         FxHashMap<FileScopeId, Ty>,
         FxHashMap<FileScopeId, Vec<FunctionParamTy>>,
         crate::inference::DefaultParameterInference<'db>,
+        FxHashMap<FileScopeId, crate::inference::NestedLambdaInference<'db>>,
     ) {
         let diagnostics = self.context.finish();
         (
@@ -1149,6 +1250,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.nested_lambda_types,
             self.template_body_params,
             self.default_parameter_inference,
+            self.nested_lambda_inference,
         )
     }
 
@@ -1318,7 +1420,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn expand_alias_chains(&self, ty: Ty) -> Ty {
-        crate::inference::expand_alias_chains(ty, &self.aliases)
+        crate::inference::expand_alias_chains(ty, &self.aliases.aliases)
     }
 
     /// Pattern-matrix-internal normalization of a scrutinee type.
@@ -1833,7 +1935,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn container_arg_subtype_without_nominal(&self, actual: &Ty, expected: &Ty) -> bool {
-        crate::normalize::is_subtype_of(actual, expected, &self.aliases)
+        crate::normalize::is_subtype_of(actual, expected, self.aliases)
     }
 
     fn function_coercion_for(
@@ -2004,20 +2106,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             _ => return None,
         };
         let db = self.context.db();
-        let sig = baml_compiler2_ppir::elaborated_function_signature(db, func_loc);
-        // The enclosing class's generic params (`[]` for a free function). These
-        // are always in scope when lowering the method's *bounds* — a bound may
-        // reference a class generic (`<U extends Eq<C>>` on a method of
-        // `class Box<C>`) regardless of how the class args are supplied — so they
-        // must be visible or `C` would resolve to `unknown`.
-        let file = func_loc.file(db);
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-        let enclosing_class_params: Vec<Name> = item_tree
-            .classes
-            .values()
-            .find(|class_data| class_data.methods.contains(&func_loc.id(db)))
-            .map(|class_data| class_data.generic_params.clone())
-            .unwrap_or_default();
+        let data = callee_generics_for_func(db, func_loc);
         // Only user-declared generic params are *supplied at the call site*;
         // synthetic effect params are always inferred. For static-method-on-
         // generic-class calls, the class params are also supplied (`Class<...>.m`)
@@ -2026,41 +2115,21 @@ impl<'db> TypeInferenceBuilder<'db> {
         // params (their own bounds, where any, are enforced at receiver
         // specialization).
         let class_params: &[Name] = if treat_as_static_method {
-            &enclosing_class_params
+            &data.class_params
         } else {
             &[]
         };
 
-        // Lower the user generic params' interface bounds in the callee's own
-        // package/namespace, with the class params in scope (see above). The
-        // bounds were already validated at the declaration site, so discard
-        // re-lowering diagnostics here.
-        let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
-        let pkg_id = PackageId::new(db, pkg_info.package.clone());
-        let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
-        let mut bound_scope = enclosing_class_params.clone();
-        bound_scope.extend(sig.user_generic_params.iter().cloned());
-        let mut diags = Vec::new();
-        let user_bounds = lower_generic_param_bounds(
-            db,
-            &function_generic_param_bounds_exprs(db, func_loc),
-            pkg_items,
-            &pkg_info.namespace_path,
-            &bound_scope,
-            None,
-            &mut diags,
-        );
-
         let mut declared_params: Vec<Name> = class_params.to_vec();
-        declared_params.extend(sig.user_generic_params.iter().cloned());
+        declared_params.extend(data.user_params.iter().cloned());
         let mut declared_bounds: Vec<Option<Ty>> = vec![None; class_params.len()];
-        declared_bounds.extend(user_bounds);
+        declared_bounds.extend(data.user_bounds.iter().cloned());
         // A user bound that references an enclosing class param (`<U extends
         // Eq<C>>` on a method of `class Box<C>`) is lowered with `C` as a type
         // variable here; on a bound-method call the receiver's value for `C` is
         // seeded into the call-site bindings (see `owner_type_arg_binding_seed`) so
         // the bound resolves to e.g. `Eq<int>` before it is checked.
-        Some((declared_params, declared_bounds, sig.name.clone()))
+        Some((declared_params, declared_bounds, data.name.clone()))
     }
 
     /// Resolve explicit type arguments written at a call site (e.g. `foo<int, string>(x)`).
@@ -5447,15 +5516,14 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
 
         // Infer the lambda body using save/restore approach
-        let (ret_ty, _lambda_expressions, lambda_fsi, lambda_effective_throws) = self
-            .infer_lambda_body(
-                func_def,
-                &param_tys,
-                return_annotation.as_ref(),
-                &throws_ty,
-                throws_span,
-                warn_extraneous_throws,
-            );
+        let (ret_ty, lambda_fsi, lambda_effective_throws) = self.infer_lambda_body(
+            func_def,
+            &param_tys,
+            return_annotation.as_ref(),
+            &throws_ty,
+            throws_span,
+            warn_extraneous_throws,
+        );
         let surface_ret_ty = return_annotation.unwrap_or(ret_ty);
 
         let surface_throws = if infer_throws_from_body {
@@ -5909,7 +5977,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         self.package_id,
                         &inferred,
                         expected,
-                        &self.aliases,
+                        self.aliases,
                         |a, b| self.is_subtype(a, b),
                     )
                 } else {
@@ -6403,15 +6471,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                     );
 
                 // Infer/check the lambda body using save/restore approach
-                let (ret_ty, _lambda_expressions, lambda_fsi, lambda_effective_throws) = self
-                    .infer_lambda_body(
-                        func_def,
-                        &param_tys,
-                        Some(effective_ret),
-                        &throws_ty,
-                        throws_span,
-                        warn_extraneous_throws,
-                    );
+                let (ret_ty, lambda_fsi, lambda_effective_throws) = self.infer_lambda_body(
+                    func_def,
+                    &param_tys,
+                    Some(effective_ret),
+                    &throws_ty,
+                    throws_span,
+                    warn_extraneous_throws,
+                );
                 let surface_ret_ty = return_annotation.unwrap_or_else(|| {
                     if matches!(
                         expected_ret.as_ref(),
@@ -8674,7 +8741,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         match ty {
             Ty::Class(qtn, _, _) => qtn.is_panic_type().then(|| ty.clone()),
             Ty::TypeAlias(qtn, _) => {
-                if let Some(expanded) = self.aliases.get(qtn) {
+                if let Some(expanded) = self.aliases.aliases.get(qtn) {
                     self.ty_panic_subset(expanded)
                 } else if qtn.is_panic_type() {
                     Some(ty.clone())
@@ -14175,12 +14242,11 @@ impl<'db> TypeInferenceBuilder<'db> {
     ///
     /// Saves the current locals, `declared_return_ty`, `generic_params`, and
     /// `expressions` (to avoid `ExprId` collisions between
-    /// the lambda's arena and the parent's arena). After inference, restores all
-    /// saved state and returns the lambda's expression types separately.
+    /// the lambda's arena and the parent's arena). After inference, restores
+    /// all saved state; the lambda's own tables are moved into
+    /// `nested_lambda_inference` keyed by the lambda's `FileScopeId`.
     ///
-    /// Returns `(inferred_return_ty, lambda_expressions)` where
-    /// `lambda_expressions` contains the expression types for the lambda body
-    /// only (keyed by the lambda's own `ExprId`s, which start at 0).
+    /// Returns `(inferred_return_ty, lambda_file_scope_id, effective_throws)`.
     pub fn infer_lambda_body(
         &mut self,
         func_def: &baml_compiler2_ast::FunctionDef,
@@ -14189,7 +14255,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         chosen_throws: &Ty,
         throws_report_span: TextRange,
         warn_extraneous_throws: bool,
-    ) -> (Ty, FxHashMap<ExprId, Ty>, Option<FileScopeId>, Ty) {
+    ) -> (Ty, Option<FileScopeId>, Ty) {
         use baml_compiler2_ast::FunctionBodyDef;
 
         // Get the lambda's ExprBody
@@ -14198,7 +14264,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Ty::Unknown {
                     attr: TyAttr::default(),
                 },
-                FxHashMap::default(),
                 None,
                 Ty::Never {
                     attr: TyAttr::default(),
@@ -14211,7 +14276,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Ty::Void {
                     attr: TyAttr::default(),
                 },
-                FxHashMap::default(),
                 None,
                 Ty::Never {
                     attr: TyAttr::default(),
@@ -14297,7 +14361,17 @@ impl<'db> TypeInferenceBuilder<'db> {
             let index = baml_compiler2_ppir::file_semantic_index(db, file);
             // Captures are seeded only if the lambda scope is located (it
             // always should be, but be defensive).
-            let found_fsi = index.lambda_scope_for(func_def.span);
+            //
+            // Synthetic lambdas (desugared `test` / `testset` bodies) carry a
+            // default `FunctionDef::span`, but their `Expr::Lambda` node — and
+            // thus the HIR Lambda scope — spans the original block. That range
+            // equals the lowered body's root-expression span, so fall back to
+            // it when the def span misses.
+            let found_fsi = index.lambda_scope_for(func_def.span).or_else(|| {
+                lambda_body
+                    .root_expr
+                    .and_then(|root| index.lambda_scope_for(lambda_source_map.expr_span(root)))
+            });
             if let Some(fsi) = found_fsi {
                 let captures_to_seed: Vec<(Name, baml_compiler2_hir::semantic_index::BindingId)> =
                     index.scope_bindings[fsi.index() as usize]
@@ -14375,21 +14449,76 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         // Collect the lambda's expression types and restore parent state
         let lambda_expressions = std::mem::replace(&mut self.expressions, saved_expressions);
-        self.pattern_types = saved_bindings;
+        // Capture this lambda's complete inference tables (keyed by its own
+        // body arena's IDs) so the standalone `ScopeKind::Lambda` query can
+        // project them out instead of re-inferring the body from scratch.
+        // Each table is *moved* out while the saved parent state is swapped
+        // back in — the lambda's tables have exactly one consumer, so no
+        // clones. `nested_lambda_inference` itself is NOT restored, so entries
+        // for nested lambdas (recorded by inner `infer_lambda_body` calls)
+        // bubble up to the owning Function/Let scope.
+        if let Some(fsi) = lambda_file_scope_id {
+            let lambda_param_types: Vec<(Name, Ty)> = func_def
+                .params
+                .iter()
+                .zip(param_tys.iter())
+                .map(|(param, param_ty)| (param.name.clone(), param_ty.ty.clone()))
+                .collect();
+            self.nested_lambda_inference.insert(
+                fsi,
+                crate::inference::NestedLambdaInference {
+                    expressions: lambda_expressions,
+                    pattern_types: std::mem::replace(&mut self.pattern_types, saved_bindings),
+                    resolutions: std::mem::replace(&mut self.resolutions, saved_resolutions),
+                    catch_residual_throws: std::mem::replace(
+                        &mut self.catch_residual_throws,
+                        saved_catch_residual_throws,
+                    ),
+                    exhaustive_matches: std::mem::replace(
+                        &mut self.exhaustive_matches,
+                        saved_exhaustive_matches,
+                    ),
+                    path_root_types: std::mem::replace(
+                        &mut self.path_root_types,
+                        saved_path_root_types,
+                    ),
+                    path_segment_types: std::mem::replace(
+                        &mut self.path_segment_types,
+                        saved_path_segment_types,
+                    ),
+                    path_member_resolutions: std::mem::replace(
+                        &mut self.path_member_resolutions,
+                        saved_path_member_resolutions,
+                    ),
+                    param_types: lambda_param_types,
+                    call_plans: std::mem::replace(&mut self.call_plans, saved_call_plans),
+                    call_type_instantiations: std::mem::replace(
+                        &mut self.call_type_instantiations,
+                        saved_call_type_instantiations,
+                    ),
+                    function_coercions: std::mem::replace(
+                        &mut self.function_coercions,
+                        saved_function_coercions,
+                    ),
+                },
+            );
+        } else {
+            self.pattern_types = saved_bindings;
+            self.resolutions = saved_resolutions;
+            self.catch_residual_throws = saved_catch_residual_throws;
+            self.exhaustive_matches = saved_exhaustive_matches;
+            self.path_root_types = saved_path_root_types;
+            self.path_segment_types = saved_path_segment_types;
+            self.path_member_resolutions = saved_path_member_resolutions;
+            self.call_plans = saved_call_plans;
+            self.call_type_instantiations = saved_call_type_instantiations;
+            self.function_coercions = saved_function_coercions;
+        }
         self.pattern_natural_cache = saved_pattern_natural_cache;
-        self.resolutions = saved_resolutions;
-        self.exhaustive_matches = saved_exhaustive_matches;
-        self.catch_residual_throws = saved_catch_residual_throws;
-        self.path_root_types = saved_path_root_types;
-        self.path_segment_types = saved_path_segment_types;
-        self.path_member_resolutions = saved_path_member_resolutions;
         self.interface_method_generic_params = saved_interface_method_generic_params;
         self.owner_type_arg_binding_seed = saved_owner_type_arg_binding_seed;
         self.self_pinned_rigid_var = saved_self_pinned_rigid_var;
         self.lambda_effective_throws = saved_lambda_effective_throws;
-        self.call_plans = saved_call_plans;
-        self.call_type_instantiations = saved_call_type_instantiations;
-        self.function_coercions = saved_function_coercions;
         self.locals = saved_locals;
         self.scoped_local_declarations = saved_scoped_local_declarations;
         self.scoped_local_assignments = saved_scoped_local_assignments;
@@ -14403,12 +14532,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .freeze_diagnostic_spans_from(lambda_diag_start, lambda_source_map);
         self.body_source_map = saved_body_source_map;
 
-        (
-            ret_ty,
-            lambda_expressions,
-            lambda_file_scope_id,
-            lambda_effective_throws,
-        )
+        (ret_ty, lambda_file_scope_id, lambda_effective_throws)
     }
 }
 

--- a/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
@@ -449,11 +449,11 @@ pub(crate) fn scope_types_equivalent(
 ) -> bool {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let gctx = GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds,
     };
     baml_type::normalize::equivalent(a, b, &gctx)
@@ -775,7 +775,7 @@ pub(crate) fn resolve_concrete_realized_interface(
 ) -> Option<baml_type::Interface> {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let realized = !crate::generics::contains_typevar(base)
         && !interface
             .generics
@@ -787,12 +787,12 @@ pub(crate) fn resolve_concrete_realized_interface(
             .any(|(_, ty)| crate::generics::contains_typevar(ty));
     let resolved = if realized {
         // Realized fast path: unique by coherence, bounds discharged by bounded re-entry.
-        crate::interfaces::get_implements_block(db, pkg_id, base, interface, &aliases)
+        crate::interfaces::get_implements_block(db, pkg_id, base, interface, aliases)
     } else {
         let gctx = GlobalTypeContext {
             db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds,
         };
         crate::interfaces::get_implements_block_symbolic(
@@ -800,7 +800,7 @@ pub(crate) fn resolve_concrete_realized_interface(
             pkg_id,
             base,
             interface,
-            &aliases,
+            aliases,
             |a, b| baml_type::normalize::is_subtype(a, b, &gctx),
         )
     };
@@ -827,16 +827,16 @@ pub(crate) fn resolve_concrete_projection(
 ) -> ConcreteProjection {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let gctx = GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds,
     };
 
     let mut declarers: Vec<baml_type::Interface> = Vec::new();
-    for resolved in crate::interfaces::impls_for_type(db, pkg_id, base, &aliases, |a, b| {
+    for resolved in crate::interfaces::impls_for_type(db, pkg_id, base, aliases, |a, b| {
         baml_type::normalize::is_subtype(a, b, &gctx)
     }) {
         let interface = resolved.implemented_interface(db);

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -570,7 +570,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.context.db(),
             self.package_id,
             base_ty,
-            &self.aliases,
+            self.aliases,
             |a, b| self.is_subtype(a, b),
         )
     }

--- a/baml_language/crates/baml_compiler2_tir/src/callable.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/callable.rs
@@ -390,15 +390,17 @@ pub fn callable_throws<'db>(db: &'db dyn crate::Db, function: FunctionLoc<'db>) 
                 };
             };
             let inference = infer_scope_types(db, scope_id);
-            let res_ctx = package_resolution_context(db, pkg_id);
-            let aliases = crate::inference::package_alias_map(db, res_ctx);
+            let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
             let facts = crate::throws_analysis::collect_escaping_throws(
                 &CallableThrowsAnalysis {
                     db,
                     pkg_id,
                     ns_context: &pkg_info.namespace_path,
                     inference,
-                    aliases: &aliases,
+                    // `throws_analysis` only expands alias chains — it never
+                    // calls the structural normalizer — so it needs just the
+                    // raw alias map, not the full `ResolvedAliases` bundle.
+                    aliases: &aliases.aliases,
                 },
                 body,
             );

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -3019,7 +3019,7 @@ pub fn enum_variants<'db>(
 /// Salsa-tracked and keyed by package: before this was a query, the map was
 /// rebuilt (with a full clone of every alias `Ty` plus a recursive-alias DFS)
 /// on every `infer_scope_types` execution — ~16k times per compile on the
-/// test corpus, ~13% of cold CPU. See `crates/baml_compiler2_profile/README.md`.
+/// test corpus, ~13% of cold CPU. See `crates/tools_compile_profile/README.md`.
 /// Cycle seed for `package_resolved_aliases`: aliases whose RHS is an
 /// associated-type projection resolve through `package_items` →
 /// `infer_scope_types`, which itself consults this query — a legitimate
@@ -3053,7 +3053,7 @@ pub fn package_resolved_aliases<'db>(
     }
     // Compute the recursive-alias set once here so `is_same_normalized_type` /
     // `is_subtype_of` don't re-DFS the alias graph on every call — see the
-    // audit in `crates/baml_compiler2_profile/README.md`. Callers now hold
+    // audit in `crates/tools_compile_profile/README.md`. Callers now hold
     // `ResolvedAliases` end-to-end and pass it into the normalizer directly.
     let recursive = crate::normalize::find_recursive_aliases(&aliases);
     baml_type::ResolvedAliases { aliases, recursive }

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -1079,6 +1079,12 @@ pub struct ScopeInference<'db> {
     /// these up (via this owning Function/Let scope) to seed params that have no
     /// HIR binding — see the `ScopeKind::Lambda` arm of `infer_scope_types`.
     template_body_params: FxHashMap<FileScopeId, Vec<FunctionParamTy>>,
+    /// Nested lambda scope → the full inference tables captured during this
+    /// (owning) scope's inline pass over the lambda's body. The standalone
+    /// `ScopeKind::Lambda` query projects its `ScopeInference` out of this map
+    /// instead of re-inferring the body. Populated only on Function/Let owner
+    /// scopes; contains entries for lambdas at every nesting depth.
+    nested_lambda_inference: FxHashMap<FileScopeId, NestedLambdaInference<'db>>,
     /// Lambda/function parameter types by index (name, inferred type).
     /// Populated for lambda scopes so LSP can resolve unannotated lambda
     /// parameter types (e.g. `items.map((item) -> { item. })`).
@@ -1106,6 +1112,32 @@ pub struct ScopeInference<'db> {
     parameter_defaults: DefaultParameterInference<'db>,
     /// Diagnostics and other rare data. Heap-allocated only when non-empty.
     extra: Option<Box<ScopeInferenceExtra<'db>>>,
+}
+
+/// The complete inference tables of one nested lambda body, captured during
+/// the owning Function/Let scope's inline pass (`infer_lambda_body`).
+///
+/// Before this existed, every lambda body was type-inferred twice: once
+/// inline while inferring the enclosing function (needed to type the lambda
+/// expression itself) and a second time from scratch by the standalone
+/// `ScopeKind::Lambda` arm of `infer_scope_types` (needed by MIR/LSP for the
+/// lambda scope's own tables). Recording the inline results here lets the
+/// Lambda arm project them out instead of re-inferring — and stops the
+/// lambda's diagnostics from being reported twice (they stay with the owner).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NestedLambdaInference<'db> {
+    pub(crate) expressions: FxHashMap<ExprId, Ty>,
+    pub(crate) pattern_types: FxHashMap<PatId, Ty>,
+    pub(crate) resolutions: FxHashMap<ExprId, MemberResolution<'db>>,
+    pub(crate) catch_residual_throws: FxHashMap<ExprId, BTreeSet<Ty>>,
+    pub(crate) exhaustive_matches: FxHashSet<ExprId>,
+    pub(crate) path_root_types: FxHashMap<ExprId, Ty>,
+    pub(crate) path_segment_types: FxHashMap<(ExprId, usize), Ty>,
+    pub(crate) path_member_resolutions: FxHashMap<ExprId, Vec<MemberResolution<'db>>>,
+    pub(crate) param_types: Vec<(Name, Ty)>,
+    pub(crate) call_plans: FxHashMap<ExprId, CallPlan>,
+    pub(crate) call_type_instantiations: FxHashMap<ExprId, Vec<Ty>>,
+    pub(crate) function_coercions: FxHashMap<ExprId, FunctionCoercion>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1250,6 +1282,15 @@ impl<'db> ScopeInference<'db> {
     /// standalone scope inference to seed params that have no HIR binding.
     pub fn template_body_params(&self, fsi: FileScopeId) -> Option<&[FunctionParamTy]> {
         self.template_body_params.get(&fsi).map(Vec::as_slice)
+    }
+
+    /// The captured inline-inference tables for a nested lambda scope, if this
+    /// scope owns (transitively) that lambda's body.
+    pub(crate) fn nested_lambda_inference(
+        &self,
+        fsi: FileScopeId,
+    ) -> Option<&NestedLambdaInference<'db>> {
+        self.nested_lambda_inference.get(&fsi)
     }
 
     /// Look up the binding type for a pattern (the type the variable is bound to,
@@ -1601,6 +1642,7 @@ fn infer_scope_types_cycle_initial<'db>(
         path_member_resolutions: FxHashMap::default(),
         nested_lambda_types: FxHashMap::default(),
         template_body_params: FxHashMap::default(),
+        nested_lambda_inference: FxHashMap::default(),
         param_types: Vec::new(),
         call_plans: FxHashMap::default(),
         call_type_instantiations: FxHashMap::default(),
@@ -1626,7 +1668,7 @@ pub fn infer_scope_types<'db>(
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
 
-    let aliases = package_alias_map(db, res_ctx);
+    let aliases = package_resolved_aliases(db, pkg_id);
     let context = InferContext::new(db, scope_id);
     let mut builder = TypeInferenceBuilder::new(context, res_ctx, pkg_id, scope_id, aliases);
 
@@ -2114,6 +2156,54 @@ pub fn infer_scope_types<'db>(
             }
         }
         ScopeKind::Lambda => {
+            // Fast path: the owning Function/Let scope's inline pass already
+            // inferred this lambda's body and captured the full tables (see
+            // `NestedLambdaInference`). Project them out instead of
+            // re-inferring — this also keeps the lambda's diagnostics with
+            // the owner, so they are reported exactly once. Synthetic
+            // tagged-template bodies have no backing `Expr::Lambda` and are
+            // never recorded; they (and any other miss, e.g. the empty
+            // owner inference produced during a Salsa cycle iteration) fall
+            // through to the standalone inference below.
+            if !scope.is_template_body {
+                let owner_fsi =
+                    index
+                        .ancestor_scopes(file_scope)
+                        .into_iter()
+                        .find(|fsi: &FileScopeId| {
+                            matches!(
+                                index.scopes[fsi.index() as usize].kind,
+                                ScopeKind::Function | ScopeKind::Let
+                            )
+                        });
+                if let Some(owner_fsi) = owner_fsi {
+                    let owner_scope_id = index.scope_ids[owner_fsi.index() as usize];
+                    let owner_inference = infer_scope_types(db, owner_scope_id);
+                    if let Some(tables) = owner_inference.nested_lambda_inference(file_scope) {
+                        let tables = tables.clone();
+                        return ScopeInference {
+                            expressions: tables.expressions,
+                            pattern_types: tables.pattern_types,
+                            resolutions: tables.resolutions,
+                            catch_residual_throws: tables.catch_residual_throws,
+                            exhaustive_matches: tables.exhaustive_matches,
+                            path_root_types: tables.path_root_types,
+                            path_segment_types: tables.path_segment_types,
+                            path_member_resolutions: tables.path_member_resolutions,
+                            nested_lambda_types: FxHashMap::default(),
+                            template_body_params: FxHashMap::default(),
+                            nested_lambda_inference: FxHashMap::default(),
+                            param_types: tables.param_types,
+                            call_plans: tables.call_plans,
+                            call_type_instantiations: tables.call_type_instantiations,
+                            function_coercions: tables.function_coercions,
+                            parameter_defaults: DefaultParameterInference::empty(),
+                            extra: None,
+                        };
+                    }
+                }
+            }
+
             // Find the enclosing Function (or Let) scope by walking ancestors.
             // The Lambda scope does not directly store its body — we must find
             // the top-level body (Function or Let) and then locate the lambda
@@ -2828,6 +2918,7 @@ pub fn infer_scope_types<'db>(
         nested_lambda_types,
         template_body_params,
         parameter_defaults,
+        nested_lambda_inference,
     ) = builder.finish();
 
     let extra = if diagnostics.is_empty() {
@@ -2847,6 +2938,7 @@ pub fn infer_scope_types<'db>(
         path_member_resolutions,
         nested_lambda_types,
         template_body_params,
+        nested_lambda_inference,
         param_types,
         call_plans,
         call_type_instantiations,
@@ -2919,13 +3011,34 @@ pub fn enum_variants<'db>(
     Some(enum_data.variants.iter().map(|v| v.name.clone()).collect())
 }
 
-/// Build the type-alias map visible from a package: its own aliases plus those
-/// re-exported by its dependencies. Shared by per-scope inference and throws
-/// analysis so both expand the same aliases (e.g. `testing.TestSetBody`).
-pub(crate) fn package_alias_map<'db>(
+/// The type-alias environment visible from a package: its own aliases plus
+/// those re-exported by its dependencies, bundled with the precomputed
+/// recursive-alias set. Shared by per-scope inference, throws analysis, and
+/// impl checking so all expand the same aliases (e.g. `testing.TestSetBody`).
+///
+/// Salsa-tracked and keyed by package: before this was a query, the map was
+/// rebuilt (with a full clone of every alias `Ty` plus a recursive-alias DFS)
+/// on every `infer_scope_types` execution — ~16k times per compile on the
+/// test corpus, ~13% of cold CPU. See `crates/baml_compiler2_profile/README.md`.
+/// Cycle seed for `package_resolved_aliases`: aliases whose RHS is an
+/// associated-type projection resolve through `package_items` →
+/// `infer_scope_types`, which itself consults this query — a legitimate
+/// dependency cycle that Salsa resolves by fixpoint iteration starting from
+/// the empty alias environment.
+fn package_resolved_aliases_cycle_initial<'db>(
+    _db: &'db dyn crate::Db,
+    _id: salsa::Id,
+    _pkg_id: PackageId<'db>,
+) -> baml_type::ResolvedAliases {
+    baml_type::ResolvedAliases::default()
+}
+
+#[salsa::tracked(returns(ref), cycle_initial=package_resolved_aliases_cycle_initial)]
+pub fn package_resolved_aliases<'db>(
     db: &'db dyn crate::Db,
-    res_ctx: &crate::package_interface::PackageResolutionContext<'db>,
-) -> HashMap<crate::ty::QualifiedTypeName, Ty> {
+    pkg_id: PackageId<'db>,
+) -> baml_type::ResolvedAliases {
+    let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
     let mut aliases = collect_type_aliases(db, &res_ctx.own_items);
     for (_dep_name, dep_iface) in &res_ctx.dep_interfaces {
         for types_in_ns in dep_iface.types.values() {
@@ -2938,7 +3051,12 @@ pub(crate) fn package_alias_map<'db>(
             }
         }
     }
-    aliases
+    // Compute the recursive-alias set once here so `is_same_normalized_type` /
+    // `is_subtype_of` don't re-DFS the alias graph on every call — see the
+    // audit in `crates/baml_compiler2_profile/README.md`. Callers now hold
+    // `ResolvedAliases` end-to-end and pass it into the normalizer directly.
+    let recursive = crate::normalize::find_recursive_aliases(&aliases);
+    baml_type::ResolvedAliases { aliases, recursive }
 }
 
 /// Follow a chain of `Ty::TypeAlias` to the first non-alias type it resolves to,

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
@@ -12,6 +12,7 @@ mod impl_rules;
 
 use baml_base::{Literal, Name};
 use baml_compiler2_hir::{contributions::Definition, package::PackageId};
+use baml_type::ResolvedAliases;
 pub use coherence::*;
 pub use impl_rules::*;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -523,7 +524,7 @@ fn lower_interface_type_associated_bindings(
 pub fn match_ty_patterns(
     pairs: &[(&Ty, &Ty)],
     generic_params: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
 ) -> Option<TypeBindings> {
     let mut bindings = TypeBindings::default();
     for (pattern, concrete) in pairs {
@@ -539,7 +540,7 @@ pub fn match_ty_pattern_into(
     pattern: &Ty,
     concrete: &Ty,
     generic_params: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Option<()> {
     if let Ty::TypeVar(name, _) = pattern
@@ -661,7 +662,7 @@ fn match_union_members(
     pattern_members: &[Ty],
     concrete_members: &[Ty],
     generic_params: &[Name],
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Option<()> {
     let Some((pattern_head, pattern_tail)) = pattern_members.split_first() else {
@@ -709,7 +710,7 @@ fn bind_type_var(
     name: &Name,
     concrete: &Ty,
     bindings: &mut TypeBindings,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
 ) -> Option<()> {
     match bindings.get(name) {
         Some(existing) if normalize::is_same_normalized_type(existing, concrete, aliases) => {
@@ -1162,20 +1163,10 @@ mod tests {
         let params = vec![Name::new("T")];
 
         assert!(
-            match_ty_patterns(
-                &[(&pattern, &good)],
-                &params,
-                &std::collections::HashMap::default()
-            )
-            .is_some()
+            match_ty_patterns(&[(&pattern, &good)], &params, &ResolvedAliases::default()).is_some()
         );
         assert!(
-            match_ty_patterns(
-                &[(&pattern, &bad)],
-                &params,
-                &std::collections::HashMap::default()
-            )
-            .is_none()
+            match_ty_patterns(&[(&pattern, &bad)], &params, &ResolvedAliases::default()).is_none()
         );
     }
 
@@ -1186,7 +1177,7 @@ mod tests {
         let side = Ty::Enum(qtn(&[], "Side"), TyAttr::default());
         let side_left = Ty::EnumVariant(qtn(&[], "Side"), Name::new("Left"), TyAttr::default());
         let other = Ty::EnumVariant(qtn(&[], "Coin"), Name::new("Heads"), TyAttr::default());
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
 
         assert!(
             match_ty_patterns(&[(&side, &side_left)], &[], &aliases).is_some(),
@@ -1210,12 +1201,9 @@ mod tests {
         );
         let params = vec![Name::new("T")];
 
-        let bindings = match_ty_patterns(
-            &[(&pattern, &actual)],
-            &params,
-            &std::collections::HashMap::default(),
-        )
-        .expect("nested list arg should bind T");
+        let bindings =
+            match_ty_patterns(&[(&pattern, &actual)], &params, &ResolvedAliases::default())
+                .expect("nested list arg should bind T");
         assert_eq!(bindings.get(&Name::new("T")), Some(&int()));
     }
 
@@ -1244,7 +1232,7 @@ mod tests {
             match_ty_patterns(
                 &[(&pattern, &same_short_name)],
                 &[],
-                &std::collections::HashMap::default()
+                &ResolvedAliases::default()
             )
             .is_none(),
             "same short name in different namespaces must not match"
@@ -1257,12 +1245,9 @@ mod tests {
         let actual = Ty::Union(vec![string(), int()], TyAttr::default());
         let params = vec![Name::new("T")];
 
-        let bindings = match_ty_patterns(
-            &[(&pattern, &actual)],
-            &params,
-            &std::collections::HashMap::default(),
-        )
-        .expect("union members should be matched by type, not position");
+        let bindings =
+            match_ty_patterns(&[(&pattern, &actual)], &params, &ResolvedAliases::default())
+                .expect("union members should be matched by type, not position");
         assert_eq!(bindings.get(&Name::new("T")), Some(&int()));
     }
 }

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -1,6 +1,6 @@
 use baml_base::{Literal, Name, Span, TyAttr};
 use baml_compiler2_hir::{contributions::Definition, package::PackageId};
-use baml_type::{FunctionParamTy, Ty, TypeName};
+use baml_type::{FunctionParamTy, ResolvedAliases, Ty, TypeName};
 
 use crate::interfaces::{
     ImplData, TypeBindings, contains_bound_typevar, impl_data, impl_data_source_map,
@@ -138,6 +138,13 @@ pub fn package_coherence_diagnostics<'db>(
             *body = nf(body, &enum_variants);
         }
     }
+    // Bundle the alias map with its precomputed recursive-alias set so
+    // downstream `is_same_normalized_type` / `is_subtype_of` calls in
+    // the overlap solver don't re-DFS the alias graph on every pair.
+    let aliases = ResolvedAliases {
+        recursive: crate::normalize::find_recursive_aliases(&aliases),
+        aliases,
+    };
 
     let dep_impls: Vec<(&ImplData, Span)> = deps
         .iter()
@@ -183,7 +190,8 @@ fn package_impls_with_spans<'db>(
     pkg_id: PackageId<'db>,
 ) -> Vec<(&'db ImplData<'db>, Span)> {
     package_impl_locs(db, pkg_id)
-        .into_iter()
+        .iter()
+        .copied()
         .filter_map(|loc| {
             let data = impl_data(db, loc).as_ref().ok()?;
             let span = impl_data_source_map(db, loc)
@@ -199,13 +207,13 @@ fn package_impls_with_spans<'db>(
 /// resolved — aliases nested under a constructor are handled by `is_same_normalized_type`.
 /// Mirrors `expand_type_alias` in the diagnostics layer so the coherence valid-subject
 /// gate sees through the same aliases the E0138 concreteness gate does.
-fn expand_alias_head(ty: &Ty, aliases: &std::collections::HashMap<TypeName, Ty>) -> Ty {
+fn expand_alias_head(ty: &Ty, aliases: &ResolvedAliases) -> Ty {
     let mut current = ty.clone();
     for _ in 0..64 {
         let Ty::TypeAlias(qtn, _) = &current else {
             break;
         };
-        match aliases.get(qtn) {
+        match aliases.aliases.get(qtn) {
             Some(next) => current = next.clone(),
             None => break,
         }
@@ -222,7 +230,7 @@ pub fn impls_conflict<'db>(
     pkg_id: PackageId<'db>,
     a: &ImplData<'db>,
     b: &ImplData<'db>,
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
 ) -> Overlap {
     let (Some(a_qtn), Some(b_qtn)) = (
         interface_loc_qtn(db, a.interface),
@@ -281,7 +289,7 @@ fn impls_overlap<'db>(
     pkg_id: PackageId<'db>,
     a: &ImplData<'db>,
     b: &ImplData<'db>,
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
 ) -> Overlap {
     let enum_variants = |qtn: &TypeName| enum_variant_names(db, qtn);
     let (a_for, a_args) = renamed_subject(a, 'a', &enum_variants);
@@ -349,7 +357,7 @@ fn bounds_hold_at_common_instance<'db>(
     vars: &[Name],
     bindings: &TypeBindings,
     subject: &[&Ty],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
 ) -> bool {
     // Each of this impl's params, resolved to the ground type it takes at the common
     // instance (following the unifier's binding chains). Used both to read a param's own
@@ -729,7 +737,7 @@ fn unify_into(
     x: &Ty,
     y: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Overlap {
     unify_into_at(x, y, vars, aliases, bindings, 0)
@@ -743,7 +751,7 @@ fn unify_into_at(
     x: &Ty,
     y: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -968,7 +976,7 @@ fn unify_all(
     xs: &[Ty],
     ys: &[Ty],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -992,7 +1000,7 @@ fn unify_associated_bindings(
     xb: &[(Name, Ty)],
     yb: &[(Name, Ty)],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -1038,7 +1046,7 @@ fn unify_union_members_at(
     xs: &[Ty],
     ys: &[Ty],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -1096,7 +1104,7 @@ fn unify_union_members(
     xs: &[Ty],
     ys: &[Ty],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Overlap {
     unify_union_members_at(xs, ys, vars, aliases, bindings, 0)
@@ -1108,7 +1116,7 @@ fn try_union_set_equality(
     xs: &[Ty],
     ys: &[Ty],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
 ) -> Option<Overlap> {
     let has_var = |members: &[Ty]| members.iter().any(|m| contains_bound_typevar(m, vars));
     if has_var(xs) || has_var(ys) {
@@ -1139,11 +1147,7 @@ fn is_bare_var(m: &Ty, vars: &[Name]) -> bool {
 /// Whether two ground unions denote the same set of types (order-insensitive).
 /// Members are de-duplicated, so equal cardinality plus "every member of `xs`
 /// has an equal member in `ys`" implies a bijection.
-fn unions_set_equal(
-    xs: &[Ty],
-    ys: &[Ty],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
-) -> bool {
+fn unions_set_equal(xs: &[Ty], ys: &[Ty], aliases: &ResolvedAliases) -> bool {
     xs.len() == ys.len()
         && xs.iter().all(|x| {
             ys.iter()
@@ -1169,7 +1173,7 @@ fn cover_at(
     member: &Ty,
     candidate: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -1190,7 +1194,7 @@ fn cover(
     member: &Ty,
     candidate: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
 ) -> Overlap {
     cover_at(member, candidate, vars, aliases, bindings, 0)
@@ -1242,7 +1246,7 @@ fn needs_conservative_membership(a: &Ty, b: &Ty) -> bool {
 fn cover_search(
     obligations: &[(Ty, Vec<Ty>)],
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
     budget: &mut usize,
     depth: usize,
@@ -1333,7 +1337,7 @@ fn bind_unify_var(
     n: &Name,
     t: &Ty,
     vars: &[Name],
-    aliases: &std::collections::HashMap<TypeName, Ty>,
+    aliases: &ResolvedAliases,
     bindings: &mut TypeBindings,
     depth: usize,
 ) -> Overlap {
@@ -1491,7 +1495,7 @@ mod tests {
         // Each bare variable can absorb the other side, so a common instance
         // always exists.
         let vars = vec![Name::new("T"), Name::new("V")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let xs = vec![Ty::int(), Ty::type_var("T")];
         let ys = vec![Ty::string(), Ty::type_var("V")];
@@ -1506,7 +1510,7 @@ mod tests {
         // `{int, T}` vs `{int, string, Foo}`: instantiating `T = string | Foo`
         // makes them the same union — a *provable* overlap, not indeterminate.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let xs = vec![Ty::int(), Ty::type_var("T")];
         let ys = vec![Ty::int(), Ty::string(), Ty::class("Foo")];
@@ -1521,7 +1525,7 @@ mod tests {
         // `{int, T}` vs `{string, Foo}`: `int` matches no member on the right and
         // `T` cannot make it appear there, so there is no common instance.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let xs = vec![Ty::int(), Ty::type_var("T")];
         let ys = vec![Ty::string(), Ty::class("Foo")];
@@ -1537,7 +1541,7 @@ mod tests {
         // so unit propagation peels them with no search and `T` absorbs the rest —
         // a proven overlap even though the candidate set is large.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let xs = vec![Ty::class("A1"), Ty::class("A2"), Ty::type_var("T")];
         let ys: Vec<Ty> = (1..=9).map(|i| Ty::class(&format!("A{i}"))).collect();
@@ -1554,7 +1558,7 @@ mod tests {
         // exists (e.g. `T=U=A1`, with `V` absorbing the rest) — a *provable* overlap,
         // not an NP-hard cap. The search finds it in a few steps.
         let vars = vec![Name::new("T"), Name::new("U"), Name::new("V")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let xs = vec![
             Ty::list(Ty::type_var("T")),
@@ -1577,7 +1581,7 @@ mod tests {
         // equal. An injective matcher (the old model) wrongly rejected this; covering
         // (many-to-one, mutual) accepts it.
         let vars = vec![Name::new("T"), Name::new("U"), Name::new("W")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let xs = vec![
             Ty::list(Ty::type_var("T")),
@@ -1599,7 +1603,7 @@ mod tests {
         // works — but just scanning the huge candidate list exhausts the step budget
         // before the search can prove it ⇒ Unknown.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let pair = |a: Ty, b: Ty| Ty::user_class_with_args("Pair", vec![a, b]);
         let a1 = || Ty::class("A1");
@@ -1621,7 +1625,7 @@ mod tests {
         // `{1, T}` vs `{int, string}`: the literal `1` is a *subtype* of `int`, so it is
         // covered (covering uses subtype, not equality), and `T` absorbs the rest.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let xs = vec![int_literal(1), Ty::type_var("T")];
         let ys = vec![Ty::int(), Ty::string()];
@@ -1636,7 +1640,7 @@ mod tests {
         // `{int, T}` vs `{1, string}`: subtyping is directional — `int` is *not* a
         // subtype of the literal `1`, and `T` is on the left, so nothing covers `int`.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let xs = vec![Ty::int(), Ty::type_var("T")];
         let ys = vec![int_literal(1), Ty::string()];
@@ -1651,7 +1655,7 @@ mod tests {
         // `I<Item=int>` and `I<Item=string>` are distinct existential types — the
         // associated binding is part of the type's identity (one `impl I` per concrete
         // type ⇒ one `Item`), so they are provably disjoint.
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let a = interface_with_assoc("I", vec![("Item", Ty::int())]);
         let b = interface_with_assoc("I", vec![("Item", Ty::string())]);
@@ -1665,7 +1669,7 @@ mod tests {
     fn interface_associated_binding_unifies_variable() {
         // `I<Item=int>` unifies with `I<Item=T>` by binding `T = int`.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let a = interface_with_assoc("I", vec![("Item", Ty::int())]);
         let b = interface_with_assoc("I", vec![("Item", Ty::type_var("T"))]);
@@ -1687,15 +1691,19 @@ mod tests {
         // rejected, and these aliases in fact denote the same type.
         let r = TypeName::local(Name::new("R"));
         let s = TypeName::local(Name::new("S"));
-        let mut aliases = std::collections::HashMap::default();
-        aliases.insert(
+        let mut alias_map = std::collections::HashMap::default();
+        alias_map.insert(
             r.clone(),
             Ty::user_class_with_args("Box", vec![Ty::TypeAlias(r.clone(), TyAttr::default())]),
         );
-        aliases.insert(
+        alias_map.insert(
             s.clone(),
             Ty::user_class_with_args("Box", vec![Ty::TypeAlias(s.clone(), TyAttr::default())]),
         );
+        let aliases = ResolvedAliases {
+            recursive: crate::normalize::find_recursive_aliases(&alias_map),
+            aliases: alias_map,
+        };
         let mut bindings = TypeBindings::default();
         assert_eq!(
             unify_into(
@@ -1713,7 +1721,7 @@ mod tests {
     fn cover_distinct_interface_binding_is_not_conservative() {
         // Same-name interfaces are decided precisely by `unify_into`, so `cover` does not
         // fall back to the conservative `Yes` — `I<Item=int>` does not cover `I<Item=string>`.
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let a = interface_with_assoc("I", vec![("Item", Ty::int())]);
         let b = interface_with_assoc("I", vec![("Item", Ty::string())]);
@@ -1725,7 +1733,7 @@ mod tests {
         // Whether a concrete class implements an interface needs the impl registry, which
         // the solver does not yet consult here, so `cover` conservatively reports a
         // possible overlap (`Yes`) — never a wrong `No`.
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let a = Ty::class("A");
         let b = interface("I", vec![]);
@@ -1766,6 +1774,10 @@ mod tests {
         for body in aliases.values_mut() {
             *body = nf(body, &stub_enum_variants);
         }
+        let aliases = ResolvedAliases {
+            recursive: crate::normalize::find_recursive_aliases(&aliases),
+            aliases,
+        };
         let mut bindings = TypeBindings::default();
         assert_eq!(
             unify_into(
@@ -1793,7 +1805,7 @@ mod tests {
             }
         }
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         assert_eq!(
             unify_into(
@@ -1819,7 +1831,7 @@ mod tests {
             member: Name::new("Item"),
             attr: TyAttr::default(),
         };
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         assert_eq!(
             unify_into(&proj, &Ty::int(), &[], &aliases, &mut bindings),
@@ -1889,7 +1901,7 @@ mod tests {
         // `Cmp.Less | T` opposite `Cmp`: the var could complete the enum
         // (`T = Cmp.Equal | Cmp.More`), so it is conservatively a possible overlap.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let u = Ty::union(vec![enum_variant("Cmp", "Less"), Ty::type_var("T")]);
         assert_eq!(
@@ -1902,7 +1914,7 @@ mod tests {
     fn ground_partial_enum_union_is_disjoint_from_enum() {
         // No bare variable to complete the enum, and the partial variant set is a strict
         // subset of `Cmp`, so the two are disjoint.
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let u = Ty::union(vec![
             enum_variant("Cmp", "Less"),
@@ -1921,7 +1933,7 @@ mod tests {
         // analogue of `union_overlap_collapsing_members_is_yes`; routing the non-union
         // operand through covering (as the singleton `{C}`) is what catches it.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let c = || Ty::class("C");
         let u = Ty::union(vec![c(), Ty::type_var("T")]);
@@ -1936,7 +1948,7 @@ mod tests {
         // `1 | T` opposite `int`: at `T = int` the literal `1 <: int` collapses, so the
         // union equals `int` — decided precisely by `cover`'s `literal <: base` oracle.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let u = Ty::union(vec![int_literal(1), Ty::type_var("T")]);
         assert_eq!(
@@ -1951,7 +1963,7 @@ mod tests {
         // instantiation of `T` removes, so it can never equal `C`. Routing through
         // covering keeps this precise (`No`), not a conservative over-reject.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let u = Ty::union(vec![Ty::class("D"), Ty::type_var("T")]);
         let c = Ty::class("C");
@@ -1967,7 +1979,7 @@ mod tests {
         // blanket `Box<T>` overlaps `Box<unknown>` at `T = unknown`. The old bail that
         // lumped `BuiltinUnknown` in with the error sentinel wrongly rejected this.
         let vars = vec![Name::new("T")];
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         assert_eq!(
             unify_into(
@@ -1986,7 +1998,7 @@ mod tests {
         // `unknown` is a distinct atomic type under invariance, compared by equality:
         // `Box<unknown>` and `Box<int>` do not overlap, matching how the runtime
         // resolver matches `unknown` (only an `unknown` value inhabits `Box<unknown>`).
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         assert_eq!(
             unify_into(&Ty::unknown(), &Ty::int(), &[], &aliases, &mut bindings),
@@ -1997,7 +2009,7 @@ mod tests {
     // Probe helper for the pigeonhole experiments below.
     fn pigeonhole_overlap(holes: usize, pigeons: usize) -> Overlap {
         let vars: Vec<Name> = (0..holes).map(|i| Name::new(format!("T{i}"))).collect();
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let pair = |a: Ty, b: Ty| Ty::user_class_with_args("Pair", vec![a, b]);
         let xs: Vec<Ty> = (0..holes)
@@ -2040,7 +2052,7 @@ mod tests {
     /// candidate pool. The unions overlap iff the formula is satisfiable.
     /// `clauses[j] = [(var, positive?); 3]`.
     fn three_sat_overlap(num_vars: usize, clauses: &[[(usize, bool); 3]]) -> Overlap {
-        let aliases = std::collections::HashMap::default();
+        let aliases = ResolvedAliases::default();
         let mut bindings = TypeBindings::default();
         let v = |i: usize| Ty::type_var(&format!("V{i}"));
         let val = |b: bool| Ty::class(if b { "Pos" } else { "Neg" });

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use baml_base::{Name, Span, TyAttr};
 use baml_compiler2_hir::{contributions::Definition, package::PackageId};
-use baml_type::{QualifiedTypeName, Ty, normalize::TypeContext};
+use baml_type::{QualifiedTypeName, ResolvedAliases, Ty, normalize::TypeContext};
 
 use crate::{
     generics::{contains_typevar, substitute_ty},
@@ -1048,13 +1048,13 @@ pub fn validate_impl_signatures<'db>(
 
     // The canonical algebra context — fully usable in this phase (see the fn doc).
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let bounds: crate::lower_type_expr::TypeVarBoundsMap =
         data.generic_params.iter().cloned().collect();
     let ctx = crate::type_context::GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds: &bounds,
     };
 
@@ -1349,7 +1349,7 @@ pub fn validate_impl_signatures<'db>(
                 generics: generics.clone(),
                 associated_types: assoc.clone(),
             };
-            if !implements_interface(db, &for_ty, &required_iface, &aliases, |a, b| {
+            if !implements_interface(db, &for_ty, &required_iface, aliases, |a, b| {
                 baml_type::normalize::is_subtype(a, b, &ctx)
             }) {
                 diags.push((
@@ -1423,6 +1423,12 @@ pub struct ResolvedImpl<'db> {
 /// Uniform over in-body and out-of-body impls (both live in
 /// [`file_item_tree`](baml_compiler2_hir::file_item_tree)`.impls`). Public so MIR can enumerate
 /// a package's impls to rebuild the runtime interface-implementor tables on the L1 substrate.
+///
+/// Salsa-tracked: this walks *every file in the project* (to find the
+/// package's files) and is called from every impl-resolution loop, so an
+/// untracked version re-scanned the project per call — ~18% of cold CPU
+/// on the test corpus before it was tracked.
+#[salsa::tracked(returns(ref))]
 pub fn package_impl_locs<'db>(
     db: &'db dyn crate::Db,
     pkg_id: PackageId<'db>,
@@ -1548,7 +1554,7 @@ pub fn get_implements_block<'db>(
     pkg_id: PackageId<'db>,
     concrete_ty: &Ty,
     requested_iface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
 ) -> Option<ResolvedImpl<'db>> {
     get_implements_block_within_depth(
         db,
@@ -1666,7 +1672,7 @@ pub fn implements_interface(
     db: &dyn crate::Db,
     concrete: &Ty,
     interface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
     mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
 ) -> bool {
     // The orphan rule (RFC-2451 covered rule) keeps a legal impl of `(concrete,
@@ -1705,7 +1711,7 @@ pub fn type_implements_interface<'db>(
     pkg_id: PackageId<'db>,
     concrete: &Ty,
     interface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
     mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
 ) -> bool {
     // Orphan rule: an impl lives in the package of either the interface or the
@@ -1718,7 +1724,7 @@ pub fn type_implements_interface<'db>(
         db, pkg_id,
     ));
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1745,7 +1751,7 @@ pub(crate) fn get_implements_block_symbolic<'db>(
     pkg_id: PackageId<'db>,
     concrete: &Ty,
     interface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
     mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
 ) -> Option<ResolvedImpl<'db>> {
     // Orphan rule: an impl lives in the package of either the interface or the
@@ -1756,7 +1762,7 @@ pub(crate) fn get_implements_block_symbolic<'db>(
     ));
     let mut found: Option<ResolvedImpl<'db>> = None;
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1785,7 +1791,7 @@ fn get_implements_block_within_depth<'db>(
     pkg_id: PackageId<'db>,
     concrete_ty: &Ty,
     requested_iface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
     depth: u32,
 ) -> Option<ResolvedImpl<'db>> {
     debug_assert!(
@@ -1811,7 +1817,7 @@ fn get_implements_block_within_depth<'db>(
     ));
 
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1881,7 +1887,7 @@ fn match_impl_head<'db>(
     data: &ImplData<'db>,
     concrete: &Ty,
     requested_iface: &baml_type::Interface,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
 ) -> Option<TypeBindings> {
     if interface_loc_qtn(db, data.interface).as_ref() != Some(&requested_iface.name)
         || data.interface_args.len() != requested_iface.generics.len()
@@ -1967,7 +1973,7 @@ pub fn impls_for_type<'db>(
     db: &'db dyn crate::Db,
     pkg_id: PackageId<'db>,
     concrete: &Ty,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
     mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
 ) -> Vec<ResolvedImpl<'db>> {
     let mut packages = vec![pkg_id];
@@ -1976,7 +1982,7 @@ pub fn impls_for_type<'db>(
     ));
     let mut out = Vec::new();
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -2018,7 +2024,7 @@ pub(crate) fn first_failing_impl_bound<'db>(
     pkg_id: PackageId<'db>,
     concrete: &Ty,
     requested: &Ty,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
+    aliases: &ResolvedAliases,
     mut is_subtype: impl FnMut(&Ty, &Ty) -> bool,
 ) -> Option<(Name, Ty, Ty)> {
     let Ty::Interface(requested_qtn, requested_args, _, _) = requested else {
@@ -2029,7 +2035,7 @@ pub(crate) fn first_failing_impl_bound<'db>(
         db, pkg_id,
     ));
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -1438,12 +1438,12 @@ mod tests {
         let db = compile("interface Bar {}\ninterface Foo {\n  type Assoc extends Bar\n}\n");
         let user = PackageId::new(&db, Name::new("user"));
         let res_ctx = crate::package_interface::package_resolution_context(&db, user);
-        let aliases = crate::inference::package_alias_map(&db, res_ctx);
+        let aliases = crate::inference::package_resolved_aliases(&db, user);
         let bounds = TypeVarBoundsMap::default();
         let gctx = crate::type_context::GlobalTypeContext {
             db: &db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds: &bounds,
         };
         let foo = baml_type::Interface::new(
@@ -1480,12 +1480,12 @@ mod tests {
         ));
         let user = PackageId::new(&db, Name::new("user"));
         let res_ctx = crate::package_interface::package_resolution_context(&db, user);
-        let aliases = crate::inference::package_alias_map(&db, res_ctx);
+        let aliases = crate::inference::package_resolved_aliases(&db, user);
         let bounds = TypeVarBoundsMap::default();
         let gctx = crate::type_context::GlobalTypeContext {
             db: &db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds: &bounds,
         };
         let foo = baml_type::Interface::new(
@@ -3213,7 +3213,7 @@ mod tests {
         let pkg = baml_compiler2_hir::file_package::file_package(&db, file).package;
         let pkg_id = baml_compiler2_hir::package::PackageId::new(&db, pkg);
         let mut out = Vec::new();
-        for impl_loc in crate::interfaces::package_impl_locs(&db, pkg_id) {
+        for &impl_loc in crate::interfaces::package_impl_locs(&db, pkg_id) {
             match crate::interfaces::impl_data(&db, impl_loc) {
                 Ok(data) => out.extend(data.diagnostics.iter().map(|(e, _)| e.clone())),
                 Err(crate::interfaces::ImplDataError::InterfaceUnresolved { diagnostics }) => {

--- a/baml_language/crates/baml_compiler2_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/normalize.rs
@@ -16,7 +16,7 @@ use crate::ty::{FunctionParamMode, LiteralValue, MediaKind, QualifiedTypeName, T
 
 // TEMPORARY: perf-audit counters. These count how many times the public
 // entry points and internal helpers fire during a compile. Values are
-// read by `baml_compiler2_profile` at the end of a run to quantify
+// read by `tools_compile_profile` at the end of a run to quantify
 // redundant work. Remove after the audit lands.
 pub static PROF_IS_SAME_NORMALIZED_TYPE_CALLS: AtomicU64 = AtomicU64::new(0);
 pub static PROF_IS_SUBTYPE_OF_CALLS: AtomicU64 = AtomicU64::new(0);
@@ -24,7 +24,7 @@ pub static PROF_FIND_RECURSIVE_ALIASES_CALLS: AtomicU64 = AtomicU64::new(0);
 pub static PROF_HAS_CYCLE_CALLS: AtomicU64 = AtomicU64::new(0);
 pub static PROF_NORMALIZE_CALLS: AtomicU64 = AtomicU64::new(0);
 
-/// Reset all counters. Called by `baml_compiler2_profile` between runs.
+/// Reset all counters. Called by `tools_compile_profile` between runs.
 pub fn perf_audit_reset() {
     PROF_IS_SAME_NORMALIZED_TYPE_CALLS.store(0, Ordering::Relaxed);
     PROF_IS_SUBTYPE_OF_CALLS.store(0, Ordering::Relaxed);
@@ -44,7 +44,7 @@ pub fn perf_audit_reset() {
 /// re-DFS'd the alias graph on every invocation via
 /// `find_recursive_aliases` — with ~1M calls per compile that was the
 /// single biggest lever on cold-compile time. See
-/// `crates/baml_compiler2_profile/README.md` for the audit that surfaced
+/// `crates/tools_compile_profile/README.md` for the audit that surfaced
 /// this.
 pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, aliases: &ResolvedAliases) -> bool {
     PROF_IS_SUBTYPE_OF_CALLS.fetch_add(1, Ordering::Relaxed);

--- a/baml_language/crates/baml_compiler2_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/normalize.rs
@@ -4,21 +4,58 @@
 //! aliases are resolved. Recursive aliases are represented using Mu types with
 //! equirecursive (co-inductive) subtyping.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use baml_base::Name;
+use baml_type::ResolvedAliases;
 
 use crate::ty::{FunctionParamMode, LiteralValue, MediaKind, QualifiedTypeName, Ty};
+
+// TEMPORARY: perf-audit counters. These count how many times the public
+// entry points and internal helpers fire during a compile. Values are
+// read by `baml_compiler2_profile` at the end of a run to quantify
+// redundant work. Remove after the audit lands.
+pub static PROF_IS_SAME_NORMALIZED_TYPE_CALLS: AtomicU64 = AtomicU64::new(0);
+pub static PROF_IS_SUBTYPE_OF_CALLS: AtomicU64 = AtomicU64::new(0);
+pub static PROF_FIND_RECURSIVE_ALIASES_CALLS: AtomicU64 = AtomicU64::new(0);
+pub static PROF_HAS_CYCLE_CALLS: AtomicU64 = AtomicU64::new(0);
+pub static PROF_NORMALIZE_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Reset all counters. Called by `baml_compiler2_profile` between runs.
+pub fn perf_audit_reset() {
+    PROF_IS_SAME_NORMALIZED_TYPE_CALLS.store(0, Ordering::Relaxed);
+    PROF_IS_SUBTYPE_OF_CALLS.store(0, Ordering::Relaxed);
+    PROF_FIND_RECURSIVE_ALIASES_CALLS.store(0, Ordering::Relaxed);
+    PROF_HAS_CYCLE_CALLS.store(0, Ordering::Relaxed);
+    PROF_NORMALIZE_CALLS.store(0, Ordering::Relaxed);
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PUBLIC API
 // ═══════════════════════════════════════════════════════════════════════════
 
 /// Check if `sub` is a subtype of `sup`, resolving type aliases.
-pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, aliases: &HashMap<QualifiedTypeName, Ty>) -> bool {
-    let recursive = find_recursive_aliases(aliases);
-    let sub_norm = normalize(sub, aliases, &recursive);
-    let sup_norm = normalize(sup, aliases, &recursive);
+///
+/// Takes `&ResolvedAliases` (not a bare alias map) so the precomputed
+/// `recursive` set is reused. Before this change the entry point
+/// re-DFS'd the alias graph on every invocation via
+/// `find_recursive_aliases` — with ~1M calls per compile that was the
+/// single biggest lever on cold-compile time. See
+/// `crates/baml_compiler2_profile/README.md` for the audit that surfaced
+/// this.
+pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, aliases: &ResolvedAliases) -> bool {
+    PROF_IS_SUBTYPE_OF_CALLS.fetch_add(1, Ordering::Relaxed);
+    // Reflexivity fast path: structurally identical types normalize
+    // identically, so they are always mutual subtypes. Skips the two
+    // allocation-heavy `normalize` walks for the common `T <: T` case.
+    if sub == sup {
+        return true;
+    }
+    let sub_norm = normalize(sub, &aliases.aliases, &aliases.recursive);
+    let sup_norm = normalize(sup, &aliases.aliases, &aliases.recursive);
     sub_norm.is_subtype_of(&sup_norm, &mut HashSet::new())
 }
 
@@ -28,20 +65,74 @@ pub(crate) fn is_subtype_of(sub: &Ty, sup: &Ty, aliases: &HashMap<QualifiedTypeN
 /// This is not an assignability/subtyping check. Use it for invariant positions
 /// where two type spellings may differ but still denote the same type, such as
 /// interface field implementations.
-pub fn is_same_normalized_type(
-    lhs: &Ty,
-    rhs: &Ty,
-    aliases: &HashMap<QualifiedTypeName, Ty>,
-) -> bool {
-    let recursive = find_recursive_aliases(aliases);
-    normalize(lhs, aliases, &recursive).canonicalize()
-        == normalize(rhs, aliases, &recursive).canonicalize()
+///
+/// Takes `&ResolvedAliases` (not a bare alias map) so the precomputed
+/// `recursive` set is reused. See [`is_subtype_of`].
+pub fn is_same_normalized_type(lhs: &Ty, rhs: &Ty, aliases: &ResolvedAliases) -> bool {
+    PROF_IS_SAME_NORMALIZED_TYPE_CALLS.fetch_add(1, Ordering::Relaxed);
+    // Reflexivity fast path: structurally identical types trivially
+    // normalize to the same canonical form.
+    if lhs == rhs {
+        return true;
+    }
+    // Cheap definite-mismatch filter. MIR impl dispatch probes every
+    // candidate impl's pattern against the receiver through this function,
+    // so the overwhelmingly common case is a miss between two types with
+    // different nominal heads — decidable without the two allocation-heavy
+    // normalization walks.
+    if heads_definitely_differ(lhs, rhs) {
+        return false;
+    }
+    normalize(lhs, &aliases.aliases, &aliases.recursive).canonicalize()
+        == normalize(rhs, &aliases.aliases, &aliases.recursive).canonicalize()
+}
+
+/// True only when `lhs` and `rhs` provably normalize to different canonical
+/// forms, judged from their outermost constructor alone.
+///
+/// Soundness rests on `normalize_impl` being head-stable for every variant
+/// this decides on: a `Class` normalizes to a `Class` with the same qualified
+/// name (only its args are rewritten), primitives map to fixed leaves, and so
+/// on. Variants whose normal form can change shape entirely — `TypeAlias`
+/// (expands), `Union` (canonicalization can collapse it to a single member) —
+/// return `false` (undecided), as does any same-kind pair whose equality
+/// depends on inner structure.
+fn heads_definitely_differ(lhs: &Ty, rhs: &Ty) -> bool {
+    // Unstable heads: normalization may rewrite these into any other shape.
+    fn unstable(t: &Ty) -> bool {
+        matches!(
+            t,
+            Ty::TypeAlias(..)
+                | Ty::Union(..)
+                | Ty::AssociatedTypeProjection { .. }
+                | Ty::Media(baml_type::MediaKind::Generic, _)
+                | Ty::Infer { .. }
+        )
+    }
+    if unstable(lhs) || unstable(rhs) {
+        return false;
+    }
+    match (lhs, rhs) {
+        // Nominal heads: different names can never normalize equal.
+        (Ty::Class(q1, ..), Ty::Class(q2, ..))
+        | (Ty::Interface(q1, ..), Ty::Interface(q2, ..))
+        | (Ty::Enum(q1, _), Ty::Enum(q2, _)) => q1 != q2,
+        (Ty::EnumVariant(q1, v1, _), Ty::EnumVariant(q2, v2, _)) => q1 != q2 || v1 != v2,
+        (Ty::Literal(l1, _, _), Ty::Literal(l2, _, _)) => l1 != l2,
+        (Ty::Media(k1, _), Ty::Media(k2, _)) => k1 != k2,
+        (Ty::TypeVar(n1, _), Ty::TypeVar(n2, _)) => n1 != n2,
+        // Same shape, differing only in inner structure: undecided here.
+        _ if std::mem::discriminant(lhs) == std::mem::discriminant(rhs) => false,
+        // Different stable head constructors never normalize equal.
+        _ => true,
+    }
 }
 
 /// Find all recursive type aliases via DFS.
 pub fn find_recursive_aliases(
     aliases: &HashMap<QualifiedTypeName, Ty>,
 ) -> HashSet<QualifiedTypeName> {
+    PROF_FIND_RECURSIVE_ALIASES_CALLS.fetch_add(1, Ordering::Relaxed);
     let mut recursive = HashSet::new();
     for name in aliases.keys() {
         let mut visited = HashSet::new();
@@ -527,6 +618,7 @@ fn normalize(
     aliases: &HashMap<QualifiedTypeName, Ty>,
     recursive: &HashSet<QualifiedTypeName>,
 ) -> StructuralTy {
+    PROF_NORMALIZE_CALLS.fetch_add(1, Ordering::Relaxed);
     let mut expanding = HashSet::new();
     normalize_impl(ty, aliases, recursive, &mut expanding)
 }
@@ -696,6 +788,7 @@ fn has_cycle(
     visited: &mut HashSet<QualifiedTypeName>,
     stack: &mut HashSet<QualifiedTypeName>,
 ) -> bool {
+    PROF_HAS_CYCLE_CALLS.fetch_add(1, Ordering::Relaxed);
     if stack.contains(name) {
         return true;
     }
@@ -1275,6 +1368,18 @@ mod tests {
         Ty::TypeAlias(qn(name), TyAttr::default())
     }
 
+    /// Test-only: build a [`ResolvedAliases`] from a bare alias map,
+    /// computing the recursive set. Production code holds a
+    /// [`ResolvedAliases`] end-to-end (see `package_alias_map`); this
+    /// helper only exists so we don't have to rewrite every unit test.
+    fn ra(m: HashMap<QualifiedTypeName, Ty>) -> ResolvedAliases {
+        let recursive = find_recursive_aliases(&m);
+        ResolvedAliases {
+            aliases: m,
+            recursive,
+        }
+    }
+
     fn required_param(ty: Ty) -> FunctionParamTy {
         FunctionParamTy::required(None, ty)
     }
@@ -1285,7 +1390,7 @@ mod tests {
 
     #[test]
     fn same_normalized_type_accepts_union_reordering() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let int = Ty::Int {
             attr: TyAttr::default(),
         };
@@ -1300,7 +1405,7 @@ mod tests {
 
     #[test]
     fn same_normalized_type_rejects_narrower_union_member() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let int = Ty::Int {
             attr: TyAttr::default(),
         };
@@ -1341,6 +1446,7 @@ mod tests {
             TyAttr::default(),
         );
 
+        let aliases = ra(aliases);
         assert!(is_same_normalized_type(
             &type_alias("IntOrString"),
             &direct,
@@ -1350,7 +1456,7 @@ mod tests {
 
     #[test]
     fn same_normalized_type_ignores_required_function_param_names() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let int = Ty::Int {
             attr: TyAttr::default(),
         };
@@ -1379,7 +1485,7 @@ mod tests {
 
     #[test]
     fn same_normalized_type_sorts_optional_function_params() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let int = Ty::Int {
             attr: TyAttr::default(),
         };
@@ -1424,6 +1530,7 @@ mod tests {
                 attr: TyAttr::default(),
             },
         );
+        let aliases = ra(aliases);
 
         assert!(is_subtype_of(
             &type_alias("MyInt"),
@@ -1451,6 +1558,7 @@ mod tests {
             },
         );
         aliases.insert(qn("AnotherInt"), type_alias("MyInt"));
+        let aliases = ra(aliases);
 
         assert!(is_subtype_of(
             &type_alias("AnotherInt"),
@@ -1483,6 +1591,7 @@ mod tests {
                 TyAttr::default(),
             ),
         );
+        let aliases = ra(aliases);
 
         assert!(is_subtype_of(
             &Ty::Int {
@@ -1543,7 +1652,7 @@ mod tests {
 
     #[test]
     fn test_never_is_bottom() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
 
         assert!(is_subtype_of(
             &Ty::Never {
@@ -1586,7 +1695,7 @@ mod tests {
         // `Int <: Float` was removed entirely (lossy: i64 values past 2^53
         // are not exactly representable as f64). The widening, if needed,
         // must be explicit.
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         assert!(!is_subtype_of(
             &Ty::Int {
                 attr: TyAttr::default()
@@ -1613,7 +1722,7 @@ mod tests {
         // structural (i64 and heap BigInt are different representations).
         // Widening happens only at the `bigint × int` operators and the FFI
         // boundary, never as an implicit move/subtype coercion.
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         assert!(!is_subtype_of(
             &Ty::Int {
                 attr: TyAttr::default()
@@ -1627,7 +1736,7 @@ mod tests {
 
     #[test]
     fn test_literal_widens() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // Fresh and Regular should both be subtypes of their base primitive
         assert!(is_subtype_of(
             &Ty::Literal(LiteralValue::Int(42), Freshness::Fresh, TyAttr::default()),
@@ -1687,7 +1796,7 @@ mod tests {
 
     #[test]
     fn test_enum_variant_subtype_of_enum() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         assert!(is_subtype_of(
             &Ty::EnumVariant(qn("Color"), Name::new("Red"), TyAttr::default()),
             &Ty::Enum(qn("Color"), TyAttr::default()),
@@ -1706,7 +1815,7 @@ mod tests {
         // value has no boundary at which to widen its result, so the covariance
         // uses coercion-free relations (`EnumVariant <: Enum`). The coercive
         // `int → bigint` pair is rejected in both directions.
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
 
         let returns_literal_string = Ty::Function {
             params: vec![required_param(Ty::Int {
@@ -1800,7 +1909,7 @@ mod tests {
         // checked coercion-free. A function accepting the wider `Enum` stands
         // in for one accepting an `EnumVariant`. The coercive `int`/`bigint`
         // pair is rejected in both directions.
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
 
         let accepts_string = Ty::Function {
             params: vec![required_param(Ty::String {
@@ -1898,7 +2007,7 @@ mod tests {
 
     #[test]
     fn test_function_covariant_throws() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let f1 = Ty::Function {
             params: vec![required_param(Ty::Int {
                 attr: TyAttr::default(),
@@ -1933,7 +2042,7 @@ mod tests {
 
     #[test]
     fn test_function_optional_param_dropping_subtyping() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let with_two_optionals = Ty::Function {
             params: vec![
                 required_param(Ty::String {
@@ -1995,7 +2104,7 @@ mod tests {
 
     #[test]
     fn test_function_optional_param_order_is_insignificant() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let f1 = Ty::Function {
             params: vec![
                 required_param(Ty::String {
@@ -2055,7 +2164,7 @@ mod tests {
 
     #[test]
     fn test_function_optional_and_required_params_are_incomparable() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let optional = Ty::Function {
             params: vec![optional_param(
                 "value",
@@ -2093,7 +2202,7 @@ mod tests {
 
     #[test]
     fn test_optional_subtyping() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // int <: int?
         assert!(is_subtype_of(
             &Ty::Int {
@@ -2130,7 +2239,7 @@ mod tests {
 
     #[test]
     fn test_evolving_list_subtype_of_list() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // EvolvingList(int) <: List(int)
         assert!(is_subtype_of(
             &Ty::EvolvingList(
@@ -2167,7 +2276,7 @@ mod tests {
 
     #[test]
     fn test_evolving_list_is_invariant() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // `List`/`EvolvingList` are invariant. So `EvolvingList(int)` is NOT a
         // subtype of `List(bigint)` — `int` is not a subtype of `bigint`
         // anywhere, including inside containers.
@@ -2225,7 +2334,7 @@ mod tests {
 
     #[test]
     fn test_evolving_list_never_is_bottom() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // EvolvingList(Never) <: List(int) — empty evolving is assignable anywhere
         assert!(is_subtype_of(
             &Ty::EvolvingList(
@@ -2246,7 +2355,7 @@ mod tests {
 
     #[test]
     fn test_evolving_map_subtype_of_map() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // EvolvingMap(string, int) <: Map(string, int)
         assert!(is_subtype_of(
             &Ty::EvolvingMap(
@@ -2273,7 +2382,7 @@ mod tests {
 
     #[test]
     fn test_map_key_covariance_never() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // map<never, never> <: map<string, unknown> — empty map assignable anywhere
         assert!(is_subtype_of(
             &Ty::Map {
@@ -2322,7 +2431,7 @@ mod tests {
 
     #[test]
     fn test_map_key_covariance_literal() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // map<"name", "World"> <: map<string, unknown>
         assert!(is_subtype_of(
             &Ty::Map {
@@ -2379,7 +2488,7 @@ mod tests {
 
     #[test]
     fn test_map_invariant_no_int_to_float_value_widening() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // `Map` is invariant — the value-type recursion is coercion-free.
         // `int <: float` was removed entirely (as a lossy/unsound rule),
         // so `map<string, int>` is **not** a subtype of `map<string, float>`.
@@ -2408,7 +2517,7 @@ mod tests {
 
     #[test]
     fn test_map_invariant_no_int_to_bigint_value_widening() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // `Map` is invariant, and `int` is not a subtype of `bigint` anywhere
         // (no implicit numeric widening), so `map<string, int>` is not a
         // subtype of `map<string, bigint>`.
@@ -2437,7 +2546,7 @@ mod tests {
 
     #[test]
     fn test_map_key_not_supertype() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         // map<string, int> NOT <: map<"name", int> — widening key is not subtyping
         assert!(!is_subtype_of(
             &Ty::Map {
@@ -2608,7 +2717,7 @@ mod tests {
 
     #[test]
     fn test_union_of_int_literals_subtype_of_int() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let sub = Ty::Union(
             vec![
                 Ty::Literal(LiteralValue::Int(1), Freshness::Fresh, TyAttr::default()),
@@ -2625,7 +2734,7 @@ mod tests {
 
     #[test]
     fn test_list_of_literal_union_subtype_of_list_int() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let sub = Ty::List(
             Box::new(Ty::Union(
                 vec![
@@ -2651,7 +2760,7 @@ mod tests {
         // past 2^53), so a union containing an int literal cannot widen to
         // `Float` even via the structural Union-vs-T rule (which requires
         // every member to be a subtype).
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let sub = Ty::Union(
             vec![
                 Ty::Literal(LiteralValue::Int(1), Freshness::Fresh, TyAttr::default()),
@@ -2671,7 +2780,7 @@ mod tests {
 
     #[test]
     fn test_typevar_subtype_of_union_containing_same_typevar() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let t = Ty::TypeVar(Name::new("T"), TyAttr::default());
         let union = Ty::Union(
             vec![
@@ -2688,7 +2797,7 @@ mod tests {
 
     #[test]
     fn test_typevar_not_subtype_of_union_without_same_typevar() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let t = Ty::TypeVar(Name::new("T"), TyAttr::default());
         let union = Ty::Union(
             vec![
@@ -2707,7 +2816,7 @@ mod tests {
 
     #[test]
     fn test_typevar_subtype_of_optional_same_typevar() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let t = Ty::TypeVar(Name::new("T"), TyAttr::default());
         let opt_t = Ty::optional(t.clone());
         // T <: T? should hold
@@ -2716,7 +2825,7 @@ mod tests {
 
     #[test]
     fn test_typevar_not_subtype_of_concrete() {
-        let aliases = HashMap::new();
+        let aliases = ResolvedAliases::default();
         let t = Ty::TypeVar(Name::new("T"), TyAttr::default());
         // T <: Int should NOT hold
         assert!(!is_subtype_of(

--- a/baml_language/crates/baml_compiler2_tir/src/type_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/type_context.rs
@@ -16,9 +16,8 @@
 //! never disagree, and type-expression lowering — which has no builder —
 //! constructs one directly.
 
-use std::collections::HashMap;
-
 use baml_base::Name;
+use baml_type::ResolvedAliases;
 
 use crate::{
     package_interface::PackageResolutionContext,
@@ -36,7 +35,11 @@ use crate::{
 pub struct GlobalTypeContext<'a, 'db> {
     pub db: &'db dyn crate::Db,
     pub res_ctx: &'db PackageResolutionContext<'db>,
-    pub aliases: &'a HashMap<QualifiedTypeName, Ty>,
+    /// Alias environment with the precomputed recursive-alias set. The
+    /// `is_same_normalized_type` / `is_subtype_of` entry points use
+    /// `aliases.recursive` directly instead of re-DFS'ing the alias
+    /// graph on every call — the redundant work this hoisting fixes.
+    pub aliases: &'a ResolvedAliases,
     /// A scope's type-variable bounds as interface-constraint conjunctions
     /// (`T: A & B`). The single representation both the builder and
     /// type-expression lowering hold.

--- a/baml_language/crates/baml_compiler_diagnostics/src/render.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/render.rs
@@ -208,7 +208,10 @@ pub fn render_diagnostic(
     config: &RenderConfig,
 ) -> String {
     match config.format {
-        DiagnosticFormat::Ariadne => render_ariadne(diagnostic, sources, file_paths, config.color),
+        DiagnosticFormat::Ariadne => {
+            let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
+            render_ariadne(diagnostic, sources, &mut cache, config.color)
+        }
         DiagnosticFormat::Concise => render_concise(diagnostic, sources, file_paths),
     }
 }
@@ -223,9 +226,20 @@ pub fn render_diagnostics(
     file_paths: &HashMap<FileId, PathBuf>,
     config: &RenderConfig,
 ) -> String {
+    // Build the ariadne source cache ONCE for the whole batch. Constructing
+    // it per diagnostic (each `Source::from` computes a line index for every
+    // file in the project) measured ~35% of `baml check` wall time on a
+    // warning-heavy project.
+    let mut ariadne_cache = matches!(config.format, DiagnosticFormat::Ariadne)
+        .then(|| SourceCache::new(sources.clone(), file_paths.clone()));
     diagnostics
         .iter()
-        .map(|d| render_diagnostic(d, sources, file_paths, config))
+        .map(|d| match (&config.format, &mut ariadne_cache) {
+            (DiagnosticFormat::Ariadne, Some(cache)) => {
+                render_ariadne(d, sources, cache, config.color)
+            }
+            _ => render_concise(d, sources, file_paths),
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -259,10 +273,13 @@ fn translate_span(span: Span, sources: &HashMap<FileId, String>) -> Span {
 }
 
 /// Render a diagnostic using Ariadne (pretty CLI output).
+///
+/// Takes a pre-built [`SourceCache`] so batch rendering shares one line-index
+/// computation across all diagnostics.
 fn render_ariadne(
     diagnostic: &Diagnostic,
     sources: &HashMap<FileId, String>,
-    file_paths: &HashMap<FileId, PathBuf>,
+    cache: &mut SourceCache,
     color: bool,
 ) -> String {
     // BAML CLI uses lowercase `error:` / `warning:` everywhere (matching
@@ -321,7 +338,7 @@ fn render_ariadne(
         .finish();
 
     // Render to string using SourceCache for proper filename display.
-    let rendered = render_report_to_string(&report, sources, file_paths);
+    let rendered = render_report_to_string(&report, cache);
 
     // See the rant above the `report_kind` match — ariadne paints the
     // `Custom` keyword unconditionally, so `with_color(false)` doesn't
@@ -427,17 +444,10 @@ fn render_concise(
 }
 
 /// Render an ariadne Report to a String using `SourceCache` for proper filename display.
-fn render_report_to_string(
-    report: &Report<'_, Span>,
-    sources: &HashMap<FileId, String>,
-    file_paths: &HashMap<FileId, PathBuf>,
-) -> String {
+fn render_report_to_string(report: &Report<'_, Span>, cache: &mut SourceCache) -> String {
     let mut output = Vec::new();
 
-    // Use SourceCache for proper filename display
-    let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
-
-    report.write(&mut cache, &mut output).unwrap_or_else(|_| {
+    report.write(cache, &mut output).unwrap_or_else(|_| {
         output.clear();
         output.extend_from_slice(b"<error rendering diagnostic>");
     });

--- a/baml_language/crates/baml_lsp2_actions/Cargo.toml
+++ b/baml_language/crates/baml_lsp2_actions/Cargo.toml
@@ -15,6 +15,7 @@ baml_compiler2_tir = { workspace = true }
 baml_compiler_diagnostics = { workspace = true }
 baml_compiler_parser = { workspace = true }
 baml_compiler_syntax = { workspace = true }
+baml_type = { workspace = true }
 sys_jinja_types = { workspace = true }
 bitflags = { workspace = true }
 indexmap = { workspace = true }

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -153,16 +153,12 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
     let pkg_id = baml_compiler2_hir::package::PackageId::new(db, pkg_info.package.clone());
     let res_ctx = baml_compiler2_tir::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
-    let aliases = collect_type_aliases_for_resolution_context(db, res_ctx);
-    let ast_items = {
-        let tree = baml_compiler_parser::syntax_tree(db, file);
-        let (items, _, _) = baml_compiler2_ast::lower_file(&tree);
-        items
-    };
+    let aliases = baml_compiler2_tir::inference::package_resolved_aliases(db, pkg_id);
+    let ast_items = &baml_compiler2_hir::file_ast(db, file).items;
     diagnostics.extend(validate_associated_type_bindings_in_items(
         db,
         file_id,
-        &ast_items,
+        ast_items,
         pkg_items,
         &pkg_info.namespace_path,
     ));
@@ -399,11 +395,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
         if let Some(scope_id) = function_scope_id(index, func_data) {
             let context = baml_compiler2_tir::infer_context::InferContext::new(db, scope_id);
             let mut builder = baml_compiler2_tir::builder::TypeInferenceBuilder::new(
-                context,
-                res_ctx,
-                pkg_id,
-                scope_id,
-                aliases.clone(),
+                context, res_ctx, pkg_id, scope_id, aliases,
             );
             builder.set_generic_params(generic_params);
             for (name, ty) in &param_types {
@@ -435,6 +427,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
                 _call_throws,
                 _template_body_params,
                 _default_parameter_inference,
+                _nested_lambda_inference,
             ) = builder.finish();
             for tir_diag in type_check_diagnostics.diagnostics {
                 if !is_function_default_signature_diagnostic(&tir_diag) {
@@ -1624,28 +1617,6 @@ fn jinja_diagnostic_id(message: &str) -> DiagnosticId {
     } else {
         DiagnosticId::JinjaInvalidType
     }
-}
-
-fn collect_type_aliases_for_resolution_context<'db>(
-    db: &'db dyn Db,
-    res_ctx: &'db baml_compiler2_tir::package_interface::PackageResolutionContext<'db>,
-) -> std::collections::HashMap<baml_compiler2_tir::ty::QualifiedTypeName, baml_compiler2_tir::ty::Ty>
-{
-    let mut aliases = baml_compiler2_tir::inference::collect_type_aliases(db, &res_ctx.own_items);
-    for (_dep_name, dep_iface) in &res_ctx.dep_interfaces {
-        for types_in_ns in dep_iface.types.values() {
-            for exported in types_in_ns.values() {
-                if let baml_compiler2_tir::package_interface::ExportedType::TypeAlias {
-                    qtn,
-                    resolved,
-                } = exported
-                {
-                    aliases.insert(qtn.clone(), resolved.clone());
-                }
-            }
-        }
-    }
-    aliases
 }
 
 fn function_scope_id<'db>(

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -59,8 +59,21 @@ pub fn collect_diagnostics(
 /// stable snapshot output.
 pub fn collect_compiler2_diagnostics(db: &ProjectDatabase) -> Vec<Diagnostic> {
     let source_files = baml_compiler2_hir::compiler2_all_files(db);
+    // Diagnostics are only collected for *user* files. The builtin stdlib
+    // (`compiler2_extra_files`) ships with the compiler: eagerly type-checking
+    // every builtin scope on every `baml check` costs a fixed ~15% of cold
+    // compile time and can never produce a diagnostic the user can act on.
+    // Builtin scopes the user's code actually touches are still inferred
+    // lazily through the normal query path.
+    let builtin_files: std::collections::HashSet<SourceFile> =
+        baml_compiler2_hir::Db::compiler2_extra_files(db)
+            .map(|extra| extra.files(db).iter().copied().collect())
+            .unwrap_or_default();
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     for file in &source_files {
+        if builtin_files.contains(file) {
+            continue;
+        }
         diagnostics.extend(lsp2_check_file(db, *file));
     }
 

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__04_tir.snap
@@ -258,7 +258,6 @@ function user.lambda_class_destructure_field_pattern_type_mismatch_span() -> int
   !! 6917..6923: type mismatch: expected int, got string
 }
 lambda user.lambda_class_destructure_field_pattern_type_mismatch_span {
-  !! 6928..6929: type mismatch: expected int, got string
 }
 function user.class_destructure_formatter_trivia_preserved() -> int throws never {
   { : int

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__05_diagnostics.snap
@@ -320,13 +320,3 @@ source: crates/baml_tests/src/generated_tests.rs
      │ 
      │ Note: Error code: E0001
 ─────╯
-
-  [type] error: type mismatch: expected int, got string
-     ╭─[ patterns_class_destructure.baml:283:38 ]
-     │
- 283 │         let Person { age: string } = p;
-     │                                      ┬  
-     │                                      ╰── type mismatch: expected int, got string
-     │ 
-     │ Note: Error code: E0001
-─────╯

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/test_expr_name_type_error/baml_tests__diagnostic_errors__test_expr_name_type_error__04_tir.snap
@@ -34,7 +34,6 @@ lambda user.$init_test_main {
 lambda user.$init_test_main {
 }
 lambda user.$init_test_main {
-  !! 181..186: type mismatch: expected string, got int
 }
 lambda user.$init_test_main {
 }

--- a/baml_language/crates/baml_tests/src/compiler2_hir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_hir.rs
@@ -368,7 +368,7 @@ mod tests {
 
         let pkg_id = PackageId::new(&db, Name::new("user"));
         let tree = baml_compiler2_hir::file_item_tree(&db, file);
-        let aliases = std::collections::HashMap::new();
+        let aliases = baml_type::ResolvedAliases::default();
 
         let class_ty = |class_name: &str| {
             let (id, data) = tree

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -542,7 +542,7 @@ implements ToJson for Dog {
     use baml_type::normalize::TypeContext;
     let pkg_id = PackageId::new(&db, Name::new("user"));
     let res_ctx = package_resolution_context(&db, pkg_id);
-    let aliases = std::collections::HashMap::new();
+    let aliases = baml_type::ResolvedAliases::default();
     let bounds = baml_compiler2_tir::lower_type_expr::TypeVarBoundsMap::default();
     let ctx = GlobalTypeContext {
         db: &db,
@@ -608,7 +608,7 @@ fn builtin_equals_compare_visible_from_user_package() {
     // The membership query walks the interface's package (`baml`) via the orphan
     // rule, so the builtin primitive impls are visible from the user package.
     let res_ctx = package_resolution_context(&db, user_pkg);
-    let aliases = std::collections::HashMap::new();
+    let aliases = baml_type::ResolvedAliases::default();
     let bounds = baml_compiler2_tir::lower_type_expr::TypeVarBoundsMap::default();
     let ctx = GlobalTypeContext {
         db: &db,

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase3a__optional_param_default_forward_reference_checks_lambda_bodies.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase3a__optional_param_default_forward_reference_checks_lambda_bodies.snap
@@ -8,3 +8,5 @@ function user.lambda_capture_later_param(a: int = f(), b: int = 1) -> int throws
   }
   !! 46..78: default for parameter `a` cannot reference later parameter `b`
 }
+lambda user.lambda_capture_later_param {
+}

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -1065,10 +1065,6 @@ impl NormalTy {
         ctx: &C,
         assumptions: &mut HashSet<(NormalTy, NormalTy)>,
     ) -> bool {
-        let pair = (self.clone(), sup.clone());
-        if assumptions.contains(&pair) {
-            return true;
-        }
         if self == sup {
             return true;
         }
@@ -1091,8 +1087,48 @@ impl NormalTy {
             return true;
         }
 
+        // Co-inductive assumption tracking exists solely to terminate cycles,
+        // and a cycle can only regress through the arms that *expand* a type:
+        // μ-unfolding (substitution can regenerate the same pair) and
+        // variable/projection bound lookup (a bound can mention the variable).
+        // Every structural arm descends into strictly smaller subterms of
+        // finite trees. Restricting the pair bookkeeping to the expanding
+        // arms preserves termination — any infinite path must pass through an
+        // expanding arm infinitely often, and the pairs seen there are drawn
+        // from the finite subterm closure of the (regular) operands — while
+        // sparing the deep `NormalTy` clone + full-tree hash on the millions
+        // of purely structural steps, which profiling showed dominated
+        // subtype-checking cost.
+        let expanding = matches!(
+            self,
+            NormalTy::Mu { .. } | NormalTy::TypeVar(_) | NormalTy::AssociatedTypeProjection { .. }
+        ) || matches!(sup, NormalTy::Mu { .. });
+        if !expanding {
+            return self.is_subtype_of_inner(sup, ctx, assumptions);
+        }
+        // Avoid cloning just to probe: pairs on the path are few (bounded by
+        // the expanding-arm recursion depth), so a linear scan beats
+        // hash-of-whole-tree.
+        if assumptions.iter().any(|(a, b)| a == self && b == sup) {
+            return true;
+        }
+        let pair = (self.clone(), sup.clone());
         assumptions.insert(pair.clone());
-        let result = match (self, sup) {
+        let result = self.is_subtype_of_inner(sup, ctx, assumptions);
+        assumptions.remove(&pair);
+        result
+    }
+
+    /// The structural rules of [`Self::is_subtype_of`]. Callers must go
+    /// through `is_subtype_of`, which owns the fast paths and the
+    /// co-inductive assumption bookkeeping.
+    fn is_subtype_of_inner<C: TypeContext>(
+        &self,
+        sup: &NormalTy,
+        ctx: &C,
+        assumptions: &mut HashSet<(NormalTy, NormalTy)>,
+    ) -> bool {
+        match (self, sup) {
             // μ-unfolding (equirecursive).
             (NormalTy::Mu { var, body }, _) => {
                 body.substitute(var, self)
@@ -1255,9 +1291,7 @@ impl NormalTy {
             }
 
             _ => false,
-        };
-        assumptions.remove(&pair);
-        result
+        }
     }
 
     // ── conversion out: NormalTy → Ty ──────────────────────────────────────

--- a/baml_language/crates/tools_compile_profile/Cargo.toml
+++ b/baml_language/crates/tools_compile_profile/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baml_compiler2_profile"
+name = "tools_compile_profile"
 version = { workspace = true }
 publish = false
 authors = { workspace = true }
@@ -11,7 +11,7 @@ license = { workspace = true }
 description = "Standalone profiling harness for the BAML compiler pipeline (parse → HIR → PPIR → TIR → MIR → emit)."
 
 [[bin]]
-name = "baml_compiler2_profile"
+name = "tools_compile_profile"
 path = "src/main.rs"
 
 [dependencies]

--- a/baml_language/crates/tools_compile_profile/README.md
+++ b/baml_language/crates/tools_compile_profile/README.md
@@ -1,4 +1,4 @@
-# baml_compiler2_profile
+# tools_compile_profile
 
 Standalone profiling harness for the BAML compiler pipeline.
 
@@ -73,26 +73,26 @@ The cold-vs-warm table then makes three failure modes visible:
 
 ```bash
 # Build once
-cargo build --release -p baml_compiler2_profile
+cargo build --release -p tools_compile_profile
 
 # Point at any directory that contains .baml files or a baml_src/ dir
-./target/release/baml_compiler2_profile /path/to/baml/project
+./target/release/tools_compile_profile /path/to/baml/project
 
 # Cold + warm re-runs on the same db — measures Salsa's cache effect
-./target/release/baml_compiler2_profile --warm-runs 2 /path/to/project
+./target/release/tools_compile_profile --warm-runs 2 /path/to/project
 
 # JSON output (diff two runs, feed a spreadsheet, etc.)
-./target/release/baml_compiler2_profile --json /path/to/project > run.json
+./target/release/tools_compile_profile --json /path/to/project > run.json
 
 # Multiple cold-cache runs for variance measurement
-./target/release/baml_compiler2_profile --repeat 5 /path/to/project
+./target/release/tools_compile_profile --repeat 5 /path/to/project
 
 # Just measure `check`, skip bytecode (matches what `baml check` does
 # when there are diagnostic errors)
-./target/release/baml_compiler2_profile --check-only /path/to/project
+./target/release/tools_compile_profile --check-only /path/to/project
 
 # Compact one-liner for logs / dashboards
-./target/release/baml_compiler2_profile --summary-line /path/to/project | tail -1
+./target/release/tools_compile_profile --summary-line /path/to/project | tail -1
 ```
 
 ## Combining with `samply` for a real CPU flamegraph
@@ -102,13 +102,13 @@ find **which lines inside a query are hot**, sample the process:
 
 ```bash
 # Build with symbols; the workspace `release` profile already keeps them
-cargo build --release -p baml_compiler2_profile
+cargo build --release -p tools_compile_profile
 
 # Record and open in the web UI (macOS)
-samply record ./target/release/baml_compiler2_profile /path/to/project
+samply record ./target/release/tools_compile_profile /path/to/project
 
 # On Linux
-samply record ./target/release/baml_compiler2_profile /path/to/project
+samply record ./target/release/tools_compile_profile /path/to/project
 ```
 
 `samply` opens a browser UI with an inverted call tree, a top function
@@ -171,7 +171,7 @@ Reading this:
 This section documents the audit this tool was built for, both as a
 record of *why* the compiler's hot paths look the way they do now and as
 a worked example of the methodology. Several `// See
-crates/baml_compiler2_profile/README.md` comments in the compiler point
+crates/tools_compile_profile/README.md` comments in the compiler point
 here.
 
 **Result: cold `check` + `emit` on the test corpus (78 files, 25,838

--- a/baml_language/crates/tools_compile_profile/src/main.rs
+++ b/baml_language/crates/tools_compile_profile/src/main.rs
@@ -1,4 +1,4 @@
-//! `baml_compiler2_profile`: A standalone profiling harness for the BAML compiler.
+//! `tools_compile_profile`: A standalone profiling harness for the BAML compiler.
 //!
 //! This tool loads a BAML project, runs the full compiler pipeline
 //! (parse → HIR → PPIR → TIR → MIR → emit) end-to-end, and reports:
@@ -32,23 +32,23 @@
 //!
 //! ```text
 //! # Human-readable report (cold-only)
-//! cargo run --release -p baml_compiler2_profile -- /path/to/baml/project
+//! cargo run --release -p tools_compile_profile -- /path/to/baml/project
 //!
 //! # Cold run followed by 2 warm re-runs on the same db (measures cache)
-//! cargo run --release -p baml_compiler2_profile -- --warm-runs 2 /path/to/project
+//! cargo run --release -p tools_compile_profile -- --warm-runs 2 /path/to/project
 //!
 //! # JSON output for programmatic diffing
-//! cargo run --release -p baml_compiler2_profile -- --json /path/to/project
+//! cargo run --release -p tools_compile_profile -- --json /path/to/project
 //!
 //! # Repeat N times (useful for measuring cold-cache variance)
-//! cargo run --release -p baml_compiler2_profile -- --repeat 3 /path/to/project
+//! cargo run --release -p tools_compile_profile -- --repeat 3 /path/to/project
 //!
 //! # Skip bytecode generation (measure just `check`, not `check + emit`)
-//! cargo run --release -p baml_compiler2_profile -- --check-only /path/to/project
+//! cargo run --release -p tools_compile_profile -- --check-only /path/to/project
 //!
 //! # Combine with a CPU sampler for a flamegraph
-//! cargo build --release -p baml_compiler2_profile
-//! samply record ./target/release/baml_compiler2_profile /path/to/project
+//! cargo build --release -p tools_compile_profile
+//! samply record ./target/release/tools_compile_profile /path/to/project
 //! ```
 
 use std::{
@@ -78,7 +78,7 @@ use salsa::{Database, Event, EventKind};
 /// Profile a full BAML compile pipeline against a project on disk.
 #[derive(Parser, Debug)]
 #[command(
-    name = "baml_compiler2_profile",
+    name = "tools_compile_profile",
     about = "Profile a full BAML compile (parse → HIR → PPIR → TIR → MIR → emit) end-to-end."
 )]
 struct Args {
@@ -146,22 +146,22 @@ fn main() -> Result<()> {
         .map(|(_, text)| text.matches('\n').count() + 1)
         .sum();
 
-    eprintln!("[baml_compiler2_profile] project: {}", root.display());
+    eprintln!("[tools_compile_profile] project: {}", root.display());
     eprintln!(
-        "[baml_compiler2_profile] {} files, {} lines, {} bytes",
+        "[tools_compile_profile] {} files, {} lines, {} bytes",
         sources.len(),
         total_lines,
         total_bytes,
     );
     if args.repeat > 1 {
-        eprintln!("[baml_compiler2_profile] running {} times", args.repeat);
+        eprintln!("[tools_compile_profile] running {} times", args.repeat);
     }
 
     let cold_runs = args.repeat.max(1);
     let mut runs: Vec<RunReport> = Vec::with_capacity(cold_runs * (1 + args.warm_runs));
     for i in 0..cold_runs {
         eprintln!(
-            "[baml_compiler2_profile] cold run {}/{} (fresh database, empty Salsa cache)",
+            "[tools_compile_profile] cold run {}/{} (fresh database, empty Salsa cache)",
             i + 1,
             cold_runs
         );
@@ -172,7 +172,7 @@ fn main() -> Result<()> {
         let reports = run_cold_plus_warm(&root, &sources, args.check_only, args.warm_runs)?;
         for r in &reports {
             eprintln!(
-                "[baml_compiler2_profile]   [{}] total: {:.3}s  (check {:.3}s, emit {:.3}s, exec {} queries, hit {})",
+                "[tools_compile_profile]   [{}] total: {:.3}s  (check {:.3}s, emit {:.3}s, exec {} queries, hit {})",
                 r.mode.label(),
                 r.total.as_secs_f64(),
                 r.check.as_secs_f64(),
@@ -530,7 +530,7 @@ fn invoke_pipeline(
         // Matches the CLI: `check` errors abort the pipeline before
         // bytecode generation.
         eprintln!(
-            "[baml_compiler2_profile]   [{}] skipping emit: {error_count} error(s) reported by check",
+            "[tools_compile_profile]   [{}] skipping emit: {error_count} error(s) reported by check",
             mode.label()
         );
         (Duration::ZERO, false)
@@ -1031,7 +1031,7 @@ fn print_human(
     println!();
     println!("Tips:");
     println!("  * For a CPU flamegraph, wrap this binary with a sampler:");
-    println!("      samply record ./target/release/baml_compiler2_profile <project>");
+    println!("      samply record ./target/release/tools_compile_profile <project>");
     println!("  * The 'suspect' table above is a first place to look for repeated");
     println!("    work — a query that fires many times but is rarely a cache hit");
     println!("    is either recomputing per-call, or keyed too finely.");

--- a/baml_language/stow.toml
+++ b/baml_language/stow.toml
@@ -78,6 +78,9 @@ allowed_crates = [
     # validation helpers and caller-facing context.
     "baml",
     "baml_release",
+    # Standalone dev/profiling binary (never a library dependency);
+    # sits at the application boundary like the CLIs above.
+    "baml_compiler2_profile",
 ]
 regular_deps_only = true
 reason = "Use thiserror for proper error types in library crates."

--- a/baml_language/stow.toml
+++ b/baml_language/stow.toml
@@ -78,9 +78,6 @@ allowed_crates = [
     # validation helpers and caller-facing context.
     "baml",
     "baml_release",
-    # Standalone dev/profiling binary (never a library dependency);
-    # sits at the application boundary like the CLIs above.
-    "baml_compiler2_profile",
 ]
 regular_deps_only = true
 reason = "Use thiserror for proper error types in library crates."
@@ -118,7 +115,7 @@ reason = "Only compiler_emit and baml_project crates should depend on bex_vm_typ
 # tools namespace configuration
 [[namespaces]]
 name = "tools"
-approved_prefixes = ["sap", "semantic"]
+approved_prefixes = ["sap", "semantic", "compile"]
 # Allow tools_stow folder to have package name "cargo-stow" for cargo subcommand convention
 name_exceptions = { "tools_stow" = "cargo-stow", "tools_size_gate" = "cargo-size-gate" }
 


### PR DESCRIPTION
## TL;DR

Cold `check` + `emit` on the in-repo test corpus (78 files, 25,838 lines) goes from **16.0s → ~0.50s** (~32×). End-to-end `baml check` wall time on the same corpus goes from **~17s → ~0.55s**. Everything here is **single-threaded** — no parallelism, no on-disk cache. Every win is one of three things:

1. deleting work we were doing more than once,
2. turning package/project-invariant computation into a Salsa-tracked query so it runs once instead of once-per-scope/per-function, or
3. cutting allocation churn on the hot type-checking paths.

It also **fixes two user-visible bugs** found along the way (details below), and ships a new profiling harness (`crates/tools_compile_profile`) whose README documents the entire audit so the next person doesn't have to rediscover any of this.

## Why

`baml check` on a real project was taking ~17 minutes. The pipeline is Salsa-based, but a cold CLI run gets zero benefit from Salsa's memoization *across* invocations — so cold-path cost is pure single-run efficiency. Profiling (query-event counts + `samply` CPU sampling) showed the time wasn't in any one algorithm; it was the same few computations being repeated tens of thousands of times.

## How to review this PR

Each change is independent and documented at its call site with a comment explaining what was being recomputed and roughly what it cost. The full narrative, methodology, and per-change measurements live in **`crates/tools_compile_profile/README.md`** (section "The July 2026 cold-compile audit") — reading that first will make every diff hunk make sense.

## The changes

### Stop recomputing package/project-invariant data (the big one)

| What | Before | After |
|---|---|---|
| Recursive-alias analysis (`find_recursive_aliases`, a whole-alias-graph DFS) | ran inside **every** subtype/type-equality check — 18k executions | runs once per package; result travels in the new `baml_type::ResolvedAliases` (alias map + precomputed recursive set), threaded by reference through TIR/MIR |
| Package alias map & impl-block list | rebuilt (deep `Ty` clones + project walk) inside every `infer_scope_types` execution (~16k) | `package_resolved_aliases` / `package_impl_locs` tracked queries |
| CST → AST lowering | re-lowered per file by **six** different consumers (~31% of cold CPU) | `file_ast(db, file)` tracked query |
| Project-wide class → type-tag map | rebuilt per *function* lowered in MIR (~13% of cold CPU) | `class_type_tags_for_project` tracked query |
| Callee generic params + bound lowering | re-derived at every call site (~10% of cold CPU) | `callee_generics_for_func` tracked query |
| Callee function body for direct calls | PPIR cloned the entire `ExprBody` arena per call site | `ppir::function_body` tracked, returns `Arc` |

### Stop doing the same inference twice

- **Lambda bodies were type-inferred twice**: once inline while inferring the enclosing function, then again from scratch by the standalone lambda-scope query. The inline pass now captures the lambda's complete inference tables (`NestedLambdaInference`, moved not cloned) and the standalone query projects them. This is also a **bug fix**: diagnostics inside lambdas were previously **reported twice**.
- Files with no `$stream` expansions had their semantic index built twice (identical results); PPIR's `file_semantic_index` now delegates to HIR's.
- The builtin stdlib was eagerly type-checked on every `baml check` (a fixed cost floor even for a 1-line project) even though it can't produce user-actionable diagnostics. Diagnostics collection now skips builtin files; builtin scopes user code touches are still inferred lazily.

### Make the remaining hot path cheap

- **Subtype/equality fast paths** (`baml_type::normalize`): reflexivity short-circuit; co-inductive assumption bookkeeping (deep clone + full-tree hash per step) now only happens in the arms that can actually regress a cycle (μ-types, type vars, projections) — the millions of purely structural steps skip it. The safety argument is written out in a comment at the site.
- **`heads_definitely_differ` filter**: MIR impl dispatch probes are overwhelmingly misses between types with different nominal heads — now decided without the two allocation-heavy normalization walks.
- **Interface-method-name pre-filter in MIR dispatch**: `dispatch_target_for_concrete` enumerated every impl block in the package closure for every method call *and field access*. A per-package `FxHashSet` of interface-declared method names rejects the common plain-method case in one lookup (`is_same_normalized_type` calls: 952k → 275k).
- **mimalloc** as the global allocator for `baml_cli` (and the profiler). System malloc was ~35% of remaining CPU — the workload is small-allocation heavy (`Ty` trees have deep value semantics). This is mitigation; the foundational fix (interning `Ty`) is scoped as future work in the README.

### CLI-side bug fix

- **Diagnostic rendering rebuilt ariadne's line index per diagnostic.** `render_diagnostics` constructed a fresh `SourceCache` — a line index over *every project file* — for each diagnostic. With 79 warnings that was 34% of total `baml check` wall time. Built once per batch now. (CLI 0.94s → 0.55s.)

### New: `crates/tools_compile_profile`

A standalone profiling harness that runs the exact `baml check` pipeline against any project directory and reports wall-clock per stage, Salsa query execution/cache-hit counts by pipeline phase, top queries, and a "suspect" table (high-exec, low-hit queries — i.e. caching gaps). Supports `--warm-runs`, `--repeat`, `--json`, `--check-only`, and pairs with `samply` for line-level CPU profiles. The README documents how to use it, how to read its output, and the full audit above.

## Correctness

- Full test suite passes. Three snapshots changed, all expected: two reflect the duplicate-lambda-diagnostics fix (diagnostics no longer emitted twice), one reflects lambda-scope inference now being projected (same types, same diagnostics, different provenance).
- The `package_resolved_aliases` query participates in a legitimate dependency cycle (aliases whose RHS is an associated-type projection resolve through inference, which consults the alias map); it now declares `cycle_initial` and seeds fixpoint iteration with the empty environment, mirroring `infer_scope_types`.
- No language-semantics changes: every optimization computes the same values, just fewer times.

## Numbers (test corpus, cold, median of 5)

| Stage | Before | After |
|---|---|---|
| check (diagnostics) | 8.1s | 0.32s |
| emit (bytecode) | 13.2s (worst measurement) | 0.17s |
| **pipeline total** | **16.0s** | **~0.50s** |
| `baml check` CLI wall | ~17s | ~0.55s |

## Explicitly out of scope (documented as future work in the README)

- **Parallelism** — untouched, remains available as a multiplier on top of this.
- **`Ty` interning / hash-consing** — ~25% of remaining self-time is still clone/drop/malloc of `Ty` trees with deep value semantics. Staged plan (intern `QualifiedTypeName` → intern `Ty` → arena `NormalTy` temporaries) is written up in the README.

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved cold compilation performance for `baml check` and `baml build`, particularly on macOS.
  * Reduced repeated work during type checking, interface resolution, and lambda analysis.

* **Bug Fixes**
  * Improved handling of recursive type aliases and subtype checks.
  * Prevented compiler diagnostics from including internal built-in files.
  * Reduced duplicate diagnostics for nested lambda expressions.
  * Improved diagnostic rendering efficiency across multiple files.

* **Developer Tools**
  * Added a standalone compiler profiling tool with timing, cache, query, JSON, and flamegraph-supporting reports.
  * Added comprehensive documentation and usage guidance for profiling compiler performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->