### PR TITLE
docs: document CLI telemetry and how to opt out (draft, refs #4018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ baml ide install --code
 
 Or read the [quickstart](https://boundaryml.com/quickstart).
 
+## Telemetry
+
+The `baml` CLI sends anonymous usage telemetry so we can see which commands are used and on which platforms. It is sent on each CLI invocation to [PostHog](https://posthog.com) (US cloud) and includes:
+
+- the subcommand run (e.g. `generate`, `test`)
+- `baml` version and release channel
+- OS and CPU architecture
+- whether the invocation looks like CI
+- a randomly-generated anonymous ID
+
+It does **not** include your BAML source, prompts, file contents, or any personal information.
+
+### Opting out
+
+Set either environment variable to disable it:
+
+- `DO_NOT_TRACK=1` (the [Console Do Not Track](https://consoledonottrack.com) convention), or
+- `BAML_TELEMETRY=0`
+
 ## Contributing
 
 See our [guide on getting started](/CONTRIBUTING.md).


### PR DESCRIPTION
Draft for #4018.

## What this adds

A short **Telemetry** section in the README documenting the CLI's anonymous PostHog telemetry — what's sent, what isn't, and how to opt out (`DO_NOT_TRACK` / `BAML_TELEMETRY`). Everything here is taken straight from `baml_cli/src/telemetry.rs`, so it just surfaces the existing behavior; no code changes.

I've left it as a **draft** because you'll know best where this belongs — README is the most discoverable spot, but if you'd rather it live as a dedicated page under `fern/` (or worded differently, or scoped to specific fields), just say the word and I'll move/adjust it. Happy to match whatever you prefer.

---

*Disclosure: I used an AI tool to help draft this; I verified every claim against `telemetry.rs` myself and take responsibility for it. Keeping it human-reviewed and scoped, per your contributing guide.*
