### PR TITLE
perf(cli): mimalloc global allocator + build ariadne SourceCache once per diagnostic batch

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "indicatif",
  "insta",
  "libsui",
+ "mimalloc",
  "object 0.36.3",
  "regex",
  "reqwest",
@@ -4264,6 +4265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,6 +4523,15 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -203,6 +203,7 @@ bytecount = "0.6"
 reqwest = { version = "0.13.1", default-features = false, features = [
   "stream",
 ] }
+mimalloc = { version = "0.1.52" }
 rowan = { version = "0.16" }
 rustls = { version = "0.23.37", default-features = false }
 rustls-pemfile = "2"

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -44,6 +44,7 @@ hex = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
 libsui = { workspace = true }
+mimalloc = { workspace = true }
 object = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking", "json", "rustls" ] }

--- a/baml_language/crates/baml_cli/src/main.rs
+++ b/baml_language/crates/baml_cli/src/main.rs
@@ -5,6 +5,13 @@
 
 use std::io::Write as _;
 
+/// The compiler workload is dominated by small short-lived allocations
+/// (`Ty` trees, `Vec`s, `SmolStr`s): system malloc measured ~35% of
+/// remaining single-threaded CPU in the cold-compile audit. mimalloc
+/// substantially cuts cold `baml check` / `baml build` wall time.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     // TODO: baml_log is disabled for now
     // baml_log::init()?;

--- a/baml_language/crates/baml_compiler_diagnostics/src/render.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/render.rs
@@ -208,7 +208,10 @@ pub fn render_diagnostic(
     config: &RenderConfig,
 ) -> String {
     match config.format {
-        DiagnosticFormat::Ariadne => render_ariadne(diagnostic, sources, file_paths, config.color),
+        DiagnosticFormat::Ariadne => {
+            let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
+            render_ariadne(diagnostic, sources, &mut cache, config.color)
+        }
         DiagnosticFormat::Concise => render_concise(diagnostic, sources, file_paths),
     }
 }
@@ -223,9 +226,20 @@ pub fn render_diagnostics(
     file_paths: &HashMap<FileId, PathBuf>,
     config: &RenderConfig,
 ) -> String {
+    // Build the ariadne source cache ONCE for the whole batch. Constructing
+    // it per diagnostic (each `Source::from` computes a line index for every
+    // file in the project) is quadratic in practice and measurably slows
+    // `baml check` on warning-heavy projects.
+    let mut ariadne_cache = matches!(config.format, DiagnosticFormat::Ariadne)
+        .then(|| SourceCache::new(sources.clone(), file_paths.clone()));
     diagnostics
         .iter()
-        .map(|d| render_diagnostic(d, sources, file_paths, config))
+        .map(|d| match (&config.format, &mut ariadne_cache) {
+            (DiagnosticFormat::Ariadne, Some(cache)) => {
+                render_ariadne(d, sources, cache, config.color)
+            }
+            _ => render_concise(d, sources, file_paths),
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -259,10 +273,13 @@ fn translate_span(span: Span, sources: &HashMap<FileId, String>) -> Span {
 }
 
 /// Render a diagnostic using Ariadne (pretty CLI output).
+///
+/// Takes a pre-built [`SourceCache`] so batch rendering shares one line-index
+/// computation across all diagnostics.
 fn render_ariadne(
     diagnostic: &Diagnostic,
     sources: &HashMap<FileId, String>,
-    file_paths: &HashMap<FileId, PathBuf>,
+    cache: &mut SourceCache,
     color: bool,
 ) -> String {
     // BAML CLI uses lowercase `error:` / `warning:` everywhere (matching
@@ -321,7 +338,7 @@ fn render_ariadne(
         .finish();
 
     // Render to string using SourceCache for proper filename display.
-    let rendered = render_report_to_string(&report, sources, file_paths);
+    let rendered = render_report_to_string(&report, cache);
 
     // See the rant above the `report_kind` match — ariadne paints the
     // `Custom` keyword unconditionally, so `with_color(false)` doesn't
@@ -427,17 +444,10 @@ fn render_concise(
 }
 
 /// Render an ariadne Report to a String using `SourceCache` for proper filename display.
-fn render_report_to_string(
-    report: &Report<'_, Span>,
-    sources: &HashMap<FileId, String>,
-    file_paths: &HashMap<FileId, PathBuf>,
-) -> String {
+fn render_report_to_string(report: &Report<'_, Span>, cache: &mut SourceCache) -> String {
     let mut output = Vec::new();
 
-    // Use SourceCache for proper filename display
-    let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
-
-    report.write(&mut cache, &mut output).unwrap_or_else(|_| {
+    report.write(cache, &mut output).unwrap_or_else(|_| {
         output.clear();
         output.extend_from_slice(b"<error rendering diagnostic>");
     });


### PR DESCRIPTION
Re-lands the `baml_cli` slice of the cold-compile performance audit (#4016, commit c1466f3cc), re-derived against current canary. Two independent changes:

1. **mimalloc as `baml_cli`'s global allocator.** The compiler workload is dominated by small short-lived allocations (`Ty` trees, `Vec`s, `SmolStr`s); system malloc measured ~35% of remaining single-threaded CPU in the original audit.
2. **Build the ariadne `SourceCache` once per diagnostic batch** in `render_diagnostics` instead of once per diagnostic (each `Source::from` computes a line index over every project file), threading it as `&mut` through `render_ariadne` / `render_report_to_string`. Rendered output bytes are unchanged.

## Measurements

CLI wall time on the warning-heavy corpus (`baml check crates/baml_tests/baml_src`, ~100 warnings), disk cache disabled via `BAML_NO_BYTECODE_CACHE=1` + fresh `BAML_CACHE_DIR`, release builds of clean canary (2660b8b9f) vs. this branch, alternated in one hyperfine invocation:

```
Benchmark 1: BEFORE
  Time (mean ± σ):      3.947 s ±  0.587 s    [User: 3.118 s, System: 0.079 s]
  Range (min … max):    3.080 s …  5.032 s    10 runs

Benchmark 2: AFTER
  Time (mean ± σ):      1.304 s ±  0.280 s    [User: 1.182 s, System: 0.037 s]
  Range (min … max):    1.119 s …  2.012 s    10 runs

Summary
  AFTER ran
    3.02 ± 0.79 times faster than BEFORE
```

The benchmark machine was under heavy background load, hence the wide σ; user CPU time (3.12 s → 1.18 s, ~2.6x) is load-independent and consistent across all runs.

## Cache-verify gate (#3924 compatibility)

Cached diagnostics are replayed byte-for-byte on cache hits, so rendered output must not change. Verified with `BAML_CACHE_VERIFY=1` and a fresh `BAML_CACHE_DIR` (cache enabled), two runs each on before/after binaries so the second run replays cached diagnostics:

- no divergence reported, all runs exit 0;
- captured stdout+stderr of before vs. after binaries is **byte-identical** (only the wall-time suffix of the final "Finished checked 77 file(s) in Ns" status line differs between runs);
- run 1 (cold) vs. run 2 (cached replay) output identical for both binaries.

## Tests

- `cargo test --workspace`: passes. (One caveat: three targets initially failed for environmental reasons on the shared bench machine — `pack_e2e` hit ENOSPC while the disk was full, the Python SDK cancellation tests need Python ≥ 3.11 (`ExceptionGroup`, `asyncio.timeout`) and `uv` had picked 3.10, and the TS fixtures were missing `node_modules` after the disk filled up. All three pass after freeing disk / `UV_PYTHON=3.12` / re-running `setup.sh`, with no relation to this change.)
- Targeted re-run on the rebased tip: `baml_cli` (385 tests), `baml_compiler_diagnostics` (18), `baml_project` — all pass.
- Pre-commit hooks (cargo fmt, cargo stow, workspace clippy `-D warnings`) pass.
- No snapshot changes.

## Notes

- Expected **trivial merge conflict with #4038** (in-flight profiling tool), which adds the identical `mimalloc = { version = "0.1.52" }` line to `[workspace.dependencies]`.
- Provenance: #4016 (original audit branch `perf/compiler2-cold-compile`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved cold-start performance for `baml check` and `baml build`.
  * Improved rendering performance when displaying multiple compiler diagnostics.
  * Reduced repeated processing while generating Ariadne-formatted diagnostic output.
* **Bug Fixes**
  * Preserved existing fallback behavior when a diagnostic cannot be rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->