### PR TITLE
feat(compiler2): enforce a unified declaration namespace

### DIFF
--- a/baml_language/crates/baml_compiler2_hir/src/contributions.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/contributions.rs
@@ -130,6 +130,27 @@ impl<'db> Definition<'db> {
     pub fn kind_name(self) -> &'static str {
         self.kind().as_str()
     }
+
+    /// The declaration kind as written in BAML source.
+    ///
+    /// Some configuration declarations are lowered to top-level lets before
+    /// HIR. Keep that internal representation from leaking into source-level
+    /// namespace diagnostics.
+    pub fn source_kind(self, db: &'db dyn crate::Db) -> DefinitionKind {
+        let Definition::Let(loc) = self else {
+            return self.kind();
+        };
+        let item_tree = crate::file_item_tree(db, loc.file(db));
+        match item_tree.lets.get(&loc.id(db)).map(|item| item.origin) {
+            Some(baml_compiler2_ast::LetOrigin::Client) => DefinitionKind::Client,
+            Some(baml_compiler2_ast::LetOrigin::RetryPolicy) => DefinitionKind::RetryPolicy,
+            Some(baml_compiler2_ast::LetOrigin::Source) | None => DefinitionKind::Let,
+        }
+    }
+
+    pub fn source_kind_name(self, db: &'db dyn crate::Db) -> &'static str {
+        self.source_kind(db).as_str()
+    }
 }
 
 /// A symbol contribution: name, definition, and the name's source span.

--- a/baml_language/crates/baml_compiler2_hir/src/namespace.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/namespace.rs
@@ -8,6 +8,8 @@
 //! `NamespaceItems::conflicts` but do not prevent resolution — downstream
 //! layers always see a resolved symbol (the first one).
 
+use std::collections::BTreeSet;
+
 use baml_base::{Name, SourceFile, Span};
 use baml_compiler_diagnostics::diagnostic::{Diagnostic, DiagnosticId, DiagnosticPhase};
 use rustc_hash::FxHashMap;
@@ -43,15 +45,17 @@ impl<'db> NameConflict<'db> {
         let first = &self.entries[0];
         let rest = &self.entries[1..];
 
-        let first_kind = first.definition.kind();
-        let kinds_match = rest.iter().all(|e| e.definition.kind() == first_kind);
+        let first_kind = first.definition.source_kind(db);
+        let kinds_match = rest
+            .iter()
+            .all(|e| e.definition.source_kind(db) == first_kind);
         let message = if kinds_match {
             format!("Duplicate {} `{}`", first_kind, self.name)
         } else {
             let kind_list: Vec<&str> = self
                 .entries
                 .iter()
-                .map(|e| e.definition.kind_name())
+                .map(|e| e.definition.source_kind_name(db))
                 .collect();
             format!(
                 "Name `{}` defined {} times as: {}",
@@ -69,7 +73,10 @@ impl<'db> NameConflict<'db> {
                 file_id: first_file_id,
                 range: first.name_span,
             },
-            format!("first defined as {} here", first.definition.kind_name()),
+            format!(
+                "first defined as {} here",
+                first.definition.source_kind_name(db)
+            ),
         );
 
         for entry in rest {
@@ -79,7 +86,10 @@ impl<'db> NameConflict<'db> {
                     file_id,
                     range: entry.name_span,
                 },
-                format!("duplicate {} definition", entry.definition.kind_name()),
+                format!(
+                    "duplicate {} definition",
+                    entry.definition.source_kind_name(db)
+                ),
             );
         }
 
@@ -186,47 +196,63 @@ pub fn namespace_items<'db>(
         }
     }
 
-    // First definition wins; collect conflicts for names with len > 1.
+    // Lookup keeps type and value declarations separate, but BAML source does
+    // not: all namespace-level declarations with the same spelling contribute
+    // to one conflict. Build that conflict once so mixed declaration kinds do
+    // not also produce redundant type-only or value-only diagnostics.
     let mut types: FxHashMap<Name, Definition<'db>> = FxHashMap::default();
     let mut values: FxHashMap<Name, Definition<'db>> = FxHashMap::default();
     let mut conflicts: Vec<NameConflict<'db>> = Vec::new();
 
+    let declaration_names: BTreeSet<_> =
+        type_defs.keys().chain(value_defs.keys()).cloned().collect();
+    for name in declaration_names {
+        let mut entries: Vec<_> = type_defs
+            .get(&name)
+            .into_iter()
+            .flatten()
+            .chain(value_defs.get(&name).into_iter().flatten())
+            .copied()
+            .collect();
+
+        // Tests are function-scoped (identity is functionName/testName), so
+        // same-named tests for different functions remain legal.
+        let all_tests = entries
+            .iter()
+            .all(|entry| matches!(entry.definition, Definition::Test(_)));
+        if entries.len() < 2 || all_tests {
+            continue;
+        }
+
+        entries.sort_by(|left, right| {
+            left.definition
+                .file(db)
+                .path(db)
+                .cmp(&right.definition.file(db).path(db))
+                .then_with(|| left.name_span.start().cmp(&right.name_span.start()))
+                .then_with(|| {
+                    left.definition
+                        .source_kind_name(db)
+                        .cmp(right.definition.source_kind_name(db))
+                })
+        });
+        conflicts.push(NameConflict {
+            name,
+            entries: entries
+                .into_iter()
+                .map(|entry| ConflictEntry {
+                    definition: entry.definition,
+                    name_span: entry.name_span,
+                })
+                .collect(),
+        });
+    }
+
     for (name, contribs) in type_defs {
         types.insert(name.clone(), contribs[0].definition);
-        if contribs.len() > 1 {
-            conflicts.push(NameConflict {
-                name,
-                entries: contribs
-                    .into_iter()
-                    .map(|c| ConflictEntry {
-                        definition: c.definition,
-                        name_span: c.name_span,
-                    })
-                    .collect(),
-            });
-        }
     }
     for (name, contribs) in value_defs {
         values.insert(name.clone(), contribs[0].definition);
-        if contribs.len() > 1 {
-            // Tests are function-scoped (identity is functionName/testName),
-            // so same-named tests for different functions are not conflicts.
-            let all_tests = contribs
-                .iter()
-                .all(|c| matches!(c.definition, Definition::Test(_)));
-            if !all_tests {
-                conflicts.push(NameConflict {
-                    name,
-                    entries: contribs
-                        .into_iter()
-                        .map(|c| ConflictEntry {
-                            definition: c.definition,
-                            name_span: c.name_span,
-                        })
-                        .collect(),
-                });
-            }
-        }
     }
 
     // Sort conflicts by name for deterministic output.

--- a/baml_language/crates/baml_compiler2_hir/src/package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/package.rs
@@ -44,7 +44,7 @@ impl<'db> NamespaceShadow<'db> {
             "Namespace `{}` (from `ns_{}/`) shadows root-level {} `{}`",
             self.ns_name,
             self.ns_name,
-            def.kind_name(),
+            def.source_kind_name(db),
             self.ns_name
         );
 
@@ -55,7 +55,7 @@ impl<'db> NamespaceShadow<'db> {
                 Span { file_id, range },
                 format!(
                     "this {} is shadowed by namespace `{}`",
-                    def.kind_name(),
+                    def.source_kind_name(db),
                     self.ns_name
                 ),
             );

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__05_diagnostics.snap
@@ -296,7 +296,7 @@ source: crates/baml_tests/src/generated_tests.rs
      │     Note: Error code: E0001
 ─────╯
 
-  [validation] error: Name `ExtraWhitespace` defined 3 times as: class, enum, type
+  [validation] error: Name `ExtraWhitespace` defined 5 times as: class, enum, function, template_string, type
      ╭─[ class_decls.baml:296:10 ]
      │
  296 │ class    ExtraWhitespace    {
@@ -309,6 +309,18 @@ source: crates/baml_tests/src/generated_tests.rs
      │         ───────┬───────  
      │                ╰───────── duplicate enum definition
      │
+     ├─[ function_decls.baml:497:13 ]
+     │
+ 497 │ function    ExtraWhitespace   (   a   :   int   ,   b   :   int   )   ->   int   {
+     │             ───────┬───────  
+     │                    ╰───────── duplicate function definition
+     │
+     ├─[ template_string_decls.baml:364:20 ]
+     │
+ 364 │ template_string    ExtraWhitespace   (   a   :   string   ,   b   :   int   )   #"
+     │                    ───────┬───────  
+     │                           ╰───────── duplicate template_string definition
+     │
      ├─[ type_alias_decls.baml:401:9 ]
      │
  401 │ type    ExtraWhitespace    =    int   |   string   |   bool   |   float   |   null
@@ -317,6 +329,22 @@ source: crates/baml_tests/src/generated_tests.rs
      │ 
      │ Note: Error code: E0011
 ─────╯
+
+  [validation] error: Name `Minimal` defined 2 times as: enum, function
+   ╭─[ enum_decls.baml:4:6 ]
+   │
+ 4 │ enum Minimal {
+   │      ───┬───  
+   │         ╰───── first defined as enum here
+   │
+   ├─[ function_decls.baml:5:10 ]
+   │
+ 5 │ function Minimal() -> int {
+   │          ───┬───  
+   │             ╰───── duplicate function definition
+   │ 
+   │ Note: Error code: E0011
+───╯
 
   [type] error: type mismatch: expected (x: int) -> ((y: int) -> ((z: int) -> ((w: int) -> map<string, int | string | bool> throws never) throws never) throws never) throws never, got 1
     ╭─[ function_decls.baml:73:5 ]
@@ -600,18 +628,18 @@ source: crates/baml_tests/src/generated_tests.rs
      │ Note: Error code: E0011
 ─────╯
 
-  [validation] error: Name `ExtraWhitespace` defined 2 times as: function, template_string
-     ╭─[ function_decls.baml:497:13 ]
+  [validation] error: Name `T` defined 2 times as: template_string, type
+     ╭─[ template_string_decls.baml:123:17 ]
      │
- 497 │ function    ExtraWhitespace   (   a   :   int   ,   b   :   int   )   ->   int   {
-     │             ───────┬───────  
-     │                    ╰───────── first defined as function here
+ 123 │ template_string T(x: int) #"{{ x }}"#
+     │                 ┬  
+     │                 ╰── first defined as template_string here
      │
-     ├─[ template_string_decls.baml:364:20 ]
+     ├─[ type_alias_decls.baml:398:6 ]
      │
- 364 │ template_string    ExtraWhitespace   (   a   :   string   ,   b   :   int   )   #"
-     │                    ───────┬───────  
-     │                           ╰───────── duplicate template_string definition
+ 398 │ type T = int
+     │      ┬  
+     │      ╰── duplicate type definition
      │ 
      │ Note: Error code: E0011
 ─────╯

--- a/baml_language/crates/baml_tests/src/compiler2_hir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_hir.rs
@@ -596,6 +596,107 @@ mod tests {
         ));
     }
 
+    /// Type and value lookup are separate implementation details; declarations
+    /// still share one BAML namespace and produce one complete diagnostic.
+    #[test]
+    fn mixed_declaration_kinds_across_files_produce_one_conflict() {
+        let mut db = make_db();
+        let file_a = db.add_file("a.baml", "class Shared { value int }");
+        let file_b = db.add_file("b.baml", "enum Shared { One\nTwo }");
+        let file_c = db.add_file("c.baml", "type Shared = string");
+        let file_d = db.add_file("d.baml", "function Shared() -> int { 1 }");
+
+        let ns_id = NamespaceId::new(&db, Name::new("user"), vec![]);
+        let ns = baml_compiler2_hir::namespace::namespace_items(&db, ns_id);
+
+        assert_eq!(ns.conflicts().len(), 1);
+        let conflict = &ns.conflicts()[0];
+        assert_eq!(conflict.name, Name::new("Shared"));
+        assert_eq!(conflict.entries.len(), 4);
+        assert_eq!(
+            conflict
+                .entries
+                .iter()
+                .map(|entry| entry.definition.kind_name())
+                .collect::<Vec<_>>(),
+            vec!["class", "enum", "type", "function"]
+        );
+        assert!(
+            conflict
+                .entries
+                .iter()
+                .map(|entry| entry.definition.file(&db))
+                .eq([file_a, file_b, file_c, file_d])
+        );
+
+        let diagnostic = conflict.to_diagnostic(&db);
+        assert_eq!(diagnostic.annotations.len(), 4);
+        assert_eq!(
+            diagnostic
+                .annotations
+                .iter()
+                .map(|annotation| annotation.span.file_id)
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            4,
+            "every conflicting source location must be included"
+        );
+    }
+
+    #[test]
+    fn type_and_client_names_collide_across_files() {
+        let mut db = make_db();
+        let _type_file = db.add_file("types.baml", "type Backend = string");
+        let _client_file = db.add_file(
+            "clients.baml",
+            r#"client<llm> Backend {
+  provider openai
+  options { model "gpt-4o-mini" }
+}"#,
+        );
+
+        let ns_id = NamespaceId::new(&db, Name::new("user"), vec![]);
+        let ns = baml_compiler2_hir::namespace::namespace_items(&db, ns_id);
+        assert_eq!(ns.conflicts().len(), 1);
+        assert_eq!(
+            ns.conflicts()[0]
+                .entries
+                .iter()
+                .map(|entry| entry.definition.source_kind_name(&db))
+                .collect::<std::collections::HashSet<_>>(),
+            std::collections::HashSet::from(["type", "client"])
+        );
+    }
+
+    #[test]
+    fn type_and_value_names_in_different_baml_namespaces_are_legal() {
+        let mut db = make_db();
+        let _type_file = db.add_file("ns_models/types.baml", "class Shared { value int }");
+        let _value_file = db.add_file("ns_api/functions.baml", "function Shared() -> int { 1 }");
+
+        let package = PackageId::new(&db, Name::new("user"));
+        assert!(package_items(&db, package).conflicts().is_empty());
+    }
+
+    #[test]
+    fn same_named_tests_keep_function_scoped_identity() {
+        let mut db = make_db();
+        let _file_a = db.add_file(
+            "a.baml",
+            "function First() -> int { 1 }\ntest Shared { functions [First] }
+",
+        );
+        let _file_b = db.add_file(
+            "b.baml",
+            "function Second() -> int { 2 }\ntest Shared { functions [Second] }
+",
+        );
+
+        let ns_id = NamespaceId::new(&db, Name::new("user"), vec![]);
+        let ns = baml_compiler2_hir::namespace::namespace_items(&db, ns_id);
+        assert!(ns.conflicts().is_empty());
+    }
+
     /// No conflict when names are unique across files.
     #[test]
     fn no_conflict_for_unique_names() {


### PR DESCRIPTION
## Summary

- enforce one source-level declaration namespace across BAML types and values
- detect collisions within a file and across files in the same BAML namespace
- emit one deterministic diagnostic containing every conflicting declaration location
- preserve legal same-name declarations in different BAML namespaces and the distinct identity rules for test declarations

## Design

Compiler lookup may continue to separate type and value namespaces internally. The language-level collision check groups source declarations by BAML namespace and name, then emits one ordered diagnostic per conflicting name. This keeps lookup implementation details from leaking into the BAML language rule and avoids redundant type/value duplicate errors.

The diagnostic records every conflicting declaration, orders declarations deterministically, and reports each declaration kind. Tests, methods, fields, and local bindings retain their existing scope-specific identity rules.

This PR contains no codegen representation changes. The canonical CodegenTy and target-capability work is being developed separately.

## Tests

- cargo test -p baml_compiler2_hir
- cargo test -p baml_tests compiler2_hir::tests — 69 passed
- cargo test -p baml_tests diagnostic_errors::format_checks::test_05_diagnostics -- --exact — passed
- git diff --check origin/canary...HEAD

## Commit

- feat(compiler2): enforce a unified declaration namespace
