### PR TITLE
feat(beps): nested pages via parentSlug (one level)

### DIFF
--- a/typescript/apps/beps/README.md
+++ b/typescript/apps/beps/README.md
@@ -778,7 +778,9 @@ BEP-001/
 ├── README.md                 # Main content with inline comments embedded
 ├── pages/
 │   ├── background.md         # Additional pages with comments
-│   └── tooling.md
+│   ├── tooling.md
+│   └── background/           # One level of nesting supported
+│       └── research.md       # Child of the "background" page (parentSlug)
 ├── AGENT_CONTEXT.md          # AI-friendly summary
 ├── metadata.json             # Machine-readable metadata
 ├── discussion/

--- a/typescript/apps/beps/convex/beps.ts
+++ b/typescript/apps/beps/convex/beps.ts
@@ -276,6 +276,7 @@ export const create = mutation({
           slug: v.string(),
           title: v.string(),
           content: v.string(),
+          parentSlug: v.optional(v.string()),
         })
       )
     ),
@@ -316,6 +317,7 @@ export const create = mutation({
       title: string;
       content: string;
       order: number;
+      parentSlug?: string;
     }> = [];
 
     if (args.pages && args.pages.length > 0) {
@@ -327,6 +329,7 @@ export const create = mutation({
           title: page.title,
           content: page.content,
           order: i,
+          parentSlug: page.parentSlug,
           createdAt: now,
           updatedAt: now,
         });
@@ -335,6 +338,7 @@ export const create = mutation({
           title: page.title,
           content: page.content,
           order: i,
+          parentSlug: page.parentSlug,
         });
       }
     }
@@ -373,6 +377,7 @@ export const update = mutation({
           title: v.string(),
           content: v.string(),
           order: v.number(),
+          parentSlug: v.optional(v.string()),
         })
       )
     ),
@@ -421,6 +426,7 @@ export const update = mutation({
             title: page.title,
             content: page.content,
             order: page.order,
+            parentSlug: page.parentSlug,
             updatedAt: now,
           });
         } else {
@@ -431,6 +437,7 @@ export const update = mutation({
             title: page.title,
             content: page.content,
             order: page.order,
+            parentSlug: page.parentSlug,
             createdAt: now,
             updatedAt: now,
           });
@@ -449,6 +456,7 @@ export const update = mutation({
       title: p.title,
       content: p.content,
       order: p.order,
+      parentSlug: p.parentSlug,
     }));
 
     // Get the latest version for this BEP
@@ -554,6 +562,7 @@ export const createPage = mutation({
     slug: v.string(),
     title: v.string(),
     content: v.string(),
+    parentSlug: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -575,6 +584,7 @@ export const createPage = mutation({
       title: args.title,
       content: args.content,
       order: maxOrder + 1,
+      parentSlug: args.parentSlug,
       createdAt: now,
       updatedAt: now,
     });
@@ -592,6 +602,7 @@ export const updatePage = mutation({
     title: v.optional(v.string()),
     content: v.optional(v.string()),
     slug: v.optional(v.string()),
+    parentSlug: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const page = await ctx.db.get(args.pageId);
@@ -603,6 +614,7 @@ export const updatePage = mutation({
     if (args.title !== undefined) updates.title = args.title;
     if (args.content !== undefined) updates.content = args.content;
     if (args.slug !== undefined) updates.slug = args.slug;
+    if (args.parentSlug !== undefined) updates.parentSlug = args.parentSlug;
 
     await ctx.db.patch(args.pageId, updates);
 
@@ -659,6 +671,7 @@ export const importVersion = mutation({
         slug: v.string(),
         title: v.string(),
         content: v.string(),
+        parentSlug: v.optional(v.string()),
       })
     ),
     editNote: v.optional(v.string()),
@@ -710,6 +723,7 @@ export const importVersion = mutation({
       title: string;
       content: string;
       order: number;
+      parentSlug?: string;
     }> = [];
 
     // Create a set of imported page slugs for efficient lookup
@@ -733,6 +747,7 @@ export const importVersion = mutation({
         await ctx.db.patch(existingPage._id, {
           title: importedPage.title,
           content: importedPage.content,
+          parentSlug: importedPage.parentSlug,
           updatedAt: now,
         });
         processedPages.push({
@@ -740,6 +755,7 @@ export const importVersion = mutation({
           title: importedPage.title,
           content: importedPage.content,
           order: existingPage.order,
+          parentSlug: importedPage.parentSlug,
         });
       } else {
         // Create new page with incremental order
@@ -750,6 +766,7 @@ export const importVersion = mutation({
           title: importedPage.title,
           content: importedPage.content,
           order: maxOrder,
+          parentSlug: importedPage.parentSlug,
           createdAt: now,
           updatedAt: now,
         });
@@ -758,6 +775,7 @@ export const importVersion = mutation({
           title: importedPage.title,
           content: importedPage.content,
           order: maxOrder,
+          parentSlug: importedPage.parentSlug,
         });
       }
     }

--- a/typescript/apps/beps/convex/export.ts
+++ b/typescript/apps/beps/convex/export.ts
@@ -65,6 +65,7 @@ export const getAllBepsForExport = query({
             title: p.title,
             content: p.content,
             order: p.order,
+            parentSlug: p.parentSlug,
           })),
         };
       })

--- a/typescript/apps/beps/convex/schema.ts
+++ b/typescript/apps/beps/convex/schema.ts
@@ -125,6 +125,7 @@ export default defineSchema({
       title: v.string(),
       content: v.string(),
       order: v.number(),
+      parentSlug: v.optional(v.string()),              // Slug of the parent page (one level of nesting)
     }))),
 
     // Legacy fields (will be removed after migration)
@@ -151,6 +152,7 @@ export default defineSchema({
     title: v.string(),
     content: v.string(),
     order: v.number(),
+    parentSlug: v.optional(v.string()),                // Slug of the parent page (one level of nesting, e.g. "design")
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/typescript/apps/beps/src/app/api/agent/beps/route.ts
+++ b/typescript/apps/beps/src/app/api/agent/beps/route.ts
@@ -265,6 +265,7 @@ interface CreateBepRequest {
     slug: string;
     title: string;
     content: string;
+    parentSlug?: string;
   }>;
   shepherds?: string[];
 }
@@ -317,6 +318,9 @@ export async function POST(request: NextRequest): Promise<Response> {
       }
       if (!page.content || typeof page.content !== "string") {
         return jsonResponse({ error: `Page ${i}: missing or invalid 'content'.` }, 400);
+      }
+      if (page.parentSlug !== undefined && typeof page.parentSlug !== "string") {
+        return jsonResponse({ error: `Page ${i}: 'parentSlug' must be a string.` }, 400);
       }
     }
   }
@@ -378,6 +382,7 @@ interface UpdateBepRequest {
     slug: string;
     title: string;
     content: string;
+    parentSlug?: string;
   }>;
   editNote?: string;
   versionMode?: "new" | "current";
@@ -436,6 +441,9 @@ export async function PUT(request: NextRequest): Promise<Response> {
       }
       if (!page.content || typeof page.content !== "string") {
         return jsonResponse({ error: `Page ${i}: missing or invalid 'content'.` }, 400);
+      }
+      if (page.parentSlug !== undefined && typeof page.parentSlug !== "string") {
+        return jsonResponse({ error: `Page ${i}: 'parentSlug' must be a string.` }, 400);
       }
     }
   }

--- a/typescript/apps/beps/src/components/bep/bep-import-dialog.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-import-dialog.tsx
@@ -50,6 +50,7 @@ interface ParsedFile {
   content: string;
   extractedTitle?: string;
   slug?: string;
+  parentSlug?: string; // set when the file lives in a subdirectory of pages/
   isNew?: boolean; // true if this page doesn't exist yet
   error?: string;
 }
@@ -112,13 +113,21 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
 
         // Determine file type based on path
         const isReadme = innerPath.toLowerCase() === "readme.md";
-        const isPage = innerPath.toLowerCase().startsWith("pages/") &&
-          pathParts.length === 3; // Only direct children of pages/
+        // Direct children of pages/ (pages/foo.md) or one level of nesting
+        // (pages/design/api.md → parentSlug "design")
+        const inPagesDir = innerPath.toLowerCase().startsWith("pages/");
+        const isPage = inPagesDir && pathParts.length === 3;
+        const isNestedPage = inPagesDir && pathParts.length === 4;
 
-        // Skip files that aren't README or in pages/
-        if (!isReadme && !isPage) {
+        // Skip files that aren't README or in pages/ (deeper nesting is unsupported)
+        if (!isReadme && !isPage && !isNestedPage) {
           continue;
         }
+
+        // Parent slug comes from the subdirectory name
+        const parentSlug = isNestedPage
+          ? sanitizeSlug(pathParts[2])
+          : undefined;
 
         try {
           const text = await file.text();
@@ -156,10 +165,11 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
             const result = parseImportedPage(text, file.name);
             if (!hasContent(result.content)) {
               parsed.push({
-                name: `pages/${file.name}`,
+                name: innerPath,
                 type: "page",
                 content: "",
                 slug: result.slug,
+                parentSlug,
                 error: "No content after stripping comments",
               });
               continue;
@@ -168,28 +178,43 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
             const slug = sanitizeSlug(file.name);
             if (!slug) {
               parsed.push({
-                name: `pages/${file.name}`,
+                name: innerPath,
                 type: "page",
                 content: result.content,
+                parentSlug,
                 error: "Invalid filename for page slug",
               });
               continue;
             }
             if (isReservedPageSlug(slug)) {
               parsed.push({
-                name: `pages/${file.name}`,
+                name: innerPath,
                 type: "page",
                 content: result.content,
+                parentSlug,
                 error: `Slug "${slug}" is reserved for app routes`,
               });
               continue;
             }
+            // Slugs are unique per BEP, so the same filename in two
+            // subdirectories would collide
+            if (parsed.some((p) => p.type === "page" && !p.error && p.slug === slug)) {
+              parsed.push({
+                name: innerPath,
+                type: "page",
+                content: result.content,
+                parentSlug,
+                error: `Duplicate slug "${slug}" (same filename in another folder?)`,
+              });
+              continue;
+            }
             parsed.push({
-              name: `pages/${file.name}`,
+              name: innerPath,
               type: "page",
               content: result.content,
               extractedTitle: result.title,
               slug,
+              parentSlug,
               isNew: !existingPageSlugs.has(slug),
             });
           }
@@ -250,6 +275,7 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
           slug: p.slug!,
           title: p.extractedTitle || p.slug!,
           content: p.content,
+          parentSlug: p.parentSlug,
         })),
         editNote: editNote || undefined,
         userId: userId as Id<"users">,
@@ -426,7 +452,8 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
             </div>
             <p className="text-xs text-muted-foreground mt-1">
               Select the exported BEP folder (e.g., BEP-001). Will import
-              README.md and files from pages/.
+              README.md and files from pages/, including one level of
+              subfolders (e.g., pages/design/api.md).
             </p>
           </div>
 
@@ -505,7 +532,9 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
                   >
                     <div className="flex items-center gap-2">
                       <FileText className="h-4 w-4 text-destructive/70" />
-                      <span className="font-medium text-destructive">pages/{page.slug}.md</span>
+                      <span className="font-medium text-destructive">
+                        pages/{page.parentSlug ? `${page.parentSlug}/` : ""}{page.slug}.md
+                      </span>
                       <Badge variant="outline" className="font-mono text-xs text-destructive border-destructive/50">
                         {page.slug}
                       </Badge>

--- a/typescript/apps/beps/src/components/bep/bep-nav.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-nav.tsx
@@ -10,6 +10,7 @@ interface Section {
   id: string;
   title: string;
   hasContent: boolean;
+  parentSlug?: string;
 }
 
 type PageStatus = "modified" | "new" | "deleted";
@@ -83,10 +84,26 @@ export function BepNav({
   pageStatuses = {},
   onAddPage,
 }: BepNavProps) {
+  // Arrange sections as a tree: children (parentSlug) render under their
+  // parent, indented. Children whose parent isn't visible stay at top level.
+  const visibleSections = sections.filter(
+    (s) => s.hasContent || pageStatuses[s.id] === "new"
+  );
+  const visibleIds = new Set(visibleSections.map((s) => s.id));
+  const orderedSections: Array<Section & { depth: number }> = [];
+  for (const section of visibleSections) {
+    if (section.parentSlug && visibleIds.has(section.parentSlug)) continue;
+    orderedSections.push({ ...section, depth: 0 });
+    for (const child of visibleSections) {
+      if (child.parentSlug === section.id) {
+        orderedSections.push({ ...child, depth: 1 });
+      }
+    }
+  }
+
   return (
     <nav className="space-y-1">
-      {sections
-        .filter((s) => s.hasContent || pageStatuses[s.id] === "new")
+      {orderedSections
         .map((section) => {
           const status = pageStatuses[section.id];
           const isDeleted = status === "deleted";
@@ -102,7 +119,8 @@ export function BepNav({
                 activeSection === section.id
                   ? "bg-accent text-accent-foreground font-medium"
                   : "text-muted-foreground",
-                isDeleted && "opacity-50 line-through"
+                isDeleted && "opacity-50 line-through",
+                section.depth > 0 && "ml-4 border-l pl-3"
               )}
             >
               <span className="flex items-center justify-between gap-2">

--- a/typescript/apps/beps/src/components/bep/bep-nav.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-nav.tsx
@@ -92,10 +92,17 @@ export function BepNav({
   const visibleIds = new Set(visibleSections.map((s) => s.id));
   const orderedSections: Array<Section & { depth: number }> = [];
   for (const section of visibleSections) {
-    if (section.parentSlug && visibleIds.has(section.parentSlug)) continue;
+    // Self-referential pages (parentSlug === own id) render at top level
+    if (
+      section.parentSlug &&
+      section.parentSlug !== section.id &&
+      visibleIds.has(section.parentSlug)
+    ) {
+      continue;
+    }
     orderedSections.push({ ...section, depth: 0 });
     for (const child of visibleSections) {
-      if (child.parentSlug === section.id) {
+      if (child.id !== section.id && child.parentSlug === section.id) {
         orderedSections.push({ ...child, depth: 1 });
       }
     }

--- a/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
@@ -716,6 +716,7 @@ const [copied, setCopied] = useState(false);
           id: p.slug,
           title: p.title,
           hasContent: !!p.content,
+          parentSlug: p.parentSlug,
         })),
       ]
     : [
@@ -729,6 +730,7 @@ const [copied, setCopied] = useState(false);
           id: p.slug,
           title: p.title,
           hasContent: !!p.content,
+          parentSlug: p.parentSlug,
         })),
         ...newPages.map((p) => ({
           id: p.slug,

--- a/typescript/apps/beps/src/lib/export-all-utils.ts
+++ b/typescript/apps/beps/src/lib/export-all-utils.ts
@@ -33,6 +33,17 @@ export interface ExportAllPage {
   title: string;
   content: string;
   order: number;
+  parentSlug?: string;
+}
+
+/**
+ * Relative path of a page file within a BEP folder.
+ * Nested pages live in a subfolder named after their parent slug.
+ */
+function pagePath(page: { slug: string; parentSlug?: string }): string {
+  return page.parentSlug
+    ? `pages/${page.parentSlug}/${page.slug}.md`
+    : `pages/${page.slug}.md`;
 }
 
 export interface ExportAllData {
@@ -294,6 +305,7 @@ export interface BepMetadata {
     slug: string;
     title: string;
     order: number;
+    parentSlug?: string;
   }>;
 }
 
@@ -313,6 +325,7 @@ export function generateBepMetaJson(bep: ExportAllBep): string {
       slug: p.slug,
       title: p.title,
       order: p.order,
+      ...(p.parentSlug ? { parentSlug: p.parentSlug } : {}),
     })),
   };
   return JSON.stringify(metadata, null, 2);
@@ -352,11 +365,30 @@ export function generateBepReadme(bep: ExportAllBep): string {
     md += `# ${bepNum}: ${bep.title}\n\n*No content available.*\n`;
   }
 
-  // Link to additional pages if any
+  // Link to additional pages if any (children listed under their parent)
   if (bep.pages.length > 0) {
     md += `\n\n---\n\n## Additional Pages\n\n`;
+    const childrenByParent = new Map<string, ExportAllPage[]>();
     for (const page of bep.pages) {
-      md += `- [${page.title}](./pages/${page.slug}.md)\n`;
+      if (page.parentSlug) {
+        const list = childrenByParent.get(page.parentSlug) ?? [];
+        list.push(page);
+        childrenByParent.set(page.parentSlug, list);
+      }
+    }
+    for (const page of bep.pages) {
+      if (page.parentSlug) continue;
+      md += `- [${page.title}](./${pagePath(page)})\n`;
+      for (const child of childrenByParent.get(page.slug) ?? []) {
+        md += `  - [${child.title}](./${pagePath(child)})\n`;
+      }
+    }
+    // Children whose parent slug doesn't match any page
+    for (const [parentSlug, children] of childrenByParent) {
+      if (bep.pages.some((p) => !p.parentSlug && p.slug === parentSlug)) continue;
+      for (const child of children) {
+        md += `- [${child.title}](./${pagePath(child)})\n`;
+      }
     }
   }
 
@@ -419,8 +451,25 @@ BEP-001-your-proposal-slug/
 ├── README.md           # Main proposal content
 └── pages/              # Additional pages (addenda)
     ├── background.md
-    └── examples.md
+    ├── examples.md
+    └── design/         # One level of nesting is supported
+        ├── api.md      # Becomes a child of the "design" page
+        └── schema.md
 \`\`\`
+
+### Page Hierarchy
+
+Pages support **one level of nesting**: a markdown file inside a subfolder of
+\`pages/\` (e.g., \`pages/design/api.md\`) is imported as a child of the page
+whose slug matches the folder name (\`design\`). In the API this is expressed
+with the optional \`parentSlug\` field on a page object.
+
+Rules:
+- Slugs are unique per BEP, even across folders — \`pages/a/notes.md\` and
+  \`pages/b/notes.md\` would collide.
+- The parent folder name should match an existing top-level page slug so the
+  child nests under it in the UI; otherwise the child is shown at top level.
+- Folders deeper than one level are not supported and will be skipped on import.
 
 ---
 
@@ -510,6 +559,12 @@ curl -X POST "${apiBaseUrl}/api/agent/beps" \\
         "slug": "background",
         "title": "Background Research",
         "content": "# Background\\n\\nDetailed research..."
+      },
+      {
+        "slug": "api",
+        "title": "API Details",
+        "content": "# API Details\\n\\n...",
+        "parentSlug": "background"
       }
     ]
   }'
@@ -582,9 +637,10 @@ Downloads all BEPs as a ZIP archive. No authentication required.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| \`slug\` | Yes | URL-safe identifier (e.g., \`"background"\`) |
+| \`slug\` | Yes | URL-safe identifier (e.g., \`"background"\`), unique per BEP |
 | \`title\` | Yes | Display title |
 | \`content\` | Yes | Full markdown content |
+| \`parentSlug\` | No | Slug of the parent page to nest under (one level) |
 
 ### Update (PUT /api/agent/beps)
 
@@ -732,7 +788,7 @@ export function generateAllBepsExportFiles(data: ExportAllData, apiBaseUrl: stri
     // Additional pages
     for (const page of bep.pages) {
       files.push({
-        path: `${bepFolder}/pages/${page.slug}.md`,
+        path: `${bepFolder}/${pagePath(page)}`,
         content: generatePageMd(page),
       });
     }

--- a/typescript/apps/beps/src/lib/export-utils.ts
+++ b/typescript/apps/beps/src/lib/export-utils.ts
@@ -24,6 +24,17 @@ export interface ExportPage {
   title: string;
   content: string;
   order: number;
+  parentSlug?: string;
+}
+
+/**
+ * Relative path of a page file within the export bundle.
+ * Nested pages live in a subfolder named after their parent slug.
+ */
+export function pageExportPath(page: { slug: string; parentSlug?: string }): string {
+  return page.parentSlug
+    ? `pages/${page.parentSlug}/${page.slug}.md`
+    : `pages/${page.slug}.md`;
 }
 
 export interface ExportComment {
@@ -84,6 +95,7 @@ export interface ExportVersion {
     title: string;
     content: string;
     order: number;
+    parentSlug?: string;
   }>;
   editorName: string;
   editNote?: string;
@@ -328,7 +340,7 @@ export function generateReadme(data: ExportData): string {
   if (pages.length > 0) {
     md += `---\n\n## Additional Pages\n\n`;
     for (const page of pages) {
-      md += `- [${page.title}](pages/${page.slug}.md)\n`;
+      md += `- [${page.title}](${pageExportPath(page)})\n`;
     }
     md += `\n`;
   }
@@ -803,7 +815,7 @@ export function generateMetadataJson(data: ExportData): string {
     files: [
       "README.md",
       "AGENT_CONTEXT.md",
-      ...pages.map((p) => `pages/${p.slug}.md`),
+      ...pages.map((p) => pageExportPath(p)),
       "discussion/issues.md",
       "discussion/decisions.md",
       "history/versions.md",
@@ -873,7 +885,7 @@ ${contentSummary}${contentSummary.length >= 500 ? "..." : ""}
 ## Pages
 
 - Main Content (README.md) - includes current version comments only
-${pages.length > 0 ? pages.map((p) => `- ${p.title} (pages/${p.slug}.md)`).join("\n") : ""}
+${pages.length > 0 ? pages.map((p) => `- ${p.title} (${pageExportPath(p)})`).join("\n") : ""}
 
 ## Comment Overview
 
@@ -924,7 +936,7 @@ ${bepNum}/
 ├── AGENT_CONTEXT.md        # This file
 ├── metadata.json           # Machine-readable metadata${pages.length > 0 ? `
 ├── pages/                  # Additional pages + v${currentVersion} comments
-${pages.map((p) => `│   └── ${p.slug}.md`).join("\n")}` : ""}
+${pages.map((p) => `│   └── ${p.parentSlug ? `${p.parentSlug}/` : ""}${p.slug}.md`).join("\n")}` : ""}
 ├── discussion/
 │   ├── issues.md           # Open and resolved issues
 │   └── decisions.md        # Recorded decisions
@@ -996,9 +1008,10 @@ export function generateAllExportFiles(data: ExportData): ExportFile[] {
       title: page.title,
       slug: page.slug,
       order: page.order,
+      ...(page.parentSlug ? { parent: page.parentSlug } : {}),
     });
     files.push({
-      path: `pages/${page.slug}.md`,
+      path: pageExportPath(page),
       content: `${pageFrontmatter}# ${page.title}\n\n${contentWithComments}\n`,
     });
   }


### PR DESCRIPTION
## Summary

The `pages/` folder in a BEP was strictly flat: the importer only accepted direct children of `pages/`, and the `bepPages` table had no way to represent hierarchy. This PR adds **one level of page nesting** end to end:

- **Schema**: new optional `parentSlug` on `bepPages` and on `bepVersions.pagesSnapshot` entries (backwards compatible — existing rows are untouched).
- **Convex mutations**: `create`, `update`, `importVersion`, `createPage`, `updatePage` all accept and persist `parentSlug`, including version snapshots.
- **Folder import dialog**: `pages/<dir>/<file>.md` now imports with `parentSlug = <dir>`. Duplicate basenames across folders are flagged as errors (slugs remain unique per BEP). Folders deeper than one level are still skipped.
- **Agent API** (`POST`/`PUT /api/agent/beps`): page objects accept an optional `parentSlug` string.
- **Exports** (single-BEP zip and all-BEPs pull bundle): nested pages are written to `pages/<parent>/<slug>.md`, README "Additional Pages" lists group children under their parent, `meta.json`/`metadata.json` include `parentSlug`, so export → import round-trips the hierarchy.
- **NEW-BEP/INSTRUCTIONS.md**: documents the directory hierarchy, `parentSlug` API field, and the rules (unique slugs, one level max, parent folder should match a page slug).
- **Left nav**: pages with a `parentSlug` render indented under their parent (children whose parent isn't visible fall back to top level), in both current and historical version views.

## Verification

- `tsc --noEmit` clean; eslint on changed files shows only pre-existing warnings.
- Runtime check of export generation: parent/child/orphan pages produce grouped README links and `pages/design/api.md`-style paths that round-trip through the importer's path parsing.

## Notes / follow-ups

- The "Add page" modal doesn't yet expose a parent picker — nesting is currently reachable via import and the agent API. Easy follow-up if wanted.
- Only one level of nesting is supported by design, matching the flat slug-uniqueness model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Optional schema field is backward compatible, but import replaces pages by slug and nested paths change export layout; in-app edit submit may not forward parentSlug on save (not changed in this PR).
> 
> **Overview**
> Adds **one level of page nesting** across storage, APIs, import/export, and navigation via optional **`parentSlug`**.
> 
> **Data & backend:** `bepPages` and version `pagesSnapshot` gain optional `parentSlug`. Create/update/import/page mutations and bulk export queries persist it in snapshots.
> 
> **Import & agent API:** Folder import treats `pages/<parent>/<slug>.md` as a child (`parentSlug` = folder name), rejects duplicate slugs across folders, and skips deeper paths. `POST`/`PUT /api/agent/beps` accept optional `parentSlug` with validation.
> 
> **Export:** Single-BEP and all-BEPs bundles write nested files under `pages/<parent>/<slug>.md`, group README links, and include `parentSlug` in metadata so export → import round-trips.
> 
> **UI:** Left nav indents children under their parent (orphans stay top-level). Import preview shows nested paths for pages slated for removal.
> 
> **Docs:** README export layout and `NEW-BEP/INSTRUCTIONS.md` document hierarchy rules (unique slugs, one level max). In-app “Add page” still has no parent picker—nesting is via import/API only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3b010fd3971c610b38ae911a84d98c3b7fdec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for one level of nested BEP pages and folders via an optional parent page reference.
  * Nested pages now render in navigation as a simple two-level hierarchy.
  * Markdown import and BEP export preserve nested page paths and relationships.
  * Exported docs/metadata and generated file structures now reflect nested page locations.
  * BEP create/update API requests accept the optional parent page field with validation.

* **Documentation**
  * Updated BEP export/import guidance with revised “Export Format” folder-tree examples for one-level nesting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->