### PR TITLE
refactor(bridge-cffi): add target-neutral Wasm support

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "prost",
  "serde_json",
  "sys_native",
+ "sys_ops",
  "sys_types",
  "thiserror 2.0.18",
  "tokio",

--- a/baml_language/crates/bridge_cffi/Cargo.toml
+++ b/baml_language/crates/bridge_cffi/Cargo.toml
@@ -21,21 +21,24 @@ rustls = [ "sys_native/rustls" ]
 bundle-http = [ "sys_native/bundle-http" ]
 
 [dependencies]
-baml_version = { workspace = true }
-bex_events = { workspace = true }
 bex_project = { workspace = true }
 bridge_ctypes = { workspace = true }
-sys_native = { workspace = true }
-sys_types = { workspace = true }
+sys_ops = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
+prost = { workspace = true }
+thiserror = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+baml_version = { workspace = true }
+bex_events = { workspace = true }
+sys_native = { workspace = true }
+sys_types = { workspace = true }
 libc = { workspace = true }
 once_cell = { workspace = true }
-prost = { workspace = true }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, features = [ "rt", "rt-multi-thread" ] }
 vfs = { workspace = true }
 
 [package.metadata.ci]
-wasm_support = false
+wasm_support = true

--- a/baml_language/crates/bridge_cffi/src/api.rs
+++ b/baml_language/crates/bridge_cffi/src/api.rs
@@ -6,10 +6,11 @@
 
 use bex_project::HostReleaseFn;
 
-use crate::{
-    BamlBridgeInfoV1, Buffer,
+use super::{
+    BamlBridgeInfoV1,
     ffi::{callbacks::CallbackFn, handle::BamlCffiStatus, host_value::HostDispatchFn},
 };
+use crate::Buffer;
 
 /// First version of the shared BAML C API.
 ///

--- a/baml_language/crates/bridge_cffi/src/buffer.rs
+++ b/baml_language/crates/bridge_cffi/src/buffer.rs
@@ -31,3 +31,14 @@ impl Buffer {
         self.len == 0
     }
 }
+
+/// Free a buffer returned by an exported bridge function.
+#[unsafe(no_mangle)]
+pub extern "C" fn free_buffer(buf: Buffer) {
+    if !buf.ptr.is_null() {
+        unsafe {
+            // Buffer is created from a boxed slice, so length and capacity match.
+            let _ = Vec::from_raw_parts(buf.ptr as *mut u8, buf.len, buf.len);
+        }
+    }
+}

--- a/baml_language/crates/bridge_cffi/src/ffi/objects.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/objects.rs
@@ -1,18 +1,5 @@
 //! Object operations FFI entry points.
 
-use crate::Buffer;
-
-/// Free a buffer returned by FFI functions.
-#[unsafe(no_mangle)]
-pub extern "C" fn free_buffer(buf: Buffer) {
-    if !buf.ptr.is_null() {
-        unsafe {
-            // Buffer was created from boxed slice, so len == cap
-            let _ = Vec::from_raw_parts(buf.ptr as *mut u8, buf.len, buf.len);
-        }
-    }
-}
-
 /// Flush the event sink. No-op: tracing/event production has been removed.
 #[unsafe(no_mangle)]
 pub extern "C" fn flush_events() {}

--- a/baml_language/crates/bridge_cffi/src/ffi/runtime.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/runtime.rs
@@ -2,9 +2,10 @@
 
 use std::{collections::HashMap, ffi::CStr, panic::AssertUnwindSafe, sync::OnceLock};
 
+use super::super::panic::ffi_safe_ptr;
 use crate::{
     Buffer, initialize_runtime,
-    initialize_runtime_from_bytecode as initialize_runtime_from_bytecode_impl, panic::ffi_safe_ptr,
+    initialize_runtime_from_bytecode as initialize_runtime_from_bytecode_impl,
 };
 
 /// Returns the BAML version as a Buffer containing raw UTF-8 bytes.

--- a/baml_language/crates/bridge_cffi/src/lib.rs
+++ b/baml_language/crates/bridge_cffi/src/lib.rs
@@ -3,119 +3,34 @@
 //! This crate provides the same FFI interface as `engine/language_client_cffi/`
 //! but powered by `bex_engine` instead of `baml-runtime`.
 //!
-//! `lib.rs` is the crate root: it owns global runtime management and the
-//! primary `call_function` / `cancel_function_call` entry points. The
-//! result-encoding logic lives in [`baml_to_host`]; the remaining C-ABI shims
-//! (handles, host values, objects, runtime lifecycle, callbacks) live under
-//! `ffi`.
+//! `lib.rs` defines the platform-neutral bridge surface. Native implementation
+//! details live in `lib_native.rs`, while Wasm implementation details live
+//! in `lib_wasm.rs`.
 
-use std::{
-    collections::HashMap,
-    ffi::CStr,
-    panic::AssertUnwindSafe,
-    sync::{Arc, RwLock},
-};
+#[cfg(not(target_arch = "wasm32"))]
+#[path = "lib_native.rs"]
+mod platform;
+#[cfg(target_arch = "wasm32")]
+#[path = "lib_wasm.rs"]
+mod platform;
+
+use std::sync::Arc;
 
 use bex_project::Bex;
-use bridge_ctypes::{DecodeFromBuffer, HANDLE_TABLE, kwargs_to_bex_values};
-use futures::future::FutureExt;
-use once_cell::sync::OnceCell;
-use sys_native::SysOpsExt;
-use tokio::runtime::Runtime;
 
-pub mod api;
 pub mod baml_to_host;
 pub mod buffer;
-pub mod collector;
 pub mod error;
-mod ffi;
-pub mod host_spans;
-mod panic;
 
-pub use api::{BamlApiV1, baml_get_api_v1};
 pub use baml_to_host::{call_and_encode, error_to_outbound, result_to_outbound};
 pub use bridge_ctypes::baml_bridge;
-pub use buffer::Buffer;
+pub use buffer::{Buffer, free_buffer};
 pub use error::BridgeError;
-pub use ffi::{
-    callbacks::{CallbackFn, register_callback},
-    handle::{
-        __testonly_seed_function_ref, __testonly_seed_generic_media, BamlCffiStatus,
-        baml_handle_clone, baml_handle_release, baml_media_base64, baml_media_file,
-        baml_media_from_base64, baml_media_from_file, baml_media_from_url, baml_media_mime_type,
-        baml_media_url,
-    },
-    host_value::{
-        HostDispatchFn, complete_host_call, register_host_dispatch_callback,
-        register_host_release_callback,
-    },
-    objects::{flush_events, free_buffer},
-    runtime::{
-        BamlBridgeInfoV1, BridgeInfo, BridgeLanguage, create_baml_runtime, destroy_baml_runtime,
-        ensure_version_compatible,
-        initialize_runtime_from_bytecode as initialize_runtime_from_bytecode_ffi,
-        invoke_runtime_cli, register_bridge, register_bridge_ffi, registered_bridge, version,
-    },
-};
+pub use platform::*;
 
-use crate::ffi::callbacks::send_outbound_result_to_callback;
-
-// ============================================================================
-// Global Bex runtime management
-// ============================================================================
-
-/// Global Bex runtime. Uses RwLock to allow replacing the runtime.
-static RUNTIME_INSTANCE: RwLock<Option<Arc<dyn Bex>>> = RwLock::new(None);
-
-/// Global Tokio runtime for async execution.
-static TOKIO_RUNTIME: OnceCell<Arc<Runtime>> = OnceCell::new();
-
-/// Initialize the global Tokio runtime.
-pub fn get_tokio_runtime() -> Result<Arc<Runtime>, BridgeError> {
-    let result = TOKIO_RUNTIME.get_or_try_init(|| {
-        Runtime::new()
-            .map_err(|e| BridgeError::Internal(format!("Failed to create Tokio runtime: {e}")))
-            .map(Arc::new)
-    });
-    result.cloned()
-}
-
-/// Get a clone of the global runtime, or error if not initialized.
+/// Get a clone of the target's global runtime, or error if not initialized.
 pub fn get_runtime() -> Result<Arc<dyn Bex>, BridgeError> {
-    RUNTIME_INSTANCE
-        .read()
-        .map_err(|_| BridgeError::LockPoisoned)?
-        .clone()
-        .ok_or(BridgeError::NotInitialized)
-}
-
-/// Initialize the global runtime from BAML source files.
-///
-/// If a runtime is already initialized, it will be replaced with the new one.
-///
-/// # Arguments
-/// * `root_path` - Root path for BAML files
-/// * `src_files` - Map of filename to content
-pub fn initialize_runtime(
-    root_path: &str,
-    src_files: HashMap<String, String>,
-) -> Result<Arc<dyn Bex>, BridgeError> {
-    let physical_fs = vfs::PhysicalFS::new("/");
-    let vfs_root = vfs::VfsPath::new(physical_fs);
-    let vfs_path = vfs_root
-        .join(root_path)
-        .map_err(|e| bex_project::RuntimeError::Other(e.to_string()))?;
-
-    let files = src_files
-        .into_iter()
-        .map(|(k, v)| (bex_project::FsPath::from_str(k), v))
-        .collect();
-
-    let rt = bex_project::new(vfs_path, bex_project::SysOps::native(), files)?;
-
-    replace_runtime(rt.clone())?;
-
-    Ok(rt)
+    platform::get_runtime()
 }
 
 /// Initialize the global runtime from serialized BAML bytecode.
@@ -124,116 +39,31 @@ pub fn initialize_runtime(
 /// `baml pack` embeds in its pack envelope. Decoding and engine construction
 /// live behind `bex_project::new_from_bytecode` so the bridge stays on the
 /// `bex_project` surface rather than reaching into bex internals.
+pub fn initialize_runtime_from_bytecode_with_sys_ops(
+    bytecode: &[u8],
+    sys_ops: sys_ops::SysOps,
+) -> Result<Arc<dyn Bex>, BridgeError> {
+    let runtime: Arc<dyn Bex> = bex_project::new_from_bytecode(bytecode, sys_ops)?;
+    platform::replace_runtime(runtime.clone())?;
+    Ok(runtime)
+}
+
+/// Initialize the native process-global runtime from serialized BAML bytecode.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn initialize_runtime_from_bytecode(bytecode: &[u8]) -> Result<Arc<dyn Bex>, BridgeError> {
-    let rt: Arc<dyn Bex> = bex_project::new_from_bytecode(bytecode, bex_project::SysOps::native())?;
+    use sys_native::SysOpsExt as _;
 
-    replace_runtime(rt.clone())?;
-
-    Ok(rt)
-}
-
-fn replace_runtime(rt: Arc<dyn Bex>) -> Result<(), BridgeError> {
-    let mut guard = RUNTIME_INSTANCE
-        .write()
-        .map_err(|_| BridgeError::LockPoisoned)?;
-    *guard = Some(rt);
-    Ok(())
-}
-
-// ============================================================================
-// Function call entry points
-// ============================================================================
-
-/// Call a BAML function asynchronously.
-///
-/// Returns immediately after spawning the async task.
-/// Result/error is delivered via the registered callback as a
-/// `BamlOutboundResult` envelope — including pre-call host-boundary failures,
-/// which are synthesized into the envelope via [`error_to_outbound`].
-#[unsafe(no_mangle)]
-pub extern "C" fn call_function(
-    function_name: *const libc::c_char,
-    encoded_args: *const u8,
-    length: usize,
-    id: u32,
-) {
-    if let Err(e) = call_function_inner(function_name, encoded_args, length, id) {
-        // Pre-call failure: synthesize the structured envelope and deliver it
-        // through the one result channel — no separate error path.
-        send_outbound_result_to_callback(id, &error_to_outbound(e));
-    }
-}
-
-fn call_function_inner(
-    function_name: *const libc::c_char,
-    encoded_args: *const u8,
-    length: usize,
-    id: u32,
-) -> Result<(), BridgeError> {
-    use bridge_ctypes::baml_bridge::cffi::CallFunctionArgs;
-
-    let runtime = get_runtime()?;
-
-    if function_name.is_null() {
-        return Err(BridgeError::NullFunctionName);
-    }
-    let func_name = unsafe { CStr::from_ptr(function_name) }
-        .to_str()
-        .map_err(BridgeError::from)?
-        .to_owned();
-
-    let args = if encoded_args.is_null() || length == 0 {
-        CallFunctionArgs::default()
-    } else {
-        unsafe { CallFunctionArgs::from_c_buffer(encoded_args, length) }?
-    };
-    let call_id = decoded_call_id(args.call_id)?;
-    let type_args = bridge_ctypes::proto_ty_args_to_named(&args.type_args)?;
-    let kwargs = kwargs_to_bex_values(args.kwargs, &HANDLE_TABLE)?;
-
-    let call_ctx = function_call_context_builder(call_id).with_type_args(type_args);
-
-    get_tokio_runtime()?.spawn(async move {
-        // `call_and_encode` already wraps the engine call in its own
-        // `catch_unwind` and turns a call-time panic into a `SdkPanic`
-        // envelope. The outer `catch_unwind` here is the C-ABI safety net for
-        // a panic during *encoding* — which must not cross the C boundary.
-        let encoded = AssertUnwindSafe(call_and_encode(
-            runtime,
-            func_name,
-            kwargs.into(),
-            call_ctx.build(),
-        ))
-        .catch_unwind()
-        .await;
-
-        let bytes = match encoded {
-            Ok(bytes) => bytes,
-            // An encode-stage panic also rides the envelope as an `SdkPanic`,
-            // uniform with every other result.
-            Err(panic_info) => baml_to_host::panic_to_outbound(panic_info.as_ref()),
-        };
-        send_outbound_result_to_callback(id, &bytes);
-    });
-
-    Ok(())
-}
-
-fn decoded_call_id(id: u64) -> Result<sys_types::CallId, BridgeError> {
-    if id == 0 {
-        return Err(BridgeError::InvalidCallId);
-    }
-    Ok(sys_types::CallId(id))
+    initialize_runtime_from_bytecode_with_sys_ops(bytecode, sys_ops::SysOps::native())
 }
 
 /// Allocate a new process-unique function-call ID.
 pub fn new_function_call_id() -> u64 {
-    sys_types::CallId::next().0
+    bex_project::CallId::next().0
 }
 
 /// Build a function-call context builder for a CFFI-owned call id.
 pub fn function_call_context_builder(
-    call_id: sys_types::CallId,
+    call_id: bex_project::CallId,
 ) -> bex_project::FunctionCallContextBuilder {
     bex_project::FunctionCallContextBuilder::new(call_id)
 }
@@ -248,7 +78,7 @@ pub fn cancel_function_call_by_id(id: u64) -> bool {
     get_runtime()
         .and_then(|runtime| {
             runtime
-                .cancel_function_call(sys_types::CallId(id))
+                .cancel_function_call(bex_project::CallId(id))
                 .map_err(BridgeError::from)
         })
         .is_ok()

--- a/baml_language/crates/bridge_cffi/src/lib_native.rs
+++ b/baml_language/crates/bridge_cffi/src/lib_native.rs
@@ -1,0 +1,183 @@
+//! Native runtime and C ABI implementation for `bridge_cffi`.
+
+use std::{
+    collections::HashMap,
+    ffi::CStr,
+    panic::AssertUnwindSafe,
+    sync::{Arc, RwLock},
+};
+
+use bex_project::Bex;
+use bridge_ctypes::{DecodeFromBuffer, HANDLE_TABLE, kwargs_to_bex_values};
+use futures::future::FutureExt;
+use once_cell::sync::OnceCell;
+use sys_native::SysOpsExt;
+use tokio::runtime::Runtime;
+
+use crate::{
+    BridgeError, baml_to_host, call_and_encode, error_to_outbound, function_call_context_builder,
+};
+
+#[path = "api.rs"]
+pub mod api;
+#[path = "collector.rs"]
+pub mod collector;
+#[path = "ffi/mod.rs"]
+mod ffi;
+#[path = "host_spans.rs"]
+pub mod host_spans;
+#[path = "panic.rs"]
+mod panic;
+
+pub use api::{BamlApiV1, baml_get_api_v1};
+use ffi::callbacks::send_outbound_result_to_callback;
+pub use ffi::{
+    callbacks::{CallbackFn, register_callback},
+    handle::{
+        __testonly_seed_function_ref, __testonly_seed_generic_media, BamlCffiStatus,
+        baml_handle_clone, baml_handle_release, baml_media_base64, baml_media_file,
+        baml_media_from_base64, baml_media_from_file, baml_media_from_url, baml_media_mime_type,
+        baml_media_url,
+    },
+    host_value::{
+        HostDispatchFn, complete_host_call, register_host_dispatch_callback,
+        register_host_release_callback,
+    },
+    objects::flush_events,
+    runtime::{
+        BamlBridgeInfoV1, BridgeInfo, BridgeLanguage, create_baml_runtime, destroy_baml_runtime,
+        ensure_version_compatible,
+        initialize_runtime_from_bytecode as initialize_runtime_from_bytecode_ffi,
+        invoke_runtime_cli, register_bridge, register_bridge_ffi, registered_bridge, version,
+    },
+};
+
+/// Global Bex runtime. Uses RwLock to allow replacing the runtime.
+static RUNTIME_INSTANCE: RwLock<Option<Arc<dyn Bex>>> = RwLock::new(None);
+
+/// Global Tokio runtime for async execution.
+static TOKIO_RUNTIME: OnceCell<Arc<Runtime>> = OnceCell::new();
+
+/// Initialize the global Tokio runtime.
+pub fn get_tokio_runtime() -> Result<Arc<Runtime>, BridgeError> {
+    let result = TOKIO_RUNTIME.get_or_try_init(|| {
+        Runtime::new()
+            .map_err(|e| BridgeError::Internal(format!("Failed to create Tokio runtime: {e}")))
+            .map(Arc::new)
+    });
+    result.cloned()
+}
+
+pub(crate) fn get_runtime() -> Result<Arc<dyn Bex>, BridgeError> {
+    RUNTIME_INSTANCE
+        .read()
+        .map_err(|_| BridgeError::LockPoisoned)?
+        .clone()
+        .ok_or(BridgeError::NotInitialized)
+}
+
+/// Initialize the global runtime from BAML source files.
+///
+/// If a runtime is already initialized, it will be replaced with the new one.
+///
+/// # Arguments
+/// * `root_path` - Root path for BAML files
+/// * `src_files` - Map of filename to content
+pub fn initialize_runtime(
+    root_path: &str,
+    src_files: HashMap<String, String>,
+) -> Result<Arc<dyn Bex>, BridgeError> {
+    let physical_fs = vfs::PhysicalFS::new("/");
+    let vfs_root = vfs::VfsPath::new(physical_fs);
+    let vfs_path = vfs_root
+        .join(root_path)
+        .map_err(|e| bex_project::RuntimeError::Other(e.to_string()))?;
+
+    let files = src_files
+        .into_iter()
+        .map(|(k, v)| (bex_project::FsPath::from_str(k), v))
+        .collect();
+
+    let rt = bex_project::new(vfs_path, bex_project::SysOps::native(), files)?;
+    replace_runtime(rt.clone())?;
+    Ok(rt)
+}
+
+pub(crate) fn replace_runtime(rt: Arc<dyn Bex>) -> Result<(), BridgeError> {
+    let mut guard = RUNTIME_INSTANCE
+        .write()
+        .map_err(|_| BridgeError::LockPoisoned)?;
+    *guard = Some(rt);
+    Ok(())
+}
+
+/// Call a BAML function asynchronously.
+///
+/// Returns immediately after spawning the async task. Result/error is delivered
+/// via the registered callback as a `BamlOutboundResult` envelope.
+#[unsafe(no_mangle)]
+pub extern "C" fn call_function(
+    function_name: *const libc::c_char,
+    encoded_args: *const u8,
+    length: usize,
+    id: u32,
+) {
+    if let Err(e) = call_function_inner(function_name, encoded_args, length, id) {
+        send_outbound_result_to_callback(id, &error_to_outbound(e));
+    }
+}
+
+fn call_function_inner(
+    function_name: *const libc::c_char,
+    encoded_args: *const u8,
+    length: usize,
+    id: u32,
+) -> Result<(), BridgeError> {
+    use bridge_ctypes::baml_bridge::cffi::CallFunctionArgs;
+
+    let runtime = get_runtime()?;
+
+    if function_name.is_null() {
+        return Err(BridgeError::NullFunctionName);
+    }
+    let func_name = unsafe { CStr::from_ptr(function_name) }
+        .to_str()
+        .map_err(BridgeError::from)?
+        .to_owned();
+
+    let args = if encoded_args.is_null() || length == 0 {
+        CallFunctionArgs::default()
+    } else {
+        unsafe { CallFunctionArgs::from_c_buffer(encoded_args, length) }?
+    };
+    let call_id = decoded_call_id(args.call_id)?;
+    let type_args = bridge_ctypes::proto_ty_args_to_named(&args.type_args)?;
+    let kwargs = kwargs_to_bex_values(args.kwargs, &HANDLE_TABLE)?;
+    let call_ctx = function_call_context_builder(call_id).with_type_args(type_args);
+
+    get_tokio_runtime()?.spawn(async move {
+        let encoded = AssertUnwindSafe(call_and_encode(
+            runtime,
+            func_name,
+            kwargs.into(),
+            call_ctx.build(),
+        ))
+        .catch_unwind()
+        .await;
+
+        let bytes = match encoded {
+            Ok(bytes) => bytes,
+            Err(panic_info) => baml_to_host::panic_to_outbound(panic_info.as_ref()),
+        };
+        send_outbound_result_to_callback(id, &bytes);
+    });
+
+    Ok(())
+}
+
+fn decoded_call_id(id: u64) -> Result<sys_types::CallId, BridgeError> {
+    if id == 0 {
+        return Err(BridgeError::InvalidCallId);
+    }
+    Ok(sys_types::CallId(id))
+}

--- a/baml_language/crates/bridge_cffi/src/lib_wasm.rs
+++ b/baml_language/crates/bridge_cffi/src/lib_wasm.rs
@@ -1,0 +1,63 @@
+//! Wasm runtime implementation for `bridge_cffi`.
+
+use std::{cell::RefCell, sync::Arc};
+
+use bex_project::{Bex, BexArgs};
+use bridge_ctypes::{HANDLE_TABLE, kwargs_to_bex_values};
+use prost::Message;
+
+use crate::{BridgeError, call_and_encode, error_to_outbound, function_call_context_builder};
+
+thread_local! {
+    static RUNTIME: RefCell<Option<Arc<dyn Bex>>> = RefCell::new(None);
+}
+
+pub(crate) fn replace_runtime(runtime: Arc<dyn Bex>) -> Result<(), BridgeError> {
+    RUNTIME.with(|slot| {
+        *slot.borrow_mut() = Some(runtime);
+    });
+    Ok(())
+}
+
+pub(crate) fn get_runtime() -> Result<Arc<dyn Bex>, BridgeError> {
+    RUNTIME.with(|slot| slot.borrow().clone().ok_or(BridgeError::NotInitialized))
+}
+
+struct DecodedCall {
+    runtime: Arc<dyn Bex>,
+    function_name: String,
+    args: BexArgs,
+    context: bex_project::FunctionCallContext,
+}
+
+fn decode_call(function_name: &str, encoded_args: &[u8]) -> Result<DecodedCall, BridgeError> {
+    use bridge_ctypes::baml_bridge::cffi::CallFunctionArgs;
+
+    let call = CallFunctionArgs::decode(encoded_args).map_err(bridge_ctypes::CtypesError::from)?;
+    if call.call_id == 0 {
+        return Err(BridgeError::InvalidCallId);
+    }
+    let type_args = bridge_ctypes::proto_ty_args_to_named(&call.type_args)?;
+    let kwargs = kwargs_to_bex_values(call.kwargs, &HANDLE_TABLE)?;
+    let context = function_call_context_builder(bex_project::CallId(call.call_id))
+        .with_type_args(type_args)
+        .build();
+    Ok(DecodedCall {
+        runtime: crate::get_runtime()?,
+        function_name: function_name.to_string(),
+        args: kwargs.into(),
+        context,
+    })
+}
+
+pub async fn call_function_in_wasm(function_name: &str, encoded_args: &[u8]) -> Vec<u8> {
+    let call = match decode_call(function_name, encoded_args) {
+        Ok(call) => call,
+        Err(error) => return error_to_outbound(error),
+    };
+    call_and_encode(call.runtime, call.function_name, call.args, call.context).await
+}
+
+pub fn call_function_in_wasm_sync(function_name: &str, encoded_args: &[u8]) -> Vec<u8> {
+    futures::executor::block_on(call_function_in_wasm(function_name, encoded_args))
+}


### PR DESCRIPTION
## Summary

- Split `bridge_cffi` into native and Wasm platform layers while keeping common runtime initialization target-neutral.
- Add `initialize_runtime_from_bytecode_with_sys_ops` so callers can inject platform-specific system operations without introducing a `sys_wasm` dependency into the shared bridge.
- Preserve the native Rust/C ABI, including the versioned bridge registration API now present on `canary`.

## Why

This creates the shared bridge layer required by TypeScript/Web without mixing browser, Workers, or `sys_wasm` behavior into `bridge_cffi`.

## Impact

This is stack 1 of 3 and is based on `canary`; the TypeScript foundation it previously depended on has merged. Native consumers continue using the existing API; Wasm consumers receive the target-neutral entry point used by the next PR.

## Checks

- `mise run stow`
- `mise run fmt`
- `mise run clippy`
- `cargo check -p bridge_cffi`
- `cargo check -p bridge_cffi --target wasm32-unknown-unknown --no-default-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebAssembly support for runtime initialization and function calls.
  * Added native and WASM runtime handling through platform-specific implementations.
  * Added a public buffer-release API for safely freeing returned data.
  * Added support for initializing runtimes with explicit system operations.
  * Improved function-call handling across native and WASM environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->