### PR TITLE
fix(compiler2): subtype-reduce control-flow joins and establish empty collections (B-236)

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -4418,7 +4418,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                 let result_ty = if let Some(else_id) = else_branch {
                     let else_ty = self.infer_expr(*else_id, body);
-                    Self::join_types(&then_ty, &else_ty)
+                    self.join_types(&then_ty, &else_ty)
                 } else {
                     Ty::Void {
                         attr: TyAttr::default(),
@@ -4502,23 +4502,30 @@ impl<'db> TypeInferenceBuilder<'db> {
                 } else {
                     let elem_types: Vec<Ty> =
                         elements.iter().map(|e| self.infer_expr(*e, body)).collect();
-                    let elem_ty = Self::join_all(&elem_types).widen_fresh();
+                    let elem_ty = self.join_all(&elem_types).widen_fresh();
                     Ty::List(Box::new(elem_ty), TyAttr::default())
                 }
             }
             Expr::Map { entries } => {
-                let mut key_types = Vec::new();
-                let mut val_types = Vec::new();
-                for (k, v) in entries {
-                    key_types.push(self.infer_expr(*k, body));
-                    val_types.push(self.infer_expr(*v, body));
-                }
-                let key_ty = Self::join_all(&key_types).widen_fresh();
-                let val_ty = Self::join_all(&val_types).widen_fresh();
-                Ty::Map {
-                    key: Box::new(key_ty),
-                    value: Box::new(val_ty),
-                    attr: TyAttr::default(),
+                // An empty map literal evolves to fit its use rather than
+                // committing to the unsound `map<never, never>` (see
+                // `empty_evolving_map`).
+                if entries.is_empty() {
+                    Self::empty_evolving_map()
+                } else {
+                    let mut key_types = Vec::new();
+                    let mut val_types = Vec::new();
+                    for (k, v) in entries {
+                        key_types.push(self.infer_expr(*k, body));
+                        val_types.push(self.infer_expr(*v, body));
+                    }
+                    let key_ty = self.join_all(&key_types).widen_fresh();
+                    let val_ty = self.join_all(&val_types).widen_fresh();
+                    Ty::Map {
+                        key: Box::new(key_ty),
+                        value: Box::new(val_ty),
+                        attr: TyAttr::default(),
+                    }
                 }
             }
             Expr::Binary { op, lhs, rhs } => {
@@ -5554,7 +5561,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .iter()
             .map(|(_, value)| self.infer_expr(*value, body))
             .collect();
-        let val_ty = Self::join_all(&val_types).widen_fresh();
+        let val_ty = self.join_all(&val_types).widen_fresh();
         Ty::Map {
             key: Box::new(Ty::string()),
             value: Box::new(val_ty),
@@ -6576,7 +6583,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                 let ty = if let Some(else_id) = else_branch {
                     let else_ty = self.check_expr(*else_id, body, expected);
-                    Self::join_types(&then_ty, &else_ty)
+                    self.join_types(&then_ty, &else_ty)
                 } else {
                     if !matches!(expected, Ty::Void { .. } | Ty::Unknown { .. }) {
                         self.context
@@ -7762,7 +7769,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         }
 
-        Self::join_all(&arm_types)
+        self.join_all(&arm_types)
     }
 
     /// Type-check `if let PATTERN = SCRUTINEE { THEN } else { ELSE }`.
@@ -7912,7 +7919,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
 
         match else_ty {
-            Some(else_ty) => Self::join_types(&then_ty, &else_ty),
+            Some(else_ty) => self.join_types(&then_ty, &else_ty),
             None => Ty::Void {
                 attr: TyAttr::default(),
             },
@@ -7987,7 +7994,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     attr: TyAttr::default(),
                 }
             } else {
-                Self::facts_to_ty(&residual)
+                self.facts_to_ty(&residual)
             };
             // Record the clause binding type in the bindings map so MIR can read it.
             self.pattern_types
@@ -8077,7 +8084,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     narrowed_ty = if matches!(narrowed_ty, Ty::Never { .. }) {
                         panic_subset_ty
                     } else {
-                        Self::join_all(&[narrowed_ty, panic_subset_ty])
+                        self.join_all(&[narrowed_ty, panic_subset_ty])
                     };
                 }
 
@@ -8090,12 +8097,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                         .report_warning_simple(TirTypeError::UnreachableArm, arm.body);
                 }
 
-                let mut narrowed_binding_ty = Self::facts_to_ty(&throw_matches.may_match);
+                let mut narrowed_binding_ty = self.facts_to_ty(&throw_matches.may_match);
                 if let Some(panic_subset_ty) = panic_subset_ty {
                     narrowed_binding_ty = if matches!(narrowed_binding_ty, Ty::Never { .. }) {
                         panic_subset_ty
                     } else {
-                        Self::join_all(&[narrowed_binding_ty, panic_subset_ty])
+                        self.join_all(&[narrowed_binding_ty, panic_subset_ty])
                     };
                 }
 
@@ -8186,7 +8193,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         self.catch_residual_throws
             .insert(catch_expr_id, residual.clone());
-        Self::join_all(&result_members)
+        self.join_all(&result_members)
     }
 
     /// Validate declared `throws` against effective escaping throws from the body.
@@ -8504,7 +8511,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     {
                         elem_tys.push(*elem);
                     }
-                    let elem_ty = (!elem_tys.is_empty()).then(|| Self::join_all(&elem_tys))?;
+                    let elem_ty = (!elem_tys.is_empty()).then(|| self.join_all(&elem_tys))?;
                     Ty::List(Box::new(elem_ty), TyAttr::default())
                 }
             }
@@ -8525,7 +8532,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         None => is_full = false,
                     }
                 }
-                let ty = (!tys.is_empty()).then(|| Self::join_all(&tys))?;
+                let ty = (!tys.is_empty()).then(|| self.join_all(&tys))?;
                 return Some(if is_full {
                     PatternExpectedTy::Full(ty)
                 } else {
@@ -8687,7 +8694,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 if panic_members.is_empty() {
                     None
                 } else {
-                    Some(Self::join_all(&panic_members))
+                    Some(self.join_all(&panic_members))
                 }
             }
             _ => None,
@@ -8701,14 +8708,14 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     /// Join a set of throw fact types into a single type.
-    fn facts_to_ty(facts: &BTreeSet<Ty>) -> Ty {
+    fn facts_to_ty(&self, facts: &BTreeSet<Ty>) -> Ty {
         if facts.is_empty() {
             return Ty::Never {
                 attr: TyAttr::default(),
             };
         }
         let tys: Vec<Ty> = facts.iter().cloned().collect();
-        Self::join_all(&tys)
+        self.join_all(&tys)
     }
 
     /// Check if a pattern type covers a throw fact type.
@@ -12904,7 +12911,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    fn join_types(a: &Ty, b: &Ty) -> Ty {
+    fn join_types(&self, a: &Ty, b: &Ty) -> Ty {
         if matches!(a, Ty::Never { .. }) {
             return b.clone();
         }
@@ -12934,6 +12941,26 @@ impl<'db> TypeInferenceBuilder<'db> {
                 );
             }
         }
+        // Two still-evolving containers join element-wise and stay evolving, so a
+        // later mutation can still establish the result (`if c { [] } else { [] }`
+        // then `x.push(5)`). Mirrors typescript-go's getUnionOrEvolvingArrayType,
+        // which combines evolving arrays at flow junctions instead of unioning.
+        match (a, b) {
+            (Ty::EvolvingList(elem_a, _), Ty::EvolvingList(elem_b, _)) => {
+                return Ty::EvolvingList(
+                    Box::new(self.join_types(elem_a, elem_b)),
+                    TyAttr::default(),
+                );
+            }
+            (Ty::EvolvingMap(key_a, val_a, _), Ty::EvolvingMap(key_b, val_b, _)) => {
+                return Ty::EvolvingMap(
+                    Box::new(self.join_types(key_a, key_b)),
+                    Box::new(self.join_types(val_a, val_b)),
+                    TyAttr::default(),
+                );
+            }
+            _ => {}
+        }
         // Build a flat union, deduplicating members
         let mut members = Vec::new();
         let mut push = |ty: &Ty| {
@@ -12949,6 +12976,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
         push(a);
         push(b);
+        self.remove_subtype_members(&mut members);
         if members.len() == 1 {
             members.into_iter().next().unwrap()
         } else {
@@ -12958,7 +12986,63 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    fn join_all(types: &[Ty]) -> Ty {
+    /// Drop union members that are subtypes of other members - typescript-go's
+    /// `removeSubtypes`, the `UnionReduction.Subtype` mode its checker applies to
+    /// unions synthesized at expression joins (ternaries, return-type inference,
+    /// array literals). `1 | int` joins to `int`, `Color.Red | Color` to `Color`.
+    ///
+    /// An unestablished empty `[]` / `{}` is additionally absorbed by any
+    /// same-category container member. It cannot be a *subtype* of one (lists
+    /// and maps are invariant), but the join is an establishing use exactly like
+    /// a `push`, and the `Evolving` wrapper proves the value is a fresh literal
+    /// no committed alias can observe. This is what TypeScript gets from
+    /// `never[]`'s covariance, restricted to the sound fresh-literal case; a
+    /// committed `never[]` (user-annotated) is not absorbed (B-236).
+    ///
+    /// Members are scanned back-to-front so the first of two mutually-subtype
+    /// (equivalent) members survives.
+    fn remove_subtype_members(&self, members: &mut Vec<Ty>) {
+        // The recovery sentinels compare bidirectionally subtype-compatible to
+        // everything (and `Infer` must not reach the normalizer at all);
+        // reducing against them would collapse the union to a sentinel and
+        // lose real members. Keep the union as built.
+        if members
+            .iter()
+            .any(|m| matches!(m, Ty::Unknown { .. } | Ty::Error { .. } | Ty::Infer { .. }))
+        {
+            return;
+        }
+        let mut i = members.len();
+        while i > 0 {
+            i -= 1;
+            let absorbed = members.iter().enumerate().any(|(j, target)| {
+                j != i
+                    && (Self::join_establishes(&members[i], target)
+                        || self.is_subtype(&members[i], target))
+            });
+            if absorbed {
+                members.remove(i);
+            }
+        }
+    }
+
+    /// Whether `source` is an unestablished empty-collection literal type that a
+    /// same-category container member establishes at a join.
+    fn join_establishes(source: &Ty, target: &Ty) -> bool {
+        match source {
+            Ty::EvolvingList(inner, _) if matches!(**inner, Ty::Never { .. }) => {
+                matches!(target, Ty::List(..) | Ty::EvolvingList(..))
+            }
+            Ty::EvolvingMap(key, value, _)
+                if matches!(**key, Ty::Never { .. }) && matches!(**value, Ty::Never { .. }) =>
+            {
+                matches!(target, Ty::Map { .. } | Ty::EvolvingMap(..))
+            }
+            _ => false,
+        }
+    }
+
+    fn join_all(&self, types: &[Ty]) -> Ty {
         if types.is_empty() {
             return Ty::Never {
                 attr: TyAttr::default(),
@@ -12967,7 +13051,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         types
             .iter()
             .skip(1)
-            .fold(types[0].clone(), |acc, t| Self::join_types(&acc, t))
+            .fold(types[0].clone(), |acc, t| self.join_types(&acc, t))
     }
 
     /// The diagnostic for a type argument `actual` checked against an interface `bound`,
@@ -13589,7 +13673,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 } else if self.is_subtype(&inner_lhs, rhs) {
                     rhs.clone()
                 } else {
-                    Self::join_types(&inner_lhs, rhs)
+                    self.join_types(&inner_lhs, rhs)
                 }
             }
         }
@@ -14916,7 +15000,7 @@ impl TypeInferenceBuilder<'_> {
                             pt_joined
                                 .entry(*k)
                                 .and_modify(|acc| {
-                                    *acc = Self::join_all(&[acc.clone(), v.clone()]);
+                                    *acc = self.join_all(&[acc.clone(), v.clone()]);
                                 })
                                 .or_insert_with(|| v.clone());
                         }
@@ -14950,7 +15034,7 @@ impl TypeInferenceBuilder<'_> {
                             |(name, (pat_id, tys))| crate::pattern_lowering::PatternBinding {
                                 name,
                                 pat_id,
-                                ty: Self::join_all(&tys),
+                                ty: self.join_all(&tys),
                             },
                         )
                         .collect();
@@ -14959,9 +15043,9 @@ impl TypeInferenceBuilder<'_> {
                     required_ty: if required_tys.is_empty() {
                         None
                     } else {
-                        Some(Self::join_all(&required_tys))
+                        Some(self.join_all(&required_tys))
                     },
-                    matched_ty: Self::join_all(&matched_tys),
+                    matched_ty: self.join_all(&matched_tys),
                     bindings: joined_bindings,
                 };
             }
@@ -15320,7 +15404,7 @@ impl TypeInferenceBuilder<'_> {
                     let elem = if elem_tys.is_empty() {
                         unconstrained.clone()
                     } else {
-                        Self::join_all(&elem_tys)
+                        self.join_all(&elem_tys)
                     };
                     Ty::List(Box::new(elem), TyAttr::default())
                 }
@@ -15330,7 +15414,7 @@ impl TypeInferenceBuilder<'_> {
                     .iter()
                     .map(|&p| self.pattern_natural_type(p, body, unconstrained))
                     .collect();
-                Self::join_all(&part_tys)
+                self.join_all(&part_tys)
             }
         };
         self.pattern_natural_cache
@@ -16046,7 +16130,7 @@ impl TypeInferenceBuilder<'_> {
         } else if element_required_tys.is_empty() {
             None
         } else {
-            let joined = Self::join_all(&element_required_tys);
+            let joined = self.join_all(&element_required_tys);
             Some(Ty::List(Box::new(joined), TyAttr::default()))
         };
 
@@ -16156,9 +16240,9 @@ impl TypeInferenceBuilder<'_> {
         let required = if required_tys.is_empty() {
             None
         } else {
-            Some(Self::join_all(&required_tys))
+            Some(self.join_all(&required_tys))
         };
-        let matched = Self::join_all(&matched_tys);
+        let matched = self.join_all(&matched_tys);
 
         let dpat = if alts.len() == 1 {
             alts.into_iter().next().unwrap()

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -3602,16 +3602,16 @@ function patterns_new_runtime.test_for_nested_rest_irrefutable() -> int {
     alloc_array 2
     load_type never
     alloc_array 0
-    load_type int[] | never[]
+    load_type int[]
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int[] | never[], Error = never>
+    load_type baml.iter.Iterable<Item = int[], Error = never>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
 
   L0:
     load_var _6
-    load_type baml.iter.Iterator<Item = int[] | never[], Error = never>
+    load_type baml.iter.Iterator<Item = int[], Error = never>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _7

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -1057,8 +1057,8 @@ class baml.http.SseStream {
   _handle: $rust_type
 }
 function baml.http._timeout_nanos(timeout: baml.time.Duration | null) -> bigint throws never {
-  { : 0n | bigint
-    match (timeout : baml.time.Duration | null) : 0n | bigint
+  { : bigint
+    match (timeout : baml.time.Duration | null) : bigint
       null =>
         0n : 0n
       t: root.time.Duration =>
@@ -1794,8 +1794,8 @@ function baml.llm.PlannerState.rr_pick_index(self: baml.llm.PlannerState, client
   }
 }
 function baml.llm.prompt_template_for(function_name: string, prompt_closure: ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null) -> string throws baml.errors.InvalidArgument {
-  { : string | ""
-    match (prompt_closure : ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null) : string | ""
+  { : string
+    match (prompt_closure : ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null) : string
       null =>
         get_jinja_template(function_name) : string
       _ =>
@@ -1839,8 +1839,8 @@ function baml.llm.parse<TStream, TFinal>(json: string) -> TFinal throws baml.err
 }
 function baml.llm.call_llm_function<T>(client: baml.llm.Client, function_name: string, args: map<string, unknown>, prompt_closure: ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null = null) -> T throws never {
   { : T
-    let jinja_string = : string | "" -> string
-      match (prompt_closure : ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null) : string | ""
+    let jinja_string = : string
+      match (prompt_closure : ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null) : string
         null =>
           get_jinja_template(function_name) : string
         _ =>
@@ -1852,8 +1852,8 @@ function baml.llm.call_llm_function<T>(client: baml.llm.Client, function_name: s
 }
 function baml.llm.stream_llm_function<TStream, TFinal>(client: baml.llm.Client, function_name: string, args: map<string, unknown>, prompt_closure: ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null = null) -> baml.llm.Stream<TStream, TFinal> throws never {
   { : baml.llm.Stream<TStream, TFinal>
-    let jinja_string = : string | "" -> string
-      match (prompt_closure : ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null) : string | ""
+    let jinja_string = : string
+      match (prompt_closure : ((baml.llm.Context) -> baml.llm.PromptAst throws never) | null) : string
         null =>
           get_jinja_template(function_name) : string
         _ =>
@@ -2205,8 +2205,8 @@ function baml.llm.Client.execute_once_oneshot<T>(self: baml.llm.Client, context:
             }
           else
             { : never
-              let error_body = : string | "" -> string
-                catch (http_response.text() : string) : string | ""
+              let error_body = : string
+                catch (http_response.text() : string) : string
                   catch (e)
                     _ =>
                       { : ""
@@ -2575,8 +2575,8 @@ class baml.media.Image$stream {
 
 --- <builtin>/baml/ns_net/net.baml ---
 function baml.net._timeout_nanos(timeout: baml.time.Duration | null) -> bigint throws never {
-  { : 0n | bigint
-    match (timeout : baml.time.Duration | null) : 0n | bigint
+  { : bigint
+    match (timeout : baml.time.Duration | null) : bigint
       null =>
         0n : 0n
       t: root.time.Duration =>
@@ -3534,8 +3534,8 @@ function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table throws 
   }
 }
 function baml.toml.item_to_json(item: baml.toml.Item) -> baml.json.json throws baml.json.JsonSerializationError {
-  { : bool | int | float | string | baml.json.json | baml.json.json[]
-    match (item : baml.toml.Item) : bool | int | float | string | baml.json.json | baml.json.json[]
+  { : baml.json.json
+    match (item : baml.toml.Item) : baml.json.json
       bool | int | float | string =>
         item : bool | int | float | string
       Table =>

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_tir.snap
@@ -557,8 +557,8 @@ function testing.glob_match(subject: string, pattern: string) -> bool throws nev
   }
 }
 function testing.filter_match(expr: string, subject: string) -> bool throws never {
-  { : true | bool
-    if (expr == "" : bool) : true | bool
+  { : bool
+    if (expr == "" : bool) : bool
       { : true
         true : true
       }

--- a/baml_language/crates/baml_tests/snapshots/compiles/backtick_strings/baml_tests__compiles__backtick_strings__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/backtick_strings/baml_tests__compiles__backtick_strings__04_tir.snap
@@ -100,8 +100,8 @@ function user.BacktickInterpBlockBody(items: int[]) -> string throws never {
   }
 }
 function user.bangs(n: int) -> string throws never {
-  { : "" | string
-    if (n <= 0 : bool) : "" | string
+  { : string
+    if (n <= 0 : bool) : string
       { : ""
         "" : ""
       }

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_all_keyword/baml_tests__compiles__catch_all_keyword__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_all_keyword/baml_tests__compiles__catch_all_keyword__04_tir.snap
@@ -14,24 +14,24 @@ function user.MayFailIntOrString(x: int) -> string throws never {
   }
 }
 function user.PartialCatch(x: int) -> string throws never {
-  { : string | "caught string"
-    catch (MayFailIntOrString(x) : string) : string | "caught string"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch (e)
         string =>
           "caught string" : "caught string"
   }
 }
 function user.CatchAllWildcard(x: int) -> string throws never {
-  { : string | "caught all"
-    catch (MayFailIntOrString(x) : string) : string | "caught all"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch_all (e)
         _ =>
           "caught all" : "caught all"
   }
 }
 function user.CatchAllTyped(x: int) -> string throws never {
-  { : string | "caught string" | "caught int"
-    catch (MayFailIntOrString(x) : string) : string | "caught string" | "caught int"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch_all (e)
         string =>
           "caught string" : "caught string"
@@ -40,8 +40,8 @@ function user.CatchAllTyped(x: int) -> string throws never {
   }
 }
 function user.CatchThenCatchAll(x: int) -> string throws never {
-  { : string | "caught string" | "caught rest"
-    catch (MayFailIntOrString(x) : string) : string | "caught string" | "caught rest"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch (e)
         string =>
           "caught string" : "caught string"

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_all_panics/baml_tests__compiles__catch_all_panics__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_all_panics/baml_tests__compiles__catch_all_panics__04_tir.snap
@@ -14,16 +14,16 @@ function user.MayFailIntOrString(x: int) -> string throws never {
   }
 }
 function user.CatchAllPanicsWildcard(x: int) -> string throws never {
-  { : string | "caught all"
-    catch (MayFailIntOrString(x) : string) : string | "caught all"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch_all_panics (e)
         _ =>
           "caught all" : "caught all"
   }
 }
 function user.CatchAllPanicsTyped(x: int) -> string throws never {
-  { : string | "caught string" | "caught int"
-    catch (MayFailIntOrString(x) : string) : string | "caught string" | "caught int"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch_all_panics (e)
         string =>
           "caught string" : "caught string"
@@ -32,8 +32,8 @@ function user.CatchAllPanicsTyped(x: int) -> string throws never {
   }
 }
 function user.CatchThenCatchAllPanics(x: int) -> string throws never {
-  { : string | "caught string" | "caught rest"
-    catch (MayFailIntOrString(x) : string) : string | "caught string" | "caught rest"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch (e)
         string =>
           "caught string" : "caught string"

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_throw/baml_tests__compiles__catch_throw__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_throw/baml_tests__compiles__catch_throw__04_tir.snap
@@ -32,24 +32,24 @@ function user.AlsoMayFail(x: int) -> string throws never {
   }
 }
 function user.SingleCatchWildcard(x: int) -> string throws never {
-  { : string | "caught"
-    catch (MayFail(x) : string) : string | "caught"
+  { : string
+    catch (MayFail(x) : string) : string
       catch (e)
         _ =>
           "caught" : "caught"
   }
 }
 function user.SingleCatchTyped(x: int) -> string throws never {
-  { : string | "caught string"
-    catch (MayFail(x) : string) : string | "caught string"
+  { : string
+    catch (MayFail(x) : string) : string
       catch (e)
         string =>
           "caught string" : "caught string"
   }
 }
 function user.CatchWithFallback(x: int) -> string throws never {
-  { : string | "caught string" | "caught int fallback"
-    catch (MayFailIntOrString(x) : string) : string | "caught string" | "caught int fallback"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch (e)
         string =>
           "caught string" : "caught string"
@@ -59,16 +59,16 @@ function user.CatchWithFallback(x: int) -> string throws never {
   }
 }
 function user.CatchWithTypedArm(x: int) -> string throws never {
-  { : string | "caught string"
-    catch (MayFail(x) : string) : string | "caught string"
+  { : string
+    catch (MayFail(x) : string) : string
       catch (e)
         string =>
           "caught string" : "caught string"
   }
 }
 function user.MultipleCatchArms(x: int) -> string throws never {
-  { : string | "caught string" | "caught int"
-    catch (MayFailIntOrString(x) : string) : string | "caught string" | "caught int"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch (e)
         string =>
           "caught string" : "caught string"
@@ -78,8 +78,8 @@ function user.MultipleCatchArms(x: int) -> string throws never {
 }
 function user.NestedCatch(x: int) -> string throws never {
   { : string
-    let inner = : string | "inner caught" -> string
-      catch (MayFail(x) : string) : string | "inner caught"
+    let inner = : string
+      catch (MayFail(x) : string) : string
         catch (e)
           _ =>
             "inner caught" : "inner caught"
@@ -105,8 +105,8 @@ function user.ThrowStatement(x: int) -> string throws never {
   ?? 3168..3181: unreachable code: 1 statement(s) after diverging statement
 }
 function user.ChainedCatchClauses(x: int) -> string throws never {
-  { : string | "first handler" | "second handler"
-    catch (MayFailIntOrString(x) : string) : string | "first handler" | "second handler"
+  { : string
+    catch (MayFailIntOrString(x) : string) : string
       catch (e)
         string =>
           "first handler" : "first handler"

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_parse_stringify_intrinsics/baml_tests__compiles__json_parse_stringify_intrinsics__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_parse_stringify_intrinsics/baml_tests__compiles__json_parse_stringify_intrinsics__04_tir.snap
@@ -15,9 +15,9 @@ function user.parse_and_roundtrip_pretty(s: string) -> string throws never {
   }
 }
 function user.match_parsed(s: string) -> string throws never {
-  { : string | "int" | "float" | "bool" | "null"
+  { : string
     let j: baml.json.json = baml.json.parse(s) : baml.json.json -> bool | int | float | string | baml.json.json[] | map<string, baml.json.json> | null
-    match (j : bool | int | float | string | baml.json.json[] | map<string, baml.json.json> | null) : string | "int" | "float" | "bool" | "null"
+    match (j : bool | int | float | string | baml.json.json[] | map<string, baml.json.json> | null) : string
       arr: baml.json.json[] =>
         baml.json.stringify(arr) : string
       m: map<string, baml.json.json> =>

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__04_tir.snap
@@ -51,8 +51,8 @@ function user.test_multi_param() -> int throws never {
 lambda user.test_multi_param {
 }
 function user.test_in_match(x: int) -> int throws never {
-  { : int | 0
-    match (x : int) : int | 0
+  { : int
+    match (x : int) : int
       0 =>
         { : int
           let inc = : (y: int) -> int throws never

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__04_tir.snap
@@ -10,9 +10,9 @@ function user.DestructureQualifiedLet() -> int throws never {
   }
 }
 function user.DestructureQualifiedMatch() -> int throws never {
-  { : 0 | int
+  { : int
     let response = root.llm.openai.Response { text: "ok", score: 42 } : user.llm.openai.Response
-    match (response : user.llm.openai.Response) : 0 | int
+    match (response : user.llm.openai.Response) : int
       root.llm.openai.Response { score: 0 } =>
         0 : 0
       root.llm.openai.Response { score: matched } =>
@@ -27,9 +27,9 @@ function user.DestructureNamespaceQualifiedLet() -> int throws never {
   }
 }
 function user.DestructureNamespaceQualifiedMatch() -> int throws never {
-  { : 0 | int
+  { : int
     let response = llm.openai.Response { text: "ok", score: 46 } : user.llm.openai.Response
-    match (response : user.llm.openai.Response) : 0 | int
+    match (response : user.llm.openai.Response) : int
       llm.openai.Response { score: 0 } =>
         0 : 0
       llm.openai.Response { score: matched } =>

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__04_tir.snap
@@ -3,8 +3,8 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 === TIR2 ===
 function user.or_with_repeated_typed_binding(v: int | string) -> int throws never {
-  { : int | 0
-    match (v : int | string) : int | 0
+  { : int
+    match (v : int | string) : int
       x: int | x: int =>
         x : int
       _ =>
@@ -19,8 +19,8 @@ function user.or_with_repeated_bare_binding(v: int) -> int throws never {
   }
 }
 function user.chain_narrow_then_wildcard(v: int | string | bool) -> int throws never {
-  { : int | 0
-    match (v : int | string | bool) : int | 0
+  { : int
+    match (v : int | string | bool) : int
       n: int =>
         n : int
       _ =>
@@ -44,8 +44,8 @@ function user.call_int_callback(cb: (int) -> int throws never) -> int throws nev
   }
 }
 function user.dispatch_callback(cb: ((int) -> int throws never) | ((string) -> string throws never)) -> int throws never {
-  { : int | 0
-    match (cb : ((int) -> int throws never) | ((string) -> string throws never)) : int | 0
+  { : int
+    match (cb : ((int) -> int throws never) | ((string) -> string throws never)) : int
       f: (int) -> int =>
         f(0) : int
       (string) -> string =>
@@ -80,8 +80,8 @@ function user.unwrap_typed<T>(cb: ((int) -> T throws never) | ((string) -> T thr
   }
 }
 function user.unwrap_curried(f: ((int) -> ((int) -> ((int) -> int throws never) throws never) throws never) | ((string) -> ((string) -> string throws never) throws never)) -> int throws never {
-  { : int | 0
-    match (f : ((int) -> ((int) -> ((int) -> int throws never) throws never) throws never) | ((string) -> ((string) -> string throws never) throws never)) : int | 0
+  { : int
+    match (f : ((int) -> ((int) -> ((int) -> int throws never) throws never) throws never) | ((string) -> ((string) -> string throws never) throws never)) : int
       triple: (int) -> ((int) -> ((int) -> int)) =>
         triple(1)(2)(3) : int
       pair: (string) -> ((string) -> string) =>
@@ -188,24 +188,24 @@ function user.risky_error(mode: int) -> int throws user.AppError | string {
   }
 }
 function user.catch_chain_union(mode: int) -> int throws never {
-  { : int | 1
-    catch (risky_error(mode) : int) : int | 1
+  { : int
+    catch (risky_error(mode) : int) : int
       catch (e)
         AppError | string =>
           1 : 1
   }
 }
 function user.catch_paren_or_chain(mode: int) -> int throws never {
-  { : int | 1
-    catch (risky_error(mode) : int) : int | 1
+  { : int
+    catch (risky_error(mode) : int) : int
       catch (e)
         AppError | string =>
           1 : 1
   }
 }
 function user.catch_widening_chain(mode: int) -> int throws never {
-  { : int | 1 | 2
-    catch (risky_error(mode) : int) : int | 1 | 2
+  { : int
+    catch (risky_error(mode) : int) : int
       catch (e)
         s: string =>
           1 : 1

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/catch_throw_regressions/baml_tests__diagnostic_errors__catch_throw_regressions__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/catch_throw_regressions/baml_tests__diagnostic_errors__catch_throw_regressions__04_tir.snap
@@ -75,8 +75,8 @@ function user.RecB(n: int) -> string throws never {
   }
 }
 function user.CatchRecursiveThrow(n: int) -> string throws never {
-  { : string | "handled"
-    catch (RecB(n) : string) : string | "handled"
+  { : string
+    catch (RecB(n) : string) : string
       catch (e)
         string =>
           "handled" : "handled"

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__04_tir.snap
@@ -892,8 +892,8 @@ function user.ManyNestedExprs(items: int[]) -> int throws never {
         { : int
           b : int
         }
-    let d = : 1 | int -> int
-      match (c : int) : 1 | int
+    let d = : int
+      match (c : int) : int
         0 =>
           1 : 1
         _ =>
@@ -1385,8 +1385,8 @@ function user.LoopStmts(items: int[], flag: bool) -> int throws never {
       { : void
         for j in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
           { : void
-            let computation = : int | 0 -> int
-              if (i * j > 500 && i + j < 100 : bool) : int | 0
+            let computation = : int
+              if (i * j > 500 && i + j < 100 : bool) : int
                 { : int
                   match (i % 3 : int) : int
                     0 =>
@@ -1612,7 +1612,7 @@ function user.MatchExprs(x: int, s: user.MatchStatus, r: user.MatchResult, b: bo
     match (s : user.MatchStatus) : "this arm has many long enum variant names that together push past the limit easily"
       MatchStatus.Active | MatchStatus.Inactive | MatchStatus.Pending =>
         "this arm has many..." : "this arm has many long enum variant names that together push past the limit easily"
-    match (x : int) : string | "short"
+    match (x : int) : string
       0 =>
         { : string
           let result = : "this is the true branch with a very long string" | "this is the false branch also very long" -> string
@@ -1667,7 +1667,7 @@ function user.MatchExprs(x: int, s: user.MatchStatus, r: user.MatchResult, b: bo
             "zero-false" : "zero-false"
       _ =>
         "nonzero" : "nonzero"
-    match (x : int) : "zero-true-active" | "zero-true-inactive" | "zero-true-pending" | "zero-false" | string | "one-success-false" | "other"
+    match (x : int) : string
       0 =>
         match (b : bool) : "zero-true-active" | "zero-true-inactive" | "zero-true-pending" | "zero-false"
           true =>
@@ -1681,9 +1681,9 @@ function user.MatchExprs(x: int, s: user.MatchStatus, r: user.MatchResult, b: bo
           false =>
             "zero-false" : "zero-false"
       1 =>
-        match (r : user.MatchResult) : string | "one-success-false"
+        match (r : user.MatchResult) : string
           s: MatchSuccess =>
-            match (b : bool) : string | "one-success-false"
+            match (b : bool) : string
               true =>
                 s.data : string
               false =>

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/headers_edge_cases/baml_tests__diagnostic_errors__headers_edge_cases__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/headers_edge_cases/baml_tests__diagnostic_errors__headers_edge_cases__04_tir.snap
@@ -50,8 +50,8 @@ function user.HeadersInComplexNesting() -> string throws never {
     let result = : string
       { : string
         // [2] Inside Block Expression
-        let inner = : string | "else value" -> string
-          if (true : true) : string | "else value"
+        let inner = : string
+          if (true : true) : string
             { : string
               // [3] Inside If True
               let deep = : "deep value" -> string
@@ -102,7 +102,7 @@ function user.HeadersAroundExpressions() -> string throws never {
     let x = 5 : 5 -> int
     // [2] After Let
     // [3] Before If
-    if (x > 0 : bool) : int | 0
+    if (x > 0 : bool) : int
       { : int
         // [4] Inside If
         x : int

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__04_tir.snap
@@ -43,8 +43,8 @@ function user.ExhaustiveWithUnderscore(x: int) -> int throws never {
   }
 }
 function user.ExhaustiveWithNamedCatchAll(x: int) -> int throws never {
-  { : 100 | int
-    match (x : int) : 100 | int
+  { : int
+    match (x : int) : int
       1 =>
         100 : 100
       other =>
@@ -62,8 +62,8 @@ function user.GuardedOnlyNonExhaustive(x: int) -> int throws never {
   !! 1738..1831: non-exhaustive match on `int`; missing: _
 }
 function user.GuardedWithFallback(x: int) -> int throws never {
-  { : int | 0
-    match (x : int) : int | 0
+  { : int
+    match (x : int) : int
       n: int if n > 0 =>
         n * 2 : int
       _ =>
@@ -81,8 +81,8 @@ function user.ExhaustiveTypeAlias(r: user.Result) -> string throws never {
   }
 }
 function user.ExhaustiveTypeAliasWithCatchAll(r: user.Result) -> string throws never {
-  { : string | "fallback"
-    match (r : user.Result) : string | "fallback"
+  { : string
+    match (r : user.Result) : string
       s: Success =>
         s.data : string
       _ =>
@@ -129,8 +129,8 @@ function user.OverlappingTypedPatterns(r: user.Result) -> string throws never {
   }
 }
 function user.OverlappingWithBindings(r: user.Result) -> string throws never {
-  { : string | "remaining"
-    match (r : user.Result) : string | "remaining"
+  { : string
+    match (r : user.Result) : string
       s: Success =>
         s.data : string
       x: Success | Failure =>
@@ -372,8 +372,8 @@ function user.IntLiteralUnionPattern(code: user.SuccessCode) -> string throws ne
 }
 type user.MaybeResult = user.Result | null
 function user.NestedTypeAlias(mr: user.MaybeResult) -> string throws never {
-  { : string | "nothing"
-    match (mr : user.MaybeResult) : string | "nothing"
+  { : string
+    match (mr : user.MaybeResult) : string
       s: Success =>
         s.data : string
       f: Failure =>
@@ -534,8 +534,8 @@ function user.NonExhaustiveAliasOfLiterals(code: user.OkOrCreated) -> string thr
 }
 type user.DoubleMaybe = user.MaybeResult | null
 function user.ExhaustiveDoubleMaybe(dm: user.DoubleMaybe) -> string throws never {
-  { : string | "nothing"
-    match (dm : user.DoubleMaybe) : string | "nothing"
+  { : string
+    match (dm : user.DoubleMaybe) : string
       s: Success =>
         s.data : string
       f: Failure =>
@@ -635,8 +635,8 @@ function user.NonExhaustiveNullableEnumMissingVariant(s: user.Status | null) -> 
 }
 type user.SuccessOr200 = user.Success | 200
 function user.ExhaustiveClassPlusLiteral(x: user.SuccessOr200) -> string throws never {
-  { : string | "http ok"
-    match (x : user.SuccessOr200) : string | "http ok"
+  { : string
+    match (x : user.SuccessOr200) : string
       s: Success =>
         s.data : string
       200 =>

--- a/baml_language/crates/baml_tests/tests/type_error_repro.rs
+++ b/baml_language/crates/baml_tests/tests/type_error_repro.rs
@@ -239,3 +239,140 @@ async fn map_with_int_alias_key_is_rejected_at_compile_time() {
     "#
     );
 }
+
+// ============================================================================
+// §N - Control-flow joins subtype-reduce instead of accumulating unions (B-236)
+// ============================================================================
+//
+// Port of TypeScript's flow-join simplification (typescript-go
+// `getUnionOrEvolvingArrayType` + `removeSubtypes`): at an if/else or match
+// join, an unestablished empty `[]` / `{}` branch is established by the other
+// branch's concrete container type, and union members that are subtypes of
+// other members are dropped.
+
+/// The original B-236 repro: `if c { xs } else { [] }` must join `string[]`
+/// with the empty `[]` to `string[]`, not the union `string[] | _[]`. The
+/// union made `.join` unresolvable (and before that, mis-dispatched it to the
+/// Map impl, aborting the VM with `expected map, got array`).
+#[tokio::test]
+async fn if_else_concrete_list_with_empty_else_branch_runs() {
+    let output = baml_test!(
+        r#"
+        function f(xs: string[], m: int) -> string {
+            let top = if (m > 0) { xs.slice(0, m) } else { [] };
+            top.join(" ")
+        }
+        function main() -> string {
+            f(["a", "b", "c"], 2)
+        }
+    "#
+    );
+    assert!(
+        matches!(&output.result, Ok(BexExternalValue::String(s)) if s == "a b"),
+        "expected \"a b\", got: {:?}",
+        output.result
+    );
+}
+
+/// The empty branch is not just typeable - it also runs: with `m = 0` the
+/// else-branch's actual empty array flows through the `string[]`-typed binding
+/// and `.join` returns `""`.
+#[tokio::test]
+async fn if_else_empty_else_branch_taken_at_runtime() {
+    let output = baml_test!(
+        r#"
+        function f(xs: string[], m: int) -> string {
+            let top = if (m > 0) { xs.slice(0, m) } else { [] };
+            top.join(" ")
+        }
+        function main() -> string {
+            f(["a", "b", "c"], 0)
+        }
+    "#
+    );
+    assert!(
+        matches!(&output.result, Ok(BexExternalValue::String(s)) if s.is_empty()),
+        "expected \"\", got: {:?}",
+        output.result
+    );
+}
+
+/// The map analogue: `if c { {"a": 1} } else { {} }` joins to
+/// `map<string, int>`, so indexing resolves.
+#[tokio::test]
+async fn if_else_concrete_map_with_empty_else_branch_runs() {
+    let output = baml_test!(
+        r#"
+        function main() -> int {
+            let m = if (true) { {"a": 1} } else { {} };
+            m["a"]
+        }
+    "#
+    );
+    assert!(
+        matches!(output.result, Ok(BexExternalValue::Int(1))),
+        "expected 1, got: {:?}",
+        output.result
+    );
+}
+
+/// Two empty branches stay *evolving*: the join must not prematurely commit
+/// the container, so a later `push` still establishes the element type.
+#[tokio::test]
+async fn if_else_both_empty_branches_still_establishable() {
+    let output = baml_test!(
+        r#"
+        function main() -> int {
+            let x = if (true) { [] } else { [] };
+            x.push(5);
+            x[0]
+        }
+    "#
+    );
+    assert!(
+        matches!(output.result, Ok(BexExternalValue::Int(5))),
+        "expected 5, got: {:?}",
+        output.result
+    );
+}
+
+/// Two *committed* lists of different element types do NOT element-join to
+/// `(int | string)[]` (that would let a write through the joined view corrupt
+/// an aliased `int[]`). The join stays a union, on which mutation is rejected.
+#[tokio::test]
+#[should_panic(expected = "has no member `push`")]
+async fn if_else_committed_lists_of_different_elements_stay_a_union() {
+    let _ = baml_test!(
+        r#"
+        function main() -> int {
+            let v = if (true) { [1] } else { ["a"] };
+            v.push(2);
+            0
+        }
+    "#
+    );
+}
+
+/// Subtype reduction at the join: a literal branch joined with its base type
+/// reduces to the base (`1 | int` -> `int`), so the result stays usable as a
+/// plain `int` binding.
+#[tokio::test]
+async fn if_else_literal_and_base_reduce_to_base() {
+    let output = baml_test!(
+        r#"
+        function f(n: int) -> int {
+            let v = if (n > 0) { 1 } else { n };
+            let w: int = v;
+            w
+        }
+        function main() -> int {
+            f(-3)
+        }
+    "#
+    );
+    assert!(
+        matches!(output.result, Ok(BexExternalValue::Int(-3))),
+        "expected -3, got: {:?}",
+        output.result
+    );
+}


### PR DESCRIPTION
Fixes [B-236](https://linear.app/boundaryml2/issue/B-236). Supersedes #3781.

## The bug
```baml
function f(xs: string[], m: int) -> string {
  let top = if (m > 0) { xs.slice(0, m) } else { [] };
  top.join(" ")   // E0007: type `string[] | _[]` has no member `join`
}
```
The if/else joined `string[]` with the empty-array `EvolvingList(never)` into a union. The unestablished evolving sentinel is a dead end inside a union (no later use can establish a union arm), so member resolution fails - and before the E0007 guard existed, `.join` mis-dispatched to the Map impl and aborted the VM with `expected map, got array`.

## The fix
Port of typescript-go's flow-join simplification (`getUnionOrEvolvingArrayType` + `removeSubtypes`, the `UnionReduction.Subtype` mode applied to unions synthesized at expression joins), adapted to BAML's invariant containers:

- **Subtype reduction at joins**: union members that are subtypes of other members are dropped. `1 | int` -> `int`, `Color.Red | Color` -> `Color`, `int | unknown` -> `unknown`. Declared (user-written) unions are untouched, as in TS.
- **Empty-collection establishment**: an unestablished `[]` / `{}` branch is absorbed by any same-category container member. It cannot be a *subtype* of one (lists/maps are invariant), but the join is an establishing use exactly like a `push`, and the `Evolving` wrapper proves the value is a fresh literal no committed alias can observe. This is what TS gets from `never[]` covariance, restricted to the sound fresh-literal case: a user-annotated committed `never[]` is NOT absorbed.
- **Two still-evolving containers** join element-wise and stay evolving, so `let x = if c { [] } else { [] }; x.push(5)` still establishes.
- **Deliberately NOT ported from #3781**: two committed lists of different element types do not element-join to `(a | b)[]` - that would let a write through the joined view corrupt an aliased `a[]`. They stay a union, matching TS (which keeps `string[] | number[]` and rejects mutation through it).
- Also fixes empty `Expr::Map` literals committing to `map<never, never>` instead of an evolving map (the `Expr::Array` arm already had the special case).

## Tests
Six regression tests in `type_error_repro.rs`: the B-236 repro (both runtime paths, including the else-branch's actual empty array flowing through the `string[]` binding), the map analogue, both-empty-stays-establishable, a soundness guard that committed `int[]`/`string[]` branches stay a union with mutation rejected, and literal-base reduction.

Local: `type_error_repro` suite green (18/18); full workspace suite left to CI. TIR/corpus snapshot diffs may surface there (e.g. stdlib `OrchestrationStep[] | never[]` -> `OrchestrationStep[]`); flagging for review rather than pre-accepting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for conditional branches, pattern matching, and exception flows.
  * Empty lists and maps now combine correctly with typed collections, enabling expected operations such as joining strings and indexing maps.
  * Simplified inferred unions by removing redundant subtype entries.
  * Empty collections can now establish their element types when later mutated.
  * Preserved type safety when combining collections with incompatible element types.

* **Tests**
  * Added regression coverage for collection inference, runtime behavior, mutation, and subtype reduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->