### PR TITLE
feat(cffi): add versioned bridge API foundation

### DIFF
--- a/baml_language/crates/bridge_cffi/src/api.rs
+++ b/baml_language/crates/bridge_cffi/src/api.rs
@@ -1,0 +1,181 @@
+//! Versioned function-table entry point for dynamically loaded host bridges.
+//!
+//! Hosts resolve only [`baml_get_api_v1`] with the platform loader. Every
+//! callable used by that ABI version is then obtained from this table, which
+//! makes completeness and compatibility validation explicit.
+
+use bex_project::HostReleaseFn;
+
+use crate::{
+    BamlBridgeInfoV1, Buffer,
+    ffi::{callbacks::CallbackFn, handle::BamlCffiStatus, host_value::HostDispatchFn},
+};
+
+/// First version of the shared BAML C API.
+///
+/// Fields may only be appended. Existing fields must retain their order,
+/// signatures, and semantics for the lifetime of ABI version 1.
+#[repr(C)]
+pub struct BamlApiV1 {
+    /// ABI version represented by this table. Always `1` for this type.
+    pub abi_version: u32,
+    /// Size of the table in bytes, allowing hosts to reject truncated tables.
+    pub struct_size: usize,
+    /// Return the canonical BAML product version.
+    pub version: extern "C" fn() -> Buffer,
+    /// Replace the process-wide runtime with a serialized BAML program.
+    pub initialize_runtime_from_bytecode:
+        extern "C" fn(bytecode: *const u8, length: usize) -> Buffer,
+    /// Release a buffer allocated by the runtime.
+    pub free_buffer: extern "C" fn(buffer: Buffer),
+    /// Register the host callback that receives completed calls.
+    pub register_callback: extern "C" fn(callback: CallbackFn),
+    /// Begin a BAML function call.
+    pub call_function: extern "C" fn(
+        function_name: *const libc::c_char,
+        encoded_args: *const u8,
+        length: usize,
+        callback_id: u32,
+    ),
+    /// Allocate a process-unique function-call identifier.
+    pub new_function_call: extern "C" fn() -> u64,
+    /// Cancel a function call. Zero means success.
+    pub cancel_function_call: extern "C" fn(id: u64) -> i32,
+    /// Register the host callback used when BAML invokes a host value.
+    pub register_host_dispatch_callback: extern "C" fn(callback: HostDispatchFn),
+    /// Register the callback used to release host-language values.
+    pub register_host_release_callback: extern "C" fn(callback: HostReleaseFn),
+    /// Complete one host-value invocation.
+    pub complete_host_call:
+        extern "C" fn(call_id: u32, is_error: i32, content: *const i8, length: usize),
+    /// Clone an owned CFFI handle.
+    pub handle_clone: unsafe extern "C" fn(key: u64, out_key: *mut u64) -> BamlCffiStatus,
+    /// Release an owned CFFI handle.
+    pub handle_release: unsafe extern "C" fn(key: u64) -> BamlCffiStatus,
+    /// Construct a media handle backed by a URL.
+    pub media_from_url: unsafe extern "C" fn(
+        media_kind: i32,
+        url: *const libc::c_char,
+        mime_type_or_null: *const libc::c_char,
+        out_key: *mut u64,
+        out_handle_type: *mut i32,
+    ) -> BamlCffiStatus,
+    /// Construct a media handle backed by a local file.
+    pub media_from_file: unsafe extern "C" fn(
+        media_kind: i32,
+        path: *const libc::c_char,
+        mime_type_or_null: *const libc::c_char,
+        out_key: *mut u64,
+        out_handle_type: *mut i32,
+    ) -> BamlCffiStatus,
+    /// Construct a media handle backed by base64 data.
+    pub media_from_base64: unsafe extern "C" fn(
+        media_kind: i32,
+        base64: *const libc::c_char,
+        mime_type_or_null: *const libc::c_char,
+        out_key: *mut u64,
+        out_handle_type: *mut i32,
+    ) -> BamlCffiStatus,
+    /// Read the URL of a media handle.
+    pub media_url:
+        unsafe extern "C" fn(key: u64, handle_type: i32, out: *mut Buffer) -> BamlCffiStatus,
+    /// Read the local path of a media handle.
+    pub media_file:
+        unsafe extern "C" fn(key: u64, handle_type: i32, out: *mut Buffer) -> BamlCffiStatus,
+    /// Read the base64 contents of a media handle.
+    pub media_base64:
+        unsafe extern "C" fn(key: u64, handle_type: i32, out: *mut Buffer) -> BamlCffiStatus,
+    /// Read the MIME type of a media handle.
+    pub media_mime_type:
+        unsafe extern "C" fn(key: u64, handle_type: i32, out: *mut Buffer) -> BamlCffiStatus,
+    /// Register the calling bridge and require an exact release-version match.
+    ///
+    /// An empty buffer means compatible. A non-empty buffer is an owned UTF-8
+    /// diagnostic that must be released with [`crate::free_buffer`].
+    pub register_bridge: unsafe extern "C" fn(info: *const BamlBridgeInfoV1) -> Buffer,
+}
+
+static BAML_API_V1: BamlApiV1 = BamlApiV1 {
+    abi_version: 1,
+    struct_size: std::mem::size_of::<BamlApiV1>(),
+    version: crate::version,
+    initialize_runtime_from_bytecode: crate::initialize_runtime_from_bytecode_ffi,
+    free_buffer: crate::free_buffer,
+    register_callback: crate::register_callback,
+    call_function: crate::call_function,
+    new_function_call: crate::new_function_call,
+    cancel_function_call: crate::cancel_function_call,
+    register_host_dispatch_callback: crate::register_host_dispatch_callback,
+    register_host_release_callback: crate::register_host_release_callback,
+    complete_host_call: crate::complete_host_call,
+    handle_clone: crate::baml_handle_clone,
+    handle_release: crate::baml_handle_release,
+    media_from_url: crate::baml_media_from_url,
+    media_from_file: crate::baml_media_from_file,
+    media_from_base64: crate::baml_media_from_base64,
+    media_url: crate::baml_media_url,
+    media_file: crate::baml_media_file,
+    media_base64: crate::baml_media_base64,
+    media_mime_type: crate::baml_media_mime_type,
+    register_bridge: crate::register_bridge_ffi,
+};
+
+/// Return the immutable version-1 BAML C API function table.
+///
+/// This is the only symbol a manually loaded host bridge needs to resolve.
+#[unsafe(no_mangle)]
+pub extern "C" fn baml_get_api_v1() -> *const BamlApiV1 {
+    &BAML_API_V1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_v1_reports_its_exact_layout() {
+        let api = unsafe { &*baml_get_api_v1() };
+        assert_eq!(api.abi_version, 1);
+        assert_eq!(api.struct_size, std::mem::size_of::<BamlApiV1>());
+    }
+
+    #[test]
+    fn api_v1_contains_the_complete_production_cffi_surface() {
+        macro_rules! assert_same_function {
+            ($actual:expr, $expected:path) => {
+                assert_eq!($actual as *const (), $expected as *const ());
+            };
+        }
+
+        let api = unsafe { &*baml_get_api_v1() };
+        assert_same_function!(api.version, crate::version);
+        assert_same_function!(
+            api.initialize_runtime_from_bytecode,
+            crate::initialize_runtime_from_bytecode_ffi
+        );
+        assert_same_function!(api.free_buffer, crate::free_buffer);
+        assert_same_function!(api.register_callback, crate::register_callback);
+        assert_same_function!(api.call_function, crate::call_function);
+        assert_same_function!(api.new_function_call, crate::new_function_call);
+        assert_same_function!(api.cancel_function_call, crate::cancel_function_call);
+        assert_same_function!(
+            api.register_host_dispatch_callback,
+            crate::register_host_dispatch_callback
+        );
+        assert_same_function!(
+            api.register_host_release_callback,
+            crate::register_host_release_callback
+        );
+        assert_same_function!(api.complete_host_call, crate::complete_host_call);
+        assert_same_function!(api.handle_clone, crate::baml_handle_clone);
+        assert_same_function!(api.handle_release, crate::baml_handle_release);
+        assert_same_function!(api.media_from_url, crate::baml_media_from_url);
+        assert_same_function!(api.media_from_file, crate::baml_media_from_file);
+        assert_same_function!(api.media_from_base64, crate::baml_media_from_base64);
+        assert_same_function!(api.media_url, crate::baml_media_url);
+        assert_same_function!(api.media_file, crate::baml_media_file);
+        assert_same_function!(api.media_base64, crate::baml_media_base64);
+        assert_same_function!(api.media_mime_type, crate::baml_media_mime_type);
+        assert_same_function!(api.register_bridge, crate::register_bridge_ffi);
+    }
+}

--- a/baml_language/crates/bridge_cffi/src/ffi/runtime.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/runtime.rs
@@ -1,6 +1,6 @@
 //! Runtime management FFI functions.
 
-use std::{collections::HashMap, ffi::CStr};
+use std::{collections::HashMap, ffi::CStr, panic::AssertUnwindSafe, sync::OnceLock};
 
 use crate::{
     Buffer, initialize_runtime,
@@ -12,6 +12,218 @@ use crate::{
 #[unsafe(no_mangle)]
 pub extern "C" fn version() -> Buffer {
     Buffer::from(baml_version::CANONICAL_VERSION.as_bytes().to_vec())
+}
+
+/// Require an exact match between a host SDK and this native runtime.
+///
+/// BAML releases are kept in lockstep while the public bridge contracts are
+/// evolving. Compatibility is therefore deliberately stricter than SemVer:
+/// the SDK and runtime must report the same canonical release version.
+pub fn ensure_version_compatible(expected_version: &str) -> Result<(), String> {
+    let actual_version = baml_version::CANONICAL_VERSION;
+    if expected_version == actual_version {
+        Ok(())
+    } else {
+        Err(format!(
+            "BAML runtime version mismatch: SDK requires {expected_version}, but library reports {actual_version}"
+        ))
+    }
+}
+
+/// Stable identity of an official host-language bridge.
+///
+/// Discriminants are part of the C ABI and may never be reused. The C-facing
+/// registration struct stores the raw value as a `u32`, so an unknown value
+/// can be rejected without constructing an invalid Rust enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum BridgeLanguage {
+    NodeJs = 1,
+    Python = 2,
+    Go = 3,
+    Rust = 4,
+    CSharp = 5,
+}
+
+impl BridgeLanguage {
+    pub const fn telemetry_name(self) -> &'static str {
+        match self {
+            Self::NodeJs => "nodejs",
+            Self::Python => "python",
+            Self::Go => "go",
+            Self::Rust => "rust",
+            Self::CSharp => "csharp",
+        }
+    }
+
+    const fn display_name(self) -> &'static str {
+        match self {
+            Self::NodeJs => "Node.js",
+            Self::Python => "Python",
+            Self::Go => "Go",
+            Self::Rust => "Rust",
+            Self::CSharp => "C#",
+        }
+    }
+}
+
+impl TryFrom<u32> for BridgeLanguage {
+    type Error = String;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::NodeJs),
+            2 => Ok(Self::Python),
+            3 => Ok(Self::Go),
+            4 => Ok(Self::Rust),
+            5 => Ok(Self::CSharp),
+            _ => Err(format!("unknown BAML bridge language ID {value}")),
+        }
+    }
+}
+
+/// Host bridge metadata retained by the runtime for diagnostics and telemetry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeInfo {
+    pub language: BridgeLanguage,
+    pub sdk_version: String,
+}
+
+/// Version-1 C representation of bridge registration metadata.
+///
+/// Fields may only be appended. Existing fields must retain their order,
+/// types, and semantics for the lifetime of ABI version 1. The `language`
+/// field is a raw `uint32_t` at the C boundary and is validated before it is
+/// converted to [`BridgeLanguage`].
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct BamlBridgeInfoV1 {
+    pub struct_size: usize,
+    pub language: u32,
+    pub sdk_version: *const u8,
+    pub sdk_version_len: usize,
+}
+
+struct BridgeRegistry {
+    info: OnceLock<BridgeInfo>,
+}
+
+impl BridgeRegistry {
+    const fn new() -> Self {
+        Self {
+            info: OnceLock::new(),
+        }
+    }
+
+    fn register(&self, requested: BridgeInfo) -> Result<&BridgeInfo, String> {
+        if let Some(existing) = self.info.get() {
+            return compatible_registration(existing, &requested).map(|()| existing);
+        }
+
+        if let Err(requested) = self.info.set(requested) {
+            let existing = self
+                .info
+                .get()
+                .expect("bridge registration was initialized concurrently");
+            return compatible_registration(existing, &requested).map(|()| existing);
+        }
+        Ok(self
+            .info
+            .get()
+            .expect("bridge registration was just initialized"))
+    }
+}
+
+fn compatible_registration(existing: &BridgeInfo, requested: &BridgeInfo) -> Result<(), String> {
+    if existing == requested {
+        return Ok(());
+    }
+    Err(format!(
+        "BAML native runtime is already registered by the {} SDK {}; cannot also register the {} SDK {}",
+        existing.language.display_name(),
+        existing.sdk_version,
+        requested.language.display_name(),
+        requested.sdk_version,
+    ))
+}
+
+static REGISTERED_BRIDGE: BridgeRegistry = BridgeRegistry::new();
+
+/// Return the registered bridge identity for telemetry and diagnostics.
+pub fn registered_bridge() -> Option<&'static BridgeInfo> {
+    REGISTERED_BRIDGE.info.get()
+}
+
+/// Register a host bridge and require an exact canonical release match.
+pub fn register_bridge(info: BridgeInfo) -> Result<&'static BridgeInfo, String> {
+    if ensure_version_compatible(&info.sdk_version).is_err() {
+        return Err(format!(
+            "BAML {} SDK {} cannot use native runtime {}. Install the matching native runtime or update the {} SDK",
+            info.language.display_name(),
+            info.sdk_version,
+            baml_version::CANONICAL_VERSION,
+            info.language.display_name(),
+        ));
+    }
+    REGISTERED_BRIDGE.register(info)
+}
+
+/// Register the calling bridge and check SDK/runtime compatibility.
+///
+/// An empty buffer means success. Otherwise the returned buffer contains a
+/// shared UTF-8 diagnostic and must be released with [`crate::free_buffer`].
+///
+/// # Safety
+///
+/// `info` must be null or point to an aligned C object whose readable extent
+/// is at least the value of its `struct_size` field. Any non-null
+/// `sdk_version` must be readable for `sdk_version_len` bytes.
+pub unsafe extern "C" fn register_bridge_ffi(info: *const BamlBridgeInfoV1) -> Buffer {
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        if info.is_null() {
+            return Err("BAML bridge registration pointer is null".to_string());
+        }
+        // Read only the leading size field before trusting that the caller's
+        // allocation is large enough for the rest of the version-1 struct.
+        let struct_size = unsafe { std::ptr::addr_of!((*info).struct_size).read() };
+        if struct_size < std::mem::size_of::<BamlBridgeInfoV1>() {
+            return Err(format!(
+                "truncated BAML bridge registration: got {} bytes, need {}",
+                struct_size,
+                std::mem::size_of::<BamlBridgeInfoV1>(),
+            ));
+        }
+        let info = unsafe { info.read() };
+        let language = BridgeLanguage::try_from(info.language)?;
+        if info.sdk_version.is_null() && info.sdk_version_len != 0 {
+            return Err("BAML SDK version pointer is null but length is nonzero".to_string());
+        }
+        if info.sdk_version_len > isize::MAX as usize {
+            return Err(format!(
+                "BAML SDK version length {} exceeds isize::MAX",
+                info.sdk_version_len,
+            ));
+        }
+
+        let bytes = if info.sdk_version_len == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(info.sdk_version, info.sdk_version_len) }
+        };
+        let sdk_version = std::str::from_utf8(bytes)
+            .map_err(|error| format!("BAML SDK version is not valid UTF-8: {error}"))?;
+        register_bridge(BridgeInfo {
+            language,
+            sdk_version: sdk_version.to_string(),
+        })
+        .map(|_| ())
+    }));
+
+    match result {
+        Ok(Ok(())) => Buffer::from(Vec::new()),
+        Ok(Err(error)) => Buffer::from(error.into_bytes()),
+        Err(_) => Buffer::from(b"panic while registering BAML bridge".to_vec()),
+    }
 }
 
 /// Create/initialize the BAML runtime (global BexEngine).
@@ -112,6 +324,135 @@ pub extern "C" fn invoke_runtime_cli(_args: *const *const libc::c_char) -> libc:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_version_is_compatible() {
+        assert!(ensure_version_compatible(baml_version::CANONICAL_VERSION).is_ok());
+    }
+
+    #[test]
+    fn any_nonidentical_version_is_incompatible() {
+        let error = ensure_version_compatible("999.0.0").unwrap_err();
+        assert!(error.contains("SDK requires 999.0.0"));
+        assert!(error.contains(baml_version::CANONICAL_VERSION));
+    }
+
+    #[test]
+    fn bridge_registry_is_idempotent_for_identical_registration() {
+        let registry = BridgeRegistry::new();
+        let info = BridgeInfo {
+            language: BridgeLanguage::NodeJs,
+            sdk_version: baml_version::CANONICAL_VERSION.to_string(),
+        };
+        assert_eq!(registry.register(info.clone()).unwrap(), &info);
+        assert_eq!(registry.register(info.clone()).unwrap(), &info);
+    }
+
+    #[test]
+    fn bridge_registry_rejects_conflicting_registration() {
+        let registry = BridgeRegistry::new();
+        registry
+            .register(BridgeInfo {
+                language: BridgeLanguage::NodeJs,
+                sdk_version: baml_version::CANONICAL_VERSION.to_string(),
+            })
+            .unwrap();
+        let error = registry
+            .register(BridgeInfo {
+                language: BridgeLanguage::Python,
+                sdk_version: baml_version::CANONICAL_VERSION.to_string(),
+            })
+            .unwrap_err();
+        assert!(error.contains("already registered by the Node.js SDK"));
+        assert!(error.contains("cannot also register the Python SDK"));
+    }
+
+    #[test]
+    fn ffi_registration_returns_shared_language_aware_diagnostic() {
+        let expected = b"999.0.0";
+        let info = BamlBridgeInfoV1 {
+            struct_size: std::mem::size_of::<BamlBridgeInfoV1>(),
+            language: BridgeLanguage::Python as u32,
+            sdk_version: expected.as_ptr(),
+            sdk_version_len: expected.len(),
+        };
+        let buffer = unsafe { register_bridge_ffi(&info) };
+        assert!(!buffer.is_empty());
+        let bytes = unsafe { std::slice::from_raw_parts(buffer.ptr.cast::<u8>(), buffer.len) };
+        let message = std::str::from_utf8(bytes).unwrap();
+        assert!(message.contains("BAML Python SDK 999.0.0 cannot use native runtime"));
+        assert!(message.contains("Install the matching native runtime"));
+        crate::free_buffer(buffer);
+    }
+
+    #[test]
+    fn ffi_registration_records_bridge_identity_for_telemetry() {
+        let expected = baml_version::CANONICAL_VERSION.as_bytes();
+        let info = BamlBridgeInfoV1 {
+            struct_size: std::mem::size_of::<BamlBridgeInfoV1>(),
+            language: BridgeLanguage::Rust as u32,
+            sdk_version: expected.as_ptr(),
+            sdk_version_len: expected.len(),
+        };
+
+        let first = unsafe { register_bridge_ffi(&info) };
+        assert!(first.is_empty());
+        crate::free_buffer(first);
+        let second = unsafe { register_bridge_ffi(&info) };
+        assert!(second.is_empty());
+        crate::free_buffer(second);
+
+        let registered = registered_bridge().unwrap();
+        assert_eq!(registered.language, BridgeLanguage::Rust);
+        assert_eq!(registered.language.telemetry_name(), "rust");
+        assert_eq!(registered.sdk_version, baml_version::CANONICAL_VERSION);
+    }
+
+    #[test]
+    fn ffi_registration_rejects_unknown_language_without_undefined_behavior() {
+        let expected = baml_version::CANONICAL_VERSION.as_bytes();
+        let info = BamlBridgeInfoV1 {
+            struct_size: std::mem::size_of::<BamlBridgeInfoV1>(),
+            language: u32::MAX,
+            sdk_version: expected.as_ptr(),
+            sdk_version_len: expected.len(),
+        };
+        let buffer = unsafe { register_bridge_ffi(&info) };
+        let bytes = unsafe { std::slice::from_raw_parts(buffer.ptr.cast::<u8>(), buffer.len) };
+        let message = std::str::from_utf8(bytes).unwrap();
+        assert_eq!(message, "unknown BAML bridge language ID 4294967295");
+        crate::free_buffer(buffer);
+    }
+
+    #[test]
+    fn ffi_registration_rejects_truncated_metadata() {
+        let info = BamlBridgeInfoV1 {
+            struct_size: std::mem::size_of::<usize>(),
+            language: BridgeLanguage::Rust as u32,
+            sdk_version: std::ptr::null(),
+            sdk_version_len: 0,
+        };
+        let buffer = unsafe { register_bridge_ffi(&info) };
+        let bytes = unsafe { std::slice::from_raw_parts(buffer.ptr.cast::<u8>(), buffer.len) };
+        let message = std::str::from_utf8(bytes).unwrap();
+        assert!(message.starts_with("truncated BAML bridge registration:"));
+        crate::free_buffer(buffer);
+    }
+
+    #[test]
+    fn ffi_registration_rejects_impossible_version_length() {
+        let info = BamlBridgeInfoV1 {
+            struct_size: std::mem::size_of::<BamlBridgeInfoV1>(),
+            language: BridgeLanguage::Rust as u32,
+            sdk_version: std::ptr::dangling(),
+            sdk_version_len: usize::MAX,
+        };
+        let buffer = unsafe { register_bridge_ffi(&info) };
+        let bytes = unsafe { std::slice::from_raw_parts(buffer.ptr.cast::<u8>(), buffer.len) };
+        let message = std::str::from_utf8(bytes).unwrap();
+        assert!(message.contains("exceeds isize::MAX"));
+        crate::free_buffer(buffer);
+    }
 
     #[test]
     fn bytecode_initializer_rejects_null_pointer_with_nonzero_length() {

--- a/baml_language/crates/bridge_cffi/src/lib.rs
+++ b/baml_language/crates/bridge_cffi/src/lib.rs
@@ -23,6 +23,7 @@ use once_cell::sync::OnceCell;
 use sys_native::SysOpsExt;
 use tokio::runtime::Runtime;
 
+pub mod api;
 pub mod baml_to_host;
 pub mod buffer;
 pub mod collector;
@@ -31,6 +32,7 @@ mod ffi;
 pub mod host_spans;
 mod panic;
 
+pub use api::{BamlApiV1, baml_get_api_v1};
 pub use baml_to_host::{call_and_encode, error_to_outbound, result_to_outbound};
 pub use bridge_ctypes::baml_bridge;
 pub use buffer::Buffer;
@@ -48,7 +50,12 @@ pub use ffi::{
         register_host_release_callback,
     },
     objects::{flush_events, free_buffer},
-    runtime::{create_baml_runtime, destroy_baml_runtime, invoke_runtime_cli, version},
+    runtime::{
+        BamlBridgeInfoV1, BridgeInfo, BridgeLanguage, create_baml_runtime, destroy_baml_runtime,
+        ensure_version_compatible,
+        initialize_runtime_from_bytecode as initialize_runtime_from_bytecode_ffi,
+        invoke_runtime_cli, register_bridge, register_bridge_ffi, registered_bridge, version,
+    },
 };
 
 use crate::ffi::callbacks::send_outbound_result_to_callback;

--- a/baml_language/sdks/nodejs/bridge_nodejs/src/lib.rs
+++ b/baml_language/sdks/nodejs/bridge_nodejs/src/lib.rs
@@ -15,6 +15,13 @@ use napi_derive::napi;
 
 #[napi_derive::module_init]
 fn init() {
+    if let Err(error) = bridge_cffi::register_bridge(bridge_cffi::BridgeInfo {
+        language: bridge_cffi::BridgeLanguage::NodeJs,
+        sdk_version: baml_version::CANONICAL_VERSION.to_string(),
+    }) {
+        eprintln!("failed to register BAML Node.js bridge: {error}");
+    }
+
     // Wire the bridge_cffi C entry points to this bridge's per-process
     // Node host-value registry. First-call-wins inside bridge_cffi, so
     // repeated module loads (rare under napi-rs, which loads each addon

--- a/baml_language/sdks/python/rust/bridge_python/src/lib.rs
+++ b/baml_language/sdks/python/rust/bridge_python/src/lib.rs
@@ -13,6 +13,7 @@ pub mod types;
 
 use pyo3::{
     Bound,
+    exceptions::PyImportError,
     prelude::{PyModule, PyResult, pyfunction, pymodule},
     types::PyModuleMethods,
     wrap_pyfunction,
@@ -45,6 +46,12 @@ fn cancel_function_call(call_id: u64) -> bool {
 
 #[pymodule]
 fn baml_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    bridge_cffi::register_bridge(bridge_cffi::BridgeInfo {
+        language: bridge_cffi::BridgeLanguage::Python,
+        sdk_version: baml_version::CANONICAL_VERSION.to_string(),
+    })
+    .map_err(PyImportError::new_err)?;
+
     m.add_class::<baml_call_context::BamlCallContext>()?;
     m.add_class::<py_handle::BamlPyHandle>()?;
     m.add_wrapped(wrap_pyfunction!(py_handle::_seed_function_ref_handle))?;


### PR DESCRIPTION
## Summary

- add the append-only BamlApiV1 function table and baml_get_api_v1 loader entry point
- add shared bridge registration with exact canonical-version validation, stable language IDs, idempotency, conflict diagnostics, and retained identity
- register the existing Python and Node.js bridges with baml_version::CANONICAL_VERSION
- reject truncated metadata, impossible lengths, invalid UTF-8, and unknown raw language IDs safely

## ABI scope

The table contains the production CFFI surface used by dynamic bridges. Test-only seed functions and obsolete/no-op legacy lifecycle functions remain available as direct legacy exports but are intentionally absent from BamlApiV1. register_bridge is available through the table and is not a separately resolved dynamic symbol.

No Go SDK, packaging, release, workflow, manifest, nextest, generated, or lockfile changes are included.

## Validation

- cargo fmt --all --check
- cargo test -p bridge_cffi (22 passed)
- PYO3_PYTHON=/Users/vbv/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 cargo clippy -p bridge_cffi -p bridge_python -p bridge_nodejs --all-targets -- -D warnings
- built libbridge_cffi.dylib and confirmed baml_get_api_v1 is exported while register_bridge_ffi is not separately exported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a versioned C-compatible API for dynamically loaded bridges.
  - Added bridge registration with SDK version and language compatibility checks.
  - Added support for tracking registered bridge identity and reporting registration errors.
  - Node.js and Python integrations now register themselves with the runtime during initialization.

- **Bug Fixes**
  - Invalid, truncated, incompatible, or conflicting bridge registrations are rejected with diagnostics.

- **Tests**
  - Added coverage for API wiring, compatibility validation, registration behavior, and FFI error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->