### PR TITLE
perf(compiler2+cli): re-land #4016 cold-compile optimizations — tracks A, D, E combined

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "indicatif",
  "insta",
  "libsui",
+ "mimalloc",
  "object 0.36.3",
  "regex",
  "reqwest",
@@ -4264,6 +4265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,6 +4523,15 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -203,6 +203,7 @@ bytecount = "0.6"
 reqwest = { version = "0.13.1", default-features = false, features = [
   "stream",
 ] }
+mimalloc = { version = "0.1.52" }
 rowan = { version = "0.16" }
 rustls = { version = "0.23.37", default-features = false }
 rustls-pemfile = "2"

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -44,6 +44,7 @@ hex = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
 libsui = { workspace = true }
+mimalloc = { workspace = true }
 object = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking", "json", "rustls" ] }

--- a/baml_language/crates/baml_cli/src/main.rs
+++ b/baml_language/crates/baml_cli/src/main.rs
@@ -5,6 +5,13 @@
 
 use std::io::Write as _;
 
+/// The compiler workload is dominated by small short-lived allocations
+/// (`Ty` trees, `Vec`s, `SmolStr`s): system malloc measured ~35% of
+/// remaining single-threaded CPU in the cold-compile audit. mimalloc
+/// substantially cuts cold `baml check` / `baml build` wall time.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     // TODO: baml_log is disabled for now
     // baml_log::init()?;

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// A reference to an environment variable found in source code (`env.VAR_NAME`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvVarRef {
     /// The variable name (e.g., `"OPENAI_API_KEY"`).
     pub name: String,

--- a/baml_language/crates/baml_compiler2_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/lib.rs
@@ -98,6 +98,57 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
     files
 }
 
+// ── file_ast ──────────────────────────────────────────────────────────────────
+
+/// The CST → AST lowering output for one file: top-level items plus the
+/// lowering diagnostics and `env.*` references produced along the way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileAst {
+    pub items: Vec<baml_compiler2_ast::Item>,
+    pub diagnostics: Vec<baml_compiler2_ast::LoweringDiagnostic>,
+    pub env_var_refs: Vec<baml_compiler2_ast::EnvVarRef>,
+}
+
+// Safety: `FileAst` holds only plain (non-`'db`) data, so storing it by value
+// is sound. Manual `Update` impl uses `PartialEq` for Salsa early-cutoff.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for FileAst {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// CST → AST lowering for one file, computed once and shared.
+///
+/// Salsa-tracked because several different consumers need a file's AST items
+/// (both `file_semantic_index` queries, `ppir_expansion_items`, the two
+/// project-wide expansion-map collectors, and the LSP check pass). Before
+/// this query existed each of them re-lowered the syntax tree from scratch —
+/// repeated CST traversal was ~31% of cold-compile CPU on the test corpus.
+#[salsa::tracked(returns(ref))]
+pub fn file_ast(db: &dyn Db, file: SourceFile) -> FileAst {
+    let tree = baml_compiler_parser::syntax_tree(db, file);
+    let path = file.path(db);
+    let (items, diagnostics, env_var_refs) =
+        baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
+    FileAst {
+        items,
+        diagnostics,
+        env_var_refs,
+    }
+}
+
 // ── file_semantic_index ───────────────────────────────────────────────────────
 
 /// Coarse per-file query — always re-runs on file change (`no_eq`).
@@ -108,15 +159,14 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
 pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
-    let (items, lowering_diags, env_var_refs) =
-        baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
+    // CST → AST lowering is shared via `file_ast` instead of being redone here.
+    let ast = file_ast(db, file);
 
     let builder = SemanticIndexBuilder::new(db, file);
     builder
-        .with_lowering_diagnostics(lowering_diags)
-        .with_env_var_refs(env_var_refs)
-        .build(&items, file_range)
+        .with_lowering_diagnostics(ast.diagnostics.clone())
+        .with_env_var_refs(ast.env_var_refs.clone())
+        .build(&ast.items, file_range)
 }
 
 // ── Projection helpers ────────────────────────────────────────────────────────

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1523,7 +1523,7 @@ use baml_compiler2_tir::{
     inference::infer_scope_types,
     resolve::{ResolvedName, resolve_name_at_in_scope},
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 type ClassFieldIndices = IndexMap<TypeName, IndexMap<String, usize>>;
 type ClassFieldTypes = IndexMap<TypeName, IndexMap<String, RuntimeTy>>;
@@ -1646,6 +1646,12 @@ struct PackageLoweringData {
     enum_variants: EnumVariantIndices,
     interface_implementors: ImplementorsByInterface,
     resolved_aliases: ResolvedAliases,
+    /// Every method name any in-scope interface (own package + dependency
+    /// closure) declares, required or default. Fast pre-filter for
+    /// [`LoweringContext::dispatch_target_for_concrete`]: a member name absent
+    /// here can never dispatch through an interface impl, so the (hot) impl
+    /// enumeration is skipped for the overwhelmingly common plain-method case.
+    interface_method_names: FxHashSet<Name>,
 }
 
 /// # Safety
@@ -1720,12 +1726,50 @@ fn package_lowering_data<'db>(
         );
     }
 
+    // Collect every interface-declared method name in scope (own package +
+    // dependency closure). `dispatch_target_for_concrete` previously enumerated
+    // every impl block in the closure for EVERY method call and field access
+    // just to conclude "no impl provides this member" for the overwhelmingly
+    // common non-interface member; this set lets it answer that in one hash
+    // lookup. Names are collected package-wide (not per receiver type), so the
+    // filter is a pure fast path: any name declared by ANY reachable interface
+    // still goes through the full impl enumeration.
+    let mut interface_method_names = FxHashSet::default();
+    let mut all_pkgs = vec![pkg_id];
+    all_pkgs.extend(
+        baml_compiler2_hir::package::package_dependency_closure(db, pkg_id)
+            .iter()
+            .copied(),
+    );
+    for pkg in all_pkgs {
+        let items = package_items(db, pkg);
+        for ns in items.namespaces.values() {
+            for def in ns.types.values() {
+                let baml_compiler2_hir::contributions::Definition::Interface(iface_loc) = def
+                else {
+                    continue;
+                };
+                let itree = file_item_tree(db, iface_loc.file(db));
+                let Some(iface_data) = itree.interfaces.get(&iface_loc.id(db)) else {
+                    continue;
+                };
+                for sig in &iface_data.required_methods {
+                    interface_method_names.insert(sig.name.clone());
+                }
+                for &fn_id in &iface_data.default_methods {
+                    interface_method_names.insert(itree[fn_id].name.clone());
+                }
+            }
+        }
+    }
+
     PackageLoweringData {
         class_fields,
         class_field_types,
         enum_variants,
         interface_implementors,
         resolved_aliases,
+        interface_method_names,
     }
 }
 
@@ -1852,6 +1896,10 @@ struct LoweringContext<'db> {
     // Borrowed from `package_lowering_data` (shared across every function in
     // the package) rather than cloned per context.
     resolved_aliases: &'db ResolvedAliases,
+
+    /// All method names declared by in-scope interfaces — see
+    /// [`PackageLoweringData::interface_method_names`].
+    interface_method_names: &'db FxHashSet<Name>,
 
     /// Stack of pending `defer` block bodies (BEP-042), parallel to
     /// lexical scopes. Each entry is the `AstExprId` of a defer body
@@ -2736,6 +2784,7 @@ impl<'db> LoweringContext<'db> {
             transitive_captures_needed: Vec::new(),
             tagged_body_param_bindings: HashMap::new(),
             resolved_aliases: &pkg_data.resolved_aliases,
+            interface_method_names: &pkg_data.interface_method_names,
             defer_stack: Vec::new(),
             synthetic_name_counts: HashMap::new(),
             chain_null_exits: Vec::new(),
@@ -2821,6 +2870,7 @@ impl<'db> LoweringContext<'db> {
             class_type_tags,
             interface_implementors: &pkg_data.interface_implementors,
             resolved_aliases: &pkg_data.resolved_aliases,
+            interface_method_names: &pkg_data.interface_method_names,
             defer_stack: Vec::new(),
             synthetic_name_counts: HashMap::new(),
             pending_lambdas: Vec::new(),
@@ -3565,6 +3615,14 @@ impl<'db> LoweringContext<'db> {
                 | Tir2Ty::Map { .. }
                 | Tir2Ty::Future(..)
         ) {
+            return None;
+        }
+        // Fast pre-filter: a name no in-scope interface declares can never
+        // dispatch through an impl. Skips the per-call impl enumeration
+        // (`l1_impls_for_recv` probes every impl block's pattern against the
+        // receiver, invoking alias normalization / subtype checks per probe)
+        // for plain method calls and field accesses.
+        if !self.interface_method_names.contains(method) {
             return None;
         }
         for resolved in self.l1_impls_for_recv(recv_ty) {

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -54,9 +54,9 @@ pub fn collect_block_attrs(
     let mut result = FxHashMap::default();
     for file in project.files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, *file);
-        let cst = baml_compiler_parser::syntax_tree(db, *file);
-        let (items, _, _) = ast::lower_file(&cst);
-        for item in &items {
+        // Reuse the memoized CST → AST lowering instead of re-lowering here.
+        let items = &baml_compiler2_hir::file_ast(db, *file).items;
+        for item in items {
             let (name, item_attrs) = match item {
                 ast::Item::Class(c) => (&c.name, &c.attributes),
                 ast::Item::Enum(e) => (&e.name, &e.attributes),
@@ -85,9 +85,9 @@ pub fn collect_alias_bodies(
     let mut result = FxHashMap::default();
     for file in project.files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, *file);
-        let cst = baml_compiler_parser::syntax_tree(db, *file);
-        let (items, _, _) = ast::lower_file(&cst);
-        for item in &items {
+        // Reuse the memoized CST → AST lowering instead of re-lowering here.
+        let items = &baml_compiler2_hir::file_ast(db, *file).items;
+        for item in items {
             if let ast::Item::TypeAlias(a) = item {
                 let ty = a.type_expr.as_ref().map(PpirTy::from_type_expr).unwrap_or(
                     PpirTy::CannotBeStreamed {
@@ -191,8 +191,8 @@ fn make_raw_attr_no_args(name: &str) -> ast::RawAttribute {
 /// Compute synthetic `*$stream` AST items for a single file in one pass.
 #[salsa::tracked]
 pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems<'_> {
-    let cst = baml_compiler_parser::syntax_tree(db, file);
-    let (items, _, _) = ast::lower_file(&cst);
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let items = &baml_compiler2_hir::file_ast(db, file).items;
 
     // Get HIR classification for the file's package (original types only)
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
@@ -215,7 +215,7 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
     let mut seen_class_names = FxHashSet::default();
     let mut seen_alias_names = FxHashSet::default();
 
-    for item in &items {
+    for item in items {
         match item {
             ast::Item::Class(c) => {
                 if c.name.ends_with("$stream") {
@@ -578,13 +578,28 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
 // -- Canonical queries (original + *$stream) ----------------------------------
 
 /// Canonical semantic index: original AST items + PPIR synthetic *$stream items.
+///
+/// When a file has no synthetic items, the post-expansion index is byte-for-byte
+/// the pre-expansion one (same AST items, same builder, same file range), so
+/// this delegates to HIR's already-computed index instead of rebuilding
+/// scopes/bindings/contributions a second time.
+pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> &FileSemanticIndex<'_> {
+    let expansion = ppir_expansion_items(db, file);
+    if expansion.items(db).is_empty() {
+        return baml_compiler2_hir::file_semantic_index(db, file);
+    }
+    file_semantic_index_expanded(db, file)
+}
+
+/// The merged (original + *$stream) index for files that actually have
+/// synthetic items. Callers must go through [`file_semantic_index`].
 #[salsa::tracked(returns(ref), no_eq)]
-pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
+fn file_semantic_index_expanded(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
-    let (mut items, lowering_diags, env_var_refs) =
-        ast::lower_file_with_path(&tree, Some(path.as_path()));
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let ast_result = baml_compiler2_hir::file_ast(db, file);
+    let mut items = ast_result.items.clone();
 
     // Merge synthetic *$stream items
     let expansion = ppir_expansion_items(db, file);
@@ -592,8 +607,8 @@ pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'
 
     // Re-run HIR builder on merged items
     baml_compiler2_hir::SemanticIndexBuilder::new(db, file)
-        .with_lowering_diagnostics(lowering_diags)
-        .with_env_var_refs(env_var_refs)
+        .with_lowering_diagnostics(ast_result.diagnostics.clone())
+        .with_env_var_refs(ast_result.env_var_refs.clone())
         .build(&items, file_range)
 }
 
@@ -616,6 +631,11 @@ pub fn file_item_tree(db: &dyn Db, file: SourceFile) -> Arc<ItemTree> {
 ///
 /// TIR should call this instead of `baml_compiler2_hir::body::function_body`
 /// so that PPIR-synthesized functions (like `$parse_stream`) are found.
+///
+/// Salsa-tracked (mirroring HIR's `function_body`): MIR lowering fetches the
+/// callee's body at every direct-call site, and the untracked version cloned
+/// the entire `ExprBody` arena out of the item tree each time.
+#[salsa::tracked]
 pub fn function_body<'db>(
     db: &'db dyn Db,
     function: baml_compiler2_hir::loc::FunctionLoc<'db>,

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -137,6 +137,92 @@ fn function_generic_param_bounds_exprs(
     item_tree[func_loc.id(db)].generic_param_bounds.clone()
 }
 
+/// Per-callee generic-parameter facts consumed at every call site:
+/// the enclosing class's generic params (empty for free functions), the
+/// callee's user-declared params, their lowered interface bounds, and the
+/// callee's name for diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct CalleeGenerics {
+    pub(crate) class_params: Vec<Name>,
+    pub(crate) user_params: Vec<Name>,
+    pub(crate) user_bounds: Vec<Option<Ty>>,
+    pub(crate) name: Name,
+}
+
+// Safety: `CalleeGenerics` holds only plain (non-`'db`) data. Manual `Update`
+// impl uses `PartialEq` for Salsa early-cutoff.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for CalleeGenerics {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: `old_pointer` is valid, aligned, and Salsa-owned.
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// The declared generic params and lowered bounds of a callable, memoized per
+/// function. Every call site used to redo this from scratch — an item-tree
+/// scan for the enclosing class plus a re-lowering of the bound type
+/// expressions — even though it is a pure function of the callee's
+/// declaration, so memoizing per `FunctionLoc` is safe.
+#[salsa::tracked(returns(ref))]
+pub(crate) fn callee_generics_for_func<'db>(
+    db: &'db dyn crate::Db,
+    func_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
+) -> CalleeGenerics {
+    let sig = baml_compiler2_ppir::elaborated_function_signature(db, func_loc);
+    // The enclosing class's generic params (`[]` for a free function). These
+    // are always in scope when lowering the method's *bounds* — a bound may
+    // reference a class generic (`<U extends Eq<C>>` on a method of
+    // `class Box<C>`) regardless of how the class args are supplied — so they
+    // must be visible or `C` would resolve to `unknown`.
+    let file = func_loc.file(db);
+    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
+    let class_params: Vec<Name> = item_tree
+        .classes
+        .values()
+        .find(|class_data| class_data.methods.contains(&func_loc.id(db)))
+        .map(|class_data| class_data.generic_params.clone())
+        .unwrap_or_default();
+
+    // Lower the user generic params' interface bounds in the callee's own
+    // package/namespace, with the class params in scope (see above). The
+    // bounds were already validated at the declaration site, so discard
+    // re-lowering diagnostics here.
+    let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
+    let pkg_id = PackageId::new(db, pkg_info.package.clone());
+    let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
+    let mut bound_scope = class_params.clone();
+    bound_scope.extend(sig.user_generic_params.iter().cloned());
+    let mut diags = Vec::new();
+    let user_bounds = lower_generic_param_bounds(
+        db,
+        &function_generic_param_bounds_exprs(db, func_loc),
+        pkg_items,
+        &pkg_info.namespace_path,
+        &bound_scope,
+        None,
+        &mut diags,
+    );
+
+    CalleeGenerics {
+        class_params,
+        user_params: sig.user_generic_params.clone(),
+        user_bounds,
+        name: sig.name.clone(),
+    }
+}
+
 pub(crate) fn lower_generic_param_bounds(
     db: &dyn crate::Db,
     bounds: &[Option<TypeExpr>],
@@ -544,7 +630,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         GlobalTypeContext {
             db: self.context.db(),
             res_ctx: self.res_ctx,
-            aliases: &self.aliases,
+            aliases: self.aliases,
             bounds: &self.generic_param_bounds,
         }
     }
@@ -664,8 +750,10 @@ pub struct TypeInferenceBuilder<'db> {
     /// Declared return type for the function (used to check return statements).
     declared_return_ty: Option<Ty>,
     /// Resolved type alias map: alias qualified name → expanded Ty.
-    /// Used by the normalizer for structural subtype checking.
-    aliases: HashMap<crate::ty::QualifiedTypeName, Ty>,
+    /// Used by the normalizer for structural subtype checking. Held by
+    /// reference to the Salsa-cached `package_resolved_aliases` value so it is
+    /// not cloned per scope (it used to be rebuilt for every scope inference).
+    aliases: &'db HashMap<crate::ty::QualifiedTypeName, Ty>,
     /// Namespace path for the file being analyzed (e.g. `["env"]` for `baml/env.baml`).
     ns_context: Vec<Name>,
     /// BEP-044: when this body is the override of an interface method
@@ -967,7 +1055,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         res_ctx: &'db PackageResolutionContext<'db>,
         package_id: PackageId<'db>,
         scope: ScopeId<'db>,
-        aliases: HashMap<crate::ty::QualifiedTypeName, Ty>,
+        aliases: &'db HashMap<crate::ty::QualifiedTypeName, Ty>,
     ) -> Self {
         let db = context.db();
         let package_items = &res_ctx.own_items;
@@ -1319,7 +1407,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn expand_alias_chains(&self, ty: Ty) -> Ty {
-        crate::inference::expand_alias_chains(ty, &self.aliases)
+        crate::inference::expand_alias_chains(ty, self.aliases)
     }
 
     /// Pattern-matrix-internal normalization of a scrutinee type.
@@ -2001,20 +2089,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             _ => return None,
         };
         let db = self.context.db();
-        let sig = baml_compiler2_ppir::elaborated_function_signature(db, func_loc);
-        // The enclosing class's generic params (`[]` for a free function). These
-        // are always in scope when lowering the method's *bounds* — a bound may
-        // reference a class generic (`<U extends Eq<C>>` on a method of
-        // `class Box<C>`) regardless of how the class args are supplied — so they
-        // must be visible or `C` would resolve to `unknown`.
-        let file = func_loc.file(db);
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-        let enclosing_class_params: Vec<Name> = item_tree
-            .classes
-            .values()
-            .find(|class_data| class_data.methods.contains(&func_loc.id(db)))
-            .map(|class_data| class_data.generic_params.clone())
-            .unwrap_or_default();
+        // The callee's declared params and lowered bounds are a pure function
+        // of its declaration — previously re-derived here (item-tree scan +
+        // bound re-lowering) at every call site; now Salsa-memoized per callee.
+        let data = callee_generics_for_func(db, func_loc);
         // Only user-declared generic params are *supplied at the call site*;
         // synthetic effect params are always inferred. For static-method-on-
         // generic-class calls, the class params are also supplied (`Class<...>.m`)
@@ -2023,41 +2101,21 @@ impl<'db> TypeInferenceBuilder<'db> {
         // params (their own bounds, where any, are enforced at receiver
         // specialization).
         let class_params: &[Name] = if treat_as_static_method {
-            &enclosing_class_params
+            &data.class_params
         } else {
             &[]
         };
 
-        // Lower the user generic params' interface bounds in the callee's own
-        // package/namespace, with the class params in scope (see above). The
-        // bounds were already validated at the declaration site, so discard
-        // re-lowering diagnostics here.
-        let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
-        let pkg_id = PackageId::new(db, pkg_info.package.clone());
-        let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
-        let mut bound_scope = enclosing_class_params.clone();
-        bound_scope.extend(sig.user_generic_params.iter().cloned());
-        let mut diags = Vec::new();
-        let user_bounds = lower_generic_param_bounds(
-            db,
-            &function_generic_param_bounds_exprs(db, func_loc),
-            pkg_items,
-            &pkg_info.namespace_path,
-            &bound_scope,
-            None,
-            &mut diags,
-        );
-
         let mut declared_params: Vec<Name> = class_params.to_vec();
-        declared_params.extend(sig.user_generic_params.iter().cloned());
+        declared_params.extend(data.user_params.iter().cloned());
         let mut declared_bounds: Vec<Option<Ty>> = vec![None; class_params.len()];
-        declared_bounds.extend(user_bounds);
+        declared_bounds.extend(data.user_bounds.iter().cloned());
         // A user bound that references an enclosing class param (`<U extends
         // Eq<C>>` on a method of `class Box<C>`) is lowered with `C` as a type
         // variable here; on a bound-method call the receiver's value for `C` is
         // seeded into the call-site bindings (see `owner_type_arg_binding_seed`) so
         // the bound resolves to e.g. `Eq<int>` before it is checked.
-        Some((declared_params, declared_bounds, sig.name.clone()))
+        Some((declared_params, declared_bounds, data.name.clone()))
     }
 
     /// Resolve explicit type arguments written at a call site (e.g. `foo<int, string>(x)`).
@@ -5906,7 +5964,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         self.package_id,
                         &inferred,
                         expected,
-                        &self.aliases,
+                        self.aliases,
                         |a, b| self.is_subtype(a, b),
                     )
                 } else {

--- a/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
@@ -443,11 +443,11 @@ pub(crate) fn scope_types_equivalent(
 ) -> bool {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let gctx = GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds,
     };
     baml_type::normalize::equivalent(a, b, &gctx)
@@ -769,7 +769,7 @@ pub(crate) fn resolve_concrete_realized_interface(
 ) -> Option<baml_type::Interface> {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let realized = !crate::generics::contains_typevar(base)
         && !interface
             .generics
@@ -781,12 +781,12 @@ pub(crate) fn resolve_concrete_realized_interface(
             .any(|(_, ty)| crate::generics::contains_typevar(ty));
     let resolved = if realized {
         // Realized fast path: unique by coherence, bounds discharged by bounded re-entry.
-        crate::interfaces::get_implements_block(db, pkg_id, base, interface, &aliases)
+        crate::interfaces::get_implements_block(db, pkg_id, base, interface, aliases)
     } else {
         let gctx = GlobalTypeContext {
             db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds,
         };
         crate::interfaces::get_implements_block_symbolic(
@@ -794,7 +794,7 @@ pub(crate) fn resolve_concrete_realized_interface(
             pkg_id,
             base,
             interface,
-            &aliases,
+            aliases,
             |a, b| baml_type::normalize::is_subtype(a, b, &gctx),
         )
     };
@@ -821,16 +821,16 @@ pub(crate) fn resolve_concrete_projection(
 ) -> ConcreteProjection {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let gctx = GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds,
     };
 
     let mut declarers: Vec<baml_type::Interface> = Vec::new();
-    for resolved in crate::interfaces::impls_for_type(db, pkg_id, base, &aliases, |a, b| {
+    for resolved in crate::interfaces::impls_for_type(db, pkg_id, base, aliases, |a, b| {
         baml_type::normalize::is_subtype(a, b, &gctx)
     }) {
         let interface = resolved.implemented_interface(db);

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -570,7 +570,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.context.db(),
             self.package_id,
             base_ty,
-            &self.aliases,
+            self.aliases,
             |a, b| self.is_subtype(a, b),
         )
     }

--- a/baml_language/crates/baml_compiler2_tir/src/callable.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/callable.rs
@@ -417,15 +417,15 @@ pub fn callable_throws<'db>(db: &'db dyn crate::Db, function: FunctionLoc<'db>) 
                 };
             };
             let inference = infer_scope_types(db, scope_id);
-            let res_ctx = package_resolution_context(db, pkg_id);
-            let aliases = crate::inference::package_alias_map(db, res_ctx);
+            // Salsa-cached per package — previously rebuilt for every callable.
+            let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
             let facts = crate::throws_analysis::collect_escaping_throws(
                 &CallableThrowsAnalysis {
                     db,
                     pkg_id,
                     ns_context: &pkg_info.namespace_path,
                     inference,
-                    aliases: &aliases,
+                    aliases,
                 },
                 body,
             );

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -1644,7 +1644,9 @@ pub fn infer_scope_types<'db>(
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
 
-    let aliases = package_alias_map(db, res_ctx);
+    // Salsa-cached per package (with cycle handling) — previously rebuilt from
+    // scratch on every scope inference.
+    let aliases = package_resolved_aliases(db, pkg_id);
     let context = InferContext::new(db, scope_id);
     let mut builder = TypeInferenceBuilder::new(context, res_ctx, pkg_id, scope_id, aliases);
 
@@ -2937,13 +2939,41 @@ pub fn enum_variants<'db>(
     Some(enum_data.variants.iter().map(|v| v.name.clone()).collect())
 }
 
-/// Build the type-alias map visible from a package: its own aliases plus those
-/// re-exported by its dependencies. Shared by per-scope inference and throws
-/// analysis so both expand the same aliases (e.g. `testing.TestSetBody`).
-pub(crate) fn package_alias_map<'db>(
-    db: &'db dyn crate::Db,
-    res_ctx: &crate::package_interface::PackageResolutionContext<'db>,
+/// Cycle seed for [`package_resolved_aliases`]: the empty alias environment.
+///
+/// An alias whose RHS contains an associated-type projection (`type A = T.Member`)
+/// resolves through impl resolution and inference, which in turn read this very
+/// alias map — a legitimate Salsa dependency cycle. Salsa resolves it by fixpoint
+/// iteration seeded here with an empty environment (mirroring
+/// [`infer_scope_types`]'s empty [`ScopeInference`] seed and
+/// [`resolve_type_alias`]'s "still inferring" sentinel): the first iteration
+/// resolves every alias it can without the map, and iteration re-runs until the
+/// environment stops changing.
+fn package_resolved_aliases_cycle_initial<'db>(
+    _db: &'db dyn crate::Db,
+    _id: salsa::Id,
+    _pkg_id: PackageId<'db>,
 ) -> HashMap<crate::ty::QualifiedTypeName, Ty> {
+    HashMap::new()
+}
+
+/// The type-alias map visible from a package: its own aliases plus those
+/// re-exported by its dependencies. Shared by per-scope inference, throws
+/// analysis, and impl checking so all expand the same aliases (e.g.
+/// `testing.TestSetBody`).
+///
+/// Salsa-tracked and keyed by package: before this was a query, the map was
+/// rebuilt — a full clone of every alias `Ty` plus a project walk — inside
+/// every `infer_scope_types` execution (~15.6k executions on the test corpus).
+/// Hoisting is safe because the map is a pure function of the package's
+/// declarations (never of any per-scope inference state); the alias-resolution
+/// cycle it sits in is handled by `cycle_initial` above.
+#[salsa::tracked(returns(ref), cycle_initial = package_resolved_aliases_cycle_initial)]
+pub fn package_resolved_aliases<'db>(
+    db: &'db dyn crate::Db,
+    pkg_id: PackageId<'db>,
+) -> HashMap<crate::ty::QualifiedTypeName, Ty> {
+    let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
     let mut aliases = collect_type_aliases(db, &res_ctx.own_items);
     for (_dep_name, dep_iface) in &res_ctx.dep_interfaces {
         for types_in_ns in dep_iface.types.values() {

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -186,8 +186,8 @@ fn package_impls_with_spans<'db>(
     pkg_id: PackageId<'db>,
 ) -> Vec<(&'db ImplData<'db>, Span)> {
     package_impl_locs(db, pkg_id)
-        .into_iter()
-        .filter_map(|loc| {
+        .iter()
+        .filter_map(|&loc| {
             let data = impl_data(db, loc).as_ref().ok()?;
             let span = impl_data_source_map(db, loc)
                 .as_ref()

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -1048,13 +1048,13 @@ pub fn validate_impl_signatures<'db>(
 
     // The canonical algebra context — fully usable in this phase (see the fn doc).
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let bounds: crate::lower_type_expr::TypeVarBoundsMap =
         data.generic_params.iter().cloned().collect();
     let ctx = crate::type_context::GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds: &bounds,
     };
 
@@ -1349,7 +1349,7 @@ pub fn validate_impl_signatures<'db>(
                 generics: generics.clone(),
                 associated_types: assoc.clone(),
             };
-            if !implements_interface(db, &for_ty, &required_iface, &aliases, |a, b| {
+            if !implements_interface(db, &for_ty, &required_iface, aliases, |a, b| {
                 baml_type::normalize::is_subtype(a, b, &ctx)
             }) {
                 diags.push((
@@ -1423,6 +1423,13 @@ pub struct ResolvedImpl<'db> {
 /// Uniform over in-body and out-of-body impls (both live in
 /// [`file_item_tree`](baml_compiler2_hir::file_item_tree)`.impls`). Public so MIR can enumerate
 /// a package's impls to rebuild the runtime interface-implementor tables on the L1 substrate.
+///
+/// Salsa-tracked: this walks *every file in the project* (to find the
+/// package's files) and is called from every impl-resolution loop, coherence
+/// checking, and type-expression lowering, so an untracked version re-scanned
+/// the whole project on each call. The result is a pure function of the
+/// project's files and their item trees, so memoizing per package is safe.
+#[salsa::tracked(returns(ref))]
 pub fn package_impl_locs<'db>(
     db: &'db dyn crate::Db,
     pkg_id: PackageId<'db>,
@@ -1716,7 +1723,7 @@ pub fn type_implements_interface<'db>(
         db, pkg_id,
     ));
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1754,7 +1761,7 @@ pub(crate) fn get_implements_block_symbolic<'db>(
     ));
     let mut found: Option<ResolvedImpl<'db>> = None;
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1809,7 +1816,7 @@ fn get_implements_block_within_depth<'db>(
     ));
 
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1971,7 +1978,7 @@ pub fn impls_for_type<'db>(
     ));
     let mut out = Vec::new();
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -2024,7 +2031,7 @@ pub(crate) fn first_failing_impl_bound<'db>(
         db, pkg_id,
     ));
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -1431,12 +1431,12 @@ mod tests {
         let db = compile("interface Bar {}\ninterface Foo {\n  type Assoc extends Bar\n}\n");
         let user = PackageId::new(&db, Name::new("user"));
         let res_ctx = crate::package_interface::package_resolution_context(&db, user);
-        let aliases = crate::inference::package_alias_map(&db, res_ctx);
+        let aliases = crate::inference::package_resolved_aliases(&db, user);
         let bounds = TypeVarBoundsMap::default();
         let gctx = crate::type_context::GlobalTypeContext {
             db: &db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds: &bounds,
         };
         let foo = baml_type::Interface::new(
@@ -1473,12 +1473,12 @@ mod tests {
         ));
         let user = PackageId::new(&db, Name::new("user"));
         let res_ctx = crate::package_interface::package_resolution_context(&db, user);
-        let aliases = crate::inference::package_alias_map(&db, res_ctx);
+        let aliases = crate::inference::package_resolved_aliases(&db, user);
         let bounds = TypeVarBoundsMap::default();
         let gctx = crate::type_context::GlobalTypeContext {
             db: &db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds: &bounds,
         };
         let foo = baml_type::Interface::new(
@@ -3170,7 +3170,7 @@ mod tests {
         let pkg = baml_compiler2_hir::file_package::file_package(&db, file).package;
         let pkg_id = baml_compiler2_hir::package::PackageId::new(&db, pkg);
         let mut out = Vec::new();
-        for impl_loc in crate::interfaces::package_impl_locs(&db, pkg_id) {
+        for &impl_loc in crate::interfaces::package_impl_locs(&db, pkg_id) {
             match crate::interfaces::impl_data(&db, impl_loc) {
                 Ok(data) => out.extend(data.diagnostics.iter().map(|(e, _)| e.clone())),
                 Err(crate::interfaces::ImplDataError::InterfaceUnresolved { diagnostics }) => {

--- a/baml_language/crates/baml_compiler_diagnostics/src/render.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/render.rs
@@ -208,7 +208,10 @@ pub fn render_diagnostic(
     config: &RenderConfig,
 ) -> String {
     match config.format {
-        DiagnosticFormat::Ariadne => render_ariadne(diagnostic, sources, file_paths, config.color),
+        DiagnosticFormat::Ariadne => {
+            let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
+            render_ariadne(diagnostic, sources, &mut cache, config.color)
+        }
         DiagnosticFormat::Concise => render_concise(diagnostic, sources, file_paths),
     }
 }
@@ -223,9 +226,20 @@ pub fn render_diagnostics(
     file_paths: &HashMap<FileId, PathBuf>,
     config: &RenderConfig,
 ) -> String {
+    // Build the ariadne source cache ONCE for the whole batch. Constructing
+    // it per diagnostic (each `Source::from` computes a line index for every
+    // file in the project) is quadratic in practice and measurably slows
+    // `baml check` on warning-heavy projects.
+    let mut ariadne_cache = matches!(config.format, DiagnosticFormat::Ariadne)
+        .then(|| SourceCache::new(sources.clone(), file_paths.clone()));
     diagnostics
         .iter()
-        .map(|d| render_diagnostic(d, sources, file_paths, config))
+        .map(|d| match (&config.format, &mut ariadne_cache) {
+            (DiagnosticFormat::Ariadne, Some(cache)) => {
+                render_ariadne(d, sources, cache, config.color)
+            }
+            _ => render_concise(d, sources, file_paths),
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -259,10 +273,13 @@ fn translate_span(span: Span, sources: &HashMap<FileId, String>) -> Span {
 }
 
 /// Render a diagnostic using Ariadne (pretty CLI output).
+///
+/// Takes a pre-built [`SourceCache`] so batch rendering shares one line-index
+/// computation across all diagnostics.
 fn render_ariadne(
     diagnostic: &Diagnostic,
     sources: &HashMap<FileId, String>,
-    file_paths: &HashMap<FileId, PathBuf>,
+    cache: &mut SourceCache,
     color: bool,
 ) -> String {
     // BAML CLI uses lowercase `error:` / `warning:` everywhere (matching
@@ -321,7 +338,7 @@ fn render_ariadne(
         .finish();
 
     // Render to string using SourceCache for proper filename display.
-    let rendered = render_report_to_string(&report, sources, file_paths);
+    let rendered = render_report_to_string(&report, cache);
 
     // See the rant above the `report_kind` match — ariadne paints the
     // `Custom` keyword unconditionally, so `with_color(false)` doesn't
@@ -427,17 +444,10 @@ fn render_concise(
 }
 
 /// Render an ariadne Report to a String using `SourceCache` for proper filename display.
-fn render_report_to_string(
-    report: &Report<'_, Span>,
-    sources: &HashMap<FileId, String>,
-    file_paths: &HashMap<FileId, PathBuf>,
-) -> String {
+fn render_report_to_string(report: &Report<'_, Span>, cache: &mut SourceCache) -> String {
     let mut output = Vec::new();
 
-    // Use SourceCache for proper filename display
-    let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
-
-    report.write(&mut cache, &mut output).unwrap_or_else(|_| {
+    report.write(cache, &mut output).unwrap_or_else(|_| {
         output.clear();
         output.extend_from_slice(b"<error rendering diagnostic>");
     });

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -153,7 +153,9 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
     let pkg_id = baml_compiler2_hir::package::PackageId::new(db, pkg_info.package.clone());
     let res_ctx = baml_compiler2_tir::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
-    let aliases = collect_type_aliases_for_resolution_context(db, res_ctx);
+    // Salsa-cached per package — previously rebuilt (and cloned per function
+    // below) on every file check.
+    let aliases = baml_compiler2_tir::inference::package_resolved_aliases(db, pkg_id);
     let ast_items = {
         let tree = baml_compiler_parser::syntax_tree(db, file);
         let (items, _, _) = baml_compiler2_ast::lower_file(&tree);
@@ -399,11 +401,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
         if let Some(scope_id) = function_scope_id(index, func_data) {
             let context = baml_compiler2_tir::infer_context::InferContext::new(db, scope_id);
             let mut builder = baml_compiler2_tir::builder::TypeInferenceBuilder::new(
-                context,
-                res_ctx,
-                pkg_id,
-                scope_id,
-                aliases.clone(),
+                context, res_ctx, pkg_id, scope_id, aliases,
             );
             builder.set_generic_params(generic_params);
             for (name, ty) in &param_types {
@@ -1624,28 +1622,6 @@ fn jinja_diagnostic_id(message: &str) -> DiagnosticId {
     } else {
         DiagnosticId::JinjaInvalidType
     }
-}
-
-fn collect_type_aliases_for_resolution_context<'db>(
-    db: &'db dyn Db,
-    res_ctx: &'db baml_compiler2_tir::package_interface::PackageResolutionContext<'db>,
-) -> std::collections::HashMap<baml_compiler2_tir::ty::QualifiedTypeName, baml_compiler2_tir::ty::Ty>
-{
-    let mut aliases = baml_compiler2_tir::inference::collect_type_aliases(db, &res_ctx.own_items);
-    for (_dep_name, dep_iface) in &res_ctx.dep_interfaces {
-        for types_in_ns in dep_iface.types.values() {
-            for exported in types_in_ns.values() {
-                if let baml_compiler2_tir::package_interface::ExportedType::TypeAlias {
-                    qtn,
-                    resolved,
-                } = exported
-                {
-                    aliases.insert(qtn.clone(), resolved.clone());
-                }
-            }
-        }
-    }
-    aliases
 }
 
 fn function_scope_id<'db>(

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -154,15 +154,12 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
     let res_ctx = baml_compiler2_tir::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
     let aliases = collect_type_aliases_for_resolution_context(db, res_ctx);
-    let ast_items = {
-        let tree = baml_compiler_parser::syntax_tree(db, file);
-        let (items, _, _) = baml_compiler2_ast::lower_file(&tree);
-        items
-    };
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let ast_items = &baml_compiler2_hir::file_ast(db, file).items;
     diagnostics.extend(validate_associated_type_bindings_in_items(
         db,
         file_id,
-        &ast_items,
+        ast_items,
         pkg_items,
         &pkg_info.namespace_path,
     ));

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -1056,10 +1056,6 @@ impl NormalTy {
         ctx: &C,
         assumptions: &mut HashSet<(NormalTy, NormalTy)>,
     ) -> bool {
-        let pair = (self.clone(), sup.clone());
-        if assumptions.contains(&pair) {
-            return true;
-        }
         if self == sup {
             return true;
         }
@@ -1082,8 +1078,48 @@ impl NormalTy {
             return true;
         }
 
+        // Co-inductive assumption tracking exists solely to terminate cycles,
+        // and a cycle can only regress through the arms that *expand* a type:
+        // μ-unfolding (substitution can regenerate the same pair) and
+        // variable/projection bound lookup (a bound can mention the variable).
+        // Every structural arm descends into strictly smaller subterms of
+        // finite trees. Restricting the pair bookkeeping to the expanding
+        // arms preserves termination — any infinite path must pass through an
+        // expanding arm infinitely often, and the pairs seen there are drawn
+        // from the finite subterm closure of the (regular) operands — while
+        // sparing the deep `NormalTy` clone + full-tree hash on the millions
+        // of purely structural steps, which profiling showed dominated
+        // subtype-checking cost.
+        let expanding = matches!(
+            self,
+            NormalTy::Mu { .. } | NormalTy::TypeVar(_) | NormalTy::AssociatedTypeProjection { .. }
+        ) || matches!(sup, NormalTy::Mu { .. });
+        if !expanding {
+            return self.is_subtype_of_inner(sup, ctx, assumptions);
+        }
+        // Avoid cloning just to probe: pairs on the path are few (bounded by
+        // the expanding-arm recursion depth), so a linear scan beats
+        // hash-of-whole-tree.
+        if assumptions.iter().any(|(a, b)| a == self && b == sup) {
+            return true;
+        }
+        let pair = (self.clone(), sup.clone());
         assumptions.insert(pair.clone());
-        let result = match (self, sup) {
+        let result = self.is_subtype_of_inner(sup, ctx, assumptions);
+        assumptions.remove(&pair);
+        result
+    }
+
+    /// The structural rules of [`Self::is_subtype_of`]. Callers must go
+    /// through `is_subtype_of`, which owns the fast paths and the
+    /// co-inductive assumption bookkeeping.
+    fn is_subtype_of_inner<C: TypeContext>(
+        &self,
+        sup: &NormalTy,
+        ctx: &C,
+        assumptions: &mut HashSet<(NormalTy, NormalTy)>,
+    ) -> bool {
+        match (self, sup) {
             // μ-unfolding (equirecursive).
             (NormalTy::Mu { var, body }, _) => {
                 body.substitute(var, self)
@@ -1240,9 +1276,7 @@ impl NormalTy {
             }
 
             _ => false,
-        };
-        assumptions.remove(&pair);
-        result
+        }
     }
 
     // ── conversion out: NormalTy → Ty ──────────────────────────────────────

--- a/baml_language/crates/tools_compile_profile/README.md
+++ b/baml_language/crates/tools_compile_profile/README.md
@@ -76,8 +76,9 @@ The cold-vs-warm table then makes three failure modes visible:
 2. **Warm executes 0 queries but still spends real wall-clock time.**
    That work lives outside any Salsa query. Salsa can't cache it — the
    wrapper (`db.check()` / `db.get_bytecode()`) is doing per-invocation
-   materialization / walking / cloning. **This is what we see on the
-   test corpus today for `emit`: cold 13.6s, warm 12.1s.**
+   materialization / walking / cloning. **This is what the pre-audit
+   test corpus showed for `emit`: cold 13.6s, warm 12.1s (historical
+   numbers — see the audit section below).**
 3. **Warm total ≈ 0.** Salsa is fully caching this workload; nothing
    further to chase in the caching layer.
 


### PR DESCRIPTION
## Summary

Combined re-landing of the still-orthogonal optimizations from #4016, re-derived against current canary and measured individually with the profiler from #4038. Folds in three reviewed track branches (their PRs are closed as superseded by this one, branches kept):

- **Track A** (#4043, `perf/reland-file-ast`): salsa-tracked `file_ast(db, file)` so CST→AST lowering runs once per file instead of once per consumer (~6 sites); PPIR `file_semantic_index` delegates to HIR's for expansion-free files; PPIR `function_body` tracked returning `Arc<FunctionBody>`. Individually: −22% cold total, instructions retired −18.5%.
- **Track D** (#4044, `perf/reland-mir-dispatch-prefilter`): interface-method-name pre-filter in `dispatch_target_for_concrete` (FxHashSet in `PackageLoweringData`; early `None` for plain member accesses); `is_subtype_of` co-inductive assumption bookkeeping restricted to the expanding arms (`Mu`/`TypeVar`/`AssociatedTypeProjection` left, `Mu` right) via `is_subtype_of_inner`, with the termination argument documented. Individually: −18% cold total, −28% emit.
- **Track E** (#4049, `perf/reland-cli-alloc-diag-render`): mimalloc as `baml_cli`'s global allocator; `render_diagnostics` builds the ariadne `SourceCache` once per batch instead of per diagnostic. Individually: 3.0× CLI wall time.

Plus a one-line docs fix labeling the pre-audit warm-run figures in the profiler README as historical (last open CodeRabbit item from #4038).

Two further tracks from the re-landing plan (TIR package-level queries; lambda double-inference fix) are still in progress and will follow separately.

## Performance: canary (0e58a20d7) vs this branch

Pipeline profiler (#4038's `tools_compile_profile`, `BAML_NO_BYTECODE_CACHE=1`, fresh cache dir, corpus `baml_language/crates/baml_tests/baml_src`, 77 files / 25,212 lines). Measured as 7 interleaved baseline/combined pairs on the same machine; the machine carried background load, so the paired per-run ratio is the robust statistic:

| metric | canary median | combined median | paired speedup (median) |
|---|---|---|---|
| check | 2.552 s | 1.638 s | ~1.6× |
| emit | 3.414 s | 2.173 s | ~1.6× |
| total | 6.017 s | 3.853 s | **~1.62×** (per-pair ratios 1.52–1.67 across 6 of 7 pairs) |

On the quietest pairs (machine idle-ish), combined total was ~2.2 s vs ~3.6 s baseline. Query executions: 25,972 → 26,054 (+82: the new tracked queries themselves; 37 → 39 unique).

End-to-end CLI (`hyperfine --warmup 1 --runs 7`, `baml check` over the corpus, disk cache disabled) — this additionally captures the mimalloc win the profiler can't see (it uses mimalloc itself):

| | mean ± σ | user CPU |
|---|---|---|
| canary | 3.959 s ± 0.219 s | 3.510 s |
| combined | 1.178 s ± 0.055 s | 1.011 s |

**3.36× ± 0.24 faster** (user CPU 3.47×, load-independent).

## Safety checks

- `BAML_CACHE_VERIFY=1` with the disk cache enabled, two consecutive runs (second replays cached diagnostics): exit 0, no divergence, rendered output byte-identical modulo the timing suffix.
- Each track individually passed the full workspace test suite with zero snapshot diffs on its own branch (see #4043 / #4044 / #4049 for details). Full-suite validation of this merge is deferred to CI per maintainer preference.

Provenance: #4016 (original audit; see `tools_compile_profile/README.md`). Superseded findings not re-landed: recursive-alias hoisting (fixed by #4032), builtin-diagnostics skip and counter-based class type tags (superseded by #3924's caching and content-addressed tags).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved cold compilation performance via shared, memoized CST→AST lowering and reused diagnostics/data across compiler stages.
  * Accelerated interface dispatch using package-wide pre-filtering, and faster Ariadne diagnostic rendering via a reusable source cache.
* **Bug Fixes**
  * Improved subtype checking for recursive/assumed relationships and better consistency across compiler validation and language-server type-alias checks.
* **Documentation**
  * Updated compile-profile documentation wording for the “cold by default” timing explanation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->