### PR TITLE
fix(docs): unreadable Ask Baaaml chat text in dark mode

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -66,6 +66,22 @@ span:not(a span) {
   color: rgba(237, 237, 237, 0.9);
 }
 
+/* The Ask Baaaml chatbot (#fern-chatbot-root) and custom search (#baml-search-wrap)
+   style themselves inline with a light theme. Without this guard, the global
+   text-color rules above wash out their text in dark mode (near-white on white). */
+#fern-chatbot-root p,
+#fern-chatbot-root ul,
+#fern-chatbot-root h1,
+#fern-chatbot-root h2,
+#fern-chatbot-root h3,
+#fern-chatbot-root h4,
+#fern-chatbot-root h5,
+#fern-chatbot-root h6,
+#fern-chatbot-root span:not(a span),
+#baml-search-wrap span:not(a span) {
+  color: inherit;
+}
+
 /* Background Colors */
 .dark body {
   background-color: var(--background) !important;

--- a/typescript/apps/ask-baml-client/src/ChatBot.tsx
+++ b/typescript/apps/ask-baml-client/src/ChatBot.tsx
@@ -541,7 +541,7 @@ const ChatBot: React.FC<{}> = () => {
                     animation: 'pulse 1.5s ease-in-out infinite 0.4s',
                   }}
                 />
-                <span>Thinking...</span>
+                <span style={{ color: 'inherit' }}>Thinking...</span>
               </div>
             );
           }
@@ -616,7 +616,9 @@ const ChatBot: React.FC<{}> = () => {
                     components={{
                       // Custom styles for markdown elements
                       p: ({ children }) => (
-                        <p style={{ margin: '0 0 12px 0', lineHeight: '1.6' }}>{children}</p>
+                        <p style={{ margin: '0 0 12px 0', lineHeight: '1.6', color: 'inherit' }}>
+                          {children}
+                        </p>
                       ),
                       h1: ({ children }) => (
                         <h1
@@ -708,6 +710,7 @@ const ChatBot: React.FC<{}> = () => {
                             margin: '0 0 12px 0',
                             paddingLeft: '20px',
                             listStyleType: 'disc',
+                            color: 'inherit',
                           }}
                         >
                           {children}


### PR DESCRIPTION
## What's broken

In dark mode, the Ask Baaaml chat on the docs site is basically unreadable — answers render as near-white text on the widget's white bubbles. Repro: open any docs page (e.g. https://docs.boundaryml.com/agents-md/claude-code) in dark mode and ask the chat anything.

## Root cause

**It's the docs custom CSS leaking into the widget** — `fern/assets/styles.css` has global element selectors for dark mode:

```css
.dark p, .dark ul, .dark h1, ... .dark span:not(a span) {
  color: rgba(237, 237, 237, 0.9);
}
```

These match every bare `p`/`ul`/`span` on the page, including the markdown the chat widget renders. The widget (`typescript/apps/ask-baml-client`) styles itself with hardcoded light-theme inline styles, but inline styles only protect the properties set on that exact element — children that rely on *inherited* color lose to any stylesheet rule that matches them directly. So the docs' near-white dark-mode text color wins inside the white chat bubbles.

## The fix (both sides)

- **`fern/assets/styles.css`** — added an ID-scoped guard right after the global rules: descendants of `#fern-chatbot-root` (chat) and `#baml-search-wrap` (search) get `color: inherit`, so they follow the widget's own colors again. ID specificity beats the `.dark` class rules, in both themes.
- **`typescript/apps/ask-baml-client/src/ChatBot.tsx`** — set explicit `color: 'inherit'` on the markdown `p`/`ul` components and the "Thinking..." span, so the widget stays readable even if another global selector shows up later.

No `fern/custom.js` committed — that's gitignored and CI rebuilds it from source on every docs publish.

## Before / After

| Before (dark mode) | After (fix, local preview) |
| --- | --- |
| ![Ask Baaaml chat with washed-out, unreadable text in dark mode](https://raw.githubusercontent.com/ashley-ha/baml/ask-baml-dark-fix-assets/before-dark-mode.png) | ![Ask Baaaml chat with readable dark text after the fix](https://raw.githubusercontent.com/ashley-ha/baml/ask-baml-dark-fix-assets/after-dark-mode.png) |

## Testing

- Rebuilt the widget (`pnpm run build` in `typescript/apps/ask-baml-client`) and confirmed the new inline styles land in the generated `fern/custom.js`.
- Ran the docs locally with `fern docs dev` and verified the chat text is readable in dark mode with the rebuilt bundle — that's the "after" screenshot.
- The Fern preview URL CI posts on this PR is the full end-to-end check.

Worth noting: the widget has no dark theme at all (the panel itself stays light). A proper dark theme for the chat panel would be a follow-up — this PR just makes the text readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text color consistency in the chatbot and search interfaces, especially when using dark mode.
  * Updated assistant progress messages, paragraphs, and lists to inherit the surrounding theme’s text color.
  * Prevented headings, lists, paragraphs, and non-link text from appearing washed out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->