### PR TITLE
perf(web): make /changelog paint instantly (ISR + body-free list payload)

### DIFF
--- a/typescript2/app-website/app/api/changelog-feed/entries/[version]/route.ts
+++ b/typescript2/app-website/app/api/changelog-feed/entries/[version]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { fetchChangelogEntries } from '@/app/changelog/feed';
+
+// Single published entry by version, for the /changelog article view (the
+// list payload carries no bodies). Published bodies are effectively
+// immutable, so cache aggressively at the CDN.
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ version: string }> },
+) {
+  const { version } = await params;
+  const wanted = decodeURIComponent(version);
+  try {
+    const entries = await fetchChangelogEntries();
+    const entry = entries.find((e) => e.version === wanted);
+    if (!entry) {
+      return new NextResponse('no such release', { status: 404 });
+    }
+    return NextResponse.json(entry, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=86400',
+      },
+    });
+  } catch {
+    return new NextResponse('changelog data source unavailable', {
+      headers: { 'Cache-Control': 'no-store' },
+      status: 503,
+    });
+  }
+}

--- a/typescript2/app-website/app/api/changelog-feed/entries/route.ts
+++ b/typescript2/app-website/app/api/changelog-feed/entries/route.ts
@@ -1,83 +1,38 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
+import { fetchChangelogEntries } from '@/app/changelog/feed';
 
-// The public changelog feed, read DIRECTLY from Convex (the changelogEntries
-// table in the same deployment the /atb dashboard reads) instead of proxying to
-// the bammy changelog service. This removes the dependency on a running backend
-// service: as long as the changelog worker keeps writing entries to Convex, the
-// public page renders. Shape matches the old service contract: { entries: [...] }
-// with one object per published (status=done) entry, newest-first.
+// The public changelog feed. The /changelog page no longer depends on this
+// route (it server-renders via ISR from the same shared feed module); this
+// stays up as the external contract: { entries: [...] } with one object per
+// published entry, newest-first.
 
-const CONVEX_URL = process.env.NEXT_PUBLIC_ATB_CONVEX_URL;
-
-// The fields the website's changelog renderer consumes.
 const ENTRY_FIELDS = [
-  "version",
-  "date",
-  "title",
-  "body",
-  "authors",
-  "channel",
+  'version',
+  'date',
+  'title',
+  'body',
+  'authors',
+  'channel',
 ] as const;
 
-interface ChangelogRow {
-  version?: string;
-  date?: string | null;
-  title?: string | null;
-  body?: string | null;
-  authors?: string[] | null;
-  channel?: string | null;
-  createdAt?: number | null;
-}
-
-async function convexQuery<T>(path: string, args: object): Promise<T> {
-  const res = await fetch(`${CONVEX_URL}/api/query`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path, args, format: "json" }),
-    cache: "no-store",
-  });
-  if (!res.ok) throw new Error(`convex ${path}: ${res.status}`);
-  const body = (await res.json()) as { status: string; value: T };
-  if (body.status !== "success") throw new Error(`convex ${path} failed`);
-  return body.value;
-}
-
 export async function GET() {
-  if (!CONVEX_URL) {
-    return new NextResponse("changelog data source not configured", {
-      status: 503,
-    });
-  }
   try {
-    const rows = await convexQuery<ChangelogRow[]>("changelogEntries:list", {
-      field: "status",
-      value: "done",
-      index: "by_status_created",
-      limit: 1000,
-    });
-    // Newest-first by published date, then creation time (matches the old service).
-    const sorted = [...rows].sort((a, b) => {
-      const d = (b.date ?? "").localeCompare(a.date ?? "");
-      if (d !== 0) return d;
-      return (b.createdAt ?? 0) - (a.createdAt ?? 0);
-    });
-    const entries = sorted.map((e) =>
+    const entries = (await fetchChangelogEntries()).map((e) =>
       Object.fromEntries(ENTRY_FIELDS.map((k) => [k, e[k] ?? null])),
     );
     return NextResponse.json(
       { entries },
       {
         headers: {
-          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
         },
       },
     );
   } catch {
-    // Never 500 the changelog: degrade to an empty feed (the page shows
-    // "No entries yet." rather than an error).
+    // Never 500 the changelog: degrade to an empty feed.
     return NextResponse.json(
       { entries: [] },
-      { headers: { "Cache-Control": "no-store" } },
+      { headers: { 'Cache-Control': 'no-store' } },
     );
   }
 }

--- a/typescript2/app-website/app/changelog/changelog-list.tsx
+++ b/typescript2/app-website/app/changelog/changelog-list.tsx
@@ -2,10 +2,11 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-interface Entry {
-  authors: string[];
-  body: string;
+// List item shape the server component passes in — deliberately body-free
+// (bodies dwarf the rest of the feed; the article view fetches its own).
+export interface ChangelogListEntry {
   date: string;
+  lede: string;
   title: string;
   version: string;
 }
@@ -19,24 +20,6 @@ function formatDate(iso: string): string {
     timeZone: 'UTC',
     year: 'numeric',
   });
-}
-
-// First paragraph of the markdown body, flattened to plain text, for the list
-// preview. Strips fenced code, headings, list markers, and inline markdown.
-function lede(body: string): string {
-  const withoutCode = body.replace(/```[\s\S]*?```/g, '');
-  const para =
-    withoutCode
-      .split(/\n\s*\n/)
-      .map((p) => p.trim())
-      .find((p) => p && !p.startsWith('#')) ?? '';
-  return para
-    .replace(/^[#>\-*\s]+/, '')
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/\*\*([^*]+)\*\*/g, '$1')
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/\s+/g, ' ')
-    .trim();
 }
 
 // ---- release channels --------------------------------------------------------
@@ -135,20 +118,38 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function Article({ entry, onBack }: { entry: Entry; onBack: () => void }) {
+function Article({
+  entry,
+  onBack,
+}: {
+  entry: ChangelogListEntry;
+  onBack: () => void;
+}) {
+  const [authors, setAuthors] = useState<string[]>([]);
   const [html, setHtml] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
 
+  // The list payload has no bodies, so fetch this release's full entry, then
+  // render its markdown. Shiki failures degrade to escaped plain text.
   useEffect(() => {
     let alive = true;
-    getRenderer()
-      .then((render) => render(entry.body))
-      .then((h) => alive && setHtml(h))
-      // If shiki ever fails, degrade to escaped plain text rather than blow up.
-      .catch(() => alive && setHtml(`<pre>${escapeHtml(entry.body)}</pre>`));
+    fetch(`/api/changelog-feed/entries/${encodeURIComponent(entry.version)}`)
+      .then((r) =>
+        r.ok ? r.json() : Promise.reject(new Error('bad status')),
+      )
+      .then(async (full: { authors: string[]; body: string }) => {
+        if (!alive) return;
+        setAuthors(full.authors ?? []);
+        const h = await getRenderer()
+          .then((render) => render(full.body))
+          .catch(() => `<pre>${escapeHtml(full.body)}</pre>`);
+        if (alive) setHtml(h);
+      })
+      .catch(() => alive && setFailed(true));
     return () => {
       alive = false;
     };
-  }, [entry.body]);
+  }, [entry.version]);
 
   return (
     <article>
@@ -168,37 +169,32 @@ function Article({ entry, onBack }: { entry: Entry; onBack: () => void }) {
       </p>
       <h1 className="chlog-article-title">{entry.title}</h1>
 
-      {html === null ? (
+      {failed ? (
+        <p style={{ color: '#6b6456' }}>
+          Could not load this release. Please try again.
+        </p>
+      ) : html === null ? (
         <p style={{ color: '#6b6456' }}>Loading…</p>
       ) : (
         // eslint-disable-next-line react/no-danger
         <div className="chlog-md" dangerouslySetInnerHTML={{ __html: html }} />
       )}
 
-      {entry.authors.length > 0 && (
-        <p className="chlog-authors">By {entry.authors.join(', ')}</p>
+      {authors.length > 0 && (
+        <p className="chlog-authors">By {authors.join(', ')}</p>
       )}
     </article>
   );
 }
 
-export function ChangelogList() {
-  const [entries, setEntries] = useState<Entry[] | null>(null);
+export function ChangelogList({
+  entries,
+}: {
+  entries: ChangelogListEntry[];
+}) {
   const [selected, setSelected] = useState<string | null>(null);
   // Default the view to the Canary channel (the recommended channel).
   const [filter, setFilter] = useState<string | null>('canary');
-
-  // Load entries from the same-origin edge proxy (see next.config.mjs rewrites).
-  useEffect(() => {
-    let alive = true;
-    fetch('/api/changelog-feed/entries')
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error('bad status'))))
-      .then((d: { entries?: Entry[] }) => alive && setEntries(d.entries ?? []))
-      .catch(() => alive && setEntries([]));
-    return () => {
-      alive = false;
-    };
-  }, []);
 
   // Selected article is driven by the `?v=` query param so URLs are shareable
   // and the browser back button works — all client-side, page stays static.
@@ -224,10 +220,6 @@ export function ChangelogList() {
     window.history.pushState({}, '', '/changelog');
     setSelected(null);
   }, []);
-
-  if (entries === null) {
-    return <p style={{ color: '#6b6456' }}>Loading…</p>;
-  }
 
   const active = selected
     ? entries.find((e) => e.version === selected)
@@ -314,7 +306,7 @@ export function ChangelogList() {
                       {c.label}
                     </span>
                   </div>
-                  <p className="chlog-tl-lede">{lede(e.body)}</p>
+                  <p className="chlog-tl-lede">{e.lede}</p>
                   <button
                     type="button"
                     className="chlog-tl-read"

--- a/typescript2/app-website/app/changelog/feed.ts
+++ b/typescript2/app-website/app/changelog/feed.ts
@@ -1,0 +1,78 @@
+// Server-side access to the changelog feed, read DIRECTLY from Convex (the
+// changelogEntries table in the same deployment the /atb dashboard reads).
+// Shared by the /changelog page (ISR) and the /api/changelog-feed routes so
+// there is exactly one Convex query + sort + shape in the codebase.
+
+const CONVEX_URL = process.env.NEXT_PUBLIC_ATB_CONVEX_URL;
+
+export interface ChangelogEntry {
+  authors: string[];
+  body: string;
+  channel: string | null;
+  date: string;
+  title: string;
+  version: string;
+}
+
+interface ChangelogRow {
+  version?: string;
+  date?: string | null;
+  title?: string | null;
+  body?: string | null;
+  authors?: string[] | null;
+  channel?: string | null;
+  createdAt?: number | null;
+}
+
+async function convexQuery<T>(
+  path: string,
+  args: object,
+  revalidate: number | undefined,
+): Promise<T> {
+  if (!CONVEX_URL) throw new Error('changelog data source not configured');
+  const res = await fetch(`${CONVEX_URL}/api/query`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path, args, format: 'json' }),
+    // With `revalidate`, the response participates in ISR/data cache; without
+    // it (route handlers), always hit Convex live.
+    ...(revalidate === undefined
+      ? { cache: 'no-store' as const }
+      : { next: { revalidate } }),
+  });
+  if (!res.ok) throw new Error(`convex ${path}: ${res.status}`);
+  const body = (await res.json()) as { status: string; value: T };
+  if (body.status !== 'success') throw new Error(`convex ${path} failed`);
+  return body.value;
+}
+
+// All published entries, newest-first by published date then creation time
+// (matches the old changelog service contract). Throws on any upstream
+// failure — callers decide how to degrade.
+export async function fetchChangelogEntries(opts?: {
+  revalidate?: number;
+}): Promise<ChangelogEntry[]> {
+  const rows = await convexQuery<ChangelogRow[]>(
+    'changelogEntries:list',
+    {
+      field: 'status',
+      value: 'done',
+      index: 'by_status_created',
+      limit: 1000,
+    },
+    opts?.revalidate,
+  );
+  const sorted = [...rows].sort((a, b) => {
+    const d = (b.date ?? '').localeCompare(a.date ?? '');
+    if (d !== 0) return d;
+    return (b.createdAt ?? 0) - (a.createdAt ?? 0);
+  });
+  return sorted.map((e) => ({
+    authors: e.authors ?? [],
+    body: e.body ?? '',
+    channel: e.channel ?? null,
+    date: e.date ?? '',
+    title: e.title ?? '',
+    version: e.version ?? '',
+  }));
+}

--- a/typescript2/app-website/app/changelog/page.tsx
+++ b/typescript2/app-website/app/changelog/page.tsx
@@ -2,15 +2,18 @@ import { createMetadata } from '@/app/_lib/metadata';
 import { FooterSection } from '@/components/footer-section';
 import { Navbar } from '@/components/navbar';
 import { ChangelogList } from './changelog-list';
+import { fetchChangelogEntries } from './feed';
 
-// This page is intentionally STATIC (no `force-dynamic`, no server-side data
-// fetch). It is prerendered to plain HTML and served from the CDN, so the page
-// itself can never 500. The entries are loaded client-side from
-// `/api/changelog-feed/entries`, a Next route handler that reads the
-// changelogEntries table DIRECTLY from Convex (see that route) — no dependency
-// on a running changelog backend service. Code blocks are syntax-highlighted
-// client-side with shiki (incl. the BAML grammar). Clicking a release opens its
-// article via a `?v=` query param, handled fully client-side.
+// This page is prerendered with ISR (`revalidate = 60`), NOT force-dynamic, so
+// it keeps the never-500 property: visitors always get CDN-cached HTML with the
+// release list already rendered, and Convex is only consulted during background
+// regeneration — if that fails, the stale page keeps serving. Entry BODIES are
+// deliberately left out of the list payload (they dwarf everything else);
+// clicking a release opens its article via a `?v=` query param and the client
+// fetches the body from `/api/changelog-feed/entries/[version]`. Code blocks
+// are syntax-highlighted client-side with shiki (incl. the BAML grammar).
+
+export const revalidate = 60;
 
 export const metadata = createMetadata({
   description: 'The latest releases of BAML, shipped continuously.',
@@ -96,14 +99,44 @@ const CSS = `
 .chlog-md th, .chlog-md td { border: 1px solid #e7e2d6; padding: 8px 12px; text-align: left; }
 `;
 
-export default function ChangelogPage() {
+// First paragraph of the markdown body, flattened to plain text, for the list
+// preview. Strips fenced code, headings, list markers, and inline markdown.
+function lede(body: string): string {
+  const withoutCode = body.replace(/```[\s\S]*?```/g, '');
+  const para =
+    withoutCode
+      .split(/\n\s*\n/)
+      .map((p) => p.trim())
+      .find((p) => p && !p.startsWith('#')) ?? '';
+  return para
+    .replace(/^[#>\-*\s]+/, '')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export default async function ChangelogPage() {
+  // Degrade to an empty list rather than failing the render: a fresh build
+  // with Convex down shows "No entries yet." and self-heals on revalidation.
+  const entries = await fetchChangelogEntries({ revalidate: 60 }).catch(
+    () => [],
+  );
+  const listEntries = entries.map((e) => ({
+    date: e.date,
+    lede: lede(e.body),
+    title: e.title,
+    version: e.version,
+  }));
+
   return (
     <>
       {/* eslint-disable-next-line react/no-danger */}
       <style dangerouslySetInnerHTML={{ __html: CSS }} />
       <Navbar />
       <main className="chlog-wrap">
-        <ChangelogList />
+        <ChangelogList entries={listEntries} />
       </main>
       <FooterSection />
     </>


### PR DESCRIPTION
The changelog took a couple of seconds to load: a static shell fetched the full feed client-side after hydration, through a mostly-cold serverless route that pulled every entry body from Convex (264KB JSON for 170 entries, of which 227KB is bodies the list never renders).

- Server-render the page with `revalidate = 60`: visitors get CDN-cached HTML with the release list already in it. Convex only runs during background regeneration, and a failed regeneration keeps serving the stale page, so the never-500 property this page was originally made static for is preserved.
- Drop bodies from the list payload (server-computed ledes instead); the article view fetches a single release from the new `/api/changelog-feed/entries/[version]` route, CDN-cached with `s-maxage=300, stale-while-revalidate=86400`.
- One shared Convex query/sort/shape in `app/changelog/feed.ts`, used by the page and both API routes. The full-feed route keeps its external contract.

Verified locally with a production build against the live Convex deployment: `/changelog` serves prerendered in ~4ms with all entries in the payload and zero bodies; the per-version route returns 2.2KB and 404s on unknown versions.