### PR TITLE
refactor(codegen): use canonical compiler-owned types

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -771,6 +771,7 @@ name = "baml_codegen_types"
 version = "0.0.0-beta"
 dependencies = [
  "baml_base",
+ "baml_type",
  "strum",
 ]
 

--- a/baml_language/crates/baml_codegen_types/Cargo.toml
+++ b/baml_language/crates/baml_codegen_types/Cargo.toml
@@ -18,4 +18,5 @@ workspace = true
 
 [dependencies]
 baml_base = { workspace = true }
+baml_type = { workspace = true }
 strum = { workspace = true }

--- a/baml_language/crates/baml_codegen_types/src/errors.rs
+++ b/baml_language/crates/baml_codegen_types/src/errors.rs
@@ -1,6 +1,7 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CodegenTypeError {
-    InvalidUnionUsage(super::Ty),
-    InvalidOptionalUsage(super::Ty),
-    InvalidMapKey(super::Ty),
-    InvalidUnit(super::Ty),
+    InvalidUnionUsage(Box<super::Ty>),
+    InvalidOptionalUsage(Box<super::Ty>),
+    InvalidMapKey(Box<super::Ty>),
+    InvalidUnit(Box<super::Ty>),
 }

--- a/baml_language/crates/baml_codegen_types/src/symbols.rs
+++ b/baml_language/crates/baml_codegen_types/src/symbols.rs
@@ -271,8 +271,6 @@ impl WalkAllUnions for Ty {
             | Ty::PromptAst { .. }
             | Ty::BuiltinUnknown { .. }
             | Ty::Never { .. }
-            // Canonical unions cannot contain nested unions.
-            | Ty::Union(..)
             | Ty::Literal(..) => {}
             Ty::Class(_, args, _) => {
                 for arg in args {
@@ -307,6 +305,13 @@ impl WalkAllUnions for Ty {
             Ty::Future(value, error, _) => {
                 unions.extend(value.walk_all_unions());
                 unions.extend(error.walk_all_unions());
+            }
+            // Codegen types are canonical at the compiler boundary, but keep
+            // this public symbol traversal total for manually assembled pools.
+            Ty::Union(members, _) => {
+                for member in members {
+                    unions.extend(member.walk_all_unions());
+                }
             }
         }
 
@@ -487,5 +492,32 @@ mod tests {
                 "{label} alias key must be rejected"
             );
         }
+    }
+
+    #[test]
+    fn union_walker_is_total_for_noncanonical_pools() {
+        let nested = Ty::Union(
+            vec![
+                Ty::String {
+                    attr: TyAttr::EMPTY,
+                },
+                Ty::Null {
+                    attr: TyAttr::EMPTY,
+                },
+            ],
+            TyAttr::EMPTY,
+        );
+        let outer = Ty::Union(
+            vec![
+                Ty::Int {
+                    attr: TyAttr::EMPTY,
+                },
+                nested.clone(),
+            ],
+            TyAttr::EMPTY,
+        );
+        let symbol = alias(name("Nested"), outer.clone());
+
+        assert_eq!(symbol.walk_all_unions(), HashSet::from([outer, nested]));
     }
 }

--- a/baml_language/crates/baml_codegen_types/src/symbols.rs
+++ b/baml_language/crates/baml_codegen_types/src/symbols.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::{CodegenTypeError, Ty};
+use crate::{CodegenTypeError, Ty, ty::validate_ty};
 
 pub type SymbolPool = std::collections::HashMap<super::Name, Symbol>;
 
@@ -120,6 +120,8 @@ pub struct TypeAlias {
 }
 
 impl Symbol {
+    /// Validate this symbol's local structure. Pool-level alias resolution is
+    /// performed by [`validate_symbol_pool_map_keys`].
     pub fn validate(&self) -> Result<(), CodegenTypeError> {
         match self {
             Symbol::Function(function) => function.validate(),
@@ -139,13 +141,32 @@ impl Symbol {
     }
 }
 
+/// Validate map keys throughout a complete generator-facing symbol pool.
+///
+/// This is the authoritative alias-aware check: it follows canonical alias
+/// declaration targets by fully-qualified name, rejects missing or cyclic
+/// targets, and accepts only the string-denoting types supported by BAML.
+pub fn validate_symbol_pool_map_keys(pool: &SymbolPool) -> Result<(), CodegenTypeError> {
+    for symbol in pool.values() {
+        match symbol {
+            Symbol::Function(function) => function.validate_map_keys(pool)?,
+            Symbol::Class(class) => class.validate_map_keys(pool)?,
+            Symbol::Enum(_) => {}
+            Symbol::TypeAlias(alias) => {
+                validate_map_keys_ty(&alias.resolves_to, pool, &mut HashSet::new())?;
+            }
+        }
+    }
+    Ok(())
+}
+
 impl Function {
     fn validate(&self) -> Result<(), CodegenTypeError> {
         self.arguments
             .iter()
-            .map(|args| args.ty.validate())
+            .map(|args| validate_ty(&args.ty))
             .collect::<Result<Vec<_>, _>>()?;
-        self.return_type.validate()?;
+        validate_ty(&self.return_type)?;
 
         Ok(())
     }
@@ -157,13 +178,27 @@ impl Function {
             .chain(self.return_type.walk_all_unions())
             .collect()
     }
+
+    fn validate_map_keys(&self, pool: &SymbolPool) -> Result<(), CodegenTypeError> {
+        for argument in &self.arguments {
+            validate_map_keys_ty(&argument.ty, pool, &mut HashSet::new())?;
+        }
+        validate_map_keys_ty(&self.return_type, pool, &mut HashSet::new())?;
+        if let Some(throws) = &self.throws {
+            validate_map_keys_ty(throws, pool, &mut HashSet::new())?;
+        }
+        for (_, watcher) in &self.watchers {
+            validate_map_keys_ty(watcher, pool, &mut HashSet::new())?;
+        }
+        Ok(())
+    }
 }
 
 impl Class {
     fn validate(&self) -> Result<(), CodegenTypeError> {
         self.properties
             .iter()
-            .map(|prop| prop.ty.validate())
+            .map(|prop| validate_ty(&prop.ty))
             .collect::<Result<Vec<_>, _>>()?;
         for method in self.static_methods.iter().chain(&self.instance_methods) {
             method.validate()?;
@@ -183,11 +218,21 @@ impl Class {
             )
             .collect::<_>()
     }
+
+    fn validate_map_keys(&self, pool: &SymbolPool) -> Result<(), CodegenTypeError> {
+        for property in &self.properties {
+            validate_map_keys_ty(&property.ty, pool, &mut HashSet::new())?;
+        }
+        for method in self.static_methods.iter().chain(&self.instance_methods) {
+            method.validate_map_keys(pool)?;
+        }
+        Ok(())
+    }
 }
 
 impl TypeAlias {
     fn validate(&self) -> Result<(), CodegenTypeError> {
-        self.resolves_to.validate()
+        validate_ty(&self.resolves_to)
     }
 
     fn walk_all_unions(&self) -> HashSet<super::Ty> {
@@ -195,48 +240,252 @@ impl TypeAlias {
     }
 }
 
-impl super::Ty {
-    pub fn walk_all_unions(&self) -> HashSet<super::Ty> {
-        let mut unions = HashSet::<Ty>::default();
-        if matches!(self, Ty::Union(_)) {
+trait WalkAllUnions {
+    fn walk_all_unions(&self) -> HashSet<Ty>;
+}
+
+impl WalkAllUnions for Ty {
+    fn walk_all_unions(&self) -> HashSet<Ty> {
+        let mut unions = HashSet::default();
+        if matches!(self, Ty::Union(..)) {
             unions.insert(self.clone());
         }
 
         match self {
-            Ty::Int
-            | Ty::Bigint
-            | Ty::Float
-            | Ty::String
-            | Ty::Bool
-            | Ty::Null
-            | Ty::Unit
-            | Ty::Uint8Array
-            | Ty::Media(_)
-            | Ty::Enum(_)
-            | Ty::TypeAlias(_)
-            | Ty::TypeVar(_)
-            | Ty::RustType
-            | Ty::BuiltinUnknown
-            // Unions are guaranteed to not have unions thanks to .validate()
-            | Ty::Union(_)
-            | Ty::Literal(_) => {}
-            Ty::Class(_, args) => {
-                for a in args {
-                    unions.extend(a.walk_all_unions());
+            Ty::Int { .. }
+            | Ty::Bigint { .. }
+            | Ty::Float { .. }
+            | Ty::String { .. }
+            | Ty::Bool { .. }
+            | Ty::Null { .. }
+            | Ty::Void { .. }
+            | Ty::Uint8Array { .. }
+            | Ty::Media(..)
+            | Ty::Enum(..)
+            | Ty::EnumVariant(..)
+            | Ty::TypeAlias(..)
+            | Ty::TypeVar(..)
+            | Ty::RustType { .. }
+            | Ty::Type { .. }
+            | Ty::Resource { .. }
+            | Ty::PromptAst { .. }
+            | Ty::BuiltinUnknown { .. }
+            | Ty::Never { .. }
+            // Canonical unions cannot contain nested unions.
+            | Ty::Union(..)
+            | Ty::Literal(..) => {}
+            Ty::Class(_, args, _) => {
+                for arg in args {
+                    unions.extend(arg.walk_all_unions());
                 }
             }
-            Ty::List(ty) | Ty::Map { key: _, value: ty } => {
-                unions.extend(ty.walk_all_unions());
+            Ty::Interface(_, generics, associated_types, _) => {
+                for generic in generics {
+                    unions.extend(generic.walk_all_unions());
+                }
+                for (_, ty) in associated_types {
+                    unions.extend(ty.walk_all_unions());
+                }
             }
-            Ty::Callable { params, ret } => {
-                for p in params {
-                    unions.extend(p.ty.walk_all_unions());
+            Ty::List(ty, _) => unions.extend(ty.walk_all_unions()),
+            Ty::Map { key, value, .. } => {
+                unions.extend(key.walk_all_unions());
+                unions.extend(value.walk_all_unions());
+            }
+            Ty::Function {
+                params,
+                ret,
+                throws,
+                ..
+            } => {
+                for param in params {
+                    unions.extend(param.ty.walk_all_unions());
                 }
                 unions.extend(ret.walk_all_unions());
+                unions.extend(throws.walk_all_unions());
             }
-            Ty::BamlOptions => {}
+            Ty::Future(value, error, _) => {
+                unions.extend(value.walk_all_unions());
+                unions.extend(error.walk_all_unions());
+            }
         }
 
         unions
+    }
+}
+
+fn validate_map_keys_ty(
+    ty: &Ty,
+    pool: &SymbolPool,
+    resolving_aliases: &mut HashSet<super::Name>,
+) -> Result<(), CodegenTypeError> {
+    match ty {
+        Ty::Map { key, value, .. } => {
+            if !map_key_resolves_to_string(key, pool, resolving_aliases) {
+                return Err(CodegenTypeError::InvalidMapKey(key.clone()));
+            }
+            validate_map_keys_ty(value, pool, resolving_aliases)
+        }
+        Ty::Class(_, args, _) => args
+            .iter()
+            .try_for_each(|arg| validate_map_keys_ty(arg, pool, resolving_aliases)),
+        Ty::Interface(_, generics, associated_types, _) => {
+            generics
+                .iter()
+                .try_for_each(|ty| validate_map_keys_ty(ty, pool, resolving_aliases))?;
+            associated_types
+                .iter()
+                .try_for_each(|(_, ty)| validate_map_keys_ty(ty, pool, resolving_aliases))
+        }
+        Ty::List(inner, _) => validate_map_keys_ty(inner, pool, resolving_aliases),
+        Ty::Union(members, _) => members
+            .iter()
+            .try_for_each(|member| validate_map_keys_ty(member, pool, resolving_aliases)),
+        Ty::Function {
+            params,
+            ret,
+            throws,
+            ..
+        } => {
+            for param in params {
+                validate_map_keys_ty(&param.ty, pool, resolving_aliases)?;
+            }
+            validate_map_keys_ty(ret, pool, resolving_aliases)?;
+            validate_map_keys_ty(throws, pool, resolving_aliases)
+        }
+        Ty::Future(value, error, _) => {
+            validate_map_keys_ty(value, pool, resolving_aliases)?;
+            validate_map_keys_ty(error, pool, resolving_aliases)
+        }
+        _ => Ok(()),
+    }
+}
+
+fn map_key_resolves_to_string(
+    key: &Ty,
+    pool: &SymbolPool,
+    resolving_aliases: &mut HashSet<super::Name>,
+) -> bool {
+    match key {
+        Ty::String { .. } | Ty::Literal(baml_base::Literal::String(_), ..) => true,
+        Ty::Never { .. } => true,
+        Ty::Union(members, _) => members
+            .iter()
+            .all(|member| map_key_resolves_to_string(member, pool, resolving_aliases)),
+        Ty::TypeAlias(name, _) => {
+            if !resolving_aliases.insert(name.clone()) {
+                return false;
+            }
+            let valid = matches!(pool.get(name), Some(Symbol::TypeAlias(alias)) if
+                map_key_resolves_to_string(&alias.resolves_to, pool, resolving_aliases));
+            resolving_aliases.remove(name);
+            valid
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use baml_base::{Name as BaseName, TyAttr};
+
+    use super::*;
+
+    fn name(value: &str) -> crate::Name {
+        crate::Name::new(BaseName::new("user"), Vec::new(), BaseName::new(value))
+    }
+
+    fn origin() -> Origin {
+        Origin {
+            source_file_path: "types.baml".to_string(),
+            span_start: 0,
+        }
+    }
+
+    fn alias(name: crate::Name, resolves_to: Ty) -> Symbol {
+        Symbol::TypeAlias(TypeAlias {
+            name,
+            resolves_to,
+            recursive: false,
+            origin: origin(),
+        })
+    }
+
+    fn map_with_key(key: Ty) -> Symbol {
+        Symbol::Class(Class {
+            name: name("Holder"),
+            generic_params: Vec::new(),
+            docstring: None,
+            properties: vec![ClassProperty {
+                name: BaseName::new("values"),
+                docstring: None,
+                ty: Ty::Map {
+                    key: Box::new(key),
+                    value: Box::new(Ty::Int {
+                        attr: TyAttr::EMPTY,
+                    }),
+                    attr: TyAttr::EMPTY,
+                },
+            }],
+            static_methods: Vec::new(),
+            instance_methods: Vec::new(),
+            origin: origin(),
+        })
+    }
+
+    #[test]
+    fn map_key_validation_follows_alias_chains() {
+        let key = name("Key");
+        let key_chain = name("KeyChain");
+        let mut pool = SymbolPool::new();
+        pool.insert(
+            key.clone(),
+            alias(
+                key.clone(),
+                Ty::String {
+                    attr: TyAttr::EMPTY,
+                },
+            ),
+        );
+        pool.insert(
+            key_chain.clone(),
+            alias(key_chain.clone(), Ty::TypeAlias(key, TyAttr::EMPTY)),
+        );
+        pool.insert(
+            name("Holder"),
+            map_with_key(Ty::TypeAlias(key_chain, TyAttr::EMPTY)),
+        );
+
+        assert_eq!(validate_symbol_pool_map_keys(&pool), Ok(()));
+    }
+
+    #[test]
+    fn map_key_validation_rejects_non_string_and_cyclic_aliases() {
+        for (label, target) in [
+            (
+                "non-string",
+                Ty::Int {
+                    attr: TyAttr::EMPTY,
+                },
+            ),
+            ("cycle", Ty::TypeAlias(name("Key"), TyAttr::EMPTY)),
+        ] {
+            let key = name("Key");
+            let mut pool = SymbolPool::new();
+            pool.insert(key.clone(), alias(key.clone(), target));
+            pool.insert(
+                name("Holder"),
+                map_with_key(Ty::TypeAlias(key, TyAttr::EMPTY)),
+            );
+
+            assert!(
+                matches!(
+                    validate_symbol_pool_map_keys(&pool),
+                    Err(CodegenTypeError::InvalidMapKey(key))
+                        if matches!(key.as_ref(), Ty::TypeAlias(..))
+                ),
+                "{label} alias key must be rejected"
+            );
+        }
     }
 }

--- a/baml_language/crates/baml_codegen_types/src/ty.rs
+++ b/baml_language/crates/baml_codegen_types/src/ty.rs
@@ -1,274 +1,108 @@
-//! Type system BAML exposes for code-gen (this is both for streaming and non-streaming types).
+//! Shared BAML types exposed to every code generator.
 //!
-//! Types are fully resolved - no unresolved references. Class and Enum IDs
-//! from VIR are resolved to their names during lowering.
+//! The representation itself belongs to `baml_type`: generators consume the
+//! same compiler-owned qualified names and the same structurally narrowed type
+//! family instead of maintaining a parallel enum with lossy conversions.
 
-use std::fmt;
+use baml_base::Literal;
+pub use baml_type::{
+    CodegenFunctionParamTy as CallableParam, CodegenTy as Ty, Freshness,
+    FunctionParamMode as CodegenFunctionParamMode, QualifiedTypeName as Name,
+};
 
-/// Fully qualified type name carried by `Ty::Class`, `Ty::Enum`, and
-/// `Ty::TypeAlias`.
-///
-/// The triple `(pkg, namespace_path, name)` mirrors `baml_compiler2_tir::QualifiedTypeName`
-/// and is preserved end-to-end so language-specific code generators can route
-/// each type to the correct module path (e.g. `vendor.<pkg>.…`, `baml.…`,
-/// or the user package's root layout).
-///
-/// `$stream` companions live on the `name` field as a `…$stream` suffix —
-/// there is no separate stream-types namespace.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Name {
-    pub pkg: baml_base::Name,
-    pub namespace_path: Vec<baml_base::Name>,
-    pub name: baml_base::Name,
-}
+use crate::CodegenTypeError;
 
-impl Name {
-    pub fn new(
-        pkg: baml_base::Name,
-        namespace_path: Vec<baml_base::Name>,
-        name: baml_base::Name,
-    ) -> Self {
-        Self {
-            pkg,
-            namespace_path,
-            name,
+pub(crate) fn validate_ty(ty: &Ty) -> Result<(), CodegenTypeError> {
+    match ty {
+        Ty::Int { .. }
+        | Ty::Bigint { .. }
+        | Ty::Float { .. }
+        | Ty::String { .. }
+        | Ty::Bool { .. }
+        | Ty::Null { .. }
+        | Ty::Uint8Array { .. }
+        | Ty::Media(..)
+        | Ty::Literal(..)
+        | Ty::Enum(..)
+        | Ty::EnumVariant(..)
+        | Ty::TypeAlias(..)
+        | Ty::TypeVar(..)
+        | Ty::RustType { .. }
+        | Ty::Type { .. }
+        | Ty::Resource { .. }
+        | Ty::PromptAst { .. }
+        | Ty::BuiltinUnknown { .. }
+        | Ty::Never { .. }
+        | Ty::Void { .. } => Ok(()),
+        Ty::Class(_, args, _) => args.iter().try_for_each(validate_ty),
+        Ty::Interface(_, generics, associated_types, _) => {
+            generics.iter().try_for_each(validate_ty)?;
+            associated_types
+                .iter()
+                .try_for_each(|(_, ty)| validate_ty(ty))
         }
-    }
-
-    /// `true` if the bare name carries the `$stream` suffix.
-    pub fn is_stream(&self) -> bool {
-        self.name.as_str().ends_with("$stream")
-    }
-
-    /// The bare name without any `$stream` suffix.
-    pub fn bare_name(&self) -> &str {
-        self.name
-            .as_str()
-            .strip_suffix("$stream")
-            .unwrap_or_else(|| self.name.as_str())
-    }
-}
-
-impl fmt::Display for Name {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.pkg)?;
-        for seg in &self.namespace_path {
-            write!(f, ".{seg}")?;
+        Ty::List(inner, _) => {
+            if matches!(inner.as_ref(), Ty::Void { .. }) {
+                return Err(CodegenTypeError::InvalidUnit(inner.clone()));
+            }
+            validate_ty(inner)
         }
-        write!(f, ".{}", self.name)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CallableParam {
-    pub name: Option<baml_base::Name>,
-    pub ty: Ty,
-    pub mode: CodegenFunctionParamMode,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CodegenFunctionParamMode {
-    Required,
-    Optional,
-}
-
-/// A resolved type in BAML.
-///
-/// Unlike `baml_compiler_vir::Ty` which may contain `Unknown`, `Error`, `Never` references,
-/// this type is guaranteed to be valid.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Ty {
-    // Primitive types
-    Int,
-    Bigint,
-    Float,
-    String,
-    Bool,
-    Null,
-    Literal(baml_base::Literal),
-
-    // Binary data
-    Uint8Array,
-
-    // Media types
-    Media(baml_base::MediaKind),
-
-    /// Class type with resolved name and concrete generic arguments.
-    /// `generic_args` is empty for non-generic classes; otherwise it has one
-    /// entry per declared `generic_params` slot, in order. Mirrors TIR's
-    /// `Ty::Class(QualifiedTypeName, Vec<Ty>, TyAttr)`.
-    Class(Name, Vec<Ty>),
-
-    /// Enum type with resolved name.
-    Enum(Name),
-
-    /// Type alias with resolved name (used for recursive type aliases).
-    TypeAlias(Name),
-
-    /// A type-variable reference — `T` inside `class Box<T> { item T }` or
-    /// `function deep_copy<T>(value: T) -> T`. Carries the bare `TypeVar`
-    /// identifier; generators render it as a `typing.TypeVar`. Mirrors
-    /// TIR's `Ty::TypeVar(Name, TyAttr)`.
-    TypeVar(baml_base::Name),
-
-    // Type constructors
-    List(Box<Ty>),
-    Map {
-        key: Box<Ty>,
-        value: Box<Ty>,
-    },
-
-    /// Assumes no unions within unions
-    Union(Vec<Ty>),
-
-    /// BAML's `unknown` type — the top type where every type is a subtype.
-    /// Renders to `typing.Any` in Python.
-    BuiltinUnknown,
-
-    /// Callable type, e.g. `callable<[int, string], bool>`.
-    Callable {
-        params: Vec<CallableParam>,
-        ret: Box<Ty>,
-    },
-
-    // Special types
-    /// Void/Unit type - the type of effectful expressions.
-    Unit,
-    BamlOptions,
-    /// Opaque Rust-managed state — `$rust_type` fields in stdlib stubs
-    /// (e.g. `Response._body`, `SseStream._handle`). Generators render
-    /// this as the host-language opaque-handle type (Python:
-    /// `baml.baml_bridge.BamlPyHandle`).
-    RustType,
-}
-
-impl Ty {
-    pub(crate) fn validate(&self) -> Result<(), super::CodegenTypeError> {
-        match self {
-            Ty::BamlOptions => Ok(()),
-            Ty::Int
-            | Ty::Bigint
-            | Ty::Float
-            | Ty::String
-            | Ty::Bool
-            | Ty::Uint8Array
-            | Ty::Media(_)
-            | Ty::Enum(_)
-            | Ty::TypeAlias(_)
-            | Ty::TypeVar(_)
-            | Ty::RustType
-            | Ty::BuiltinUnknown => Ok(()),
-            Ty::Class(_, args) => args.iter().try_for_each(Ty::validate),
-            Ty::Callable { params, ret } => {
-                params.iter().try_for_each(|param| param.ty.validate())?;
-                ret.validate()
+        Ty::Map { key, value, .. } => {
+            if !is_potential_map_key(key) {
+                return Err(CodegenTypeError::InvalidMapKey(key.clone()));
             }
-            Ty::Null => Ok(()),
-            Ty::Literal(_) => Ok(()),
-            Ty::List(ty) => {
-                if matches!(ty.as_ref(), Ty::Unit) {
-                    return Err(super::CodegenTypeError::InvalidUnit(*ty.clone()));
-                }
-                ty.validate()
+            validate_ty(key)?;
+            if matches!(value.as_ref(), Ty::Void { .. }) {
+                return Err(CodegenTypeError::InvalidUnit(value.clone()));
             }
-            Ty::Map { key, value } => {
-                if !matches!(key.as_ref(), Ty::String | Ty::Enum(_)) {
-                    return Err(super::CodegenTypeError::InvalidMapKey(*key.clone()));
-                }
-                if matches!(value.as_ref(), Ty::Unit) {
-                    return Err(super::CodegenTypeError::InvalidUnit(*value.clone()));
-                }
-                value.validate()
+            validate_ty(value)
+        }
+        Ty::Union(items, _) => {
+            if items.is_empty() {
+                return Err(CodegenTypeError::InvalidUnionUsage(Box::new(ty.clone())));
             }
-            Ty::Union(items) => {
-                if items.is_empty() {
-                    return Err(super::CodegenTypeError::InvalidUnionUsage(self.clone()));
-                }
-                items
+            items.iter().try_for_each(validate_ty)?;
+            let null_count = items
+                .iter()
+                .filter(|ty| matches!(ty, Ty::Null { .. }))
+                .count();
+            if null_count > 1
+                || items
                     .iter()
-                    .map(Ty::validate)
-                    .reduce(|acc, res| match (acc, res) {
-                        (Ok(()), Ok(())) => Ok(()),
-                        (Err(err), _) => Err(err),
-                        (_, Err(err)) => Err(err),
-                    })
-                    .expect("Union is guaranteed to have atleast 1 item")?;
-
-                // A single `null` member encodes optionality (`T | null` ==
-                // `T?`) and is allowed. Nested unions/optionals, `Unit`, and
-                // more than one `null` are still rejected.
-                let null_count = items.iter().filter(|ty| matches!(ty, Ty::Null)).count();
-                if null_count > 1 || items.iter().any(|ty| matches!(ty, Ty::Union(_) | Ty::Unit)) {
-                    Err(super::CodegenTypeError::InvalidUnionUsage(self.clone()))
-                } else {
-                    Ok(())
-                }
+                    .any(|ty| matches!(ty, Ty::Union(..) | Ty::Void { .. }))
+            {
+                Err(CodegenTypeError::InvalidUnionUsage(Box::new(ty.clone())))
+            } else {
+                Ok(())
             }
-            Ty::Unit => Ok(()),
+        }
+        Ty::Function {
+            params,
+            ret,
+            throws,
+            ..
+        } => {
+            params.iter().try_for_each(|param| validate_ty(&param.ty))?;
+            validate_ty(ret)?;
+            validate_ty(throws)
+        }
+        Ty::Future(value, error, _) => {
+            validate_ty(value)?;
+            validate_ty(error)
         }
     }
 }
 
-impl fmt::Display for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Ty::BamlOptions => write!(f, "baml.Options"),
-            Ty::Int => write!(f, "int"),
-            Ty::Bigint => write!(f, "bigint"),
-            Ty::Float => write!(f, "float"),
-            Ty::String => write!(f, "string"),
-            Ty::Bool => write!(f, "bool"),
-            Ty::Null => write!(f, "null"),
-            Ty::Uint8Array => write!(f, "uint8array"),
-            Ty::Media(kind) => write!(f, "{kind}"),
-            Ty::Class(name, args) => {
-                if args.is_empty() {
-                    write!(f, "{name}")
-                } else {
-                    let parts: Vec<std::string::String> =
-                        args.iter().map(std::string::ToString::to_string).collect();
-                    write!(f, "{name}<{}>", parts.join(", "))
-                }
-            }
-            Ty::Enum(name) | Ty::TypeAlias(name) => write!(f, "{name}"),
-            Ty::TypeVar(name) => write!(f, "{name}"),
-            Ty::List(inner) => write!(f, "{inner}[]"),
-            Ty::Map { key, value } => write!(f, "map<{key}, {value}>"),
-            Ty::Union(types) => {
-                // `?` is sugar that exists only in source/lowering; after that a
-                // nullable type is a plain union.
-                let parts: Vec<std::string::String> =
-                    types.iter().map(std::string::ToString::to_string).collect();
-                write!(f, "({})", parts.join(" | "))
-            }
-            Ty::RustType => write!(f, "$rust_type"),
-            Ty::Literal(lit) => match lit {
-                baml_base::Literal::Int(v) => write!(f, "int({v})"),
-                baml_base::Literal::Bigint(n) => write!(f, "bigint({n})"),
-                baml_base::Literal::Float(s) => write!(f, "float({s})"),
-                baml_base::Literal::String(v) => write!(f, "string({v:?})"),
-                baml_base::Literal::Bool(v) => write!(f, "bool({v})"),
-            },
-            Ty::Unit => write!(f, "void"),
-            Ty::BuiltinUnknown => write!(f, "unknown"),
-            Ty::Callable { params, ret } => {
-                let param_strs: Vec<std::string::String> = params
-                    .iter()
-                    .map(|param| {
-                        let ty = &param.ty;
-                        match (&param.name, param.mode) {
-                            (Some(name), CodegenFunctionParamMode::Optional) => {
-                                format!("{name}?: {ty}")
-                            }
-                            (Some(name), CodegenFunctionParamMode::Required) => {
-                                format!("{name}: {ty}")
-                            }
-                            (None, _) => ty.to_string(),
-                        }
-                    })
-                    .collect();
-                write!(f, "callable<[{}], {ret}>", param_strs.join(", "))
-            }
-        }
+/// Structural pre-check used before a symbol pool is available. Alias nodes
+/// are candidates here; pool validation follows the declarations and proves
+/// that their resolved targets are string-denoting.
+fn is_potential_map_key(ty: &Ty) -> bool {
+    match ty {
+        Ty::String { .. }
+        | Ty::Literal(Literal::String(_), ..)
+        | Ty::TypeAlias(..)
+        | Ty::Never { .. } => true,
+        Ty::Union(members, _) => members.iter().all(is_potential_map_key),
+        _ => false,
     }
 }

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -17,9 +17,10 @@ use baml_compiler2_hir::{
 use baml_compiler2_tir::{
     lower_type_expr,
     normalize::find_recursive_aliases,
-    ty::{FunctionParamMode, MediaKind, QualifiedTypeName, Ty as TirTy},
+    ty::{QualifiedTypeName, Ty as TirTy},
 };
 use baml_db::Name;
+use baml_type::{Freshness, TyAttr};
 
 use crate::ProjectDatabase;
 
@@ -30,11 +31,7 @@ use crate::ProjectDatabase;
 /// Build a `cg::Name` from a `QualifiedTypeName`. Preserves `pkg`, the full
 /// namespace path, and the bare name (including any `$stream` suffix).
 fn name_from_qtn(qtn: &QualifiedTypeName) -> cg::Name {
-    cg::Name {
-        pkg: qtn.package().clone(),
-        namespace_path: qtn.namespace().clone(),
-        name: qtn.name().clone(),
-    }
+    qtn.clone()
 }
 
 fn lower_codegen_default(
@@ -160,11 +157,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
 
         // Classes
         for class in item_tree.classes.values() {
-            let cg_name = cg::Name {
-                pkg: pkg.clone(),
-                namespace_path: ns_path.clone(),
-                name: class.name.clone(),
-            };
+            let cg_name = cg::Name::new(pkg.clone(), ns_path.clone(), class.name.clone());
             let class_generic_params: Vec<Name> = class.generic_params.clone();
             let properties = class
                 .fields
@@ -268,7 +261,9 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                     alias_map,
                     recursive_aliases,
                 )
-                .unwrap_or(cg::Ty::Unit);
+                .unwrap_or(cg::Ty::Void {
+                    attr: TyAttr::default(),
+                });
 
                 let cg_method = cg::Function {
                     name: method.name.clone(),
@@ -310,11 +305,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
 
         // Enums
         for enum_def in item_tree.enums.values() {
-            let cg_name = cg::Name {
-                pkg: pkg.clone(),
-                namespace_path: ns_path.clone(),
-                name: enum_def.name.clone(),
-            };
+            let cg_name = cg::Name::new(pkg.clone(), ns_path.clone(), enum_def.name.clone());
             let variants = enum_def
                 .variants
                 .iter()
@@ -349,11 +340,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 alias_map,
                 recursive_aliases,
             ) {
-                let cg_name = cg::Name {
-                    pkg: pkg.clone(),
-                    namespace_path: ns_path.clone(),
-                    name: alias.name.clone(),
-                };
+                let cg_name = cg::Name::new(pkg.clone(), ns_path.clone(), alias.name.clone());
 
                 let qtn = QualifiedTypeName::new(
                     pkg_info.package.clone(),
@@ -446,7 +433,9 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 alias_map,
                 recursive_aliases,
             )
-            .unwrap_or(cg::Ty::Unit);
+            .unwrap_or(cg::Ty::Void {
+                attr: TyAttr::default(),
+            });
 
             let cg_func = cg::Function {
                 name: func.name.clone(),
@@ -462,11 +451,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 },
             };
 
-            let cg_name = cg::Name {
-                pkg: pkg.clone(),
-                namespace_path: ns_path.clone(),
-                name: func.name.clone(),
-            };
+            let cg_name = cg::Name::new(pkg.clone(), ns_path.clone(), func.name.clone());
             pool.insert(cg_name, cg::Symbol::Function(cg_func));
         }
     }
@@ -544,219 +529,104 @@ fn resolve_throws<'db>(
     }
 }
 
-/// Convert a TIR `Ty` to a `baml_codegen_types::Ty`, simplifying as we go.
+/// Convert a TIR type to the compiler-owned codegen family.
 ///
-/// Simplification (analogous to `simplify_sap` but for codegen, without attrs):
-/// - Optional → union with null
-/// - Flatten nested unions
-/// - Deduplicate variants (structural equality)
-/// - Push null to end
-/// - Unwrap singleton unions
+/// Public alias references remain nominal. The corresponding `TypeAlias`
+/// symbol stores the separately resolved target, so alias chains survive all
+/// the way to generators. Canonicalization is centralized on `CodegenTy` and
+/// recursively normalizes every container.
 fn convert_tir_to_codegen_ty(
     ty: &TirTy,
-    alias_map: &HashMap<QualifiedTypeName, TirTy>,
-    recursive_aliases: &std::collections::HashSet<QualifiedTypeName>,
+    _alias_map: &HashMap<QualifiedTypeName, TirTy>,
+    _recursive_aliases: &std::collections::HashSet<QualifiedTypeName>,
 ) -> cg::Ty {
-    let converted = convert_tir_leaf(ty, alias_map, recursive_aliases);
-    // Simplify unions that were built during conversion.
-    simplify_codegen_ty(converted)
+    convert_tir_leaf(ty).canonicalize()
 }
 
-/// Convert a single TIR type node without simplifying unions yet.
-fn convert_tir_leaf(
-    ty: &TirTy,
-    alias_map: &HashMap<QualifiedTypeName, TirTy>,
-    recursive_aliases: &std::collections::HashSet<QualifiedTypeName>,
-) -> cg::Ty {
+fn convert_tir_leaf(ty: &TirTy) -> cg::Ty {
+    let attr = TyAttr::default;
+    let convert = |ty: &TirTy| convert_tir_leaf(ty);
     match ty {
-        // Primitives
-        TirTy::Int { .. } => cg::Ty::Int,
-        TirTy::Bigint { .. } => cg::Ty::Bigint,
-        TirTy::Float { .. } => cg::Ty::Float,
-        TirTy::String { .. } => cg::Ty::String,
-        TirTy::Bool { .. } => cg::Ty::Bool,
-        TirTy::Null { .. } => cg::Ty::Null,
-        TirTy::Uint8Array { .. } => cg::Ty::Uint8Array,
-        TirTy::Media(MediaKind::Image, _) => cg::Ty::Media(baml_db::MediaKind::Image),
-        TirTy::Media(MediaKind::Audio, _) => cg::Ty::Media(baml_db::MediaKind::Audio),
-        TirTy::Media(MediaKind::Video, _) => cg::Ty::Media(baml_db::MediaKind::Video),
-        TirTy::Media(MediaKind::Pdf, _) => cg::Ty::Media(baml_db::MediaKind::Pdf),
-        // `MediaKind::Generic` is never produced by TIR; handled defensively.
-        TirTy::Media(MediaKind::Generic, _) => cg::Ty::BuiltinUnknown,
-
-        // Named class types — preserve full QualifiedTypeName via name_from_qtn.
+        TirTy::Int { .. } => cg::Ty::Int { attr: attr() },
+        TirTy::Bigint { .. } => cg::Ty::Bigint { attr: attr() },
+        TirTy::Float { .. } => cg::Ty::Float { attr: attr() },
+        TirTy::String { .. } => cg::Ty::String { attr: attr() },
+        TirTy::Bool { .. } => cg::Ty::Bool { attr: attr() },
+        TirTy::Null { .. } => cg::Ty::Null { attr: attr() },
+        TirTy::Uint8Array { .. } => cg::Ty::Uint8Array { attr: attr() },
+        TirTy::Media(kind, _) => cg::Ty::Media(*kind, attr()),
+        TirTy::Literal(literal, _, _) => {
+            cg::Ty::Literal(literal.clone(), Freshness::Regular, attr())
+        }
         TirTy::Class(qtn, type_args, _) => cg::Ty::Class(
             name_from_qtn(qtn),
-            type_args
-                .iter()
-                .map(|t| convert_tir_to_codegen_ty(t, alias_map, recursive_aliases))
-                .collect(),
+            type_args.iter().map(convert).collect(),
+            attr(),
         ),
-        // Interfaces are BAML-side contracts, not serializable host SDK
-        // models. Until codegen grows a structural interface representation,
-        // surface interface-typed boundary positions as opaque values instead
-        // of emitting references to types the SDK does not define.
-        TirTy::Interface(_, _, _, _) => cg::Ty::BuiltinUnknown,
-        TirTy::Enum(qtn, _) => cg::Ty::Enum(name_from_qtn(qtn)),
-        TirTy::EnumVariant(qtn, _variant, _) => cg::Ty::Enum(name_from_qtn(qtn)),
-
-        // Type aliases: if recursive, keep as TypeAlias (opaque); otherwise inline.
-        TirTy::TypeAlias(qtn, _) => {
-            if recursive_aliases.contains(qtn) {
-                cg::Ty::TypeAlias(name_from_qtn(qtn))
-            } else if let Some(target) = alias_map.get(qtn) {
-                // Inline non-recursive aliases.
-                convert_tir_to_codegen_ty(target, alias_map, recursive_aliases)
-            } else {
-                // Unknown alias (e.g. from another package) — keep opaque as TypeAlias.
-                cg::Ty::TypeAlias(name_from_qtn(qtn))
-            }
+        TirTy::Interface(qtn, generics, associated_types, _) => cg::Ty::Interface(
+            name_from_qtn(qtn),
+            generics.iter().map(convert).collect(),
+            associated_types
+                .iter()
+                .map(|(name, ty)| (name.clone(), convert(ty)))
+                .collect(),
+            attr(),
+        ),
+        TirTy::Enum(qtn, _) => cg::Ty::Enum(name_from_qtn(qtn), attr()),
+        TirTy::EnumVariant(qtn, variant, _) => {
+            cg::Ty::EnumVariant(name_from_qtn(qtn), variant.clone(), attr())
         }
-
-        // Containers — recurse via convert_tir_to_codegen_ty so children are simplified.
-        TirTy::List(inner, _) | TirTy::EvolvingList(inner, _) => cg::Ty::List(Box::new(
-            convert_tir_to_codegen_ty(inner, alias_map, recursive_aliases),
-        )),
+        TirTy::TypeAlias(qtn, _) => cg::Ty::TypeAlias(name_from_qtn(qtn), attr()),
+        TirTy::List(inner, _) | TirTy::EvolvingList(inner, _) => {
+            cg::Ty::List(Box::new(convert(inner)), attr())
+        }
         TirTy::Map {
             key: k, value: v, ..
         }
         | TirTy::EvolvingMap(k, v, _) => cg::Ty::Map {
-            key: Box::new(convert_tir_to_codegen_ty(k, alias_map, recursive_aliases)),
-            value: Box::new(convert_tir_to_codegen_ty(v, alias_map, recursive_aliases)),
+            key: Box::new(convert(k)),
+            value: Box::new(convert(v)),
+            attr: attr(),
         },
-        // Unions: convert children, then let simplify_codegen_ty handle them.
-        // Nullable types (`T | null`) are just unions whose members include null.
-        TirTy::Union(members, _) => cg::Ty::Union(
-            members
-                .iter()
-                .map(|m| convert_tir_to_codegen_ty(m, alias_map, recursive_aliases))
-                .collect(),
-        ),
-        TirTy::Literal(lit, _freshness, _) => cg::Ty::Literal(lit.clone()),
-
-        // BEP-030: BAML's `unknown` top type → BuiltinUnknown.
-        TirTy::BuiltinUnknown { .. } => cg::Ty::BuiltinUnknown,
-        TirTy::AssociatedTypeProjection { .. } => cg::Ty::BuiltinUnknown,
-
-        // BEP-030: Function types → Callable.
-        TirTy::Function { params, ret, .. } => cg::Ty::Callable {
+        TirTy::Union(members, _) => cg::Ty::Union(members.iter().map(convert).collect(), attr()),
+        TirTy::Function {
+            params,
+            ret,
+            throws,
+            ..
+        } => cg::Ty::Function {
             params: params
                 .iter()
                 .map(|param| cg::CallableParam {
                     name: param.name.clone(),
-                    ty: convert_tir_to_codegen_ty(&param.ty, alias_map, recursive_aliases),
-                    mode: match param.mode {
-                        FunctionParamMode::Required => cg::CodegenFunctionParamMode::Required,
-                        FunctionParamMode::Optional => cg::CodegenFunctionParamMode::Optional,
-                    },
+                    ty: convert(&param.ty),
+                    mode: param.mode,
                 })
                 .collect(),
-            ret: Box::new(convert_tir_to_codegen_ty(ret, alias_map, recursive_aliases)),
+            ret: Box::new(convert(ret)),
+            throws: Box::new(convert(throws)),
+            attr: attr(),
         },
-
-        // Type variable — codegen-side `Ty::TypeVar` mirrors TIR.
-        TirTy::TypeVar(name, _) => cg::Ty::TypeVar(name.clone()),
-
-        // `$rust_type` — opaque Rust-managed state. Surfaces as
-        // `BamlPyHandle` in Python codegen; other languages will pick
-        // their own opaque-handle mapping.
-        TirTy::RustType { .. } => cg::Ty::RustType,
-
-        // Bottom / sentinel / error recovery — map to Unit. An inference hole
-        // (`_`) should have been filled before codegen; map defensively to Unit.
-        TirTy::Void { .. }
-        | TirTy::Never { .. }
-        | TirTy::Unknown { .. }
-        | TirTy::Error { .. }
-        | TirTy::Infer { .. }
-        | TirTy::Type { .. } => cg::Ty::Unit,
-
-        // BEP-034: surface a `Future<T, E>` as the codegen-side `Unit`
-        // for v1 — codegen for the host-side `Future` shape is a
-        // follow-up. The error path is acceptable since BAML code that
-        // returns futures must `await` them before crossing the host
-        // boundary in v1.
-        TirTy::Future(_, _, _) => cg::Ty::Unit,
-        // `Resource`/`PromptAst` are never produced by TIR; the
-        // arms exist only so the match stays exhaustive over the shared
-        // `baml_type::Ty`.
-        TirTy::Resource { .. } | TirTy::PromptAst { .. } => cg::Ty::BuiltinUnknown,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Codegen type simplification
-// ---------------------------------------------------------------------------
-
-/// Simplify a codegen type: flatten unions, dedup, null-to-end, unwrap singletons.
-fn simplify_codegen_ty(ty: cg::Ty) -> cg::Ty {
-    match ty {
-        cg::Ty::Union(variants) => simplify_union(variants),
-        // Recurse into containers.
-        cg::Ty::List(inner) => cg::Ty::List(Box::new(simplify_codegen_ty(*inner))),
-        cg::Ty::Map { key, value } => cg::Ty::Map {
-            key: Box::new(simplify_codegen_ty(*key)),
-            value: Box::new(simplify_codegen_ty(*value)),
-        },
-        // Leaf types pass through unchanged.
-        other => other,
-    }
-}
-
-fn simplify_union(variants: Vec<cg::Ty>) -> cg::Ty {
-    // 1. Flatten nested unions.
-    let variants = flatten_union(variants);
-
-    // 2. Deduplicate (structural equality).
-    let variants = dedup_variants(variants);
-
-    // 3. Push null to end.
-    let variants = null_to_end(variants);
-
-    // 4. Unwrap singleton.
-    if variants.len() == 1 {
-        variants.into_iter().next().unwrap()
-    } else {
-        cg::Ty::Union(variants)
-    }
-}
-
-/// Flatten nested unions into a single level.
-fn flatten_union(variants: Vec<cg::Ty>) -> Vec<cg::Ty> {
-    let mut out = Vec::new();
-    for v in variants {
-        match v {
-            cg::Ty::Union(inner) => out.extend(flatten_union(inner)),
-            other => out.push(other),
+        TirTy::Future(value, error, _) => {
+            cg::Ty::Future(Box::new(convert(value)), Box::new(convert(error)), attr())
         }
-    }
-    out
-}
+        TirTy::RustType { .. } => cg::Ty::RustType { attr: attr() },
+        TirTy::Type { .. } => cg::Ty::Type { attr: attr() },
+        TirTy::Resource { .. } => cg::Ty::Resource { attr: attr() },
+        TirTy::PromptAst { .. } => cg::Ty::PromptAst { attr: attr() },
+        TirTy::Void { .. } => cg::Ty::Void { attr: attr() },
+        TirTy::TypeVar(name, _) => cg::Ty::TypeVar(name.clone(), attr()),
+        TirTy::BuiltinUnknown { .. } => cg::Ty::BuiltinUnknown { attr: attr() },
+        TirTy::Never { .. } => cg::Ty::Never { attr: attr() },
 
-/// Remove structurally duplicate variants.
-fn dedup_variants(variants: Vec<cg::Ty>) -> Vec<cg::Ty> {
-    let mut result: Vec<cg::Ty> = Vec::new();
-    for candidate in variants {
-        if !result.contains(&candidate) {
-            result.push(candidate);
+        // These are compiler recovery/inference states, not public API types.
+        // Diagnostics have already been emitted; retain the historical opaque
+        // fallback so code generation remains total in error-tolerant flows.
+        TirTy::AssociatedTypeProjection { .. } | TirTy::Unknown { .. } | TirTy::Error { .. } => {
+            cg::Ty::BuiltinUnknown { attr: attr() }
         }
+        TirTy::Infer { .. } => cg::Ty::Void { attr: attr() },
     }
-    result
-}
-
-/// Push `Null` variants to the end.
-fn null_to_end(variants: Vec<cg::Ty>) -> Vec<cg::Ty> {
-    let mut non_null = Vec::new();
-    let mut nulls = Vec::new();
-    for v in variants {
-        if matches!(v, cg::Ty::Null) {
-            nulls.push(v);
-        } else {
-            non_null.push(v);
-        }
-    }
-    non_null.extend(nulls);
-    non_null
 }
 
 // ---------------------------------------------------------------------------
@@ -769,6 +639,22 @@ mod tests {
 
     use super::*;
     use crate::ProjectDatabase;
+
+    fn codegen_attr() -> TyAttr {
+        TyAttr::default()
+    }
+
+    fn codegen_alias(name: cg::Name) -> cg::Ty {
+        cg::Ty::TypeAlias(name, codegen_attr())
+    }
+
+    fn codegen_list(inner: cg::Ty) -> cg::Ty {
+        cg::Ty::List(Box::new(inner), codegen_attr())
+    }
+
+    fn codegen_union(members: Vec<cg::Ty>) -> cg::Ty {
+        cg::Ty::Union(members, codegen_attr())
+    }
 
     // ── Unit tests for pure helpers ─────────────────────────────────────────
 
@@ -806,14 +692,14 @@ mod tests {
             Name::new("Sentiment"),
         );
         let cg_name = name_from_qtn(&qtn);
-        assert_eq!(cg_name.pkg.as_str(), "user");
+        assert_eq!(cg_name.package().as_str(), "user");
         assert_eq!(
-            cg_name.namespace_path,
-            vec![Name::new("foo")],
+            cg_name.namespace(),
+            &vec![Name::new("foo")],
             "namespace_path mismatch: {:?}",
-            cg_name.namespace_path,
+            cg_name.namespace(),
         );
-        assert_eq!(cg_name.name.as_str(), "Sentiment");
+        assert_eq!(cg_name.name().as_str(), "Sentiment");
         assert!(!cg_name.is_stream());
     }
 
@@ -854,7 +740,7 @@ mod tests {
         ] {
             let key = pool
                 .keys()
-                .find(|k| k.name.as_str() == expected)
+                .find(|k| k.name().as_str() == expected)
                 .unwrap_or_else(|| panic!("{expected} must be in the pool"));
             assert!(
                 matches!(pool.get(key), Some(cg::Symbol::Function(_))),
@@ -899,11 +785,7 @@ function ExtractResume(resume: string) -> Resume {
             ("ExtractResume$parse", &["json"][..]),
             ("ExtractResume$parse_stream", &["sse"][..]),
         ] {
-            let key = cg::Name {
-                pkg: Name::new("user"),
-                namespace_path: vec![],
-                name: Name::new(bare),
-            };
+            let key = cg::Name::new(Name::new("user"), vec![], Name::new(bare));
             let Some(cg::Symbol::Function(func)) = pool.get(&key) else {
                 panic!("missing function {bare}");
             };
@@ -923,7 +805,7 @@ function ExtractResume(resume: string) -> Resume {
                 "client default for {bare}",
             );
             match &client_arg.ty {
-                cg::Ty::Class(name, args) => {
+                cg::Ty::Class(name, args, _) => {
                     assert_eq!(name.to_string(), "baml.llm.Client");
                     assert!(args.is_empty());
                 }
@@ -986,7 +868,7 @@ function Extract(client: string, text: string) -> string {
 
         let doc_key = pool
             .keys()
-            .find(|k| k.name.as_str() == "Doc")
+            .find(|k| k.name().as_str() == "Doc")
             .expect("Doc class missing from pool");
         let cg::Symbol::Class(doc) = &pool[doc_key] else {
             panic!("Doc must be a Class");
@@ -1009,7 +891,7 @@ function Extract(client: string, text: string) -> string {
 
         let enum_key = pool
             .keys()
-            .find(|k| k.name.as_str() == "Sentiment")
+            .find(|k| k.name().as_str() == "Sentiment")
             .expect("Sentiment enum missing");
         let cg::Symbol::Enum(en) = &pool[enum_key] else {
             panic!("Sentiment must be an Enum");
@@ -1040,10 +922,10 @@ function Extract(client: string, text: string) -> string {
     fn test_throws_reaches_symbol_pool() {
         fn walk(ty: &cg::Ty, out: &mut Vec<String>) {
             match ty {
-                cg::Ty::Class(n, _) | cg::Ty::Enum(n) | cg::Ty::TypeAlias(n) => {
-                    out.push(n.name.as_str().to_string());
+                cg::Ty::Class(n, _, _) | cg::Ty::Enum(n, _) | cg::Ty::TypeAlias(n, _) => {
+                    out.push(n.name().as_str().to_string());
                 }
-                cg::Ty::Union(ms) => ms.iter().for_each(|m| walk(m, out)),
+                cg::Ty::Union(ms, _) => ms.iter().for_each(|m| walk(m, out)),
                 _ => {}
             }
         }
@@ -1070,7 +952,7 @@ function Extract(client: string, text: string) -> string {
         let throws_names = |fn_name: &str| -> Vec<String> {
             let key = pool
                 .keys()
-                .find(|k| k.name.as_str() == fn_name)
+                .find(|k| k.name().as_str() == fn_name)
                 .unwrap_or_else(|| panic!("{fn_name} missing from pool"));
             let cg::Symbol::Function(f) = &pool[key] else {
                 panic!("{fn_name} must be a Function");
@@ -1181,7 +1063,7 @@ function Extract(client: string, text: string) -> string {
 
         let key = pool
             .keys()
-            .find(|k| k.name.as_str() == "Counter")
+            .find(|k| k.name().as_str() == "Counter")
             .expect("Counter class missing from pool");
         let Some(cg::Symbol::Class(class)) = pool.get(key) else {
             panic!("Counter must be a Class");
@@ -1222,16 +1104,16 @@ function Extract(client: string, text: string) -> string {
 
         let pool = build_symbol_pool(&db);
 
-        let sentiment_key = pool.keys().find(|k| k.name.as_str() == "Sentiment");
+        let sentiment_key = pool.keys().find(|k| k.name().as_str() == "Sentiment");
         assert!(sentiment_key.is_some(), "Sentiment must be in the pool");
 
         let key = sentiment_key.unwrap();
-        assert_eq!(key.pkg.as_str(), "user", "pkg mismatch: {:?}", key.pkg);
+        assert_eq!(key.package().as_str(), "user", "pkg mismatch: {key:?}");
         assert_eq!(
-            key.namespace_path,
-            vec![Name::new("foo")],
+            key.namespace(),
+            &vec![Name::new("foo")],
             "namespace_path mismatch: {:?}",
-            key.namespace_path,
+            key.namespace(),
         );
         assert!(!key.is_stream(), "Sentiment must not be marked as stream");
     }
@@ -1255,7 +1137,7 @@ function Extract(client: string, text: string) -> string {
 
         let key = pool
             .keys()
-            .find(|k| k.name.as_str() == "ReturnInt")
+            .find(|k| k.name().as_str() == "ReturnInt")
             .expect("ReturnInt must be in the pool");
         assert!(
             matches!(pool.get(key), Some(cg::Symbol::Function(_))),
@@ -1295,12 +1177,12 @@ function top() -> int { 0 }
         assert!(
             !pool
                 .keys()
-                .any(|k| k.name.as_str() == "run" && k.namespace_path.is_empty()),
+                .any(|k| k.name().as_str() == "run" && k.namespace().is_empty()),
             "interface/default-impl methods must not become free SDK functions"
         );
         let key = pool
             .keys()
-            .find(|k| k.name.as_str() == "top")
+            .find(|k| k.name().as_str() == "top")
             .expect("top must be in the pool");
         assert!(
             matches!(pool.get(key), Some(cg::Symbol::Function(_))),
@@ -1309,7 +1191,7 @@ function top() -> int { 0 }
     }
 
     #[test]
-    fn test_interface_typed_sdk_boundaries_are_opaque() {
+    fn test_interface_typed_sdk_boundaries_preserve_compiler_type() {
         let root = Path::new("/tmp/interface_typed_sdk_boundaries_are_opaque");
         let mut db = ProjectDatabase::new();
         db.set_project_root(root);
@@ -1332,21 +1214,242 @@ function passthrough(x: Marker) -> Marker { x }
         let pool = build_symbol_pool(&db);
         let key = pool
             .keys()
-            .find(|k| k.name.as_str() == "passthrough")
+            .find(|k| k.name().as_str() == "passthrough")
             .expect("passthrough must be in the pool");
         let Some(cg::Symbol::Function(function)) = pool.get(key) else {
             panic!("passthrough must be a function");
         };
 
-        assert_eq!(
-            function.arguments[0].ty,
-            cg::Ty::BuiltinUnknown,
-            "interface parameters should be opaque at the SDK boundary"
+        for ty in [&function.arguments[0].ty, &function.return_type] {
+            assert!(
+                matches!(ty, cg::Ty::Interface(name, generics, associated, _)
+                    if name.bare_name() == "Marker"
+                        && generics.is_empty()
+                        && associated.is_empty()),
+                "interface identity should survive in shared codegen IR: {ty:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn aliases_keep_identity_chains_and_canonical_targets_in_codegen() {
+        let root = Path::new("/tmp/codegen_alias_identity");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("main.baml").as_path(),
+            r#"
+type Text = string
+type TextChain = Text
+type MaybeText = null | TextChain | null
+type Rec = int | Rec[]
+
+class Holder {
+  direct Text
+  chain TextChain
+  maybe MaybeText
+  nested MaybeText[]
+  mapped map<string, TextChain[]>
+}
+
+function normalize(value: null | string | null) -> null | string | null { value }
+"#,
         );
+
+        let diagnostics = crate::collect_compiler2_diagnostics(&db);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:#?}");
+
+        let pool = build_symbol_pool(&db);
+        let name = |name: &str| cg::Name::new(Name::new("user"), vec![], Name::new(name));
+        let text = name("Text");
+        let text_chain = name("TextChain");
+        let maybe_text = name("MaybeText");
+        let rec = name("Rec");
+
+        let cg::Symbol::TypeAlias(text_decl) = &pool[&text] else {
+            panic!("Text must be an alias")
+        };
         assert_eq!(
-            function.return_type,
-            cg::Ty::BuiltinUnknown,
-            "interface returns should be opaque at the SDK boundary"
+            text_decl.resolves_to,
+            cg::Ty::String {
+                attr: codegen_attr()
+            }
         );
+
+        let cg::Symbol::TypeAlias(chain_decl) = &pool[&text_chain] else {
+            panic!("TextChain must be an alias")
+        };
+        assert_eq!(chain_decl.resolves_to, codegen_alias(text.clone()));
+
+        let cg::Symbol::TypeAlias(maybe_decl) = &pool[&maybe_text] else {
+            panic!("MaybeText must be an alias")
+        };
+        assert_eq!(
+            maybe_decl.resolves_to,
+            codegen_union(vec![
+                codegen_alias(text_chain.clone()),
+                cg::Ty::Null {
+                    attr: codegen_attr()
+                }
+            ])
+        );
+
+        let cg::Symbol::TypeAlias(rec_decl) = &pool[&rec] else {
+            panic!("Rec must be an alias")
+        };
+        assert!(rec_decl.recursive);
+        assert_eq!(
+            rec_decl.resolves_to,
+            codegen_union(vec![
+                cg::Ty::Int {
+                    attr: codegen_attr()
+                },
+                codegen_list(codegen_alias(rec.clone())),
+            ])
+        );
+
+        let cg::Symbol::Class(holder) = &pool[&name("Holder")] else {
+            panic!("Holder must be a class")
+        };
+        let property = |property_name: &str| {
+            &holder
+                .properties
+                .iter()
+                .find(|property| property.name.as_str() == property_name)
+                .unwrap_or_else(|| panic!("missing Holder.{property_name}"))
+                .ty
+        };
+        assert_eq!(property("direct"), &codegen_alias(text));
+        assert_eq!(property("chain"), &codegen_alias(text_chain.clone()));
+        assert_eq!(property("maybe"), &codegen_alias(maybe_text.clone()));
+        assert_eq!(property("nested"), &codegen_list(codegen_alias(maybe_text)));
+        assert_eq!(
+            property("mapped"),
+            &cg::Ty::Map {
+                key: Box::new(cg::Ty::String {
+                    attr: codegen_attr()
+                }),
+                value: Box::new(codegen_list(codegen_alias(text_chain))),
+                attr: codegen_attr(),
+            }
+        );
+
+        let cg::Symbol::Function(normalize) = &pool[&name("normalize")] else {
+            panic!("normalize must be a function")
+        };
+        let nullable_string = codegen_union(vec![
+            cg::Ty::String {
+                attr: codegen_attr(),
+            },
+            cg::Ty::Null {
+                attr: codegen_attr(),
+            },
+        ]);
+        assert_eq!(normalize.arguments[0].ty, nullable_string);
+        assert_eq!(normalize.return_type, nullable_string);
+        cg::validate_symbol_pool_map_keys(&pool).expect("canonical alias map keys must validate");
+    }
+
+    #[test]
+    fn aliased_map_keys_are_checked_through_resolved_targets() {
+        use baml_compiler_diagnostics::diagnostic::DiagnosticId;
+
+        let legal_root = Path::new("/tmp/codegen_legal_alias_map_key");
+        let mut legal_db = ProjectDatabase::new();
+        legal_db.set_project_root(legal_root);
+        legal_db.add_or_update_file(
+            legal_root.join("main.baml").as_path(),
+            "type Key = \"first\" | \"second\"\ntype KeyChain = Key\nclass Lookup { values map<KeyChain, int> }\n",
+        );
+        let diagnostics = crate::collect_compiler2_diagnostics(&legal_db);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:#?}");
+        let legal_pool = build_symbol_pool(&legal_db);
+        let lookup_name = cg::Name::new(Name::new("user"), vec![], Name::new("Lookup"));
+        let key_chain = cg::Name::new(Name::new("user"), vec![], Name::new("KeyChain"));
+        let cg::Symbol::Class(lookup) = &legal_pool[&lookup_name] else {
+            panic!("Lookup must be a class")
+        };
+        assert_eq!(
+            lookup.properties[0].ty,
+            cg::Ty::Map {
+                key: Box::new(codegen_alias(key_chain)),
+                value: Box::new(cg::Ty::Int {
+                    attr: codegen_attr()
+                }),
+                attr: codegen_attr(),
+            }
+        );
+        cg::validate_symbol_pool_map_keys(&legal_pool)
+            .expect("string-denoting alias key must validate");
+
+        let illegal_root = Path::new("/tmp/codegen_illegal_alias_map_key");
+        let mut illegal_db = ProjectDatabase::new();
+        illegal_db.set_project_root(illegal_root);
+        illegal_db.add_or_update_file(
+            illegal_root.join("main.baml").as_path(),
+            "type BadKey = int\nclass Lookup { values map<BadKey, string> }\n",
+        );
+        let diagnostics = crate::collect_compiler2_diagnostics(&illegal_db);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.id == DiagnosticId::InvalidMapKeyType),
+            "the compiler must reject an int-denoting alias map key: {diagnostics:#?}"
+        );
+        let illegal_pool = build_symbol_pool(&illegal_db);
+        assert!(matches!(
+            cg::validate_symbol_pool_map_keys(&illegal_pool),
+            Err(cg::CodegenTypeError::InvalidMapKey(key))
+                if matches!(key.as_ref(), cg::Ty::TypeAlias(..))
+        ));
+    }
+
+    #[test]
+    fn same_alias_name_in_different_namespaces_stays_qualified() {
+        let root = Path::new("/tmp/codegen_namespaced_alias_identity");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("ns_left/types.baml").as_path(),
+            "type Shared = string\nclass Left { value Shared }\n",
+        );
+        db.add_or_update_file(
+            root.join("ns_right/types.baml").as_path(),
+            "type Shared = int\nclass Right { value Shared }\n",
+        );
+
+        let diagnostics = crate::collect_compiler2_diagnostics(&db);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:#?}");
+        let pool = build_symbol_pool(&db);
+        let qualified = |namespace: &str, name: &str| {
+            cg::Name::new(
+                Name::new("user"),
+                vec![Name::new(namespace)],
+                Name::new(name),
+            )
+        };
+        let left_alias = qualified("left", "Shared");
+        let right_alias = qualified("right", "Shared");
+        assert_ne!(left_alias, right_alias);
+        assert!(matches!(
+            &pool[&left_alias],
+            cg::Symbol::TypeAlias(alias)
+                if alias.resolves_to == cg::Ty::String { attr: codegen_attr() }
+        ));
+        assert!(matches!(
+            &pool[&right_alias],
+            cg::Symbol::TypeAlias(alias)
+                if alias.resolves_to == cg::Ty::Int { attr: codegen_attr() }
+        ));
+
+        for (class_name, alias_name) in [
+            (qualified("left", "Left"), left_alias),
+            (qualified("right", "Right"), right_alias),
+        ] {
+            let cg::Symbol::Class(class) = &pool[&class_name] else {
+                panic!("{class_name} must be a class")
+            };
+            assert_eq!(class.properties[0].ty, codegen_alias(alias_name));
+        }
     }
 }

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -544,7 +544,9 @@ fn convert_tir_to_codegen_ty(
 }
 
 fn convert_tir_leaf(ty: &TirTy) -> cg::Ty {
-    let attr = TyAttr::default;
+    // Each recursive invocation reads the attribute from its own source node,
+    // so nested SAP/streaming annotations survive the codegen boundary.
+    let attr = || ty.attr().clone();
     let convert = |ty: &TirTy| convert_tir_leaf(ty);
     match ty {
         TirTy::Int { .. } => cg::Ty::Int { attr: attr() },
@@ -637,6 +639,8 @@ fn convert_tir_leaf(ty: &TirTy) -> cg::Ty {
 mod tests {
     use std::path::Path;
 
+    use baml_type::TyAttrValue;
+
     use super::*;
     use crate::ProjectDatabase;
 
@@ -654,6 +658,29 @@ mod tests {
 
     fn codegen_union(members: Vec<cg::Ty>) -> cg::Ty {
         cg::Ty::Union(members, codegen_attr())
+    }
+
+    #[test]
+    fn tir_attributes_survive_recursive_codegen_lowering() {
+        let outer_attr = TyAttr {
+            sap_pending_never: TyAttrValue::Set,
+            ..TyAttr::default()
+        };
+        let inner_attr = TyAttr {
+            sap_parse_without_null: TyAttrValue::Set,
+            ..TyAttr::default()
+        };
+        let tir = TirTy::List(
+            Box::new(TirTy::String {
+                attr: inner_attr.clone(),
+            }),
+            outer_attr.clone(),
+        );
+
+        assert_eq!(
+            convert_tir_to_codegen_ty(&tir, &HashMap::new(), &std::collections::HashSet::new(),),
+            cg::Ty::List(Box::new(cg::Ty::String { attr: inner_attr }), outer_attr,)
+        );
     }
 
     // ── Unit tests for pure helpers ─────────────────────────────────────────

--- a/baml_language/crates/baml_type/src/codegen_ty.rs
+++ b/baml_language/crates/baml_type/src/codegen_ty.rs
@@ -8,50 +8,49 @@ impl CodegenTy {
     /// Normalize a compiler type at the code-generation boundary.
     ///
     /// The codegen family deliberately preserves nominal aliases and generic
-    /// type variables. This pass removes compiler-only type-expression
-    /// attributes and canonicalizes structure recursively, including inside
-    /// generic arguments, interfaces, functions, futures, lists, and maps.
+    /// type variables and SAP/streaming attributes. This pass canonicalizes
+    /// structure recursively, including inside generic arguments, interfaces,
+    /// functions, futures, lists, and maps.
     #[must_use]
     pub fn canonicalize(self) -> Self {
-        let empty = TyAttr::default;
         match self {
-            Self::Int { .. } => Self::Int { attr: empty() },
-            Self::Bigint { .. } => Self::Bigint { attr: empty() },
-            Self::Float { .. } => Self::Float { attr: empty() },
-            Self::String { .. } => Self::String { attr: empty() },
-            Self::Bool { .. } => Self::Bool { attr: empty() },
-            Self::Null { .. } => Self::Null { attr: empty() },
-            Self::Uint8Array { .. } => Self::Uint8Array { attr: empty() },
-            Self::Media(kind, _) => Self::Media(kind, empty()),
-            Self::Literal(literal, _, _) => Self::Literal(literal, Freshness::Regular, empty()),
-            Self::Class(name, args, _) => Self::Class(
+            Self::Int { attr } => Self::Int { attr },
+            Self::Bigint { attr } => Self::Bigint { attr },
+            Self::Float { attr } => Self::Float { attr },
+            Self::String { attr } => Self::String { attr },
+            Self::Bool { attr } => Self::Bool { attr },
+            Self::Null { attr } => Self::Null { attr },
+            Self::Uint8Array { attr } => Self::Uint8Array { attr },
+            Self::Media(kind, attr) => Self::Media(kind, attr),
+            Self::Literal(literal, _, attr) => Self::Literal(literal, Freshness::Regular, attr),
+            Self::Class(name, args, attr) => Self::Class(
                 name,
                 args.into_iter().map(Self::canonicalize).collect(),
-                empty(),
+                attr,
             ),
-            Self::Interface(name, generics, associated_types, _) => Self::Interface(
+            Self::Interface(name, generics, associated_types, attr) => Self::Interface(
                 name,
                 generics.into_iter().map(Self::canonicalize).collect(),
                 associated_types
                     .into_iter()
                     .map(|(name, ty)| (name, ty.canonicalize()))
                     .collect(),
-                empty(),
+                attr,
             ),
-            Self::Enum(name, _) => Self::Enum(name, empty()),
-            Self::EnumVariant(name, variant, _) => Self::EnumVariant(name, variant, empty()),
-            Self::List(inner, _) => Self::List(Box::new(inner.canonicalize()), empty()),
-            Self::Map { key, value, .. } => Self::Map {
+            Self::Enum(name, attr) => Self::Enum(name, attr),
+            Self::EnumVariant(name, variant, attr) => Self::EnumVariant(name, variant, attr),
+            Self::List(inner, attr) => Self::List(Box::new(inner.canonicalize()), attr),
+            Self::Map { key, value, attr } => Self::Map {
                 key: Box::new(key.canonicalize()),
                 value: Box::new(value.canonicalize()),
-                attr: empty(),
+                attr,
             },
-            Self::Union(members, _) => canonical_union(members),
+            Self::Union(members, attr) => canonical_union(members, attr),
             Self::Function {
                 params,
                 ret,
                 throws,
-                ..
+                attr,
             } => Self::Function {
                 params: params
                     .into_iter()
@@ -63,39 +62,46 @@ impl CodegenTy {
                     .collect(),
                 ret: Box::new(ret.canonicalize()),
                 throws: Box::new(throws.canonicalize()),
-                attr: empty(),
+                attr,
             },
-            Self::Future(value, error, _) => Self::Future(
+            Self::Future(value, error, attr) => Self::Future(
                 Box::new(value.canonicalize()),
                 Box::new(error.canonicalize()),
-                empty(),
+                attr,
             ),
-            Self::RustType { .. } => Self::RustType { attr: empty() },
-            Self::Type { .. } => Self::Type { attr: empty() },
-            Self::Resource { .. } => Self::Resource { attr: empty() },
-            Self::PromptAst { .. } => Self::PromptAst { attr: empty() },
-            Self::Void { .. } => Self::Void { attr: empty() },
-            Self::TypeAlias(name, _) => Self::TypeAlias(name, empty()),
-            Self::TypeVar(name, _) => Self::TypeVar(name, empty()),
-            Self::BuiltinUnknown { .. } => Self::BuiltinUnknown { attr: empty() },
-            Self::Never { .. } => Self::Never { attr: empty() },
+            Self::RustType { attr } => Self::RustType { attr },
+            Self::Type { attr } => Self::Type { attr },
+            Self::Resource { attr } => Self::Resource { attr },
+            Self::PromptAst { attr } => Self::PromptAst { attr },
+            Self::Void { attr } => Self::Void { attr },
+            Self::TypeAlias(name, attr) => Self::TypeAlias(name, attr),
+            Self::TypeVar(name, attr) => Self::TypeVar(name, attr),
+            Self::BuiltinUnknown { attr } => Self::BuiltinUnknown { attr },
+            Self::Never { attr } => Self::Never { attr },
         }
     }
 }
 
-fn canonical_union(members: Vec<CodegenTy>) -> CodegenTy {
+fn merge_attr(inner: &TyAttr, outer: &TyAttr) -> TyAttr {
+    TyAttr {
+        sap_parse_without_null: inner
+            .sap_parse_without_null
+            .or(outer.sap_parse_without_null),
+        sap_pending_never: inner.sap_pending_never.or(outer.sap_pending_never),
+        sap_in_progress_never: inner.sap_in_progress_never.or(outer.sap_in_progress_never),
+    }
+}
+
+fn canonical_union(members: Vec<CodegenTy>, attr: TyAttr) -> CodegenTy {
     let mut canonical = Vec::new();
     for member in members {
         match member.canonicalize() {
             CodegenTy::Union(nested, _) => {
                 for nested_member in nested {
-                    if !canonical.contains(&nested_member) {
-                        canonical.push(nested_member);
-                    }
+                    push_canonical_member(&mut canonical, nested_member, &attr);
                 }
             }
-            member if !canonical.contains(&member) => canonical.push(member),
-            _ => {}
+            member => push_canonical_member(&mut canonical, member, &attr),
         }
     }
 
@@ -108,11 +114,28 @@ fn canonical_union(members: Vec<CodegenTy>) -> CodegenTy {
     }
 
     match canonical.len() {
-        0 => CodegenTy::Never {
-            attr: TyAttr::default(),
-        },
+        0 => CodegenTy::Never { attr },
         1 => canonical.pop().expect("singleton union has one member"),
-        _ => CodegenTy::Union(canonical, TyAttr::default()),
+        _ => CodegenTy::Union(canonical, attr),
+    }
+}
+
+fn push_canonical_member(canonical: &mut Vec<CodegenTy>, member: CodegenTy, outer: &TyAttr) {
+    let merged = merge_attr(member.attr(), outer);
+    let member = member.with_attr(merged);
+
+    if matches!(member, CodegenTy::Null { .. })
+        && let Some(existing) = canonical
+            .iter_mut()
+            .find(|existing| matches!(existing, CodegenTy::Null { .. }))
+    {
+        let merged = merge_attr(existing.attr(), member.attr());
+        *existing = existing.clone().with_attr(merged);
+        return;
+    }
+
+    if !canonical.contains(&member) {
+        canonical.push(member);
     }
 }
 
@@ -124,7 +147,9 @@ impl fmt::Display for CodegenTy {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CodegenFunctionParamTy, CodegenTy, FunctionParamMode, Name, TyAttr, TypeName};
+    use crate::{
+        CodegenFunctionParamTy, CodegenTy, FunctionParamMode, Name, TyAttr, TyAttrValue, TypeName,
+    };
 
     fn a() -> TyAttr {
         TyAttr::default()
@@ -210,6 +235,54 @@ mod tests {
         assert_eq!(
             CodegenTy::TypeAlias(alias.clone(), a()).canonicalize(),
             CodegenTy::TypeAlias(alias, a())
+        );
+    }
+
+    #[test]
+    fn canonicalization_preserves_and_distributes_attributes() {
+        let outer = TyAttr {
+            sap_pending_never: TyAttrValue::Set,
+            ..a()
+        };
+        let nested = TyAttr {
+            sap_parse_without_null: TyAttrValue::Set,
+            ..a()
+        };
+        let string = TyAttr {
+            sap_in_progress_never: TyAttrValue::Set,
+            ..a()
+        };
+        let ty = CodegenTy::Union(
+            vec![
+                CodegenTy::Union(
+                    vec![
+                        CodegenTy::String { attr: string },
+                        CodegenTy::Null { attr: a() },
+                    ],
+                    nested,
+                ),
+                CodegenTy::Null { attr: a() },
+            ],
+            outer.clone(),
+        );
+
+        let CodegenTy::Union(members, attr) = ty.canonicalize() else {
+            panic!("two distinct members must remain a union");
+        };
+        assert_eq!(attr, outer);
+        assert_eq!(members.len(), 2);
+        assert_eq!(
+            members[0].attr().attr_names(),
+            vec![
+                "sap.parse_without_null",
+                "sap.pending_never",
+                "sap.in_progress_never"
+            ]
+        );
+        assert!(matches!(members[1], CodegenTy::Null { .. }));
+        assert_eq!(
+            members[1].attr().attr_names(),
+            vec!["sap.parse_without_null", "sap.pending_never"]
         );
     }
 }

--- a/baml_language/crates/baml_type/src/codegen_ty.rs
+++ b/baml_language/crates/baml_type/src/codegen_ty.rs
@@ -1,0 +1,215 @@
+//! Generator-independent normalization for [`CodegenTy`].
+
+use std::fmt;
+
+use crate::{CodegenFunctionParamTy, CodegenTy, Freshness, Ty, TyAttr};
+
+impl CodegenTy {
+    /// Normalize a compiler type at the code-generation boundary.
+    ///
+    /// The codegen family deliberately preserves nominal aliases and generic
+    /// type variables. This pass removes compiler-only type-expression
+    /// attributes and canonicalizes structure recursively, including inside
+    /// generic arguments, interfaces, functions, futures, lists, and maps.
+    #[must_use]
+    pub fn canonicalize(self) -> Self {
+        let empty = TyAttr::default;
+        match self {
+            Self::Int { .. } => Self::Int { attr: empty() },
+            Self::Bigint { .. } => Self::Bigint { attr: empty() },
+            Self::Float { .. } => Self::Float { attr: empty() },
+            Self::String { .. } => Self::String { attr: empty() },
+            Self::Bool { .. } => Self::Bool { attr: empty() },
+            Self::Null { .. } => Self::Null { attr: empty() },
+            Self::Uint8Array { .. } => Self::Uint8Array { attr: empty() },
+            Self::Media(kind, _) => Self::Media(kind, empty()),
+            Self::Literal(literal, _, _) => Self::Literal(literal, Freshness::Regular, empty()),
+            Self::Class(name, args, _) => Self::Class(
+                name,
+                args.into_iter().map(Self::canonicalize).collect(),
+                empty(),
+            ),
+            Self::Interface(name, generics, associated_types, _) => Self::Interface(
+                name,
+                generics.into_iter().map(Self::canonicalize).collect(),
+                associated_types
+                    .into_iter()
+                    .map(|(name, ty)| (name, ty.canonicalize()))
+                    .collect(),
+                empty(),
+            ),
+            Self::Enum(name, _) => Self::Enum(name, empty()),
+            Self::EnumVariant(name, variant, _) => Self::EnumVariant(name, variant, empty()),
+            Self::List(inner, _) => Self::List(Box::new(inner.canonicalize()), empty()),
+            Self::Map { key, value, .. } => Self::Map {
+                key: Box::new(key.canonicalize()),
+                value: Box::new(value.canonicalize()),
+                attr: empty(),
+            },
+            Self::Union(members, _) => canonical_union(members),
+            Self::Function {
+                params,
+                ret,
+                throws,
+                ..
+            } => Self::Function {
+                params: params
+                    .into_iter()
+                    .map(|param| CodegenFunctionParamTy {
+                        name: param.name,
+                        ty: param.ty.canonicalize(),
+                        mode: param.mode,
+                    })
+                    .collect(),
+                ret: Box::new(ret.canonicalize()),
+                throws: Box::new(throws.canonicalize()),
+                attr: empty(),
+            },
+            Self::Future(value, error, _) => Self::Future(
+                Box::new(value.canonicalize()),
+                Box::new(error.canonicalize()),
+                empty(),
+            ),
+            Self::RustType { .. } => Self::RustType { attr: empty() },
+            Self::Type { .. } => Self::Type { attr: empty() },
+            Self::Resource { .. } => Self::Resource { attr: empty() },
+            Self::PromptAst { .. } => Self::PromptAst { attr: empty() },
+            Self::Void { .. } => Self::Void { attr: empty() },
+            Self::TypeAlias(name, _) => Self::TypeAlias(name, empty()),
+            Self::TypeVar(name, _) => Self::TypeVar(name, empty()),
+            Self::BuiltinUnknown { .. } => Self::BuiltinUnknown { attr: empty() },
+            Self::Never { .. } => Self::Never { attr: empty() },
+        }
+    }
+}
+
+fn canonical_union(members: Vec<CodegenTy>) -> CodegenTy {
+    let mut canonical = Vec::new();
+    for member in members {
+        match member.canonicalize() {
+            CodegenTy::Union(nested, _) => {
+                for nested_member in nested {
+                    if !canonical.contains(&nested_member) {
+                        canonical.push(nested_member);
+                    }
+                }
+            }
+            member if !canonical.contains(&member) => canonical.push(member),
+            _ => {}
+        }
+    }
+
+    if let Some(null_index) = canonical
+        .iter()
+        .position(|member| matches!(member, CodegenTy::Null { .. }))
+    {
+        let null = canonical.remove(null_index);
+        canonical.push(null);
+    }
+
+    match canonical.len() {
+        0 => CodegenTy::Never {
+            attr: TyAttr::default(),
+        },
+        1 => canonical.pop().expect("singleton union has one member"),
+        _ => CodegenTy::Union(canonical, TyAttr::default()),
+    }
+}
+
+impl fmt::Display for CodegenTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ty::from(self).fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CodegenFunctionParamTy, CodegenTy, FunctionParamMode, Name, TyAttr, TypeName};
+
+    fn a() -> TyAttr {
+        TyAttr::default()
+    }
+
+    fn nullable_string_with_repeated_nulls() -> CodegenTy {
+        CodegenTy::Union(
+            vec![
+                CodegenTy::Null { attr: a() },
+                CodegenTy::Union(
+                    vec![
+                        CodegenTy::String { attr: a() },
+                        CodegenTy::Null { attr: a() },
+                    ],
+                    a(),
+                ),
+                CodegenTy::Null { attr: a() },
+            ],
+            a(),
+        )
+    }
+
+    #[test]
+    fn canonicalization_is_recursive_in_every_container() {
+        let ty = CodegenTy::Function {
+            params: vec![CodegenFunctionParamTy::required(
+                Some(Name::new("value")),
+                CodegenTy::Class(
+                    TypeName::local(Name::new("Box")),
+                    vec![CodegenTy::List(
+                        Box::new(nullable_string_with_repeated_nulls()),
+                        a(),
+                    )],
+                    a(),
+                ),
+            )],
+            ret: Box::new(CodegenTy::Map {
+                key: Box::new(CodegenTy::String { attr: a() }),
+                value: Box::new(nullable_string_with_repeated_nulls()),
+                attr: a(),
+            }),
+            throws: Box::new(nullable_string_with_repeated_nulls()),
+            attr: a(),
+        };
+        let nullable = CodegenTy::Union(
+            vec![
+                CodegenTy::String { attr: a() },
+                CodegenTy::Null { attr: a() },
+            ],
+            a(),
+        );
+
+        assert_eq!(
+            ty.canonicalize(),
+            CodegenTy::Function {
+                params: vec![CodegenFunctionParamTy {
+                    name: Some(Name::new("value")),
+                    ty: CodegenTy::Class(
+                        TypeName::local(Name::new("Box")),
+                        vec![CodegenTy::List(Box::new(nullable.clone()), a())],
+                        a(),
+                    ),
+                    mode: FunctionParamMode::Required,
+                }],
+                ret: Box::new(CodegenTy::Map {
+                    key: Box::new(CodegenTy::String { attr: a() }),
+                    value: Box::new(nullable.clone()),
+                    attr: a(),
+                }),
+                throws: Box::new(nullable),
+                attr: a(),
+            }
+        );
+    }
+
+    #[test]
+    fn aliases_remain_nominal_during_canonicalization() {
+        let alias = TypeName::new(
+            Name::new("vendor"),
+            vec![Name::new("models")],
+            Name::new("Text"),
+        );
+        assert_eq!(
+            CodegenTy::TypeAlias(alias.clone(), a()).canonicalize(),
+            CodegenTy::TypeAlias(alias, a())
+        );
+    }
+}

--- a/baml_language/crates/baml_type/src/family.rs
+++ b/baml_language/crates/baml_type/src/family.rs
@@ -400,6 +400,7 @@ mod tests {
     fn conversion_matrix_round_trips() {
         let t = deep_concrete();
         let rt = RuntimeTy::try_from(&t).unwrap();
+        let cg = CodegenTy::try_from(&t).unwrap();
         let rz = RealizedTy::try_from(&t).unwrap();
         let ct = ConcreteTy::try_from(&rt).unwrap();
         let crz = ConcreteRealizedTy::try_from(&rz).unwrap();
@@ -407,6 +408,9 @@ mod tests {
         // RealizedTy ≤ RuntimeTy ≤ Ty (deep), by ref + owned move.
         assert_eq!(Ty::from(&rt), t);
         assert_eq!(Ty::from(rt.clone()), t);
+        assert_eq!(RuntimeTy::from(&cg), rt);
+        assert_eq!(RuntimeTy::from(cg.clone()), rt);
+        assert_eq!(CodegenTy::try_from(&rt).unwrap(), cg);
         assert_eq!(Ty::from(&rz), t);
         assert_eq!(RuntimeTy::from(&rz), rt);
         assert_eq!(RuntimeTy::from(rz.clone()), rt);
@@ -446,7 +450,10 @@ mod tests {
     /// projections to have been resolved at the compiler boundary.
     #[test]
     fn codegen_accepts_type_variables_and_rejects_projections() {
-        assert!(CodegenTy::try_from(&with_typevar()).is_ok());
+        let typevar = with_typevar();
+        let runtime = RuntimeTy::try_from(&typevar).unwrap();
+        let codegen = CodegenTy::try_from(&runtime).unwrap();
+        assert_eq!(RuntimeTy::from(&codegen), runtime);
 
         let projection = Ty::AssociatedTypeProjection {
             base: Box::new(Ty::TypeVar(Name::new("T"), a())),

--- a/baml_language/crates/baml_type/src/family.rs
+++ b/baml_language/crates/baml_type/src/family.rs
@@ -1,8 +1,8 @@
 //! The `Ty` type family, generated from a single tagged definition.
 //!
 //! [`ty_family!`](baml_type_macros::ty_family) expands the master `Ty` enum
-//! below into the whole family — `Ty`, [`RuntimeTy`], [`RealizedTy`],
-//! [`ConcreteTy`], [`ConcreteRealizedTy`] — plus the per-member
+//! below into the whole family — `Ty`, [`RuntimeTy`], [`CodegenTy`],
+//! [`RealizedTy`], [`ConcreteTy`], [`ConcreteRealizedTy`] — plus the per-member
 //! `FunctionParamTy` companion structs. Membership is by axis: each variant is
 //! tagged with exactly one `#[axis(..)]`, and each member includes a set of
 //! axes (a variant is present iff its axis is included). Nested positions are
@@ -29,6 +29,11 @@ ty_family! {
 
     type Ty                 { includes: [concrete, abstract, literal, never, typevar, projection, tir, special], child: Self }
     type RuntimeTy          { includes: [concrete, abstract, literal, never, typevar, projection, special],      child: Self }
+    // A deep, generator-independent public API type. Unlike `RuntimeTy`, this
+    // excludes unresolved associated-type projections; unlike `RealizedTy`, it
+    // retains named type variables for generic declarations. Type aliases are
+    // deliberately retained as nominal references at public use sites.
+    type CodegenTy          { includes: [concrete, abstract, literal, never, typevar, special],                  child: Self }
     type RealizedTy         { includes: [concrete, abstract, literal, never, special],                           child: Self }
     type ConcreteTy         { includes: [concrete, never],                                                       child: RuntimeTy }
     type ConcreteRealizedTy { includes: [concrete, never],                                                       child: RealizedTy }
@@ -340,8 +345,8 @@ mod tests {
     use borsh::BorshDeserialize;
 
     use crate::{
-        ConcreteRealizedTy, ConcreteTy, FunctionParamTy, MediaKind, Name, NotRealizedTy,
-        NotRuntimeTy, RealizedTy, RuntimeTy, Ty, TyAttr, TyTemplate, TypeName,
+        CodegenTy, ConcreteRealizedTy, ConcreteTy, FunctionParamTy, MediaKind, Name, NotCodegenTy,
+        NotRealizedTy, NotRuntimeTy, RealizedTy, RuntimeTy, Ty, TyAttr, TyTemplate, TypeName,
     };
 
     fn a() -> TyAttr {
@@ -434,6 +439,30 @@ mod tests {
         assert_eq!(
             RealizedTy::try_from(&t),
             Err(NotRealizedTy { variant: "TypeVar" })
+        );
+    }
+
+    /// Codegen types retain generic parameters but require associated
+    /// projections to have been resolved at the compiler boundary.
+    #[test]
+    fn codegen_accepts_type_variables_and_rejects_projections() {
+        assert!(CodegenTy::try_from(&with_typevar()).is_ok());
+
+        let projection = Ty::AssociatedTypeProjection {
+            base: Box::new(Ty::TypeVar(Name::new("T"), a())),
+            interface: Box::new(crate::Interface::new(
+                qtn("Iterator"),
+                Vec::new(),
+                Vec::new(),
+            )),
+            member: Name::new("Item"),
+            attr: a(),
+        };
+        assert_eq!(
+            CodegenTy::try_from(&projection),
+            Err(NotCodegenTy {
+                variant: "AssociatedTypeProjection"
+            })
         );
     }
 

--- a/baml_language/crates/baml_type/src/family.rs
+++ b/baml_language/crates/baml_type/src/family.rs
@@ -478,6 +478,7 @@ mod tests {
     fn borsh_round_trips() {
         let t = deep_concrete();
         let rt = RuntimeTy::try_from(&t).unwrap();
+        let cg = CodegenTy::try_from(&t).unwrap();
         let rz = RealizedTy::try_from(&t).unwrap();
         let ct = ConcreteTy::try_from(&rt).unwrap();
         let crz = ConcreteRealizedTy::try_from(&rz).unwrap();
@@ -486,6 +487,10 @@ mod tests {
         assert_eq!(
             RuntimeTy::try_from_slice(&borsh::to_vec(&rt).unwrap()).unwrap(),
             rt
+        );
+        assert_eq!(
+            CodegenTy::try_from_slice(&borsh::to_vec(&cg).unwrap()).unwrap(),
+            cg
         );
         assert_eq!(
             RealizedTy::try_from_slice(&borsh::to_vec(&rz).unwrap()).unwrap(),
@@ -562,12 +567,15 @@ mod tests {
         // `typevar` and `projection` variants before it, yet its tag stays 27.
         assert_eq!(in_memory_tag(&Ty::BuiltinUnknown { attr: a() }), 27);
         assert_eq!(in_memory_tag(&RuntimeTy::BuiltinUnknown { attr: a() }), 27);
+        assert_eq!(in_memory_tag(&CodegenTy::BuiltinUnknown { attr: a() }), 27);
         assert_eq!(in_memory_tag(&RealizedTy::BuiltinUnknown { attr: a() }), 27);
         // `Never` (#28) is shared and tag-stable across the deep members.
         assert_eq!(in_memory_tag(&Ty::Never { attr: a() }), 28);
+        assert_eq!(in_memory_tag(&CodegenTy::Never { attr: a() }), 28);
         assert_eq!(in_memory_tag(&RealizedTy::Never { attr: a() }), 28);
         // A leaf concrete variant present in every member, shallow ones included.
         assert_eq!(in_memory_tag(&Ty::Int { attr: a() }), 0);
+        assert_eq!(in_memory_tag(&CodegenTy::Int { attr: a() }), 0);
         assert_eq!(in_memory_tag(&ConcreteTy::Int { attr: a() }), 0);
         assert_eq!(in_memory_tag(&ConcreteRealizedTy::Int { attr: a() }), 0);
     }
@@ -580,15 +588,20 @@ mod tests {
     fn borrowed_upcast_matches_owned_widening() {
         let t = deep_concrete();
         let rt = RuntimeTy::try_from(&t).unwrap();
+        let cg = CodegenTy::try_from(&t).unwrap();
         let rz = RealizedTy::try_from(&t).unwrap();
 
         // Reinterpreting the narrower value yields the wider value by reference.
         assert_eq!(rt.as_ty(), &t);
+        assert_eq!(cg.as_ty(), &t);
+        assert_eq!(cg.as_runtime_ty(), &rt);
         assert_eq!(rz.as_ty(), &t);
+        assert_eq!(rz.as_codegen_ty(), &cg);
         assert_eq!(rz.as_runtime_ty(), &rt);
 
         // And it agrees with the owned `From` (also a transmute) on equal input.
         assert_eq!(rt.as_ty(), &Ty::from(rt.clone()));
+        assert_eq!(cg.as_runtime_ty(), &RuntimeTy::from(cg.clone()));
         assert_eq!(rz.as_runtime_ty(), &RuntimeTy::from(rz.clone()));
     }
 
@@ -600,15 +613,20 @@ mod tests {
     fn downcast_validates_then_reinterprets() {
         let t = deep_concrete();
         let rt = RuntimeTy::try_from(&t).unwrap();
+        let cg = CodegenTy::try_from(&t).unwrap();
         let rz = RealizedTy::try_from(&t).unwrap();
 
         // Borrow-to-borrow narrowing yields `Ok(&narrower)` at every depth.
         assert_eq!(<&RuntimeTy>::try_from(&t), Ok(&rt));
+        assert_eq!(<&CodegenTy>::try_from(&t), Ok(&cg));
+        assert_eq!(<&CodegenTy>::try_from(&rt), Ok(&cg));
         assert_eq!(<&RealizedTy>::try_from(&t), Ok(&rz));
         assert_eq!(<&RealizedTy>::try_from(&rt), Ok(&rz));
 
         // Owned `TryFrom` (validate + move-transmute, no rebuild) agrees.
         assert_eq!(RuntimeTy::try_from(t.clone()).unwrap(), rt);
+        assert_eq!(CodegenTy::try_from(t.clone()).unwrap(), cg);
+        assert_eq!(CodegenTy::try_from(rt.clone()).unwrap(), cg);
         assert_eq!(RealizedTy::try_from(t.clone()).unwrap(), rz);
         assert_eq!(RealizedTy::try_from(rt.clone()).unwrap(), rz);
     }
@@ -641,6 +659,10 @@ mod tests {
         assert_eq!(
             <&RuntimeTy>::try_from(&bad),
             Err(NotRuntimeTy { variant: "Unknown" })
+        );
+        assert_eq!(
+            <&CodegenTy>::try_from(&bad),
+            Err(NotCodegenTy { variant: "Unknown" })
         );
         assert_eq!(
             <&RealizedTy>::try_from(&bad),

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -1,8 +1,11 @@
 //! Unified type system for BAML.
 //!
-//! Includes five main type representations:
+//! Includes six main type representations:
 //! - [`Ty`]: the full type representation containing all compiler and runtime types.
 //! - [`RuntimeTy`]: the runtime-facing deep subset of [`Ty`] that excludes type inference helper types.
+//! - [`CodegenTy`]: the generator-independent deep subset used for public API
+//!   declarations. It preserves aliases and generic type variables, but excludes
+//!   compiler-only inference states and unresolved associated-type projections.
 //! - [`ConcreteTy`]: like [`RuntimeTy`] but only the concrete-layout variants (plus `never`).
 //!   Not deep: parameter types are [`RuntimeTy`]s.
 //! - [`RealizedTy`]: the realized deep subset of [`RuntimeTy`] that excludes type variables.
@@ -13,9 +16,11 @@
 //! ```text
 //!     `Ty`
 //!      ↑
-//!  `RuntimeTy` <- `RealizedTy`
-//!      ↑               ↑
-//! `ConcreteTy` <- `ConcreteRealizedTy`
+//!  `RuntimeTy` <- `CodegenTy`
+//!      ↑              ↑
+//! `ConcreteTy`    `RealizedTy`
+//!      ↑              ↑
+//!      `ConcreteRealizedTy`
 //! ```
 
 use std::fmt;
@@ -26,6 +31,7 @@ pub use baml_base::{Literal, MediaKind, Name, Span};
 use borsh::{BorshDeserialize, BorshSerialize};
 
 mod attr;
+mod codegen_ty;
 mod defs;
 mod family;
 mod names;

--- a/baml_language/crates/baml_type/src/names.rs
+++ b/baml_language/crates/baml_type/src/names.rs
@@ -117,6 +117,23 @@ impl QualifiedTypeName {
         &self.name
     }
 
+    /// Whether this is the generated stream-view companion for a local type.
+    ///
+    /// Stream types currently use the `$stream` source-level suffix. Keeping
+    /// this query on the compiler-owned qualified name avoids duplicating that
+    /// identity rule in each code generator.
+    pub fn is_stream(&self) -> bool {
+        self.name.as_str().ends_with("$stream")
+    }
+
+    /// The unqualified source name, without the generated stream prefix.
+    pub fn bare_name(&self) -> &str {
+        self.name
+            .as_str()
+            .strip_suffix("$stream")
+            .unwrap_or_else(|| self.name.as_str())
+    }
+
     pub fn is_builtin_root_type(&self, name: &str) -> bool {
         self.package().as_str() == "baml" && self.namespace.is_empty() && self.name.as_str() == name
     }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/mod.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/mod.rs
@@ -172,7 +172,7 @@ fn expand_function(
     // end. The Python LHS strips the `$<suffix>` form into the
     // companion's bare identifier (`__<suffix>` or `_stream`).
     let fqn_root = key.to_string();
-    let bare = bare_callable_name(key.name.as_str());
+    let bare = bare_callable_name(key.name().as_str());
     let func_generic_params: Vec<String> = f
         .generic_params
         .iter()
@@ -215,13 +215,13 @@ fn collect_raises_names(throws: Option<&baml_codegen_types::Ty>) -> Vec<String> 
 
     fn walk(ty: &Ty, out: &mut Vec<String>) {
         match ty {
-            Ty::Class(name, _) | Ty::Enum(name) | Ty::TypeAlias(name) => {
-                let n = name.name.as_str().to_string();
+            Ty::Class(name, _, _) | Ty::Enum(name, _) | Ty::TypeAlias(name, _) => {
+                let n = name.name().as_str().to_string();
                 if !out.contains(&n) {
                     out.push(n);
                 }
             }
-            Ty::Union(members) => members.iter().for_each(|m| walk(m, out)),
+            Ty::Union(members, _) => members.iter().for_each(|m| walk(m, out)),
             _ => {}
         }
     }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
@@ -120,15 +120,26 @@ impl LeafBody {
     pub(crate) fn needs_baml_pyhandle(&self) -> bool {
         fn ty_uses_rust_type(ty: &Ty) -> bool {
             match ty {
-                Ty::RustType => true,
-                Ty::List(inner) => ty_uses_rust_type(inner),
-                Ty::Map { key, value } => ty_uses_rust_type(key) || ty_uses_rust_type(value),
-                Ty::Union(items) => items.iter().any(ty_uses_rust_type),
-                Ty::Class(_, args) => args.iter().any(ty_uses_rust_type),
-                Ty::Callable { params, ret } => {
+                Ty::RustType { .. } => true,
+                Ty::List(inner, _) => ty_uses_rust_type(inner),
+                Ty::Map { key, value, .. } => ty_uses_rust_type(key) || ty_uses_rust_type(value),
+                Ty::Union(items, _) => items.iter().any(ty_uses_rust_type),
+                Ty::Class(_, args, _) => args.iter().any(ty_uses_rust_type),
+                Ty::Interface(_, generics, associated_types, _) => {
+                    generics.iter().any(ty_uses_rust_type)
+                        || associated_types.iter().any(|(_, ty)| ty_uses_rust_type(ty))
+                }
+                Ty::Function {
+                    params,
+                    ret,
+                    throws,
+                    ..
+                } => {
                     params.iter().any(|param| ty_uses_rust_type(&param.ty))
                         || ty_uses_rust_type(ret)
+                        || ty_uses_rust_type(throws)
                 }
+                Ty::Future(value, error, _) => ty_uses_rust_type(value) || ty_uses_rust_type(error),
                 _ => false,
             }
         }
@@ -158,7 +169,7 @@ impl LeafBody {
         self.symbols.is_empty()
     }
 
-    /// The optional-argument `Ty::Callable`s reachable from this leaf's
+    /// The optional-argument `Ty::Function`s reachable from this leaf's
     /// function/method/field signatures, in deterministic first-seen order,
     /// each paired with the `_<owner>__<param>` prefix for its Protocol name
     /// (`render_leaf_body_pyi` appends a per-prefix counter, giving e.g.
@@ -503,7 +514,7 @@ fn fqn_leaf(fqn: &str) -> &str {
     fqn.rsplit('.').next().unwrap_or(fqn)
 }
 
-/// Recursively collect every optional-argument `Ty::Callable` reachable from
+/// Recursively collect every optional-argument `Ty::Function` reachable from
 /// `ty`, in first-seen order, skipping duplicates (`seen`). Each is paired with
 /// `base` — the `_<owner>__<param>` prefix for its Protocol name (the final
 /// name appends a per-base counter in `LeafBody::callback_protocols`). Children
@@ -516,22 +527,22 @@ fn collect_optional_callables(
     out: &mut Vec<(Ty, String)>,
 ) {
     match ty {
-        Ty::List(inner) => collect_optional_callables(inner, base, seen, out),
-        Ty::Map { key, value } => {
+        Ty::List(inner, _) => collect_optional_callables(inner, base, seen, out),
+        Ty::Map { key, value, .. } => {
             collect_optional_callables(key, base, seen, out);
             collect_optional_callables(value, base, seen, out);
         }
-        Ty::Union(items) => {
+        Ty::Union(items, _) => {
             for item in items {
                 collect_optional_callables(item, base, seen, out);
             }
         }
-        Ty::Class(_, args) => {
+        Ty::Class(_, args, _) => {
             for a in args {
                 collect_optional_callables(a, base, seen, out);
             }
         }
-        Ty::Callable { params, ret } => {
+        Ty::Function { params, ret, .. } => {
             for p in params {
                 collect_optional_callables(&p.ty, base, seen, out);
             }
@@ -549,26 +560,26 @@ fn collect_optional_callables(
 
 fn collect_root_imports(ty: &Ty, current: &LeafPath, out: &mut RootImportSets) {
     match ty {
-        Ty::Class(name, args) => {
+        Ty::Class(name, args, _) => {
             record_name_routing(name, current, out);
             for a in args {
                 collect_root_imports(a, current, out);
             }
         }
-        Ty::Enum(name) | Ty::TypeAlias(name) => {
+        Ty::Enum(name, _) | Ty::EnumVariant(name, _, _) | Ty::TypeAlias(name, _) => {
             record_name_routing(name, current, out);
         }
-        Ty::List(inner) => collect_root_imports(inner, current, out),
-        Ty::Map { key, value } => {
+        Ty::List(inner, _) => collect_root_imports(inner, current, out),
+        Ty::Map { key, value, .. } => {
             collect_root_imports(key, current, out);
             collect_root_imports(value, current, out);
         }
-        Ty::Union(items) => {
+        Ty::Union(items, _) => {
             for item in items {
                 collect_root_imports(item, current, out);
             }
         }
-        Ty::Callable { params, ret } => {
+        Ty::Function { params, ret, .. } => {
             for p in params {
                 collect_root_imports(&p.ty, current, out);
             }
@@ -585,7 +596,7 @@ fn collect_root_imports(ty: &Ty, current: &LeafPath, out: &mut RootImportSets) {
         // `from baml_bridge import BamlPyHandle as _BamlPyHandle`
         // line via `needs_baml_pyhandle` — it does *not* go through
         // the cross-leaf segment set.
-        Ty::Media(_) => {
+        Ty::Media(..) => {
             // Skip when current leaf IS `baml/media` (same-leaf ref).
             let target: &[&str] = &["baml", "media"];
             let target_eq = current.segments.len() == target.len()
@@ -606,19 +617,24 @@ fn collect_root_imports(ty: &Ty, current: &LeafPath, out: &mut RootImportSets) {
                 anchor: "baml".to_string(),
             });
         }
-        Ty::Int
-        | Ty::Bigint
-        | Ty::Float
-        | Ty::String
-        | Ty::Bool
-        | Ty::Null
-        | Ty::Literal(_)
-        | Ty::Uint8Array
-        | Ty::TypeVar(_)
-        | Ty::RustType
-        | Ty::BuiltinUnknown
-        | Ty::Unit
-        | Ty::BamlOptions => {}
+        Ty::Int { .. }
+        | Ty::Bigint { .. }
+        | Ty::Float { .. }
+        | Ty::String { .. }
+        | Ty::Bool { .. }
+        | Ty::Null { .. }
+        | Ty::Literal(..)
+        | Ty::Uint8Array { .. }
+        | Ty::TypeVar(..)
+        | Ty::RustType { .. }
+        | Ty::Type { .. }
+        | Ty::Resource { .. }
+        | Ty::PromptAst { .. }
+        | Ty::BuiltinUnknown { .. }
+        | Ty::Never { .. }
+        | Ty::Void { .. }
+        | Ty::Interface(..)
+        | Ty::Future(..) => {}
     }
 }
 
@@ -1040,9 +1056,9 @@ fn render_type_alias(a: &crate::emit::type_alias::PyTypeAlias, leaf: &LeafPath) 
     // TODO: replace with a proper recursive-alias representation once
     // pyright handles `TypeAliasType` forward-refs (or once we move json to
     // a stricter codegen surface).
-    if a.source.pkg.as_str() == "baml"
-        && a.source.namespace_path.len() == 1
-        && a.source.namespace_path[0].as_str() == "json"
+    if a.source.package().as_str() == "baml"
+        && a.source.namespace().len() == 1
+        && a.source.namespace()[0].as_str() == "json"
         && a.source.bare_name() == "json"
     {
         let py_name = &a.py_name;
@@ -2053,7 +2069,7 @@ pub(crate) fn render_leaf_body_pyi(
             callback_protocols: Some(map.clone()),
         };
         for (ty, _base) in &protocol_tys {
-            if let Ty::Callable { params, ret } = ty {
+            if let Ty::Function { params, ret, .. } = ty {
                 out.push_str("\n\n");
                 out.push_str(&render_callback_protocol(&map[ty], params, ret, &proto_ctx));
             }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -567,6 +567,30 @@ mod tests {
         )
     }
 
+    fn class_ty(name: Name, args: Vec<Ty>) -> Ty {
+        Ty::Class(name, args, baml_base::TyAttr::EMPTY)
+    }
+
+    fn enum_ty(name: Name) -> Ty {
+        Ty::Enum(name, baml_base::TyAttr::EMPTY)
+    }
+
+    fn alias_ty(name: Name) -> Ty {
+        Ty::TypeAlias(name, baml_base::TyAttr::EMPTY)
+    }
+
+    fn type_var(name: BaseName) -> Ty {
+        Ty::TypeVar(name, baml_base::TyAttr::EMPTY)
+    }
+
+    fn list(inner: Box<Ty>) -> Ty {
+        Ty::List(inner, baml_base::TyAttr::EMPTY)
+    }
+
+    fn union(members: Vec<Ty>) -> Ty {
+        Ty::Union(members, baml_base::TyAttr::EMPTY)
+    }
+
     fn origin(file: &str, span: u32) -> Origin {
         Origin {
             source_file_path: file.to_string(),
@@ -586,7 +610,9 @@ mod tests {
             properties: vec![ClassProperty {
                 name: BaseName::new("a"),
                 docstring: None,
-                ty: Ty::Int,
+                ty: Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
             }],
             static_methods: vec![],
             instance_methods: vec![],
@@ -610,7 +636,9 @@ mod tests {
     fn alias(name: Name, file: &str, span: u32) -> Symbol {
         Symbol::TypeAlias(TypeAlias {
             name,
-            resolves_to: Ty::Int,
+            resolves_to: Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
             recursive: false,
             origin: origin(file, span),
         })
@@ -624,10 +652,14 @@ mod tests {
             arguments: vec![FunctionArgument {
                 name: BaseName::new("x"),
                 docstring: None,
-                ty: Ty::Int,
+                ty: Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 default: None,
             }],
-            return_type: Ty::Int,
+            return_type: Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
             throws: None,
             watchers: vec![],
             origin: origin(file, span),
@@ -771,11 +803,25 @@ mod tests {
         let mut pool: SymbolPool = HashMap::new();
         pool.insert(
             cg_name("boundary", &[], "id"),
-            zero_arg_func("id", Ty::String, "core.baml", 0),
+            zero_arg_func(
+                "id",
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                "core.baml",
+                0,
+            ),
         );
         pool.insert(
             cg_name("boundary", &["id"], "current"),
-            zero_arg_func("current", Ty::String, "id.baml", 0),
+            zero_arg_func(
+                "current",
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                "id.baml",
+                0,
+            ),
         );
 
         let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
@@ -825,7 +871,9 @@ mod tests {
                 vec![ClassProperty {
                     name: BaseName::new("a"),
                     docstring: None,
-                    ty: Ty::Int,
+                    ty: Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 }],
             ),
         );
@@ -852,7 +900,9 @@ mod tests {
                 vec![ClassProperty {
                     name: BaseName::new("a"),
                     docstring: Some("Identifier".to_string()),
-                    ty: Ty::Int,
+                    ty: Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 }],
             ),
         );
@@ -886,12 +936,21 @@ mod tests {
                     ClassProperty {
                         name: BaseName::new("title"),
                         docstring: Some("Title shown in lists.".to_string()),
-                        ty: Ty::String,
+                        ty: Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                     },
                     ClassProperty {
                         name: BaseName::new("body"),
                         docstring: Some("Free-form body text.".to_string()),
-                        ty: Ty::Union(vec![Ty::String, Ty::Null]),
+                        ty: union(vec![
+                            Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                            Ty::Null {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                        ]),
                     },
                 ],
             ),
@@ -919,7 +978,9 @@ mod tests {
                 vec![ClassProperty {
                     name: BaseName::new("a"),
                     docstring: None,
-                    ty: Ty::Int,
+                    ty: Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 }],
             ),
         );
@@ -1027,12 +1088,16 @@ mod tests {
                     ClassProperty {
                         name: BaseName::new("a"),
                         docstring: None,
-                        ty: Ty::Int,
+                        ty: Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                     },
                     ClassProperty {
                         name: BaseName::new("b"),
                         docstring: None,
-                        ty: Ty::Int,
+                        ty: Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                     },
                 ],
             ),
@@ -1062,12 +1127,16 @@ mod tests {
                     ClassProperty {
                         name: BaseName::new("a"),
                         docstring: Some("First.".to_string()),
-                        ty: Ty::Int,
+                        ty: Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                     },
                     ClassProperty {
                         name: BaseName::new("b"),
                         docstring: None,
-                        ty: Ty::Int,
+                        ty: Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                     },
                 ],
             ),
@@ -1141,7 +1210,7 @@ mod tests {
         method.arguments = vec![FunctionArgument {
             name: BaseName::new("self"),
             docstring: None,
-            ty: Ty::Class(n.clone(), vec![]),
+            ty: class_ty(n.clone(), vec![]),
             default: None,
         }];
         pool.insert(
@@ -1153,7 +1222,9 @@ mod tests {
                 properties: vec![ClassProperty {
                     name: BaseName::new("a"),
                     docstring: None,
-                    ty: Ty::Int,
+                    ty: Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 }],
                 static_methods: vec![],
                 instance_methods: vec![method],
@@ -1534,9 +1605,29 @@ mod tests {
             class_with_props(
                 n,
                 vec![
-                    ("name", Ty::String),
-                    ("email", Ty::Union(vec![Ty::String, Ty::Null])),
-                    ("tags", Ty::List(Box::new(Ty::String))),
+                    (
+                        "name",
+                        Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    ),
+                    (
+                        "email",
+                        union(vec![
+                            Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                            Ty::Null {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                        ]),
+                    ),
+                    (
+                        "tags",
+                        list(Box::new(Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        })),
+                    ),
                 ],
                 "x.baml",
                 0,
@@ -1630,10 +1721,14 @@ mod tests {
         // schema build.
         let mut pool: SymbolPool = HashMap::new();
         let n = cg_name("user", &["tree"], "JsonValue");
-        let rhs = Ty::Union(vec![
-            Ty::Int,
-            Ty::String,
-            Ty::List(Box::new(Ty::TypeAlias(n.clone()))),
+        let rhs = union(vec![
+            Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
+            Ty::String {
+                attr: baml_base::TyAttr::EMPTY,
+            },
+            list(Box::new(alias_ty(n.clone()))),
         ]);
         pool.insert(n.clone(), alias_full(n, rhs, true, "tree.baml", 0));
         let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
@@ -1662,10 +1757,10 @@ mod tests {
             alias.clone(),
             alias_full(
                 alias.clone(),
-                Ty::Union(vec![
-                    Ty::Class(foo, vec![]),
-                    Ty::Class(bar, vec![]),
-                    Ty::List(Box::new(Ty::TypeAlias(alias))),
+                union(vec![
+                    class_ty(foo, vec![]),
+                    class_ty(bar, vec![]),
+                    list(Box::new(alias_ty(alias))),
                 ]),
                 true,
                 "lorem.baml",
@@ -1692,7 +1787,12 @@ mod tests {
             json.clone(),
             alias_full(
                 json.clone(),
-                Ty::Union(vec![Ty::Int, Ty::TypeAlias(json.clone())]),
+                union(vec![
+                    Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    alias_ty(json.clone()),
+                ]),
                 true,
                 "tree.baml",
                 0,
@@ -1700,13 +1800,7 @@ mod tests {
         );
         pool.insert(
             bar.clone(),
-            alias_full(
-                bar,
-                Ty::List(Box::new(Ty::TypeAlias(json))),
-                false,
-                "tree.baml",
-                100,
-            ),
+            alias_full(bar, list(Box::new(alias_ty(json))), false, "tree.baml", 100),
         );
         let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
         let leaf = &out[&PathBuf::from("tree/__init__.py")];
@@ -1721,16 +1815,36 @@ mod tests {
         let stream = cg_name("user", &["lorem"], "Resume$stream");
         pool.insert(
             non_stream.clone(),
-            class_with_props(non_stream.clone(), vec![("name", Ty::String)], "x.baml", 0),
+            class_with_props(
+                non_stream.clone(),
+                vec![(
+                    "name",
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                )],
+                "x.baml",
+                0,
+            ),
         );
         pool.insert(
             stream.clone(),
             class_with_props(
                 stream,
                 vec![
-                    ("summary", Ty::Union(vec![Ty::String, Ty::Null])),
+                    (
+                        "summary",
+                        union(vec![
+                            Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                            Ty::Null {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                        ]),
+                    ),
                     // Non-stream FQN -> resolves to baml_sdk.lorem.Resume
-                    ("origin", Ty::Class(non_stream, vec![])),
+                    ("origin", class_ty(non_stream, vec![])),
                 ],
                 "x.baml",
                 0,
@@ -1790,7 +1904,7 @@ mod tests {
             envelope.clone(),
             class_with_props(
                 envelope,
-                vec![("sentiment", Ty::Enum(sentiment))],
+                vec![("sentiment", enum_ty(sentiment))],
                 "lorem.baml",
                 0,
             ),
@@ -1820,11 +1934,15 @@ mod tests {
                 .map(|n| FunctionArgument {
                     name: BaseName::new(*n),
                     docstring: None,
-                    ty: Ty::String,
+                    ty: Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                     default: None,
                 })
                 .collect(),
-            return_type: Ty::Int,
+            return_type: Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
             throws: None,
             watchers: vec![],
             origin: origin(file, span),
@@ -1918,13 +2036,17 @@ mod tests {
                     FunctionArgument {
                         name: BaseName::new("query"),
                         docstring: None,
-                        ty: Ty::String,
+                        ty: Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                         default: None,
                     },
                     FunctionArgument {
                         name: BaseName::new("max_results"),
                         docstring: None,
-                        ty: Ty::Int,
+                        ty: Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                         default: Some(FunctionArgumentDefault::Literal(DefaultLiteral::Scalar(
                             baml_base::Literal::Int(10),
                         ))),
@@ -1932,7 +2054,9 @@ mod tests {
                     FunctionArgument {
                         name: BaseName::new("filter"),
                         docstring: None,
-                        ty: Ty::String,
+                        ty: Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                         default: Some(FunctionArgumentDefault::Expression {
                             source: Some("default_filter()".to_string()),
                         }),
@@ -1940,26 +2064,42 @@ mod tests {
                     FunctionArgument {
                         name: BaseName::new("tags"),
                         docstring: None,
-                        ty: Ty::List(Box::new(Ty::String)),
+                        ty: list(Box::new(Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        })),
                         default: Some(FunctionArgumentDefault::Literal(DefaultLiteral::EmptyList)),
                     },
                     FunctionArgument {
                         name: BaseName::new("metadata"),
                         docstring: None,
                         ty: Ty::Map {
-                            key: Box::new(Ty::String),
-                            value: Box::new(Ty::String),
+                            key: Box::new(Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            }),
+                            value: Box::new(Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            }),
+                            attr: baml_base::TyAttr::EMPTY,
                         },
                         default: Some(FunctionArgumentDefault::Literal(DefaultLiteral::EmptyMap)),
                     },
                     FunctionArgument {
                         name: BaseName::new("fallback"),
                         docstring: None,
-                        ty: Ty::Union(vec![Ty::String, Ty::Null]),
+                        ty: union(vec![
+                            Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                            Ty::Null {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                        ]),
                         default: Some(FunctionArgumentDefault::Null),
                     },
                 ],
-                return_type: Ty::String,
+                return_type: Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 throws: None,
                 watchers: vec![],
                 origin: origin("x.baml", 0),
@@ -1991,7 +2131,7 @@ mod tests {
     #[test]
     fn llm_default_client_argument_renders_in_function_and_companion_signatures() {
         let mut pool: SymbolPool = HashMap::new();
-        let client_ty = Ty::Class(cg_name("baml", &["llm"], "Client"), vec![]);
+        let client_ty = class_ty(cg_name("baml", &["llm"], "Client"), vec![]);
         let client_default = Some(FunctionArgumentDefault::Expression {
             source: Some("GPT4".to_string()),
         });
@@ -2018,8 +2158,15 @@ mod tests {
                 generic_params: Vec::new(),
                 name: BaseName::new("extract_resume"),
                 docstring: None,
-                arguments: make_args("resume", Ty::String),
-                return_type: Ty::String,
+                arguments: make_args(
+                    "resume",
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ),
+                return_type: Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 throws: None,
                 watchers: vec![],
                 origin: origin("x.baml", 0),
@@ -2031,8 +2178,13 @@ mod tests {
                 generic_params: Vec::new(),
                 name: BaseName::new("extract_resume$build_request"),
                 docstring: None,
-                arguments: make_args("resume", Ty::String),
-                return_type: Ty::Class(cg_name("baml", &["http"], "Request"), vec![]),
+                arguments: make_args(
+                    "resume",
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ),
+                return_type: class_ty(cg_name("baml", &["http"], "Request"), vec![]),
                 throws: None,
                 watchers: vec![],
                 origin: origin("x.baml", 0),
@@ -2071,26 +2223,42 @@ mod tests {
                     FunctionArgument {
                         name: BaseName::new("tags"),
                         docstring: None,
-                        ty: Ty::List(Box::new(Ty::String)),
+                        ty: list(Box::new(Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        })),
                         default: Some(FunctionArgumentDefault::Literal(DefaultLiteral::EmptyList)),
                     },
                     FunctionArgument {
                         name: BaseName::new("metadata"),
                         docstring: None,
                         ty: Ty::Map {
-                            key: Box::new(Ty::String),
-                            value: Box::new(Ty::Int),
+                            key: Box::new(Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            }),
+                            value: Box::new(Ty::Int {
+                                attr: baml_base::TyAttr::EMPTY,
+                            }),
+                            attr: baml_base::TyAttr::EMPTY,
                         },
                         default: Some(FunctionArgumentDefault::Literal(DefaultLiteral::EmptyMap)),
                     },
                     FunctionArgument {
                         name: BaseName::new("fallback"),
                         docstring: None,
-                        ty: Ty::Union(vec![Ty::String, Ty::Null]),
+                        ty: union(vec![
+                            Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                            Ty::Null {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                        ]),
                         default: Some(FunctionArgumentDefault::Null),
                     },
                 ],
-                return_type: Ty::String,
+                return_type: Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 throws: None,
                 watchers: vec![],
                 origin: origin("x.baml", 0),
@@ -2242,11 +2410,31 @@ mod tests {
         let b = cg_name("user", &["lorem"], "Beta");
         pool.insert(
             a.clone(),
-            class_with_props(a, vec![("x", Ty::Int)], "a.baml", 0),
+            class_with_props(
+                a,
+                vec![(
+                    "x",
+                    Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                )],
+                "a.baml",
+                0,
+            ),
         );
         pool.insert(
             b.clone(),
-            class_with_props(b, vec![("y", Ty::String)], "b.baml", 0),
+            class_with_props(
+                b,
+                vec![(
+                    "y",
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                )],
+                "b.baml",
+                0,
+            ),
         );
         let out1 = to_source_code(&pool, &[], NamingConvention::PreserveCase);
         let out2 = to_source_code(&pool, &[], NamingConvention::PreserveCase);
@@ -2289,11 +2477,15 @@ mod tests {
                 .map(|n| FunctionArgument {
                     name: BaseName::new(*n),
                     docstring: None,
-                    ty: Ty::Int,
+                    ty: Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                     default: None,
                 })
                 .collect(),
-            return_type: Ty::Int,
+            return_type: Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
             throws: None,
             watchers: vec![],
             origin: origin(file, span),
@@ -2486,8 +2678,23 @@ mod tests {
             class_with_props(
                 n,
                 vec![
-                    ("name", Ty::String),
-                    ("email", Ty::Union(vec![Ty::String, Ty::Null])),
+                    (
+                        "name",
+                        Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    ),
+                    (
+                        "email",
+                        union(vec![
+                            Ty::String {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                            Ty::Null {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                        ]),
+                    ),
                 ],
                 "x.baml",
                 0,
@@ -2564,10 +2771,12 @@ mod tests {
                 arguments: vec![FunctionArgument {
                     name: BaseName::new("text"),
                     docstring: None,
-                    ty: Ty::String,
+                    ty: Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                     default: None,
                 }],
-                return_type: Ty::Class(resume, vec![]),
+                return_type: class_ty(resume, vec![]),
                 throws: None,
                 watchers: vec![],
                 origin: origin("x.baml", 100),
@@ -2612,10 +2821,12 @@ mod tests {
                 arguments: vec![FunctionArgument {
                     name: BaseName::new("json"),
                     docstring: None,
-                    ty: Ty::String,
+                    ty: Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                     default: None,
                 }],
-                return_type: Ty::Class(resume.clone(), vec![]),
+                return_type: class_ty(resume.clone(), vec![]),
                 throws: None,
                 watchers: vec![],
                 // Companions share the parent's span so they cluster.
@@ -2631,10 +2842,12 @@ mod tests {
                 arguments: vec![FunctionArgument {
                     name: BaseName::new("text"),
                     docstring: None,
-                    ty: Ty::String,
+                    ty: Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                     default: None,
                 }],
-                return_type: Ty::Class(resume, vec![]),
+                return_type: class_ty(resume, vec![]),
                 throws: None,
                 watchers: vec![],
                 origin: origin("x.baml", 100),
@@ -2675,10 +2888,14 @@ mod tests {
         // `typing_extensions.TypeAliasType` (18c).
         let mut pool: SymbolPool = HashMap::new();
         let n = cg_name("user", &["tree"], "JsonValue");
-        let rhs = Ty::Union(vec![
-            Ty::Int,
-            Ty::String,
-            Ty::List(Box::new(Ty::TypeAlias(n.clone()))),
+        let rhs = union(vec![
+            Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
+            Ty::String {
+                attr: baml_base::TyAttr::EMPTY,
+            },
+            list(Box::new(alias_ty(n.clone()))),
         ]);
         pool.insert(n.clone(), alias_full(n, rhs, true, "tree.baml", 0));
 
@@ -2854,7 +3071,7 @@ mod tests {
             envelope.clone(),
             class_with_props(
                 envelope,
-                vec![("sentiment", Ty::Enum(sentiment))],
+                vec![("sentiment", enum_ty(sentiment))],
                 "lorem.baml",
                 0,
             ),
@@ -2900,7 +3117,7 @@ mod tests {
             envelope.clone(),
             class_with_props(
                 envelope,
-                vec![("inner", Ty::Class(foo, vec![]))],
+                vec![("inner", class_ty(foo, vec![]))],
                 "lorem.baml",
                 0,
             ),
@@ -2936,7 +3153,7 @@ mod tests {
             consumer.clone(),
             class_with_props(
                 consumer,
-                vec![("inner", Ty::Class(foo, vec![]))],
+                vec![("inner", class_ty(foo, vec![]))],
                 "root.baml",
                 0,
             ),
@@ -2963,7 +3180,7 @@ mod tests {
             envelope.clone(),
             class_with_props(
                 envelope,
-                vec![("resp", Ty::Class(response, vec![]))],
+                vec![("resp", class_ty(response, vec![]))],
                 "x.baml",
                 0,
             ),
@@ -2994,12 +3211,7 @@ mod tests {
         pool.insert(bucket.clone(), class(bucket.clone()));
         pool.insert(
             envelope.clone(),
-            class_with_props(
-                envelope,
-                vec![("b", Ty::Class(bucket, vec![]))],
-                "x.baml",
-                0,
-            ),
+            class_with_props(envelope, vec![("b", class_ty(bucket, vec![]))], "x.baml", 0),
         );
         let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
         let py = &out[&PathBuf::from("lorem/__init__.py")];
@@ -3025,13 +3237,23 @@ mod tests {
         let stream = cg_name("user", &["lorem"], "Resume$stream");
         pool.insert(
             non_stream.clone(),
-            class_with_props(non_stream.clone(), vec![("name", Ty::String)], "x.baml", 0),
+            class_with_props(
+                non_stream.clone(),
+                vec![(
+                    "name",
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                )],
+                "x.baml",
+                0,
+            ),
         );
         pool.insert(
             stream.clone(),
             class_with_props(
                 stream,
-                vec![("origin", Ty::Class(non_stream, vec![]))],
+                vec![("origin", class_ty(non_stream, vec![]))],
                 "x.baml",
                 0,
             ),
@@ -3065,7 +3287,7 @@ mod tests {
             stream_bucket.clone(),
             class_with_props(
                 stream_bucket,
-                vec![("resp", Ty::Class(response, vec![]))],
+                vec![("resp", class_ty(response, vec![]))],
                 "x.baml",
                 0,
             ),
@@ -3113,9 +3335,9 @@ mod tests {
             class_with_props(
                 resume,
                 vec![
-                    ("s", Ty::Enum(sentiment)),
-                    ("b", Ty::Class(bucket, vec![])),
-                    ("r", Ty::Class(response, vec![])),
+                    ("s", enum_ty(sentiment)),
+                    ("b", class_ty(bucket, vec![])),
+                    ("r", class_ty(response, vec![])),
                 ],
                 "x.baml",
                 0,
@@ -3164,8 +3386,8 @@ mod tests {
             class_with_props(
                 resume,
                 vec![
-                    ("a", Ty::Class(s3_bucket, vec![])),
-                    ("b", Ty::Class(gcs_object, vec![])),
+                    ("a", class_ty(s3_bucket, vec![])),
+                    ("b", class_ty(gcs_object, vec![])),
                 ],
                 "x.baml",
                 0,
@@ -3192,7 +3414,7 @@ mod tests {
         pool.insert(resume.clone(), class(resume.clone()));
         pool.insert(
             other.clone(),
-            class_with_props(other, vec![("r", Ty::Class(resume, vec![]))], "x.baml", 100),
+            class_with_props(other, vec![("r", class_ty(resume, vec![]))], "x.baml", 100),
         );
         let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
         let py = &out[&PathBuf::from("lorem/__init__.py")];
@@ -3232,10 +3454,12 @@ mod tests {
                 arguments: vec![FunctionArgument {
                     name: BaseName::new("text"),
                     docstring: None,
-                    ty: Ty::String,
+                    ty: Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                     default: None,
                 }],
-                return_type: Ty::Enum(sentiment),
+                return_type: enum_ty(sentiment),
                 throws: None,
                 watchers: vec![],
                 origin: origin("x.baml", 100),
@@ -3315,7 +3539,7 @@ mod tests {
                 properties: vec![ClassProperty {
                     name: BaseName::new("item"),
                     docstring: None,
-                    ty: Ty::TypeVar(BaseName::new("T")),
+                    ty: type_var(BaseName::new("T")),
                 }],
                 static_methods: vec![],
                 instance_methods: vec![],
@@ -3331,9 +3555,9 @@ mod tests {
                 properties: vec![ClassProperty {
                     name: BaseName::new("contents"),
                     docstring: None,
-                    ty: Ty::List(Box::new(Ty::Class(
+                    ty: list(Box::new(class_ty(
                         cg_name("user", &["lorem"], "Box"),
-                        vec![Ty::TypeVar(BaseName::new("T"))],
+                        vec![type_var(BaseName::new("T"))],
                     ))),
                 }],
                 static_methods: vec![],
@@ -3406,10 +3630,10 @@ mod tests {
                 arguments: vec![FunctionArgument {
                     name: BaseName::new("value"),
                     docstring: None,
-                    ty: Ty::TypeVar(BaseName::new("T")),
+                    ty: type_var(BaseName::new("T")),
                     default: None,
                 }],
-                return_type: Ty::TypeVar(BaseName::new("T")),
+                return_type: type_var(BaseName::new("T")),
                 throws: None,
                 watchers: vec![],
                 origin: origin("echo.baml", 0),

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/routing.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/routing.rs
@@ -93,7 +93,7 @@ fn route_inner(name: &Name, honor_stream_suffix: bool) -> LeafPath {
         segs.push("stream_types".to_string());
     }
 
-    match name.pkg.as_str() {
+    match name.package().as_str() {
         "user" => {}
         "baml" => segs.push("baml".to_string()),
         other => {
@@ -102,7 +102,7 @@ fn route_inner(name: &Name, honor_stream_suffix: bool) -> LeafPath {
         }
     }
 
-    for seg in &name.namespace_path {
+    for seg in name.namespace() {
         segs.push(sanitize_python_module_segment(seg.as_str()));
     }
 
@@ -165,10 +165,14 @@ mod tests {
             arguments: vec![FunctionArgument {
                 name: BaseName::new("x"),
                 docstring: None,
-                ty: Ty::Int,
+                ty: Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 default: None,
             }],
-            return_type: Ty::Int,
+            return_type: Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
             throws: None,
             watchers: Vec::new(),
             origin: origin(),

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
@@ -29,7 +29,7 @@ pub(crate) struct TranslateCtx {
     /// quoted form defers resolution until pydantic walks the alias
     /// later.
     pub(crate) defer_name_refs: bool,
-    /// `.pyi`-only: maps each optional-argument `Ty::Callable` in the leaf to
+    /// `.pyi`-only: maps each optional-argument `Ty::Function` in the leaf to
     /// the name of the `typing.Protocol` emitted for it. A function *type*
     /// (`typing.Callable[[…], R]`) cannot express per-parameter optionality,
     /// so a callback with optional params is rendered as a named Protocol
@@ -48,33 +48,33 @@ pub(crate) struct SelfRef {
 
 pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
     match ty {
-        Ty::Int => "int".to_string(),
-        Ty::Bigint => "int".to_string(),
-        Ty::Float => "float".to_string(),
-        Ty::String => "str".to_string(),
-        Ty::Bool => "bool".to_string(),
-        Ty::Null => "None".to_string(),
-        Ty::Literal(Literal::Int(value)) => format!("typing.Literal[{value}]"),
-        Ty::Literal(Literal::Bigint(value)) => format!("typing.Literal[{value}]"),
-        Ty::Literal(Literal::String(value)) => {
+        Ty::Int { .. } => "int".to_string(),
+        Ty::Bigint { .. } => "int".to_string(),
+        Ty::Float { .. } => "float".to_string(),
+        Ty::String { .. } => "str".to_string(),
+        Ty::Bool { .. } => "bool".to_string(),
+        Ty::Null { .. } => "None".to_string(),
+        Ty::Literal(Literal::Int(value), ..) => format!("typing.Literal[{value}]"),
+        Ty::Literal(Literal::Bigint(value), ..) => format!("typing.Literal[{value}]"),
+        Ty::Literal(Literal::String(value), ..) => {
             format!("typing.Literal[{}]", py_string(value))
         }
-        Ty::Literal(Literal::Bool(true)) => "typing.Literal[True]".to_string(),
-        Ty::Literal(Literal::Bool(false)) => "typing.Literal[False]".to_string(),
+        Ty::Literal(Literal::Bool(true), ..) => "typing.Literal[True]".to_string(),
+        Ty::Literal(Literal::Bool(false), ..) => "typing.Literal[False]".to_string(),
         // Python does not allow float parameters to typing.Literal.
-        Ty::Literal(Literal::Float(_)) => "typing.Any".to_string(),
-        Ty::Uint8Array => "bytes".to_string(),
-        Ty::Media(MediaKind::Image) => media_ref("Image", ctx),
-        Ty::Media(MediaKind::Audio) => media_ref("Audio", ctx),
-        Ty::Media(MediaKind::Video) => media_ref("Video", ctx),
-        Ty::Media(MediaKind::Pdf) => media_ref("Pdf", ctx),
-        Ty::Media(MediaKind::Generic) => "typing.Any".to_string(),
-        Ty::Class(name, args) => {
+        Ty::Literal(Literal::Float(_), ..) => "typing.Any".to_string(),
+        Ty::Uint8Array { .. } => "bytes".to_string(),
+        Ty::Media(MediaKind::Image, _) => media_ref("Image", ctx),
+        Ty::Media(MediaKind::Audio, _) => media_ref("Audio", ctx),
+        Ty::Media(MediaKind::Video, _) => media_ref("Video", ctx),
+        Ty::Media(MediaKind::Pdf, _) => media_ref("Pdf", ctx),
+        Ty::Media(MediaKind::Generic, _) => "typing.Any".to_string(),
+        Ty::Class(name, args, _) => {
             let arg_strs: Vec<String> = args.iter().map(|a| translate_ty(a, ctx)).collect();
             render_name_ref_or_self_ref(name, ctx, &arg_strs.join(", "))
         }
-        Ty::TypeAlias(name) => render_name_ref_or_self_ref(name, ctx, ""),
-        Ty::Enum(name) => {
+        Ty::TypeAlias(name, _) => render_name_ref_or_self_ref(name, ctx, ""),
+        Ty::Enum(name, _) | Ty::EnumVariant(name, _, _) => {
             let head = render_name_ref(name, ctx);
             if should_defer_name_ref(ctx) {
                 py_string(&head)
@@ -82,20 +82,23 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
                 head
             }
         }
-        Ty::TypeVar(name) => name.as_str().to_string(),
-        Ty::List(inner) => format!("typing.List[{}]", translate_ty(inner, ctx)),
-        Ty::Map { key, value } => {
+        Ty::TypeVar(name, _) => name.as_str().to_string(),
+        Ty::List(inner, _) => format!("typing.List[{}]", translate_ty(inner, ctx)),
+        Ty::Map { key, value, .. } => {
             format!(
                 "typing.Dict[{}, {}]",
                 translate_ty(key, ctx),
                 translate_ty(value, ctx)
             )
         }
-        Ty::Union(items) => {
+        Ty::Union(items, _) => {
             // `T | null` (a single non-null member plus null) is optionality —
             // emit idiomatic `typing.Optional[T]`. Multi-member nullable unions
             // fall through to `typing.Union[A, B, None]` (Null → "None").
-            let non_null: Vec<&Ty> = items.iter().filter(|t| !matches!(t, Ty::Null)).collect();
+            let non_null: Vec<&Ty> = items
+                .iter()
+                .filter(|t| !matches!(t, Ty::Null { .. }))
+                .collect();
             if non_null.len() == 1 && non_null.len() < items.len() {
                 format!("typing.Optional[{}]", translate_ty(non_null[0], ctx))
             } else {
@@ -109,8 +112,13 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
                 )
             }
         }
-        Ty::BuiltinUnknown => "typing.Any".to_string(),
-        Ty::Callable { params, ret } => {
+        Ty::BuiltinUnknown { .. }
+        | Ty::Interface(..)
+        | Ty::Type { .. }
+        | Ty::Resource { .. }
+        | Ty::PromptAst { .. }
+        | Ty::Future(..) => "typing.Any".to_string(),
+        Ty::Function { params, ret, .. } => {
             let has_optional = params
                 .iter()
                 .any(|param| param.mode == baml_codegen_types::CodegenFunctionParamMode::Optional);
@@ -136,8 +144,7 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
                 )
             }
         }
-        Ty::Unit => "None".to_string(),
-        Ty::BamlOptions => "baml.Options".to_string(),
+        Ty::Void { .. } | Ty::Never { .. } => "None".to_string(),
         // `$rust_type` fields in stdlib stubs (Response._body, SseStream._handle, …).
         // The host-language opaque-handle wrapper is `BamlPyHandle` from the
         // bridge runtime, imported as `_BamlPyHandle` to keep `baml` (the
@@ -145,7 +152,7 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
         // field name still triggers Pydantic v2's private-attribute handling
         // regardless of the annotation; `_decode_class` injects the value
         // into `__pydantic_private__` post-construction.
-        Ty::RustType => "_BamlPyHandle".to_string(),
+        Ty::RustType { .. } => "_BamlPyHandle".to_string(),
     }
 }
 
@@ -282,6 +289,47 @@ mod tests {
             BaseName::new(bare_name),
         )
     }
+    fn class_ty(name: Name, args: Vec<Ty>) -> Ty {
+        Ty::Class(name, args, baml_base::TyAttr::EMPTY)
+    }
+    fn enum_ty(name: Name) -> Ty {
+        Ty::Enum(name, baml_base::TyAttr::EMPTY)
+    }
+    fn alias_ty(name: Name) -> Ty {
+        Ty::TypeAlias(name, baml_base::TyAttr::EMPTY)
+    }
+    fn type_var(name: BaseName) -> Ty {
+        Ty::TypeVar(name, baml_base::TyAttr::EMPTY)
+    }
+    fn list(inner: Box<Ty>) -> Ty {
+        Ty::List(inner, baml_base::TyAttr::EMPTY)
+    }
+    fn union(members: Vec<Ty>) -> Ty {
+        Ty::Union(members, baml_base::TyAttr::EMPTY)
+    }
+    fn media(kind: MediaKind) -> Ty {
+        Ty::Media(kind, baml_base::TyAttr::EMPTY)
+    }
+    fn literal(value: Literal) -> Ty {
+        Ty::Literal(
+            value,
+            baml_codegen_types::Freshness::Regular,
+            baml_base::TyAttr::EMPTY,
+        )
+    }
+    fn baml_options() -> Ty {
+        class_ty(name("baml", &[], "Options"), Vec::new())
+    }
+    fn callable(params: Vec<baml_codegen_types::CallableParam>, ret: Box<Ty>) -> Ty {
+        Ty::Function {
+            params,
+            ret,
+            throws: Box::new(Ty::Never {
+                attr: baml_base::TyAttr::EMPTY,
+            }),
+            attr: baml_base::TyAttr::EMPTY,
+        }
+    }
 
     fn callable_param(ty: Ty) -> baml_codegen_types::CallableParam {
         baml_codegen_types::CallableParam {
@@ -311,27 +359,33 @@ mod tests {
 
     fn check_exhaustive(ty: &Ty) {
         match ty {
-            Ty::Int
-            | Ty::Bigint
-            | Ty::Float
-            | Ty::String
-            | Ty::Bool
-            | Ty::Null
-            | Ty::Literal(_)
-            | Ty::Uint8Array
-            | Ty::Media(_)
-            | Ty::Class(_, _)
-            | Ty::Enum(_)
-            | Ty::TypeAlias(_)
-            | Ty::TypeVar(_)
-            | Ty::List(_)
+            Ty::Int { .. }
+            | Ty::Bigint { .. }
+            | Ty::Float { .. }
+            | Ty::String { .. }
+            | Ty::Bool { .. }
+            | Ty::Null { .. }
+            | Ty::Literal(..)
+            | Ty::Uint8Array { .. }
+            | Ty::Media(..)
+            | Ty::Class(..)
+            | Ty::Interface(..)
+            | Ty::Enum(..)
+            | Ty::EnumVariant(..)
+            | Ty::TypeAlias(..)
+            | Ty::TypeVar(..)
+            | Ty::List(..)
             | Ty::Map { .. }
-            | Ty::Union(_)
-            | Ty::BuiltinUnknown
-            | Ty::Callable { .. }
-            | Ty::Unit
-            | Ty::RustType
-            | Ty::BamlOptions => {}
+            | Ty::Union(..)
+            | Ty::BuiltinUnknown { .. }
+            | Ty::Function { .. }
+            | Ty::Future(..)
+            | Ty::Void { .. }
+            | Ty::Never { .. }
+            | Ty::RustType { .. }
+            | Ty::Type { .. }
+            | Ty::Resource { .. }
+            | Ty::PromptAst { .. } => {}
         }
     }
 
@@ -340,243 +394,273 @@ mod tests {
         let cases = vec![
             Case {
                 label: "int",
-                ty: Ty::Int,
+                ty: Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&["lorem"]),
                 expected: "int",
             },
             Case {
                 label: "float",
-                ty: Ty::Float,
+                ty: Ty::Float {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&["lorem"]),
                 expected: "float",
             },
             Case {
                 label: "string",
-                ty: Ty::String,
+                ty: Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&["lorem"]),
                 expected: "str",
             },
             Case {
                 label: "bool",
-                ty: Ty::Bool,
+                ty: Ty::Bool {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&["lorem"]),
                 expected: "bool",
             },
             Case {
                 label: "null",
-                ty: Ty::Null,
+                ty: Ty::Null {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&["lorem"]),
                 expected: "None",
             },
             Case {
                 label: "uint8array",
-                ty: Ty::Uint8Array,
+                ty: Ty::Uint8Array {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&["lorem"]),
                 expected: "bytes",
             },
             Case {
                 label: "builtin unknown",
-                ty: Ty::BuiltinUnknown,
+                ty: Ty::BuiltinUnknown {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Any",
             },
             Case {
                 label: "unit",
-                ty: Ty::Unit,
+                ty: Ty::Void {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&["lorem"]),
                 expected: "None",
             },
             Case {
                 label: "baml options",
-                ty: Ty::BamlOptions,
+                ty: baml_options(),
                 ctx: ctx(&["lorem"]),
                 expected: "baml.Options",
             },
             Case {
                 label: "literal int",
-                ty: Ty::Literal(Literal::Int(42)),
+                ty: literal(Literal::Int(42)),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Literal[42]",
             },
             Case {
                 label: "literal negative int",
-                ty: Ty::Literal(Literal::Int(-1)),
+                ty: literal(Literal::Int(-1)),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Literal[-1]",
             },
             Case {
                 label: "literal string",
-                ty: Ty::Literal(Literal::String("draft".to_string())),
+                ty: literal(Literal::String("draft".to_string())),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Literal[\"draft\"]",
             },
             Case {
                 label: "literal escaped string",
-                ty: Ty::Literal(Literal::String("has \"quotes\"".to_string())),
+                ty: literal(Literal::String("has \"quotes\"".to_string())),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Literal[\"has \\\"quotes\\\"\"]",
             },
             Case {
                 label: "literal bool true",
-                ty: Ty::Literal(Literal::Bool(true)),
+                ty: literal(Literal::Bool(true)),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Literal[True]",
             },
             Case {
                 label: "literal bool false",
-                ty: Ty::Literal(Literal::Bool(false)),
+                ty: literal(Literal::Bool(false)),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Literal[False]",
             },
             Case {
                 label: "literal float fallback",
-                ty: Ty::Literal(Literal::Float("3.14".to_string())),
+                ty: literal(Literal::Float("3.14".to_string())),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Any",
             },
             Case {
                 label: "media image",
-                ty: Ty::Media(MediaKind::Image),
+                ty: media(MediaKind::Image),
                 ctx: ctx(&["lorem"]),
                 expected: "baml.media.Image",
             },
             Case {
                 label: "media audio",
-                ty: Ty::Media(MediaKind::Audio),
+                ty: media(MediaKind::Audio),
                 ctx: ctx(&["lorem"]),
                 expected: "baml.media.Audio",
             },
             Case {
                 label: "media video",
-                ty: Ty::Media(MediaKind::Video),
+                ty: media(MediaKind::Video),
                 ctx: ctx(&["lorem"]),
                 expected: "baml.media.Video",
             },
             Case {
                 label: "media pdf",
-                ty: Ty::Media(MediaKind::Pdf),
+                ty: media(MediaKind::Pdf),
                 ctx: ctx(&["lorem"]),
                 expected: "baml.media.Pdf",
             },
             Case {
                 label: "media generic fallback",
-                ty: Ty::Media(MediaKind::Generic),
+                ty: media(MediaKind::Generic),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Any",
             },
             Case {
                 label: "class same leaf root namespace",
-                ty: Ty::Class(name("user", &["lorem"], "Resume"), vec![]),
+                ty: class_ty(name("user", &["lorem"], "Resume"), vec![]),
                 ctx: ctx(&["lorem"]),
                 expected: "Resume",
             },
             Case {
                 label: "class cross leaf root namespace",
-                ty: Ty::Class(name("user", &["lorem"], "Resume"), vec![]),
+                ty: class_ty(name("user", &["lorem"], "Resume"), vec![]),
                 ctx: ctx(&["ipsum"]),
                 expected: "lorem.Resume",
             },
             Case {
                 label: "class same leaf root init",
-                ty: Ty::Class(name("user", &[], "Foo"), vec![]),
+                ty: class_ty(name("user", &[], "Foo"), vec![]),
                 ctx: ctx(&[]),
                 expected: "Foo",
             },
             Case {
                 label: "class root init from namespaced leaf",
-                ty: Ty::Class(name("user", &[], "Foo"), vec![]),
+                ty: class_ty(name("user", &[], "Foo"), vec![]),
                 ctx: ctx(&["lorem"]),
                 expected: "Foo",
             },
             Case {
                 label: "class vendor cross leaf",
-                ty: Ty::Class(name("aws", &["s3"], "Bucket"), vec![]),
+                ty: class_ty(name("aws", &["s3"], "Bucket"), vec![]),
                 ctx: ctx(&["lorem"]),
                 expected: "vendor.aws.s3.Bucket",
             },
             Case {
                 label: "class vendor same leaf",
-                ty: Ty::Class(name("aws", &["s3"], "Bucket"), vec![]),
+                ty: class_ty(name("aws", &["s3"], "Bucket"), vec![]),
                 ctx: ctx(&["vendor", "aws", "s3"]),
                 expected: "Bucket",
             },
             Case {
                 label: "class vendor other vendor leaf",
-                ty: Ty::Class(name("aws", &["s3"], "Bucket"), vec![]),
+                ty: class_ty(name("aws", &["s3"], "Bucket"), vec![]),
                 ctx: ctx(&["vendor", "aws", "ec2"]),
                 expected: "vendor.aws.s3.Bucket",
             },
             Case {
                 label: "class stdlib cross leaf",
-                ty: Ty::Class(name("baml", &["http"], "Response"), vec![]),
+                ty: class_ty(name("baml", &["http"], "Response"), vec![]),
                 ctx: ctx(&["lorem"]),
                 expected: "baml.http.Response",
             },
             Case {
                 label: "class stdlib same leaf",
-                ty: Ty::Class(name("baml", &["http"], "Response"), vec![]),
+                ty: class_ty(name("baml", &["http"], "Response"), vec![]),
                 ctx: ctx(&["baml", "http"]),
                 expected: "Response",
             },
             Case {
                 label: "class stream from non stream leaf",
-                ty: Ty::Class(name("user", &["lorem"], "Resume$stream"), vec![]),
+                ty: class_ty(name("user", &["lorem"], "Resume$stream"), vec![]),
                 ctx: ctx(&["lorem"]),
                 expected: "stream_types.lorem.Resume",
             },
             Case {
                 label: "class stream same leaf",
-                ty: Ty::Class(name("user", &["lorem"], "Resume$stream"), vec![]),
+                ty: class_ty(name("user", &["lorem"], "Resume$stream"), vec![]),
                 ctx: ctx(&["stream_types", "lorem"]),
                 expected: "Resume",
             },
             Case {
                 label: "class non stream from stream leaf",
-                ty: Ty::Class(name("user", &["lorem"], "Resume"), vec![]),
+                ty: class_ty(name("user", &["lorem"], "Resume"), vec![]),
                 ctx: ctx(&["stream_types", "lorem"]),
                 expected: "lorem.Resume",
             },
             Case {
                 label: "enum same leaf",
-                ty: Ty::Enum(name("user", &["ipsum"], "Sentiment")),
+                ty: enum_ty(name("user", &["ipsum"], "Sentiment")),
                 ctx: ctx(&["ipsum"]),
                 expected: "Sentiment",
             },
             Case {
                 label: "enum cross leaf",
-                ty: Ty::Enum(name("user", &["ipsum"], "Sentiment")),
+                ty: enum_ty(name("user", &["ipsum"], "Sentiment")),
                 ctx: ctx(&["lorem"]),
                 expected: "ipsum.Sentiment",
             },
             Case {
                 label: "type alias same leaf",
-                ty: Ty::TypeAlias(name("user", &["util"], "StringList")),
+                ty: alias_ty(name("user", &["util"], "StringList")),
                 ctx: ctx(&["util"]),
                 expected: "StringList",
             },
             Case {
                 label: "type alias cross leaf",
-                ty: Ty::TypeAlias(name("user", &["util"], "StringList")),
+                ty: alias_ty(name("user", &["util"], "StringList")),
                 ctx: ctx(&["lorem"]),
                 expected: "util.StringList",
             },
             Case {
                 label: "optional string",
-                ty: Ty::Union(vec![Ty::String, Ty::Null]),
+                ty: union(vec![
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Optional[str]",
             },
             Case {
                 label: "list int",
-                ty: Ty::List(Box::new(Ty::Int)),
+                ty: list(Box::new(Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                })),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.List[int]",
             },
             Case {
                 label: "map string int",
                 ty: Ty::Map {
-                    key: Box::new(Ty::String),
-                    value: Box::new(Ty::Int),
+                    key: Box::new(Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                    value: Box::new(Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                    attr: baml_base::TyAttr::EMPTY,
                 },
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Dict[str, int]",
@@ -584,156 +668,226 @@ mod tests {
             Case {
                 label: "map enum to class",
                 ty: Ty::Map {
-                    key: Box::new(Ty::Enum(name("user", &["ipsum"], "Sentiment"))),
-                    value: Box::new(Ty::Class(name("user", &["lorem"], "Resume"), vec![])),
+                    key: Box::new(enum_ty(name("user", &["ipsum"], "Sentiment"))),
+                    value: Box::new(class_ty(name("user", &["lorem"], "Resume"), vec![])),
+                    attr: baml_base::TyAttr::EMPTY,
                 },
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Dict[ipsum.Sentiment, Resume]",
             },
             Case {
                 label: "union int string",
-                ty: Ty::Union(vec![Ty::Int, Ty::String]),
+                ty: union(vec![
+                    Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Union[int, str]",
             },
             Case {
                 label: "union int string bool",
-                ty: Ty::Union(vec![Ty::Int, Ty::String, Ty::Bool]),
+                ty: union(vec![
+                    Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::Bool {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Union[int, str, bool]",
             },
             Case {
                 label: "optional list same leaf class",
-                ty: Ty::Union(vec![
-                    Ty::List(Box::new(Ty::Class(
+                ty: union(vec![
+                    list(Box::new(class_ty(
                         name("user", &["lorem"], "Resume"),
                         vec![],
                     ))),
-                    Ty::Null,
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 ]),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Optional[typing.List[Resume]]",
             },
             Case {
                 label: "list optional string",
-                ty: Ty::List(Box::new(Ty::Union(vec![Ty::String, Ty::Null]))),
+                ty: list(Box::new(union(vec![
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]))),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.List[typing.Optional[str]]",
             },
             Case {
                 label: "map vendor list",
                 ty: Ty::Map {
-                    key: Box::new(Ty::String),
-                    value: Box::new(Ty::List(Box::new(Ty::Class(
+                    key: Box::new(Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                    value: Box::new(list(Box::new(class_ty(
                         name("aws", &["s3"], "Bucket"),
                         vec![],
                     )))),
+                    attr: baml_base::TyAttr::EMPTY,
                 },
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Dict[str, typing.List[vendor.aws.s3.Bucket]]",
             },
             Case {
                 label: "callable two params",
-                ty: Ty::Callable {
-                    params: vec![callable_param(Ty::Int), callable_param(Ty::String)],
-                    ret: Box::new(Ty::Bool),
-                },
+                ty: callable(
+                    vec![
+                        callable_param(Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        }),
+                        callable_param(Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        }),
+                    ],
+                    Box::new(Ty::Bool {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                ),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Callable[[int, str], bool]",
             },
             Case {
                 label: "callable no params",
-                ty: Ty::Callable {
-                    params: vec![],
-                    ret: Box::new(Ty::Unit),
-                },
+                ty: callable(
+                    vec![],
+                    Box::new(Ty::Void {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                ),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Callable[[], None]",
             },
             Case {
                 label: "callable nested params",
-                ty: Ty::Callable {
-                    params: vec![callable_param(Ty::List(Box::new(Ty::Int)))],
-                    ret: Box::new(Ty::Union(vec![Ty::String, Ty::Null])),
-                },
+                ty: callable(
+                    vec![callable_param(list(Box::new(Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    })))],
+                    Box::new(union(vec![
+                        Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                        Ty::Null {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    ])),
+                ),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Callable[[typing.List[int]], typing.Optional[str]]",
             },
             Case {
                 label: "callable optional params",
-                ty: Ty::Callable {
-                    params: vec![
-                        callable_param(Ty::String),
-                        optional_callable_param("limit", Ty::Int),
+                ty: callable(
+                    vec![
+                        callable_param(Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        }),
+                        optional_callable_param(
+                            "limit",
+                            Ty::Int {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                        ),
                     ],
-                    ret: Box::new(Ty::Bool),
-                },
+                    Box::new(Ty::Bool {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                ),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Callable[..., bool]",
             },
             Case {
                 label: "union stream and non stream classes",
-                ty: Ty::Union(vec![
-                    Ty::Class(name("user", &["lorem"], "Resume"), vec![]),
-                    Ty::Class(name("user", &["lorem"], "Resume$stream"), vec![]),
+                ty: union(vec![
+                    class_ty(name("user", &["lorem"], "Resume"), vec![]),
+                    class_ty(name("user", &["lorem"], "Resume$stream"), vec![]),
                 ]),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Union[Resume, stream_types.lorem.Resume]",
             },
             Case {
                 label: "optional media",
-                ty: Ty::Union(vec![Ty::Media(MediaKind::Image), Ty::Null]),
+                ty: union(vec![
+                    media(MediaKind::Image),
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Optional[baml.media.Image]",
             },
             Case {
                 label: "recursive alias self ref",
-                ty: Ty::TypeAlias(name("user", &["util"], "RecList")),
+                ty: alias_ty(name("user", &["util"], "RecList")),
                 ctx: ctx_with_self(&["util"], &["util"], "RecList"),
                 expected: "\"RecList\"",
             },
             Case {
                 label: "self-ref class no args",
-                ty: Ty::Class(name("user", &["lorem"], "Node"), vec![]),
+                ty: class_ty(name("user", &["lorem"], "Node"), vec![]),
                 ctx: ctx_with_self(&["lorem"], &["lorem"], "Node"),
                 expected: "\"Node\"",
             },
             Case {
                 label: "self-ref generic class wraps args inside quotes",
-                ty: Ty::Class(name("user", &["lorem"], "Node"), vec![Ty::String]),
+                ty: class_ty(
+                    name("user", &["lorem"], "Node"),
+                    vec![Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }],
+                ),
                 ctx: ctx_with_self(&["lorem"], &["lorem"], "Node"),
                 expected: "\"Node[str]\"",
             },
             Case {
                 label: "self-ref generic class nested in list wraps args inside quotes",
-                ty: Ty::List(Box::new(Ty::Class(
+                ty: list(Box::new(class_ty(
                     name("user", &["lorem"], "Node"),
-                    vec![Ty::Int],
+                    vec![Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }],
                 ))),
                 ctx: ctx_with_self(&["lorem"], &["lorem"], "Node"),
                 expected: "typing.List[\"Node[int]\"]",
             },
             Case {
                 label: "recursive alias inside list",
-                ty: Ty::List(Box::new(Ty::TypeAlias(name("user", &["util"], "RecList")))),
+                ty: list(Box::new(alias_ty(name("user", &["util"], "RecList")))),
                 ctx: ctx_with_self(&["util"], &["util"], "RecList"),
                 expected: "typing.List[\"RecList\"]",
             },
             Case {
                 label: "recursive alias inside union",
-                ty: Ty::Union(vec![
-                    Ty::Int,
-                    Ty::List(Box::new(Ty::TypeAlias(name("user", &["util"], "RecList")))),
+                ty: union(vec![
+                    Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    list(Box::new(alias_ty(name("user", &["util"], "RecList")))),
                 ]),
                 ctx: ctx_with_self(&["util"], &["util"], "RecList"),
                 expected: "typing.Union[int, typing.List[\"RecList\"]]",
             },
             Case {
                 label: "recursive alias leaves other refs unquoted under self_ref-only",
-                ty: Ty::List(Box::new(Ty::Class(
-                    name("user", &["util"], "Other"),
-                    vec![],
-                ))),
+                ty: list(Box::new(class_ty(name("user", &["util"], "Other"), vec![]))),
                 ctx: ctx_with_self(&["util"], &["util"], "RecList"),
                 expected: "typing.List[Other]",
             },
@@ -745,73 +899,73 @@ mod tests {
             // in scope then (hoisting + TYPE_CHECKING guards).
             Case {
                 label: "recursive body quotes same-leaf sibling",
-                ty: Ty::List(Box::new(Ty::Class(
-                    name("user", &["util"], "Other"),
-                    vec![],
-                ))),
+                ty: list(Box::new(class_ty(name("user", &["util"], "Other"), vec![]))),
                 ctx: ctx_recursive_alias_body(&["util"], &["util"], "RecList"),
                 expected: "typing.List[\"Other\"]",
             },
             Case {
                 label: "recursive body quotes cross-leaf class as dotted forward-ref",
-                ty: Ty::List(Box::new(Ty::Class(name("user", &["util"], "Bar"), vec![]))),
+                ty: list(Box::new(class_ty(name("user", &["util"], "Bar"), vec![]))),
                 ctx: ctx_recursive_alias_body(&["lorem"], &["lorem"], "RecList"),
                 expected: "typing.List[\"util.Bar\"]",
             },
             Case {
                 label: "recursive body quotes root-routed name",
-                ty: Ty::Class(name("user", &[], "Foo"), vec![]),
+                ty: class_ty(name("user", &[], "Foo"), vec![]),
                 ctx: ctx_recursive_alias_body(&["lorem"], &["lorem"], "RecList"),
                 expected: "\"Foo\"",
             },
             Case {
                 label: "recursive body quotes cross-leaf enum",
-                ty: Ty::Enum(name("user", &["ipsum"], "Sentiment")),
+                ty: enum_ty(name("user", &["ipsum"], "Sentiment")),
                 ctx: ctx_recursive_alias_body(&["lorem"], &["lorem"], "RecList"),
                 expected: "\"ipsum.Sentiment\"",
             },
             Case {
                 label: "non recursive alias same leaf",
-                ty: Ty::TypeAlias(name("user", &["util"], "RecList")),
+                ty: alias_ty(name("user", &["util"], "RecList")),
                 ctx: ctx(&["util"]),
                 expected: "RecList",
             },
             Case {
                 label: "non recursive alias cross leaf",
-                ty: Ty::TypeAlias(name("user", &["util"], "RecList")),
+                ty: alias_ty(name("user", &["util"], "RecList")),
                 ctx: ctx(&["lorem"]),
                 expected: "util.RecList",
             },
             Case {
                 label: "optional stdlib class",
-                ty: Ty::Union(vec![
-                    Ty::Class(name("baml", &["http"], "Response"), vec![]),
-                    Ty::Null,
+                ty: union(vec![
+                    class_ty(name("baml", &["http"], "Response"), vec![]),
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 ]),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Optional[baml.http.Response]",
             },
             Case {
                 label: "list vendor class",
-                ty: Ty::List(Box::new(Ty::Class(name("aws", &["s3"], "Bucket"), vec![]))),
+                ty: list(Box::new(class_ty(name("aws", &["s3"], "Bucket"), vec![]))),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.List[vendor.aws.s3.Bucket]",
             },
             Case {
                 label: "map enum to stream vendor class",
                 ty: Ty::Map {
-                    key: Box::new(Ty::Enum(name("user", &["ipsum"], "Sentiment"))),
-                    value: Box::new(Ty::Class(name("aws", &["s3"], "Bucket$stream"), vec![])),
+                    key: Box::new(enum_ty(name("user", &["ipsum"], "Sentiment"))),
+                    value: Box::new(class_ty(name("aws", &["s3"], "Bucket$stream"), vec![])),
+                    attr: baml_base::TyAttr::EMPTY,
                 },
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Dict[ipsum.Sentiment, stream_types.vendor.aws.s3.Bucket]",
             },
             Case {
                 label: "union across placements",
-                ty: Ty::Union(vec![
-                    Ty::Class(name("user", &["lorem"], "Resume"), vec![]),
-                    Ty::Class(name("aws", &["s3"], "Bucket"), vec![]),
-                    Ty::Class(name("baml", &["http"], "Response"), vec![]),
+                ty: union(vec![
+                    class_ty(name("user", &["lorem"], "Resume"), vec![]),
+                    class_ty(name("aws", &["s3"], "Bucket"), vec![]),
+                    class_ty(name("baml", &["http"], "Response"), vec![]),
                 ]),
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Union[Resume, vendor.aws.s3.Bucket, baml.http.Response]",
@@ -819,60 +973,85 @@ mod tests {
             // Generics — `13a` §3.1, §3.2, §3.4.
             Case {
                 label: "generic class same leaf concrete int",
-                ty: Ty::Class(name("user", &["lorem"], "Box"), vec![Ty::Int]),
+                ty: class_ty(
+                    name("user", &["lorem"], "Box"),
+                    vec![Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }],
+                ),
                 ctx: ctx(&["lorem"]),
                 expected: "Box[int]",
             },
             Case {
                 label: "generic class cross leaf concrete int",
-                ty: Ty::Class(name("user", &["lorem"], "Box"), vec![Ty::Int]),
+                ty: class_ty(
+                    name("user", &["lorem"], "Box"),
+                    vec![Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }],
+                ),
                 ctx: ctx(&["ipsum"]),
                 expected: "lorem.Box[int]",
             },
             Case {
                 label: "generic class with list arg",
-                ty: Ty::Class(
+                ty: class_ty(
                     name("user", &["lorem"], "Box"),
-                    vec![Ty::List(Box::new(Ty::Int))],
+                    vec![list(Box::new(Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }))],
                 ),
                 ctx: ctx(&["lorem"]),
                 expected: "Box[typing.List[int]]",
             },
             Case {
                 label: "generic class nested generic arg",
-                ty: Ty::Class(
+                ty: class_ty(
                     name("user", &["lorem"], "Box"),
-                    vec![Ty::Class(name("user", &["lorem"], "Box"), vec![Ty::Int])],
+                    vec![class_ty(
+                        name("user", &["lorem"], "Box"),
+                        vec![Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        }],
+                    )],
                 ),
                 ctx: ctx(&["lorem"]),
                 expected: "Box[Box[int]]",
             },
             Case {
                 label: "generic class stream from non-stream leaf",
-                ty: Ty::Class(name("user", &["lorem"], "Box$stream"), vec![Ty::Int]),
+                ty: class_ty(
+                    name("user", &["lorem"], "Box$stream"),
+                    vec![Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }],
+                ),
                 ctx: ctx(&["lorem"]),
                 expected: "stream_types.lorem.Box[int]",
             },
             Case {
                 label: "generic class with typevar arg",
-                ty: Ty::Class(
+                ty: class_ty(
                     name("user", &["lorem"], "Box"),
-                    vec![Ty::TypeVar(baml_base::Name::new("T"))],
+                    vec![type_var(baml_base::Name::new("T"))],
                 ),
                 ctx: ctx(&["lorem"]),
                 expected: "Box[T]",
             },
             Case {
                 label: "bare typevar",
-                ty: Ty::TypeVar(baml_base::Name::new("T")),
+                ty: type_var(baml_base::Name::new("T")),
                 ctx: ctx(&["lorem"]),
                 expected: "T",
             },
             Case {
                 label: "map with typevar key and value",
                 ty: Ty::Map {
-                    key: Box::new(Ty::String),
-                    value: Box::new(Ty::TypeVar(baml_base::Name::new("V"))),
+                    key: Box::new(Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                    value: Box::new(type_var(baml_base::Name::new("V"))),
+                    attr: baml_base::TyAttr::EMPTY,
                 },
                 ctx: ctx(&["lorem"]),
                 expected: "typing.Dict[str, V]",

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/emit/mod.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/emit/mod.rs
@@ -55,7 +55,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
         // identifier char, so a `$stream` companion class is emitted as
         // e.g. `Resume$stream` (not stripped to `Resume`). Non-stream
         // symbols are unaffected (their name carries no `$stream`).
-        let bare = key.name.as_str().to_string();
+        let bare = key.name().as_str().to_string();
 
         match symbol {
             Symbol::Class(c) => {
@@ -150,7 +150,7 @@ fn expand_function(
     out: &mut Vec<(LeafPath, EmittedSymbol, SortKey)>,
 ) {
     let fqn_root = key.to_string();
-    let bare = bare_callable_name(key.name.as_str());
+    let bare = bare_callable_name(key.name().as_str());
     let func_generic_params: Vec<String> = f
         .generic_params
         .iter()
@@ -193,13 +193,13 @@ fn collect_raises_names(throws: Option<&baml_codegen_types::Ty>) -> Vec<String> 
 
     fn walk(ty: &Ty, out: &mut Vec<String>) {
         match ty {
-            Ty::Class(name, _) | Ty::Enum(name) | Ty::TypeAlias(name) => {
-                let n = name.name.as_str().to_string();
+            Ty::Class(name, _, _) | Ty::Enum(name, _) | Ty::TypeAlias(name, _) => {
+                let n = name.name().as_str().to_string();
                 if !out.contains(&n) {
                     out.push(n);
                 }
             }
-            Ty::Union(members) => members.iter().for_each(|m| walk(m, out)),
+            Ty::Union(members, _) => members.iter().for_each(|m| walk(m, out)),
             _ => {}
         }
     }

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/leaf.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/leaf.rs
@@ -1068,7 +1068,20 @@ mod tests {
             vec![class_sym(
                 "Resume",
                 name("user", &["lorem"], "Resume"),
-                vec![("name", Ty::String), ("age", Ty::Int)],
+                vec![
+                    (
+                        "name",
+                        Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    ),
+                    (
+                        "age",
+                        Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    ),
+                ],
             )],
         );
         let ts = render_index_ts(&b, &BTreeSet::new(), false, TEST_RUNTIME_PACKAGE);
@@ -1102,15 +1115,29 @@ mod tests {
                     "extract",
                     "user.lorem.extract",
                     SyncAsync::Sync,
-                    vec![("text", Ty::String)],
-                    Ty::Int,
+                    vec![(
+                        "text",
+                        Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    )],
+                    Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 ),
                 func_sym(
                     "extract_async",
                     "user.lorem.extract",
                     SyncAsync::Async,
-                    vec![("text", Ty::String)],
-                    Ty::Int,
+                    vec![(
+                        "text",
+                        Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    )],
+                    Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 ),
             ],
         );
@@ -1129,23 +1156,35 @@ mod tests {
                 "user.lorem.extract",
                 SyncAsync::Sync,
                 vec![
-                    ("arg0", Ty::Int, None),
+                    (
+                        "arg0",
+                        Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                        None,
+                    ),
                     (
                         "default",
-                        Ty::Int,
+                        Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                         Some(FunctionArgumentDefault::Literal(DefaultLiteral::Scalar(
                             Literal::Int(1),
                         ))),
                     ),
                     (
                         "not-valid",
-                        Ty::String,
+                        Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                         Some(FunctionArgumentDefault::Literal(DefaultLiteral::Scalar(
                             Literal::String("x".to_string()),
                         ))),
                     ),
                 ],
-                Ty::Int,
+                Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
             )],
         );
         let ts = render_index_ts(&b, &BTreeSet::new(), false, TEST_RUNTIME_PACKAGE);
@@ -1162,7 +1201,14 @@ mod tests {
             vec![class_sym(
                 "Holder",
                 name("user", &["consumer"], "Holder"),
-                vec![("r", Ty::Class(name("user", &["lorem"], "Resume"), vec![]))],
+                vec![(
+                    "r",
+                    Ty::Class(
+                        name("user", &["lorem"], "Resume"),
+                        vec![],
+                        baml_base::TyAttr::EMPTY,
+                    ),
+                )],
             )],
         );
         let ts = render_index_ts(&b, &BTreeSet::new(), false, TEST_RUNTIME_PACKAGE);
@@ -1207,14 +1253,22 @@ mod tests {
                     "boundary.id",
                     SyncAsync::Sync,
                     vec![],
-                    Ty::Class(name("boundary", &[], "LocalId"), vec![]),
+                    Ty::Class(
+                        name("boundary", &[], "LocalId"),
+                        vec![],
+                        baml_base::TyAttr::EMPTY,
+                    ),
                 ),
                 func_sym(
                     "id_async",
                     "boundary.id",
                     SyncAsync::Async,
                     vec![],
-                    Ty::Class(name("boundary", &[], "LocalId"), vec![]),
+                    Ty::Class(
+                        name("boundary", &[], "LocalId"),
+                        vec![],
+                        baml_base::TyAttr::EMPTY,
+                    ),
                 ),
                 class_sym("LocalId", name("boundary", &[], "LocalId"), vec![]),
             ],
@@ -1243,7 +1297,9 @@ mod tests {
                 "user.make_foo",
                 SyncAsync::Sync,
                 vec![],
-                Ty::Int,
+                Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
             )],
         );
         let mut kids = BTreeSet::new();

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/lib.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/lib.rs
@@ -289,10 +289,14 @@ mod tests {
             arguments: vec![FunctionArgument {
                 name: BaseName::new("x"),
                 docstring: None,
-                ty: Ty::Int,
+                ty: Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 default: None,
             }],
-            return_type: Ty::Int,
+            return_type: Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
             throws: None,
             watchers: Vec::new(),
             origin: origin(span),

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/routing.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/routing.rs
@@ -84,7 +84,7 @@ pub(crate) fn route_class_ref(name: &Name) -> LeafPath {
 fn route_inner(name: &Name) -> LeafPath {
     let mut segs: Vec<String> = Vec::new();
 
-    match name.pkg.as_str() {
+    match name.package().as_str() {
         "user" => {}
         "baml" => segs.push("baml".to_string()),
         other => {
@@ -93,7 +93,7 @@ fn route_inner(name: &Name) -> LeafPath {
         }
     }
 
-    for seg in &name.namespace_path {
+    for seg in name.namespace() {
         segs.push(sanitize_module_segment(seg.as_str()));
     }
 

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
@@ -56,7 +56,8 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
         Ty::Null { .. } => TranslatedType::bare("null"),
         Ty::Uint8Array { .. } => TranslatedType::bare("Uint8Array"),
         Ty::BuiltinUnknown { .. } | Ty::Interface(..) => TranslatedType::bare("unknown"),
-        Ty::Void { .. } | Ty::Never { .. } => TranslatedType::bare("null"),
+        Ty::Void { .. } => TranslatedType::bare("null"),
+        Ty::Never { .. } => TranslatedType::bare("never"),
         // `_BamlHandle` is the runtime opaque-handle type; Phase 4 emits the
         // `import type { BamlHandle as _BamlHandle }` when this token appears.
         Ty::RustType { .. } => TranslatedType::bare("_BamlHandle"),
@@ -148,7 +149,13 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
             }
             result
         }
-        Ty::Enum(name, _) | Ty::EnumVariant(name, _, _) => render_name_ref(name, ctx),
+        Ty::Enum(name, _) => render_name_ref(name, ctx),
+        Ty::EnumVariant(name, variant, _) => {
+            let mut result = render_name_ref(name, ctx);
+            result.expr.push('.');
+            result.expr.push_str(variant.as_str());
+            result
+        }
         Ty::TypeAlias(name, _) => render_name_ref(name, ctx),
         Ty::TypeVar(name, _) => TranslatedType::bare(name.as_str().to_string()),
 
@@ -291,6 +298,9 @@ mod tests {
     }
     fn enum_ty(name: Name) -> Ty {
         Ty::Enum(name, baml_base::TyAttr::EMPTY)
+    }
+    fn enum_variant_ty(name: Name, variant: &str) -> Ty {
+        Ty::EnumVariant(name, BaseName::new(variant), baml_base::TyAttr::EMPTY)
     }
     fn alias_ty(name: Name) -> Ty {
         Ty::TypeAlias(name, baml_base::TyAttr::EMPTY)
@@ -485,6 +495,15 @@ mod tests {
                 },
                 ctx: ctx(&[]),
                 expected_expr: "null",
+                expected_imports: &[],
+            },
+            Case {
+                label: "never",
+                ty: Ty::Never {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                ctx: ctx(&[]),
+                expected_expr: "never",
                 expected_imports: &[],
             },
             Case {
@@ -736,6 +755,13 @@ mod tests {
                 ty: enum_ty(name("user", &["ipsum"], "Sentiment")),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "ipsum.Sentiment",
+                expected_imports: &[&["ipsum"]],
+            },
+            Case {
+                label: "enum_variant_cross_leaf",
+                ty: enum_variant_ty(name("user", &["ipsum"], "Status"), "Active"),
+                ctx: ctx(&["lorem"]),
+                expected_expr: "ipsum.Status.Active",
                 expected_imports: &[&["ipsum"]],
             },
             Case {

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
@@ -80,10 +80,10 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
         Ty::Media(MediaKind::Generic, _) => TranslatedType::bare("unknown"),
 
         Ty::List(inner, _) => {
+            let needs_parentheses = matches!(inner.as_ref(), Ty::Union(..) | Ty::Function { .. });
             let inner = translate_ty(inner, ctx);
-            // Postfix `[]` binds tighter than `|`, so a union/optional element
-            // must be parenthesized: `(string | null)[]`.
-            let elem = if inner.expr.contains(" | ") {
+            // Postfix `[]` binds tighter than unions and function arrows.
+            let elem = if needs_parentheses {
                 format!("({})", inner.expr)
             } else {
                 inner.expr
@@ -118,7 +118,11 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
                 .map(|item| {
                     let t = translate_ty(item, ctx);
                     imports.extend(t.imports);
-                    t.expr
+                    if matches!(item, Ty::Function { .. }) {
+                        format!("({})", t.expr)
+                    } else {
+                        t.expr
+                    }
                 })
                 .collect();
             TranslatedType {
@@ -624,6 +628,18 @@ mod tests {
                 expected_imports: &[],
             },
             Case {
+                label: "list_callback",
+                ty: list(boxed(callable(
+                    Vec::new(),
+                    boxed(Ty::Bool {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                ))),
+                ctx: ctx(&[]),
+                expected_expr: "(() => boolean)[]",
+                expected_imports: &[],
+            },
+            Case {
                 label: "optional_list_string",
                 ty: union(vec![
                     list(boxed(Ty::String {
@@ -667,6 +683,23 @@ mod tests {
                 ]),
                 ctx: ctx(&[]),
                 expected_expr: "number | string | boolean",
+                expected_imports: &[],
+            },
+            Case {
+                label: "nullable_callback",
+                ty: union(vec![
+                    callable(
+                        Vec::new(),
+                        boxed(Ty::Bool {
+                            attr: baml_base::TyAttr::EMPTY,
+                        }),
+                    ),
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]),
+                ctx: ctx(&[]),
+                expected_expr: "(() => boolean) | null",
                 expected_imports: &[],
             },
             // ── Name refs (same / cross leaf) ──

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
@@ -48,46 +48,38 @@ impl TranslatedType {
 
 pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
     match ty {
-        Ty::Int => TranslatedType::bare("number"),
-        Ty::Bigint => TranslatedType::bare("bigint"),
-        Ty::Float => TranslatedType::bare("number"),
-        Ty::String => TranslatedType::bare("string"),
-        Ty::Bool => TranslatedType::bare("boolean"),
-        Ty::Null => TranslatedType::bare("null"),
-        Ty::Uint8Array => TranslatedType::bare("Uint8Array"),
-        Ty::BuiltinUnknown => TranslatedType::bare("unknown"),
-        Ty::Unit => TranslatedType::bare("null"),
-        Ty::BamlOptions => {
-            // `baml.Options` lives in the `baml` namespace; record the import.
-            let mut imports = BTreeSet::new();
-            imports.insert(LeafPath {
-                segments: vec!["baml".to_string()],
-            });
-            TranslatedType {
-                expr: "baml.Options".to_string(),
-                imports,
-            }
-        }
+        Ty::Int { .. } => TranslatedType::bare("number"),
+        Ty::Bigint { .. } => TranslatedType::bare("bigint"),
+        Ty::Float { .. } => TranslatedType::bare("number"),
+        Ty::String { .. } => TranslatedType::bare("string"),
+        Ty::Bool { .. } => TranslatedType::bare("boolean"),
+        Ty::Null { .. } => TranslatedType::bare("null"),
+        Ty::Uint8Array { .. } => TranslatedType::bare("Uint8Array"),
+        Ty::BuiltinUnknown { .. } | Ty::Interface(..) => TranslatedType::bare("unknown"),
+        Ty::Void { .. } | Ty::Never { .. } => TranslatedType::bare("null"),
         // `_BamlHandle` is the runtime opaque-handle type; Phase 4 emits the
         // `import type { BamlHandle as _BamlHandle }` when this token appears.
-        Ty::RustType => TranslatedType::bare("_BamlHandle"),
+        Ty::RustType { .. } => TranslatedType::bare("_BamlHandle"),
+        Ty::Type { .. } | Ty::Resource { .. } | Ty::PromptAst { .. } | Ty::Future(..) => {
+            TranslatedType::bare("unknown")
+        }
 
-        Ty::Literal(Literal::Int(value)) => TranslatedType::bare(format!("{value}")),
+        Ty::Literal(Literal::Int(value), ..) => TranslatedType::bare(format!("{value}")),
         // `bigint` literal types use the `n` suffix in TypeScript: `42n`.
-        Ty::Literal(Literal::Bigint(value)) => TranslatedType::bare(format!("{value}n")),
-        Ty::Literal(Literal::String(value)) => TranslatedType::bare(ts_string(value)),
-        Ty::Literal(Literal::Bool(true)) => TranslatedType::bare("true"),
-        Ty::Literal(Literal::Bool(false)) => TranslatedType::bare("false"),
+        Ty::Literal(Literal::Bigint(value), ..) => TranslatedType::bare(format!("{value}n")),
+        Ty::Literal(Literal::String(value), ..) => TranslatedType::bare(ts_string(value)),
+        Ty::Literal(Literal::Bool(true), ..) => TranslatedType::bare("true"),
+        Ty::Literal(Literal::Bool(false), ..) => TranslatedType::bare("false"),
         // Float literals have no TS literal-type form; widen to `number`.
-        Ty::Literal(Literal::Float(_)) => TranslatedType::bare("number"),
+        Ty::Literal(Literal::Float(_), ..) => TranslatedType::bare("number"),
 
-        Ty::Media(MediaKind::Image) => media_ref("Image", ctx),
-        Ty::Media(MediaKind::Audio) => media_ref("Audio", ctx),
-        Ty::Media(MediaKind::Video) => media_ref("Video", ctx),
-        Ty::Media(MediaKind::Pdf) => media_ref("Pdf", ctx),
-        Ty::Media(MediaKind::Generic) => TranslatedType::bare("unknown"),
+        Ty::Media(MediaKind::Image, _) => media_ref("Image", ctx),
+        Ty::Media(MediaKind::Audio, _) => media_ref("Audio", ctx),
+        Ty::Media(MediaKind::Video, _) => media_ref("Video", ctx),
+        Ty::Media(MediaKind::Pdf, _) => media_ref("Pdf", ctx),
+        Ty::Media(MediaKind::Generic, _) => TranslatedType::bare("unknown"),
 
-        Ty::List(inner) => {
+        Ty::List(inner, _) => {
             let inner = translate_ty(inner, ctx);
             // Postfix `[]` binds tighter than `|`, so a union/optional element
             // must be parenthesized: `(string | null)[]`.
@@ -101,7 +93,7 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
                 imports: inner.imports,
             }
         }
-        Ty::Map { key, value } => {
+        Ty::Map { key, value, .. } => {
             let key = translate_ty(key, ctx);
             let value = translate_ty(value, ctx);
             let mut imports = key.imports;
@@ -119,7 +111,7 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
             };
             TranslatedType { expr, imports }
         }
-        Ty::Union(items) => {
+        Ty::Union(items, _) => {
             let mut imports = BTreeSet::new();
             let parts: Vec<String> = items
                 .iter()
@@ -135,7 +127,7 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
             }
         }
 
-        Ty::Class(name, args) => {
+        Ty::Class(name, args, _) => {
             let mut result = render_name_ref(name, ctx);
             if !args.is_empty() {
                 let mut arg_imports = BTreeSet::new();
@@ -152,11 +144,11 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
             }
             result
         }
-        Ty::Enum(name) => render_name_ref(name, ctx),
-        Ty::TypeAlias(name) => render_name_ref(name, ctx),
-        Ty::TypeVar(name) => TranslatedType::bare(name.as_str().to_string()),
+        Ty::Enum(name, _) | Ty::EnumVariant(name, _, _) => render_name_ref(name, ctx),
+        Ty::TypeAlias(name, _) => render_name_ref(name, ctx),
+        Ty::TypeVar(name, _) => TranslatedType::bare(name.as_str().to_string()),
 
-        Ty::Callable { params, ret } => {
+        Ty::Function { params, ret, .. } => {
             let ret_t = translate_ty(ret, ctx);
             let mut imports = ret_t.imports;
             // Required params stay positional; optional params are grouped into
@@ -236,7 +228,7 @@ pub(crate) const ROOT_ALIAS: &str = "_bamlRoot";
 ///   `LeafPath` in `imports`.
 fn render_name_ref(name: &Name, ctx: &TranslateCtx) -> TranslatedType {
     let routed = route_class_ref(name);
-    let ident = name.name.as_str();
+    let ident = name.name().as_str();
     if routed == ctx.current_leaf {
         return TranslatedType::bare(ident.to_string());
     }
@@ -290,6 +282,47 @@ mod tests {
             BaseName::new(bare_name),
         )
     }
+    fn class_ty(name: Name, args: Vec<Ty>) -> Ty {
+        Ty::Class(name, args, baml_base::TyAttr::EMPTY)
+    }
+    fn enum_ty(name: Name) -> Ty {
+        Ty::Enum(name, baml_base::TyAttr::EMPTY)
+    }
+    fn alias_ty(name: Name) -> Ty {
+        Ty::TypeAlias(name, baml_base::TyAttr::EMPTY)
+    }
+    fn type_var(name: BaseName) -> Ty {
+        Ty::TypeVar(name, baml_base::TyAttr::EMPTY)
+    }
+    fn list(inner: Box<Ty>) -> Ty {
+        Ty::List(inner, baml_base::TyAttr::EMPTY)
+    }
+    fn union(members: Vec<Ty>) -> Ty {
+        Ty::Union(members, baml_base::TyAttr::EMPTY)
+    }
+    fn media(kind: MediaKind) -> Ty {
+        Ty::Media(kind, baml_base::TyAttr::EMPTY)
+    }
+    fn literal(value: Literal) -> Ty {
+        Ty::Literal(
+            value,
+            baml_codegen_types::Freshness::Regular,
+            baml_base::TyAttr::EMPTY,
+        )
+    }
+    fn baml_options() -> Ty {
+        class_ty(name("baml", &[], "Options"), Vec::new())
+    }
+    fn callable(params: Vec<baml_codegen_types::CallableParam>, ret: Box<Ty>) -> Ty {
+        Ty::Function {
+            params,
+            ret,
+            throws: Box::new(Ty::Never {
+                attr: baml_base::TyAttr::EMPTY,
+            }),
+            attr: baml_base::TyAttr::EMPTY,
+        }
+    }
     fn callable_param(ty: Ty) -> baml_codegen_types::CallableParam {
         baml_codegen_types::CallableParam {
             name: None,
@@ -308,27 +341,33 @@ mod tests {
     /// Forces this test file to be updated whenever a `Ty` variant is added.
     fn check_exhaustive(ty: &Ty) {
         match ty {
-            Ty::Int
-            | Ty::Bigint
-            | Ty::Float
-            | Ty::String
-            | Ty::Bool
-            | Ty::Null
-            | Ty::Literal(_)
-            | Ty::Uint8Array
-            | Ty::Media(_)
-            | Ty::Class(_, _)
-            | Ty::Enum(_)
-            | Ty::TypeAlias(_)
-            | Ty::TypeVar(_)
-            | Ty::List(_)
+            Ty::Int { .. }
+            | Ty::Bigint { .. }
+            | Ty::Float { .. }
+            | Ty::String { .. }
+            | Ty::Bool { .. }
+            | Ty::Null { .. }
+            | Ty::Literal(..)
+            | Ty::Uint8Array { .. }
+            | Ty::Media(..)
+            | Ty::Class(..)
+            | Ty::Interface(..)
+            | Ty::Enum(..)
+            | Ty::EnumVariant(..)
+            | Ty::TypeAlias(..)
+            | Ty::TypeVar(..)
+            | Ty::List(..)
             | Ty::Map { .. }
-            | Ty::Union(_)
-            | Ty::BuiltinUnknown
-            | Ty::Callable { .. }
-            | Ty::Unit
-            | Ty::BamlOptions
-            | Ty::RustType => {}
+            | Ty::Union(..)
+            | Ty::BuiltinUnknown { .. }
+            | Ty::Function { .. }
+            | Ty::Future(..)
+            | Ty::Void { .. }
+            | Ty::Never { .. }
+            | Ty::RustType { .. }
+            | Ty::Type { .. }
+            | Ty::Resource { .. }
+            | Ty::PromptAst { .. } => {}
         }
     }
 
@@ -360,82 +399,102 @@ mod tests {
 
     #[test]
     fn translate_ty_matrix() {
-        let cls = |pkg, ns: &[&str], n| Ty::Class(name(pkg, ns, n), vec![]);
+        let cls = |pkg, ns: &[&str], n| class_ty(name(pkg, ns, n), vec![]);
         let cases: Vec<Case> = vec![
             // ── Primitives ──
             Case {
                 label: "int",
-                ty: Ty::Int,
+                ty: Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "number",
                 expected_imports: &[],
             },
             Case {
                 label: "bigint",
-                ty: Ty::Bigint,
+                ty: Ty::Bigint {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "bigint",
                 expected_imports: &[],
             },
             Case {
                 label: "float",
-                ty: Ty::Float,
+                ty: Ty::Float {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "number",
                 expected_imports: &[],
             },
             Case {
                 label: "string",
-                ty: Ty::String,
+                ty: Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "string",
                 expected_imports: &[],
             },
             Case {
                 label: "bool",
-                ty: Ty::Bool,
+                ty: Ty::Bool {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "boolean",
                 expected_imports: &[],
             },
             Case {
                 label: "null",
-                ty: Ty::Null,
+                ty: Ty::Null {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "null",
                 expected_imports: &[],
             },
             Case {
                 label: "uint8array",
-                ty: Ty::Uint8Array,
+                ty: Ty::Uint8Array {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "Uint8Array",
                 expected_imports: &[],
             },
             Case {
                 label: "builtin_unknown",
-                ty: Ty::BuiltinUnknown,
+                ty: Ty::BuiltinUnknown {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "unknown",
                 expected_imports: &[],
             },
             Case {
                 label: "unit",
-                ty: Ty::Unit,
+                ty: Ty::Void {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "null",
                 expected_imports: &[],
             },
             Case {
                 label: "baml_options",
-                ty: Ty::BamlOptions,
+                ty: baml_options(),
                 ctx: ctx(&[]),
                 expected_expr: "baml.Options",
                 expected_imports: &[&["baml"]],
             },
             Case {
                 label: "rust_type",
-                ty: Ty::RustType,
+                ty: Ty::RustType {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
                 ctx: ctx(&[]),
                 expected_expr: "_BamlHandle",
                 expected_imports: &[],
@@ -443,42 +502,42 @@ mod tests {
             // ── Literals ──
             Case {
                 label: "lit_int",
-                ty: Ty::Literal(Literal::Int(42)),
+                ty: literal(Literal::Int(42)),
                 ctx: ctx(&[]),
                 expected_expr: "42",
                 expected_imports: &[],
             },
             Case {
                 label: "lit_bigint",
-                ty: Ty::Literal(Literal::Bigint(42i64.into())),
+                ty: literal(Literal::Bigint(42i64.into())),
                 ctx: ctx(&[]),
                 expected_expr: "42n",
                 expected_imports: &[],
             },
             Case {
                 label: "lit_string",
-                ty: Ty::Literal(Literal::String("hi \"x\"".into())),
+                ty: literal(Literal::String("hi \"x\"".into())),
                 ctx: ctx(&[]),
                 expected_expr: "\"hi \\\"x\\\"\"",
                 expected_imports: &[],
             },
             Case {
                 label: "lit_true",
-                ty: Ty::Literal(Literal::Bool(true)),
+                ty: literal(Literal::Bool(true)),
                 ctx: ctx(&[]),
                 expected_expr: "true",
                 expected_imports: &[],
             },
             Case {
                 label: "lit_false",
-                ty: Ty::Literal(Literal::Bool(false)),
+                ty: literal(Literal::Bool(false)),
                 ctx: ctx(&[]),
                 expected_expr: "false",
                 expected_imports: &[],
             },
             Case {
                 label: "lit_float",
-                ty: Ty::Literal(Literal::Float("3.14".into())),
+                ty: literal(Literal::Float("3.14".into())),
                 ctx: ctx(&[]),
                 expected_expr: "number",
                 expected_imports: &[],
@@ -486,42 +545,42 @@ mod tests {
             // ── Media ──
             Case {
                 label: "media_image_from_user",
-                ty: Ty::Media(MediaKind::Image),
+                ty: media(MediaKind::Image),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "baml.media.Image",
                 expected_imports: &[&["baml", "media"]],
             },
             Case {
                 label: "media_audio_from_user",
-                ty: Ty::Media(MediaKind::Audio),
+                ty: media(MediaKind::Audio),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "baml.media.Audio",
                 expected_imports: &[&["baml", "media"]],
             },
             Case {
                 label: "media_video_from_user",
-                ty: Ty::Media(MediaKind::Video),
+                ty: media(MediaKind::Video),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "baml.media.Video",
                 expected_imports: &[&["baml", "media"]],
             },
             Case {
                 label: "media_pdf_from_user",
-                ty: Ty::Media(MediaKind::Pdf),
+                ty: media(MediaKind::Pdf),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "baml.media.Pdf",
                 expected_imports: &[&["baml", "media"]],
             },
             Case {
                 label: "media_image_same_leaf",
-                ty: Ty::Media(MediaKind::Image),
+                ty: media(MediaKind::Image),
                 ctx: ctx(&["baml", "media"]),
                 expected_expr: "Image",
                 expected_imports: &[],
             },
             Case {
                 label: "media_generic",
-                ty: Ty::Media(MediaKind::Generic),
+                ty: media(MediaKind::Generic),
                 ctx: ctx(&[]),
                 expected_expr: "unknown",
                 expected_imports: &[],
@@ -529,28 +588,51 @@ mod tests {
             // ── Containers ──
             Case {
                 label: "optional_string",
-                ty: Ty::Union(vec![Ty::String, Ty::Null]),
+                ty: union(vec![
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]),
                 ctx: ctx(&[]),
                 expected_expr: "string | null",
                 expected_imports: &[],
             },
             Case {
                 label: "list_int",
-                ty: Ty::List(boxed(Ty::Int)),
+                ty: list(boxed(Ty::Int {
+                    attr: baml_base::TyAttr::EMPTY,
+                })),
                 ctx: ctx(&[]),
                 expected_expr: "number[]",
                 expected_imports: &[],
             },
             Case {
                 label: "list_optional_string",
-                ty: Ty::List(boxed(Ty::Union(vec![Ty::String, Ty::Null]))),
+                ty: list(boxed(union(vec![
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]))),
                 ctx: ctx(&[]),
                 expected_expr: "(string | null)[]",
                 expected_imports: &[],
             },
             Case {
                 label: "optional_list_string",
-                ty: Ty::Union(vec![Ty::List(boxed(Ty::String)), Ty::Null]),
+                ty: union(vec![
+                    list(boxed(Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    })),
+                    Ty::Null {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]),
                 ctx: ctx(&[]),
                 expected_expr: "string[] | null",
                 expected_imports: &[],
@@ -558,8 +640,13 @@ mod tests {
             Case {
                 label: "map_string_int",
                 ty: Ty::Map {
-                    key: boxed(Ty::String),
-                    value: boxed(Ty::Int),
+                    key: boxed(Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                    value: boxed(Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                    attr: baml_base::TyAttr::EMPTY,
                 },
                 ctx: ctx(&[]),
                 expected_expr: "{ [key: string]: number }",
@@ -567,7 +654,17 @@ mod tests {
             },
             Case {
                 label: "union_three",
-                ty: Ty::Union(vec![Ty::Int, Ty::String, Ty::Bool]),
+                ty: union(vec![
+                    Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    Ty::Bool {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                ]),
                 ctx: ctx(&[]),
                 expected_expr: "number | string | boolean",
                 expected_imports: &[],
@@ -603,14 +700,14 @@ mod tests {
             },
             Case {
                 label: "enum_cross_leaf",
-                ty: Ty::Enum(name("user", &["ipsum"], "Sentiment")),
+                ty: enum_ty(name("user", &["ipsum"], "Sentiment")),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "ipsum.Sentiment",
                 expected_imports: &[&["ipsum"]],
             },
             Case {
                 label: "alias_cross_leaf",
-                ty: Ty::TypeAlias(name("user", &["aliases"], "Json")),
+                ty: alias_ty(name("user", &["aliases"], "Json")),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "aliases.Json",
                 expected_imports: &[&["aliases"]],
@@ -659,7 +756,7 @@ mod tests {
             },
             Case {
                 label: "typevar",
-                ty: Ty::TypeVar(BaseName::new("T")),
+                ty: type_var(BaseName::new("T")),
                 ctx: ctx(&[]),
                 expected_expr: "T",
                 expected_imports: &[],
@@ -667,23 +764,35 @@ mod tests {
             // ── Generics ──
             Case {
                 label: "generic_same_leaf",
-                ty: Ty::Class(name("user", &["lorem"], "Box"), vec![Ty::Int]),
+                ty: class_ty(
+                    name("user", &["lorem"], "Box"),
+                    vec![Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }],
+                ),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "Box<number>",
                 expected_imports: &[],
             },
             Case {
                 label: "generic_cross_leaf",
-                ty: Ty::Class(name("user", &["lorem"], "Box"), vec![Ty::Int]),
+                ty: class_ty(
+                    name("user", &["lorem"], "Box"),
+                    vec![Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }],
+                ),
                 ctx: ctx(&["ipsum"]),
                 expected_expr: "lorem.Box<number>",
                 expected_imports: &[&["lorem"]],
             },
             Case {
                 label: "generic_list_arg",
-                ty: Ty::Class(
+                ty: class_ty(
                     name("user", &["lorem"], "Box"),
-                    vec![Ty::List(boxed(Ty::Int))],
+                    vec![list(boxed(Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }))],
                 ),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "Box<number[]>",
@@ -691,9 +800,14 @@ mod tests {
             },
             Case {
                 label: "generic_nested",
-                ty: Ty::Class(
+                ty: class_ty(
                     name("user", &["lorem"], "Box"),
-                    vec![Ty::Class(name("user", &["lorem"], "Box"), vec![Ty::Int])],
+                    vec![class_ty(
+                        name("user", &["lorem"], "Box"),
+                        vec![Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        }],
+                    )],
                 ),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "Box<Box<number>>",
@@ -701,9 +815,9 @@ mod tests {
             },
             Case {
                 label: "generic_typevar_arg",
-                ty: Ty::Class(
+                ty: class_ty(
                     name("user", &["lorem"], "Box"),
-                    vec![Ty::TypeVar(BaseName::new("T"))],
+                    vec![type_var(BaseName::new("T"))],
                 ),
                 ctx: ctx(&["lorem"]),
                 expected_expr: "Box<T>",
@@ -712,8 +826,11 @@ mod tests {
             Case {
                 label: "map_typevar_value",
                 ty: Ty::Map {
-                    key: boxed(Ty::String),
-                    value: boxed(Ty::TypeVar(BaseName::new("V"))),
+                    key: boxed(Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                    value: boxed(type_var(BaseName::new("V"))),
+                    attr: baml_base::TyAttr::EMPTY,
                 },
                 ctx: ctx(&[]),
                 expected_expr: "{ [key: string]: V }",
@@ -722,57 +839,93 @@ mod tests {
             // ── Callable ──
             Case {
                 label: "callable_zero",
-                ty: Ty::Callable {
-                    params: vec![],
-                    ret: boxed(Ty::Bool),
-                },
+                ty: callable(
+                    vec![],
+                    boxed(Ty::Bool {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                ),
                 ctx: ctx(&[]),
                 expected_expr: "() => boolean",
                 expected_imports: &[],
             },
             Case {
                 label: "callable_required",
-                ty: Ty::Callable {
-                    params: vec![callable_param(Ty::Int), callable_param(Ty::String)],
-                    ret: boxed(Ty::Bool),
-                },
+                ty: callable(
+                    vec![
+                        callable_param(Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        }),
+                        callable_param(Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        }),
+                    ],
+                    boxed(Ty::Bool {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                ),
                 ctx: ctx(&[]),
                 expected_expr: "(arg0: number, arg1: string) => boolean",
                 expected_imports: &[],
             },
             Case {
                 label: "callable_optional_only",
-                ty: Ty::Callable {
-                    params: vec![optional_callable_param("x", Ty::Int)],
-                    ret: boxed(Ty::Bool),
-                },
+                ty: callable(
+                    vec![optional_callable_param(
+                        "x",
+                        Ty::Int {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    )],
+                    boxed(Ty::Bool {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                ),
                 ctx: ctx(&[]),
                 expected_expr: "($opts?: { x?: number | undefined } | undefined) => boolean",
                 expected_imports: &[],
             },
             Case {
                 label: "callable_required_and_optional",
-                ty: Ty::Callable {
-                    params: vec![
+                ty: callable(
+                    vec![
                         baml_codegen_types::CallableParam {
                             name: Some(BaseName::new("x")),
-                            ty: Ty::Int,
+                            ty: Ty::Int {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
                             mode: CodegenFunctionParamMode::Required,
                         },
-                        optional_callable_param("y", Ty::Int),
+                        optional_callable_param(
+                            "y",
+                            Ty::Int {
+                                attr: baml_base::TyAttr::EMPTY,
+                            },
+                        ),
                     ],
-                    ret: boxed(Ty::String),
-                },
+                    boxed(Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    }),
+                ),
                 ctx: ctx(&[]),
                 expected_expr: "(x: number, $opts?: { y?: number | undefined } | undefined) => string",
                 expected_imports: &[],
             },
             Case {
                 label: "callable_generic_arg",
-                ty: Ty::Callable {
-                    params: vec![callable_param(Ty::List(boxed(Ty::Int)))],
-                    ret: boxed(Ty::Union(vec![Ty::String, Ty::Null])),
-                },
+                ty: callable(
+                    vec![callable_param(list(boxed(Ty::Int {
+                        attr: baml_base::TyAttr::EMPTY,
+                    })))],
+                    boxed(union(vec![
+                        Ty::String {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                        Ty::Null {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    ])),
+                ),
                 ctx: ctx(&[]),
                 expected_expr: "(arg0: number[]) => string | null",
                 expected_imports: &[],


### PR DESCRIPTION
## Summary

Builds the generator-independent codegen type foundation on top of the unified declaration namespace landed in #4047.

- adds `CodegenTy` to the compiler-owned `baml_type` family instead of maintaining a parallel codegen enum
- preserves declared alias identity at public use sites and stores each alias's canonical resolved target on its declaration
- preserves alias chains and terminates safely for recursive aliases
- canonicalizes unions recursively through containers, including flattening nested unions and collapsing repeated `null`
- reuses typed `QualifiedTypeName` values end to end
- resolves aliases before validating map-key legality, so only aliases whose compiler-resolved target is a legal BAML string key are accepted
- migrates the shared symbol pool plus the existing Python and TypeScript consumers without changing their generated type behavior

## Design boundary

`CodegenTy` describes shared, semantically valid BAML types. It deliberately does not encode target languages or generator capability policy.

A BAML-wide rule such as legal map-key types is validated while building the shared symbol pool. Target-dependent representability (for example, whether a generator can emit recursive type aliases directly) should be checked separately using named features such as `RecursiveTypeAliases`, rather than adding language-specific variants or conditions to this IR. The alias symbol retains recursion metadata so that check can be added without reconstructing the type graph.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p baml_type`
- `cargo test -p baml_codegen_types`
- `cargo test -p baml_project client_codegen`
- `cargo test -p sdkgen_typescript_node`
- `cargo test -p sdkgen_python_pydantic2`
- `cargo check -p sdkgen_go`

Coverage includes primitive aliases, alias chains, recursive aliases, nullable aliases, aliases in containers, legal and illegal aliased map keys, repeated/nested null unions, and same alias names in different BAML namespaces.

## Scope audit

No Go generator source, Go CLI/runtime/packaging, `OutputType::Go`, `sdk_import_path`, language-version, CFFI, ABI-header, or wire-fixture changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added canonicalization for code-generation types via a new `CodegenTy` representation.
  * Introduced shared codegen type validation with alias-aware map-key rules.
  * Improved name utilities for stream types and enhanced TypeScript rendering (including `map` support and updated function/union formatting).

* **Bug Fixes**
  * Updated Python and TypeScript SDK generation to match the new type shapes, improving emitted results for interfaces, aliases, `void`/`never`, and precedence.

* **Refactor / Tests**
  * Centralized validation/traversal logic and refreshed internal/SDK tests and fixtures to align with the new representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->