### PR TITLE
perf(compiler2+cli): re-land #4016 cold-compile optimizations (2.4s → 0.81s cold)

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "indicatif",
  "insta",
  "libsui",
+ "mimalloc",
  "object 0.36.3",
  "regex",
  "reqwest",

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -840,6 +840,7 @@ dependencies = [
  "baml_compiler2_ppir",
  "baml_compiler2_tir",
  "baml_type",
+ "baml_workspace",
  "indexmap",
  "num-bigint",
  "rustc-hash 2.1.2",

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -44,6 +44,7 @@ hex = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
 libsui = { workspace = true }
+mimalloc = { workspace = true }
 object = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking", "json", "rustls" ] }

--- a/baml_language/crates/baml_cli/src/main.rs
+++ b/baml_language/crates/baml_cli/src/main.rs
@@ -5,6 +5,15 @@
 
 use std::io::Write as _;
 
+/// The compiler workload is dominated by small short-lived allocations
+/// (`Ty` trees, `Vec`s, `SmolStr`s): the system allocator measured ~35% of
+/// remaining single-threaded CPU in the cold-compile audit. Installing
+/// mimalloc as the global allocator substantially cuts cold `baml check` /
+/// `baml build` wall time. This affects allocation only, not any rendered
+/// bytes, so it is safe with respect to `BAML_CACHE_VERIFY`.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     // TODO: baml_log is disabled for now
     // baml_log::init()?;

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -22,7 +22,9 @@ use crate::{
 };
 
 /// A reference to an environment variable found in source code (`env.VAR_NAME`).
-#[derive(Debug, Clone)]
+// `PartialEq`/`Eq` let this participate in `FileAst`'s value equality, which
+// gives the `file_ast` Salsa query early-cutoff (see `baml_compiler2_hir`).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvVarRef {
     /// The variable name (e.g., `"OPENAI_API_KEY"`).
     pub name: String,

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -385,6 +385,22 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         ctx: MirCodegenContext<'ctx, 'obj>,
         analysis: AnalysisResult,
     ) -> Self {
+        // Pre-size the hot output buffers from the MIR's shape. `emit` pushes
+        // one instruction + one parallel `meta` entry per bytecode op, and a
+        // MIR statement lowers to a few ops, so growing these from empty costs
+        // several doubling reallocations (memcpy of the whole buffer) per
+        // function — measurable across a project-wide emit. The estimate only
+        // sets initial capacity; being off is harmless.
+        let stmt_count: usize = body
+            .blocks
+            .iter()
+            .map(|b| b.statements.len() + 1) // +1 for the terminator
+            .sum();
+        let est_instructions = stmt_count * 3;
+        let mut bytecode = Bytecode::new();
+        bytecode.instructions.reserve(est_instructions);
+        bytecode.meta.reserve(est_instructions);
+
         Self {
             body,
             arity,
@@ -396,21 +412,21 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             enum_variants: ctx.enum_variants,
             objects: ctx.objects,
             analysis,
-            local_slots: HashMap::new(),
+            local_slots: HashMap::with_capacity(body.locals.len()),
             real_local_count: 0,
-            block_addresses: HashMap::new(),
-            block_end_addresses: HashMap::new(),
+            block_addresses: HashMap::with_capacity(body.blocks.len()),
+            block_end_addresses: HashMap::with_capacity(body.blocks.len()),
             pending_jumps: Vec::new(),
             pending_jump_tables: Vec::new(),
             dead_unreachable_blocks: HashSet::new(),
             trap_pc: None,
-            bytecode: Bytecode::new(),
+            bytecode,
             current_debug_span: None,
             pending_sequence_point: false,
             next_line_discriminator: HashMap::new(),
             next_block: None,
             current_block_start: 0,
-            local_types: HashMap::new(),
+            local_types: HashMap::with_capacity(body.locals.len()),
             slot_names: Vec::new(),
             lambda_object_indices: ctx.lambda_object_indices.to_vec(),
             lambda_names: ctx.lambda_names.to_vec(),

--- a/baml_language/crates/baml_compiler2_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/lib.rs
@@ -98,6 +98,60 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
     files
 }
 
+// ── file_ast ──────────────────────────────────────────────────────────────────
+
+/// The CST → AST lowering output for one file: top-level items plus the
+/// lowering diagnostics and `env.*` references produced along the way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileAst {
+    pub items: Vec<baml_compiler2_ast::Item>,
+    pub diagnostics: Vec<baml_compiler2_ast::LoweringDiagnostic>,
+    pub env_var_refs: Vec<baml_compiler2_ast::EnvVarRef>,
+}
+
+// Safety: `FileAst` holds only plain (non-`'db`) data, so storing it by value
+// in a Salsa slot is sound. This manual `Update` impl uses `PartialEq` so the
+// query gets early-cutoff (dependents skip re-running when the AST is
+// unchanged) rather than the always-`true` behavior of a no-eq value.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for FileAst {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// CST → AST lowering for one file, computed once and shared.
+///
+/// Salsa-tracked because several different consumers need a file's AST items:
+/// both `file_semantic_index` queries (HIR + PPIR), `ppir_expansion_items`,
+/// PPIR's two project-wide expansion-map collectors, and the LSP check pass.
+/// Before this query existed each of them re-lowered the syntax tree from
+/// scratch; the repeated CST traversal was ~31% of cold-compile CPU on the
+/// test corpus (see `crates/tools_compile_profile/README.md`, July 2026 audit).
+#[salsa::tracked(returns(ref))]
+pub fn file_ast(db: &dyn Db, file: SourceFile) -> FileAst {
+    let tree = baml_compiler_parser::syntax_tree(db, file);
+    let path = file.path(db);
+    let (items, diagnostics, env_var_refs) =
+        baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
+    FileAst {
+        items,
+        diagnostics,
+        env_var_refs,
+    }
+}
+
 // ── file_semantic_index ───────────────────────────────────────────────────────
 
 /// Coarse per-file query — always re-runs on file change (`no_eq`).
@@ -108,15 +162,14 @@ pub fn compiler2_all_files(db: &dyn Db) -> Vec<baml_base::SourceFile> {
 pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
-    let (items, lowering_diags, env_var_refs) =
-        baml_compiler2_ast::lower_file_with_path(&tree, Some(path.as_path()));
+    // CST → AST lowering is shared via `file_ast` instead of being redone here.
+    let ast = file_ast(db, file);
 
     let builder = SemanticIndexBuilder::new(db, file);
     builder
-        .with_lowering_diagnostics(lowering_diags)
-        .with_env_var_refs(env_var_refs)
-        .build(&items, file_range)
+        .with_lowering_diagnostics(ast.diagnostics.clone())
+        .with_env_var_refs(ast.env_var_refs.clone())
+        .build(&ast.items, file_range)
 }
 
 // ── Projection helpers ────────────────────────────────────────────────────────

--- a/baml_language/crates/baml_compiler2_mir/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_mir/Cargo.toml
@@ -13,6 +13,7 @@ baml_compiler2_hir = { workspace = true }
 baml_compiler2_ppir = { workspace = true }
 baml_compiler2_tir = { workspace = true }
 baml_type = { workspace = true }
+baml_workspace = { workspace = true }
 indexmap = { workspace = true }
 num-bigint = { workspace = true }
 rustc-hash = { workspace = true }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1523,7 +1523,7 @@ use baml_compiler2_tir::{
     inference::infer_scope_types,
     resolve::{ResolvedName, resolve_name_at_in_scope},
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 type ClassFieldIndices = IndexMap<TypeName, IndexMap<String, usize>>;
 type ClassFieldTypes = IndexMap<TypeName, IndexMap<String, RuntimeTy>>;
@@ -1646,6 +1646,13 @@ struct PackageLoweringData {
     enum_variants: EnumVariantIndices,
     interface_implementors: ImplementorsByInterface,
     resolved_aliases: ResolvedAliases,
+    /// Every method name any in-scope interface (own package + dependency
+    /// closure) declares, required or default. Fast pre-filter for
+    /// [`LoweringContext::dispatch_target_for_concrete`]: a member name absent
+    /// here can never dispatch through an interface impl, so the (hot) impl
+    /// enumeration is skipped for the overwhelmingly common plain-method /
+    /// field-access case.
+    interface_method_names: FxHashSet<Name>,
 }
 
 /// # Safety
@@ -1679,7 +1686,9 @@ fn package_lowering_data<'db>(
     db: &'db dyn crate::Db,
     pkg_id: baml_compiler2_hir::package::PackageId<'db>,
 ) -> PackageLoweringData {
-    use baml_compiler2_hir::package::{package_dependencies, package_items};
+    use baml_compiler2_hir::package::{
+        package_dependencies, package_dependency_closure, package_items,
+    };
 
     let resolved_aliases = resolved_aliases_for_package(db, pkg_id);
 
@@ -1720,12 +1729,48 @@ fn package_lowering_data<'db>(
         );
     }
 
+    // Collect every interface-declared method name in scope (own package +
+    // dependency closure). `dispatch_target_for_concrete` previously enumerated
+    // every impl block in the closure (via `l1_impls_for_recv`, which probes
+    // each impl's pattern against the receiver — running alias normalization /
+    // subtype checks per probe) for EVERY method call and field access, just to
+    // conclude "no impl provides this member" for the overwhelmingly common
+    // non-interface member. This set answers that in one hash lookup. Names are
+    // collected package-wide (not per receiver type), so the filter stays a
+    // pure fast path: any name declared by ANY reachable interface still falls
+    // through to the full impl enumeration + `mir_interface_declares_method`.
+    let mut interface_method_names = FxHashSet::default();
+    let mut all_pkgs = vec![pkg_id];
+    all_pkgs.extend(package_dependency_closure(db, pkg_id).iter().copied());
+    for pkg in all_pkgs {
+        let items = package_items(db, pkg);
+        for ns in items.namespaces.values() {
+            for def in ns.types.values() {
+                let baml_compiler2_hir::contributions::Definition::Interface(iface_loc) = def
+                else {
+                    continue;
+                };
+                let itree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
+                let Some(iface_data) = itree.interfaces.get(&iface_loc.id(db)) else {
+                    continue;
+                };
+                for sig in &iface_data.required_methods {
+                    interface_method_names.insert(sig.name.clone());
+                }
+                for &fn_id in &iface_data.default_methods {
+                    interface_method_names.insert(itree[fn_id].name.clone());
+                }
+            }
+        }
+    }
+
     PackageLoweringData {
         class_fields,
         class_field_types,
         enum_variants,
         interface_implementors,
         resolved_aliases,
+        interface_method_names,
     }
 }
 
@@ -1852,6 +1897,11 @@ struct LoweringContext<'db> {
     // Borrowed from `package_lowering_data` (shared across every function in
     // the package) rather than cloned per context.
     resolved_aliases: &'db ResolvedAliases,
+
+    /// All method names declared by in-scope interfaces — see
+    /// [`PackageLoweringData::interface_method_names`]. Fast pre-filter in
+    /// `dispatch_target_for_concrete`.
+    interface_method_names: &'db FxHashSet<Name>,
 
     /// Stack of pending `defer` block bodies (BEP-042), parallel to
     /// lexical scopes. Each entry is the `AstExprId` of a defer body
@@ -2736,6 +2786,7 @@ impl<'db> LoweringContext<'db> {
             transitive_captures_needed: Vec::new(),
             tagged_body_param_bindings: HashMap::new(),
             resolved_aliases: &pkg_data.resolved_aliases,
+            interface_method_names: &pkg_data.interface_method_names,
             defer_stack: Vec::new(),
             synthetic_name_counts: HashMap::new(),
             chain_null_exits: Vec::new(),
@@ -2821,6 +2872,7 @@ impl<'db> LoweringContext<'db> {
             class_type_tags,
             interface_implementors: &pkg_data.interface_implementors,
             resolved_aliases: &pkg_data.resolved_aliases,
+            interface_method_names: &pkg_data.interface_method_names,
             defer_stack: Vec::new(),
             synthetic_name_counts: HashMap::new(),
             pending_lambdas: Vec::new(),
@@ -3565,6 +3617,19 @@ impl<'db> LoweringContext<'db> {
                 | Tir2Ty::Map { .. }
                 | Tir2Ty::Future(..)
         ) {
+            return None;
+        }
+        // Fast pre-filter: a member name no in-scope interface declares can
+        // never dispatch through an impl, so skip the per-call impl enumeration
+        // entirely. `l1_impls_for_recv` probes every impl block's pattern
+        // against the receiver (each probe running alias normalization / subtype
+        // checks via the canonical algebra), so this hash lookup collapses the
+        // dominant "plain method / field access" case — where the accessed
+        // member is not an interface method — to O(1). Correctness: the set is
+        // the union of every method declared by any reachable interface, so any
+        // name that COULD dispatch is still present and falls through to the
+        // full enumeration + `mir_interface_declares_method` check below.
+        if !self.interface_method_names.contains(method) {
             return None;
         }
         for resolved in self.l1_impls_for_recv(recv_ty) {

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1679,6 +1679,77 @@ unsafe impl salsa::Update for PackageLoweringData {
     }
 }
 
+/// Project-wide class → runtime type-tag map. See
+/// [`class_type_tags_for_project`].
+#[derive(Debug, PartialEq)]
+struct ProjectClassTypeTags {
+    tags: IndexMap<TypeName, i64>,
+}
+
+/// Mirrors [`PackageLoweringData`]'s impl: the map holds no Salsa-interned
+/// (`'db`) data, so storing it by value is sound; `maybe_update` uses
+/// `PartialEq` for proper Salsa early-cutoff.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for ProjectClassTypeTags {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: `old_pointer` is valid, aligned, and Salsa-owned.
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// Build `class_type_tags` for every class in the project, once, memoized by
+/// Salsa.
+///
+/// Tags are content-addressed (`typetag::class_type_tag` over the
+/// fully-qualified name), so they match the `class.type_tag` values the
+/// emitter assigns by construction — no iteration-order coupling — and a
+/// class keeps its tag regardless of what other code exists.
+///
+/// This was previously an untracked helper called from every
+/// `LoweringContext` construction — i.e. the whole project's item trees were
+/// walked, and every class name re-rendered and re-hashed, once per lowered
+/// function/let (see `crates/tools_compile_profile/README.md`, July 2026
+/// audit, item #4). `project` is only the memo key; the body's file/item
+/// reads are tracked as dependencies through `db` as usual.
+#[salsa::tracked(returns(ref))]
+fn class_type_tags_for_project(
+    db: &dyn crate::Db,
+    _project: baml_workspace::Project,
+) -> ProjectClassTypeTags {
+    let all_files = compiler2_all_files(db);
+    let mut tags: IndexMap<TypeName, i64> = IndexMap::new();
+
+    for file in &all_files {
+        let item_tree = file_item_tree(db, *file);
+        let pkg_info = file_package(db, *file);
+
+        for class_data in item_tree.classes.values() {
+            let class_qtn = QualifiedTypeName::new(
+                pkg_info.package.clone(),
+                pkg_info.namespace_path.clone(),
+                class_data.name.clone(),
+            );
+            let type_tag = baml_type::typetag::class_type_tag(&class_qtn.render_dotted(false));
+            // Use entry to avoid overwriting if the same class appears via multiple paths
+            // (e.g., both FQ and short names). First encounter wins — consistent with emit.rs.
+            tags.entry(class_qtn).or_insert(type_tag);
+        }
+    }
+
+    ProjectClassTypeTags { tags }
+}
+
 /// Build the package-invariant [`PackageLoweringData`] once per package,
 /// memoized by Salsa and shared across every function's `LoweringContext`.
 #[salsa::tracked(returns(ref))]
@@ -1882,8 +1953,10 @@ struct LoweringContext<'db> {
     class_field_types: &'db ClassFieldTypes,
     enum_variants: &'db EnumVariantIndices,
     /// Pre-computed type tags for class types, used by `SwitchKind::TypeTag`
-    /// for union-type switch optimization (ported from MIR 1).
-    class_type_tags: IndexMap<TypeName, i64>,
+    /// for union-type switch optimization (ported from MIR 1). Borrowed from
+    /// the Salsa-memoized [`class_type_tags_for_project`] (was rebuilt per
+    /// lowered function).
+    class_type_tags: &'db IndexMap<TypeName, i64>,
     /// BEP-044: for every interface, the list of classes that implement it
     /// (directly or transitively through interface `requires`). Lets the field-access
     /// and method-call lowering paths emit a type-tag switch over the
@@ -2237,8 +2310,9 @@ impl<'db> LoweringContext<'db> {
 
     /// Populate `class_fields` and `enum_variants` from a single package's items.
     ///
-    /// Note: `class_type_tags` is built separately via `build_class_type_tags` to ensure
-    /// the same file-iteration order as the emitter (`generate_project_bytecode`).
+    /// Note: `class_type_tags` is built separately via the project-wide
+    /// [`class_type_tags_for_project`] query (tags are content-addressed, so
+    /// they match the emitter's values without iteration-order coupling).
     fn populate_from_package(
         db: &'db dyn crate::Db,
         pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
@@ -2518,36 +2592,6 @@ impl<'db> LoweringContext<'db> {
         }
     }
 
-    /// Build `class_type_tags` for every class in the project.
-    ///
-    /// Tags are content-addressed (`typetag::class_type_tag` over the
-    /// fully-qualified name), so they match the `class.type_tag` values the
-    /// emitter assigns by construction — no iteration-order coupling — and a
-    /// class keeps its tag regardless of what other code exists.
-    fn build_class_type_tags(db: &'db dyn crate::Db) -> IndexMap<TypeName, i64> {
-        let all_files = compiler2_all_files(db);
-        let mut class_type_tags: IndexMap<TypeName, i64> = IndexMap::new();
-
-        for file in &all_files {
-            let item_tree = file_item_tree(db, *file);
-            let pkg_info = file_package(db, *file);
-
-            for class_data in item_tree.classes.values() {
-                let class_qtn = QualifiedTypeName::new(
-                    pkg_info.package.clone(),
-                    pkg_info.namespace_path.clone(),
-                    class_data.name.clone(),
-                );
-                let type_tag = baml_type::typetag::class_type_tag(&class_qtn.render_dotted(false));
-                // Use entry to avoid overwriting if the same class appears via multiple paths
-                // (e.g., both FQ and short names). First encounter wins — consistent with emit.rs.
-                class_type_tags.entry(class_qtn).or_insert(type_tag);
-            }
-        }
-
-        class_type_tags
-    }
-
     fn new(
         db: &'db dyn crate::Db,
         func_loc: FunctionLoc<'db>,
@@ -2724,9 +2768,10 @@ impl<'db> LoweringContext<'db> {
         // (was rebuilt — and every class field re-lowered — per function).
         let pkg_data = package_lowering_data(db, pkg_id);
 
-        // Build class_type_tags using the same file-iteration order as the emitter,
-        // so that switch arms get the same integer tags as runtime class.type_tag fields.
-        let class_type_tags = Self::build_class_type_tags(db);
+        // Tags are content-addressed over each class's fully-qualified name,
+        // so they match the emitter's `class.type_tag` values by construction.
+        // Memoized project-wide (was rebuilt here per lowered function).
+        let class_type_tags = &class_type_tags_for_project(db, db.project()).tags;
 
         // --- Determine arity from function signature ---
         let sig = baml_compiler2_ppir::function_signature(db, func_loc);
@@ -2841,9 +2886,10 @@ impl<'db> LoweringContext<'db> {
         // (was rebuilt — and every class field re-lowered — per let binding).
         let pkg_data = package_lowering_data(db, pkg_id);
 
-        // Build class_type_tags using the same file-iteration order as the emitter,
-        // so that switch arms get the same integer tags as runtime class.type_tag fields.
-        let class_type_tags = Self::build_class_type_tags(db);
+        // Tags are content-addressed over each class's fully-qualified name,
+        // so they match the emitter's `class.type_tag` values by construction.
+        // Memoized project-wide (was rebuilt here per lowered function).
+        let class_type_tags = &class_type_tags_for_project(db, db.project()).tags;
 
         LoweringContext {
             db,

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -54,9 +54,9 @@ pub fn collect_block_attrs(
     let mut result = FxHashMap::default();
     for file in project.files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, *file);
-        let cst = baml_compiler_parser::syntax_tree(db, *file);
-        let (items, _, _) = ast::lower_file(&cst);
-        for item in &items {
+        // Reuse the memoized CST → AST lowering instead of re-lowering here.
+        let items = &baml_compiler2_hir::file_ast(db, *file).items;
+        for item in items {
             let (name, item_attrs) = match item {
                 ast::Item::Class(c) => (&c.name, &c.attributes),
                 ast::Item::Enum(e) => (&e.name, &e.attributes),
@@ -85,9 +85,9 @@ pub fn collect_alias_bodies(
     let mut result = FxHashMap::default();
     for file in project.files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, *file);
-        let cst = baml_compiler_parser::syntax_tree(db, *file);
-        let (items, _, _) = ast::lower_file(&cst);
-        for item in &items {
+        // Reuse the memoized CST → AST lowering instead of re-lowering here.
+        let items = &baml_compiler2_hir::file_ast(db, *file).items;
+        for item in items {
             if let ast::Item::TypeAlias(a) = item {
                 let ty = a.type_expr.as_ref().map(PpirTy::from_type_expr).unwrap_or(
                     PpirTy::CannotBeStreamed {
@@ -191,8 +191,8 @@ fn make_raw_attr_no_args(name: &str) -> ast::RawAttribute {
 /// Compute synthetic `*$stream` AST items for a single file in one pass.
 #[salsa::tracked]
 pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems<'_> {
-    let cst = baml_compiler_parser::syntax_tree(db, file);
-    let (items, _, _) = ast::lower_file(&cst);
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let items = &baml_compiler2_hir::file_ast(db, file).items;
 
     // Get HIR classification for the file's package (original types only)
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
@@ -215,7 +215,7 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
     let mut seen_class_names = FxHashSet::default();
     let mut seen_alias_names = FxHashSet::default();
 
-    for item in &items {
+    for item in items {
         match item {
             ast::Item::Class(c) => {
                 if c.name.ends_with("$stream") {
@@ -578,13 +578,28 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
 // -- Canonical queries (original + *$stream) ----------------------------------
 
 /// Canonical semantic index: original AST items + PPIR synthetic *$stream items.
+///
+/// When a file has no synthetic `*$stream` items, the post-expansion index is
+/// byte-for-byte the pre-expansion one (same AST items from `file_ast`, same
+/// builder, same file range), so this delegates to HIR's already-computed index
+/// instead of rebuilding scopes/bindings/contributions a second time.
+pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> &FileSemanticIndex<'_> {
+    let expansion = ppir_expansion_items(db, file);
+    if expansion.items(db).is_empty() {
+        return baml_compiler2_hir::file_semantic_index(db, file);
+    }
+    file_semantic_index_expanded(db, file)
+}
+
+/// The merged (original + `*$stream`) index for files that actually have
+/// synthetic items. Callers must go through [`file_semantic_index`].
 #[salsa::tracked(returns(ref), no_eq)]
-pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
+fn file_semantic_index_expanded(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'_> {
     let tree = baml_compiler_parser::syntax_tree(db, file);
     let file_range = tree.text_range();
-    let path = file.path(db);
-    let (mut items, lowering_diags, env_var_refs) =
-        ast::lower_file_with_path(&tree, Some(path.as_path()));
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let ast_result = baml_compiler2_hir::file_ast(db, file);
+    let mut items = ast_result.items.clone();
 
     // Merge synthetic *$stream items
     let expansion = ppir_expansion_items(db, file);
@@ -592,8 +607,8 @@ pub fn file_semantic_index(db: &dyn Db, file: SourceFile) -> FileSemanticIndex<'
 
     // Re-run HIR builder on merged items
     baml_compiler2_hir::SemanticIndexBuilder::new(db, file)
-        .with_lowering_diagnostics(lowering_diags)
-        .with_env_var_refs(env_var_refs)
+        .with_lowering_diagnostics(ast_result.diagnostics.clone())
+        .with_env_var_refs(ast_result.env_var_refs.clone())
         .build(&items, file_range)
 }
 
@@ -616,6 +631,12 @@ pub fn file_item_tree(db: &dyn Db, file: SourceFile) -> Arc<ItemTree> {
 ///
 /// TIR should call this instead of `baml_compiler2_hir::body::function_body`
 /// so that PPIR-synthesized functions (like `$parse_stream`) are found.
+///
+/// Salsa-tracked (mirroring HIR's `function_body`): MIR lowering fetches the
+/// callee's body at every direct-call site, and the untracked version cloned
+/// the entire `ExprBody` arena out of the item tree on every one of those
+/// calls. Tracking it caches the `Arc<FunctionBody>` so repeat calls are O(1).
+#[salsa::tracked]
 pub fn function_body<'db>(
     db: &'db dyn Db,
     function: baml_compiler2_hir::loc::FunctionLoc<'db>,

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -862,6 +862,16 @@ pub struct TypeInferenceBuilder<'db> {
     /// to the owning Function/Let scope) lets that standalone inference seed
     /// them — see `infer_scope_types`'s `ScopeKind::Lambda` arm.
     pub template_body_params: FxHashMap<FileScopeId, Vec<FunctionParamTy>>,
+    /// Accumulates each nested lambda's full inline-inference tables, keyed by
+    /// the lambda's `FileScopeId`. Captured at the end of `infer_lambda_body`
+    /// (moved, not cloned) before parent state is restored. Like
+    /// `nested_lambda_types`, NOT saved/restored by `infer_lambda_body`, so
+    /// entries for arbitrarily nested lambdas bubble up to the owning
+    /// Function/Let scope, where the standalone `ScopeKind::Lambda` query
+    /// projects them out instead of re-inferring the body (and re-emitting its
+    /// diagnostics).
+    pub nested_lambda_inference:
+        FxHashMap<FileScopeId, crate::inference::NestedLambdaInference<'db>>,
     /// Diagnostic-only concrete escaping throws for lambda expressions in the
     /// current scope. Used to explain callback forwarding without affecting
     /// call instantiation or throws checking semantics.
@@ -1100,6 +1110,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             default_parameter_inference: crate::inference::DefaultParameterInference::empty(),
             nested_lambda_types: FxHashMap::default(),
             template_body_params: FxHashMap::default(),
+            nested_lambda_inference: FxHashMap::default(),
             lambda_effective_throws: FxHashMap::default(),
             is_auto_derived_body: false,
         }
@@ -1219,6 +1230,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         FxHashMap<FileScopeId, Ty>,
         FxHashMap<FileScopeId, Vec<FunctionParamTy>>,
         crate::inference::DefaultParameterInference<'db>,
+        FxHashMap<FileScopeId, crate::inference::NestedLambdaInference<'db>>,
     ) {
         let diagnostics = self.context.finish();
         (
@@ -1238,6 +1250,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.nested_lambda_types,
             self.template_body_params,
             self.default_parameter_inference,
+            self.nested_lambda_inference,
         )
     }
 
@@ -5502,15 +5515,14 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
 
         // Infer the lambda body using save/restore approach
-        let (ret_ty, _lambda_expressions, lambda_fsi, lambda_effective_throws) = self
-            .infer_lambda_body(
-                func_def,
-                &param_tys,
-                return_annotation.as_ref(),
-                &throws_ty,
-                throws_span,
-                warn_extraneous_throws,
-            );
+        let (ret_ty, lambda_fsi, lambda_effective_throws) = self.infer_lambda_body(
+            func_def,
+            &param_tys,
+            return_annotation.as_ref(),
+            &throws_ty,
+            throws_span,
+            warn_extraneous_throws,
+        );
         let surface_ret_ty = return_annotation.unwrap_or(ret_ty);
 
         let surface_throws = if infer_throws_from_body {
@@ -6458,15 +6470,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                     );
 
                 // Infer/check the lambda body using save/restore approach
-                let (ret_ty, _lambda_expressions, lambda_fsi, lambda_effective_throws) = self
-                    .infer_lambda_body(
-                        func_def,
-                        &param_tys,
-                        Some(effective_ret),
-                        &throws_ty,
-                        throws_span,
-                        warn_extraneous_throws,
-                    );
+                let (ret_ty, lambda_fsi, lambda_effective_throws) = self.infer_lambda_body(
+                    func_def,
+                    &param_tys,
+                    Some(effective_ret),
+                    &throws_ty,
+                    throws_span,
+                    warn_extraneous_throws,
+                );
                 let surface_ret_ty = return_annotation.unwrap_or_else(|| {
                     if matches!(
                         expected_ret.as_ref(),
@@ -14224,13 +14235,14 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// Infer/check a lambda body using a save/restore approach.
     ///
     /// Saves the current locals, `declared_return_ty`, `generic_params`, and
-    /// `expressions` (to avoid `ExprId` collisions between
-    /// the lambda's arena and the parent's arena). After inference, restores all
-    /// saved state and returns the lambda's expression types separately.
+    /// `expressions` (to avoid `ExprId` collisions between the lambda's arena
+    /// and the parent's arena). After inference, restores all saved state; the
+    /// lambda's own inference tables are *moved* into `nested_lambda_inference`
+    /// keyed by the lambda's `FileScopeId`, so the standalone
+    /// `ScopeKind::Lambda` query can project them instead of re-inferring the
+    /// body (which also stops its diagnostics from being reported twice).
     ///
-    /// Returns `(inferred_return_ty, lambda_expressions)` where
-    /// `lambda_expressions` contains the expression types for the lambda body
-    /// only (keyed by the lambda's own `ExprId`s, which start at 0).
+    /// Returns `(inferred_return_ty, lambda_file_scope_id, effective_throws)`.
     pub fn infer_lambda_body(
         &mut self,
         func_def: &baml_compiler2_ast::FunctionDef,
@@ -14239,7 +14251,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         chosen_throws: &Ty,
         throws_report_span: TextRange,
         warn_extraneous_throws: bool,
-    ) -> (Ty, FxHashMap<ExprId, Ty>, Option<FileScopeId>, Ty) {
+    ) -> (Ty, Option<FileScopeId>, Ty) {
         use baml_compiler2_ast::FunctionBodyDef;
 
         // Get the lambda's ExprBody
@@ -14248,7 +14260,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Ty::Unknown {
                     attr: TyAttr::default(),
                 },
-                FxHashMap::default(),
                 None,
                 Ty::Never {
                     attr: TyAttr::default(),
@@ -14261,7 +14272,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Ty::Void {
                     attr: TyAttr::default(),
                 },
-                FxHashMap::default(),
                 None,
                 Ty::Never {
                     attr: TyAttr::default(),
@@ -14345,10 +14355,33 @@ impl<'db> TypeInferenceBuilder<'db> {
             let db = self.context.db();
             let file = self.context.scope().file(db);
             let index = baml_compiler2_ppir::file_semantic_index(db, file);
-            // Captures are seeded only if the lambda scope is located (it
-            // always should be, but be defensive).
-            let found_fsi = index.lambda_scope_for(func_def.span);
-            if let Some(fsi) = found_fsi {
+            // The lambda's own `FileScopeId`, matched by the surface lambda's
+            // span. Real `(...) -> { ... }` lambdas resolve here.
+            //
+            // Synthetic lambdas (desugared `test` / `testset` bodies) carry a
+            // default `FunctionDef::span`, so this misses. For capture *seeding*
+            // (defensive suppression of false "unresolved name" diagnostics on
+            // captures) we still want the scope, so we fall back to the body's
+            // root-expression span to locate it — but ONLY for seeding.
+            //
+            // The capture *key* (`lambda_file_scope_id`, used to record this
+            // body's tables in `nested_lambda_inference` for the standalone
+            // `ScopeKind::Lambda` query to project) is deliberately left `None`
+            // for these synthetic bodies. Their diagnostics (e.g. `unresolved
+            // name: functions` inside an experimental `test T() { functions
+            // [...] args { } }` block) are emitted ONLY by the standalone Lambda
+            // inference, not by this owning inline pass; projecting an empty
+            // table would drop them. Falling through to standalone re-inference
+            // keeps them. Real lambda bodies, whose diagnostics the owner inline
+            // pass does emit, are keyed and projected so they are not inferred
+            // (or reported) twice.
+            let key_fsi = index.lambda_scope_for(func_def.span);
+            let seed_fsi = key_fsi.or_else(|| {
+                lambda_body
+                    .root_expr
+                    .and_then(|root| index.lambda_scope_for(lambda_source_map.expr_span(root)))
+            });
+            if let Some(fsi) = seed_fsi {
                 let captures_to_seed: Vec<(Name, baml_compiler2_hir::semantic_index::BindingId)> =
                     index.scope_bindings[fsi.index() as usize]
                         .captures
@@ -14361,7 +14394,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     self.seed_capture(capture_name, ty);
                 }
             }
-            found_fsi
+            key_fsi
         };
 
         // Set return type context for return statement checking inside lambda
@@ -14423,23 +14456,84 @@ impl<'db> TypeInferenceBuilder<'db> {
                 attr: TyAttr::default(),
             });
 
-        // Collect the lambda's expression types and restore parent state
+        // Move the lambda's expression types out and swap the parent's back in.
         let lambda_expressions = std::mem::replace(&mut self.expressions, saved_expressions);
-        self.pattern_types = saved_bindings;
+        // Capture this lambda's complete inference tables (keyed by its own body
+        // arena's IDs) so the standalone `ScopeKind::Lambda` query can project
+        // them out instead of re-inferring the body from scratch — the second
+        // inference that this eliminates was both wasted work AND the source of
+        // duplicated diagnostics inside lambdas. Each table is *moved* out while
+        // the saved parent state is swapped back in (`mem::replace`), so there
+        // are no clones: the lambda's tables have exactly one consumer.
+        // `nested_lambda_inference` itself is NOT restored below, so entries
+        // recorded by inner `infer_lambda_body` calls bubble up to the owning
+        // Function/Let scope. `pattern_natural_cache` and the other fields
+        // outside `NestedLambdaInference` are always just restored — they are
+        // caches/context, not part of the lambda's projected result.
+        if let Some(fsi) = lambda_file_scope_id {
+            let lambda_param_types: Vec<(Name, Ty)> = func_def
+                .params
+                .iter()
+                .zip(param_tys.iter())
+                .map(|(param, param_ty)| (param.name.clone(), param_ty.ty.clone()))
+                .collect();
+            self.nested_lambda_inference.insert(
+                fsi,
+                crate::inference::NestedLambdaInference {
+                    expressions: lambda_expressions,
+                    pattern_types: std::mem::replace(&mut self.pattern_types, saved_bindings),
+                    resolutions: std::mem::replace(&mut self.resolutions, saved_resolutions),
+                    catch_residual_throws: std::mem::replace(
+                        &mut self.catch_residual_throws,
+                        saved_catch_residual_throws,
+                    ),
+                    exhaustive_matches: std::mem::replace(
+                        &mut self.exhaustive_matches,
+                        saved_exhaustive_matches,
+                    ),
+                    path_root_types: std::mem::replace(
+                        &mut self.path_root_types,
+                        saved_path_root_types,
+                    ),
+                    path_segment_types: std::mem::replace(
+                        &mut self.path_segment_types,
+                        saved_path_segment_types,
+                    ),
+                    path_member_resolutions: std::mem::replace(
+                        &mut self.path_member_resolutions,
+                        saved_path_member_resolutions,
+                    ),
+                    param_types: lambda_param_types,
+                    call_plans: std::mem::replace(&mut self.call_plans, saved_call_plans),
+                    call_type_instantiations: std::mem::replace(
+                        &mut self.call_type_instantiations,
+                        saved_call_type_instantiations,
+                    ),
+                    function_coercions: std::mem::replace(
+                        &mut self.function_coercions,
+                        saved_function_coercions,
+                    ),
+                },
+            );
+        } else {
+            // Synthetic lambda with no locatable scope: just restore, dropping
+            // its tables (nothing will project them).
+            self.pattern_types = saved_bindings;
+            self.resolutions = saved_resolutions;
+            self.catch_residual_throws = saved_catch_residual_throws;
+            self.exhaustive_matches = saved_exhaustive_matches;
+            self.path_root_types = saved_path_root_types;
+            self.path_segment_types = saved_path_segment_types;
+            self.path_member_resolutions = saved_path_member_resolutions;
+            self.call_plans = saved_call_plans;
+            self.call_type_instantiations = saved_call_type_instantiations;
+            self.function_coercions = saved_function_coercions;
+        }
         self.pattern_natural_cache = saved_pattern_natural_cache;
-        self.resolutions = saved_resolutions;
-        self.exhaustive_matches = saved_exhaustive_matches;
-        self.catch_residual_throws = saved_catch_residual_throws;
-        self.path_root_types = saved_path_root_types;
-        self.path_segment_types = saved_path_segment_types;
-        self.path_member_resolutions = saved_path_member_resolutions;
         self.interface_method_generic_params = saved_interface_method_generic_params;
         self.owner_type_arg_binding_seed = saved_owner_type_arg_binding_seed;
         self.self_pinned_rigid_var = saved_self_pinned_rigid_var;
         self.lambda_effective_throws = saved_lambda_effective_throws;
-        self.call_plans = saved_call_plans;
-        self.call_type_instantiations = saved_call_type_instantiations;
-        self.function_coercions = saved_function_coercions;
         self.locals = saved_locals;
         self.scoped_local_declarations = saved_scoped_local_declarations;
         self.scoped_local_assignments = saved_scoped_local_assignments;
@@ -14453,12 +14547,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .freeze_diagnostic_spans_from(lambda_diag_start, lambda_source_map);
         self.body_source_map = saved_body_source_map;
 
-        (
-            ret_ty,
-            lambda_expressions,
-            lambda_file_scope_id,
-            lambda_effective_throws,
-        )
+        (ret_ty, lambda_file_scope_id, lambda_effective_throws)
     }
 }
 

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -7815,11 +7815,22 @@ impl<'db> TypeInferenceBuilder<'db> {
         // second matrix of error-free arms only, so an invalid arm cannot
         // spuriously mark a *later* valid arm unreachable.
         if !reachability_arms.is_empty() {
-            let reachability_report = crate::pattern_lowering::compute_match_usefulness(
-                self,
-                &reachability_arms,
-                scrutinee_ty_for_matrix,
-            );
+            // In the common case no arm had a pattern error, so
+            // `reachability_arms` is exactly `matrix_arms` (same DPats, same
+            // order) and the exhaustiveness report above was computed from the
+            // identical matrix — reuse its arm-reachability instead of running
+            // the whole usefulness algorithm a second time. The matrix walk is
+            // the hottest part of match checking, so this halves its cost per
+            // error-free `match`.
+            let reachability_report = if reachability_arms.len() == matrix_arms.len() {
+                report
+            } else {
+                crate::pattern_lowering::compute_match_usefulness(
+                    self,
+                    &reachability_arms,
+                    scrutinee_ty_for_matrix,
+                )
+            };
             for arm in reachability_report.unreachable_arms {
                 if let Some(&body_expr) = reachability_arm_ids.get(arm.0) {
                     self.context

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -137,6 +137,92 @@ fn function_generic_param_bounds_exprs(
     item_tree[func_loc.id(db)].generic_param_bounds.clone()
 }
 
+/// Per-callee generic-parameter facts consumed at every call site:
+/// the enclosing class's generic params (empty for free functions), the
+/// callee's user-declared params, their lowered interface bounds, and the
+/// callee's name for diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct CalleeGenerics {
+    pub(crate) class_params: Vec<Name>,
+    pub(crate) user_params: Vec<Name>,
+    pub(crate) user_bounds: Vec<Option<Ty>>,
+    pub(crate) name: Name,
+}
+
+// Safety: `CalleeGenerics` holds only plain (non-`'db`) data. Manual `Update`
+// impl uses `PartialEq` for Salsa early-cutoff.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for CalleeGenerics {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: `old_pointer` is valid, aligned, and Salsa-owned.
+        #[allow(unsafe_code)]
+        let old = unsafe { &*old_pointer };
+        if old == &new_value {
+            false
+        } else {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            true
+        }
+    }
+}
+
+/// The declared generic params and lowered bounds of a callable, memoized per
+/// function. Every call site used to redo this from scratch — an item-tree
+/// scan for the enclosing class plus a re-lowering of the bound type
+/// expressions — even though it is a pure function of the callee's
+/// declaration, so memoizing per `FunctionLoc` is safe.
+#[salsa::tracked(returns(ref))]
+pub(crate) fn callee_generics_for_func<'db>(
+    db: &'db dyn crate::Db,
+    func_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
+) -> CalleeGenerics {
+    let sig = baml_compiler2_ppir::elaborated_function_signature(db, func_loc);
+    // The enclosing class's generic params (`[]` for a free function). These
+    // are always in scope when lowering the method's *bounds* — a bound may
+    // reference a class generic (`<U extends Eq<C>>` on a method of
+    // `class Box<C>`) regardless of how the class args are supplied — so they
+    // must be visible or `C` would resolve to `unknown`.
+    let file = func_loc.file(db);
+    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
+    let class_params: Vec<Name> = item_tree
+        .classes
+        .values()
+        .find(|class_data| class_data.methods.contains(&func_loc.id(db)))
+        .map(|class_data| class_data.generic_params.clone())
+        .unwrap_or_default();
+
+    // Lower the user generic params' interface bounds in the callee's own
+    // package/namespace, with the class params in scope (see above). The
+    // bounds were already validated at the declaration site, so discard
+    // re-lowering diagnostics here.
+    let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
+    let pkg_id = PackageId::new(db, pkg_info.package.clone());
+    let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
+    let mut bound_scope = class_params.clone();
+    bound_scope.extend(sig.user_generic_params.iter().cloned());
+    let mut diags = Vec::new();
+    let user_bounds = lower_generic_param_bounds(
+        db,
+        &function_generic_param_bounds_exprs(db, func_loc),
+        pkg_items,
+        &pkg_info.namespace_path,
+        &bound_scope,
+        None,
+        &mut diags,
+    );
+
+    CalleeGenerics {
+        class_params,
+        user_params: sig.user_generic_params.clone(),
+        user_bounds,
+        name: sig.name.clone(),
+    }
+}
+
 pub(crate) fn lower_generic_param_bounds(
     db: &dyn crate::Db,
     bounds: &[Option<TypeExpr>],
@@ -544,7 +630,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         GlobalTypeContext {
             db: self.context.db(),
             res_ctx: self.res_ctx,
-            aliases: &self.aliases,
+            aliases: self.aliases,
             bounds: &self.generic_param_bounds,
         }
     }
@@ -664,8 +750,10 @@ pub struct TypeInferenceBuilder<'db> {
     /// Declared return type for the function (used to check return statements).
     declared_return_ty: Option<Ty>,
     /// Resolved type alias map: alias qualified name → expanded Ty.
-    /// Used by the normalizer for structural subtype checking.
-    aliases: HashMap<crate::ty::QualifiedTypeName, Ty>,
+    /// Used by the normalizer for structural subtype checking. Held by
+    /// reference to the Salsa-cached `package_resolved_aliases` value so it is
+    /// not cloned per scope (it used to be rebuilt for every scope inference).
+    aliases: &'db HashMap<crate::ty::QualifiedTypeName, Ty>,
     /// Namespace path for the file being analyzed (e.g. `["env"]` for `baml/env.baml`).
     ns_context: Vec<Name>,
     /// BEP-044: when this body is the override of an interface method
@@ -967,7 +1055,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         res_ctx: &'db PackageResolutionContext<'db>,
         package_id: PackageId<'db>,
         scope: ScopeId<'db>,
-        aliases: HashMap<crate::ty::QualifiedTypeName, Ty>,
+        aliases: &'db HashMap<crate::ty::QualifiedTypeName, Ty>,
     ) -> Self {
         let db = context.db();
         let package_items = &res_ctx.own_items;
@@ -1319,7 +1407,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn expand_alias_chains(&self, ty: Ty) -> Ty {
-        crate::inference::expand_alias_chains(ty, &self.aliases)
+        crate::inference::expand_alias_chains(ty, self.aliases)
     }
 
     /// Pattern-matrix-internal normalization of a scrutinee type.
@@ -2001,20 +2089,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             _ => return None,
         };
         let db = self.context.db();
-        let sig = baml_compiler2_ppir::elaborated_function_signature(db, func_loc);
-        // The enclosing class's generic params (`[]` for a free function). These
-        // are always in scope when lowering the method's *bounds* — a bound may
-        // reference a class generic (`<U extends Eq<C>>` on a method of
-        // `class Box<C>`) regardless of how the class args are supplied — so they
-        // must be visible or `C` would resolve to `unknown`.
-        let file = func_loc.file(db);
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-        let enclosing_class_params: Vec<Name> = item_tree
-            .classes
-            .values()
-            .find(|class_data| class_data.methods.contains(&func_loc.id(db)))
-            .map(|class_data| class_data.generic_params.clone())
-            .unwrap_or_default();
+        // The callee's declared params and lowered bounds are a pure function
+        // of its declaration — previously re-derived here (item-tree scan +
+        // bound re-lowering) at every call site; now Salsa-memoized per callee.
+        let data = callee_generics_for_func(db, func_loc);
         // Only user-declared generic params are *supplied at the call site*;
         // synthetic effect params are always inferred. For static-method-on-
         // generic-class calls, the class params are also supplied (`Class<...>.m`)
@@ -2023,41 +2101,21 @@ impl<'db> TypeInferenceBuilder<'db> {
         // params (their own bounds, where any, are enforced at receiver
         // specialization).
         let class_params: &[Name] = if treat_as_static_method {
-            &enclosing_class_params
+            &data.class_params
         } else {
             &[]
         };
 
-        // Lower the user generic params' interface bounds in the callee's own
-        // package/namespace, with the class params in scope (see above). The
-        // bounds were already validated at the declaration site, so discard
-        // re-lowering diagnostics here.
-        let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
-        let pkg_id = PackageId::new(db, pkg_info.package.clone());
-        let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
-        let mut bound_scope = enclosing_class_params.clone();
-        bound_scope.extend(sig.user_generic_params.iter().cloned());
-        let mut diags = Vec::new();
-        let user_bounds = lower_generic_param_bounds(
-            db,
-            &function_generic_param_bounds_exprs(db, func_loc),
-            pkg_items,
-            &pkg_info.namespace_path,
-            &bound_scope,
-            None,
-            &mut diags,
-        );
-
         let mut declared_params: Vec<Name> = class_params.to_vec();
-        declared_params.extend(sig.user_generic_params.iter().cloned());
+        declared_params.extend(data.user_params.iter().cloned());
         let mut declared_bounds: Vec<Option<Ty>> = vec![None; class_params.len()];
-        declared_bounds.extend(user_bounds);
+        declared_bounds.extend(data.user_bounds.iter().cloned());
         // A user bound that references an enclosing class param (`<U extends
         // Eq<C>>` on a method of `class Box<C>`) is lowered with `C` as a type
         // variable here; on a bound-method call the receiver's value for `C` is
         // seeded into the call-site bindings (see `owner_type_arg_binding_seed`) so
         // the bound resolves to e.g. `Eq<int>` before it is checked.
-        Some((declared_params, declared_bounds, sig.name.clone()))
+        Some((declared_params, declared_bounds, data.name.clone()))
     }
 
     /// Resolve explicit type arguments written at a call site (e.g. `foo<int, string>(x)`).
@@ -5906,7 +5964,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         self.package_id,
                         &inferred,
                         expected,
-                        &self.aliases,
+                        self.aliases,
                         |a, b| self.is_subtype(a, b),
                     )
                 } else {

--- a/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
@@ -443,11 +443,11 @@ pub(crate) fn scope_types_equivalent(
 ) -> bool {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let gctx = GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds,
     };
     baml_type::normalize::equivalent(a, b, &gctx)
@@ -769,7 +769,7 @@ pub(crate) fn resolve_concrete_realized_interface(
 ) -> Option<baml_type::Interface> {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let realized = !crate::generics::contains_typevar(base)
         && !interface
             .generics
@@ -781,12 +781,12 @@ pub(crate) fn resolve_concrete_realized_interface(
             .any(|(_, ty)| crate::generics::contains_typevar(ty));
     let resolved = if realized {
         // Realized fast path: unique by coherence, bounds discharged by bounded re-entry.
-        crate::interfaces::get_implements_block(db, pkg_id, base, interface, &aliases)
+        crate::interfaces::get_implements_block(db, pkg_id, base, interface, aliases)
     } else {
         let gctx = GlobalTypeContext {
             db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds,
         };
         crate::interfaces::get_implements_block_symbolic(
@@ -794,7 +794,7 @@ pub(crate) fn resolve_concrete_realized_interface(
             pkg_id,
             base,
             interface,
-            &aliases,
+            aliases,
             |a, b| baml_type::normalize::is_subtype(a, b, &gctx),
         )
     };
@@ -821,16 +821,16 @@ pub(crate) fn resolve_concrete_projection(
 ) -> ConcreteProjection {
     let pkg_id = PackageId::new(db, pkg.clone());
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let gctx = GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds,
     };
 
     let mut declarers: Vec<baml_type::Interface> = Vec::new();
-    for resolved in crate::interfaces::impls_for_type(db, pkg_id, base, &aliases, |a, b| {
+    for resolved in crate::interfaces::impls_for_type(db, pkg_id, base, aliases, |a, b| {
         baml_type::normalize::is_subtype(a, b, &gctx)
     }) {
         let interface = resolved.implemented_interface(db);

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -570,7 +570,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.context.db(),
             self.package_id,
             base_ty,
-            &self.aliases,
+            self.aliases,
             |a, b| self.is_subtype(a, b),
         )
     }

--- a/baml_language/crates/baml_compiler2_tir/src/callable.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/callable.rs
@@ -417,15 +417,15 @@ pub fn callable_throws<'db>(db: &'db dyn crate::Db, function: FunctionLoc<'db>) 
                 };
             };
             let inference = infer_scope_types(db, scope_id);
-            let res_ctx = package_resolution_context(db, pkg_id);
-            let aliases = crate::inference::package_alias_map(db, res_ctx);
+            // Salsa-cached per package — previously rebuilt for every callable.
+            let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
             let facts = crate::throws_analysis::collect_escaping_throws(
                 &CallableThrowsAnalysis {
                     db,
                     pkg_id,
                     ns_context: &pkg_info.namespace_path,
                     inference,
-                    aliases: &aliases,
+                    aliases,
                 },
                 body,
             );

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -1644,7 +1644,9 @@ pub fn infer_scope_types<'db>(
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
 
-    let aliases = package_alias_map(db, res_ctx);
+    // Salsa-cached per package (with cycle handling) — previously rebuilt from
+    // scratch on every scope inference.
+    let aliases = package_resolved_aliases(db, pkg_id);
     let context = InferContext::new(db, scope_id);
     let mut builder = TypeInferenceBuilder::new(context, res_ctx, pkg_id, scope_id, aliases);
 
@@ -2937,13 +2939,41 @@ pub fn enum_variants<'db>(
     Some(enum_data.variants.iter().map(|v| v.name.clone()).collect())
 }
 
-/// Build the type-alias map visible from a package: its own aliases plus those
-/// re-exported by its dependencies. Shared by per-scope inference and throws
-/// analysis so both expand the same aliases (e.g. `testing.TestSetBody`).
-pub(crate) fn package_alias_map<'db>(
-    db: &'db dyn crate::Db,
-    res_ctx: &crate::package_interface::PackageResolutionContext<'db>,
+/// Cycle seed for [`package_resolved_aliases`]: the empty alias environment.
+///
+/// An alias whose RHS contains an associated-type projection (`type A = T.Member`)
+/// resolves through impl resolution and inference, which in turn read this very
+/// alias map — a legitimate Salsa dependency cycle. Salsa resolves it by fixpoint
+/// iteration seeded here with an empty environment (mirroring
+/// [`infer_scope_types`]'s empty [`ScopeInference`] seed and
+/// [`resolve_type_alias`]'s "still inferring" sentinel): the first iteration
+/// resolves every alias it can without the map, and iteration re-runs until the
+/// environment stops changing.
+fn package_resolved_aliases_cycle_initial<'db>(
+    _db: &'db dyn crate::Db,
+    _id: salsa::Id,
+    _pkg_id: PackageId<'db>,
 ) -> HashMap<crate::ty::QualifiedTypeName, Ty> {
+    HashMap::new()
+}
+
+/// The type-alias map visible from a package: its own aliases plus those
+/// re-exported by its dependencies. Shared by per-scope inference, throws
+/// analysis, and impl checking so all expand the same aliases (e.g.
+/// `testing.TestSetBody`).
+///
+/// Salsa-tracked and keyed by package: before this was a query, the map was
+/// rebuilt — a full clone of every alias `Ty` plus a project walk — inside
+/// every `infer_scope_types` execution (~15.6k executions on the test corpus).
+/// Hoisting is safe because the map is a pure function of the package's
+/// declarations (never of any per-scope inference state); the alias-resolution
+/// cycle it sits in is handled by `cycle_initial` above.
+#[salsa::tracked(returns(ref), cycle_initial = package_resolved_aliases_cycle_initial)]
+pub fn package_resolved_aliases<'db>(
+    db: &'db dyn crate::Db,
+    pkg_id: PackageId<'db>,
+) -> HashMap<crate::ty::QualifiedTypeName, Ty> {
+    let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
     let mut aliases = collect_type_aliases(db, &res_ctx.own_items);
     for (_dep_name, dep_iface) in &res_ctx.dep_interfaces {
         for types_in_ns in dep_iface.types.values() {

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -1093,6 +1093,14 @@ pub struct ScopeInference<'db> {
     /// these up (via this owning Function/Let scope) to seed params that have no
     /// HIR binding — see the `ScopeKind::Lambda` arm of `infer_scope_types`.
     template_body_params: FxHashMap<FileScopeId, Vec<FunctionParamTy>>,
+    /// Nested lambda scope → the full inference tables captured during this
+    /// (owning) scope's inline pass over the lambda's body. The standalone
+    /// `ScopeKind::Lambda` query projects its `ScopeInference` out of this map
+    /// instead of re-inferring the body — which previously inferred every lambda
+    /// body a second time and (because both passes emit diagnostics) reported
+    /// diagnostics inside lambdas twice. Populated only on Function/Let owner
+    /// scopes; contains entries for lambdas at every nesting depth.
+    nested_lambda_inference: FxHashMap<FileScopeId, NestedLambdaInference<'db>>,
     /// Lambda/function parameter types by index (name, inferred type).
     /// Populated for lambda scopes so LSP can resolve unannotated lambda
     /// parameter types (e.g. `items.map((item) -> { item. })`).
@@ -1120,6 +1128,32 @@ pub struct ScopeInference<'db> {
     parameter_defaults: DefaultParameterInference<'db>,
     /// Diagnostics and other rare data. Heap-allocated only when non-empty.
     extra: Option<Box<ScopeInferenceExtra<'db>>>,
+}
+
+/// The complete inference tables of one nested lambda body, captured during
+/// the owning Function/Let scope's inline pass (`infer_lambda_body`).
+///
+/// Before this existed, every lambda body was type-inferred twice: once inline
+/// while inferring the enclosing function (needed to type the lambda expression
+/// itself) and a second time from scratch by the standalone `ScopeKind::Lambda`
+/// arm of `infer_scope_types` (needed by MIR/LSP for the lambda scope's own
+/// tables). Recording the inline results here lets the Lambda arm project them
+/// out instead of re-inferring — and stops the lambda's diagnostics from being
+/// reported twice (they stay with the owner scope's inference).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NestedLambdaInference<'db> {
+    pub(crate) expressions: FxHashMap<ExprId, Ty>,
+    pub(crate) pattern_types: FxHashMap<PatId, Ty>,
+    pub(crate) resolutions: FxHashMap<ExprId, MemberResolution<'db>>,
+    pub(crate) catch_residual_throws: FxHashMap<ExprId, BTreeSet<Ty>>,
+    pub(crate) exhaustive_matches: FxHashSet<ExprId>,
+    pub(crate) path_root_types: FxHashMap<ExprId, Ty>,
+    pub(crate) path_segment_types: FxHashMap<(ExprId, usize), Ty>,
+    pub(crate) path_member_resolutions: FxHashMap<ExprId, Vec<MemberResolution<'db>>>,
+    pub(crate) param_types: Vec<(Name, Ty)>,
+    pub(crate) call_plans: FxHashMap<ExprId, CallPlan>,
+    pub(crate) call_type_instantiations: FxHashMap<ExprId, Vec<Ty>>,
+    pub(crate) function_coercions: FxHashMap<ExprId, FunctionCoercion>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1264,6 +1298,17 @@ impl<'db> ScopeInference<'db> {
     /// standalone scope inference to seed params that have no HIR binding.
     pub fn template_body_params(&self, fsi: FileScopeId) -> Option<&[FunctionParamTy]> {
         self.template_body_params.get(&fsi).map(Vec::as_slice)
+    }
+
+    /// The captured inline-inference tables for a nested lambda scope, if this
+    /// scope owns (transitively) that lambda's body. Present only on the owning
+    /// Function/Let scope's inference; the standalone `ScopeKind::Lambda` query
+    /// uses it to avoid re-inferring the body.
+    pub(crate) fn nested_lambda_inference(
+        &self,
+        fsi: FileScopeId,
+    ) -> Option<&NestedLambdaInference<'db>> {
+        self.nested_lambda_inference.get(&fsi)
     }
 
     /// Look up the binding type for a pattern (the type the variable is bound to,
@@ -1615,6 +1660,7 @@ fn infer_scope_types_cycle_initial<'db>(
         path_member_resolutions: FxHashMap::default(),
         nested_lambda_types: FxHashMap::default(),
         template_body_params: FxHashMap::default(),
+        nested_lambda_inference: FxHashMap::default(),
         param_types: Vec::new(),
         call_plans: FxHashMap::default(),
         call_type_instantiations: FxHashMap::default(),
@@ -2134,6 +2180,60 @@ pub fn infer_scope_types<'db>(
             }
         }
         ScopeKind::Lambda => {
+            // Fast path: the owning Function/Let scope's inline pass already
+            // inferred this lambda's body and captured its full tables (see
+            // `NestedLambdaInference`). Project them out instead of re-inferring
+            // the body here. This is what makes lambda-body inference happen
+            // exactly once — the standalone Lambda query used to re-walk the
+            // body from scratch, duplicating both the work AND every diagnostic
+            // reported inside the lambda. The projected `ScopeInference` carries
+            // no `extra`/diagnostics, so the lambda's diagnostics stay with the
+            // owner scope and are reported once.
+            //
+            // Synthetic tagged-template bodies (`is_template_body`) have no
+            // backing `Expr::Lambda` and are never captured, so they fall
+            // through to the standalone inference below; likewise any miss
+            // (e.g. the empty owner inference produced during a Salsa cycle
+            // iteration).
+            if !scope.is_template_body {
+                let owner_fsi =
+                    index
+                        .ancestor_scopes(file_scope)
+                        .into_iter()
+                        .find(|fsi: &FileScopeId| {
+                            matches!(
+                                index.scopes[fsi.index() as usize].kind,
+                                ScopeKind::Function | ScopeKind::Let
+                            )
+                        });
+                if let Some(owner_fsi) = owner_fsi {
+                    let owner_scope_id = index.scope_ids[owner_fsi.index() as usize];
+                    let owner_inference = infer_scope_types(db, owner_scope_id);
+                    if let Some(tables) = owner_inference.nested_lambda_inference(file_scope) {
+                        let tables = tables.clone();
+                        return ScopeInference {
+                            expressions: tables.expressions,
+                            pattern_types: tables.pattern_types,
+                            resolutions: tables.resolutions,
+                            catch_residual_throws: tables.catch_residual_throws,
+                            exhaustive_matches: tables.exhaustive_matches,
+                            path_root_types: tables.path_root_types,
+                            path_segment_types: tables.path_segment_types,
+                            path_member_resolutions: tables.path_member_resolutions,
+                            nested_lambda_types: FxHashMap::default(),
+                            template_body_params: FxHashMap::default(),
+                            nested_lambda_inference: FxHashMap::default(),
+                            param_types: tables.param_types,
+                            call_plans: tables.call_plans,
+                            call_type_instantiations: tables.call_type_instantiations,
+                            function_coercions: tables.function_coercions,
+                            parameter_defaults: DefaultParameterInference::empty(),
+                            extra: None,
+                        };
+                    }
+                }
+            }
+
             // Find the enclosing Function (or Let) scope by walking ancestors.
             // The Lambda scope does not directly store its body — we must find
             // the top-level body (Function or Let) and then locate the lambda
@@ -2848,6 +2948,7 @@ pub fn infer_scope_types<'db>(
         nested_lambda_types,
         template_body_params,
         parameter_defaults,
+        nested_lambda_inference,
     ) = builder.finish();
 
     let extra = if diagnostics.is_empty() {
@@ -2867,6 +2968,7 @@ pub fn infer_scope_types<'db>(
         path_member_resolutions,
         nested_lambda_types,
         template_body_params,
+        nested_lambda_inference,
         param_types,
         call_plans,
         call_type_instantiations,

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -186,8 +186,8 @@ fn package_impls_with_spans<'db>(
     pkg_id: PackageId<'db>,
 ) -> Vec<(&'db ImplData<'db>, Span)> {
     package_impl_locs(db, pkg_id)
-        .into_iter()
-        .filter_map(|loc| {
+        .iter()
+        .filter_map(|&loc| {
             let data = impl_data(db, loc).as_ref().ok()?;
             let span = impl_data_source_map(db, loc)
                 .as_ref()

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -1048,13 +1048,13 @@ pub fn validate_impl_signatures<'db>(
 
     // The canonical algebra context — fully usable in this phase (see the fn doc).
     let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
-    let aliases = crate::inference::package_alias_map(db, res_ctx);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
     let bounds: crate::lower_type_expr::TypeVarBoundsMap =
         data.generic_params.iter().cloned().collect();
     let ctx = crate::type_context::GlobalTypeContext {
         db,
         res_ctx,
-        aliases: &aliases,
+        aliases,
         bounds: &bounds,
     };
 
@@ -1349,7 +1349,7 @@ pub fn validate_impl_signatures<'db>(
                 generics: generics.clone(),
                 associated_types: assoc.clone(),
             };
-            if !implements_interface(db, &for_ty, &required_iface, &aliases, |a, b| {
+            if !implements_interface(db, &for_ty, &required_iface, aliases, |a, b| {
                 baml_type::normalize::is_subtype(a, b, &ctx)
             }) {
                 diags.push((
@@ -1423,6 +1423,13 @@ pub struct ResolvedImpl<'db> {
 /// Uniform over in-body and out-of-body impls (both live in
 /// [`file_item_tree`](baml_compiler2_hir::file_item_tree)`.impls`). Public so MIR can enumerate
 /// a package's impls to rebuild the runtime interface-implementor tables on the L1 substrate.
+///
+/// Salsa-tracked: this walks *every file in the project* (to find the
+/// package's files) and is called from every impl-resolution loop, coherence
+/// checking, and type-expression lowering, so an untracked version re-scanned
+/// the whole project on each call. The result is a pure function of the
+/// project's files and their item trees, so memoizing per package is safe.
+#[salsa::tracked(returns(ref))]
 pub fn package_impl_locs<'db>(
     db: &'db dyn crate::Db,
     pkg_id: PackageId<'db>,
@@ -1716,7 +1723,7 @@ pub fn type_implements_interface<'db>(
         db, pkg_id,
     ));
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1754,7 +1761,7 @@ pub(crate) fn get_implements_block_symbolic<'db>(
     ));
     let mut found: Option<ResolvedImpl<'db>> = None;
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1809,7 +1816,7 @@ fn get_implements_block_within_depth<'db>(
     ));
 
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -1971,7 +1978,7 @@ pub fn impls_for_type<'db>(
     ));
     let mut out = Vec::new();
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };
@@ -2024,7 +2031,7 @@ pub(crate) fn first_failing_impl_bound<'db>(
         db, pkg_id,
     ));
     for pkg in packages {
-        for impl_loc in package_impl_locs(db, pkg) {
+        for &impl_loc in package_impl_locs(db, pkg) {
             let Ok(data) = impl_data(db, impl_loc).as_ref() else {
                 continue;
             };

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -1440,12 +1440,12 @@ mod tests {
         let db = compile("interface Bar {}\ninterface Foo {\n  type Assoc extends Bar\n}\n");
         let user = PackageId::new(&db, Name::new("user"));
         let res_ctx = crate::package_interface::package_resolution_context(&db, user);
-        let aliases = crate::inference::package_alias_map(&db, res_ctx);
+        let aliases = crate::inference::package_resolved_aliases(&db, user);
         let bounds = TypeVarBoundsMap::default();
         let gctx = crate::type_context::GlobalTypeContext {
             db: &db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds: &bounds,
         };
         let foo = baml_type::Interface::new(
@@ -1482,12 +1482,12 @@ mod tests {
         ));
         let user = PackageId::new(&db, Name::new("user"));
         let res_ctx = crate::package_interface::package_resolution_context(&db, user);
-        let aliases = crate::inference::package_alias_map(&db, res_ctx);
+        let aliases = crate::inference::package_resolved_aliases(&db, user);
         let bounds = TypeVarBoundsMap::default();
         let gctx = crate::type_context::GlobalTypeContext {
             db: &db,
             res_ctx,
-            aliases: &aliases,
+            aliases,
             bounds: &bounds,
         };
         let foo = baml_type::Interface::new(
@@ -3181,7 +3181,7 @@ mod tests {
         let pkg = baml_compiler2_hir::file_package::file_package(&db, file).package;
         let pkg_id = baml_compiler2_hir::package::PackageId::new(&db, pkg);
         let mut out = Vec::new();
-        for impl_loc in crate::interfaces::package_impl_locs(&db, pkg_id) {
+        for &impl_loc in crate::interfaces::package_impl_locs(&db, pkg_id) {
             match crate::interfaces::impl_data(&db, impl_loc) {
                 Ok(data) => out.extend(data.diagnostics.iter().map(|(e, _)| e.clone())),
                 Err(crate::interfaces::ImplDataError::InterfaceUnresolved { diagnostics }) => {

--- a/baml_language/crates/baml_compiler_diagnostics/src/render.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/render.rs
@@ -208,7 +208,14 @@ pub fn render_diagnostic(
     config: &RenderConfig,
 ) -> String {
     match config.format {
-        DiagnosticFormat::Ariadne => render_ariadne(diagnostic, sources, file_paths, config.color),
+        DiagnosticFormat::Ariadne => {
+            // Single-diagnostic path builds its own one-shot cache. The batch
+            // path (`render_diagnostics`) shares one cache across diagnostics
+            // instead; this cache is exactly what that code used to build
+            // per-diagnostic, so the rendered bytes are unchanged.
+            let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
+            render_ariadne(diagnostic, sources, &mut cache, config.color)
+        }
         DiagnosticFormat::Concise => render_concise(diagnostic, sources, file_paths),
     }
 }
@@ -223,9 +230,25 @@ pub fn render_diagnostics(
     file_paths: &HashMap<FileId, PathBuf>,
     config: &RenderConfig,
 ) -> String {
+    // Build the ariadne `SourceCache` ONCE for the whole batch. Previously
+    // each diagnostic reconstructed its own cache inside
+    // `render_report_to_string`, and every `SourceCache::new` eagerly clones
+    // `sources`/`file_paths` and ariadne then computes a line index over every
+    // touched file. On warning-heavy projects that per-diagnostic rebuild was a
+    // large fraction of `baml check` wall time. Hoisting it is a pure
+    // construction move: the cache handed to `render_ariadne` is byte-for-byte
+    // the same object it would have built itself, so rendered output is
+    // identical (safe under `BAML_CACHE_VERIFY`).
+    let mut ariadne_cache = matches!(config.format, DiagnosticFormat::Ariadne)
+        .then(|| SourceCache::new(sources.clone(), file_paths.clone()));
     diagnostics
         .iter()
-        .map(|d| render_diagnostic(d, sources, file_paths, config))
+        .map(|d| match (&config.format, &mut ariadne_cache) {
+            (DiagnosticFormat::Ariadne, Some(cache)) => {
+                render_ariadne(d, sources, cache, config.color)
+            }
+            _ => render_concise(d, sources, file_paths),
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -259,10 +282,15 @@ fn translate_span(span: Span, sources: &HashMap<FileId, String>) -> Span {
 }
 
 /// Render a diagnostic using Ariadne (pretty CLI output).
+///
+/// Takes a pre-built [`SourceCache`] by `&mut` so batch rendering can share a
+/// single line-index computation across all diagnostics instead of rebuilding
+/// it per diagnostic. The cache carries the same `sources`/`file_paths` used
+/// elsewhere here, so filename display and rendered bytes are unchanged.
 fn render_ariadne(
     diagnostic: &Diagnostic,
     sources: &HashMap<FileId, String>,
-    file_paths: &HashMap<FileId, PathBuf>,
+    cache: &mut SourceCache,
     color: bool,
 ) -> String {
     // BAML CLI uses lowercase `error:` / `warning:` everywhere (matching
@@ -321,7 +349,7 @@ fn render_ariadne(
         .finish();
 
     // Render to string using SourceCache for proper filename display.
-    let rendered = render_report_to_string(&report, sources, file_paths);
+    let rendered = render_report_to_string(&report, cache);
 
     // See the rant above the `report_kind` match — ariadne paints the
     // `Custom` keyword unconditionally, so `with_color(false)` doesn't
@@ -427,17 +455,15 @@ fn render_concise(
 }
 
 /// Render an ariadne Report to a String using `SourceCache` for proper filename display.
-fn render_report_to_string(
-    report: &Report<'_, Span>,
-    sources: &HashMap<FileId, String>,
-    file_paths: &HashMap<FileId, PathBuf>,
-) -> String {
+///
+/// The `SourceCache` is now supplied by the caller (built once per batch)
+/// rather than reconstructed here per diagnostic. `report.write` only reads
+/// from the cache (populating ariadne's internal line index lazily), so
+/// reusing one cache across reports produces identical bytes.
+fn render_report_to_string(report: &Report<'_, Span>, cache: &mut SourceCache) -> String {
     let mut output = Vec::new();
 
-    // Use SourceCache for proper filename display
-    let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
-
-    report.write(&mut cache, &mut output).unwrap_or_else(|_| {
+    report.write(cache, &mut output).unwrap_or_else(|_| {
         output.clear();
         output.extend_from_slice(b"<error rendering diagnostic>");
     });

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -430,6 +430,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
                 _call_throws,
                 _template_body_params,
                 _default_parameter_inference,
+                _nested_lambda_inference,
             ) = builder.finish();
             for tir_diag in type_check_diagnostics.diagnostics {
                 if !is_function_default_signature_diagnostic(&tir_diag) {

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -154,15 +154,12 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
     let res_ctx = baml_compiler2_tir::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
     let aliases = collect_type_aliases_for_resolution_context(db, res_ctx);
-    let ast_items = {
-        let tree = baml_compiler_parser::syntax_tree(db, file);
-        let (items, _, _) = baml_compiler2_ast::lower_file(&tree);
-        items
-    };
+    // Reuse the memoized CST → AST lowering instead of re-lowering here.
+    let ast_items = &baml_compiler2_hir::file_ast(db, file).items;
     diagnostics.extend(validate_associated_type_bindings_in_items(
         db,
         file_id,
-        &ast_items,
+        ast_items,
         pkg_items,
         &pkg_info.namespace_path,
     ));

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -153,7 +153,9 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
     let pkg_id = baml_compiler2_hir::package::PackageId::new(db, pkg_info.package.clone());
     let res_ctx = baml_compiler2_tir::package_interface::package_resolution_context(db, pkg_id);
     let pkg_items = &res_ctx.own_items;
-    let aliases = collect_type_aliases_for_resolution_context(db, res_ctx);
+    // Salsa-cached per package — previously rebuilt (and cloned per function
+    // below) on every file check.
+    let aliases = baml_compiler2_tir::inference::package_resolved_aliases(db, pkg_id);
     // Reuse the memoized CST → AST lowering instead of re-lowering here.
     let ast_items = &baml_compiler2_hir::file_ast(db, file).items;
     diagnostics.extend(validate_associated_type_bindings_in_items(
@@ -396,11 +398,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
         if let Some(scope_id) = function_scope_id(index, func_data) {
             let context = baml_compiler2_tir::infer_context::InferContext::new(db, scope_id);
             let mut builder = baml_compiler2_tir::builder::TypeInferenceBuilder::new(
-                context,
-                res_ctx,
-                pkg_id,
-                scope_id,
-                aliases.clone(),
+                context, res_ctx, pkg_id, scope_id, aliases,
             );
             builder.set_generic_params(generic_params);
             for (name, ty) in &param_types {
@@ -1621,28 +1619,6 @@ fn jinja_diagnostic_id(message: &str) -> DiagnosticId {
     } else {
         DiagnosticId::JinjaInvalidType
     }
-}
-
-fn collect_type_aliases_for_resolution_context<'db>(
-    db: &'db dyn Db,
-    res_ctx: &'db baml_compiler2_tir::package_interface::PackageResolutionContext<'db>,
-) -> std::collections::HashMap<baml_compiler2_tir::ty::QualifiedTypeName, baml_compiler2_tir::ty::Ty>
-{
-    let mut aliases = baml_compiler2_tir::inference::collect_type_aliases(db, &res_ctx.own_items);
-    for (_dep_name, dep_iface) in &res_ctx.dep_interfaces {
-        for types_in_ns in dep_iface.types.values() {
-            for exported in types_in_ns.values() {
-                if let baml_compiler2_tir::package_interface::ExportedType::TypeAlias {
-                    qtn,
-                    resolved,
-                } = exported
-                {
-                    aliases.insert(qtn.clone(), resolved.clone());
-                }
-            }
-        }
-    }
-    aliases
 }
 
 fn function_scope_id<'db>(

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__04_tir.snap
@@ -258,7 +258,6 @@ function user.lambda_class_destructure_field_pattern_type_mismatch_span() -> int
   !! 6930..6936: type mismatch: expected int, got string
 }
 lambda user.lambda_class_destructure_field_pattern_type_mismatch_span {
-  !! 6941..6942: type mismatch: expected int, got string
 }
 function user.class_destructure_formatter_trivia_preserved() -> int throws never {
   { : int

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure/baml_tests__diagnostic_errors__patterns_class_destructure__05_diagnostics.snap
@@ -320,13 +320,3 @@ source: crates/baml_tests/src/generated_tests.rs
      │ 
      │ Note: Error code: E0001
 ─────╯
-
-  [type] error: type mismatch: expected int, got string
-     ╭─[ patterns_class_destructure.baml:283:38 ]
-     │
- 283 │         let Person { age: string } = p;
-     │                                      ┬  
-     │                                      ╰── type mismatch: expected int, got string
-     │ 
-     │ Note: Error code: E0001
-─────╯

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase3a__optional_param_default_forward_reference_checks_lambda_bodies.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase3a__optional_param_default_forward_reference_checks_lambda_bodies.snap
@@ -8,3 +8,5 @@ function user.lambda_capture_later_param(a: int = f(), b: int = 1) -> int throws
   }
   !! 46..78: default for parameter `a` cannot reference later parameter `b`
 }
+lambda user.lambda_capture_later_param {
+}

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -220,6 +220,20 @@ pub trait TypeContext {
     where
         Self: Sized,
     {
+        // Reflexivity fast path: structurally identical spellings (attrs
+        // included) trivially canonicalize to the same form.
+        if a == b {
+            return true;
+        }
+        // Cheap definite-mismatch filter. MIR impl dispatch probes every
+        // candidate impl's pattern against the receiver through `equivalent`
+        // (`match_ty_pattern_into`), so the overwhelmingly common case is a
+        // miss between two nominal types with different names — decidable from
+        // the outermost constructor alone, without the two allocation-heavy
+        // canonicalization walks below.
+        if heads_definitely_differ(a, b) {
+            return false;
+        }
         NormalTy::canonical(a, self) == NormalTy::canonical(b, self)
     }
 
@@ -342,6 +356,38 @@ pub fn equivalent<C: TypeContext>(a: &Ty, b: &Ty, ctx: &C) -> bool {
 /// Pending removal once every caller uses the method form.
 pub fn is_subtype<C: TypeContext>(sub: &Ty, sup: &Ty, ctx: &C) -> bool {
     ctx.is_subtype(sub, sup)
+}
+
+/// True only when `a` and `b` provably canonicalize to different forms, judged
+/// from their outermost constructor alone — a cheap reject for [`TypeContext::
+/// equivalent`] that skips the two canonicalization walks on the common
+/// nominal-mismatch case (e.g. probing an `impl for Foo` pattern against a
+/// receiver of an unrelated class).
+///
+/// Soundness rests on `NormalTy::from_ty` being *head-stable* for the variants
+/// decided here: a `Class`/`Interface`/`Enum`/`EnumVariant` maps to the same
+/// constructor carrying the *verbatim* qualified name (only its type arguments
+/// are rewritten), and equality is nominal, so two of the same kind with
+/// different names can never share a canonical form.
+///
+/// This is deliberately *conservative* — it decides only same-kind pairs whose
+/// heads are stable and never uses a cross-kind "different discriminant ⇒
+/// differ" catch-all. That catch-all would be unsound under the current
+/// normalization: `List`/`EvolvingList` and `Map`/`EvolvingMap` are distinct
+/// `Ty` constructors that canonicalize to the *same* `NormalTy` head, and
+/// `TypeAlias` / `Union` / `AssociatedTypeProjection` / generic `Media` /
+/// `Infer` heads can be rewritten into any other shape. Leaving every such case
+/// undecided (`false`) preserves correctness; only the unambiguous nominal
+/// misses are fast-rejected. Context-independent: canonicalization preserves
+/// these nominal heads regardless of the `TypeContext`.
+fn heads_definitely_differ(a: &Ty, b: &Ty) -> bool {
+    match (a, b) {
+        (Ty::Class(q1, ..), Ty::Class(q2, ..))
+        | (Ty::Interface(q1, ..), Ty::Interface(q2, ..))
+        | (Ty::Enum(q1, ..), Ty::Enum(q2, ..)) => q1 != q2,
+        (Ty::EnumVariant(q1, v1, ..), Ty::EnumVariant(q2, v2, ..)) => q1 != q2 || v1 != v2,
+        _ => false,
+    }
 }
 
 /// Free-function form of [`TypeContext::definitely_disjoint`], for a context held
@@ -1056,10 +1102,6 @@ impl NormalTy {
         ctx: &C,
         assumptions: &mut HashSet<(NormalTy, NormalTy)>,
     ) -> bool {
-        let pair = (self.clone(), sup.clone());
-        if assumptions.contains(&pair) {
-            return true;
-        }
         if self == sup {
             return true;
         }
@@ -1082,8 +1124,57 @@ impl NormalTy {
             return true;
         }
 
+        // ── Termination argument ──────────────────────────────────────────
+        // The co-inductive assumption set exists *only* to terminate cycles,
+        // and a cycle can only arise through an arm that *expands* (regenerates)
+        // a type rather than descending into a strictly-smaller subterm:
+        //   * μ-unfolding — `body.substitute(var, self)` can reproduce the same
+        //     pair (`(_, Mu)` on the right, `(Mu, _)` on the left);
+        //   * a `TypeVar` / `AssociatedTypeProjection` on the left — its bound is
+        //     looked up through the context and may mention the variable itself.
+        // Every *structural* arm (unions, invariant containers, functions,
+        // literals, enum-variant, the nominal interface facts) either recurses
+        // into a strictly-smaller subterm of a finite regular tree or is
+        // terminal, so those arms terminate WITHOUT any assumption bookkeeping.
+        // Any infinite derivation must therefore pass through an expanding arm
+        // infinitely often, and the pairs seen at those arms are drawn from the
+        // finite subterm closure of the (regular) operands — so recording pairs
+        // only at the expanding arms still guarantees a repeat is detected and
+        // the recursion is capped. Restricting the bookkeeping this way spares
+        // the deep `NormalTy` clone + full-tree hash on the millions of purely
+        // structural steps, which profiling showed dominated subtype-checking
+        // cost (this is now the *only* equivalence path post-unification).
+        let expanding = matches!(
+            self,
+            NormalTy::Mu { .. } | NormalTy::TypeVar(_) | NormalTy::AssociatedTypeProjection { .. }
+        ) || matches!(sup, NormalTy::Mu { .. });
+        if !expanding {
+            return self.is_subtype_of_inner(sup, ctx, assumptions);
+        }
+        // On the (few) expanding arms, probe by linear scan rather than cloning
+        // to hash: the pairs on the current path are bounded by the
+        // expanding-arm recursion depth, so a scan beats hashing the whole tree.
+        if assumptions.iter().any(|(a, b)| a == self && b == sup) {
+            return true;
+        }
+        let pair = (self.clone(), sup.clone());
         assumptions.insert(pair.clone());
-        let result = match (self, sup) {
+        let result = self.is_subtype_of_inner(sup, ctx, assumptions);
+        assumptions.remove(&pair);
+        result
+    }
+
+    /// The structural rules of [`Self::is_subtype_of`]. Callers MUST go through
+    /// `is_subtype_of`, which owns the reflexivity / sentinel fast paths and the
+    /// co-inductive assumption bookkeeping (only performed on the expanding
+    /// arms — see the termination argument there).
+    fn is_subtype_of_inner<C: TypeContext>(
+        &self,
+        sup: &NormalTy,
+        ctx: &C,
+        assumptions: &mut HashSet<(NormalTy, NormalTy)>,
+    ) -> bool {
+        match (self, sup) {
             // μ-unfolding (equirecursive).
             (NormalTy::Mu { var, body }, _) => {
                 body.substitute(var, self)
@@ -1240,9 +1331,7 @@ impl NormalTy {
             }
 
             _ => false,
-        };
-        assumptions.remove(&pair);
-        result
+        }
     }
 
     // ── conversion out: NormalTy → Ty ──────────────────────────────────────

--- a/baml_language/crates/tools_compile_profile/src/main.rs
+++ b/baml_language/crates/tools_compile_profile/src/main.rs
@@ -634,6 +634,7 @@ fn phase_for_query(name: &str) -> &'static str {
 
         // HIR (baml_compiler2_hir)
         "file_semantic_index"
+        | "file_ast"
         | "file_item_tree"
         | "file_package"
         | "namespace_items"
@@ -646,7 +647,7 @@ fn phase_for_query(name: &str) -> &'static str {
         | "compiler2_all_files" => "hir",
 
         // PPIR (baml_compiler2_ppir)
-        "ppir_expansion_items" => "ppir",
+        "ppir_expansion_items" | "file_semantic_index_expanded" => "ppir",
 
         // TIR (baml_compiler2_tir)
         "infer_scope_types"
@@ -654,6 +655,9 @@ fn phase_for_query(name: &str) -> &'static str {
         | "resolve_type_alias"
         | "resolve_name_at"
         | "callable_throws"
+        | "callee_generics_for_func"
+        | "package_resolved_aliases"
+        | "package_impl_locs"
         | "impl_data"
         | "impl_data_source_map"
         | "validate_impl_signatures"
@@ -661,7 +665,10 @@ fn phase_for_query(name: &str) -> &'static str {
         | "package_resolution_context" => "tir",
 
         // MIR (baml_compiler2_mir)
-        "lower_function" | "lower_let_body" => "mir",
+        "lower_function"
+        | "lower_let_body"
+        | "package_lowering_data"
+        | "class_type_tags_for_project" => "mir",
 
         // Emit (baml_compiler2_emit)
         "generate_project_bytecode" => "emit",


### PR DESCRIPTION
Re-lands the still-orthogonal cold-compile optimizations from #4016, re-derived from
scratch against current `canary` (which moved underneath #4016 via #4032 and #3924).
Not a rebase of #4016 — every change was re-derived and re-measured. #4016's single
biggest win (recursive-alias hoist) is intentionally **not** here: #4032 already captured
it by deleting the old TIR `StructuralTy` algebra. The profiler itself already landed
separately as #4038.

## Measurement

Corpus: `crates/baml_tests/baml_src` (77 files, 25,212 lines). Protocol:
`tools_compile_profile ... --repeat 5`, disk cache disabled (`BAML_NO_BYTECODE_CACHE=1`,
fresh `BAML_CACHE_DIR`). Cold-cache medians of 5 runs, single-threaded.

| | check | emit | **total** |
|---|---|---|---|
| canary (`8c29c827e`) | 1.114 s | 1.277 s | **2.392 s** (min 2.354 / max 2.537) |
| this branch | 0.462 s | 0.345 s | **0.808 s** (min 0.791 / max 0.828) |

**3.0x faster** cold check+emit, single-threaded.

(For reference, the pre-#4032 baseline this work originally started from was ~16 s; #4032
alone brought cold compile to a few seconds, and this branch takes it under ~1 s.)

Key query-count deltas (cold, corpus): `infer_scope_types` 15,590 → **13,331** (PPIR→HIR
`file_semantic_index` delegation removes duplicate scope inference); `package_resolved_aliases`
/ `package_impl_locs` no longer rebuilt inside every one of those inference calls (now a
handful of per-package executions); new memoized queries `file_ast` (131, once/file),
`callee_generics_for_func` (1,834), tracked PPIR `function_body`.

## What's in it (one commit per track)

- **`file_ast` tracked query** — lower CST→AST once per file (items + lowering diagnostics +
  env refs), shared by both `file_semantic_index` queries, `ppir_expansion_items`, the
  project-wide expansion collectors, and the LSP check path; PPIR `file_semantic_index`
  delegates to HIR's when a file has no `$stream` expansions; PPIR `function_body` tracked.
- **package-level TIR queries** — `package_resolved_aliases` (+ `cycle_initial` seeding an
  empty env, mirroring `infer_scope_types` — it sits in a real salsa cycle via
  associated-type-projection alias RHS) and `package_impl_locs` as tracked queries, plus
  `callee_generics_for_func`, so the alias map / impl-block list / callee generics stop
  being rebuilt per inference call.
- **nested-lambda inference projection** — lambda bodies were inferred twice (inline in the
  owner scope, then again by the standalone `ScopeKind::Lambda` query), which also emitted
  duplicate diagnostics inside lambdas. The inline pass now captures the lambda's tables and
  the Lambda arm projects them; synthetic desugared `test`/`testset` bodies fall through to
  standalone inference so their diagnostics are still emitted. Snapshot updates where the
  duplicate lambda diagnostics disappear are the point.
- **MIR dispatch prefilter + subtype fast paths** — `dispatch_target_for_concrete` gates its
  per-call impl enumeration behind a package-wide `FxHashSet` of interface-declared method
  names (own package + dependency closure); `baml_type::normalize` gets a reflexivity +
  `heads_definitely_differ` fast-reject in `equivalent()` (conservative: same-kind nominal
  pairs only — List/EvolvingList collapse to the same canonical head post-#4032) and
  restricts `is_subtype_of` co-inductive assumption bookkeeping to the expanding arms
  (Mu / TypeVar / AssociatedTypeProjection) via `is_subtype_of_inner`, with a termination
  argument in-comment. Re-derived onto the post-#4032 `baml_type` algebra (the only
  equivalence path now).
- **memoized `class_type_tags_for_project`** — the project-wide class → type-tag map was
  rebuilt (every file's item tree walked, every class name re-rendered and re-hashed)
  inside every `LoweringContext` construction, i.e. once per lowered function (~420x on
  the corpus; the hottest MIR frame in a CPU sample). Now a `#[salsa::tracked]` query
  keyed on the `Project` input; `LoweringContext` borrows it. This is #4016 audit item #4,
  initially assumed superseded by #3924's content-addressed tags — #3924 changed the tag
  *values* but left the per-function rebuild in place. Also adds this PR chain's new
  tracked queries to the profiler's `phase_for_query` table.
- **match usefulness report reuse + emit buffer pre-sizing** — match checking ran the full
  usefulness matrix twice per `match` (exhaustiveness, then an identical second pass for
  unreachable-arm detection whenever no arm had a pattern error); the reachability pass now
  reuses the exhaustiveness report (exhaustiveness: ~11% -> ~1.7% of CPU inclusive).
  `StackifyCodegen` pre-sizes its bytecode/meta buffers and local/block maps from the MIR's
  shape instead of growing from empty per function.
- **CLI mimalloc + diagnostic rendering** — mimalloc as `baml_cli`'s global allocator; build
  the ariadne `SourceCache` once per diagnostic batch instead of once per diagnostic. Verified
  byte-for-byte identical rendered diagnostics and clean `BAML_CACHE_VERIFY=1` (so #3924's
  cached-diagnostic replay does not diverge).

## Deliberately not re-landed

- The #4016 recursive-alias hoist — superseded by #4032.
- Skip-builtin-diagnostics — superseded by #3924's per-toolchain builtin-diagnostics cache.

## Testing

Full workspace test suite green except two pre-existing/environmental failures unrelated to
this change: a Python cancellation pytest that fails identically on clean `canary` (local
Python < 3.11: `ExceptionGroup`/`CancelledError.reason`). `cargo fmt` + `clippy -D warnings`
clean.

Provenance: #4016 (reference implementation, kept as reference, not merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
