### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -38,13 +38,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 17.50 MB file.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 18_026_879
+max_file_bytes = 18_078_116
 # Linux x86_64: baseline 22.77 MB file.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 23_455_737
+max_file_bytes = 23_523_717
 # Windows x86_64: baseline 18.73 MB file (18_726_400), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 19_288_192
+max_file_bytes = 19_726_429
 
 [artifacts.packed-program]
 kind = "pack"
@@ -52,13 +52,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 12.64 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 13_019_350
+max_file_bytes = 13_019_384
 # Linux x86_64: baseline 16.26 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 16_746_597
+max_file_bytes = 16_771_886
 # Windows x86_64: baseline 13.53 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 13_938_290
+max_file_bytes = 13_944_063
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -82,4 +82,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.27 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_395_795
+max_gzip_bytes = 4_400_547

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-14T21:08:03Z"
-git_sha = "344ccfd80bf82ec34bd174ad8da3615ad1996432"
+recorded_at = "2026-07-16T10:00:08Z"
+git_sha = "79aa0f44e323e356a172e16e6b0f4a42e569959d"
 
 [artifacts.baml-cli]
-file_bytes = 17501824
-stripped_bytes = 17501872
-gzip_bytes = 8443116
+file_bytes = 17551568
+stripped_bytes = 17551616
+gzip_bytes = 8465231
 
 [artifacts.packed-program]
-file_bytes = 12640146
-gzip_bytes = 5991791
+file_bytes = 12640178
+gzip_bytes = 5993393

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-07-14T21:08:03Z"
-git_sha = "344ccfd80bf82ec34bd174ad8da3615ad1996432"
+recorded_at = "2026-07-16T10:00:08Z"
+git_sha = "79aa0f44e323e356a172e16e6b0f4a42e569959d"
 
 [artifacts.bridge_wasm]
-file_bytes = 15136949
-gzip_bytes = 4267762
+file_bytes = 15157305
+gzip_bytes = 4272375

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-14T21:08:03Z"
-git_sha = "344ccfd80bf82ec34bd174ad8da3615ad1996432"
+recorded_at = "2026-07-16T10:00:08Z"
+git_sha = "79aa0f44e323e356a172e16e6b0f4a42e569959d"
 
 [artifacts.baml-cli]
-file_bytes = 18726400
-stripped_bytes = 18726400
-gzip_bytes = 8506545
+file_bytes = 19151872
+stripped_bytes = 19151872
+gzip_bytes = 8683129
 
 [artifacts.packed-program]
-file_bytes = 13532320
-gzip_bytes = 6080600
+file_bytes = 13537925
+gzip_bytes = 6082881

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-14T21:08:03Z"
-git_sha = "344ccfd80bf82ec34bd174ad8da3615ad1996432"
+recorded_at = "2026-07-16T10:00:08Z"
+git_sha = "79aa0f44e323e356a172e16e6b0f4a42e569959d"
 
 [artifacts.baml-cli]
-file_bytes = 22772560
-stripped_bytes = 22772552
-gzip_bytes = 9733356
+file_bytes = 22838560
+stripped_bytes = 22838552
+gzip_bytes = 9748462
 
 [artifacts.packed-program]
-file_bytes = 16258832
-gzip_bytes = 6840907
+file_bytes = 16283384
+gzip_bytes = 6846279


### PR DESCRIPTION
Adopted from CI run [`79aa0f44e323e356a172e16e6b0f4a42e569959d`](https://github.com/BoundaryML/baml/actions/runs/29480928632).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 22.8 MB | 9.7 MB | **file** | 22.8 MB | +66.0 KB (+0.3%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 16.3 MB | 6.8 MB | **file** | 16.3 MB | +24.6 KB (+0.2%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 17.6 MB | 8.5 MB | **file** | 17.5 MB | +49.7 KB (+0.3%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 12.6 MB | 6.0 MB | **file** | 12.6 MB | +32 B (+0.0%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 15.2 MB | 🔒 4.3 MB | **gzip** | 4.3 MB | +4.6 KB (+0.1%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 19.2 MB | 8.7 MB | **file** | 18.7 MB | +425.5 KB (+2.3%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 13.5 MB | 6.1 MB | **file** | 13.5 MB | +5.6 KB (+0.0%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build artifact size baselines across supported platforms.
  * Adjusted size limits for command-line, packaged program, and WebAssembly artifacts.
  * Refreshed recorded build metadata and artifact measurements for size validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->