### PR TITLE
perf(compiler2): tracked file_ast query — lower CST→AST once per file

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// A reference to an environment variable found in source code (`env.VAR_NAME`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvVarRef {
     /// The variable name (e.g., `"OPENAI_API_KEY"`).
     pub name: String,

--- a/baml_language/crates/baml_compiler2_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/lib.rs
@@ -98,6 +98,57 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
     files
 }
 
+// ── file_ast ──────────────────────────────────────────────────────────────────
+
+/// The CST → AST lowering output for one file: top-level items plus the
+/// lowering diagnostics and `env.*` references produced along the way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileAst {
+    pub items: Vec<baml_compiler2_ast::Item>,
+    pub diagnostics: Vec<baml_compiler2_ast::LoweringDiagnostic>,
+    pub env_var_refs: Vec<baml_compiler2_ast::EnvVarRef>,
+}
+
+// Safety: `FileAst` holds only plain (non-`'db`) data, so storing it by value
+// is sound. Manual `Update` impl uses `PartialEq` for Salsa early-cutoff.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for FileAst {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// CST → AST lowering for one file, computed once and shared.
+///
+/// Salsa-tracked because several different consumers need a file's AST items
+/// (both `file_semantic_index` queries, `ppir_expansion_items`, the two
+/// project-wide expansion-map collectors, and the LSP check pass). Before
+/// this query existed each of them re-lowered the syntax tree from scratch —
+/// repeated CST traversal was ~31% of cold-compile CPU on the test corpus.
+#[salsa::tracked(returns(ref))]
+pub fn file_ast(db: &dyn Db, file: SourceFile) -> FileAst {
+    let tree = baml_compiler_parser::syntax_tree(db, file);
+    let path = file.path(db);
+    let (items, diagnostics, env_var_refs) =
+        baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
+    FileAst {
+        items,
+        diagnostics,
+        env_var_refs,
+    }
+}
+
 // ── file_semantic_index ───────────────────────────────────────────────────────
 
 /// Coarse per-file query — always re-runs on file change (`no_eq`).
@@ -108,15 +159,14 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
 pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
-    let (items, lowering_diags, env_var_refs) =
-        baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
+    // CST → AST lowering is shared via `file_ast` instead of being redone here.
+    let ast = file_ast(db, file);
 
     let builder = SemanticIndexBuilder::new(db, file);
     builder
-        .with_lowering_diagnostics(lowering_diags)
-        .with_env_var_refs(env_var_refs)
-        .build(&items, file_range)
+        .with_lowering_diagnostics(ast.diagnostics.clone())
+        .with_env_var_refs(ast.env_var_refs.clone())
+        .build(&ast.items, file_range)
 }
 
 // ── Projection helpers ────────────────────────────────────────────────────────

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -54,9 +54,9 @@ pub fn collect_block_attrs(
     let mut result = FxHashMap::default();
     for file in project.files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, *file);
-        let cst = baml_compiler_parser::syntax_tree(db, *file);
-        let (items, _, _) = ast::lower_file(&cst);
-        for item in &items {
+        // Reuse the memoized CST → AST lowering instead of re-lowering here.
+        let items = &baml_compiler2_hir::file_ast(db, *file).items;
+        for item in items {
             let (name, item_attrs) = match item {
                 ast::Item::Class(c) => (&c.name, &c.attributes),
                 ast::Item::Enum(e) => (&e.name, &e.attributes),
@@ -85,9 +85,9 @@ pub fn collect_alias_bodies(
     let mut result = FxHashMap::default();
     for file in project.files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, *file);
-        let cst = baml_compiler_parser::syntax_tree(db, *file);
-        let (items, _, _) = ast::lower_file(&cst);
-        for item in &items {
+        // Reuse the memoized CST → AST lowering instead of re-lowering here.
+        let items = &baml_compiler2_hir::file_ast(db, *file).items;
+        for item in items {
             if let ast::Item::TypeAlias(a) = item {
                 let ty = a.type_expr.as_ref().map(PpirTy::from_type_expr).unwrap_or(
                     PpirTy::CannotBeStreamed {
@@ -191,8 +191,8 @@ fn make_raw_attr_no_args(name: &str) -> ast::RawAttribute {
 /// Compute synthetic `*$stream` AST items for a single file in one pass.
 #[salsa::tracked]
 pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems<'_> {
-    let cst = baml_compiler_parser::syntax_tree(db, file);
-    let (items, _, _) = ast::lower_file(&cst);
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let items = &baml_compiler2_hir::file_ast(db, file).items;
 
     // Get HIR classification for the file's package (original types only)
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
@@ -215,7 +215,7 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
     let mut seen_class_names = FxHashSet::default();
     let mut seen_alias_names = FxHashSet::default();
 
-    for item in &items {
+    for item in items {
         match item {
             ast::Item::Class(c) => {
                 if c.name.ends_with("$stream") {
@@ -578,13 +578,28 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
 // -- Canonical queries (original + *$stream) ----------------------------------
 
 /// Canonical semantic index: original AST items + PPIR synthetic *$stream items.
+///
+/// When a file has no synthetic items, the post-expansion index is byte-for-byte
+/// the pre-expansion one (same AST items, same builder, same file range), so
+/// this delegates to HIR's already-computed index instead of rebuilding
+/// scopes/bindings/contributions a second time.
+pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> &FileSemanticIndex<'_> {
+    let expansion = ppir_expansion_items(db, file);
+    if expansion.items(db).is_empty() {
+        return baml_compiler2_hir::file_semantic_index(db, file);
+    }
+    file_semantic_index_expanded(db, file)
+}
+
+/// The merged (original + *$stream) index for files that actually have
+/// synthetic items. Callers must go through [`file_semantic_index`].
 #[salsa::tracked(returns(ref), no_eq)]
-pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
+fn file_semantic_index_expanded(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
-    let (mut items, lowering_diags, env_var_refs) =
-        ast::lower_file_with_path(&tree, Some(path.as_path()));
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let ast_result = baml_compiler2_hir::file_ast(db, file);
+    let mut items = ast_result.items.clone();
 
     // Merge synthetic *$stream items
     let expansion = ppir_expansion_items(db, file);
@@ -592,8 +607,8 @@ pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'
 
     // Re-run HIR builder on merged items
     baml_compiler2_hir::SemanticIndexBuilder::new(db, file)
-        .with_lowering_diagnostics(lowering_diags)
-        .with_env_var_refs(env_var_refs)
+        .with_lowering_diagnostics(ast_result.diagnostics.clone())
+        .with_env_var_refs(ast_result.env_var_refs.clone())
         .build(&items, file_range)
 }
 
@@ -616,6 +631,11 @@ pub fn file_item_tree(db: &dyn Db, file: SourceFile) -> Arc<ItemTree> {
 ///
 /// TIR should call this instead of `baml_compiler2_hir::body::function_body`
 /// so that PPIR-synthesized functions (like `$parse_stream`) are found.
+///
+/// Salsa-tracked (mirroring HIR's `function_body`): MIR lowering fetches the
+/// callee's body at every direct-call site, and the untracked version cloned
+/// the entire `ExprBody` arena out of the item tree each time.
+#[salsa::tracked]
 pub fn function_body<'db>(
     db: &'db dyn Db,
     function: baml_compiler2_hir::loc::FunctionLoc<'db>,

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -154,15 +154,12 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
     let res_ctx = baml_compiler2_tir::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
     let aliases = collect_type_aliases_for_resolution_context(db, res_ctx);
-    let ast_items = {
-        let tree = baml_compiler_parser::syntax_tree(db, file);
-        let (items, _, _) = baml_compiler2_ast::lower_file(&tree);
-        items
-    };
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let ast_items = &baml_compiler2_hir::file_ast(db, file).items;
     diagnostics.extend(validate_associated_type_bindings_in_items(
         db,
         file_id,
-        &ast_items,
+        ast_items,
         pkg_items,
         &pkg_info.namespace_path,
     ));


### PR DESCRIPTION
## What

On `canary` the CST→AST lowering step (`baml_compiler2_ast::lower_file`) is a plain, **untracked** function that six different consumers each re-run from scratch for the same file:

- `baml_compiler2_hir::file_semantic_index`
- `baml_compiler2_ppir::file_semantic_index`
- `baml_compiler2_ppir::ppir_expansion_items`
- the two project-wide expansion-map collectors (`collect_block_attrs` / `collect_alias_bodies`)
- the `baml_lsp2_actions` check pass

Repeated CST traversal was ~31% of cold-compile CPU on the test corpus in the original audit. This PR memoizes lowering and removes two other redundant rebuilds.

## Changes

1. **`baml_compiler2_hir::file_ast(db, file)`** — a new `#[salsa::tracked]` query that lowers the CST once per file and shares `items` + lowering `diagnostics` + `env_var_refs`. All six consumers now read it instead of re-lowering. (`EnvVarRef` gains `PartialEq, Eq` so `FileAst` can use `PartialEq` for Salsa early-cutoff.)
2. **PPIR `file_semantic_index` delegates to HIR** when a file has no expansion items. The post-expansion index is byte-for-byte identical to the pre-expansion one for such files (same AST items, same builder, same file range), so rebuilding it was pure wasted work. The merged path is preserved as `file_semantic_index_expanded` for files that actually have `*$stream` companions. The delegation also unifies scope identity for expansion-free files, which cuts `infer_scope_types` executions (15,590 → 13,331).
3. **PPIR `function_body` is now `#[salsa::tracked]`** returning `Arc<FunctionBody>` (mirroring HIR's `function_body`). MIR lowering fetches the callee body at every direct-call site; the untracked version cloned the entire `ExprBody` arena each time.

Each changed site carries a short comment explaining what was being recomputed.

## Before / after (cold compile)

Measured with the `tools_compile_profile` harness from #4038 (not committed here), disk cache disabled via `BAML_NO_BYTECODE_CACHE=1`, on `crates/baml_tests/baml_src` (77 files, 25 212 lines). Numbers are medians of 5 fresh-database cold runs, before/after binaries run interleaved on a quiet machine (two full rounds, both consistent; quietest round shown):

| phase | before (canary 2660b8b9f) | after | delta |
|-------|--------------------------|-------|-------|
| check | 1.118 s | 0.752 s | −33 % |
| emit  | 1.361 s | 1.181 s | −13 % |
| total | 2.480 s | 1.934 s | −22 % |

Load-independent evidence, same direction:

- instructions retired (3 cold runs, `/usr/bin/time -l`): 93.7 G → 76.4 G (−18.5 %), stable across 3 interleaved rounds
- `file_ast` executes 131× (exactly once per file) instead of lowering inline ~6× per file
- `file_semantic_index_expanded` runs only 78× (files that really have `*$stream` expansions); the other 53 files reuse HIR's index
- `infer_scope_types`: 15,590 → 13,331 executions

## Tests

- `cargo test --workspace`: **all suites pass** (~190 binaries). Initial failures were environmental only and reproduced on clean canary too: disk-full during the run, the Python SDK venv resolving to Python 3.10 (fixed with `UV_PYTHON=3.12`), and the Node fixtures needing `sdk_tests/crates/typescript_node/setup.sh` run once; after that `sdk_test_python_pydantic2` (14/14) and `sdk_test_typescript_node` (15/15) pass.
- **Zero snapshot diffs** (no `.snap.new` files) — outputs are byte-identical, as required for this track.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt` check: clean.

## Provenance

Re-derived against current `canary`; reference implementation: #4016 (`perf/compiler2-cold-compile`), audit items 3, 9, 13.
