### PR TITLE
fix(beps): stable sidebar scroll position when navigating

### DIFF
--- a/typescript/apps/beps/src/components/bep/bep-nav.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-nav.tsx
@@ -4,7 +4,7 @@ import { Plus, MessageSquare } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { buildBepPath, MAIN_CONTENT_ID } from "@/lib/bep-routes";
-import type { MouseEvent } from "react";
+import { useEffect, useRef, type MouseEvent } from "react";
 
 interface Section {
   id: string;
@@ -108,8 +108,31 @@ export function BepNav({
     }
   }
 
+  // Keep the active item visible inside the sidebar's own scroll container
+  // without touching window scroll (scrollIntoView would also scroll
+  // ancestors, which is exactly the jarring jump we're avoiding).
+  const navRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    const nav = navRef.current;
+    if (!nav) return;
+    const active = nav.querySelector<HTMLElement>('[aria-current="page"]');
+    if (!active) return;
+    // The scrollable ancestor is the sticky wrapper around this nav
+    const container = nav.parentElement;
+    if (!container || container.scrollHeight <= container.clientHeight) return;
+    const containerTop = container.getBoundingClientRect().top;
+    const activeRect = active.getBoundingClientRect();
+    const top = activeRect.top - containerTop + container.scrollTop;
+    const bottom = top + activeRect.height;
+    if (top < container.scrollTop) {
+      container.scrollTop = top - 8;
+    } else if (bottom > container.scrollTop + container.clientHeight) {
+      container.scrollTop = bottom - container.clientHeight + 8;
+    }
+  }, [activeSection]);
+
   return (
-    <nav className="space-y-1">
+    <nav ref={navRef} className="space-y-1">
       {orderedSections
         .map((section) => {
           const status = pageStatuses[section.id];
@@ -120,6 +143,7 @@ export function BepNav({
               key={section.id}
               href={sectionHref(section.id, bepNumber, versionNumber)}
               onClick={(e) => handleNavClick(e, section.id, onSectionClick)}
+              aria-current={activeSection === section.id ? "page" : undefined}
               className={cn(
                 "block w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
                 "hover:bg-accent hover:text-accent-foreground",

--- a/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
+++ b/typescript/apps/beps/src/components/bep/bep-route-shell.tsx
@@ -59,6 +59,10 @@ function withQueryParam(path: string, key: string, value: string): string {
   return `${pathname}${nextQuery ? `?${nextQuery}` : ""}${hash ? `#${hash}` : ""}`;
 }
 
+// Sidebar scroll offsets per BEP, so the nav keeps its place when the shell
+// remounts (e.g. loading skeleton → content). Module-level on purpose.
+const navScrollPositions = new Map<number, number>();
+
 function highlightElement(target: Element) {
   target.scrollIntoView({ behavior: "smooth", block: "center" });
   target.classList.add("ring-2", "ring-primary", "ring-offset-2");
@@ -439,6 +443,17 @@ const [copied, setCopied] = useState(false);
   const handleSectionChange = (section: string) => {
     navigateToSection(section);
   };
+
+  // Restore the sidebar's scroll offset when its container (re)mounts, so
+  // navigating doesn't visibly reset a long page list back to the top.
+  const restoreNavScroll = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (!el) return;
+      const saved = navScrollPositions.get(bepNumber);
+      if (saved) el.scrollTop = saved;
+    },
+    [bepNumber]
+  );
 
   const handleNavigateToComment = (
     commentId: Id<"comments">,
@@ -920,7 +935,13 @@ const [copied, setCopied] = useState(false);
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
           <aside className="lg:col-span-1">
             {/* max-h + overflow so a long page list stays reachable while stuck */}
-            <div className="sticky top-8 max-h-[calc(100vh-4rem)] overflow-y-auto overscroll-contain pr-1">
+            <div
+              ref={restoreNavScroll}
+              onScroll={(e) =>
+                navScrollPositions.set(bepNumber, e.currentTarget.scrollTop)
+              }
+              className="sticky top-8 max-h-[calc(100vh-4rem)] overflow-y-auto overscroll-contain pr-1"
+            >
               <BepNav
                 sections={allSections}
                 activeSection={activeSection}


### PR DESCRIPTION
## Summary

Clicking a link caused the left sidebar to visibly reset — jarring on BEPs with long page lists (e.g. BEP-064's 70 pages). Two mechanisms, both fixed:

1. **Nothing kept your place in the sidebar's scroll container.** Navigation resets window scroll (expected for content), but the sidebar list gave no anchor back to where you were. The nav now keeps the active item visible by adjusting **only its own scroll container** — deliberate manual `scrollTop` math rather than `scrollIntoView`, since the latter scrolls ancestor containers/window too, which is exactly the jump being avoided. Active links also get `aria-current="page"` (used as the selector, and an a11y win).

2. **Shell remounts dropped the scroll offset.** When `BepRouteShell` remounts (loading skeleton → content), the sidebar container is recreated at `scrollTop = 0`. The offset is now remembered per BEP number in a module-level map (written on scroll) and restored via a callback ref on mount.

Builds on #4023, which made the sidebar its own bounded scroll container.

## Verification

- `tsc --noEmit` clean; eslint shows only a pre-existing warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only sidebar scroll and a11y attributes; no auth, data, or API changes.
> 
> **Overview**
> Fixes the BEP left sidebar **jumping back to the top** on section navigation and when the route shell remounts (e.g. loading skeleton → content).
> 
> **`BepRouteShell`** now keeps each BEP’s sidebar `scrollTop` in a module-level map, updates it on the sticky scroll container’s `onScroll`, and restores it via a callback ref when that container mounts again.
> 
> **`BepNav`** scrolls only the sidebar’s parent container so the active link stays in view when `activeSection` changes, using manual `scrollTop` math instead of `scrollIntoView` so the main window doesn’t move. Active page links get `aria-current="page"` for accessibility and as the scroll target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523a3fb97b140359093174384d8f5a1d342c9e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar navigation by automatically keeping the active section visible.
  * Preserved sidebar scroll position when navigating between sections and returning to a BEP page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->