### PR TITLE
perf(compiler2): interface-method-name pre-filter in MIR dispatch + is_subtype_of assumption fast path

### DIFF
--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1523,7 +1523,7 @@ use baml_compiler2_tir::{
     inference::infer_scope_types,
     resolve::{ResolvedName, resolve_name_at_in_scope},
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 type ClassFieldIndices = IndexMap<TypeName, IndexMap<String, usize>>;
 type ClassFieldTypes = IndexMap<TypeName, IndexMap<String, RuntimeTy>>;
@@ -1646,6 +1646,12 @@ struct PackageLoweringData {
     enum_variants: EnumVariantIndices,
     interface_implementors: ImplementorsByInterface,
     resolved_aliases: ResolvedAliases,
+    /// Every method name any in-scope interface (own package + dependency
+    /// closure) declares, required or default. Fast pre-filter for
+    /// [`LoweringContext::dispatch_target_for_concrete`]: a member name absent
+    /// here can never dispatch through an interface impl, so the (hot) impl
+    /// enumeration is skipped for the overwhelmingly common plain-method case.
+    interface_method_names: FxHashSet<Name>,
 }
 
 /// # Safety
@@ -1720,12 +1726,50 @@ fn package_lowering_data<'db>(
         );
     }
 
+    // Collect every interface-declared method name in scope (own package +
+    // dependency closure). `dispatch_target_for_concrete` previously enumerated
+    // every impl block in the closure for EVERY method call and field access
+    // just to conclude "no impl provides this member" for the overwhelmingly
+    // common non-interface member; this set lets it answer that in one hash
+    // lookup. Names are collected package-wide (not per receiver type), so the
+    // filter is a pure fast path: any name declared by ANY reachable interface
+    // still goes through the full impl enumeration.
+    let mut interface_method_names = FxHashSet::default();
+    let mut all_pkgs = vec![pkg_id];
+    all_pkgs.extend(
+        baml_compiler2_hir::package::package_dependency_closure(db, pkg_id)
+            .iter()
+            .copied(),
+    );
+    for pkg in all_pkgs {
+        let items = package_items(db, pkg);
+        for ns in items.namespaces.values() {
+            for def in ns.types.values() {
+                let baml_compiler2_hir::contributions::Definition::Interface(iface_loc) = def
+                else {
+                    continue;
+                };
+                let itree = file_item_tree(db, iface_loc.file(db));
+                let Some(iface_data) = itree.interfaces.get(&iface_loc.id(db)) else {
+                    continue;
+                };
+                for sig in &iface_data.required_methods {
+                    interface_method_names.insert(sig.name.clone());
+                }
+                for &fn_id in &iface_data.default_methods {
+                    interface_method_names.insert(itree[fn_id].name.clone());
+                }
+            }
+        }
+    }
+
     PackageLoweringData {
         class_fields,
         class_field_types,
         enum_variants,
         interface_implementors,
         resolved_aliases,
+        interface_method_names,
     }
 }
 
@@ -1852,6 +1896,10 @@ struct LoweringContext<'db> {
     // Borrowed from `package_lowering_data` (shared across every function in
     // the package) rather than cloned per context.
     resolved_aliases: &'db ResolvedAliases,
+
+    /// All method names declared by in-scope interfaces — see
+    /// [`PackageLoweringData::interface_method_names`].
+    interface_method_names: &'db FxHashSet<Name>,
 
     /// Stack of pending `defer` block bodies (BEP-042), parallel to
     /// lexical scopes. Each entry is the `AstExprId` of a defer body
@@ -2736,6 +2784,7 @@ impl<'db> LoweringContext<'db> {
             transitive_captures_needed: Vec::new(),
             tagged_body_param_bindings: HashMap::new(),
             resolved_aliases: &pkg_data.resolved_aliases,
+            interface_method_names: &pkg_data.interface_method_names,
             defer_stack: Vec::new(),
             synthetic_name_counts: HashMap::new(),
             chain_null_exits: Vec::new(),
@@ -2821,6 +2870,7 @@ impl<'db> LoweringContext<'db> {
             class_type_tags,
             interface_implementors: &pkg_data.interface_implementors,
             resolved_aliases: &pkg_data.resolved_aliases,
+            interface_method_names: &pkg_data.interface_method_names,
             defer_stack: Vec::new(),
             synthetic_name_counts: HashMap::new(),
             pending_lambdas: Vec::new(),
@@ -3565,6 +3615,14 @@ impl<'db> LoweringContext<'db> {
                 | Tir2Ty::Map { .. }
                 | Tir2Ty::Future(..)
         ) {
+            return None;
+        }
+        // Fast pre-filter: a name no in-scope interface declares can never
+        // dispatch through an impl. Skips the per-call impl enumeration
+        // (`l1_impls_for_recv` probes every impl block's pattern against the
+        // receiver, invoking alias normalization / subtype checks per probe)
+        // for plain method calls and field accesses.
+        if !self.interface_method_names.contains(method) {
             return None;
         }
         for resolved in self.l1_impls_for_recv(recv_ty) {

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -1056,10 +1056,6 @@ impl NormalTy {
         ctx: &C,
         assumptions: &mut HashSet<(NormalTy, NormalTy)>,
     ) -> bool {
-        let pair = (self.clone(), sup.clone());
-        if assumptions.contains(&pair) {
-            return true;
-        }
         if self == sup {
             return true;
         }
@@ -1082,8 +1078,48 @@ impl NormalTy {
             return true;
         }
 
+        // Co-inductive assumption tracking exists solely to terminate cycles,
+        // and a cycle can only regress through the arms that *expand* a type:
+        // μ-unfolding (substitution can regenerate the same pair) and
+        // variable/projection bound lookup (a bound can mention the variable).
+        // Every structural arm descends into strictly smaller subterms of
+        // finite trees. Restricting the pair bookkeeping to the expanding
+        // arms preserves termination — any infinite path must pass through an
+        // expanding arm infinitely often, and the pairs seen there are drawn
+        // from the finite subterm closure of the (regular) operands — while
+        // sparing the deep `NormalTy` clone + full-tree hash on the millions
+        // of purely structural steps, which profiling showed dominated
+        // subtype-checking cost.
+        let expanding = matches!(
+            self,
+            NormalTy::Mu { .. } | NormalTy::TypeVar(_) | NormalTy::AssociatedTypeProjection { .. }
+        ) || matches!(sup, NormalTy::Mu { .. });
+        if !expanding {
+            return self.is_subtype_of_inner(sup, ctx, assumptions);
+        }
+        // Avoid cloning just to probe: pairs on the path are few (bounded by
+        // the expanding-arm recursion depth), so a linear scan beats
+        // hash-of-whole-tree.
+        if assumptions.iter().any(|(a, b)| a == self && b == sup) {
+            return true;
+        }
+        let pair = (self.clone(), sup.clone());
         assumptions.insert(pair.clone());
-        let result = match (self, sup) {
+        let result = self.is_subtype_of_inner(sup, ctx, assumptions);
+        assumptions.remove(&pair);
+        result
+    }
+
+    /// The structural rules of [`Self::is_subtype_of`]. Callers must go
+    /// through `is_subtype_of`, which owns the fast paths and the
+    /// co-inductive assumption bookkeeping.
+    fn is_subtype_of_inner<C: TypeContext>(
+        &self,
+        sup: &NormalTy,
+        ctx: &C,
+        assumptions: &mut HashSet<(NormalTy, NormalTy)>,
+    ) -> bool {
+        match (self, sup) {
             // μ-unfolding (equirecursive).
             (NormalTy::Mu { var, body }, _) => {
                 body.substitute(var, self)
@@ -1240,9 +1276,7 @@ impl NormalTy {
             }
 
             _ => false,
-        };
-        assumptions.remove(&pair);
-        result
+        }
     }
 
     // ── conversion out: NormalTy → Ty ──────────────────────────────────────


### PR DESCRIPTION
Re-lands two slices of the cold-compile performance audit (items 12 and 7 of PR #4016), re-derived against current canary. Both are pure fast paths: dispatch results and subtype verdicts are unchanged.

## What was being recomputed

**1. MIR dispatch pre-filter (`baml_compiler2_mir/src/lower.rs`)**

`dispatch_target_for_concrete` enumerated every impl block in the package closure (`l1_impls_for_recv`, which probes each impl's pattern against the receiver, invoking alias normalization / subtype checks per probe) for **every** method call and field access — almost always just to conclude "no impl provides this member". Since #4032 deleted the TIR structural algebra, each of those probes goes through `AliasEquivCtx` / `baml_type::normalize`, making the per-call enumeration even more expensive.

Fix: collect every interface-declared method name (required + default, own package + dependency closure) once per package into the existing Salsa-tracked `PackageLoweringData`, and have `dispatch_target_for_concrete` return `None` in one hash lookup when the member name is absent. The set is package-wide, not per receiver type, so any name declared by **any** reachable interface still takes the full enumeration — the filter cannot change dispatch results.

**2. `is_subtype_of` assumption fast path (`baml_type/src/normalize.rs`)**

The co-inductive assumption bookkeeping (deep `NormalTy` clone + full-tree hash of the `(lhs, rhs)` pair, insert + remove) ran on **every** recursive step of the subtype check. Canary already had the reflexivity short-circuit, so only the bookkeeping split was needed.

Fix: split the structural rules into `is_subtype_of_inner`; the outer function performs the pair bookkeeping only for the *expanding* arms — `Mu`, `TypeVar`, `AssociatedTypeProjection` on the left, or `Mu` on the right.

**Termination argument** (also documented as a comment at the split): assumption tracking exists solely to terminate cycles, and a cycle can only regress through arms that expand a type — μ-unfolding (substitution can regenerate the same pair) and variable/projection bound lookup (a bound can mention the variable). Purely structural arms descend into strictly smaller subterms of finite trees, so no cycle can form through them; any infinite path must pass through an expanding arm infinitely often, and those still record assumptions (drawn from the finite subterm closure of the regular operands).

## Measurements

Profiler from PR #4038 (`tools_compile_profile`, not part of this PR), `crates/baml_tests/baml_src` (77 files, 25k lines), `BAML_NO_BYTECODE_CACHE=1`, fresh Salsa db per run, `--repeat 5`, Apple Silicon:

| | check (median) | emit (median) | total (median) |
|---|---|---|---|
| canary (2660b8b9f) | 1.454s | 1.791s | 3.250s |
| this PR | 1.358s | 1.295s | 2.675s |

Emit (where MIR lowering and dispatch run) drops ~28%; total cold compile ~18%.

## Testing

- `cargo test --workspace`: all compiler/runtime suites pass, including the 442-test `baml_tests` suite — no snapshot diffs, so dispatch results and subtype verdicts are byte-identical.
- Only failures were environmental, unrelated to this change: `sdk_test_typescript_node` (missing `node_modules` in the test sandbox — `tsc`/`vitest`/`attw` not installed) and 4 `sdk_test_python_pydantic2` cancellation tests (fixture uses `ExceptionGroup`, undefined on the sandbox's Python 3.10, plus asyncio-timing asserts).
- Pre-commit hooks (cargo fmt, workspace clippy `-D warnings`) pass.

Provenance: re-derivation of c1466f3cc (PR #4016) items 12 and 7.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type compatibility checks involving recursive types, type variables, and associated types, helping prevent incorrect results or excessive processing.
  * Optimized method dispatch checks by quickly rejecting methods that are not declared by applicable interfaces, improving compilation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->