### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -40,13 +40,13 @@ policy.max_delta_pct = 3.0
 # engine/compiler/sdkgen generics support, +499 KB / +3.2% vs the prior
 # 15.59 MB baseline).
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 17_480_864
+max_file_bytes = 17_480_913
 # Linux x86_64: baseline 21.51 MB file.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 22_747_163
+max_file_bytes = 22_762_869
 # Windows x86_64: baseline 18.11 MB file.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 19_098_870
+max_file_bytes = 19_105_199
 
 [artifacts.packed-program]
 kind = "pack"
@@ -54,13 +54,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 12.01 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 12_593_524
+max_file_bytes = 12_593_557
 # Linux x86_64: baseline 15.62 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 16_305_593
+max_file_bytes = 16_314_006
 # Windows x86_64: baseline 13.00 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 13_505_727
+max_file_bytes = 13_513_082
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -84,4 +84,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.06 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_262_473
+max_gzip_bytes = 4_267_289

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-14T09:58:35Z"
-git_sha = "4146a2afc4d11a7fd274b1ade60efe868a6ac829"
+recorded_at = "2026-07-15T09:59:30Z"
+git_sha = "ab43021fbdda9240bf5b7e49e8820e6caa2130b0"
 
 [artifacts.baml-cli]
-file_bytes = 16971712
-stripped_bytes = 16971744
-gzip_bytes = 8191659
+file_bytes = 16971760
+stripped_bytes = 16971792
+gzip_bytes = 8198059
 
 [artifacts.packed-program]
-file_bytes = 12226722
-gzip_bytes = 5884693
+file_bytes = 12226754
+gzip_bytes = 5884470

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-07-14T09:58:35Z"
-git_sha = "4146a2afc4d11a7fd274b1ade60efe868a6ac829"
+recorded_at = "2026-07-15T09:59:30Z"
+git_sha = "ab43021fbdda9240bf5b7e49e8820e6caa2130b0"
 
 [artifacts.bridge_wasm]
-file_bytes = 14601922
-gzip_bytes = 4138323
+file_bytes = 14624846
+gzip_bytes = 4142999

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-14T09:58:35Z"
-git_sha = "4146a2afc4d11a7fd274b1ade60efe868a6ac829"
+recorded_at = "2026-07-15T09:59:30Z"
+git_sha = "ab43021fbdda9240bf5b7e49e8820e6caa2130b0"
 
 [artifacts.baml-cli]
-file_bytes = 18542592
-stripped_bytes = 18542592
-gzip_bytes = 8402923
+file_bytes = 18548736
+stripped_bytes = 18548736
+gzip_bytes = 8404228
 
 [artifacts.packed-program]
-file_bytes = 13112356
-gzip_bytes = 5965731
+file_bytes = 13119497
+gzip_bytes = 5965954

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-14T09:58:35Z"
-git_sha = "4146a2afc4d11a7fd274b1ade60efe868a6ac829"
+recorded_at = "2026-07-15T09:59:30Z"
+git_sha = "ab43021fbdda9240bf5b7e49e8820e6caa2130b0"
 
 [artifacts.baml-cli]
-file_bytes = 22084624
-stripped_bytes = 22084616
-gzip_bytes = 9439970
+file_bytes = 22099872
+stripped_bytes = 22099864
+gzip_bytes = 9440439
 
 [artifacts.packed-program]
-file_bytes = 15830672
-gzip_bytes = 6727114
+file_bytes = 15838840
+gzip_bytes = 6723946


### PR DESCRIPTION
Adopted from CI run [`ab43021fbdda9240bf5b7e49e8820e6caa2130b0`](https://github.com/BoundaryML/baml/actions/runs/29380167791).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 22.1 MB | 9.4 MB | **file** | 22.1 MB | +15.2 KB (+0.1%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 15.8 MB | 6.7 MB | **file** | 15.8 MB | +8.2 KB (+0.1%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 17.0 MB | 8.2 MB | **file** | 17.0 MB | +48 B (+0.0%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 12.2 MB | 5.9 MB | **file** | 12.2 MB | +32 B (+0.0%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 14.6 MB | 🔒 4.1 MB | **gzip** | 4.1 MB | +4.7 KB (+0.1%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 18.5 MB | 8.4 MB | **file** | 18.5 MB | +6.1 KB (+0.0%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 13.1 MB | 6.0 MB | **file** | 13.1 MB | +7.1 KB (+0.1%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build artifact size thresholds across macOS, Linux, Windows, and WebAssembly targets.
  * Refreshed recorded artifact measurements and build metadata for current releases.
  * Ensured size checks reflect the latest CLI, packaged program, and WebAssembly bundle outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->