### PR TITLE
fix(beps): sidebar scrolling, TOC anchor clicks, and update-API title bug

### DIFF
--- a/typescript/apps/beps/convex/beps.ts
+++ b/typescript/apps/beps/convex/beps.ts
@@ -665,14 +665,18 @@ export const reorderPages = mutation({
 export const importVersion = mutation({
   args: {
     bepId: v.id("beps"),
-    content: v.string(), // Clean main content (README)
-    pages: v.array(
-      v.object({
-        slug: v.string(),
-        title: v.string(),
-        content: v.string(),
-        parentSlug: v.optional(v.string()),
-      })
+    title: v.optional(v.string()), // New BEP title (kept unchanged when omitted)
+    content: v.optional(v.string()), // Clean main content (kept unchanged when omitted)
+    // Omitted = keep existing pages unchanged. An empty array deletes all pages.
+    pages: v.optional(
+      v.array(
+        v.object({
+          slug: v.string(),
+          title: v.string(),
+          content: v.string(),
+          parentSlug: v.optional(v.string()),
+        })
+      )
     ),
     editNote: v.optional(v.string()),
     userId: v.id("users"),
@@ -697,9 +701,12 @@ export const importVersion = mutation({
     const newVersionNumber = (latestVersion?.version ?? 0) + 1;
     const now = Date.now();
 
-    // 3. Update BEP's main content
+    // 3. Update BEP's main content (omitted fields keep their current values)
+    const newTitle = args.title?.trim() || bep.title;
+    const newContent = args.content ?? bep.content ?? "";
     await ctx.db.patch(args.bepId, {
-      content: args.content,
+      title: newTitle,
+      content: newContent,
       updatedAt: now,
     });
 
@@ -726,8 +733,19 @@ export const importVersion = mutation({
       parentSlug?: string;
     }> = [];
 
+    // When pages is omitted entirely, keep the existing pages untouched and
+    // snapshot them as-is. An explicit array (even empty) replaces the set.
+    const importedPages =
+      args.pages ??
+      existingPages.map((p) => ({
+        slug: p.slug,
+        title: p.title,
+        content: p.content,
+        parentSlug: p.parentSlug,
+      }));
+
     // Create a set of imported page slugs for efficient lookup
-    const importedSlugs = new Set(args.pages.map((p) => p.slug));
+    const importedSlugs = new Set(importedPages.map((p) => p.slug));
 
     // Delete existing pages that are not in the import bundle
     // This ensures the new version fully replaces the old content
@@ -739,7 +757,7 @@ export const importVersion = mutation({
       }
     }
 
-    for (const importedPage of args.pages) {
+    for (const importedPage of importedPages) {
       const existingPage = existingPagesBySlug.get(importedPage.slug);
 
       if (existingPage) {
@@ -783,10 +801,10 @@ export const importVersion = mutation({
     // Sort by order for the snapshot
     processedPages.sort((a, b) => a.order - b.order);
 
-    const pagesCreated = args.pages.filter(
+    const pagesCreated = importedPages.filter(
       (p) => !existingPagesBySlug.has(p.slug)
     ).length;
-    const pagesUpdated = args.pages.filter((p) =>
+    const pagesUpdated = importedPages.filter((p) =>
       existingPagesBySlug.has(p.slug)
     ).length;
 
@@ -795,8 +813,8 @@ export const importVersion = mutation({
       const versionId = await ctx.db.insert("bepVersions", {
         bepId: args.bepId,
         version: newVersionNumber,
-        title: bep.title, // Keep the existing title
-        content: args.content,
+        title: newTitle,
+        content: newContent,
         pagesSnapshot: processedPages.length > 0 ? processedPages : undefined,
         editedBy: args.userId,
         editNote: args.editNote ?? "Imported from markdown",
@@ -835,8 +853,8 @@ export const importVersion = mutation({
 
     const versionId = latestVersion._id;
     await ctx.db.patch(latestVersion._id, {
-      title: bep.title,
-      content: args.content,
+      title: newTitle,
+      content: newContent,
       pagesSnapshot: processedPages.length > 0 ? processedPages : undefined,
       editedBy: args.userId,
       editNote: args.editNote ?? latestVersion.editNote,

--- a/typescript/apps/beps/src/app/api/agent/beps/route.ts
+++ b/typescript/apps/beps/src/app/api/agent/beps/route.ts
@@ -481,8 +481,11 @@ export async function PUT(request: NextRequest): Promise<Response> {
   try {
     const result = await convex.mutation(api.beps.importVersion, {
       bepId: targetBep._id as Id<"beps">,
-      content: body.content ?? "",
-      pages: body.pages ?? [],
+      title: body.title,
+      // Omitted fields keep their current values (importVersion treats
+      // undefined as "leave unchanged"); pages: [] would delete all pages.
+      content: body.content,
+      pages: body.pages,
       editNote: body.editNote,
       userId: user._id as Id<"users">,
       versionMode: body.versionMode ?? "new",

--- a/typescript/apps/beps/src/components/bep/bep-content.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-content.tsx
@@ -7,7 +7,13 @@ import { ShikiCodeBlock } from "@/components/ui/shiki-code-block";
 import Link from "next/link";
 import { ReactNode, isValidElement, useMemo } from "react";
 import type { Components } from "react-markdown";
+import type { Element } from "hast";
 import { BepLinkContext, resolveBepLink } from "@/lib/bep-link-resolver";
+import {
+  extractHeadings,
+  slugifyHeading,
+  stripFrontmatter,
+} from "@/lib/heading-utils";
 
 interface BepContentProps {
   content: string;
@@ -44,24 +50,50 @@ function getHeadingText(children: ReactNode): string {
   return "";
 }
 
-function slugifyHeading(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, "")
-    .replace(/[\s_]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
+/**
+ * Deterministic heading-id lookup, precomputed from the raw markdown.
+ *
+ * Ids must not depend on render order or count: react-markdown re-invokes
+ * the heading components on every re-render, so a mutable dedup counter in
+ * a closure drifts (summary → summary-2 → …) and breaks TOC anchors. We
+ * key by source line (exact) with heading text as a fallback.
+ */
+interface HeadingIdLookup {
+  byLine: Map<number, string>;
+  byText: Map<string, string>;
+}
+
+function buildHeadingIdLookup(content: string): HeadingIdLookup {
+  const byLine = new Map<number, string>();
+  const byText = new Map<string, string>();
+  for (const heading of extractHeadings(content)) {
+    byLine.set(heading.line, heading.id);
+    // First occurrence wins for the text fallback
+    if (!byText.has(heading.text)) {
+      byText.set(heading.text, heading.id);
+    }
+  }
+  return { byLine, byText };
 }
 
 function createHeadingComponent(
   tag: "h1" | "h2" | "h3" | "h4",
   className: string,
-  getId: (headingText: string) => string | undefined
+  lookup: HeadingIdLookup
 ): Components["h1"] {
-  const Heading = ({ children }: { children?: ReactNode }) => {
-    const headingText = getHeadingText(children);
-    const id = headingText ? getId(headingText) : undefined;
+  const Heading = ({
+    children,
+    node,
+  }: {
+    children?: ReactNode;
+    node?: Element;
+  }) => {
+    const headingText = getHeadingText(children).trim();
+    const line = node?.position?.start.line;
+    const id =
+      (line !== undefined ? lookup.byLine.get(line) : undefined) ??
+      lookup.byText.get(headingText) ??
+      (headingText ? slugifyHeading(headingText) || undefined : undefined);
     const Tag = tag;
     return (
       <Tag id={id} className={className}>
@@ -72,36 +104,30 @@ function createHeadingComponent(
   return Heading;
 }
 
-function createComponents(linkContext?: BepLinkContext): Components {
-  const slugCounts = new Map<string, number>();
-  const getUniqueId = (headingText: string) => {
-    const base = slugifyHeading(headingText);
-    if (!base) return undefined;
-    const count = (slugCounts.get(base) ?? 0) + 1;
-    slugCounts.set(base, count);
-    return count === 1 ? base : `${base}-${count}`;
-  };
-
+function createComponents(
+  lookup: HeadingIdLookup,
+  linkContext?: BepLinkContext
+): Components {
   return {
     h1: createHeadingComponent(
       "h1",
       "text-3xl font-bold mt-8 mb-4 first:mt-0 scroll-mt-24",
-      getUniqueId
+      lookup
     ),
     h2: createHeadingComponent(
       "h2",
       "text-2xl font-semibold mt-6 mb-3 pb-2 border-b border-border scroll-mt-24",
-      getUniqueId
+      lookup
     ),
     h3: createHeadingComponent(
       "h3",
       "text-xl font-semibold mt-5 mb-2 scroll-mt-24",
-      getUniqueId
+      lookup
     ),
     h4: createHeadingComponent(
       "h4",
       "text-lg font-medium mt-4 mb-2 scroll-mt-24",
-      getUniqueId
+      lookup
     ),
     pre: ({ children, node }) => {
       const codeElement = node?.children?.find(
@@ -162,13 +188,22 @@ function createComponents(linkContext?: BepLinkContext): Components {
 }
 
 export function BepContent({ content, linkContext }: BepContentProps) {
-  const components = useMemo(() => createComponents(linkContext), [linkContext]);
+  const contentWithoutFrontmatter = useMemo(
+    () => stripFrontmatter(content ?? ""),
+    [content]
+  );
+  const components = useMemo(
+    () =>
+      createComponents(
+        buildHeadingIdLookup(contentWithoutFrontmatter),
+        linkContext
+      ),
+    [contentWithoutFrontmatter, linkContext]
+  );
 
   if (!content) {
     return <div className="text-muted-foreground">No content</div>;
   }
-
-  const contentWithoutFrontmatter = content.replace(/^---[\s\S]*?---\n*/, "");
 
   return (
     <article

--- a/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
@@ -919,7 +919,8 @@ const [copied, setCopied] = useState(false);
 
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
           <aside className="lg:col-span-1">
-            <div className="sticky top-8">
+            {/* max-h + overflow so a long page list stays reachable while stuck */}
+            <div className="sticky top-8 max-h-[calc(100vh-4rem)] overflow-y-auto overscroll-contain pr-1">
               <BepNav
                 sections={allSections}
                 activeSection={activeSection}

--- a/typescript/apps/beps/src/components/bep/bep-table-of-contents.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-table-of-contents.tsx
@@ -4,51 +4,17 @@ import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { ChevronDown, ChevronUp, List } from "lucide-react";
 
-interface TocItem {
-  id: string;
-  text: string;
-  level: number;
-}
+import {
+  extractHeadings,
+  stripFrontmatter,
+  type HeadingInfo,
+} from "@/lib/heading-utils";
+
+type TocItem = HeadingInfo;
 
 interface BepTableOfContentsProps {
   content: string;
   className?: string;
-}
-
-function slugifyHeading(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, "")
-    .replace(/[\s_]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-}
-
-function extractHeadings(content: string): TocItem[] {
-  if (!content) return [];
-
-  const contentWithoutFrontmatter = content.replace(/^---[\s\S]*?---\n*/, "");
-  const headingRegex = /^(#{1,4})\s+(.+)$/gm;
-  const headings: TocItem[] = [];
-  const slugCounts = new Map<string, number>();
-
-  let match;
-  while ((match = headingRegex.exec(contentWithoutFrontmatter)) !== null) {
-    const level = match[1].length;
-    const text = match[2].trim();
-    const baseSlug = slugifyHeading(text);
-
-    if (!baseSlug) continue;
-
-    const count = (slugCounts.get(baseSlug) ?? 0) + 1;
-    slugCounts.set(baseSlug, count);
-    const id = count === 1 ? baseSlug : `${baseSlug}-${count}`;
-
-    headings.push({ id, text, level });
-  }
-
-  return headings;
 }
 
 function TocList({
@@ -96,7 +62,10 @@ export function BepTableOfContents({ content, className }: BepTableOfContentsPro
   const observerRef = useRef<IntersectionObserver | null>(null);
   const headingElementsRef = useRef<Map<string, IntersectionObserverEntry>>(new Map());
 
-  const headings = useMemo(() => extractHeadings(content), [content]);
+  const headings = useMemo(
+    () => extractHeadings(stripFrontmatter(content ?? "")),
+    [content]
+  );
 
   const getActiveHeading = useCallback(() => {
     const entries = Array.from(headingElementsRef.current.values());
@@ -144,18 +113,62 @@ export function BepTableOfContents({ content, className }: BepTableOfContentsPro
 
     const observer = observerRef.current;
 
-    headings.forEach(({ id }) => {
-      const element = document.getElementById(id);
-      if (element) {
-        observer.observe(element);
+    // The markdown renders asynchronously, so some headings may not be in
+    // the DOM yet — keep retrying until they appear (or we time out).
+    let cancelled = false;
+    const pending = new Set(headings.map((h) => h.id));
+    const deadline = Date.now() + 5000;
+    const attach = () => {
+      if (cancelled) return;
+      for (const id of pending) {
+        const element = document.getElementById(id);
+        if (element) {
+          observer.observe(element);
+          pending.delete(id);
+        }
       }
-    });
+      if (pending.size > 0 && Date.now() < deadline) {
+        requestAnimationFrame(attach);
+      }
+    };
+    attach();
 
     return () => {
+      cancelled = true;
       observer.disconnect();
       headingElements.clear();
     };
   }, [headings, getActiveHeading]);
+
+  // Honor a #hash on initial load. The markdown renders asynchronously
+  // (MarkdownHooks), so the browser's native anchor jump fires before the
+  // heading exists — retry briefly until it appears.
+  const scrolledToHashRef = useRef(false);
+  useEffect(() => {
+    if (scrolledToHashRef.current || headings.length === 0) return;
+    const hash = decodeURIComponent(window.location.hash.slice(1));
+    if (!hash || !headings.some((h) => h.id === hash)) return;
+
+    let cancelled = false;
+    const deadline = Date.now() + 3000;
+    const tryScroll = () => {
+      if (cancelled) return;
+      const element = document.getElementById(hash);
+      if (element) {
+        element.scrollIntoView({ block: "start" });
+        setActiveId(hash);
+        scrolledToHashRef.current = true;
+        return;
+      }
+      if (Date.now() < deadline) {
+        requestAnimationFrame(tryScroll);
+      }
+    };
+    tryScroll();
+    return () => {
+      cancelled = true;
+    };
+  }, [headings]);
 
   const handleClick = useCallback((id: string) => {
     const element = document.getElementById(id);

--- a/typescript/apps/beps/src/lib/heading-utils.ts
+++ b/typescript/apps/beps/src/lib/heading-utils.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared heading extraction for BEP content.
+ *
+ * Both the rendered markdown (BepContent) and the table of contents derive
+ * heading anchor ids from this module. Keeping one implementation is what
+ * guarantees TOC clicks land on an element that actually exists.
+ */
+
+export interface HeadingInfo {
+  /** Anchor id (deduped slug) */
+  id: string;
+  text: string;
+  level: number;
+  /** 1-indexed line number within the frontmatter-stripped content */
+  line: number;
+}
+
+export function stripFrontmatter(content: string): string {
+  return content.replace(/^---[\s\S]*?---\n*/, "");
+}
+
+export function slugifyHeading(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Extract headings (h1-h4) from markdown, skipping fenced code blocks so
+ * `# comment` lines inside ``` fences don't produce phantom TOC entries or
+ * shift the duplicate-slug counters.
+ *
+ * @param content - Markdown WITHOUT frontmatter (see stripFrontmatter)
+ */
+export function extractHeadings(content: string): HeadingInfo[] {
+  if (!content) return [];
+
+  const headings: HeadingInfo[] = [];
+  const slugCounts = new Map<string, number>();
+  const lines = content.split("\n");
+  let fenceMarker: string | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const fenceMatch = /^\s*(```+|~~~+)/.exec(line);
+    if (fenceMatch) {
+      if (fenceMarker === null) {
+        fenceMarker = fenceMatch[1][0].repeat(3);
+      } else if (fenceMatch[1].startsWith(fenceMarker)) {
+        fenceMarker = null;
+      }
+      continue;
+    }
+    if (fenceMarker !== null) continue;
+
+    const match = /^(#{1,4})\s+(.+)$/.exec(line);
+    if (!match) continue;
+
+    const level = match[1].length;
+    const text = match[2].trim();
+    const baseSlug = slugifyHeading(text);
+    if (!baseSlug) continue;
+
+    const count = (slugCounts.get(baseSlug) ?? 0) + 1;
+    slugCounts.set(baseSlug, count);
+    const id = count === 1 ? baseSlug : `${baseSlug}-${count}`;
+
+    headings.push({ id, text, level, line: i + 1 });
+  }
+
+  return headings;
+}


### PR DESCRIPTION
## Summary

Navigation fixes for the BEPs site, plus the agent-API bug where uploading a BEP didn't update its title.

### Left sidebar can't scroll
The nav was `sticky top-8` with no height limit, so on BEPs with many pages the list extended below the viewport and was unreachable. It now gets `max-h-[calc(100vh-4rem)] overflow-y-auto`.

### "On this page" (right panel) clicks don't scroll
Two independent causes:
1. **Heading ids drifted across re-renders.** `BepContent` generated ids with a mutable dedup counter captured in a memoized closure; react-markdown re-invokes the heading components on every parent re-render, so after the first state change ids became `summary-2`, `summary-3`, … while the TOC still computed `summary` — `getElementById` missed and nothing scrolled. Ids are now precomputed from the raw markdown and looked up by source line (with text fallback), so they're stable.
2. **Code fences produced phantom headings.** The TOC's regex matched `# comment` lines inside ``` fences (BEP content is full of code blocks), creating junk TOC entries and shifting the duplicate-slug counters out of sync with the renderer.

Both the renderer and the TOC now share one fence-aware extraction in `src/lib/heading-utils.ts`, which is the structural guarantee the anchors stay in sync.

### Async-render races
The markdown renders via `MarkdownHooks` (async), so the scroll-spy `IntersectionObserver` attached before headings existed, and opening a URL with a `#hash` never jumped to the section. Both now retry (rAF loop with a deadline) until the elements appear.

### PUT /api/agent/beps ignored `title`
Uploading a BEP updated content/pages but the site header kept the old title: the route never forwarded `body.title`, and `importVersion` hardcoded `title: bep.title`. `importVersion` now takes an optional `title` and applies it to the BEP and version snapshots.

Related latent footgun fixed: the route sent `content ?? ""` / `pages ?? []`, so a PUT with only `title` would have blanked the content and **deleted every page** — despite the API docs promising "omit `pages` → keep existing pages unchanged". Omitted `content`/`pages` now genuinely keep current values (an explicit empty array still replaces/deletes, matching docs).

## Verification

- `tsc --noEmit` clean; eslint shows only pre-existing warnings.
- Runtime test of the shared extraction: fenced `#` lines skipped, duplicate headings deduped, line numbers stable against frontmatter-stripped content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `importVersion` semantics changed for omitted vs empty `pages`/`content`, affecting agent PUT and import flows; UI changes are localized to BEP rendering/navigation.
> 
> **Overview**
> Fixes BEP reading navigation (sidebar, TOC, deep links) and corrects agent/API updates so partial PUTs no longer wipe content or ignore titles.
> 
> **Navigation:** The left nav sticky container now caps height and scrolls so long page lists stay reachable. TOC and rendered headings share **`heading-utils`** (fence-aware extraction, stable deduped ids). **`BepContent`** assigns ids from a precomputed lookup (source line + text fallback) instead of a re-render-sensitive counter. **`BepTableOfContents`** retries attaching the scroll spy and honoring `#hash` until async markdown headings exist in the DOM.
> 
> **Agent API / `importVersion`:** Optional **`title`**, **`content`**, and **`pages`**—omitted fields keep current values; explicit **`pages: []`** still replaces/deletes. PUT forwards **`body.title`** and stops defaulting omitted **`content`/`pages`** to empty values that could blank README and delete all pages. Version snapshots use the resolved title and content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ee20c1f6aab9d9dc2651a493a67094a93e3728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BEP updates can now change only the fields provided, preserving omitted content and pages.
  * Page imports support replacing pages or leaving existing pages unchanged.
  * Added reliable heading links and table-of-contents navigation for Markdown content.

* **Bug Fixes**
  * Improved heading anchor consistency and URL-hash navigation.
  * Long page lists now scroll within the navigation panel instead of extending beyond the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->