### PR TITLE
fix(codegen): escape reserved words in generated Python, TypeScript and C++ identifiers

### DIFF
--- a/baml_language/sdk_tests/crates/python_pydantic2/reserved_keywords/customizable/test_reserved_keywords.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/reserved_keywords/customizable/test_reserved_keywords.py
@@ -41,7 +41,9 @@ def test_lowercase_keyword_named_types_import_and_escape():
     assert import_.A.value == "A"
     assert lambda_ is int  # `type lambda = int` -> `lambda_: typing.TypeAlias = int`
     # Cross-reference escaping: PassHolder.p is typed as the escaped `pass_`.
-    assert "p" in PassHolder.model_fields
+    # The field name `p` is not a keyword, so only the resolved *type* can regress
+    # here; assert the annotation itself, not mere field presence.
+    assert PassHolder.model_fields["p"].annotation is pass_
 
 
 def test_lowercase_keyword_named_class_round_trips_through_engine():

--- a/baml_language/sdk_tests/crates/python_pydantic2/reserved_keywords/customizable/test_reserved_keywords.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/reserved_keywords/customizable/test_reserved_keywords.py
@@ -14,9 +14,14 @@ from baml_sdk import (
     None_,
     True_,
     False_,
+    pass_,
+    import_,
+    lambda_,
+    PassHolder,
     round_trip_kw,
     round_trip_fields,
     round_trip_none,
+    round_trip_pass,
 )
 
 
@@ -26,6 +31,28 @@ def test_keyword_named_types_import_cleanly():
     assert issubclass(None_, pydantic.BaseModel)
     assert True_.A.value == "A"
     assert False_ is int  # `type False = int` -> `False_: typing.TypeAlias = int`
+
+
+def test_lowercase_keyword_named_types_import_and_escape():
+    # Lowercase keyword NAMES (`class pass`, `enum import`, `type lambda`) escape
+    # through the identical path as the uppercase trio — refuting the old comment
+    # that only None/True/False are admissible in NAME position.
+    assert issubclass(pass_, pydantic.BaseModel)
+    assert import_.A.value == "A"
+    assert lambda_ is int  # `type lambda = int` -> `lambda_: typing.TypeAlias = int`
+    # Cross-reference escaping: PassHolder.p is typed as the escaped `pass_`.
+    assert "p" in PassHolder.model_fields
+
+
+def test_lowercase_keyword_named_class_round_trips_through_engine():
+    # NAME-position decode for a LOWERCASE keyword class: the engine returns the
+    # raw wire FQN "user.pass"; the bridge resolves it via the raw typemap key to
+    # the escaped Python class `pass_` and reconstructs it end-to-end.
+    p = pass_(value=1)
+    out = round_trip_pass(p=p)
+    assert isinstance(out, pass_)
+    assert out.value == 1
+    assert out == p
 
 
 def test_escaped_enum_member_keeps_wire_value():

--- a/baml_language/sdk_tests/crates/python_pydantic2/reserved_keywords/customizable/test_reserved_keywords.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/reserved_keywords/customizable/test_reserved_keywords.py
@@ -1,0 +1,95 @@
+"""Round-trip + import coverage for the reserved_keywords fixture (#4059).
+
+The generated SDK must import without SyntaxError (the core #4059 bug) and
+round-trip escaped enum members and class fields through the engine, which
+exercises the bridge encode-by-value / encode-by-alias fix end-to-end.
+"""
+
+import pydantic
+
+import baml_sdk  # noqa: F401 — initializes the BAML runtime
+from baml_sdk import (
+    Kw,
+    Fields,
+    None_,
+    True_,
+    False_,
+    round_trip_kw,
+    round_trip_fields,
+    round_trip_none,
+)
+
+
+def test_keyword_named_types_import_cleanly():
+    # The NAME-position keyword types are importable and escaped — the SDK no
+    # longer fails to import at all (the headline #4059 symptom).
+    assert issubclass(None_, pydantic.BaseModel)
+    assert True_.A.value == "A"
+    assert False_ is int  # `type False = int` -> `False_: typing.TypeAlias = int`
+
+
+def test_escaped_enum_member_keeps_wire_value():
+    # `Kw.None_` has Python member name `None_` but its wire value is "None".
+    assert Kw.None_.value == "None"
+    assert Kw.lambda_.value == "lambda"
+    assert Kw.False_.value == "False"
+
+
+def test_all_24_baml_admissible_keywords_are_covered():
+    # Completeness: the three keywords the fixture previously omitted
+    # (`elif`/`except`/`finally`) are present and escape with their raw wire
+    # value preserved, so the E2E gate spans the full BAML-admissible set.
+    assert Kw.elif_.value == "elif"
+    assert Kw.except_.value == "except"
+    assert Kw.finally_.value == "finally"
+
+
+def test_soft_keywords_are_not_escaped():
+    # `case` (enum member) and `type` (class field) are Python SOFT keywords —
+    # valid identifiers — so the generator must emit them verbatim. This is the
+    # negative control: it fails loudly if a future change over-escapes them.
+    assert Kw.case.value == "case"
+    assert not hasattr(Kw, "case_")
+    assert "type" in Fields.model_fields
+    assert "type_" not in Fields.model_fields
+
+
+def test_escaped_enum_member_round_trips_through_engine():
+    # Encode (by value) -> engine identity -> decode (by value).
+    assert round_trip_kw(k=Kw.None_) == Kw.None_
+    assert round_trip_kw(k=Kw.lambda_) == Kw.lambda_
+    assert round_trip_kw(k=Kw.pass_) == Kw.pass_
+    assert round_trip_kw(k=Kw.True_) == Kw.True_
+
+
+def test_escaped_class_field_round_trips_by_alias():
+    # `type` is a soft keyword and stays unescaped; its wire key is the bare name.
+    f = Fields(**{"pass": 1, "lambda": 2, "from": 3, "global": 4, "del": 5, "async": 6, "type": 7})
+    # Escaped attributes are accessible under their Python names.
+    assert f.pass_ == 1
+    assert f.lambda_ == 2
+    assert f.from_ == 3
+    assert f.type == 7  # soft keyword: unescaped attribute
+    # Full round-trip through the engine preserves every escaped field
+    # (encode by alias -> engine identity -> decode by alias).
+    assert round_trip_fields(f=f) == f
+
+
+def test_construct_by_escaped_name_via_populate_by_name():
+    # populate_by_name=True lets callers build by the escaped Python name too.
+    f = Fields(pass_=1, lambda_=2, from_=3, global_=4, del_=5, async_=6, type=7)
+    assert f.pass_ == 1
+    assert f.type == 7
+    assert round_trip_fields(f=f) == f
+
+
+def test_keyword_named_class_round_trips_through_engine():
+    # The NAME-position decode this PR enables end-to-end: the engine returns the
+    # raw wire FQN "user.None"; the bridge resolves it via the raw typemap key to
+    # the escaped Python class `None_` and reconstructs it. Previously this path
+    # was only unit-probed, never exercised through the real engine.
+    n = None_(value=1)
+    out = round_trip_none(n=n)
+    assert isinstance(out, None_)
+    assert out.value == 1
+    assert out == n

--- a/baml_language/sdk_tests/fixtures/reserved_keywords/baml_src/main.baml
+++ b/baml_language/sdk_tests/fixtures/reserved_keywords/baml_src/main.baml
@@ -3,9 +3,10 @@
 //
 // Covers the 24 hard keywords BAML admits at source; the other 11 hard keywords
 // are also BAML keywords and are rejected by the grammar. NAME positions (class
-// / enum / type-alias names) use the three uppercase-initial keywords BAML
-// allows as type names: None, True, False. Python SOFT keywords (`case`, `type`)
-// are valid identifiers and appear as negative controls that must NOT be escaped.
+// / enum / type-alias names) admit those keywords too — both the uppercase-initial
+// None / True / False and lowercase ones like pass / import / lambda — all through
+// the same escape path. Python SOFT keywords (`case`, `type`) are valid
+// identifiers and appear as negative controls that must NOT be escaped.
 
 // (a) enum members — the headline #4059 case (`None` etc. would emit a bare
 //     `None = "None"` and fail to import).
@@ -65,6 +66,26 @@ enum True {
 // (e) keyword type-alias name.
 type False = int
 
+// (f) LOWERCASE keyword NAMES — the same escape path as the uppercase trio above.
+//     `class pass` is referenced by another class field so cross-reference
+//     escaping (`p: pass_`) is exercised, not just the definition site.
+class pass {
+  value int
+}
+
+class PassHolder {
+  p pass
+}
+
+// (g) lowercase keyword enum name.
+enum import {
+  A
+  B
+}
+
+// (h) lowercase keyword type-alias name.
+type lambda = int
+
 // Identity round-trips so the sdk-test pytest exercises encode + decode of
 // escaped enum members and class fields end-to-end through the engine.
 function round_trip_kw(k: Kw) -> Kw {
@@ -80,4 +101,11 @@ function round_trip_fields(f: Fields) -> Fields {
 // only in unit probes.
 function round_trip_none(n: None) -> None {
   n
+}
+
+// Lowercase NAME-position round-trip: same proof for `class pass` (raw wire FQN
+// `user.pass` -> escaped Python class `pass_`), covering the lowercase escape
+// path end-to-end through the engine.
+function round_trip_pass(p: pass) -> pass {
+  p
 }

--- a/baml_language/sdk_tests/fixtures/reserved_keywords/baml_src/main.baml
+++ b/baml_language/sdk_tests/fixtures/reserved_keywords/baml_src/main.baml
@@ -1,0 +1,83 @@
+// Regression fixture for issue #4059: BAML identifiers that are Python
+// reserved words must generate importable, round-trippable Python.
+//
+// Covers the 24 hard keywords BAML admits at source; the other 11 hard keywords
+// are also BAML keywords and are rejected by the grammar. NAME positions (class
+// / enum / type-alias names) use the three uppercase-initial keywords BAML
+// allows as type names: None, True, False. Python SOFT keywords (`case`, `type`)
+// are valid identifiers and appear as negative controls that must NOT be escaped.
+
+// (a) enum members — the headline #4059 case (`None` etc. would emit a bare
+//     `None = "None"` and fail to import).
+enum Kw {
+  False
+  None
+  True
+  and
+  as
+  assert
+  async
+  def
+  del
+  elif
+  except
+  finally
+  from
+  global
+  import
+  lambda
+  nonlocal
+  not
+  or
+  pass
+  raise
+  try
+  with
+  yield
+  // soft keyword — valid Python identifier, must NOT be escaped (control)
+  case
+}
+
+// (b) class fields, including the `lambda` silent-corruption trap (a bare
+//     `lambda: int` parses as a lambda expression and drops the field).
+class Fields {
+  pass int
+  lambda int
+  from int
+  global int
+  del int
+  async int
+  // soft keyword — valid Python identifier, must NOT be escaped (control)
+  type int
+}
+
+// (c) keyword class name.
+class None {
+  value int
+}
+
+// (d) keyword enum name.
+enum True {
+  A
+  B
+}
+
+// (e) keyword type-alias name.
+type False = int
+
+// Identity round-trips so the sdk-test pytest exercises encode + decode of
+// escaped enum members and class fields end-to-end through the engine.
+function round_trip_kw(k: Kw) -> Kw {
+  k
+}
+
+function round_trip_fields(f: Fields) -> Fields {
+  f
+}
+
+// NAME-position round-trip: proves the engine's raw wire FQN `user.None` decodes
+// back to the escaped Python class `None_` end-to-end through the engine, not
+// only in unit probes.
+function round_trip_none(n: None) -> None {
+  n
+}

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/naming.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/naming.rs
@@ -352,25 +352,47 @@ fn reserved_in(scope_kind: CppNameKind, token: &str) -> bool {
 // Projection (clean-name normalization)
 // ---------------------------------------------------------------------------
 
+/// Every token C++ refuses to accept as an identifier: the 81 keywords of
+/// [lex.key], plus the 11 alternative tokens of [lex.digraph], which
+/// [lex.digraph]/2 makes equally unspellable ("each alternative token behaves
+/// the same [...] as its primary token, except for its spelling"). Sorted and
+/// duplicate-free so it can be checked against the standard by eye; both
+/// properties are asserted by `test_cpp_keywords_match_the_standard_table`.
 const CPP_KEYWORDS: &[&str] = &[
     "alignas",
     "alignof",
+    "and",
+    "and_eq",
     "asm",
     "auto",
+    "bitand",
+    "bitor",
     "bool",
     "break",
     "case",
     "catch",
     "char",
+    "char16_t",
+    "char32_t",
+    "char8_t",
     "class",
+    "co_await",
+    "co_return",
+    "co_yield",
+    "compl",
     "concept",
     "const",
+    "const_cast",
+    "consteval",
     "constexpr",
+    "constinit",
     "continue",
+    "decltype",
     "default",
     "delete",
     "do",
     "double",
+    "dynamic_cast",
     "else",
     "enum",
     "explicit",
@@ -389,22 +411,30 @@ const CPP_KEYWORDS: &[&str] = &[
     "namespace",
     "new",
     "noexcept",
+    "not",
+    "not_eq",
     "nullptr",
     "operator",
+    "or",
+    "or_eq",
     "private",
     "protected",
     "public",
     "register",
+    "reinterpret_cast",
     "requires",
     "return",
     "short",
     "signed",
     "sizeof",
     "static",
+    "static_assert",
+    "static_cast",
     "struct",
     "switch",
     "template",
     "this",
+    "thread_local",
     "throw",
     "true",
     "try",
@@ -417,7 +447,10 @@ const CPP_KEYWORDS: &[&str] = &[
     "virtual",
     "void",
     "volatile",
+    "wchar_t",
     "while",
+    "xor",
+    "xor_eq",
 ];
 
 /// Projects a BAML token to its preferred C++ identifier: keywords take a
@@ -685,6 +718,53 @@ mod tests {
         assert_eq!(project("void"), "void_");
         assert_eq!(project("value"), "value");
         assert_eq!(project("9lives"), "_9lives");
+    }
+
+    #[test]
+    fn test_alternative_operator_tokens_are_escaped() {
+        // [lex.digraph]/2: an alternative token behaves as its primary token in
+        // all respects, so it is not spellable as an identifier. Without these
+        // an `and` / `not` / `or` enum variant emits `and = 0x...ULL,` and the
+        // generated header does not parse.
+        for token in [
+            "and", "and_eq", "bitand", "bitor", "compl", "not", "not_eq", "or", "or_eq", "xor",
+            "xor_eq",
+        ] {
+            assert_eq!(project(token), format!("{token}_"));
+        }
+        // Matching is ordinal, so the capitalized spellings stay untouched.
+        assert_eq!(project("True"), "True");
+        assert_eq!(project("False"), "False");
+    }
+
+    #[test]
+    fn test_cpp_keywords_match_the_standard_table() {
+        assert!(
+            CPP_KEYWORDS.windows(2).all(|pair| pair[0] < pair[1]),
+            "CPP_KEYWORDS must stay sorted and duplicate-free"
+        );
+        // 81 keywords ([lex.key]) + 11 alternative tokens ([lex.digraph]).
+        assert_eq!(CPP_KEYWORDS.len(), 92);
+        for token in [
+            "char8_t",
+            "char16_t",
+            "char32_t",
+            "wchar_t",
+            "const_cast",
+            "dynamic_cast",
+            "reinterpret_cast",
+            "static_cast",
+            "consteval",
+            "constinit",
+            "decltype",
+            "static_assert",
+            "thread_local",
+            "co_await",
+            "co_return",
+            "co_yield",
+        ] {
+            assert_eq!(project(token), format!("{token}_"));
+        }
     }
 
     #[test]

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/class.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/class.rs
@@ -43,8 +43,15 @@ pub(crate) struct PyClass {
 }
 
 pub(crate) struct PyClassProperty {
+    /// Python identifier for the field. Equal to the raw BAML field name
+    /// except when that name is a Python hard keyword, in which case it is
+    /// escaped (`pass` → `pass_`) and `alias` carries the raw name.
     pub(crate) name: String,
     pub(crate) ty: Ty,
+    /// `Some(raw)` when `name` was escaped off a keyword — the raw BAML field
+    /// name, which stays the JSON/wire key via `pydantic.Field(alias=raw)`.
+    /// `None` for the common case (field renders byte-identically to today).
+    pub(crate) alias: Option<String>,
     /// Joined `///` doc-comment lines preceding the field. Folded into
     /// the parent `PyClass`'s `"""…"""` docstring under an
     /// `Attributes:` section — never rendered as an inline `# …`

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/class.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/class.rs
@@ -7,7 +7,7 @@
 
 use baml_codegen_types::{Name, Ty};
 
-use crate::emit::method::PyMethodBinding;
+use crate::emit::{TypeVarMap, method::PyMethodBinding};
 
 /// Python class definition. G4 populates `properties`; 12b populates
 /// `static_methods` and `instance_methods`; §7 handle-backed
@@ -24,6 +24,10 @@ pub(crate) struct PyClass {
     /// `typing.Generic[T, …]` second base and the leaf-level `TypeVar`
     /// declarations include each name.
     pub(crate) generic_params: Vec<String>,
+    /// Raw→emitted map for `generic_params`, threaded into the field-body
+    /// `TranslateCtx` so a `TypeVar` reference resolves to the same spelling the
+    /// declaration allocated. Empty for non-generic classes.
+    pub(crate) type_var_map: TypeVarMap,
     /// Joined `///` doc-comment lines from the BAML class declaration.
     /// Combined with `PyClassProperty.docstring` from each entry in
     /// `properties` to produce the `"""…"""` Python class docstring;

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/enum_.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/enum_.rs
@@ -23,6 +23,13 @@ pub(crate) struct PyEnumVariant {
     pub(crate) ident: String,
     /// RHS string literal (IR's `EnumVariant.value`, verbatim).
     pub(crate) value: String,
+    /// `Some(raw)` when `ident` was escaped off a hard keyword — the raw BAML
+    /// variant name, which stays the wire spelling. Drives the enum's
+    /// `__baml_wire_values__` provenance marker so the bridge encoder
+    /// can recover the wire name without shape-guessing. `None` for the common
+    /// case (member renders byte-identically to today), mirroring
+    /// `PyClassProperty::alias`.
+    pub(crate) wire_name: Option<String>,
     /// Joined `///` doc-comment lines preceding the variant. Folded
     /// into the parent `PyEnum`'s `"""…"""` docstring under a
     /// `Members:` section — never rendered as an inline `# …` comment

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/function.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/function.rs
@@ -2,6 +2,8 @@
 
 use baml_codegen_types::{FunctionArgumentDefault, Ty};
 
+use crate::emit::TypeVarMap;
+
 /// Async/sync marker carried by factory bindings. Each BAML
 /// `Function` (and each of its companions) fans out into one sync
 /// and one async binding.
@@ -50,6 +52,10 @@ pub(crate) struct PyFunction {
     /// functions. Surfaces only in `.pyi` rendering — the `.py` factory
     /// binding is type-erased.
     pub(crate) generic_params: Vec<String>,
+    /// Raw→emitted map for `generic_params`, threaded into the `.pyi`
+    /// signature `TranslateCtx` so a `TypeVar` reference resolves to the same
+    /// spelling the declaration allocated. Empty for non-generic functions.
+    pub(crate) type_var_map: TypeVarMap,
     /// Joined `///` doc-comment lines from the BAML function declaration.
     /// Surfaced only by `.pyi` rendering as a `"""..."""` body so
     /// `__doc__` resolves at runtime.

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/method.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/method.rs
@@ -6,7 +6,7 @@
 
 use baml_codegen_types::{FunctionArgumentDefault, Ty};
 
-use crate::emit::function::SyncAsync;
+use crate::emit::{TypeVarMap, function::SyncAsync};
 
 pub(crate) struct PyMethodBinding {
     /// Python identifier as it appears on the LHS of the binding. Sync
@@ -33,6 +33,10 @@ pub(crate) struct PyMethodBinding {
     /// methods. Surfaces only in `.pyi` rendering — the `.py` factory
     /// binding is type-erased.
     pub(crate) generic_params: Vec<String>,
+    /// Raw→emitted map for `generic_params` (the method's own `<…>` scope),
+    /// merged with the enclosing class's map for instance methods and threaded
+    /// into the `.pyi` signature `TranslateCtx`. Empty for non-generic methods.
+    pub(crate) type_var_map: TypeVarMap,
     /// Joined `///` doc-comment lines from the BAML method declaration.
     /// Surfaced only by `.pyi` rendering as a `"""..."""` body, since
     /// `.py` factory bindings have no meaningful body.

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/mod.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/mod.rs
@@ -84,7 +84,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                     .map(|p| p.name.as_str().to_string())
                     .collect();
                 let escaped_prop_names = escape_keywords_in_scope(&raw_prop_names);
-                let properties = c
+                let mut properties: Vec<PyClassProperty> = c
                     .properties
                     .iter()
                     .zip(escaped_prop_names)
@@ -104,21 +104,39 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 // append `.<method_bare>`; companions further append
                 // `$<suffix>` per the existing free-function rule.
                 let class_fqn_root = key.to_string();
-                let static_methods =
+                let mut static_methods =
                     expand_methods(&c.static_methods, &class_fqn_root, MethodKind::Static);
-                let instance_methods =
+                let mut instance_methods =
                     expand_methods(&c.instance_methods, &class_fqn_root, MethodKind::Instance);
-                let generic_params = c
+                // Reserve the `__baml_wire_names__` marker name across the
+                // combined field+method member set when the marker will be
+                // emitted, so a user member of that name is bumped rather than
+                // clobbering the marker dict at class creation. Keyword-free
+                // classes emit no marker, so this is a no-op for them.
+                reserve_class_wire_marker(
+                    &mut properties,
+                    &mut static_methods,
+                    &mut instance_methods,
+                );
+                // TypeVar names are allocated LEAF-globally by
+                // `leaf::allocate_leaf_type_vars` after `group_and_sort`, so a
+                // bumped keyword TypeVar can never collide with a sibling
+                // class/enum/alias name and distinct raw TypeVar spellings never
+                // collapse onto one emitted name (identical spellings deliberately
+                // share one module-level TypeVar). Here we only carry
+                // the RAW names forward; `type_var_map` is filled by that pass.
+                let raw_generic_params: Vec<String> = c
                     .generic_params
                     .iter()
-                    .map(|n| escape_python_keyword(n.as_str().to_string()))
+                    .map(|n| n.as_str().to_string())
                     .collect();
                 out.push((
                     leaf,
                     EmittedSymbol::Class(PyClass {
                         py_name: escape_python_keyword(bare),
                         source: key.clone(),
-                        generic_params,
+                        generic_params: raw_generic_params,
+                        type_var_map: TypeVarMap::new(),
                         docstring: c.docstring.clone(),
                         properties,
                         static_methods,
@@ -139,16 +157,28 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                     .map(|v| v.name.as_str().to_string())
                     .collect();
                 let escaped_idents = escape_keywords_in_scope(&raw_variant_idents);
-                let variants = e
+                let mut variants: Vec<PyEnumVariant> = e
                     .variants
                     .iter()
                     .zip(escaped_idents)
-                    .map(|(v, ident)| PyEnumVariant {
-                        ident,
-                        value: v.value.clone(),
-                        docstring: v.docstring.clone(),
+                    .map(|(v, ident)| {
+                        // `escaped_idents[i] != raw` exactly marks the keyword-
+                        // escaped members (escape_keywords_in_scope returns
+                        // non-keywords unchanged); carry the raw variant name as
+                        // the wire-value provenance for `__baml_wire_values__`.
+                        let raw = v.name.as_str();
+                        let wire_name = (ident != raw).then(|| raw.to_string());
+                        PyEnumVariant {
+                            ident,
+                            value: v.value.clone(),
+                            docstring: v.docstring.clone(),
+                            wire_name,
+                        }
                     })
                     .collect();
+                // Symmetric to the class marker: reserve `__baml_wire_values__`
+                // across the member idents when the enum marker will be emitted.
+                reserve_enum_wire_marker(&mut variants);
                 out.push((
                     leaf,
                     EmittedSymbol::Enum(PyEnum {
@@ -201,11 +231,14 @@ fn expand_function(
     // companion's bare identifier (`__<suffix>` or `_stream`).
     let fqn_root = key.to_string();
     let bare = bare_callable_name(key.name().as_str());
+    // Raw TypeVar names only; leaf-global allocation happens later in
+    // `leaf::allocate_leaf_type_vars`.
     let func_generic_params: Vec<String> = f
         .generic_params
         .iter()
-        .map(|n| escape_python_keyword(n.as_str().to_string()))
+        .map(|n| n.as_str().to_string())
         .collect();
+    let func_type_var_map = TypeVarMap::new();
     let func_docstring = f.docstring.clone();
     let raises_names = collect_raises_names(f.throws.as_ref());
     expand_callable(
@@ -225,6 +258,7 @@ fn expand_function(
                     arg_tys,
                     return_ty,
                     generic_params: func_generic_params.clone(),
+                    type_var_map: func_type_var_map.clone(),
                     docstring: func_docstring.clone(),
                     raises_names: raises_names.clone(),
                 }),
@@ -279,11 +313,14 @@ fn expand_methods(
         let m_name = m.name.as_str();
         let bare = bare_callable_name(m_name);
         let fqn_root = format!("{class_fqn_root}.{m_name}");
+        // Raw TypeVar names only; leaf-global allocation happens later
+        // in `leaf::allocate_leaf_type_vars`.
         let method_generic_params: Vec<String> = m
             .generic_params
             .iter()
-            .map(|n| escape_python_keyword(n.as_str().to_string()))
+            .map(|n| n.as_str().to_string())
             .collect();
+        let method_type_var_map = TypeVarMap::new();
         let method_docstring = m.docstring.clone();
         let raises_names = collect_raises_names(m.throws.as_ref());
         let (required_args, optional_args) = split_arguments(&m.arguments);
@@ -300,6 +337,7 @@ fn expand_methods(
                 kind,
                 return_ty: m.return_type.clone(),
                 generic_params: method_generic_params.clone(),
+                type_var_map: method_type_var_map.clone(),
                 docstring: method_docstring.clone(),
                 raises_names: raises_names.clone(),
             });
@@ -432,6 +470,136 @@ pub(crate) fn escape_keywords_in_scope(names: &[String]) -> Vec<String> {
         .collect()
 }
 
+/// The synthetic wire-identity markers the generator stamps into a class / enum
+/// body when at least one member is keyword-escaped (`build_wire_names_marker` /
+/// `build_wire_values_marker`, `leaf.rs`). Python binds the marker as an ordinary
+/// (dunder) class attribute, so a user member that lands on the same spelling
+/// would clobber it at class-creation time (the later binding wins). These names
+/// are therefore reserved across the body's member namespace whenever the marker
+/// is emitted.
+const WIRE_NAMES_MARKER: &str = "__baml_wire_names__";
+const WIRE_VALUES_MARKER: &str = "__baml_wire_values__";
+
+/// Bump `name` past everything already in `reserved` by appending `_` (the same
+/// trailing-underscore rule [`escape_keywords_in_scope`] uses), then reserve and
+/// return the result.
+fn bump_past_reserved(name: &str, reserved: &mut std::collections::HashSet<String>) -> String {
+    let mut candidate = format!("{name}_");
+    while reserved.contains(&candidate) {
+        candidate.push('_');
+    }
+    reserved.insert(candidate.clone());
+    candidate
+}
+
+/// Project a class FIELD that collides with the `__baml_wire_names__` marker onto
+/// a pydantic-legal attribute spelling. A METHOD collision can keep the marker's
+/// leading underscores ([`bump_past_reserved`] appends one `_`) because it renders
+/// as a bare class-body assignment; a FIELD cannot. pydantic rejects a model field
+/// whose name begins with an underscore (`NameError: Fields must not use names with
+/// leading underscores`) at class creation, which fails `import` of the whole leaf
+/// module. So shed the leading underscores to form the base, then apply the same
+/// trailing-underscore disambiguation against `reserved`. The raw
+/// `__baml_wire_names__` is preserved as the field's `pydantic.Field(alias=…)` and
+/// as the marker's wire value, so wire identity is unchanged.
+fn project_field_off_marker(reserved: &mut std::collections::HashSet<String>) -> String {
+    let base = WIRE_NAMES_MARKER.trim_start_matches('_');
+    let mut candidate = format!("{base}_");
+    while reserved.contains(&candidate) {
+        candidate.push('_');
+    }
+    reserved.insert(candidate.clone());
+    candidate
+}
+
+/// Reserve the `__baml_wire_names__` marker identifier across a class's combined
+/// field + method member namespace, but ONLY when the marker will actually be
+/// emitted (>= 1 field carries an `alias`, i.e. was keyword-escaped). A METHOD
+/// whose emitted name equals the marker is bumped one trailing underscore past it
+/// (it renders as a bare class-body assignment, so leading underscores are fine).
+/// A FIELD named like the marker is instead projected onto a leading-underscore-
+/// free spelling by [`project_field_off_marker`], because pydantic refuses a model
+/// field whose name starts with `_` (a plain trailing-underscore bump would still
+/// lead with `__` and crash `import` at class creation); it records
+/// `alias = "__baml_wire_names__"` so the marker still lists it and its raw wire
+/// identity is preserved. Keyword-free classes emit no marker, so nothing is
+/// reserved and their output stays byte-identical (the digest gate enforces this).
+fn reserve_class_wire_marker(
+    properties: &mut [PyClassProperty],
+    static_methods: &mut [PyMethodBinding],
+    instance_methods: &mut [PyMethodBinding],
+) {
+    let marker_emitted = properties.iter().any(|p| p.alias.is_some());
+    if !marker_emitted {
+        return;
+    }
+    // Reserve every member name that is NOT itself the marker token (those keep
+    // their spelling), plus the marker token (the marker occupies it). Bumps
+    // search past this set.
+    let mut reserved: std::collections::HashSet<String> = properties
+        .iter()
+        .map(|p| p.name.clone())
+        .chain(static_methods.iter().map(|m| m.py_name.clone()))
+        .chain(instance_methods.iter().map(|m| m.py_name.clone()))
+        .filter(|n| n != WIRE_NAMES_MARKER)
+        .collect();
+    reserved.insert(WIRE_NAMES_MARKER.to_string());
+
+    for p in properties.iter_mut() {
+        if p.name == WIRE_NAMES_MARKER {
+            // Fields must not lead with `_` (pydantic raises at class creation),
+            // so project off the marker to a legal spelling rather than the plain
+            // trailing-underscore bump the method arm uses.
+            p.name = project_field_off_marker(&mut reserved);
+            // Preserve the raw wire key: the marker now maps projected-attr -> raw.
+            if p.alias.is_none() {
+                p.alias = Some(WIRE_NAMES_MARKER.to_string());
+            }
+        }
+    }
+    for m in static_methods.iter_mut().chain(instance_methods.iter_mut()) {
+        if m.py_name == WIRE_NAMES_MARKER {
+            m.py_name = bump_past_reserved(WIRE_NAMES_MARKER, &mut reserved);
+        }
+    }
+}
+
+/// Enum counterpart of [`reserve_class_wire_marker`]. BAML enums have no methods,
+/// so the only collision vector is a member literally named `__baml_wire_values__`;
+/// reserve the marker across the member idents whenever the enum marker is emitted
+/// (>= 1 escaped member). A bumped member records its raw wire name into the marker.
+/// Keyword-free enums emit no marker and stay byte-identical.
+fn reserve_enum_wire_marker(variants: &mut [PyEnumVariant]) {
+    let marker_emitted = variants.iter().any(|v| v.wire_name.is_some());
+    if !marker_emitted {
+        return;
+    }
+    let mut reserved: std::collections::HashSet<String> = variants
+        .iter()
+        .map(|v| v.ident.clone())
+        .filter(|n| n != WIRE_VALUES_MARKER)
+        .collect();
+    reserved.insert(WIRE_VALUES_MARKER.to_string());
+
+    for v in variants.iter_mut() {
+        if v.ident == WIRE_VALUES_MARKER {
+            let bumped = bump_past_reserved(WIRE_VALUES_MARKER, &mut reserved);
+            if v.wire_name.is_none() {
+                v.wire_name = Some(WIRE_VALUES_MARKER.to_string());
+            }
+            v.ident = bumped;
+        }
+    }
+}
+
+/// A generic scope's raw→emitted `TypeVar` name map. `translate_ty`
+/// (`Ty::TypeVar`) consults it so a reference resolves to the exact spelling the
+/// declaration site allocated — including when a `{None, None_}` twin forces one
+/// name past its natural stateless escape. Each scope's map is the restriction
+/// of the ONE leaf-global allocation (`leaf::allocate_leaf_type_vars`) to that
+/// scope's raw names. Empty for non-generic scopes and until that pass fills it.
+pub(crate) type TypeVarMap = std::collections::HashMap<String, String>;
+
 /// Shared fan-out for free functions and methods. Calls `emit` twice:
 /// once for the sync binding and once for the async binding. Companions
 /// arrive as their own callable; the suffix-aware `bare` value is
@@ -496,7 +664,7 @@ mod tests {
         // MUST equal `keyword.kwlist` on CPython 3.9–3.13. The Python bridge
         // test `test_reserved_keywords.py::test_rust_keyword_list_matches_python_kwlist`
         // anchors the same 35 to `keyword.kwlist` from the Python side, closing
-        // the cross-language loop the spec (§4) requires.
+        // the cross-language loop between the Rust and Python keyword lists.
         let mut got: Vec<&str> = PYTHON_HARD_KEYWORDS.to_vec();
         got.sort_unstable();
         let mut want: Vec<&str> = vec![

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/mod.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/emit/mod.rs
@@ -73,13 +73,30 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
         match symbol {
             Symbol::Class(c) => {
                 let sort_key = origin_key(&c.origin);
+                // Escape keyword field names collision-aware within the class
+                // scope. A field renamed off a keyword carries an `alias` = its
+                // raw BAML name so it stays the JSON/wire key (pydantic
+                // `Field(alias=…)`); non-escaped fields keep `alias: None` and
+                // render byte-identically to today.
+                let raw_prop_names: Vec<String> = c
+                    .properties
+                    .iter()
+                    .map(|p| p.name.as_str().to_string())
+                    .collect();
+                let escaped_prop_names = escape_keywords_in_scope(&raw_prop_names);
                 let properties = c
                     .properties
                     .iter()
-                    .map(|p| PyClassProperty {
-                        name: p.name.as_str().to_string(),
-                        ty: p.ty.clone(),
-                        docstring: p.docstring.clone(),
+                    .zip(escaped_prop_names)
+                    .map(|(p, escaped)| {
+                        let raw = p.name.as_str();
+                        let alias = (escaped != raw).then(|| raw.to_string());
+                        PyClassProperty {
+                            name: escaped,
+                            ty: p.ty.clone(),
+                            docstring: p.docstring.clone(),
+                            alias,
+                        }
                     })
                     .collect();
                 // The class's pool key Display form is already the
@@ -94,12 +111,12 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 let generic_params = c
                     .generic_params
                     .iter()
-                    .map(|n| n.as_str().to_string())
+                    .map(|n| escape_python_keyword(n.as_str().to_string()))
                     .collect();
                 out.push((
                     leaf,
                     EmittedSymbol::Class(PyClass {
-                        py_name: bare,
+                        py_name: escape_python_keyword(bare),
                         source: key.clone(),
                         generic_params,
                         docstring: c.docstring.clone(),
@@ -112,11 +129,22 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
             }
             Symbol::Enum(e) => {
                 let sort_key = origin_key(&e.origin);
+                // Escape keyword member idents collision-aware within the enum
+                // scope. The RHS `value` stays IR-verbatim, so `None` renders
+                // `None_ = "None"` — the wire value is unchanged and decode
+                // (which is by VALUE) keeps working with no alias machinery.
+                let raw_variant_idents: Vec<String> = e
+                    .variants
+                    .iter()
+                    .map(|v| v.name.as_str().to_string())
+                    .collect();
+                let escaped_idents = escape_keywords_in_scope(&raw_variant_idents);
                 let variants = e
                     .variants
                     .iter()
-                    .map(|v| PyEnumVariant {
-                        ident: v.name.as_str().to_string(),
+                    .zip(escaped_idents)
+                    .map(|(v, ident)| PyEnumVariant {
+                        ident,
                         value: v.value.clone(),
                         docstring: v.docstring.clone(),
                     })
@@ -124,7 +152,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 out.push((
                     leaf,
                     EmittedSymbol::Enum(PyEnum {
-                        py_name: bare,
+                        py_name: escape_python_keyword(bare),
                         source: key.clone(),
                         variants,
                         docstring: e.docstring.clone(),
@@ -137,7 +165,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 out.push((
                     leaf,
                     EmittedSymbol::TypeAlias(PyTypeAlias {
-                        py_name: bare,
+                        py_name: escape_python_keyword(bare),
                         source: key.clone(),
                         resolves_to: t.resolves_to.clone(),
                         recursive: t.recursive,
@@ -176,7 +204,7 @@ fn expand_function(
     let func_generic_params: Vec<String> = f
         .generic_params
         .iter()
-        .map(|n| n.as_str().to_string())
+        .map(|n| escape_python_keyword(n.as_str().to_string()))
         .collect();
     let func_docstring = f.docstring.clone();
     let raises_names = collect_raises_names(f.throws.as_ref());
@@ -254,7 +282,7 @@ fn expand_methods(
         let method_generic_params: Vec<String> = m
             .generic_params
             .iter()
-            .map(|n| n.as_str().to_string())
+            .map(|n| escape_python_keyword(n.as_str().to_string()))
             .collect();
         let method_docstring = m.docstring.clone();
         let raises_names = collect_raises_names(m.throws.as_ref());
@@ -323,26 +351,85 @@ pub(crate) fn bare_callable_name(name: &str) -> String {
     }
 }
 
+/// The 35 Python 3 **hard** keywords (`keyword.kwlist` on `CPython` 3.9–3.13).
+/// Soft keywords (`match`, `case`, `type`, `_`) are valid identifiers and are
+/// intentionally excluded — the source guard `RESERVED_NAMES_PYTHON` in the
+/// engine uses this same set. Kept sorted so the
+/// `python_hard_keyword_set_is_exactly_the_35_cpython_hard_keywords` test can
+/// diff it against a sorted expectation.
+const PYTHON_HARD_KEYWORDS: &[&str] = &[
+    "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue",
+    "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import",
+    "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while",
+    "with", "yield",
+];
+
+/// True when `ident` is a Python 3 hard keyword (and therefore an illegal
+/// identifier). Shared by every escape site so the generator's escape sites
+/// stay in sync with the engine's `RESERVED_NAMES_PYTHON` guard (two synced
+/// copies of one list).
+pub(crate) fn is_python_hard_keyword(ident: &str) -> bool {
+    PYTHON_HARD_KEYWORDS.contains(&ident)
+}
+
 /// Append `_` to a Python hard keyword so it is a usable identifier on the
 /// Python side (`from` → `from_`), generalizing the `assert` → `assert_` rule
 /// in [`crate::routing`] to callable identifiers. Only the rendered Python name
 /// is affected; the runtime BAML FQN (`PyMethodBinding::baml_fqn` /
 /// `PyFunction::baml_fqn`) is built from the raw `Name`, so dispatch still
 /// targets the original `from`. Non-keyword names pass through unchanged.
+///
+/// This is the *stateless* escape used for symbols whose escaped spelling has
+/// to be reproducible from the bare `Name` alone at a distance — class / enum /
+/// type-alias names (which `translate_ty::render_name_ref` re-escapes at every
+/// cross-reference) and `TypeVar` names. Collision-resolving escaping (for
+/// class fields and enum members, which live in a single self-contained scope)
+/// goes through [`escape_keywords_in_scope`].
 pub(crate) fn escape_python_keyword(ident: String) -> String {
-    // Python 3 hard keywords (soft keywords like `match`/`case`/`type` are
-    // valid identifiers and are intentionally excluded).
-    const PYTHON_KEYWORDS: &[&str] = &[
-        "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class",
-        "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global",
-        "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return",
-        "try", "while", "with", "yield",
-    ];
-    if PYTHON_KEYWORDS.contains(&ident.as_str()) {
+    if is_python_hard_keyword(&ident) {
         format!("{ident}_")
     } else {
         ident
     }
+}
+
+/// Collision-aware keyword escaping for one self-contained scope (a single
+/// class's fields, or a single enum's members). Mirrors the Go generator's
+/// per-scope allocation (PR #4067) with a used-set instead of a content hash:
+///
+/// - **Pass 1** reserves every RAW non-keyword name in the scope.
+/// - **Pass 2**, in declaration order, escapes each keyword name: start from
+///   `name + "_"` and append `_` while the candidate is a hard keyword or is
+///   already reserved, then reserve the result.
+///
+/// So a scope declaring both `pass` and `pass_` yields `{pass__, pass_}` — the
+/// raw `pass_` is reserved in pass 1, forcing `pass` past it. Deterministic and
+/// order-independent for the raw set (distinct keywords escape to disjoint
+/// prefixes, and BAML forbids duplicate field / member names, so pass-2
+/// insertions never perturb another keyword's resolution). Non-keyword names
+/// are returned unchanged, so `escaped[i] != names[i]` exactly identifies the
+/// escaped positions (used to derive the pydantic `Field(alias=…)` wire name).
+pub(crate) fn escape_keywords_in_scope(names: &[String]) -> Vec<String> {
+    let mut reserved: std::collections::HashSet<String> = names
+        .iter()
+        .filter(|n| !is_python_hard_keyword(n))
+        .cloned()
+        .collect();
+    names
+        .iter()
+        .map(|name| {
+            if !is_python_hard_keyword(name) {
+                name.clone()
+            } else {
+                let mut candidate = format!("{name}_");
+                while is_python_hard_keyword(&candidate) || reserved.contains(&candidate) {
+                    candidate.push('_');
+                }
+                reserved.insert(candidate.clone());
+                candidate
+            }
+        })
+        .collect()
 }
 
 /// Shared fan-out for free functions and methods. Calls `emit` twice:
@@ -399,7 +486,52 @@ fn origin_key(origin: &baml_codegen_types::Origin) -> SortKey {
 
 #[cfg(test)]
 mod tests {
-    use super::escape_python_keyword;
+    use super::{
+        PYTHON_HARD_KEYWORDS, escape_keywords_in_scope, escape_python_keyword,
+        is_python_hard_keyword,
+    };
+
+    #[test]
+    fn python_hard_keyword_set_is_exactly_the_35_cpython_hard_keywords() {
+        // MUST equal `keyword.kwlist` on CPython 3.9–3.13. The Python bridge
+        // test `test_reserved_keywords.py::test_rust_keyword_list_matches_python_kwlist`
+        // anchors the same 35 to `keyword.kwlist` from the Python side, closing
+        // the cross-language loop the spec (§4) requires.
+        let mut got: Vec<&str> = PYTHON_HARD_KEYWORDS.to_vec();
+        got.sort_unstable();
+        let mut want: Vec<&str> = vec![
+            "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class",
+            "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global",
+            "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise",
+            "return", "try", "while", "with", "yield",
+        ];
+        want.sort_unstable();
+        assert_eq!(got, want);
+        assert_eq!(PYTHON_HARD_KEYWORDS.len(), 35);
+        // Soft keywords stay valid identifiers and must NOT be treated as hard.
+        for soft in ["match", "case", "type", "_"] {
+            assert!(
+                !is_python_hard_keyword(soft),
+                "soft keyword {soft} misclassified"
+            );
+        }
+    }
+
+    #[test]
+    fn escape_keywords_in_scope_resolves_collisions_order_independently() {
+        // {pass, pass_} → {pass__, pass_}, regardless of declaration order:
+        // the raw `pass_` is reserved in pass 1, forcing `pass` past it.
+        let forward = escape_keywords_in_scope(&["pass".into(), "pass_".into()]);
+        assert_eq!(forward, vec!["pass__".to_string(), "pass_".to_string()]);
+        let reversed = escape_keywords_in_scope(&["pass_".into(), "pass".into()]);
+        assert_eq!(reversed, vec!["pass_".to_string(), "pass__".to_string()]);
+        // Distinct keywords escape to disjoint prefixes; non-keywords untouched.
+        let mixed = escape_keywords_in_scope(&["from".into(), "ok".into(), "class".into()]);
+        assert_eq!(
+            mixed,
+            vec!["from_".to_string(), "ok".to_string(), "class_".to_string()]
+        );
+    }
 
     #[test]
     fn keyword_identifiers_get_a_trailing_underscore() {

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
@@ -845,6 +845,17 @@ fn collect_alias_dependencies(
     }
 }
 
+/// Render-boundary guard mirroring the Go generator's `GoIdent::new`
+/// assertion (PR #4067): no identifier reaching the emitter may still be a
+/// Python hard keyword. A miss here is a codegen bug (an unescaped emit site),
+/// so it panics loudly in debug builds with the offending name. Off in release.
+fn debug_assert_identifier(name: &str) {
+    debug_assert!(
+        !crate::emit::is_python_hard_keyword(name),
+        "Python keyword escaped too late: {name}"
+    );
+}
+
 /// Non-generic: `pydantic.BaseModel`.
 /// Generic: `pydantic.BaseModel, typing.Generic[T, …]`.
 fn render_class_bases(generic_params: &[String]) -> String {
@@ -899,9 +910,9 @@ fn is_media_reexport(s: &EmittedSymbol) -> bool {
 {%- if let Some(doc) = docstring %}
     {{ doc }}
 {%- endif %}
-    model_config = pydantic.ConfigDict(extra="forbid")
+    model_config = pydantic.ConfigDict(extra="forbid"{% if populate_by_name %}, populate_by_name=True{% endif %})
 {%- for prop in properties %}
-    {{ prop.name }}: {{ prop.ty_py }}
+    {{ prop.name }}: {{ prop.ty_py }}{{ prop.field_expr }}
 {%- endfor %}
 {%- if !static_methods.is_empty() %}
 
@@ -934,6 +945,12 @@ struct ClassBodyPy {
     /// inline `# …` comment — the `Attributes:` section is the sole
     /// channel.
     docstring: Option<String>,
+    /// True when ≥1 field was keyword-escaped and therefore carries a
+    /// `pydantic.Field(alias=…)`. Adds `populate_by_name=True` to the
+    /// `ConfigDict` so the model validates from both the escaped Python
+    /// attribute name and the raw BAML/JSON key. Classes with no escaped
+    /// field leave this `false` and render byte-identically to today.
+    populate_by_name: bool,
     properties: Vec<ClassPropertyView>,
     static_methods: Vec<MethodLineView>,
     instance_methods: Vec<MethodLineView>,
@@ -942,6 +959,11 @@ struct ClassBodyPy {
 struct ClassPropertyView {
     name: String,
     ty_py: String,
+    /// Trailing field expression appended after the annotation. Empty for a
+    /// plain field; ` = pydantic.Field(alias="<raw>")` for a keyword-escaped
+    /// field so the raw BAML name stays the wire/JSON key. Only consumed by
+    /// the `.py` template — the `.pyi` stub renders the escaped name alone.
+    field_expr: String,
 }
 
 struct MethodLineView {
@@ -1057,14 +1079,25 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                     py_name = c.py_name,
                 );
             }
+            debug_assert_identifier(&c.py_name);
             let properties = c
                 .properties
                 .iter()
-                .map(|prop| ClassPropertyView {
-                    name: prop.name.clone(),
-                    ty_py: translate_ty(&prop.ty, &ctx),
+                .map(|prop| {
+                    debug_assert_identifier(&prop.name);
+                    ClassPropertyView {
+                        name: prop.name.clone(),
+                        ty_py: translate_ty(&prop.ty, &ctx),
+                        field_expr: match &prop.alias {
+                            Some(raw) => {
+                                format!(" = pydantic.Field(alias={})", py_string(raw))
+                            }
+                            None => String::new(),
+                        },
+                    }
                 })
                 .collect();
+            let populate_by_name = c.properties.iter().any(|p| p.alias.is_some());
             let attrs: Vec<(String, Option<String>)> = c
                 .properties
                 .iter()
@@ -1080,6 +1113,7 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 py_name: c.py_name.clone(),
                 bases: render_class_bases(&c.generic_params),
                 docstring,
+                populate_by_name,
                 properties,
                 static_methods: build_method_line_views(&c.static_methods, &c.generic_params),
                 instance_methods: build_method_line_views(&c.instance_methods, &c.generic_params),
@@ -1090,12 +1124,16 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
             out
         }
         EmittedSymbol::Enum(e) => {
+            debug_assert_identifier(&e.py_name);
             let variants = e
                 .variants
                 .iter()
-                .map(|v| EnumVariantView {
-                    ident: v.ident.clone(),
-                    value: py_string(&v.value),
+                .map(|v| {
+                    debug_assert_identifier(&v.ident);
+                    EnumVariantView {
+                        ident: v.ident.clone(),
+                        value: py_string(&v.value),
+                    }
                 })
                 .collect();
             let members: Vec<(String, Option<String>)> = e
@@ -1159,6 +1197,8 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
 /// through its JSON-schema definitions machinery instead of recursing.
 fn render_type_alias(a: &crate::emit::type_alias::PyTypeAlias, leaf: &LeafPath) -> String {
     use askama::Template;
+
+    debug_assert_identifier(&a.py_name);
 
     // Special-case the stdlib `baml.json.json` alias.  Its expanded form is
     // a recursive JSON-shaped union (`bool | int | float | str | List[json]
@@ -1501,6 +1541,7 @@ pub(crate) fn render_leaf_body(body: &LeafBody, callable_child_names: &BTreeSet<
     if !typevars.is_empty() {
         out.push_str("\n\n");
         for tv in &typevars {
+            debug_assert_identifier(tv);
             writeln!(out, "{tv} = typing.TypeVar(\"{tv}\")").unwrap();
         }
     }
@@ -1726,6 +1767,9 @@ fn render_symbol_pyi(
                 .map(|prop| ClassPropertyView {
                     name: prop.name.clone(),
                     ty_py: translate_ty(&prop.ty, &ctx),
+                    // The `.pyi` stub renders the escaped attribute name only;
+                    // the `Field(alias=…)` runtime detail lives in the `.py`.
+                    field_expr: String::new(),
                 })
                 .collect();
             let mut out = ClassBodyPyi {
@@ -2148,6 +2192,7 @@ pub(crate) fn render_leaf_body_pyi(
     if !typevars.is_empty() {
         out.push_str("\n\n");
         for tv in &typevars {
+            debug_assert_identifier(tv);
             writeln!(out, "{tv} = typing.TypeVar(\"{tv}\")").unwrap();
         }
     }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
@@ -3,7 +3,7 @@
 //! straight walk — no ordering logic at render time.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fmt::Write as _,
 };
 
@@ -13,13 +13,15 @@ use indexmap::IndexMap;
 
 use crate::{
     emit::{
-        EmittedSymbol, SortKey, bare_callable_name,
+        EmittedSymbol, SortKey, TypeVarMap, bare_callable_name, escape_python_keyword,
         function::{PyFunction, SyncAsync},
         method::{MethodKind, PyMethodBinding},
     },
     py_string,
     routing::{LeafPath, route_class_ref},
-    translate_ty::{SelfRef, TranslateCtx, translate_ty},
+    translate_ty::{
+        CallbackProtocolKey, SelfRef, TranslateCtx, callback_protocol_key, translate_ty,
+    },
 };
 
 /// All symbols that land in one leaf's body, in final render order.
@@ -170,55 +172,109 @@ impl LeafBody {
     }
 
     /// The optional-argument `Ty::Function`s reachable from this leaf's
-    /// function/method/field signatures, in deterministic first-seen order,
-    /// each paired with the `_<owner>__<param>` prefix for its Protocol name
+    /// function/method/field signatures, in deterministic first-seen order, each
+    /// carrying the `_<owner>__<param>` prefix for its Protocol name
     /// (`render_leaf_body_pyi` appends a per-prefix counter, giving e.g.
-    /// `_call_optional_int_callback_supplied__callback1`). Each is rendered as a
-    /// named `typing.Protocol` in the `.pyi` (see `render_callback_protocol`),
-    /// because a `typing.Callable[[…], R]` type can't express per-parameter
-    /// optionality.
+    /// `_call_optional_int_callback_supplied__callback1`) AND the OWNER scope's
+    /// `TypeVar` map. Each is rendered as a named `typing.Protocol` in the
+    /// `.pyi` (see `render_callback_protocol`), because a `typing.Callable[[…],
+    /// R]` type can't express per-parameter optionality.
+    ///
+    /// The owner map is carried so the Protocol body renders a bumped keyword
+    /// `TypeVar` with the owner's declared spelling (`None`→`None__`), not the
+    /// stateless escape (`None_`). De-duplication is deferred to the caller and
+    /// keyed on the RENDERED identity (structural `Ty` + owner-map projection),
+    /// so two owners whose maps produce the SAME spelling still share one Protocol
+    /// (keyword-free schemas always do → byte-identical) while owners that spell
+    /// the callback's `TypeVars` differently get distinct Protocols. `seen` is kept
+    /// per-owner (not leaf-wide) precisely so a shared structural `Ty` under two
+    /// incompatible owners is not collapsed before that keyed dedup runs.
     ///
     /// Type aliases are skipped: they render via the shared `.py`/`.pyi`
     /// `render_type_alias` (which has no Protocol map), so a callable alias
     /// falls back to `typing.Callable[..., R]` rather than referencing a
     /// Protocol — collecting one here would emit an unused class.
-    pub(crate) fn callback_protocols(&self) -> Vec<(Ty, String)> {
-        let mut seen: std::collections::HashSet<Ty> = std::collections::HashSet::new();
-        let mut out: Vec<(Ty, String)> = Vec::new();
+    pub(crate) fn callback_protocols(&self) -> Vec<CallbackProtocol> {
+        let mut out: Vec<CallbackProtocol> = Vec::new();
         for (sym, _) in &self.symbols {
             match sym {
                 EmittedSymbol::Class(c) => {
+                    let class_map = scope_type_var_map(&c.type_var_map);
+                    // Class fields share one `seen`: the owner is the class.
+                    let mut field_seen: HashSet<Ty> = HashSet::new();
                     for prop in &c.properties {
                         let base = format!("_{}__{}", c.py_name, prop.name);
-                        collect_optional_callables(&prop.ty, &base, &mut seen, &mut out);
+                        collect_optional_callables(
+                            &prop.ty,
+                            &base,
+                            class_map.as_ref(),
+                            &mut field_seen,
+                            &mut out,
+                        );
                     }
                     for m in c.static_methods.iter().chain(&c.instance_methods) {
                         // `bare_callable_name` applies the companion `$` rule
                         // (`$stream` → `_stream`, `$<other>` → `__<other>`) so the
-                        // Protocol identifier stays a valid Python name.
+                        // Protocol identifier stays a valid Python name. Each
+                        // method is its own owner scope: its annotation map
+                        // is the class map merged with the method's own params.
+                        let owner_map = method_scope_type_var_map(m, class_map.as_ref());
                         let owner = bare_callable_name(fqn_leaf(&m.baml_fqn));
+                        let mut method_seen: HashSet<Ty> = HashSet::new();
                         for arg in &m.required_args {
                             let base = format!("_{owner}__{}", arg.name);
-                            collect_optional_callables(&arg.ty, &base, &mut seen, &mut out);
+                            collect_optional_callables(
+                                &arg.ty,
+                                &base,
+                                owner_map.as_ref(),
+                                &mut method_seen,
+                                &mut out,
+                            );
                         }
                         for arg in &m.optional_args {
                             let base = format!("_{owner}__{}", arg.name);
-                            collect_optional_callables(&arg.ty, &base, &mut seen, &mut out);
+                            collect_optional_callables(
+                                &arg.ty,
+                                &base,
+                                owner_map.as_ref(),
+                                &mut method_seen,
+                                &mut out,
+                            );
                         }
                         let base = format!("_{owner}__ret");
-                        collect_optional_callables(&m.return_ty, &base, &mut seen, &mut out);
+                        collect_optional_callables(
+                            &m.return_ty,
+                            &base,
+                            owner_map.as_ref(),
+                            &mut method_seen,
+                            &mut out,
+                        );
                     }
                 }
                 EmittedSymbol::Function(f) => {
                     // See the method case: normalize the companion `$` suffix so
                     // the Protocol identifier is a valid Python name.
+                    let owner_map = scope_type_var_map(&f.type_var_map);
                     let owner = bare_callable_name(fqn_leaf(&f.baml_fqn));
+                    let mut fn_seen: HashSet<Ty> = HashSet::new();
                     for (name, ty) in f.param_names.iter().zip(f.arg_tys.iter()) {
                         let base = format!("_{owner}__{name}");
-                        collect_optional_callables(ty, &base, &mut seen, &mut out);
+                        collect_optional_callables(
+                            ty,
+                            &base,
+                            owner_map.as_ref(),
+                            &mut fn_seen,
+                            &mut out,
+                        );
                     }
                     let base = format!("_{owner}__ret");
-                    collect_optional_callables(&f.return_ty, &base, &mut seen, &mut out);
+                    collect_optional_callables(
+                        &f.return_ty,
+                        &base,
+                        owner_map.as_ref(),
+                        &mut fn_seen,
+                        &mut out,
+                    );
                 }
                 EmittedSymbol::TypeAlias(_) | EmittedSymbol::Enum(_) => {}
             }
@@ -514,44 +570,60 @@ fn fqn_leaf(fqn: &str) -> &str {
     fqn.rsplit('.').next().unwrap_or(fqn)
 }
 
+/// One optional-argument callback `Ty::Function` collected for `.pyi` Protocol
+/// rendering, with everything needed to name, dedup, and render it:
+/// the structural callback type, the `_<owner>__<param>` name prefix, and the
+/// OWNER scope's `TypeVar` map (so the Protocol body renders bumped keyword
+/// `TypeVars` with the owner's declared spelling).
+pub(crate) struct CallbackProtocol {
+    pub(crate) ty: Ty,
+    pub(crate) base: String,
+    pub(crate) owner_map: Option<std::rc::Rc<TypeVarMap>>,
+}
+
 /// Recursively collect every optional-argument `Ty::Function` reachable from
-/// `ty`, in first-seen order, skipping duplicates (`seen`). Each is paired with
-/// `base` — the `_<owner>__<param>` prefix for its Protocol name (the final
-/// name appends a per-base counter in `LeafBody::callback_protocols`). Children
-/// are visited before the enclosing callable so nested callbacks get earlier
-/// names.
+/// `ty`, in first-seen order, skipping duplicates within this owner (`seen`).
+/// Each carries `base` — the `_<owner>__<param>` prefix for its Protocol name
+/// (the final name appends a per-base counter in `render_leaf_body_pyi`) — and
+/// `owner_map`, the enclosing scope's raw→emitted `TypeVar` map. Children are
+/// visited before the enclosing callable so nested callbacks get earlier names.
 fn collect_optional_callables(
     ty: &Ty,
     base: &str,
-    seen: &mut std::collections::HashSet<Ty>,
-    out: &mut Vec<(Ty, String)>,
+    owner_map: Option<&std::rc::Rc<TypeVarMap>>,
+    seen: &mut HashSet<Ty>,
+    out: &mut Vec<CallbackProtocol>,
 ) {
     match ty {
-        Ty::List(inner, _) => collect_optional_callables(inner, base, seen, out),
+        Ty::List(inner, _) => collect_optional_callables(inner, base, owner_map, seen, out),
         Ty::Map { key, value, .. } => {
-            collect_optional_callables(key, base, seen, out);
-            collect_optional_callables(value, base, seen, out);
+            collect_optional_callables(key, base, owner_map, seen, out);
+            collect_optional_callables(value, base, owner_map, seen, out);
         }
         Ty::Union(items, _) => {
             for item in items {
-                collect_optional_callables(item, base, seen, out);
+                collect_optional_callables(item, base, owner_map, seen, out);
             }
         }
         Ty::Class(_, args, _) => {
             for a in args {
-                collect_optional_callables(a, base, seen, out);
+                collect_optional_callables(a, base, owner_map, seen, out);
             }
         }
         Ty::Function { params, ret, .. } => {
             for p in params {
-                collect_optional_callables(&p.ty, base, seen, out);
+                collect_optional_callables(&p.ty, base, owner_map, seen, out);
             }
-            collect_optional_callables(ret, base, seen, out);
+            collect_optional_callables(ret, base, owner_map, seen, out);
             let has_optional = params
                 .iter()
                 .any(|p| p.mode == baml_codegen_types::CodegenFunctionParamMode::Optional);
             if has_optional && seen.insert(ty.clone()) {
-                out.push((ty.clone(), base.to_string()));
+                out.push(CallbackProtocol {
+                    ty: ty.clone(),
+                    base: base.to_string(),
+                    owner_map: owner_map.cloned(),
+                });
             }
         }
         _ => {}
@@ -648,16 +720,23 @@ fn record_name_routing(
         return;
     }
     if routed.segments.is_empty() {
-        // Root-routed type referenced from a non-root leaf — translator
-        // emits the bare name (`Foo`), so we pull it in via
-        // `from <dots> import Foo`. The root leaf itself never reaches
-        // here (current is also empty there, so `routed == *current`).
+        // Root-routed type referenced from a non-root leaf — the translator
+        // emits the keyword-escaped bare name (`None_`, via
+        // `translate_ty::render_name_ref`), so the import anchor and the
+        // recorded root name must carry the SAME escaped spelling or the
+        // `from <dots> import None_` line and the root's `class None_`
+        // definition would diverge (`from .. import None` is a SyntaxError and
+        // leaves `None_` unbound). The root leaf itself never reaches here
+        // (current is also empty there, so `routed == *current`). The non-root
+        // branch below routes by module-path segment, which the routing
+        // sanitizer handles separately (upstream TODO, left to a follow-up change).
         if !current.segments.is_empty() {
-            out.root_names.insert(name.bare_name().to_string());
+            let bare = escape_python_keyword(name.bare_name().to_string());
+            out.root_names.insert(bare.clone());
             out.rel.insert(RelImport {
                 depth: current.segments.len() + 1,
                 from_path: String::new(),
-                anchor: name.bare_name().to_string(),
+                anchor: bare,
             });
         }
     } else {
@@ -845,6 +924,220 @@ fn collect_alias_dependencies(
     }
 }
 
+/// Allocate every generic scope's `TypeVar` names ONCE per leaf against
+/// a leaf-global reservation set, replacing the old per-`<…>`-list allocation.
+///
+/// Runs after `group_and_sort`, when every symbol that lands in a leaf is known.
+/// At entry each scope's `generic_params` still hold the RAW binder names and
+/// `type_var_map` is empty (see `emit::build_emitted`); this pass rewrites both.
+/// `children` is the directory→immediate-child-name map (built in `lib.rs` before
+/// this call) so the reservation set can cover module-level bindings that live
+/// outside `body.symbols`.
+///
+/// Guarantees:
+/// - **Non-keyword raw names map to themselves, unconditionally** — even if the
+///   name collides with a leaf class named `T` (that ordinary class-vs-TypeVar
+///   module collision is pre-existing on canary and explicitly NOT fixed this
+///   round). This preserves STRICT byte-identity for keyword-free schemas.
+/// - **Keyword raw names bump** (`None`→`None_`→`None__`…) past a reservation set
+///   made of every module-level binding a bumped name could shadow:
+///   (a) every leaf emitted symbol name (class/enum/alias/function `py_name`);
+///   (b) every module import anchor brought in through the SDK root;
+///   (c) `__all__`; (d) every raw `TypeVar` name in the leaf;
+///   (e) every already-allocated emitted `TypeVar` name;
+///   (f) every immediate child-package/submodule name of this leaf's directory
+///   (`from . import <child>` / `_LAZY_CHILDREN`), and every keyword-escaped
+///   callable-child import anchor aggregated into the parent stub. (f) is
+///   supplied by `compute_module_binding_reservations` — those bindings are
+///   cross-body / render-time facts the per-body walk cannot see, and omitting
+///   them would let a keyword `TypeVar` overwrite a real child module or rebind
+///   an imported child class.
+/// - **Deliberately NOT reserved, unreachable by construction:** stdlib module
+///   imports (`typing`/`pydantic`/`enum`/…) and every `_`-leading helper
+///   (`_{name}_namespace`, `_BamlCallableNamespace_…`, runtime aliases). Bumping
+///   only appends trailing `_` to a hard keyword, so an emitted `TypeVar` name
+///   can never be underscore-leading and never equals a stdlib module name — no
+///   reservation entry can ever be consulted for them.
+/// - The map is keyed by **raw name**, so distinct raw NAMES/SPELLINGS never
+///   collapse to one emitted name; identical raw spellings (the same `T` reused
+///   across scopes, or two independently-generic functions each declaring `T`)
+///   deliberately share ONE module-level `TypeVar`, which is sound because each
+///   scope is independently generic on it — closing the emitted-name and runtime
+///   `_types`-key collapse.
+pub(crate) fn allocate_leaf_type_vars(
+    bodies: &mut BTreeMap<LeafPath, LeafBody>,
+    children: &BTreeMap<Vec<String>, BTreeSet<String>>,
+) {
+    // Read-only pre-pass FIRST: collect each leaf's module-binding reservation
+    // supplement while `bodies` is only shared-borrowed, so the mutation loop
+    // below can hold the exclusive `values_mut()` borrow without conflict
+    // (the anchor set is a pure function of the already-built bodies).
+    let supplement = compute_module_binding_reservations(bodies, children);
+    for (leaf, body) in bodies.iter_mut() {
+        allocate_leaf_body_type_vars(body, supplement.get(leaf));
+    }
+}
+
+/// Per-leaf reservation supplement (category (f) in `allocate_leaf_type_vars`):
+/// module-level bindings that occupy a leaf's namespace but are NOT in
+/// `body.symbols` or `body.root_imports_py()`, so the per-body reservation walk
+/// misses them. Computed here in a read-only pre-pass over `bodies`:
+///
+/// - **(a) immediate child-package/submodule names.** `children` maps each
+///   directory to the emitted attribute names of its immediate children
+///   (`from . import None_`, `_LAZY_CHILDREN {"None_"}`, PEP-562 `__getattr__`).
+///   A keyword `TypeVar` bumping onto a child name — e.g. generic raw `None`
+///   escaping to `None_` onto a child module `None_` — would overwrite the child
+///   binding at import time. Names are the emitted segments already
+///   (routing sanitized them), so reserving them verbatim is exact.
+/// - **(b) keyword-escaped callable-child import anchors.** `render_leaf_body_pyi`
+///   aggregates a callable child's argument/return imports into the parent stub
+///   (`callable_child_parent_rel_imports`), gated to keyword-escaped classes.
+///   A bumped keyword `TypeVar` colliding with such a
+///   `from ... import None_` would rebind the imported class to the `TypeVar`.
+///   Only keyword-
+///   escaped anchors survive the gate, and those are exactly the collision
+///   candidates, so reserving just them suffices. Name-only: depth is irrelevant
+///   for a reservation set.
+fn compute_module_binding_reservations(
+    bodies: &BTreeMap<LeafPath, LeafBody>,
+    children: &BTreeMap<Vec<String>, BTreeSet<String>>,
+) -> BTreeMap<LeafPath, BTreeSet<String>> {
+    let mut out: BTreeMap<LeafPath, BTreeSet<String>> = BTreeMap::new();
+    for (leaf, body) in bodies {
+        let mut names: BTreeSet<String> = BTreeSet::new();
+        let kids = children.get(&leaf.segments).cloned().unwrap_or_default();
+        // (a) immediate child-package/submodule names.
+        names.extend(kids.iter().cloned());
+        // (b) keyword-escaped, aggregated callable-child import anchors. Mirror
+        //     the render path's aggregation but keep only the anchor NAMES.
+        let callable_child_names = body.callable_child_names(&kids);
+        let callable_child_bodies =
+            crate::callable_child_bodies(&leaf.segments, &callable_child_names, bodies);
+        for anchor in callable_child_parent_rel_imports(leaf, &callable_child_bodies) {
+            names.insert(anchor.anchor);
+        }
+        if !names.is_empty() {
+            out.insert(leaf.clone(), names);
+        }
+    }
+    out
+}
+
+fn collect_raw_type_vars(names: &[String], order: &mut Vec<String>, seen: &mut HashSet<String>) {
+    for n in names {
+        if seen.insert(n.clone()) {
+            order.push(n.clone());
+        }
+    }
+}
+
+/// Rewrite one scope: `generic_params` (still RAW at entry) becomes the emitted
+/// names in declaration order, and `type_var_map` becomes the restriction of the
+/// leaf map to this scope's raw names.
+fn project_scope_type_vars(
+    generic_params: &mut Vec<String>,
+    type_var_map: &mut TypeVarMap,
+    leaf_map: &TypeVarMap,
+) {
+    let raws = std::mem::take(generic_params);
+    let mut map = TypeVarMap::new();
+    let mut emitted = Vec::with_capacity(raws.len());
+    for raw in raws {
+        let e = leaf_map.get(&raw).cloned().unwrap_or_else(|| raw.clone());
+        map.insert(raw, e.clone());
+        emitted.push(e);
+    }
+    *generic_params = emitted;
+    *type_var_map = map;
+}
+
+fn allocate_leaf_body_type_vars(body: &mut LeafBody, extra_reserved: Option<&BTreeSet<String>>) {
+    // 1. Distinct RAW TypeVar names across every scope, first-appearance order
+    //    (class params, then its methods' params, then free functions).
+    let mut raw_order: Vec<String> = Vec::new();
+    let mut raw_set: HashSet<String> = HashSet::new();
+    for (sym, _) in &body.symbols {
+        match sym {
+            EmittedSymbol::Class(c) => {
+                collect_raw_type_vars(&c.generic_params, &mut raw_order, &mut raw_set);
+                for m in c.static_methods.iter().chain(&c.instance_methods) {
+                    collect_raw_type_vars(&m.generic_params, &mut raw_order, &mut raw_set);
+                }
+            }
+            EmittedSymbol::Function(f) => {
+                collect_raw_type_vars(&f.generic_params, &mut raw_order, &mut raw_set);
+            }
+            EmittedSymbol::Enum(_) | EmittedSymbol::TypeAlias(_) => {}
+        }
+    }
+    if raw_order.is_empty() {
+        return; // no generics in this leaf — nothing to allocate
+    }
+
+    // 2. Reservation set for keyword bumps.
+    let mut reserved: HashSet<String> = HashSet::new();
+    // (a) every leaf-level emitted symbol name (class/enum/alias/function).
+    for (sym, _) in &body.symbols {
+        reserved.insert(sym.py_name().to_string());
+    }
+    // (b) module import anchors brought in through the SDK root.
+    let imports = body.root_imports_py();
+    reserved.extend(imports.segments);
+    reserved.extend(imports.root_names);
+    // (c) the `__all__` module binding. The `_{name}_namespace` callable-child
+    //     helpers are unreachable by keyword bumping (bumping only appends `_`,
+    //     which can never produce a `_`-leading name), so they need no entry.
+    reserved.insert("__all__".to_string());
+    // (d) every raw TypeVar name in the leaf, any scope.
+    reserved.extend(raw_set.iter().cloned());
+    // (f) module-level bindings this leaf emits that are NOT symbols or import
+    //     anchors: immediate child-package/submodule names and keyword-escaped
+    //     callable-child import anchors. Threaded in from the read-only
+    //     pre-pass (`compute_module_binding_reservations`) because they are
+    //     cross-body / render-time facts the per-body walk above cannot see —
+    //     omitting them would let a keyword TypeVar overwrite a real child module
+    //     or rebind an imported child class.
+    if let Some(extra) = extra_reserved {
+        reserved.extend(extra.iter().cloned());
+    }
+
+    // 3. Allocate the ONE leaf map (raw -> emitted).
+    let mut leaf_map: TypeVarMap = TypeVarMap::new();
+    for raw in &raw_order {
+        if !crate::emit::is_python_hard_keyword(raw) {
+            leaf_map.insert(raw.clone(), raw.clone());
+        } else {
+            let mut candidate = format!("{raw}_");
+            while crate::emit::is_python_hard_keyword(&candidate) || reserved.contains(&candidate) {
+                candidate.push('_');
+            }
+            reserved.insert(candidate.clone()); // (e) already-allocated emitted names
+            leaf_map.insert(raw.clone(), candidate);
+        }
+    }
+
+    // 4. Project the leaf map onto each scope.
+    for (sym, _) in &mut body.symbols {
+        match sym {
+            EmittedSymbol::Class(c) => {
+                project_scope_type_vars(&mut c.generic_params, &mut c.type_var_map, &leaf_map);
+                for m in c
+                    .static_methods
+                    .iter_mut()
+                    .chain(c.instance_methods.iter_mut())
+                {
+                    project_scope_type_vars(&mut m.generic_params, &mut m.type_var_map, &leaf_map);
+                }
+            }
+            EmittedSymbol::Function(f) => {
+                project_scope_type_vars(&mut f.generic_params, &mut f.type_var_map, &leaf_map);
+            }
+            EmittedSymbol::Enum(_) | EmittedSymbol::TypeAlias(_) => {}
+        }
+    }
+}
+
 /// Render-boundary guard mirroring the Go generator's `GoIdent::new`
 /// assertion (PR #4067): no identifier reaching the emitter may still be a
 /// Python hard keyword. A miss here is a codegen bug (an unescaped emit site),
@@ -911,6 +1204,9 @@ fn is_media_reexport(s: &EmittedSymbol) -> bool {
     {{ doc }}
 {%- endif %}
     model_config = pydantic.ConfigDict(extra="forbid"{% if populate_by_name %}, populate_by_name=True{% endif %})
+{%- if let Some(marker) = wire_names_marker %}
+    {{ marker }}
+{%- endif %}
 {%- for prop in properties %}
     {{ prop.name }}: {{ prop.ty_py }}{{ prop.field_expr }}
 {%- endfor %}
@@ -951,6 +1247,17 @@ struct ClassBodyPy {
     /// attribute name and the raw BAML/JSON key. Classes with no escaped
     /// field leave this `false` and render byte-identically to today.
     populate_by_name: bool,
+    /// `Some("__baml_wire_names__ = {…}")` when
+    /// ≥1 field was keyword-escaped: an explicit map of escaped Python attribute
+    /// name → raw BAML/wire name, consumed by the bridge encode path
+    /// (`proto.py`) as the sole provenance signal. A dunder name keeps it out of
+    /// pydantic's field set / `model_json_schema()` (mirrors the enum
+    /// `__baml_wire_values__` marker), and avoids a runtime `typing.get_type_hints`
+    /// hazard from bare-builtin subscripts shadowed by a user `type dict = …`.
+    /// `None` (no escaped field) emits nothing, so
+    /// keyword-free classes stay byte-identical. `.py`-only — the `.pyi` stub
+    /// carries no runtime detail, mirroring `Field(alias=…)`.
+    wire_names_marker: Option<String>,
     properties: Vec<ClassPropertyView>,
     static_methods: Vec<MethodLineView>,
     instance_methods: Vec<MethodLineView>,
@@ -985,6 +1292,9 @@ struct MethodLineView {
 {%- for v in variants %}
     {{ v.ident }} = {{ v.value }}
 {%- endfor %}
+{%- endif %}
+{%- if let Some(marker) = wire_values_marker %}
+    {{ marker }}
 {%- endif %}"#,
     ext = "py.j2",
     escape = "none"
@@ -997,6 +1307,14 @@ struct EnumBodyPy {
     /// a `///`.
     docstring: Option<String>,
     variants: Vec<EnumVariantView>,
+    /// `Some("__baml_wire_values__ = {…}")` when ≥1 member was keyword-escaped: a
+    /// plain dunder dict mapping escaped Python member name → raw BAML/wire name.
+    /// A dunder is excluded from `enum.Enum` membership by
+    /// `EnumMeta`, so it never becomes a variant. Consumed by the bridge encode
+    /// path as the sole provenance signal. `None` (no escaped member)
+    /// emits nothing, so keyword-free enums stay byte-identical. `.py`-only,
+    /// mirroring the class marker and `Field(alias=…)`.
+    wire_values_marker: Option<String>,
 }
 
 struct EnumVariantView {
@@ -1055,6 +1373,85 @@ fn build_method_line_views(
     out
 }
 
+/// Wrap a scope's raw→emitted `TypeVar` map into the `Option<Rc<…>>` a
+/// `TranslateCtx` carries. `None` (the common case) when the scope declares no
+/// generics, so every non-generic body builds a byte-identical ctx.
+fn scope_type_var_map(map: &TypeVarMap) -> Option<std::rc::Rc<TypeVarMap>> {
+    if map.is_empty() {
+        None
+    } else {
+        Some(std::rc::Rc::new(map.clone()))
+    }
+}
+
+/// The map a method's `.pyi` signature is translated under: the method's own
+/// `<…>` params always bind, and the enclosing class's params bind too.
+/// BAML statics legitimately reference the enclosing class's `TypeVars` in their
+/// signatures (stdlib `Array.filled`/`generate`), so the class map is threaded
+/// for ANNOTATION resolution regardless of `MethodKind`. Only the RUNTIME
+/// `_types=` receiver binding still differs by kind (`render_method_binding`):
+/// an instance method recovers the class `TypeVars` from `self`; a static does not.
+fn method_scope_type_var_map(
+    m: &PyMethodBinding,
+    class_map: Option<&std::rc::Rc<TypeVarMap>>,
+) -> Option<std::rc::Rc<TypeVarMap>> {
+    match (class_map, m.type_var_map.is_empty()) {
+        (None, true) => None,
+        (Some(cm), true) => Some(cm.clone()),
+        (None, false) => Some(std::rc::Rc::new(m.type_var_map.clone())),
+        (Some(cm), false) => {
+            // Method params shadow class params on a name clash.
+            let mut merged: TypeVarMap = (**cm).clone();
+            merged.extend(m.type_var_map.iter().map(|(k, v)| (k.clone(), v.clone())));
+            Some(std::rc::Rc::new(merged))
+        }
+    }
+}
+
+/// Build the `__baml_wire_names__` class marker: a plain dunder dict mapping each
+/// keyword-escaped Python attribute name to its raw BAML/wire name, in declaration
+/// order. `None` when no field was escaped, so keyword-free classes emit nothing
+/// and stay byte-identical. A dunder name is excluded from pydantic's field set,
+/// so the assignment carries no annotation (mirrors the enum `__baml_wire_values__`
+/// marker) and cannot trip `typing.get_type_hints`. `.py`-only (see `ClassBodyPy`).
+fn build_wire_names_marker(properties: &[crate::emit::class::PyClassProperty]) -> Option<String> {
+    let entries: Vec<String> = properties
+        .iter()
+        .filter_map(|p| {
+            p.alias
+                .as_deref()
+                .map(|raw| format!("{}: {}", py_string(&p.name), py_string(raw)))
+        })
+        .collect();
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("__baml_wire_names__ = {{{}}}", entries.join(", ")))
+    }
+}
+
+/// Build the `__baml_wire_values__` enum marker: a plain dunder dict
+/// mapping each keyword-escaped Python member name to its raw BAML/wire variant
+/// name, in declaration order. `None` when no member was escaped, so keyword-free
+/// enums emit nothing and stay byte-identical. A dunder name is excluded from
+/// `enum.Enum` membership by `EnumMeta`, so the assignment never becomes a
+/// variant. `.py`-only (see `EnumBodyPy`).
+fn build_wire_values_marker(variants: &[crate::emit::enum_::PyEnumVariant]) -> Option<String> {
+    let entries: Vec<String> = variants
+        .iter()
+        .filter_map(|v| {
+            v.wire_name
+                .as_deref()
+                .map(|raw| format!("{}: {}", py_string(&v.ident), py_string(raw)))
+        })
+        .collect();
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("__baml_wire_values__ = {{{}}}", entries.join(", ")))
+    }
+}
+
 /// Render one symbol into its `.py` source block, including trailing `\n`.
 fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
     use askama::Template;
@@ -1065,6 +1462,8 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
         // Runtime `.py`: callback Protocols are stub-only, so optional-arg
         // callables widen to `typing.Callable[..., R]` here.
         callback_protocols: None,
+        // Set per-symbol below; only the class body translates field types.
+        type_var_map: None,
     };
 
     match s {
@@ -1080,6 +1479,11 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 );
             }
             debug_assert_identifier(&c.py_name);
+            // Field annotations resolve TypeVars through this class's scope map.
+            let ctx = TranslateCtx {
+                type_var_map: scope_type_var_map(&c.type_var_map),
+                ..ctx
+            };
             let properties = c
                 .properties
                 .iter()
@@ -1098,6 +1502,13 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 })
                 .collect();
             let populate_by_name = c.properties.iter().any(|p| p.alias.is_some());
+            // Emit `__baml_wire_names__` ONLY when ≥1 field is
+            // keyword-escaped (carries `alias`). Maps the escaped Python attr
+            // name to its raw BAML/wire name so the bridge encoder can recover
+            // the wire key without shape-guessing. Keyword-free classes
+            // have no escaped field, so the marker is absent and their output is
+            // byte-identical to today.
+            let wire_names_marker = build_wire_names_marker(&c.properties);
             let attrs: Vec<(String, Option<String>)> = c
                 .properties
                 .iter()
@@ -1114,6 +1525,7 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 bases: render_class_bases(&c.generic_params),
                 docstring,
                 populate_by_name,
+                wire_names_marker,
                 properties,
                 static_methods: build_method_line_views(&c.static_methods, &c.generic_params),
                 instance_methods: build_method_line_views(&c.instance_methods, &c.generic_params),
@@ -1147,10 +1559,15 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 "Members",
                 "    ",
             );
+            // Emit `__baml_wire_values__` ONLY when ≥1 member is
+            // keyword-escaped. Keyword-free enums have no escaped member, so the
+            // marker is absent and their output is byte-identical to today.
+            let wire_values_marker = build_wire_values_marker(&e.variants);
             let mut out = EnumBodyPy {
                 py_name: e.py_name.clone(),
                 docstring,
                 variants,
+                wire_values_marker,
             }
             .render()
             .expect("enum_body template should always render");
@@ -1243,6 +1660,9 @@ fn render_type_alias(a: &crate::emit::type_alias::PyTypeAlias, leaf: &LeafPath) 
         // with optional params widens to `typing.Callable[..., R]` rather than
         // referencing a stub-only Protocol.
         callback_protocols: None,
+        // Type aliases declare no generic scope; any `TypeVar` in the RHS is
+        // free and falls back to the stateless escape.
+        type_var_map: None,
     };
     let rhs = translate_ty(&a.resolves_to, &ctx);
     if a.recursive {
@@ -1713,10 +2133,13 @@ fn render_method_block_pyi(m: &PyMethodBinding, ctx: &TranslateCtx) -> String {
     }
 }
 
-/// `.pyi` counterpart of `build_method_line_views`.
+/// `.pyi` counterpart of `build_method_line_views`. `class_map` is the enclosing
+/// class's `TypeVar` scope map, merged per method (instance only) so a signature
+/// resolves every in-scope `TypeVar` to its declared spelling.
 fn build_method_block_views(
     methods: &[PyMethodBinding],
-    ctx: &TranslateCtx,
+    base_ctx: &TranslateCtx,
+    class_map: Option<&std::rc::Rc<TypeVarMap>>,
 ) -> Vec<MethodBlockView> {
     let mut out = Vec::with_capacity(methods.len());
     let mut prev_root: Option<&str> = None;
@@ -1726,8 +2149,12 @@ fn build_method_block_views(
             None => true,
             Some(p) => p == root,
         };
+        let ctx = TranslateCtx {
+            type_var_map: method_scope_type_var_map(m, class_map),
+            ..base_ctx.clone()
+        };
         out.push(MethodBlockView {
-            block: render_method_block_pyi(m, ctx),
+            block: render_method_block_pyi(m, &ctx),
             tight_to_prev,
         });
         prev_root = Some(root);
@@ -1743,7 +2170,7 @@ fn build_method_block_views(
 fn render_symbol_pyi(
     s: &EmittedSymbol,
     leaf: &LeafPath,
-    callback_protocols: Option<&std::rc::Rc<IndexMap<Ty, String>>>,
+    callback_protocols: Option<&std::rc::Rc<IndexMap<CallbackProtocolKey, String>>>,
 ) -> String {
     use askama::Template;
     let ctx = TranslateCtx {
@@ -1751,6 +2178,8 @@ fn render_symbol_pyi(
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        // Set per-symbol below (class fields, method and function signatures).
+        type_var_map: None,
     };
 
     match s {
@@ -1761,12 +2190,18 @@ fn render_symbol_pyi(
                     py_name = c.py_name,
                 );
             }
+            let class_map = scope_type_var_map(&c.type_var_map);
+            // Field annotations resolve TypeVars through the class scope.
+            let field_ctx = TranslateCtx {
+                type_var_map: class_map.clone(),
+                ..ctx.clone()
+            };
             let properties = c
                 .properties
                 .iter()
                 .map(|prop| ClassPropertyView {
                     name: prop.name.clone(),
-                    ty_py: translate_ty(&prop.ty, &ctx),
+                    ty_py: translate_ty(&prop.ty, &field_ctx),
                     // The `.pyi` stub renders the escaped attribute name only;
                     // the `Field(alias=…)` runtime detail lives in the `.py`.
                     field_expr: String::new(),
@@ -1776,8 +2211,16 @@ fn render_symbol_pyi(
                 py_name: c.py_name.clone(),
                 bases: render_class_bases(&c.generic_params),
                 properties,
-                static_methods: build_method_block_views(&c.static_methods, &ctx),
-                instance_methods: build_method_block_views(&c.instance_methods, &ctx),
+                static_methods: build_method_block_views(
+                    &c.static_methods,
+                    &ctx,
+                    class_map.as_ref(),
+                ),
+                instance_methods: build_method_block_views(
+                    &c.instance_methods,
+                    &ctx,
+                    class_map.as_ref(),
+                ),
             }
             .render()
             .expect("class_body.pyi template should always render");
@@ -1788,7 +2231,10 @@ fn render_symbol_pyi(
             // Enum body is identical between `.py` and `.pyi` —
             // reuse the `.py` template directly. The `.pyi` form
             // omits the body docstring; `__doc__` resolves against
-            // the `.py` definition.
+            // the `.py` definition. The `__baml_wire_values__` marker is a
+            // runtime-only provenance detail (consumed by the bridge encoder),
+            // so the stub carries `None` — mirroring how the `.pyi` drops the
+            // class `Field(alias=…)` runtime detail.
             let variants = e
                 .variants
                 .iter()
@@ -1801,6 +2247,7 @@ fn render_symbol_pyi(
                 py_name: e.py_name.clone(),
                 docstring: None,
                 variants,
+                wire_values_marker: None,
             }
             .render()
             .expect("enum_body template should always render");
@@ -1814,6 +2261,11 @@ fn render_symbol_pyi(
             out
         }
         EmittedSymbol::Function(f) => {
+            // The signature resolves TypeVars through this function's scope.
+            let ctx = TranslateCtx {
+                type_var_map: scope_type_var_map(&f.type_var_map),
+                ..ctx
+            };
             let mut out = render_function_signature_pyi(f, &ctx);
             out.push('\n');
             out
@@ -1927,19 +2379,22 @@ fn render_callable_child_protocol_pyi(
     parent_fn: &PyFunction,
     child_body: &LeafBody,
     parent_leaf: &LeafPath,
-    callback_protocols: Option<&std::rc::Rc<IndexMap<Ty, String>>>,
+    callback_protocols: Option<&std::rc::Rc<IndexMap<CallbackProtocolKey, String>>>,
 ) -> String {
     let parent_ctx = TranslateCtx {
         current_leaf: parent_leaf.clone(),
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        type_var_map: scope_type_var_map(&parent_fn.type_var_map),
     };
-    let child_ctx = TranslateCtx {
+    let child_base_ctx = TranslateCtx {
         current_leaf: child_body.leaf.clone(),
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        // Set per-child function below.
+        type_var_map: None,
     };
     let protocol_name = callable_child_protocol_name(name);
     let mut out = format!("class {protocol_name}(typing.Protocol):\n");
@@ -1950,6 +2405,10 @@ fn render_callable_child_protocol_pyi(
     ));
     for (sym, _) in &child_body.symbols {
         if let EmittedSymbol::Function(f) = sym {
+            let child_ctx = TranslateCtx {
+                type_var_map: scope_type_var_map(&f.type_var_map),
+                ..child_base_ctx.clone()
+            };
             out.push_str(&render_protocol_function_method_pyi(
                 &f.py_name, f, &child_ctx,
             ));
@@ -2103,9 +2562,117 @@ fn render_literal_default(lit: &Literal) -> String {
     }
 }
 
-/// Mirrors `render_leaf_body` with these differences: no
-/// `baml_bridge` factory imports; `typing` is needed whenever a
-/// signature is present (`needs_typing_pyi`); `enum` and `pydantic`
+/// KEYWORD-GATED: rel-imports needed by the callable-child
+/// function signatures that `render_callable_child_protocol_pyi` renders into the
+/// PARENT stub, computed relative to the PARENT leaf so depths/anchors match the
+/// parent stub (the child's own `all_rel_imports_py` would use child-leaf depths —
+/// one level too deep). Only child *functions* are rendered into the parent, so
+/// only their arg/return types are walked.
+///
+/// The walk is gated to keyword-ESCAPED class/enum/alias anchors only
+/// (`collect_keyword_escaped_root_imports`): a keyword-free callable child (one
+/// returning an ordinary root class `Widget`) contributes NOTHING, so keyword-free
+/// parent stubs stay strictly byte-identical, while keyword-escaped anchors —
+/// the only names that can collide with a bumped keyword `TypeVar` — are
+/// still aggregated and bound. The general keyword-free unbound-stub case an
+/// unconditional walk would also fix is pre-existing on canary and is left as a
+/// disclosed follow-up. Provenance is unambiguous at codegen (the arg/return `Ty`
+/// carries the class's raw BAML name), unlike the bridge's runtime shape ambiguity.
+/// Isolated to this one fn + its two callers (the render site and the reservation
+/// pre-pass) so the whole aggregation can be dropped
+/// deterministically if the keyword-free fixtures move.
+fn callable_child_parent_rel_imports(
+    parent_leaf: &LeafPath,
+    callable_child_bodies: &BTreeMap<String, &LeafBody>,
+) -> Vec<RelImport> {
+    let mut acc = RootImportSets::default();
+    for child_body in callable_child_bodies.values() {
+        for (sym, _) in &child_body.symbols {
+            if let EmittedSymbol::Function(f) = sym {
+                for ty in &f.arg_tys {
+                    collect_keyword_escaped_root_imports(ty, parent_leaf, &mut acc);
+                }
+                collect_keyword_escaped_root_imports(&f.return_ty, parent_leaf, &mut acc);
+            }
+        }
+    }
+    acc.into_rel()
+}
+
+/// Structural mirror of `collect_root_imports` restricted to root-routed
+/// references whose RAW BAML name is a Python hard keyword — i.e. the anchor the
+/// translator emits is a generated keyword-escape (`None`→`None_`). Every other
+/// reference (keyword-free classes, module-segment routes, `Ty::Media`,
+/// primitives) is intentionally skipped so the aggregation is a no-op for
+/// keyword-free schemas. Recurses through the same container/callable shapes as
+/// `collect_root_imports` so a keyword class nested in `List[..]`/`Union[..]`/a
+/// callback signature is still found.
+fn collect_keyword_escaped_root_imports(ty: &Ty, current: &LeafPath, out: &mut RootImportSets) {
+    match ty {
+        Ty::Class(name, args, _) => {
+            record_keyword_escaped_name_routing(name, current, out);
+            for a in args {
+                collect_keyword_escaped_root_imports(a, current, out);
+            }
+        }
+        Ty::Enum(name, _) | Ty::EnumVariant(name, _, _) | Ty::TypeAlias(name, _) => {
+            record_keyword_escaped_name_routing(name, current, out);
+        }
+        Ty::List(inner, _) => collect_keyword_escaped_root_imports(inner, current, out),
+        Ty::Map { key, value, .. } => {
+            collect_keyword_escaped_root_imports(key, current, out);
+            collect_keyword_escaped_root_imports(value, current, out);
+        }
+        Ty::Union(items, _) => {
+            for item in items {
+                collect_keyword_escaped_root_imports(item, current, out);
+            }
+        }
+        Ty::Function { params, ret, .. } => {
+            for p in params {
+                collect_keyword_escaped_root_imports(&p.ty, current, out);
+            }
+            collect_keyword_escaped_root_imports(ret, current, out);
+        }
+        // Everything else can never be a keyword-escaped root-class anchor:
+        // `Ty::Media` anchors on module segment `baml` (not keyword-escaped),
+        // module-segment routing for keyword namespaces is a disclosed follow-up
+        // (`sanitize_python_module_segment`), and primitives/`TypeVar`/`RustType`
+        // route nothing.
+        _ => {}
+    }
+}
+
+/// `record_name_routing` restricted to root-routed references whose RAW BAML name
+/// is a Python hard keyword. Only the root-routed branch can produce a keyword-
+/// escaped bare anchor (`None`→`None_`); a non-empty `routed.segments` is a
+/// module-segment route (never keyword-escaped today, disclosed follow-up) and is
+/// skipped. Mirrors the escaped-spelling contract of `record_name_routing`'s
+/// root branch so the reserved anchor and the emitted `from ... import None_`
+/// stay identical.
+fn record_keyword_escaped_name_routing(
+    name: &baml_codegen_types::Name,
+    current: &LeafPath,
+    out: &mut RootImportSets,
+) {
+    let routed = route_class_ref(name);
+    if routed == *current {
+        return;
+    }
+    if routed.segments.is_empty()
+        && !current.segments.is_empty()
+        && crate::emit::is_python_hard_keyword(name.bare_name())
+    {
+        let bare = escape_python_keyword(name.bare_name().to_string());
+        out.root_names.insert(bare.clone());
+        out.rel.insert(RelImport {
+            depth: current.segments.len() + 1,
+            from_path: String::new(),
+            anchor: bare,
+        });
+    }
+}
+
 /// follow the `.py` rule.
 pub(crate) fn render_leaf_body_pyi(
     body: &LeafBody,
@@ -2126,6 +2693,21 @@ pub(crate) fn render_leaf_body_pyi(
     // the stub doesn't run at runtime, so the guard is a no-op for
     // type checkers and keeps the stub minimal.
     let mut rel_imports = body.all_rel_imports_py();
+    // A callable child's function signatures are
+    // rendered into THIS parent stub (see `render_callable_child_protocol_pyi`),
+    // but their cross-leaf dependencies were never aggregated into the parent's
+    // guarded imports — a pre-existing gap the keyword escaping made visible. This
+    // block + the `callable_child_parent_rel_imports` fn are the entire fix, kept
+    // isolated so they can be reverted as one unit. Reverting is clean:
+    // `all_rel_imports_py()` already returns a sorted, deduped vec.
+    {
+        rel_imports.extend(callable_child_parent_rel_imports(
+            &body.leaf,
+            callable_child_bodies,
+        ));
+        rel_imports.sort();
+        rel_imports.dedup();
+    }
     if body.has_defaulted_call_params() && body.leaf.segments != ["baml"] {
         // Optional arguments annotate as `typing.Union[..., UNSET]` and
         // default to `UNSET`. The sentinel must be a bare name in the type
@@ -2199,38 +2781,59 @@ pub(crate) fn render_leaf_body_pyi(
 
     // Callback Protocols: each optional-argument callable in the leaf gets a
     // `typing.Protocol` with a `__call__` carrying its precise signature, named
-    // `_BamlCallback{n}`. Signatures below reference these by name. Emitted
+    // `_<owner>__<param><n>`. Signatures below reference these by name. Emitted
     // before the symbols that use them; the shared map lets nested callbacks
     // resolve to each other's Protocol names.
-    let protocol_tys = body.callback_protocols();
-    let callback_protocols: Option<std::rc::Rc<IndexMap<Ty, String>>> = if protocol_tys.is_empty() {
-        None
-    } else {
-        // Final name = `<base><n>`, where `n` is a per-base 1-based counter
-        // (usually 1; >1 only when one parameter's type nests multiple
-        // optional-arg callables under the same `_<owner>__<param>` prefix).
-        // `IndexMap` keeps deterministic (insertion-order) iteration so the
-        // emitted Protocols are stable across runs.
-        let mut base_counts: IndexMap<String, usize> = IndexMap::new();
-        let mut map: IndexMap<Ty, String> = IndexMap::new();
-        for (ty, base) in &protocol_tys {
-            let n = base_counts.entry(base.clone()).or_insert(0);
-            *n += 1;
-            map.insert(ty.clone(), format!("{base}{n}"));
+    //
+    // Distinct Protocols are keyed on the RENDERED identity — the structural
+    // callback `Ty` plus the owner-map projection over the TypeVars it names — so
+    // two owners whose maps produce different spellings (a bumped `{None, None_}`
+    // twin) get distinct Protocols, while identical renderings (every keyword-free
+    // schema) still share ONE Protocol keyed the same way, keeping output
+    // byte-identical. `translate_ty` re-derives this key from `ctx.type_var_map`
+    // at each reference, so the shared map needs no per-owner threading.
+    let protocol_entries = body.callback_protocols();
+    // `render_list` holds one distinct Protocol each: (name, callback Ty, owner
+    // map to render its body under), in first-seen order.
+    let mut render_list: Vec<(String, Ty, Option<std::rc::Rc<TypeVarMap>>)> = Vec::new();
+    let mut base_counts: IndexMap<String, usize> = IndexMap::new();
+    let mut name_by_key: IndexMap<CallbackProtocolKey, String> = IndexMap::new();
+    for cp in &protocol_entries {
+        let key = callback_protocol_key(&cp.ty, cp.owner_map.as_deref());
+        if name_by_key.contains_key(&key) {
+            continue;
         }
-        Some(std::rc::Rc::new(map))
-    };
-    if let Some(map) = &callback_protocols {
-        let proto_ctx = TranslateCtx {
-            current_leaf: body.leaf.clone(),
-            self_ref: None,
-            defer_name_refs: false,
-            callback_protocols: Some(map.clone()),
+        // `n` is a per-base 1-based counter (usually 1; >1 only when one
+        // parameter's type nests multiple optional-arg callables under the same
+        // `_<owner>__<param>` prefix).
+        let n = base_counts.entry(cp.base.clone()).or_insert(0);
+        *n += 1;
+        let name = format!("{}{}", cp.base, n);
+        name_by_key.insert(key, name.clone());
+        render_list.push((name, cp.ty.clone(), cp.owner_map.clone()));
+    }
+    let callback_protocols: Option<std::rc::Rc<IndexMap<CallbackProtocolKey, String>>> =
+        if name_by_key.is_empty() {
+            None
+        } else {
+            Some(std::rc::Rc::new(name_by_key))
         };
-        for (ty, _base) in &protocol_tys {
+    if let Some(map) = &callback_protocols {
+        for (name, ty, owner_map) in &render_list {
             if let Ty::Function { params, ret, .. } = ty {
+                let proto_ctx = TranslateCtx {
+                    current_leaf: body.leaf.clone(),
+                    self_ref: None,
+                    defer_name_refs: false,
+                    callback_protocols: Some(map.clone()),
+                    // Render the Protocol body under the OWNER scope's map so a
+                    // bumped keyword TypeVar (`None`→`None__`) matches the owner's
+                    // declared spelling; a non-generic owner carries `None`, which
+                    // falls back to the stateless escape (byte-identical).
+                    type_var_map: owner_map.clone(),
+                };
                 out.push_str("\n\n");
-                out.push_str(&render_callback_protocol(&map[ty], params, ret, &proto_ctx));
+                out.push_str(&render_callback_protocol(name, params, ret, &proto_ctx));
             }
         }
     }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
@@ -3,7 +3,7 @@
 //! straight walk — no ordering logic at render time.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fmt::Write as _,
 };
 
@@ -13,13 +13,15 @@ use indexmap::IndexMap;
 
 use crate::{
     emit::{
-        EmittedSymbol, SortKey, bare_callable_name,
+        EmittedSymbol, SortKey, TypeVarMap, bare_callable_name, escape_python_keyword,
         function::{PyFunction, SyncAsync},
         method::{MethodKind, PyMethodBinding},
     },
     py_string,
     routing::{LeafPath, route_class_ref},
-    translate_ty::{SelfRef, TranslateCtx, translate_ty},
+    translate_ty::{
+        CallbackProtocolKey, SelfRef, TranslateCtx, callback_protocol_key, translate_ty,
+    },
 };
 
 /// All symbols that land in one leaf's body, in final render order.
@@ -170,55 +172,109 @@ impl LeafBody {
     }
 
     /// The optional-argument `Ty::Function`s reachable from this leaf's
-    /// function/method/field signatures, in deterministic first-seen order,
-    /// each paired with the `_<owner>__<param>` prefix for its Protocol name
+    /// function/method/field signatures, in deterministic first-seen order, each
+    /// carrying the `_<owner>__<param>` prefix for its Protocol name
     /// (`render_leaf_body_pyi` appends a per-prefix counter, giving e.g.
-    /// `_call_optional_int_callback_supplied__callback1`). Each is rendered as a
-    /// named `typing.Protocol` in the `.pyi` (see `render_callback_protocol`),
-    /// because a `typing.Callable[[…], R]` type can't express per-parameter
-    /// optionality.
+    /// `_call_optional_int_callback_supplied__callback1`) AND the OWNER scope's
+    /// `TypeVar` map. Each is rendered as a named `typing.Protocol` in the
+    /// `.pyi` (see `render_callback_protocol`), because a `typing.Callable[[…],
+    /// R]` type can't express per-parameter optionality.
+    ///
+    /// The owner map is carried so the Protocol body renders a bumped keyword
+    /// `TypeVar` with the owner's declared spelling (`None`→`None__`), not the
+    /// stateless escape (`None_`). De-duplication is deferred to the caller and
+    /// keyed on the RENDERED identity (structural `Ty` + owner-map projection),
+    /// so two owners whose maps produce the SAME spelling still share one Protocol
+    /// (keyword-free schemas always do → byte-identical) while owners that spell
+    /// the callback's `TypeVars` differently get distinct Protocols. `seen` is kept
+    /// per-owner (not leaf-wide) precisely so a shared structural `Ty` under two
+    /// incompatible owners is not collapsed before that keyed dedup runs.
     ///
     /// Type aliases are skipped: they render via the shared `.py`/`.pyi`
     /// `render_type_alias` (which has no Protocol map), so a callable alias
     /// falls back to `typing.Callable[..., R]` rather than referencing a
     /// Protocol — collecting one here would emit an unused class.
-    pub(crate) fn callback_protocols(&self) -> Vec<(Ty, String)> {
-        let mut seen: std::collections::HashSet<Ty> = std::collections::HashSet::new();
-        let mut out: Vec<(Ty, String)> = Vec::new();
+    pub(crate) fn callback_protocols(&self) -> Vec<CallbackProtocol> {
+        let mut out: Vec<CallbackProtocol> = Vec::new();
         for (sym, _) in &self.symbols {
             match sym {
                 EmittedSymbol::Class(c) => {
+                    let class_map = scope_type_var_map(&c.type_var_map);
+                    // Class fields share one `seen`: the owner is the class.
+                    let mut field_seen: HashSet<Ty> = HashSet::new();
                     for prop in &c.properties {
                         let base = format!("_{}__{}", c.py_name, prop.name);
-                        collect_optional_callables(&prop.ty, &base, &mut seen, &mut out);
+                        collect_optional_callables(
+                            &prop.ty,
+                            &base,
+                            class_map.as_ref(),
+                            &mut field_seen,
+                            &mut out,
+                        );
                     }
                     for m in c.static_methods.iter().chain(&c.instance_methods) {
                         // `bare_callable_name` applies the companion `$` rule
                         // (`$stream` → `_stream`, `$<other>` → `__<other>`) so the
-                        // Protocol identifier stays a valid Python name.
+                        // Protocol identifier stays a valid Python name. Each
+                        // method is its own owner scope: its annotation map
+                        // is the class map merged with the method's own params.
+                        let owner_map = method_scope_type_var_map(m, class_map.as_ref());
                         let owner = bare_callable_name(fqn_leaf(&m.baml_fqn));
+                        let mut method_seen: HashSet<Ty> = HashSet::new();
                         for arg in &m.required_args {
                             let base = format!("_{owner}__{}", arg.name);
-                            collect_optional_callables(&arg.ty, &base, &mut seen, &mut out);
+                            collect_optional_callables(
+                                &arg.ty,
+                                &base,
+                                owner_map.as_ref(),
+                                &mut method_seen,
+                                &mut out,
+                            );
                         }
                         for arg in &m.optional_args {
                             let base = format!("_{owner}__{}", arg.name);
-                            collect_optional_callables(&arg.ty, &base, &mut seen, &mut out);
+                            collect_optional_callables(
+                                &arg.ty,
+                                &base,
+                                owner_map.as_ref(),
+                                &mut method_seen,
+                                &mut out,
+                            );
                         }
                         let base = format!("_{owner}__ret");
-                        collect_optional_callables(&m.return_ty, &base, &mut seen, &mut out);
+                        collect_optional_callables(
+                            &m.return_ty,
+                            &base,
+                            owner_map.as_ref(),
+                            &mut method_seen,
+                            &mut out,
+                        );
                     }
                 }
                 EmittedSymbol::Function(f) => {
                     // See the method case: normalize the companion `$` suffix so
                     // the Protocol identifier is a valid Python name.
+                    let owner_map = scope_type_var_map(&f.type_var_map);
                     let owner = bare_callable_name(fqn_leaf(&f.baml_fqn));
+                    let mut fn_seen: HashSet<Ty> = HashSet::new();
                     for (name, ty) in f.param_names.iter().zip(f.arg_tys.iter()) {
                         let base = format!("_{owner}__{name}");
-                        collect_optional_callables(ty, &base, &mut seen, &mut out);
+                        collect_optional_callables(
+                            ty,
+                            &base,
+                            owner_map.as_ref(),
+                            &mut fn_seen,
+                            &mut out,
+                        );
                     }
                     let base = format!("_{owner}__ret");
-                    collect_optional_callables(&f.return_ty, &base, &mut seen, &mut out);
+                    collect_optional_callables(
+                        &f.return_ty,
+                        &base,
+                        owner_map.as_ref(),
+                        &mut fn_seen,
+                        &mut out,
+                    );
                 }
                 EmittedSymbol::TypeAlias(_) | EmittedSymbol::Enum(_) => {}
             }
@@ -514,44 +570,60 @@ fn fqn_leaf(fqn: &str) -> &str {
     fqn.rsplit('.').next().unwrap_or(fqn)
 }
 
+/// One optional-argument callback `Ty::Function` collected for `.pyi` Protocol
+/// rendering, with everything needed to name, dedup, and render it:
+/// the structural callback type, the `_<owner>__<param>` name prefix, and the
+/// OWNER scope's `TypeVar` map (so the Protocol body renders bumped keyword
+/// `TypeVars` with the owner's declared spelling).
+pub(crate) struct CallbackProtocol {
+    pub(crate) ty: Ty,
+    pub(crate) base: String,
+    pub(crate) owner_map: Option<std::rc::Rc<TypeVarMap>>,
+}
+
 /// Recursively collect every optional-argument `Ty::Function` reachable from
-/// `ty`, in first-seen order, skipping duplicates (`seen`). Each is paired with
-/// `base` — the `_<owner>__<param>` prefix for its Protocol name (the final
-/// name appends a per-base counter in `LeafBody::callback_protocols`). Children
-/// are visited before the enclosing callable so nested callbacks get earlier
-/// names.
+/// `ty`, in first-seen order, skipping duplicates within this owner (`seen`).
+/// Each carries `base` — the `_<owner>__<param>` prefix for its Protocol name
+/// (the final name appends a per-base counter in `render_leaf_body_pyi`) — and
+/// `owner_map`, the enclosing scope's raw→emitted `TypeVar` map. Children are
+/// visited before the enclosing callable so nested callbacks get earlier names.
 fn collect_optional_callables(
     ty: &Ty,
     base: &str,
-    seen: &mut std::collections::HashSet<Ty>,
-    out: &mut Vec<(Ty, String)>,
+    owner_map: Option<&std::rc::Rc<TypeVarMap>>,
+    seen: &mut HashSet<Ty>,
+    out: &mut Vec<CallbackProtocol>,
 ) {
     match ty {
-        Ty::List(inner, _) => collect_optional_callables(inner, base, seen, out),
+        Ty::List(inner, _) => collect_optional_callables(inner, base, owner_map, seen, out),
         Ty::Map { key, value, .. } => {
-            collect_optional_callables(key, base, seen, out);
-            collect_optional_callables(value, base, seen, out);
+            collect_optional_callables(key, base, owner_map, seen, out);
+            collect_optional_callables(value, base, owner_map, seen, out);
         }
         Ty::Union(items, _) => {
             for item in items {
-                collect_optional_callables(item, base, seen, out);
+                collect_optional_callables(item, base, owner_map, seen, out);
             }
         }
         Ty::Class(_, args, _) => {
             for a in args {
-                collect_optional_callables(a, base, seen, out);
+                collect_optional_callables(a, base, owner_map, seen, out);
             }
         }
         Ty::Function { params, ret, .. } => {
             for p in params {
-                collect_optional_callables(&p.ty, base, seen, out);
+                collect_optional_callables(&p.ty, base, owner_map, seen, out);
             }
-            collect_optional_callables(ret, base, seen, out);
+            collect_optional_callables(ret, base, owner_map, seen, out);
             let has_optional = params
                 .iter()
                 .any(|p| p.mode == baml_codegen_types::CodegenFunctionParamMode::Optional);
             if has_optional && seen.insert(ty.clone()) {
-                out.push((ty.clone(), base.to_string()));
+                out.push(CallbackProtocol {
+                    ty: ty.clone(),
+                    base: base.to_string(),
+                    owner_map: owner_map.cloned(),
+                });
             }
         }
         _ => {}
@@ -648,16 +720,23 @@ fn record_name_routing(
         return;
     }
     if routed.segments.is_empty() {
-        // Root-routed type referenced from a non-root leaf — translator
-        // emits the bare name (`Foo`), so we pull it in via
-        // `from <dots> import Foo`. The root leaf itself never reaches
-        // here (current is also empty there, so `routed == *current`).
+        // Root-routed type referenced from a non-root leaf — the translator
+        // emits the keyword-escaped bare name (`None_`, via
+        // `translate_ty::render_name_ref`), so the import anchor and the
+        // recorded root name must carry the SAME escaped spelling or the
+        // `from <dots> import None_` line and the root's `class None_`
+        // definition would diverge (`from .. import None` is a SyntaxError and
+        // leaves `None_` unbound). The root leaf itself never reaches here
+        // (current is also empty there, so `routed == *current`). The non-root
+        // branch below routes by module-path segment, which the routing
+        // sanitizer handles separately (upstream TODO, left to a follow-up change).
         if !current.segments.is_empty() {
-            out.root_names.insert(name.bare_name().to_string());
+            let bare = escape_python_keyword(name.bare_name().to_string());
+            out.root_names.insert(bare.clone());
             out.rel.insert(RelImport {
                 depth: current.segments.len() + 1,
                 from_path: String::new(),
-                anchor: name.bare_name().to_string(),
+                anchor: bare,
             });
         }
     } else {
@@ -731,6 +810,220 @@ fn symbol_kind_ord(sym: &EmittedSymbol) -> u8 {
     }
 }
 
+/// Allocate every generic scope's `TypeVar` names ONCE per leaf against
+/// a leaf-global reservation set, replacing the old per-`<…>`-list allocation.
+///
+/// Runs after `group_and_sort`, when every symbol that lands in a leaf is known.
+/// At entry each scope's `generic_params` still hold the RAW binder names and
+/// `type_var_map` is empty (see `emit::build_emitted`); this pass rewrites both.
+/// `children` is the directory→immediate-child-name map (built in `lib.rs` before
+/// this call) so the reservation set can cover module-level bindings that live
+/// outside `body.symbols`.
+///
+/// Guarantees:
+/// - **Non-keyword raw names map to themselves, unconditionally** — even if the
+///   name collides with a leaf class named `T` (that ordinary class-vs-TypeVar
+///   module collision is pre-existing on canary and explicitly NOT fixed this
+///   round). This preserves STRICT byte-identity for keyword-free schemas.
+/// - **Keyword raw names bump** (`None`→`None_`→`None__`…) past a reservation set
+///   made of every module-level binding a bumped name could shadow:
+///   (a) every leaf emitted symbol name (class/enum/alias/function `py_name`);
+///   (b) every module import anchor brought in through the SDK root;
+///   (c) `__all__`; (d) every raw `TypeVar` name in the leaf;
+///   (e) every already-allocated emitted `TypeVar` name;
+///   (f) every immediate child-package/submodule name of this leaf's directory
+///   (`from . import <child>` / `_LAZY_CHILDREN`), and every keyword-escaped
+///   callable-child import anchor aggregated into the parent stub. (f) is
+///   supplied by `compute_module_binding_reservations` — those bindings are
+///   cross-body / render-time facts the per-body walk cannot see, and omitting
+///   them would let a keyword `TypeVar` overwrite a real child module or rebind
+///   an imported child class.
+/// - **Deliberately NOT reserved, unreachable by construction:** stdlib module
+///   imports (`typing`/`pydantic`/`enum`/…) and every `_`-leading helper
+///   (`_{name}_namespace`, `_BamlCallableNamespace_…`, runtime aliases). Bumping
+///   only appends trailing `_` to a hard keyword, so an emitted `TypeVar` name
+///   can never be underscore-leading and never equals a stdlib module name — no
+///   reservation entry can ever be consulted for them.
+/// - The map is keyed by **raw name**, so distinct raw NAMES/SPELLINGS never
+///   collapse to one emitted name; identical raw spellings (the same `T` reused
+///   across scopes, or two independently-generic functions each declaring `T`)
+///   deliberately share ONE module-level `TypeVar`, which is sound because each
+///   scope is independently generic on it — closing the emitted-name and runtime
+///   `_types`-key collapse.
+pub(crate) fn allocate_leaf_type_vars(
+    bodies: &mut BTreeMap<LeafPath, LeafBody>,
+    children: &BTreeMap<Vec<String>, BTreeSet<String>>,
+) {
+    // Read-only pre-pass FIRST: collect each leaf's module-binding reservation
+    // supplement while `bodies` is only shared-borrowed, so the mutation loop
+    // below can hold the exclusive `values_mut()` borrow without conflict
+    // (the anchor set is a pure function of the already-built bodies).
+    let supplement = compute_module_binding_reservations(bodies, children);
+    for (leaf, body) in bodies.iter_mut() {
+        allocate_leaf_body_type_vars(body, supplement.get(leaf));
+    }
+}
+
+/// Per-leaf reservation supplement (category (f) in `allocate_leaf_type_vars`):
+/// module-level bindings that occupy a leaf's namespace but are NOT in
+/// `body.symbols` or `body.root_imports_py()`, so the per-body reservation walk
+/// misses them. Computed here in a read-only pre-pass over `bodies`:
+///
+/// - **(a) immediate child-package/submodule names.** `children` maps each
+///   directory to the emitted attribute names of its immediate children
+///   (`from . import None_`, `_LAZY_CHILDREN {"None_"}`, PEP-562 `__getattr__`).
+///   A keyword `TypeVar` bumping onto a child name — e.g. generic raw `None`
+///   escaping to `None_` onto a child module `None_` — would overwrite the child
+///   binding at import time. Names are the emitted segments already
+///   (routing sanitized them), so reserving them verbatim is exact.
+/// - **(b) keyword-escaped callable-child import anchors.** `render_leaf_body_pyi`
+///   aggregates a callable child's argument/return imports into the parent stub
+///   (`callable_child_parent_rel_imports`), gated to keyword-escaped classes.
+///   A bumped keyword `TypeVar` colliding with such a
+///   `from ... import None_` would rebind the imported class to the `TypeVar`.
+///   Only keyword-
+///   escaped anchors survive the gate, and those are exactly the collision
+///   candidates, so reserving just them suffices. Name-only: depth is irrelevant
+///   for a reservation set.
+fn compute_module_binding_reservations(
+    bodies: &BTreeMap<LeafPath, LeafBody>,
+    children: &BTreeMap<Vec<String>, BTreeSet<String>>,
+) -> BTreeMap<LeafPath, BTreeSet<String>> {
+    let mut out: BTreeMap<LeafPath, BTreeSet<String>> = BTreeMap::new();
+    for (leaf, body) in bodies {
+        let mut names: BTreeSet<String> = BTreeSet::new();
+        let kids = children.get(&leaf.segments).cloned().unwrap_or_default();
+        // (a) immediate child-package/submodule names.
+        names.extend(kids.iter().cloned());
+        // (b) keyword-escaped, aggregated callable-child import anchors. Mirror
+        //     the render path's aggregation but keep only the anchor NAMES.
+        let callable_child_names = body.callable_child_names(&kids);
+        let callable_child_bodies =
+            crate::callable_child_bodies(&leaf.segments, &callable_child_names, bodies);
+        for anchor in callable_child_parent_rel_imports(leaf, &callable_child_bodies) {
+            names.insert(anchor.anchor);
+        }
+        if !names.is_empty() {
+            out.insert(leaf.clone(), names);
+        }
+    }
+    out
+}
+
+fn collect_raw_type_vars(names: &[String], order: &mut Vec<String>, seen: &mut HashSet<String>) {
+    for n in names {
+        if seen.insert(n.clone()) {
+            order.push(n.clone());
+        }
+    }
+}
+
+/// Rewrite one scope: `generic_params` (still RAW at entry) becomes the emitted
+/// names in declaration order, and `type_var_map` becomes the restriction of the
+/// leaf map to this scope's raw names.
+fn project_scope_type_vars(
+    generic_params: &mut Vec<String>,
+    type_var_map: &mut TypeVarMap,
+    leaf_map: &TypeVarMap,
+) {
+    let raws = std::mem::take(generic_params);
+    let mut map = TypeVarMap::new();
+    let mut emitted = Vec::with_capacity(raws.len());
+    for raw in raws {
+        let e = leaf_map.get(&raw).cloned().unwrap_or_else(|| raw.clone());
+        map.insert(raw, e.clone());
+        emitted.push(e);
+    }
+    *generic_params = emitted;
+    *type_var_map = map;
+}
+
+fn allocate_leaf_body_type_vars(body: &mut LeafBody, extra_reserved: Option<&BTreeSet<String>>) {
+    // 1. Distinct RAW TypeVar names across every scope, first-appearance order
+    //    (class params, then its methods' params, then free functions).
+    let mut raw_order: Vec<String> = Vec::new();
+    let mut raw_set: HashSet<String> = HashSet::new();
+    for (sym, _) in &body.symbols {
+        match sym {
+            EmittedSymbol::Class(c) => {
+                collect_raw_type_vars(&c.generic_params, &mut raw_order, &mut raw_set);
+                for m in c.static_methods.iter().chain(&c.instance_methods) {
+                    collect_raw_type_vars(&m.generic_params, &mut raw_order, &mut raw_set);
+                }
+            }
+            EmittedSymbol::Function(f) => {
+                collect_raw_type_vars(&f.generic_params, &mut raw_order, &mut raw_set);
+            }
+            EmittedSymbol::Enum(_) | EmittedSymbol::TypeAlias(_) => {}
+        }
+    }
+    if raw_order.is_empty() {
+        return; // no generics in this leaf — nothing to allocate
+    }
+
+    // 2. Reservation set for keyword bumps.
+    let mut reserved: HashSet<String> = HashSet::new();
+    // (a) every leaf-level emitted symbol name (class/enum/alias/function).
+    for (sym, _) in &body.symbols {
+        reserved.insert(sym.py_name().to_string());
+    }
+    // (b) module import anchors brought in through the SDK root.
+    let imports = body.root_imports_py();
+    reserved.extend(imports.segments);
+    reserved.extend(imports.root_names);
+    // (c) the `__all__` module binding. The `_{name}_namespace` callable-child
+    //     helpers are unreachable by keyword bumping (bumping only appends `_`,
+    //     which can never produce a `_`-leading name), so they need no entry.
+    reserved.insert("__all__".to_string());
+    // (d) every raw TypeVar name in the leaf, any scope.
+    reserved.extend(raw_set.iter().cloned());
+    // (f) module-level bindings this leaf emits that are NOT symbols or import
+    //     anchors: immediate child-package/submodule names and keyword-escaped
+    //     callable-child import anchors. Threaded in from the read-only
+    //     pre-pass (`compute_module_binding_reservations`) because they are
+    //     cross-body / render-time facts the per-body walk above cannot see —
+    //     omitting them would let a keyword TypeVar overwrite a real child module
+    //     or rebind an imported child class.
+    if let Some(extra) = extra_reserved {
+        reserved.extend(extra.iter().cloned());
+    }
+
+    // 3. Allocate the ONE leaf map (raw -> emitted).
+    let mut leaf_map: TypeVarMap = TypeVarMap::new();
+    for raw in &raw_order {
+        if !crate::emit::is_python_hard_keyword(raw) {
+            leaf_map.insert(raw.clone(), raw.clone());
+        } else {
+            let mut candidate = format!("{raw}_");
+            while crate::emit::is_python_hard_keyword(&candidate) || reserved.contains(&candidate) {
+                candidate.push('_');
+            }
+            reserved.insert(candidate.clone()); // (e) already-allocated emitted names
+            leaf_map.insert(raw.clone(), candidate);
+        }
+    }
+
+    // 4. Project the leaf map onto each scope.
+    for (sym, _) in &mut body.symbols {
+        match sym {
+            EmittedSymbol::Class(c) => {
+                project_scope_type_vars(&mut c.generic_params, &mut c.type_var_map, &leaf_map);
+                for m in c
+                    .static_methods
+                    .iter_mut()
+                    .chain(c.instance_methods.iter_mut())
+                {
+                    project_scope_type_vars(&mut m.generic_params, &mut m.type_var_map, &leaf_map);
+                }
+            }
+            EmittedSymbol::Function(f) => {
+                project_scope_type_vars(&mut f.generic_params, &mut f.type_var_map, &leaf_map);
+            }
+            EmittedSymbol::Enum(_) | EmittedSymbol::TypeAlias(_) => {}
+        }
+    }
+}
+
 /// Render-boundary guard mirroring the Go generator's `GoIdent::new`
 /// assertion (PR #4067): no identifier reaching the emitter may still be a
 /// Python hard keyword. A miss here is a codegen bug (an unescaped emit site),
@@ -797,6 +1090,9 @@ fn is_media_reexport(s: &EmittedSymbol) -> bool {
     {{ doc }}
 {%- endif %}
     model_config = pydantic.ConfigDict(extra="forbid"{% if populate_by_name %}, populate_by_name=True{% endif %})
+{%- if let Some(marker) = wire_names_marker %}
+    {{ marker }}
+{%- endif %}
 {%- for prop in properties %}
     {{ prop.name }}: {{ prop.ty_py }}{{ prop.field_expr }}
 {%- endfor %}
@@ -837,6 +1133,17 @@ struct ClassBodyPy {
     /// attribute name and the raw BAML/JSON key. Classes with no escaped
     /// field leave this `false` and render byte-identically to today.
     populate_by_name: bool,
+    /// `Some("__baml_wire_names__ = {…}")` when
+    /// ≥1 field was keyword-escaped: an explicit map of escaped Python attribute
+    /// name → raw BAML/wire name, consumed by the bridge encode path
+    /// (`proto.py`) as the sole provenance signal. A dunder name keeps it out of
+    /// pydantic's field set / `model_json_schema()` (mirrors the enum
+    /// `__baml_wire_values__` marker), and avoids a runtime `typing.get_type_hints`
+    /// hazard from bare-builtin subscripts shadowed by a user `type dict = …`.
+    /// `None` (no escaped field) emits nothing, so
+    /// keyword-free classes stay byte-identical. `.py`-only — the `.pyi` stub
+    /// carries no runtime detail, mirroring `Field(alias=…)`.
+    wire_names_marker: Option<String>,
     properties: Vec<ClassPropertyView>,
     static_methods: Vec<MethodLineView>,
     instance_methods: Vec<MethodLineView>,
@@ -871,6 +1178,9 @@ struct MethodLineView {
 {%- for v in variants %}
     {{ v.ident }} = {{ v.value }}
 {%- endfor %}
+{%- endif %}
+{%- if let Some(marker) = wire_values_marker %}
+    {{ marker }}
 {%- endif %}"#,
     ext = "py.j2",
     escape = "none"
@@ -883,6 +1193,14 @@ struct EnumBodyPy {
     /// a `///`.
     docstring: Option<String>,
     variants: Vec<EnumVariantView>,
+    /// `Some("__baml_wire_values__ = {…}")` when ≥1 member was keyword-escaped: a
+    /// plain dunder dict mapping escaped Python member name → raw BAML/wire name.
+    /// A dunder is excluded from `enum.Enum` membership by
+    /// `EnumMeta`, so it never becomes a variant. Consumed by the bridge encode
+    /// path as the sole provenance signal. `None` (no escaped member)
+    /// emits nothing, so keyword-free enums stay byte-identical. `.py`-only,
+    /// mirroring the class marker and `Field(alias=…)`.
+    wire_values_marker: Option<String>,
 }
 
 struct EnumVariantView {
@@ -941,6 +1259,85 @@ fn build_method_line_views(
     out
 }
 
+/// Wrap a scope's raw→emitted `TypeVar` map into the `Option<Rc<…>>` a
+/// `TranslateCtx` carries. `None` (the common case) when the scope declares no
+/// generics, so every non-generic body builds a byte-identical ctx.
+fn scope_type_var_map(map: &TypeVarMap) -> Option<std::rc::Rc<TypeVarMap>> {
+    if map.is_empty() {
+        None
+    } else {
+        Some(std::rc::Rc::new(map.clone()))
+    }
+}
+
+/// The map a method's `.pyi` signature is translated under: the method's own
+/// `<…>` params always bind, and the enclosing class's params bind too.
+/// BAML statics legitimately reference the enclosing class's `TypeVars` in their
+/// signatures (stdlib `Array.filled`/`generate`), so the class map is threaded
+/// for ANNOTATION resolution regardless of `MethodKind`. Only the RUNTIME
+/// `_types=` receiver binding still differs by kind (`render_method_binding`):
+/// an instance method recovers the class `TypeVars` from `self`; a static does not.
+fn method_scope_type_var_map(
+    m: &PyMethodBinding,
+    class_map: Option<&std::rc::Rc<TypeVarMap>>,
+) -> Option<std::rc::Rc<TypeVarMap>> {
+    match (class_map, m.type_var_map.is_empty()) {
+        (None, true) => None,
+        (Some(cm), true) => Some(cm.clone()),
+        (None, false) => Some(std::rc::Rc::new(m.type_var_map.clone())),
+        (Some(cm), false) => {
+            // Method params shadow class params on a name clash.
+            let mut merged: TypeVarMap = (**cm).clone();
+            merged.extend(m.type_var_map.iter().map(|(k, v)| (k.clone(), v.clone())));
+            Some(std::rc::Rc::new(merged))
+        }
+    }
+}
+
+/// Build the `__baml_wire_names__` class marker: a plain dunder dict mapping each
+/// keyword-escaped Python attribute name to its raw BAML/wire name, in declaration
+/// order. `None` when no field was escaped, so keyword-free classes emit nothing
+/// and stay byte-identical. A dunder name is excluded from pydantic's field set,
+/// so the assignment carries no annotation (mirrors the enum `__baml_wire_values__`
+/// marker) and cannot trip `typing.get_type_hints`. `.py`-only (see `ClassBodyPy`).
+fn build_wire_names_marker(properties: &[crate::emit::class::PyClassProperty]) -> Option<String> {
+    let entries: Vec<String> = properties
+        .iter()
+        .filter_map(|p| {
+            p.alias
+                .as_deref()
+                .map(|raw| format!("{}: {}", py_string(&p.name), py_string(raw)))
+        })
+        .collect();
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("__baml_wire_names__ = {{{}}}", entries.join(", ")))
+    }
+}
+
+/// Build the `__baml_wire_values__` enum marker: a plain dunder dict
+/// mapping each keyword-escaped Python member name to its raw BAML/wire variant
+/// name, in declaration order. `None` when no member was escaped, so keyword-free
+/// enums emit nothing and stay byte-identical. A dunder name is excluded from
+/// `enum.Enum` membership by `EnumMeta`, so the assignment never becomes a
+/// variant. `.py`-only (see `EnumBodyPy`).
+fn build_wire_values_marker(variants: &[crate::emit::enum_::PyEnumVariant]) -> Option<String> {
+    let entries: Vec<String> = variants
+        .iter()
+        .filter_map(|v| {
+            v.wire_name
+                .as_deref()
+                .map(|raw| format!("{}: {}", py_string(&v.ident), py_string(raw)))
+        })
+        .collect();
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("__baml_wire_values__ = {{{}}}", entries.join(", ")))
+    }
+}
+
 /// Render one symbol into its `.py` source block, including trailing `\n`.
 fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
     use askama::Template;
@@ -951,6 +1348,8 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
         // Runtime `.py`: callback Protocols are stub-only, so optional-arg
         // callables widen to `typing.Callable[..., R]` here.
         callback_protocols: None,
+        // Set per-symbol below; only the class body translates field types.
+        type_var_map: None,
     };
 
     match s {
@@ -966,6 +1365,11 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 );
             }
             debug_assert_identifier(&c.py_name);
+            // Field annotations resolve TypeVars through this class's scope map.
+            let ctx = TranslateCtx {
+                type_var_map: scope_type_var_map(&c.type_var_map),
+                ..ctx
+            };
             let properties = c
                 .properties
                 .iter()
@@ -984,6 +1388,13 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 })
                 .collect();
             let populate_by_name = c.properties.iter().any(|p| p.alias.is_some());
+            // Emit `__baml_wire_names__` ONLY when ≥1 field is
+            // keyword-escaped (carries `alias`). Maps the escaped Python attr
+            // name to its raw BAML/wire name so the bridge encoder can recover
+            // the wire key without shape-guessing. Keyword-free classes
+            // have no escaped field, so the marker is absent and their output is
+            // byte-identical to today.
+            let wire_names_marker = build_wire_names_marker(&c.properties);
             let attrs: Vec<(String, Option<String>)> = c
                 .properties
                 .iter()
@@ -1000,6 +1411,7 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 bases: render_class_bases(&c.generic_params),
                 docstring,
                 populate_by_name,
+                wire_names_marker,
                 properties,
                 static_methods: build_method_line_views(&c.static_methods, &c.generic_params),
                 instance_methods: build_method_line_views(&c.instance_methods, &c.generic_params),
@@ -1033,10 +1445,15 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 "Members",
                 "    ",
             );
+            // Emit `__baml_wire_values__` ONLY when ≥1 member is
+            // keyword-escaped. Keyword-free enums have no escaped member, so the
+            // marker is absent and their output is byte-identical to today.
+            let wire_values_marker = build_wire_values_marker(&e.variants);
             let mut out = EnumBodyPy {
                 py_name: e.py_name.clone(),
                 docstring,
                 variants,
+                wire_values_marker,
             }
             .render()
             .expect("enum_body template should always render");
@@ -1129,6 +1546,9 @@ fn render_type_alias(a: &crate::emit::type_alias::PyTypeAlias, leaf: &LeafPath) 
         // with optional params widens to `typing.Callable[..., R]` rather than
         // referencing a stub-only Protocol.
         callback_protocols: None,
+        // Type aliases declare no generic scope; any `TypeVar` in the RHS is
+        // free and falls back to the stateless escape.
+        type_var_map: None,
     };
     let rhs = translate_ty(&a.resolves_to, &ctx);
     if a.recursive {
@@ -1599,10 +2019,13 @@ fn render_method_block_pyi(m: &PyMethodBinding, ctx: &TranslateCtx) -> String {
     }
 }
 
-/// `.pyi` counterpart of `build_method_line_views`.
+/// `.pyi` counterpart of `build_method_line_views`. `class_map` is the enclosing
+/// class's `TypeVar` scope map, merged per method (instance only) so a signature
+/// resolves every in-scope `TypeVar` to its declared spelling.
 fn build_method_block_views(
     methods: &[PyMethodBinding],
-    ctx: &TranslateCtx,
+    base_ctx: &TranslateCtx,
+    class_map: Option<&std::rc::Rc<TypeVarMap>>,
 ) -> Vec<MethodBlockView> {
     let mut out = Vec::with_capacity(methods.len());
     let mut prev_root: Option<&str> = None;
@@ -1612,8 +2035,12 @@ fn build_method_block_views(
             None => true,
             Some(p) => p == root,
         };
+        let ctx = TranslateCtx {
+            type_var_map: method_scope_type_var_map(m, class_map),
+            ..base_ctx.clone()
+        };
         out.push(MethodBlockView {
-            block: render_method_block_pyi(m, ctx),
+            block: render_method_block_pyi(m, &ctx),
             tight_to_prev,
         });
         prev_root = Some(root);
@@ -1629,7 +2056,7 @@ fn build_method_block_views(
 fn render_symbol_pyi(
     s: &EmittedSymbol,
     leaf: &LeafPath,
-    callback_protocols: Option<&std::rc::Rc<IndexMap<Ty, String>>>,
+    callback_protocols: Option<&std::rc::Rc<IndexMap<CallbackProtocolKey, String>>>,
 ) -> String {
     use askama::Template;
     let ctx = TranslateCtx {
@@ -1637,6 +2064,8 @@ fn render_symbol_pyi(
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        // Set per-symbol below (class fields, method and function signatures).
+        type_var_map: None,
     };
 
     match s {
@@ -1647,12 +2076,18 @@ fn render_symbol_pyi(
                     py_name = c.py_name,
                 );
             }
+            let class_map = scope_type_var_map(&c.type_var_map);
+            // Field annotations resolve TypeVars through the class scope.
+            let field_ctx = TranslateCtx {
+                type_var_map: class_map.clone(),
+                ..ctx.clone()
+            };
             let properties = c
                 .properties
                 .iter()
                 .map(|prop| ClassPropertyView {
                     name: prop.name.clone(),
-                    ty_py: translate_ty(&prop.ty, &ctx),
+                    ty_py: translate_ty(&prop.ty, &field_ctx),
                     // The `.pyi` stub renders the escaped attribute name only;
                     // the `Field(alias=…)` runtime detail lives in the `.py`.
                     field_expr: String::new(),
@@ -1662,8 +2097,16 @@ fn render_symbol_pyi(
                 py_name: c.py_name.clone(),
                 bases: render_class_bases(&c.generic_params),
                 properties,
-                static_methods: build_method_block_views(&c.static_methods, &ctx),
-                instance_methods: build_method_block_views(&c.instance_methods, &ctx),
+                static_methods: build_method_block_views(
+                    &c.static_methods,
+                    &ctx,
+                    class_map.as_ref(),
+                ),
+                instance_methods: build_method_block_views(
+                    &c.instance_methods,
+                    &ctx,
+                    class_map.as_ref(),
+                ),
             }
             .render()
             .expect("class_body.pyi template should always render");
@@ -1674,7 +2117,10 @@ fn render_symbol_pyi(
             // Enum body is identical between `.py` and `.pyi` —
             // reuse the `.py` template directly. The `.pyi` form
             // omits the body docstring; `__doc__` resolves against
-            // the `.py` definition.
+            // the `.py` definition. The `__baml_wire_values__` marker is a
+            // runtime-only provenance detail (consumed by the bridge encoder),
+            // so the stub carries `None` — mirroring how the `.pyi` drops the
+            // class `Field(alias=…)` runtime detail.
             let variants = e
                 .variants
                 .iter()
@@ -1687,6 +2133,7 @@ fn render_symbol_pyi(
                 py_name: e.py_name.clone(),
                 docstring: None,
                 variants,
+                wire_values_marker: None,
             }
             .render()
             .expect("enum_body template should always render");
@@ -1700,6 +2147,11 @@ fn render_symbol_pyi(
             out
         }
         EmittedSymbol::Function(f) => {
+            // The signature resolves TypeVars through this function's scope.
+            let ctx = TranslateCtx {
+                type_var_map: scope_type_var_map(&f.type_var_map),
+                ..ctx
+            };
             let mut out = render_function_signature_pyi(f, &ctx);
             out.push('\n');
             out
@@ -1813,19 +2265,22 @@ fn render_callable_child_protocol_pyi(
     parent_fn: &PyFunction,
     child_body: &LeafBody,
     parent_leaf: &LeafPath,
-    callback_protocols: Option<&std::rc::Rc<IndexMap<Ty, String>>>,
+    callback_protocols: Option<&std::rc::Rc<IndexMap<CallbackProtocolKey, String>>>,
 ) -> String {
     let parent_ctx = TranslateCtx {
         current_leaf: parent_leaf.clone(),
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        type_var_map: scope_type_var_map(&parent_fn.type_var_map),
     };
-    let child_ctx = TranslateCtx {
+    let child_base_ctx = TranslateCtx {
         current_leaf: child_body.leaf.clone(),
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        // Set per-child function below.
+        type_var_map: None,
     };
     let protocol_name = callable_child_protocol_name(name);
     let mut out = format!("class {protocol_name}(typing.Protocol):\n");
@@ -1836,6 +2291,10 @@ fn render_callable_child_protocol_pyi(
     ));
     for (sym, _) in &child_body.symbols {
         if let EmittedSymbol::Function(f) = sym {
+            let child_ctx = TranslateCtx {
+                type_var_map: scope_type_var_map(&f.type_var_map),
+                ..child_base_ctx.clone()
+            };
             out.push_str(&render_protocol_function_method_pyi(
                 &f.py_name, f, &child_ctx,
             ));
@@ -1989,9 +2448,117 @@ fn render_literal_default(lit: &Literal) -> String {
     }
 }
 
-/// Mirrors `render_leaf_body` with these differences: no
-/// `baml_bridge` factory imports; `typing` is needed whenever a
-/// signature is present (`needs_typing_pyi`); `enum` and `pydantic`
+/// KEYWORD-GATED: rel-imports needed by the callable-child
+/// function signatures that `render_callable_child_protocol_pyi` renders into the
+/// PARENT stub, computed relative to the PARENT leaf so depths/anchors match the
+/// parent stub (the child's own `all_rel_imports_py` would use child-leaf depths —
+/// one level too deep). Only child *functions* are rendered into the parent, so
+/// only their arg/return types are walked.
+///
+/// The walk is gated to keyword-ESCAPED class/enum/alias anchors only
+/// (`collect_keyword_escaped_root_imports`): a keyword-free callable child (one
+/// returning an ordinary root class `Widget`) contributes NOTHING, so keyword-free
+/// parent stubs stay strictly byte-identical, while keyword-escaped anchors —
+/// the only names that can collide with a bumped keyword `TypeVar` — are
+/// still aggregated and bound. The general keyword-free unbound-stub case an
+/// unconditional walk would also fix is pre-existing on canary and is left as a
+/// disclosed follow-up. Provenance is unambiguous at codegen (the arg/return `Ty`
+/// carries the class's raw BAML name), unlike the bridge's runtime shape ambiguity.
+/// Isolated to this one fn + its two callers (the render site and the reservation
+/// pre-pass) so the whole aggregation can be dropped
+/// deterministically if the keyword-free fixtures move.
+fn callable_child_parent_rel_imports(
+    parent_leaf: &LeafPath,
+    callable_child_bodies: &BTreeMap<String, &LeafBody>,
+) -> Vec<RelImport> {
+    let mut acc = RootImportSets::default();
+    for child_body in callable_child_bodies.values() {
+        for (sym, _) in &child_body.symbols {
+            if let EmittedSymbol::Function(f) = sym {
+                for ty in &f.arg_tys {
+                    collect_keyword_escaped_root_imports(ty, parent_leaf, &mut acc);
+                }
+                collect_keyword_escaped_root_imports(&f.return_ty, parent_leaf, &mut acc);
+            }
+        }
+    }
+    acc.into_rel()
+}
+
+/// Structural mirror of `collect_root_imports` restricted to root-routed
+/// references whose RAW BAML name is a Python hard keyword — i.e. the anchor the
+/// translator emits is a generated keyword-escape (`None`→`None_`). Every other
+/// reference (keyword-free classes, module-segment routes, `Ty::Media`,
+/// primitives) is intentionally skipped so the aggregation is a no-op for
+/// keyword-free schemas. Recurses through the same container/callable shapes as
+/// `collect_root_imports` so a keyword class nested in `List[..]`/`Union[..]`/a
+/// callback signature is still found.
+fn collect_keyword_escaped_root_imports(ty: &Ty, current: &LeafPath, out: &mut RootImportSets) {
+    match ty {
+        Ty::Class(name, args, _) => {
+            record_keyword_escaped_name_routing(name, current, out);
+            for a in args {
+                collect_keyword_escaped_root_imports(a, current, out);
+            }
+        }
+        Ty::Enum(name, _) | Ty::EnumVariant(name, _, _) | Ty::TypeAlias(name, _) => {
+            record_keyword_escaped_name_routing(name, current, out);
+        }
+        Ty::List(inner, _) => collect_keyword_escaped_root_imports(inner, current, out),
+        Ty::Map { key, value, .. } => {
+            collect_keyword_escaped_root_imports(key, current, out);
+            collect_keyword_escaped_root_imports(value, current, out);
+        }
+        Ty::Union(items, _) => {
+            for item in items {
+                collect_keyword_escaped_root_imports(item, current, out);
+            }
+        }
+        Ty::Function { params, ret, .. } => {
+            for p in params {
+                collect_keyword_escaped_root_imports(&p.ty, current, out);
+            }
+            collect_keyword_escaped_root_imports(ret, current, out);
+        }
+        // Everything else can never be a keyword-escaped root-class anchor:
+        // `Ty::Media` anchors on module segment `baml` (not keyword-escaped),
+        // module-segment routing for keyword namespaces is a disclosed follow-up
+        // (`sanitize_python_module_segment`), and primitives/`TypeVar`/`RustType`
+        // route nothing.
+        _ => {}
+    }
+}
+
+/// `record_name_routing` restricted to root-routed references whose RAW BAML name
+/// is a Python hard keyword. Only the root-routed branch can produce a keyword-
+/// escaped bare anchor (`None`→`None_`); a non-empty `routed.segments` is a
+/// module-segment route (never keyword-escaped today, disclosed follow-up) and is
+/// skipped. Mirrors the escaped-spelling contract of `record_name_routing`'s
+/// root branch so the reserved anchor and the emitted `from ... import None_`
+/// stay identical.
+fn record_keyword_escaped_name_routing(
+    name: &baml_codegen_types::Name,
+    current: &LeafPath,
+    out: &mut RootImportSets,
+) {
+    let routed = route_class_ref(name);
+    if routed == *current {
+        return;
+    }
+    if routed.segments.is_empty()
+        && !current.segments.is_empty()
+        && crate::emit::is_python_hard_keyword(name.bare_name())
+    {
+        let bare = escape_python_keyword(name.bare_name().to_string());
+        out.root_names.insert(bare.clone());
+        out.rel.insert(RelImport {
+            depth: current.segments.len() + 1,
+            from_path: String::new(),
+            anchor: bare,
+        });
+    }
+}
+
 /// follow the `.py` rule.
 pub(crate) fn render_leaf_body_pyi(
     body: &LeafBody,
@@ -2012,6 +2579,21 @@ pub(crate) fn render_leaf_body_pyi(
     // the stub doesn't run at runtime, so the guard is a no-op for
     // type checkers and keeps the stub minimal.
     let mut rel_imports = body.all_rel_imports_py();
+    // A callable child's function signatures are
+    // rendered into THIS parent stub (see `render_callable_child_protocol_pyi`),
+    // but their cross-leaf dependencies were never aggregated into the parent's
+    // guarded imports — a pre-existing gap the keyword escaping made visible. This
+    // block + the `callable_child_parent_rel_imports` fn are the entire fix, kept
+    // isolated so they can be reverted as one unit. Reverting is clean:
+    // `all_rel_imports_py()` already returns a sorted, deduped vec.
+    {
+        rel_imports.extend(callable_child_parent_rel_imports(
+            &body.leaf,
+            callable_child_bodies,
+        ));
+        rel_imports.sort();
+        rel_imports.dedup();
+    }
     if body.has_defaulted_call_params() && body.leaf.segments != ["baml"] {
         // Optional arguments annotate as `typing.Union[..., UNSET]` and
         // default to `UNSET`. The sentinel must be a bare name in the type
@@ -2085,38 +2667,59 @@ pub(crate) fn render_leaf_body_pyi(
 
     // Callback Protocols: each optional-argument callable in the leaf gets a
     // `typing.Protocol` with a `__call__` carrying its precise signature, named
-    // `_BamlCallback{n}`. Signatures below reference these by name. Emitted
+    // `_<owner>__<param><n>`. Signatures below reference these by name. Emitted
     // before the symbols that use them; the shared map lets nested callbacks
     // resolve to each other's Protocol names.
-    let protocol_tys = body.callback_protocols();
-    let callback_protocols: Option<std::rc::Rc<IndexMap<Ty, String>>> = if protocol_tys.is_empty() {
-        None
-    } else {
-        // Final name = `<base><n>`, where `n` is a per-base 1-based counter
-        // (usually 1; >1 only when one parameter's type nests multiple
-        // optional-arg callables under the same `_<owner>__<param>` prefix).
-        // `IndexMap` keeps deterministic (insertion-order) iteration so the
-        // emitted Protocols are stable across runs.
-        let mut base_counts: IndexMap<String, usize> = IndexMap::new();
-        let mut map: IndexMap<Ty, String> = IndexMap::new();
-        for (ty, base) in &protocol_tys {
-            let n = base_counts.entry(base.clone()).or_insert(0);
-            *n += 1;
-            map.insert(ty.clone(), format!("{base}{n}"));
+    //
+    // Distinct Protocols are keyed on the RENDERED identity — the structural
+    // callback `Ty` plus the owner-map projection over the TypeVars it names — so
+    // two owners whose maps produce different spellings (a bumped `{None, None_}`
+    // twin) get distinct Protocols, while identical renderings (every keyword-free
+    // schema) still share ONE Protocol keyed the same way, keeping output
+    // byte-identical. `translate_ty` re-derives this key from `ctx.type_var_map`
+    // at each reference, so the shared map needs no per-owner threading.
+    let protocol_entries = body.callback_protocols();
+    // `render_list` holds one distinct Protocol each: (name, callback Ty, owner
+    // map to render its body under), in first-seen order.
+    let mut render_list: Vec<(String, Ty, Option<std::rc::Rc<TypeVarMap>>)> = Vec::new();
+    let mut base_counts: IndexMap<String, usize> = IndexMap::new();
+    let mut name_by_key: IndexMap<CallbackProtocolKey, String> = IndexMap::new();
+    for cp in &protocol_entries {
+        let key = callback_protocol_key(&cp.ty, cp.owner_map.as_deref());
+        if name_by_key.contains_key(&key) {
+            continue;
         }
-        Some(std::rc::Rc::new(map))
-    };
-    if let Some(map) = &callback_protocols {
-        let proto_ctx = TranslateCtx {
-            current_leaf: body.leaf.clone(),
-            self_ref: None,
-            defer_name_refs: false,
-            callback_protocols: Some(map.clone()),
+        // `n` is a per-base 1-based counter (usually 1; >1 only when one
+        // parameter's type nests multiple optional-arg callables under the same
+        // `_<owner>__<param>` prefix).
+        let n = base_counts.entry(cp.base.clone()).or_insert(0);
+        *n += 1;
+        let name = format!("{}{}", cp.base, n);
+        name_by_key.insert(key, name.clone());
+        render_list.push((name, cp.ty.clone(), cp.owner_map.clone()));
+    }
+    let callback_protocols: Option<std::rc::Rc<IndexMap<CallbackProtocolKey, String>>> =
+        if name_by_key.is_empty() {
+            None
+        } else {
+            Some(std::rc::Rc::new(name_by_key))
         };
-        for (ty, _base) in &protocol_tys {
+    if let Some(map) = &callback_protocols {
+        for (name, ty, owner_map) in &render_list {
             if let Ty::Function { params, ret, .. } = ty {
+                let proto_ctx = TranslateCtx {
+                    current_leaf: body.leaf.clone(),
+                    self_ref: None,
+                    defer_name_refs: false,
+                    callback_protocols: Some(map.clone()),
+                    // Render the Protocol body under the OWNER scope's map so a
+                    // bumped keyword TypeVar (`None`→`None__`) matches the owner's
+                    // declared spelling; a non-generic owner carries `None`, which
+                    // falls back to the stateless escape (byte-identical).
+                    type_var_map: owner_map.clone(),
+                };
                 out.push_str("\n\n");
-                out.push_str(&render_callback_protocol(&map[ty], params, ret, &proto_ctx));
+                out.push_str(&render_callback_protocol(name, params, ret, &proto_ctx));
             }
         }
     }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
@@ -731,6 +731,17 @@ fn symbol_kind_ord(sym: &EmittedSymbol) -> u8 {
     }
 }
 
+/// Render-boundary guard mirroring the Go generator's `GoIdent::new`
+/// assertion (PR #4067): no identifier reaching the emitter may still be a
+/// Python hard keyword. A miss here is a codegen bug (an unescaped emit site),
+/// so it panics loudly in debug builds with the offending name. Off in release.
+fn debug_assert_identifier(name: &str) {
+    debug_assert!(
+        !crate::emit::is_python_hard_keyword(name),
+        "Python keyword escaped too late: {name}"
+    );
+}
+
 /// Non-generic: `pydantic.BaseModel`.
 /// Generic: `pydantic.BaseModel, typing.Generic[T, …]`.
 fn render_class_bases(generic_params: &[String]) -> String {
@@ -785,9 +796,9 @@ fn is_media_reexport(s: &EmittedSymbol) -> bool {
 {%- if let Some(doc) = docstring %}
     {{ doc }}
 {%- endif %}
-    model_config = pydantic.ConfigDict(extra="forbid")
+    model_config = pydantic.ConfigDict(extra="forbid"{% if populate_by_name %}, populate_by_name=True{% endif %})
 {%- for prop in properties %}
-    {{ prop.name }}: {{ prop.ty_py }}
+    {{ prop.name }}: {{ prop.ty_py }}{{ prop.field_expr }}
 {%- endfor %}
 {%- if !static_methods.is_empty() %}
 
@@ -820,6 +831,12 @@ struct ClassBodyPy {
     /// inline `# …` comment — the `Attributes:` section is the sole
     /// channel.
     docstring: Option<String>,
+    /// True when ≥1 field was keyword-escaped and therefore carries a
+    /// `pydantic.Field(alias=…)`. Adds `populate_by_name=True` to the
+    /// `ConfigDict` so the model validates from both the escaped Python
+    /// attribute name and the raw BAML/JSON key. Classes with no escaped
+    /// field leave this `false` and render byte-identically to today.
+    populate_by_name: bool,
     properties: Vec<ClassPropertyView>,
     static_methods: Vec<MethodLineView>,
     instance_methods: Vec<MethodLineView>,
@@ -828,6 +845,11 @@ struct ClassBodyPy {
 struct ClassPropertyView {
     name: String,
     ty_py: String,
+    /// Trailing field expression appended after the annotation. Empty for a
+    /// plain field; ` = pydantic.Field(alias="<raw>")` for a keyword-escaped
+    /// field so the raw BAML name stays the wire/JSON key. Only consumed by
+    /// the `.py` template — the `.pyi` stub renders the escaped name alone.
+    field_expr: String,
 }
 
 struct MethodLineView {
@@ -943,14 +965,25 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                     py_name = c.py_name,
                 );
             }
+            debug_assert_identifier(&c.py_name);
             let properties = c
                 .properties
                 .iter()
-                .map(|prop| ClassPropertyView {
-                    name: prop.name.clone(),
-                    ty_py: translate_ty(&prop.ty, &ctx),
+                .map(|prop| {
+                    debug_assert_identifier(&prop.name);
+                    ClassPropertyView {
+                        name: prop.name.clone(),
+                        ty_py: translate_ty(&prop.ty, &ctx),
+                        field_expr: match &prop.alias {
+                            Some(raw) => {
+                                format!(" = pydantic.Field(alias={})", py_string(raw))
+                            }
+                            None => String::new(),
+                        },
+                    }
                 })
                 .collect();
+            let populate_by_name = c.properties.iter().any(|p| p.alias.is_some());
             let attrs: Vec<(String, Option<String>)> = c
                 .properties
                 .iter()
@@ -966,6 +999,7 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
                 py_name: c.py_name.clone(),
                 bases: render_class_bases(&c.generic_params),
                 docstring,
+                populate_by_name,
                 properties,
                 static_methods: build_method_line_views(&c.static_methods, &c.generic_params),
                 instance_methods: build_method_line_views(&c.instance_methods, &c.generic_params),
@@ -976,12 +1010,16 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
             out
         }
         EmittedSymbol::Enum(e) => {
+            debug_assert_identifier(&e.py_name);
             let variants = e
                 .variants
                 .iter()
-                .map(|v| EnumVariantView {
-                    ident: v.ident.clone(),
-                    value: py_string(&v.value),
+                .map(|v| {
+                    debug_assert_identifier(&v.ident);
+                    EnumVariantView {
+                        ident: v.ident.clone(),
+                        value: py_string(&v.value),
+                    }
                 })
                 .collect();
             let members: Vec<(String, Option<String>)> = e
@@ -1045,6 +1083,8 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
 /// through its JSON-schema definitions machinery instead of recursing.
 fn render_type_alias(a: &crate::emit::type_alias::PyTypeAlias, leaf: &LeafPath) -> String {
     use askama::Template;
+
+    debug_assert_identifier(&a.py_name);
 
     // Special-case the stdlib `baml.json.json` alias.  Its expanded form is
     // a recursive JSON-shaped union (`bool | int | float | str | List[json]
@@ -1387,6 +1427,7 @@ pub(crate) fn render_leaf_body(body: &LeafBody, callable_child_names: &BTreeSet<
     if !typevars.is_empty() {
         out.push_str("\n\n");
         for tv in &typevars {
+            debug_assert_identifier(tv);
             writeln!(out, "{tv} = typing.TypeVar(\"{tv}\")").unwrap();
         }
     }
@@ -1612,6 +1653,9 @@ fn render_symbol_pyi(
                 .map(|prop| ClassPropertyView {
                     name: prop.name.clone(),
                     ty_py: translate_ty(&prop.ty, &ctx),
+                    // The `.pyi` stub renders the escaped attribute name only;
+                    // the `Field(alias=…)` runtime detail lives in the `.py`.
+                    field_expr: String::new(),
                 })
                 .collect();
             let mut out = ClassBodyPyi {
@@ -2034,6 +2078,7 @@ pub(crate) fn render_leaf_body_pyi(
     if !typevars.is_empty() {
         out.push_str("\n\n");
         for tv in &typevars {
+            debug_assert_identifier(tv);
             writeln!(out, "{tv} = typing.TypeVar(\"{tv}\")").unwrap();
         }
     }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -25,7 +25,9 @@ pub use baml_codegen_types::{NamingConvention, OutputType};
 
 use crate::{
     emit::{build_emitted, typemap_file::render_typemap_module},
-    leaf::{LeafBody, group_and_sort, render_leaf_body, render_leaf_body_pyi},
+    leaf::{
+        LeafBody, allocate_leaf_type_vars, group_and_sort, render_leaf_body, render_leaf_body_pyi,
+    },
     routing::{LeafPath, route},
 };
 
@@ -207,7 +209,12 @@ fn to_source_code_internal(
     // at least one routed symbol ends up with a `LeafBody` here; all
     // others render with G1-identical content.
     let triples = build_emitted(pool);
-    let bodies: BTreeMap<LeafPath, LeafBody> = group_and_sort(triples);
+    let mut bodies: BTreeMap<LeafPath, LeafBody> = group_and_sort(triples);
+    // Allocate every generic scope's TypeVar names ONCE per leaf, against
+    // a leaf-global reservation set, now that every symbol in each leaf is known.
+    // `children` is threaded in so the reservation set also covers child-package
+    // names and keyword-escaped callable-child import anchors.
+    allocate_leaf_type_vars(&mut bodies, &children);
 
     // Emit every directory's `__init__.py` and a sibling `__init__.pyi`.
     for dir in &all_dirs {
@@ -426,7 +433,7 @@ fn render_root_init_pyi(
     out
 }
 
-fn callable_child_bodies<'a>(
+pub(crate) fn callable_child_bodies<'a>(
     dir: &[String],
     callable_child_names: &BTreeSet<String>,
     bodies: &'a BTreeMap<LeafPath, LeafBody>,
@@ -574,8 +581,8 @@ fn symbol_name(sym: &Symbol) -> Option<&Name> {
 mod tests {
     use baml_base::Name as BaseName;
     use baml_codegen_types::{
-        Class, ClassProperty, DefaultLiteral, Enum, EnumVariant, Function, FunctionArgument,
-        FunctionArgumentDefault, Origin, Ty, TypeAlias,
+        CallableParam, Class, ClassProperty, CodegenFunctionParamMode, DefaultLiteral, Enum,
+        EnumVariant, Function, FunctionArgument, FunctionArgumentDefault, Origin, Ty, TypeAlias,
     };
     use pretty_assertions::{assert_eq, assert_ne};
 
@@ -3109,6 +3116,85 @@ mod tests {
         assert!(pyi.contains("    inner: Foo\n"));
     }
 
+    /// A root-level class named with a Python keyword, referenced from a
+    /// non-root (`ns_*`) leaf, escapes at the definition site (`class None_`)
+    /// AND at the reference (`inner: None_`). The import anchor MUST carry the
+    /// same escaped spelling — `from .. import None_`, never the raw
+    /// `from .. import None` (a `SyntaxError` that also leaves `None_` unbound).
+    /// Covers a soft-name keyword (`None`) and a hard statement keyword
+    /// (`pass`) in one non-root leaf.
+    #[test]
+    fn root_routed_keyword_class_import_anchor_is_escaped() {
+        let mut pool: SymbolPool = HashMap::new();
+        let none_cls = cg_name("user", &[], "None");
+        let pass_cls = cg_name("user", &[], "pass");
+        pool.insert(none_cls.clone(), class(none_cls.clone()));
+        pool.insert(pass_cls.clone(), class(pass_cls.clone()));
+        let envelope = cg_name("user", &["ipsum"], "Envelope");
+        pool.insert(
+            envelope.clone(),
+            class_with_props(
+                envelope,
+                vec![
+                    ("n", class_ty(none_cls, vec![])),
+                    ("p", class_ty(pass_cls, vec![])),
+                ],
+                "ipsum.baml",
+                0,
+            ),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+
+        // Root leaf defines the escaped classes.
+        let root_py = &out[&PathBuf::from("__init__.py")];
+        assert!(
+            root_py.contains("class None_(pydantic.BaseModel):"),
+            "root missing escaped None_ def:\n{root_py}"
+        );
+        assert!(
+            root_py.contains("class pass_(pydantic.BaseModel):"),
+            "root missing escaped pass_ def:\n{root_py}"
+        );
+
+        // Non-root consumer: import anchor and annotation both escaped; the raw
+        // keyword import must never appear.
+        let ipsum_py = &out[&PathBuf::from("ipsum/__init__.py")];
+        assert!(
+            ipsum_py.contains("\nfrom .. import None_\n"),
+            "consumer missing escaped None_ import:\n{ipsum_py}"
+        );
+        assert!(
+            ipsum_py.contains("\nfrom .. import pass_\n"),
+            "consumer missing escaped pass_ import:\n{ipsum_py}"
+        );
+        assert!(
+            !ipsum_py.contains("from .. import None\n")
+                && !ipsum_py.contains("from .. import pass\n"),
+            "consumer emitted a raw keyword import:\n{ipsum_py}"
+        );
+        assert!(
+            ipsum_py.contains("    n: None_\n"),
+            "n annotation:\n{ipsum_py}"
+        );
+        assert!(
+            ipsum_py.contains("    p: pass_\n"),
+            "p annotation:\n{ipsum_py}"
+        );
+
+        // The `.pyi` guards the same escaped anchors under TYPE_CHECKING.
+        let ipsum_pyi = &out[&PathBuf::from("ipsum/__init__.pyi")];
+        assert!(
+            ipsum_pyi.contains("from .. import None_\n")
+                && ipsum_pyi.contains("from .. import pass_\n"),
+            "pyi missing escaped anchors:\n{ipsum_pyi}"
+        );
+        assert!(
+            !ipsum_pyi.contains("from .. import None\n")
+                && !ipsum_pyi.contains("from .. import pass\n"),
+            "pyi emitted a raw keyword import:\n{ipsum_pyi}"
+        );
+    }
+
     #[test]
     fn root_leaf_does_not_self_import_root_types() {
         // Same `Foo` referenced from a same-leaf class on the root
@@ -3762,8 +3848,10 @@ mod tests {
     #[test]
     fn keyword_class_name_escapes_at_def_ref_and_keeps_raw_typemap_fqn() {
         let mut pool: SymbolPool = HashMap::new();
-        // Class named `None` (an uppercase-initial hard keyword — the only
-        // NAME-position keywords BAML grammar admits: None / True / False).
+        // Class named `None` (an uppercase-initial hard keyword). BAML admits 24
+        // of the 35 Python hard keywords as class/enum/alias names — including
+        // lowercase ones like `pass`/`import` — all through the same escape path;
+        // `None` is used here as one representative NAME-position case.
         let none = cg_name("user", &["lorem"], "None");
         pool.insert(
             none.clone(),
@@ -3866,6 +3954,1000 @@ mod tests {
         assert!(
             leaf.contains("    item: None_\n"),
             "typevar ref not escaped:\n{leaf}"
+        );
+    }
+
+    /// Class scope: a class declaring both `None` and `None_` as
+    /// `TypeVar`s must allocate DISTINCT emitted names (`None__` for the raw
+    /// keyword, `None_` for the raw `None_`), and every field reference must
+    /// resolve to the same spelling the declaration allocated. Stateless
+    /// escaping would collapse both onto `None_` (a duplicate generic param).
+    #[test]
+    fn typevar_collision_none_and_none_underscore_diverge_class_scope() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                name: n,
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("a"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None")),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("b"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None_")),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        for path in ["lorem/__init__.py", "lorem/__init__.pyi"] {
+            let leaf = &out[&PathBuf::from(path)];
+            // Two distinct TypeVar declarations, one of each, never one shared.
+            assert!(
+                leaf.contains("None__ = typing.TypeVar(\"None__\")\n"),
+                "{path}: bumped decl missing:\n{leaf}"
+            );
+            assert!(
+                leaf.contains("None_ = typing.TypeVar(\"None_\")\n"),
+                "{path}: natural decl missing:\n{leaf}"
+            );
+            // The `Generic[…]` base lists both distinct params.
+            assert!(
+                leaf.contains("class Box(pydantic.BaseModel, typing.Generic[None__, None_]):"),
+                "{path}: generic base not distinct:\n{leaf}"
+            );
+            // References match their declarations: raw `None` → `None__`,
+            // raw `None_` → `None_`.
+            assert!(leaf.contains("    a: None__\n"), "{path}: a ref:\n{leaf}");
+            assert!(leaf.contains("    b: None_\n"), "{path}: b ref:\n{leaf}");
+        }
+    }
+
+    /// Class scope, order independence: the reversed declaration order
+    /// `{None_, None}` must yield the SAME mapping — raw `None_` keeps `None_`,
+    /// raw `None` is forced to `None__`.
+    #[test]
+    fn typevar_collision_is_order_independent_class_scope() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None_"), BaseName::new("None")],
+                name: n,
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("a"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None_")),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("b"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None")),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("class Box(pydantic.BaseModel, typing.Generic[None_, None__]):"),
+            "reversed order changed mapping:\n{leaf}"
+        );
+        assert!(leaf.contains("    a: None_\n"), "a ref:\n{leaf}");
+        assert!(leaf.contains("    b: None__\n"), "b ref:\n{leaf}");
+    }
+
+    /// Free-function scope: a generic free function declaring both
+    /// `None` and `None_` allocates distinct `TypeVar`s and its `.pyi`
+    /// signature references match the declarations.
+    #[test]
+    fn typevar_collision_none_and_none_underscore_diverge_function_scope() {
+        let mut pool: SymbolPool = HashMap::new();
+        let key = cg_name("user", &["lorem"], "echo");
+        pool.insert(
+            key,
+            Symbol::Function(Function {
+                name: BaseName::new("echo"),
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                docstring: None,
+                arguments: vec![FunctionArgument {
+                    name: BaseName::new("value"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                    default: None,
+                }],
+                return_type: type_var(BaseName::new("None_")),
+                throws: None,
+                watchers: vec![],
+                origin: origin("echo.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "bumped decl missing:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("None_ = typing.TypeVar(\"None_\")\n"),
+            "natural decl missing:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("def echo(value: None__, *, _types: dict[str, type]) -> None_: ..."),
+            "signature refs not distinct:\n{pyi}"
+        );
+    }
+
+    /// Method scope: a generic instance method declaring both `None`
+    /// and `None_` allocates distinct `TypeVar`s in its `.pyi` signature.
+    #[test]
+    fn typevar_collision_none_and_none_underscore_diverge_method_scope() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Holder");
+        let mut method = bare_func("pick", "x.baml", 100);
+        method.generic_params = vec![BaseName::new("None"), BaseName::new("None_")];
+        method.arguments = vec![
+            FunctionArgument {
+                name: BaseName::new("self"),
+                docstring: None,
+                ty: class_ty(n.clone(), vec![]),
+                default: None,
+            },
+            FunctionArgument {
+                name: BaseName::new("value"),
+                docstring: None,
+                ty: type_var(BaseName::new("None")),
+                default: None,
+            },
+        ];
+        method.return_type = type_var(BaseName::new("None_"));
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: Vec::new(),
+                name: n,
+                docstring: None,
+                properties: vec![],
+                static_methods: vec![],
+                instance_methods: vec![method],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "bumped decl missing:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("None_ = typing.TypeVar(\"None_\")\n"),
+            "natural decl missing:\n{pyi}"
+        );
+        // The method value param resolves raw `None` → `None__`; the return
+        // resolves raw `None_` → `None_`.
+        assert!(pyi.contains("value: None__"), "param ref:\n{pyi}");
+        assert!(pyi.contains(") -> None_:"), "return ref:\n{pyi}");
+    }
+
+    /// Invariant: a plain no-keyword `TypeVar` scope renders exactly as
+    /// before the collision-aware change — the map path is identity on `T`.
+    #[test]
+    fn nonkeyword_typevar_scope_is_unchanged() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("T")],
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("T")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("T = typing.TypeVar(\"T\")\n"),
+            "decl:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("class Box(pydantic.BaseModel, typing.Generic[T]):\n"),
+            "base:\n{leaf}"
+        );
+        assert!(leaf.contains("    item: T\n"), "ref:\n{leaf}");
+        // No stray extra underscore leaked into the emitted spelling.
+        assert!(
+            !leaf.contains("T_ = typing.TypeVar"),
+            "spurious escape:\n{leaf}"
+        );
+    }
+
+    // ── Reserved-word codegen: TypeVar allocation and stub aggregation ───────
+
+    /// A leaf that already declares a class named `None__` plus a
+    /// generic `<None, None_>` must bump the keyword `TypeVar` PAST the taken class
+    /// name (`None`→`None_`(raw)→`None__`(class)→`None___`), so no module name is
+    /// declared twice and the `Generic[…]` list never shadows onto the class.
+    #[test]
+    fn typevar_bump_reserves_leaf_class_names() {
+        let mut pool: SymbolPool = HashMap::new();
+        // A source-valid class literally named `None__` (not a hard keyword, so
+        // it emits verbatim and lands in the leaf namespace).
+        let taken = cg_name("user", &["lorem"], "None__");
+        pool.insert(taken.clone(), class_with_fields(taken, &[("a", int_ty())]));
+        // A generic class whose `{None, None_}` twin would, per-scope, bump `None`
+        // onto the already-taken `None__`.
+        let boxn = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            boxn.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                name: boxn,
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("a"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None")),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("b"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None_")),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("box.baml", 10),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        for path in ["lorem/__init__.py", "lorem/__init__.pyi"] {
+            let leaf = &out[&PathBuf::from(path)];
+            // The class keeps its verbatim name.
+            assert!(
+                leaf.contains("class None__(pydantic.BaseModel):"),
+                "{path}: class None__ def missing:\n{leaf}"
+            );
+            // `None` bumped clear of BOTH the raw `None_` and the class `None__`.
+            assert!(
+                leaf.contains("None___ = typing.TypeVar(\"None___\")\n"),
+                "{path}: keyword TypeVar did not bump past the class name:\n{leaf}"
+            );
+            assert!(
+                leaf.contains("None_ = typing.TypeVar(\"None_\")\n"),
+                "{path}: natural TypeVar decl missing:\n{leaf}"
+            );
+            // Critically: `None__` is NEVER declared as a TypeVar — that name
+            // belongs to the class, so a `None__` TypeVar would collide on import.
+            assert!(
+                !leaf.contains("None__ = typing.TypeVar"),
+                "{path}: TypeVar collided with the leaf class None__:\n{leaf}"
+            );
+            // The generic base lists the bumped + natural params, neither of which
+            // is the class name.
+            assert!(
+                leaf.contains("class Box(pydantic.BaseModel, typing.Generic[None___, None_]):"),
+                "{path}: generic base shadows the class or is not distinct:\n{leaf}"
+            );
+            assert!(leaf.contains("    a: None___\n"), "{path}: a ref:\n{leaf}");
+            assert!(leaf.contains("    b: None_\n"), "{path}: b ref:\n{leaf}");
+        }
+    }
+
+    /// Distinct raw `TypeVar` spellings must never collapse onto one emitted name
+    /// (identical spellings deliberately share one module-level `TypeVar`). A class
+    /// `<None, None_>` with an instance method `<None__>` yields THREE distinct
+    /// emitted `TypeVars`, and the runtime `type_params` (method) and
+    /// `class_type_params` (class) key lists are disjoint.
+    #[test]
+    fn class_and_method_typevars_stay_disjoint() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "MethodCollisionBox");
+        let mut method = bare_func("pick", "x.baml", 100);
+        method.generic_params = vec![BaseName::new("None__")];
+        method.arguments = vec![
+            FunctionArgument {
+                name: BaseName::new("self"),
+                docstring: None,
+                ty: class_ty(n.clone(), vec![]),
+                default: None,
+            },
+            FunctionArgument {
+                name: BaseName::new("other"),
+                docstring: None,
+                ty: type_var(BaseName::new("None__")),
+                default: None,
+            },
+        ];
+        method.return_type = type_var(BaseName::new("None__"));
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("value"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![method],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        // Three DISTINCT emitted names: class `None`→`None___`, class `None_`→
+        // `None_`, method `None__`→`None__`.
+        for decl in [
+            "None___ = typing.TypeVar(\"None___\")\n",
+            "None_ = typing.TypeVar(\"None_\")\n",
+            "None__ = typing.TypeVar(\"None__\")\n",
+        ] {
+            assert!(pyi.contains(decl), "missing decl {decl:?}:\n{pyi}");
+        }
+        // Class binder `None` (→`None___`) is not confused with the method's
+        // distinct `None__` binder.
+        assert!(
+            pyi.contains(
+                "class MethodCollisionBox(pydantic.BaseModel, typing.Generic[None___, None_]):"
+            ),
+            "class generic base:\n{pyi}"
+        );
+        assert!(pyi.contains("    value: None___\n"), "class field:\n{pyi}");
+        assert!(
+            pyi.contains("other: None__,") || pyi.contains("other: None__)"),
+            "method param binder:\n{pyi}"
+        );
+        // Runtime `_types=` keys are disjoint: method binds `None__`, class binds
+        // `None___`/`None_` — no shared string (the runtime half).
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            py.contains("type_params=[\"None__\"], class_type_params=[\"None___\", \"None_\"]"),
+            "runtime _types keys overlap or wrong:\n{py}"
+        );
+    }
+
+    /// A STATIC method whose annotations reference the enclosing
+    /// class's `TypeVars` resolves them through the class map (BAML statics carry
+    /// class generics), so the raw class `None` resolves to the class's emitted
+    /// `None__` — not the stateless `None_`. The runtime `_types=` receiver
+    /// binding is unchanged (statics bind no `class_type_params`).
+    #[test]
+    fn static_method_signature_uses_class_typevar_map() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Factory");
+        let mut make = bare_func("make", "x.baml", 100);
+        make.generic_params = vec![];
+        make.arguments = vec![FunctionArgument {
+            name: BaseName::new("value"),
+            docstring: None,
+            ty: type_var(BaseName::new("None")),
+            default: None,
+        }];
+        make.return_type = type_var(BaseName::new("None"));
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                name: n,
+                docstring: None,
+                properties: vec![],
+                static_methods: vec![make],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("class Factory(pydantic.BaseModel, typing.Generic[None__, None_]):"),
+            "class generic base:\n{pyi}"
+        );
+        // Static annotation resolves raw class `None` to the class's emitted
+        // `None__` (would be `None_` under the dropped-map bug).
+        assert!(
+            pyi.contains("def make(value: None__) -> None__: ..."),
+            "static sig did not resolve class TypeVar map:\n{pyi}"
+        );
+        // Runtime binding is untouched: a static binds no class_type_params.
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            !py.contains("class_type_params="),
+            "static wrongly bound class_type_params at runtime:\n{py}"
+        );
+    }
+
+    fn optional_callback(param: &str, var: &str) -> Ty {
+        Ty::Function {
+            params: vec![CallableParam {
+                name: Some(BaseName::new(param)),
+                ty: type_var(BaseName::new(var)),
+                mode: CodegenFunctionParamMode::Optional,
+            }],
+            ret: Box::new(type_var(BaseName::new(var))),
+            throws: Box::new(Ty::Never {
+                attr: baml_base::TyAttr::EMPTY,
+            }),
+            attr: baml_base::TyAttr::EMPTY,
+        }
+    }
+
+    fn callback_fn(bare: &str, generics: &[&str], cb: Ty) -> Function {
+        Function {
+            generic_params: generics.iter().map(BaseName::new).collect(),
+            name: BaseName::new(bare),
+            docstring: None,
+            arguments: vec![FunctionArgument {
+                name: BaseName::new("cb"),
+                docstring: None,
+                ty: cb,
+                default: None,
+            }],
+            return_type: int_ty(),
+            throws: None,
+            watchers: vec![],
+            origin: origin("cb.baml", 0),
+        }
+    }
+
+    /// An optional-callback Protocol renders under its generic
+    /// OWNER's map (bumped keyword spelling), not the stateless escape; two owners
+    /// whose callbacks render IDENTICALLY share one Protocol (sharing control),
+    /// while a structurally-different callback gets its own.
+    ///
+    /// Note: under the leaf-global allocation two owners in one leaf always
+    /// spell a shared raw binder identically, so the "incompatible maps" split is
+    /// unreachable within a leaf; distinctness here is driven by the callbacks
+    /// referencing DIFFERENT binders (`None` vs `None_`), which is the reachable
+    /// analog.
+    #[test]
+    fn optional_callback_protocol_uses_owner_map_and_dedups_on_rendering() {
+        let mut pool: SymbolPool = HashMap::new();
+        // fa/fb reference raw `None` (→ owner spelling `None__`) — same rendering,
+        // must share ONE Protocol. fc references raw `None_` (→ `None_`) — distinct.
+        pool.insert(
+            cg_name("user", &["lorem"], "fa"),
+            Symbol::Function(callback_fn(
+                "fa",
+                &["None", "None_"],
+                optional_callback("x", "None"),
+            )),
+        );
+        pool.insert(
+            cg_name("user", &["lorem"], "fb"),
+            Symbol::Function(callback_fn("fb", &["None"], optional_callback("x", "None"))),
+        );
+        pool.insert(
+            cg_name("user", &["lorem"], "fc"),
+            Symbol::Function(callback_fn(
+                "fc",
+                &["None", "None_"],
+                optional_callback("x", "None_"),
+            )),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        // P1: fa's Protocol renders the OWNER spelling `None__` (bug renders `None_`).
+        assert!(
+            pyi.contains("class _fa__cb1(typing.Protocol):\n    def __call__(self, x: None__ = ...) -> None__: ...\n"),
+            "P1 not rendered with owner spelling:\n{pyi}"
+        );
+        // P2: fc's structurally-distinct callback gets its own Protocol at `None_`.
+        assert!(
+            pyi.contains("class _fc__cb1(typing.Protocol):\n    def __call__(self, x: None_ = ...) -> None_: ...\n"),
+            "P2 (distinct callback) missing:\n{pyi}"
+        );
+        // Sharing control: fa AND fb both reference the SAME Protocol; fb never
+        // mints its own.
+        assert!(
+            pyi.contains("def fa(cb: _fa__cb1, *, _types: dict[str, type]) -> int: ..."),
+            "fa signature:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("def fb(cb: _fa__cb1, *, _types: dict[str, type]) -> int: ..."),
+            "fb did not share fa's Protocol:\n{pyi}"
+        );
+        assert!(
+            !pyi.contains("_fb__cb"),
+            "fb minted a redundant Protocol instead of sharing:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("def fc(cb: _fc__cb1, *, _types: dict[str, type]) -> int: ..."),
+            "fc signature:\n{pyi}"
+        );
+    }
+
+    /// A callable-child function that returns a
+    /// root-routed keyword class is rendered into the PARENT stub, so the parent
+    /// `.pyi` must aggregate the child's guarded import. The aggregation is kept
+    /// isolated so it can be reverted as a unit.
+    #[test]
+    fn callable_child_return_import_aggregated_into_parent_stub() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Root-routed keyword class → emitted `None_`.
+        let none = cg_name("user", &[], "None");
+        pool.insert(none.clone(), class(none.clone()));
+        // Parent callable `boundary.id` returns `str` (no None_ import from parent).
+        pool.insert(
+            cg_name("boundary", &[], "id"),
+            zero_arg_func(
+                "id",
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                "core.baml",
+                0,
+            ),
+        );
+        // Child `boundary.id.current` returns the root keyword class — the parent
+        // stub renders `def current(self) -> None_` but historically dropped its
+        // import.
+        pool.insert(
+            cg_name("boundary", &["id"], "current"),
+            zero_arg_func("current", class_ty(none, vec![]), "id.baml", 0),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("vendor/boundary/__init__.pyi")];
+        // The child's return type is spelled in the parent stub …
+        assert!(
+            pyi.contains("def current(self) -> None_: ..."),
+            "child signature not in parent stub:\n{pyi}"
+        );
+        // … and the aggregation now carries its guarded import (parent leaf depth = 3 dots).
+        assert!(
+            pyi.contains("from ... import None_\n"),
+            "parent stub missing aggregated child import:\n{pyi}"
+        );
+    }
+
+    /// A leaf that owns a child package whose
+    /// module name equals a keyword `TypeVar`'s natural escape must bump the
+    /// `TypeVar` PAST the child name. Leaf `lorem` owns generic raw `None` (→
+    /// escapes to `None_`) AND a child submodule `lorem/None_/`; the `TypeVar`
+    /// must allocate `None__`, leaving the lazy child binding `None_` intact so
+    /// `import baml_sdk.lorem.None_` still resolves the module (not the `TypeVar`).
+    #[test]
+    fn keyword_typevar_bumps_past_child_module_name() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Child package `lorem/None_/` (a class in namespace `lorem.None_`).
+        // `None_` is a valid identifier (not a hard keyword), so routing keeps it
+        // verbatim and it becomes an immediate child of `lorem`.
+        let child = cg_name("user", &["lorem", "None_"], "Child");
+        pool.insert(child.clone(), class(child));
+        // Parent leaf `lorem` owns a generic class whose raw binder is `None`.
+        let boxn = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            boxn.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None")],
+                name: boxn,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("box.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        // The keyword TypeVar bumps PAST the child module name `None_` → `None__`.
+        assert!(
+            py.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "TypeVar did not bump past child module None_:\n{py}"
+        );
+        // `None_` is NEVER a TypeVar — that name belongs to the child module, and
+        // a `None_` TypeVar would overwrite the lazy child binding on import.
+        assert!(
+            !py.contains("None_ = typing.TypeVar"),
+            "TypeVar collided with child module None_:\n{py}"
+        );
+        // The lazy child binding survives in the parent package.
+        assert!(
+            py.contains("_LAZY_CHILDREN = frozenset({\n") && py.contains("    \"None_\",\n"),
+            "child module None_ lazy binding dropped:\n{py}"
+        );
+        // The generic base and field reference the bumped spelling.
+        assert!(
+            py.contains("class Box(pydantic.BaseModel, typing.Generic[None__]):"),
+            "generic base did not use bumped TypeVar:\n{py}"
+        );
+        assert!(py.contains("    item: None__\n"), "field ref:\n{py}");
+        // The `.pyi` cascade re-export `from . import None_` coexists with the
+        // bumped `None__` TypeVar, un-collided.
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("from . import None_\n"),
+            "child re-export missing in stub:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "stub TypeVar not bumped:\n{pyi}"
+        );
+        assert!(
+            !pyi.contains("None_ = typing.TypeVar"),
+            "stub TypeVar collided with child re-export:\n{pyi}"
+        );
+    }
+
+    /// A parent leaf
+    /// owning generic raw `None` whose callable child returns a root KEYWORD class
+    /// (`None`→`None_`). The stub aggregation adds `from ... import None_` into the
+    /// parent stub; the reservation pre-pass reserves that anchor so the `TypeVar`
+    /// bumps to `None__`, leaving `from ... import None_` denoting the imported
+    /// class rather than being rebound to a `TypeVar`. Materializes the composed
+    /// fixture exercising the child-import-anchor and TypeVar-bump interaction
+    /// together.
+    #[test]
+    fn keyword_typevar_bumps_past_aggregated_child_import_anchor() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Root-routed keyword class → emitted `None_`.
+        let none = cg_name("user", &[], "None");
+        pool.insert(none.clone(), class(none.clone()));
+        // Parent callable `boundary.id` returns `str`.
+        pool.insert(
+            cg_name("boundary", &[], "id"),
+            zero_arg_func(
+                "id",
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                "core.baml",
+                0,
+            ),
+        );
+        // Child `boundary.id.current` returns the root keyword class, so the
+        // aggregation adds `from ... import None_` into the parent stub.
+        pool.insert(
+            cg_name("boundary", &["id"], "current"),
+            zero_arg_func("current", class_ty(none, vec![]), "id.baml", 0),
+        );
+        // The SAME parent leaf `vendor/boundary` also owns generic raw `None`,
+        // whose TypeVar would (unreserved) collide with the aggregated `None_`.
+        let boxn = cg_name("boundary", &[], "Box");
+        pool.insert(
+            boxn.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None")],
+                name: boxn,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("box.baml", 5),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("vendor/boundary/__init__.pyi")];
+        // Aggregated import retained (child return class), keyword-gate fires
+        // because `None` is a keyword.
+        assert!(
+            pyi.contains("from ... import None_\n"),
+            "aggregated child import anchor dropped:\n{pyi}"
+        );
+        // The generic TypeVar bumped PAST the anchor → `None__`.
+        assert!(
+            pyi.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "TypeVar did not bump past aggregated import anchor:\n{pyi}"
+        );
+        // `None_` is NOT rebound to a TypeVar — it still denotes the imported class.
+        assert!(
+            !pyi.contains("None_ = typing.TypeVar"),
+            "TypeVar rebound the imported child class None_:\n{pyi}"
+        );
+        // The child annotation resolves to the imported class spelling `None_`.
+        assert!(
+            pyi.contains("def current(self) -> None_: ..."),
+            "child annotation spelling:\n{pyi}"
+        );
+    }
+
+    /// Negative control that makes the restored byte-identity
+    /// universal falsifiable: a KEYWORD-FREE callable child returning ordinary
+    /// root class `Widget` must NOT change the parent stub — the keyword-gate
+    /// suppresses the stub aggregation, so no `import Widget` line appears (byte-
+    /// identical to parent/canary, whose keyword-free unbound-stub bug is a
+    /// disclosed pre-existing follow-up).
+    #[test]
+    fn keyword_free_callable_child_class_return_stays_byte_identical() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Root-routed ORDINARY class (not a keyword).
+        let widget = cg_name("user", &[], "Widget");
+        pool.insert(widget.clone(), class(widget.clone()));
+        // Parent callable `boundary.id` returns `str`.
+        pool.insert(
+            cg_name("boundary", &[], "id"),
+            zero_arg_func(
+                "id",
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                "core.baml",
+                0,
+            ),
+        );
+        // Child `boundary.id.current` returns the ordinary root class.
+        pool.insert(
+            cg_name("boundary", &["id"], "current"),
+            zero_arg_func("current", class_ty(widget, vec![]), "id.baml", 0),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("vendor/boundary/__init__.pyi")];
+        // The child signature is still rendered into the parent stub (pre-existing
+        // behavior, unchanged) …
+        assert!(
+            pyi.contains("def current(self) -> Widget: ..."),
+            "child signature not in parent stub:\n{pyi}"
+        );
+        // … but the keyword-gate suppresses the aggregated import: NO `import
+        // Widget` line. Under an unconditional aggregation this would be
+        // `from ... import Widget`, which is exactly the keyword-free output delta
+        // that broke byte-identity. Its absence pins strict byte-identity for
+        // keyword-free schemas.
+        assert!(
+            !pyi.contains("import Widget"),
+            "keyword-free callable child changed the parent stub (aggregation not gated):\n{pyi}"
+        );
+    }
+
+    /// Generator-side marker emission: the provenance markers the
+    /// bridge encoder consumes are emitted ONLY on keyword-escaped artifacts and
+    /// ONLY in the runtime `.py` (never the `.pyi` stub). A class with ≥1 escaped
+    /// field gets a plain unannotated dunder `__baml_wire_names__` mapping escaped
+    /// attr → raw wire name; an enum with ≥1 escaped member gets a plain dunder
+    /// `__baml_wire_values__`. Keyword-free symbols in the same leaf emit NO
+    /// marker, so their output stays byte-identical.
+    #[test]
+    fn wire_markers_emitted_only_for_escaped_symbols_and_py_only() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Escaped class: field `pass` → `pass_` (alias "pass"); `keep` untouched.
+        let c = cg_name("user", &["lorem"], "C");
+        pool.insert(
+            c.clone(),
+            class_with_fields(c, &[("pass", int_ty()), ("keep", int_ty())]),
+        );
+        // Escaped enum: member `None` → `None_` (wire "None"); `Ok` untouched.
+        let e = cg_name("user", &["lorem"], "E");
+        pool.insert(
+            e.clone(),
+            enum_with_variants(e, &[("None", "None"), ("Ok", "Ok")]),
+        );
+        // Keyword-free class + enum in the SAME leaf: must emit NO marker.
+        let plain_c = cg_name("user", &["lorem"], "Plain");
+        pool.insert(
+            plain_c.clone(),
+            class_with_fields(plain_c, &[("x", int_ty())]),
+        );
+        let plain_e = cg_name("user", &["lorem"], "PlainE");
+        pool.insert(plain_e.clone(), enum_with_variants(plain_e, &[("A", "A")]));
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+
+        // Class marker: exact plain dunder dict of the escaped field only, `.py` only.
+        assert!(
+            py.contains("    __baml_wire_names__ = {\"pass_\": \"pass\"}\n"),
+            "class wire-name marker missing/incorrect:\n{py}"
+        );
+        // Enum marker: exact plain dunder dict of the escaped member only, `.py` only.
+        assert!(
+            py.contains("    __baml_wire_values__ = {\"None_\": \"None\"}\n"),
+            "enum wire-value marker missing/incorrect:\n{py}"
+        );
+        // Exactly ONE of each marker across the whole leaf → keyword-free `Plain`
+        // and `PlainE` emitted none (byte-identity for keyword-free schemas).
+        assert_eq!(
+            py.matches("__baml_wire_names__").count(),
+            1,
+            "expected exactly one class marker (escaped C only):\n{py}"
+        );
+        assert_eq!(
+            py.matches("__baml_wire_values__").count(),
+            1,
+            "expected exactly one enum marker (escaped E only):\n{py}"
+        );
+        // Markers are runtime-only: the stub never carries them.
+        assert!(
+            !pyi.contains("__baml_wire_names__") && !pyi.contains("__baml_wire_values__"),
+            "provenance marker leaked into the .pyi stub:\n{pyi}"
+        );
+    }
+
+    /// A user member (here an instance method) named exactly like the generated
+    /// wire-name marker must not clobber it. On a class that also carries a
+    /// keyword-escaped field (so the marker is emitted), the colliding member is
+    /// bumped one trailing underscore past the marker and the marker survives as a
+    /// plain dunder dict, so the bridge still recovers the raw wire key.
+    #[test]
+    fn wire_name_marker_survives_user_member_named_like_marker() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Collision");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: Vec::new(),
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("pass"),
+                    docstring: None,
+                    ty: int_ty(),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![method_func(
+                    "__baml_wire_names__",
+                    &["self"],
+                    "x.baml",
+                    100,
+                )],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+
+        // The marker survives as a plain dunder dict of the escaped field.
+        assert!(
+            py.contains("    __baml_wire_names__ = {\"pass_\": \"pass\"}\n"),
+            "wire-name marker missing or clobbered:\n{py}"
+        );
+        // No `_define_function` binding targets the bare marker name (that would
+        // overwrite the dict with a callable at class creation).
+        let binds_marker_name = py.lines().any(|l| {
+            let t = l.trim_start();
+            t.starts_with("__baml_wire_names__ ") && t.contains("_define_function")
+        });
+        assert!(
+            !binds_marker_name,
+            "a method binding still targets the bare marker name:\n{py}"
+        );
+        // The colliding method is bumped one underscore past the marker.
+        let binds_bumped_name = py.lines().any(|l| {
+            let t = l.trim_start();
+            t.starts_with("__baml_wire_names___ ") && t.contains("_define_function")
+        });
+        assert!(
+            binds_bumped_name,
+            "colliding method was not bumped past the marker name:\n{py}"
+        );
+    }
+
+    /// A user FIELD named exactly like the wire-name marker is the import-crash
+    /// case: unlike a colliding method (a bare class-body assignment), a field must
+    /// not keep the marker's leading underscores. A plain trailing-underscore bump
+    /// (`__baml_wire_names___`) still leads with `__`, and
+    /// `__baml_wire_names___: T = pydantic.Field(alias=…)` raises
+    /// `NameError: Fields must not use names with leading underscores` at class
+    /// creation, breaking `import` of the whole leaf. The field is instead projected
+    /// onto a leading-underscore-free spelling (`baml_wire_names___`) while the raw
+    /// `__baml_wire_names__` stays the wire key via the alias and the marker entry,
+    /// so the generated module imports and wire identity is preserved. See the
+    /// import-level companion in `tests/test_reserved_keywords.py`.
+    #[test]
+    fn wire_name_marker_field_collision_projects_off_leading_underscore() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Collision");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: Vec::new(),
+                name: n,
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("pass"),
+                        docstring: None,
+                        ty: int_ty(),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("__baml_wire_names__"),
+                        docstring: None,
+                        ty: int_ty(),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+
+        // The user field is projected off the marker onto a pydantic-legal,
+        // leading-underscore-free spelling, aliased to its raw wire name.
+        assert!(
+            py.contains(
+                "    baml_wire_names___: int = pydantic.Field(alias=\"__baml_wire_names__\")\n"
+            ),
+            "field not projected off the marker to a legal spelling:\n{py}"
+        );
+        // The import-crashing shape (an ANNOTATED field still leading with `__`)
+        // must not be emitted. `__baml_wire_names___` as a bare assignment (a
+        // bumped METHOD) is fine; only an annotated field crashes, so key on `:`.
+        let crashing_field = py.lines().any(|l| {
+            let t = l.trim_start();
+            t.starts_with("__baml_wire_names___:")
+        });
+        assert!(
+            !crashing_field,
+            "import-crashing leading-underscore annotated field emitted:\n{py}"
+        );
+        // The marker survives as a plain dunder dict and records BOTH the escaped
+        // keyword field and the projected marker field under their raw wire names.
+        assert!(
+            py.contains(
+                "    __baml_wire_names__ = {\"pass_\": \"pass\", \
+                 \"baml_wire_names___\": \"__baml_wire_names__\"}\n"
+            ),
+            "marker missing the projected field's raw wire entry:\n{py}"
+        );
+    }
+
+    /// The class wire-name marker is emitted as a plain dunder assignment, never a
+    /// `typing.ClassVar[dict[str, str]]` annotation. A bare-builtin `dict[...]`
+    /// subscript inside a class-level annotation is shadowable by a user
+    /// `type dict = ...` lowered into the same leaf and breaks
+    /// `typing.get_type_hints`; the plain dunder dict (mirroring the enum marker)
+    /// carries no annotation and is immune.
+    #[test]
+    fn wire_name_marker_is_a_plain_dunder_assignment() {
+        let mut pool: SymbolPool = HashMap::new();
+        let c = cg_name("user", &["lorem"], "C");
+        pool.insert(c.clone(), class_with_fields(c, &[("pass", int_ty())]));
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+
+        // Emitted as a plain dunder dict, identical in shape to the enum marker.
+        assert!(
+            py.contains("    __baml_wire_names__ = {\"pass_\": \"pass\"}\n"),
+            "marker not emitted as a plain dunder dict:\n{py}"
+        );
+        // The shadowable ClassVar-annotated bare-`dict` subscript is gone.
+        assert!(
+            !py.contains("__baml_wire_names__: typing.ClassVar[dict[str, str]]"),
+            "marker still carries the shadowable ClassVar[dict[...]] annotation:\n{py}"
+        );
+        // No bare-builtin `dict[...]` subscript survives on any marker line.
+        assert!(
+            !py.contains("dict[str, str]"),
+            "a bare-builtin dict[...] subscript leaked into the leaf:\n{py}"
         );
     }
 

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -3648,4 +3648,368 @@ mod tests {
             "root still passes sdk_root: {root}"
         );
     }
+
+    // ── #4059: Python reserved-keyword escaping ─────────────────────────────
+
+    /// The 35 `CPython` hard keywords (`keyword.kwlist`, 3.9–3.13). Unit tests
+    /// build the `SymbolPool` directly, so all 35 are exercisable even though
+    /// only 24 are reachable through BAML source syntax (the other 11 are BAML
+    /// keywords too). Kept in-test as the ground truth the emitter's private
+    /// `PYTHON_HARD_KEYWORDS` const and the Python bridge test both anchor to.
+    const HARD_KEYWORDS: [&str; 35] = [
+        "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class",
+        "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global",
+        "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return",
+        "try", "while", "with", "yield",
+    ];
+
+    fn int_ty() -> Ty {
+        Ty::Int {
+            attr: baml_base::TyAttr::EMPTY,
+        }
+    }
+
+    fn enum_with_variants(name: Name, variants: &[(&str, &str)]) -> Symbol {
+        Symbol::Enum(Enum {
+            name,
+            docstring: None,
+            variants: variants
+                .iter()
+                .map(|(ident, value)| EnumVariant {
+                    name: BaseName::new(ident),
+                    docstring: None,
+                    value: value.to_string(),
+                })
+                .collect(),
+            origin: origin("x.baml", 0),
+        })
+    }
+
+    fn class_with_fields(name: Name, fields: &[(&str, Ty)]) -> Symbol {
+        Symbol::Class(Class {
+            generic_params: Vec::new(),
+            name,
+            docstring: None,
+            properties: fields
+                .iter()
+                .map(|(n, ty)| ClassProperty {
+                    name: BaseName::new(n),
+                    docstring: None,
+                    ty: ty.clone(),
+                })
+                .collect(),
+            static_methods: vec![],
+            instance_methods: vec![],
+            origin: origin("x.baml", 0),
+        })
+    }
+
+    #[test]
+    fn every_hard_keyword_enum_member_escapes_and_keeps_wire_value() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "AllKw");
+        let variants: Vec<(&str, &str)> = HARD_KEYWORDS.iter().map(|kw| (*kw, *kw)).collect();
+        pool.insert(n.clone(), enum_with_variants(n, &variants));
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        for kw in HARD_KEYWORDS {
+            // `<kw>_ = "<kw>"`: LHS escaped, RHS wire value verbatim.
+            assert!(
+                leaf.contains(&format!("    {kw}_ = \"{kw}\"\n")),
+                "enum member {kw} not escaped as {kw}_ = \"{kw}\":\n{leaf}"
+            );
+            // The bare `<kw> =` keyword-LHS spelling must never appear.
+            assert!(
+                !leaf.contains(&format!("    {kw} = ")),
+                "bare keyword member {kw} = present:\n{leaf}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_hard_keyword_class_field_escapes_with_alias_and_populate_by_name() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "AllKw");
+        let fields: Vec<(&str, Ty)> = HARD_KEYWORDS.iter().map(|kw| (*kw, int_ty())).collect();
+        pool.insert(n.clone(), class_with_fields(n, &fields));
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains(
+                "model_config = pydantic.ConfigDict(extra=\"forbid\", populate_by_name=True)\n"
+            ),
+            "populate_by_name not added to ConfigDict:\n{leaf}"
+        );
+        for kw in HARD_KEYWORDS {
+            assert!(
+                leaf.contains(&format!(
+                    "    {kw}_: int = pydantic.Field(alias=\"{kw}\")\n"
+                )),
+                "field {kw} not escaped/aliased:\n{leaf}"
+            );
+            // The bare keyword annotation target must be absent — this is the
+            // `lambda` silent-corruption assertion (a bare `lambda: int` parses
+            // as a lambda expression, dropping the field).
+            assert!(
+                !leaf.contains(&format!("    {kw}: int")),
+                "bare keyword field {kw}: present:\n{leaf}"
+            );
+        }
+    }
+
+    #[test]
+    fn keyword_class_name_escapes_at_def_ref_and_keeps_raw_typemap_fqn() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Class named `None` (an uppercase-initial hard keyword — the only
+        // NAME-position keywords BAML grammar admits: None / True / False).
+        let none = cg_name("user", &["lorem"], "None");
+        pool.insert(
+            none.clone(),
+            class_with_fields(none, &[("value", int_ty())]),
+        );
+        // Same-leaf class referencing `None`.
+        let same = cg_name("user", &["lorem"], "SameRef");
+        pool.insert(
+            same.clone(),
+            class_with_fields(
+                same,
+                &[(
+                    "child",
+                    class_ty(cg_name("user", &["lorem"], "None"), vec![]),
+                )],
+            ),
+        );
+        // Cross-leaf class referencing `None`.
+        let cross = cg_name("user", &["ipsum"], "CrossRef");
+        pool.insert(
+            cross.clone(),
+            class_with_fields(
+                cross,
+                &[(
+                    "child",
+                    class_ty(cg_name("user", &["lorem"], "None"), vec![]),
+                )],
+            ),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let lorem = &out[&PathBuf::from("lorem/__init__.py")];
+        let lorem_pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        let ipsum = &out[&PathBuf::from("ipsum/__init__.py")];
+        let typemap = &out[&PathBuf::from("_typemap.py")];
+
+        // Definition escaped in both `.py` and `.pyi`.
+        assert!(
+            lorem.contains("class None_(pydantic.BaseModel):\n"),
+            "def:\n{lorem}"
+        );
+        assert!(
+            lorem_pyi.contains("class None_(pydantic.BaseModel):\n"),
+            "pyi:\n{lorem_pyi}"
+        );
+        // `__all__` uses the escaped name.
+        assert!(lorem.contains("\"None_\","), "__all__:\n{lorem}");
+        // Same-leaf reference → bare `None_`; cross-leaf → `lorem.None_`.
+        assert!(
+            lorem.contains("    child: None_\n"),
+            "same-leaf ref:\n{lorem}"
+        );
+        assert!(ipsum.contains("lorem.None_"), "cross-leaf ref:\n{ipsum}");
+        // Typemap key stays the RAW BAML FQN; only the attr is escaped.
+        assert!(
+            typemap.contains("\"user.lorem.None\""),
+            "typemap lost raw FQN key:\n{typemap}"
+        );
+        assert!(
+            !typemap.contains("\"user.lorem.None_\""),
+            "typemap FQN key wrongly escaped:\n{typemap}"
+        );
+        assert!(
+            typemap.contains("\"None_\""),
+            "typemap attr not escaped:\n{typemap}"
+        );
+    }
+
+    #[test]
+    fn keyword_typevar_escapes_at_declaration_and_reference() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None")],
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("None_ = typing.TypeVar(\"None_\")\n"),
+            "typevar decl not escaped:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("class Box(pydantic.BaseModel, typing.Generic[None_]):\n"),
+            "generic base not escaped:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("    item: None_\n"),
+            "typevar ref not escaped:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn field_collision_pass_and_pass_underscore_diverge() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Coll");
+        pool.insert(
+            n.clone(),
+            class_with_fields(n, &[("pass", int_ty()), ("pass_", int_ty())]),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        // `pass` is pushed past the raw `pass_` (reserved in pass 1) → `pass__`,
+        // aliased to the raw wire key `pass`. `pass_` is not a keyword: unchanged
+        // and un-aliased.
+        assert!(
+            leaf.contains("    pass__: int = pydantic.Field(alias=\"pass\")\n"),
+            "pass not bumped to pass__:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("    pass_: int\n"),
+            "raw pass_ perturbed:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn enum_member_collision_pass_and_pass_underscore_diverge() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Coll");
+        pool.insert(
+            n.clone(),
+            enum_with_variants(n, &[("pass", "pass"), ("pass_", "pass_")]),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("    pass__ = \"pass\"\n"),
+            "enum pass twin:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("    pass_ = \"pass_\"\n"),
+            "enum pass_ twin:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn soft_keywords_are_never_escaped() {
+        let mut pool: SymbolPool = HashMap::new();
+        let en = cg_name("user", &["lorem"], "SoftEnum");
+        pool.insert(
+            en.clone(),
+            enum_with_variants(
+                en,
+                &[("match", "match"), ("case", "case"), ("type", "type")],
+            ),
+        );
+        let cl = cg_name("user", &["lorem"], "SoftClass");
+        pool.insert(
+            cl.clone(),
+            class_with_fields(
+                cl,
+                &[("match", int_ty()), ("case", int_ty()), ("type", int_ty())],
+            ),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        for soft in ["match", "case", "type"] {
+            assert!(
+                leaf.contains(&format!("    {soft} = \"{soft}\"\n")),
+                "soft member {soft} wrongly escaped:\n{leaf}"
+            );
+            assert!(
+                leaf.contains(&format!("    {soft}: int\n")),
+                "soft field {soft} wrongly escaped:\n{leaf}"
+            );
+        }
+        // No escaped field anywhere → no alias / populate_by_name machinery.
+        assert!(
+            !leaf.contains("pydantic.Field"),
+            "soft keywords pulled in Field:\n{leaf}"
+        );
+        assert!(
+            !leaf.contains("populate_by_name"),
+            "soft keywords flipped populate_by_name:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn no_keyword_class_config_is_byte_identical_to_baseline() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Plain");
+        pool.insert(
+            n.clone(),
+            class_with_fields(n, &[("x", int_ty()), ("y", int_ty())]),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        // Exact pre-fix shape: no populate_by_name, no Field, plain annotations.
+        assert!(
+            leaf.contains(
+                "    model_config = pydantic.ConfigDict(extra=\"forbid\")\n    \
+                 x: int\n    y: int\n"
+            ),
+            "non-keyword class churned:\n{leaf}"
+        );
+        assert!(!leaf.contains("populate_by_name"));
+        assert!(!leaf.contains("pydantic.Field"));
+    }
+
+    #[test]
+    fn canonical_4059_repro_cases_render_valid_python() {
+        // The three canonical #4059 repros: enum member `None`,
+        // class field `pass`, class field `lambda` (the silent-corruption trap).
+        let mut pool: SymbolPool = HashMap::new();
+        let e = cg_name("user", &["lorem"], "E");
+        pool.insert(e.clone(), enum_with_variants(e, &[("None", "None")]));
+        let c = cg_name("user", &["lorem"], "C");
+        pool.insert(
+            c.clone(),
+            class_with_fields(c, &[("pass", int_ty()), ("lambda", int_ty())]),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        // (a) `None` enum member → `None_ = "None"`.
+        assert!(
+            leaf.contains("    None_ = \"None\"\n"),
+            "enum None:\n{leaf}"
+        );
+        // (b) `pass` field → aliased escape.
+        assert!(
+            leaf.contains("    pass_: int = pydantic.Field(alias=\"pass\")\n"),
+            "field pass:\n{leaf}"
+        );
+        // (b/lambda) `lambda` field → a real annotated field, NOT a bare
+        // `lambda: int` (which would parse as a lambda expression and vanish).
+        assert!(
+            leaf.contains("    lambda_: int = pydantic.Field(alias=\"lambda\")\n"),
+            "field lambda:\n{leaf}"
+        );
+        assert!(
+            !leaf.contains("    lambda: int"),
+            "lambda silent-corruption:\n{leaf}"
+        );
+    }
 }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -3680,4 +3680,368 @@ mod tests {
             "root still passes sdk_root: {root}"
         );
     }
+
+    // ── #4059: Python reserved-keyword escaping ─────────────────────────────
+
+    /// The 35 `CPython` hard keywords (`keyword.kwlist`, 3.9–3.13). Unit tests
+    /// build the `SymbolPool` directly, so all 35 are exercisable even though
+    /// only 24 are reachable through BAML source syntax (the other 11 are BAML
+    /// keywords too). Kept in-test as the ground truth the emitter's private
+    /// `PYTHON_HARD_KEYWORDS` const and the Python bridge test both anchor to.
+    const HARD_KEYWORDS: [&str; 35] = [
+        "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class",
+        "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global",
+        "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return",
+        "try", "while", "with", "yield",
+    ];
+
+    fn int_ty() -> Ty {
+        Ty::Int {
+            attr: baml_base::TyAttr::EMPTY,
+        }
+    }
+
+    fn enum_with_variants(name: Name, variants: &[(&str, &str)]) -> Symbol {
+        Symbol::Enum(Enum {
+            name,
+            docstring: None,
+            variants: variants
+                .iter()
+                .map(|(ident, value)| EnumVariant {
+                    name: BaseName::new(ident),
+                    docstring: None,
+                    value: value.to_string(),
+                })
+                .collect(),
+            origin: origin("x.baml", 0),
+        })
+    }
+
+    fn class_with_fields(name: Name, fields: &[(&str, Ty)]) -> Symbol {
+        Symbol::Class(Class {
+            generic_params: Vec::new(),
+            name,
+            docstring: None,
+            properties: fields
+                .iter()
+                .map(|(n, ty)| ClassProperty {
+                    name: BaseName::new(n),
+                    docstring: None,
+                    ty: ty.clone(),
+                })
+                .collect(),
+            static_methods: vec![],
+            instance_methods: vec![],
+            origin: origin("x.baml", 0),
+        })
+    }
+
+    #[test]
+    fn every_hard_keyword_enum_member_escapes_and_keeps_wire_value() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "AllKw");
+        let variants: Vec<(&str, &str)> = HARD_KEYWORDS.iter().map(|kw| (*kw, *kw)).collect();
+        pool.insert(n.clone(), enum_with_variants(n, &variants));
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        for kw in HARD_KEYWORDS {
+            // `<kw>_ = "<kw>"`: LHS escaped, RHS wire value verbatim.
+            assert!(
+                leaf.contains(&format!("    {kw}_ = \"{kw}\"\n")),
+                "enum member {kw} not escaped as {kw}_ = \"{kw}\":\n{leaf}"
+            );
+            // The bare `<kw> =` keyword-LHS spelling must never appear.
+            assert!(
+                !leaf.contains(&format!("    {kw} = ")),
+                "bare keyword member {kw} = present:\n{leaf}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_hard_keyword_class_field_escapes_with_alias_and_populate_by_name() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "AllKw");
+        let fields: Vec<(&str, Ty)> = HARD_KEYWORDS.iter().map(|kw| (*kw, int_ty())).collect();
+        pool.insert(n.clone(), class_with_fields(n, &fields));
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains(
+                "model_config = pydantic.ConfigDict(extra=\"forbid\", populate_by_name=True)\n"
+            ),
+            "populate_by_name not added to ConfigDict:\n{leaf}"
+        );
+        for kw in HARD_KEYWORDS {
+            assert!(
+                leaf.contains(&format!(
+                    "    {kw}_: int = pydantic.Field(alias=\"{kw}\")\n"
+                )),
+                "field {kw} not escaped/aliased:\n{leaf}"
+            );
+            // The bare keyword annotation target must be absent — this is the
+            // `lambda` silent-corruption assertion (a bare `lambda: int` parses
+            // as a lambda expression, dropping the field).
+            assert!(
+                !leaf.contains(&format!("    {kw}: int")),
+                "bare keyword field {kw}: present:\n{leaf}"
+            );
+        }
+    }
+
+    #[test]
+    fn keyword_class_name_escapes_at_def_ref_and_keeps_raw_typemap_fqn() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Class named `None` (an uppercase-initial hard keyword — the only
+        // NAME-position keywords BAML grammar admits: None / True / False).
+        let none = cg_name("user", &["lorem"], "None");
+        pool.insert(
+            none.clone(),
+            class_with_fields(none, &[("value", int_ty())]),
+        );
+        // Same-leaf class referencing `None`.
+        let same = cg_name("user", &["lorem"], "SameRef");
+        pool.insert(
+            same.clone(),
+            class_with_fields(
+                same,
+                &[(
+                    "child",
+                    class_ty(cg_name("user", &["lorem"], "None"), vec![]),
+                )],
+            ),
+        );
+        // Cross-leaf class referencing `None`.
+        let cross = cg_name("user", &["ipsum"], "CrossRef");
+        pool.insert(
+            cross.clone(),
+            class_with_fields(
+                cross,
+                &[(
+                    "child",
+                    class_ty(cg_name("user", &["lorem"], "None"), vec![]),
+                )],
+            ),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let lorem = &out[&PathBuf::from("lorem/__init__.py")];
+        let lorem_pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        let ipsum = &out[&PathBuf::from("ipsum/__init__.py")];
+        let typemap = &out[&PathBuf::from("_typemap.py")];
+
+        // Definition escaped in both `.py` and `.pyi`.
+        assert!(
+            lorem.contains("class None_(pydantic.BaseModel):\n"),
+            "def:\n{lorem}"
+        );
+        assert!(
+            lorem_pyi.contains("class None_(pydantic.BaseModel):\n"),
+            "pyi:\n{lorem_pyi}"
+        );
+        // `__all__` uses the escaped name.
+        assert!(lorem.contains("\"None_\","), "__all__:\n{lorem}");
+        // Same-leaf reference → bare `None_`; cross-leaf → `lorem.None_`.
+        assert!(
+            lorem.contains("    child: None_\n"),
+            "same-leaf ref:\n{lorem}"
+        );
+        assert!(ipsum.contains("lorem.None_"), "cross-leaf ref:\n{ipsum}");
+        // Typemap key stays the RAW BAML FQN; only the attr is escaped.
+        assert!(
+            typemap.contains("\"user.lorem.None\""),
+            "typemap lost raw FQN key:\n{typemap}"
+        );
+        assert!(
+            !typemap.contains("\"user.lorem.None_\""),
+            "typemap FQN key wrongly escaped:\n{typemap}"
+        );
+        assert!(
+            typemap.contains("\"None_\""),
+            "typemap attr not escaped:\n{typemap}"
+        );
+    }
+
+    #[test]
+    fn keyword_typevar_escapes_at_declaration_and_reference() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None")],
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("None_ = typing.TypeVar(\"None_\")\n"),
+            "typevar decl not escaped:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("class Box(pydantic.BaseModel, typing.Generic[None_]):\n"),
+            "generic base not escaped:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("    item: None_\n"),
+            "typevar ref not escaped:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn field_collision_pass_and_pass_underscore_diverge() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Coll");
+        pool.insert(
+            n.clone(),
+            class_with_fields(n, &[("pass", int_ty()), ("pass_", int_ty())]),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        // `pass` is pushed past the raw `pass_` (reserved in pass 1) → `pass__`,
+        // aliased to the raw wire key `pass`. `pass_` is not a keyword: unchanged
+        // and un-aliased.
+        assert!(
+            leaf.contains("    pass__: int = pydantic.Field(alias=\"pass\")\n"),
+            "pass not bumped to pass__:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("    pass_: int\n"),
+            "raw pass_ perturbed:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn enum_member_collision_pass_and_pass_underscore_diverge() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Coll");
+        pool.insert(
+            n.clone(),
+            enum_with_variants(n, &[("pass", "pass"), ("pass_", "pass_")]),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("    pass__ = \"pass\"\n"),
+            "enum pass twin:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("    pass_ = \"pass_\"\n"),
+            "enum pass_ twin:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn soft_keywords_are_never_escaped() {
+        let mut pool: SymbolPool = HashMap::new();
+        let en = cg_name("user", &["lorem"], "SoftEnum");
+        pool.insert(
+            en.clone(),
+            enum_with_variants(
+                en,
+                &[("match", "match"), ("case", "case"), ("type", "type")],
+            ),
+        );
+        let cl = cg_name("user", &["lorem"], "SoftClass");
+        pool.insert(
+            cl.clone(),
+            class_with_fields(
+                cl,
+                &[("match", int_ty()), ("case", int_ty()), ("type", int_ty())],
+            ),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        for soft in ["match", "case", "type"] {
+            assert!(
+                leaf.contains(&format!("    {soft} = \"{soft}\"\n")),
+                "soft member {soft} wrongly escaped:\n{leaf}"
+            );
+            assert!(
+                leaf.contains(&format!("    {soft}: int\n")),
+                "soft field {soft} wrongly escaped:\n{leaf}"
+            );
+        }
+        // No escaped field anywhere → no alias / populate_by_name machinery.
+        assert!(
+            !leaf.contains("pydantic.Field"),
+            "soft keywords pulled in Field:\n{leaf}"
+        );
+        assert!(
+            !leaf.contains("populate_by_name"),
+            "soft keywords flipped populate_by_name:\n{leaf}"
+        );
+    }
+
+    #[test]
+    fn no_keyword_class_config_is_byte_identical_to_baseline() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Plain");
+        pool.insert(
+            n.clone(),
+            class_with_fields(n, &[("x", int_ty()), ("y", int_ty())]),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        // Exact pre-fix shape: no populate_by_name, no Field, plain annotations.
+        assert!(
+            leaf.contains(
+                "    model_config = pydantic.ConfigDict(extra=\"forbid\")\n    \
+                 x: int\n    y: int\n"
+            ),
+            "non-keyword class churned:\n{leaf}"
+        );
+        assert!(!leaf.contains("populate_by_name"));
+        assert!(!leaf.contains("pydantic.Field"));
+    }
+
+    #[test]
+    fn canonical_4059_repro_cases_render_valid_python() {
+        // The three canonical #4059 repros: enum member `None`,
+        // class field `pass`, class field `lambda` (the silent-corruption trap).
+        let mut pool: SymbolPool = HashMap::new();
+        let e = cg_name("user", &["lorem"], "E");
+        pool.insert(e.clone(), enum_with_variants(e, &[("None", "None")]));
+        let c = cg_name("user", &["lorem"], "C");
+        pool.insert(
+            c.clone(),
+            class_with_fields(c, &[("pass", int_ty()), ("lambda", int_ty())]),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        // (a) `None` enum member → `None_ = "None"`.
+        assert!(
+            leaf.contains("    None_ = \"None\"\n"),
+            "enum None:\n{leaf}"
+        );
+        // (b) `pass` field → aliased escape.
+        assert!(
+            leaf.contains("    pass_: int = pydantic.Field(alias=\"pass\")\n"),
+            "field pass:\n{leaf}"
+        );
+        // (b/lambda) `lambda` field → a real annotated field, NOT a bare
+        // `lambda: int` (which would parse as a lambda expression and vanish).
+        assert!(
+            leaf.contains("    lambda_: int = pydantic.Field(alias=\"lambda\")\n"),
+            "field lambda:\n{leaf}"
+        );
+        assert!(
+            !leaf.contains("    lambda: int"),
+            "lambda silent-corruption:\n{leaf}"
+        );
+    }
 }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -25,7 +25,9 @@ pub use baml_codegen_types::{NamingConvention, OutputType};
 
 use crate::{
     emit::{build_emitted, typemap_file::render_typemap_module},
-    leaf::{LeafBody, group_and_sort, render_leaf_body, render_leaf_body_pyi},
+    leaf::{
+        LeafBody, allocate_leaf_type_vars, group_and_sort, render_leaf_body, render_leaf_body_pyi,
+    },
     routing::{LeafPath, route},
 };
 
@@ -193,7 +195,12 @@ fn to_source_code_internal(
     // at least one routed symbol ends up with a `LeafBody` here; all
     // others render with G1-identical content.
     let triples = build_emitted(pool);
-    let bodies: BTreeMap<LeafPath, LeafBody> = group_and_sort(triples);
+    let mut bodies: BTreeMap<LeafPath, LeafBody> = group_and_sort(triples);
+    // Allocate every generic scope's TypeVar names ONCE per leaf, against
+    // a leaf-global reservation set, now that every symbol in each leaf is known.
+    // `children` is threaded in so the reservation set also covers child-package
+    // names and keyword-escaped callable-child import anchors.
+    allocate_leaf_type_vars(&mut bodies, &children);
 
     // Emit every directory's `__init__.py` and a sibling `__init__.pyi`.
     for dir in &all_dirs {
@@ -412,7 +419,7 @@ fn render_root_init_pyi(
     out
 }
 
-fn callable_child_bodies<'a>(
+pub(crate) fn callable_child_bodies<'a>(
     dir: &[String],
     callable_child_names: &BTreeSet<String>,
     bodies: &'a BTreeMap<LeafPath, LeafBody>,
@@ -552,8 +559,8 @@ fn symbol_name(sym: &Symbol) -> Option<&Name> {
 mod tests {
     use baml_base::Name as BaseName;
     use baml_codegen_types::{
-        Class, ClassProperty, DefaultLiteral, Enum, EnumVariant, Function, FunctionArgument,
-        FunctionArgumentDefault, Origin, Ty, TypeAlias,
+        CallableParam, Class, ClassProperty, CodegenFunctionParamMode, DefaultLiteral, Enum,
+        EnumVariant, Function, FunctionArgument, FunctionArgumentDefault, Origin, Ty, TypeAlias,
     };
     use pretty_assertions::{assert_eq, assert_ne};
 
@@ -3141,6 +3148,85 @@ mod tests {
         assert!(pyi.contains("    inner: Foo\n"));
     }
 
+    /// A root-level class named with a Python keyword, referenced from a
+    /// non-root (`ns_*`) leaf, escapes at the definition site (`class None_`)
+    /// AND at the reference (`inner: None_`). The import anchor MUST carry the
+    /// same escaped spelling — `from .. import None_`, never the raw
+    /// `from .. import None` (a `SyntaxError` that also leaves `None_` unbound).
+    /// Covers a soft-name keyword (`None`) and a hard statement keyword
+    /// (`pass`) in one non-root leaf.
+    #[test]
+    fn root_routed_keyword_class_import_anchor_is_escaped() {
+        let mut pool: SymbolPool = HashMap::new();
+        let none_cls = cg_name("user", &[], "None");
+        let pass_cls = cg_name("user", &[], "pass");
+        pool.insert(none_cls.clone(), class(none_cls.clone()));
+        pool.insert(pass_cls.clone(), class(pass_cls.clone()));
+        let envelope = cg_name("user", &["ipsum"], "Envelope");
+        pool.insert(
+            envelope.clone(),
+            class_with_props(
+                envelope,
+                vec![
+                    ("n", class_ty(none_cls, vec![])),
+                    ("p", class_ty(pass_cls, vec![])),
+                ],
+                "ipsum.baml",
+                0,
+            ),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+
+        // Root leaf defines the escaped classes.
+        let root_py = &out[&PathBuf::from("__init__.py")];
+        assert!(
+            root_py.contains("class None_(pydantic.BaseModel):"),
+            "root missing escaped None_ def:\n{root_py}"
+        );
+        assert!(
+            root_py.contains("class pass_(pydantic.BaseModel):"),
+            "root missing escaped pass_ def:\n{root_py}"
+        );
+
+        // Non-root consumer: import anchor and annotation both escaped; the raw
+        // keyword import must never appear.
+        let ipsum_py = &out[&PathBuf::from("ipsum/__init__.py")];
+        assert!(
+            ipsum_py.contains("\nfrom .. import None_\n"),
+            "consumer missing escaped None_ import:\n{ipsum_py}"
+        );
+        assert!(
+            ipsum_py.contains("\nfrom .. import pass_\n"),
+            "consumer missing escaped pass_ import:\n{ipsum_py}"
+        );
+        assert!(
+            !ipsum_py.contains("from .. import None\n")
+                && !ipsum_py.contains("from .. import pass\n"),
+            "consumer emitted a raw keyword import:\n{ipsum_py}"
+        );
+        assert!(
+            ipsum_py.contains("    n: None_\n"),
+            "n annotation:\n{ipsum_py}"
+        );
+        assert!(
+            ipsum_py.contains("    p: pass_\n"),
+            "p annotation:\n{ipsum_py}"
+        );
+
+        // The `.pyi` guards the same escaped anchors under TYPE_CHECKING.
+        let ipsum_pyi = &out[&PathBuf::from("ipsum/__init__.pyi")];
+        assert!(
+            ipsum_pyi.contains("from .. import None_\n")
+                && ipsum_pyi.contains("from .. import pass_\n"),
+            "pyi missing escaped anchors:\n{ipsum_pyi}"
+        );
+        assert!(
+            !ipsum_pyi.contains("from .. import None\n")
+                && !ipsum_pyi.contains("from .. import pass\n"),
+            "pyi emitted a raw keyword import:\n{ipsum_pyi}"
+        );
+    }
+
     #[test]
     fn root_leaf_does_not_self_import_root_types() {
         // Same `Foo` referenced from a same-leaf class on the root
@@ -3794,8 +3880,10 @@ mod tests {
     #[test]
     fn keyword_class_name_escapes_at_def_ref_and_keeps_raw_typemap_fqn() {
         let mut pool: SymbolPool = HashMap::new();
-        // Class named `None` (an uppercase-initial hard keyword — the only
-        // NAME-position keywords BAML grammar admits: None / True / False).
+        // Class named `None` (an uppercase-initial hard keyword). BAML admits 24
+        // of the 35 Python hard keywords as class/enum/alias names — including
+        // lowercase ones like `pass`/`import` — all through the same escape path;
+        // `None` is used here as one representative NAME-position case.
         let none = cg_name("user", &["lorem"], "None");
         pool.insert(
             none.clone(),
@@ -3898,6 +3986,1000 @@ mod tests {
         assert!(
             leaf.contains("    item: None_\n"),
             "typevar ref not escaped:\n{leaf}"
+        );
+    }
+
+    /// Class scope: a class declaring both `None` and `None_` as
+    /// `TypeVar`s must allocate DISTINCT emitted names (`None__` for the raw
+    /// keyword, `None_` for the raw `None_`), and every field reference must
+    /// resolve to the same spelling the declaration allocated. Stateless
+    /// escaping would collapse both onto `None_` (a duplicate generic param).
+    #[test]
+    fn typevar_collision_none_and_none_underscore_diverge_class_scope() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                name: n,
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("a"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None")),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("b"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None_")),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        for path in ["lorem/__init__.py", "lorem/__init__.pyi"] {
+            let leaf = &out[&PathBuf::from(path)];
+            // Two distinct TypeVar declarations, one of each, never one shared.
+            assert!(
+                leaf.contains("None__ = typing.TypeVar(\"None__\")\n"),
+                "{path}: bumped decl missing:\n{leaf}"
+            );
+            assert!(
+                leaf.contains("None_ = typing.TypeVar(\"None_\")\n"),
+                "{path}: natural decl missing:\n{leaf}"
+            );
+            // The `Generic[…]` base lists both distinct params.
+            assert!(
+                leaf.contains("class Box(pydantic.BaseModel, typing.Generic[None__, None_]):"),
+                "{path}: generic base not distinct:\n{leaf}"
+            );
+            // References match their declarations: raw `None` → `None__`,
+            // raw `None_` → `None_`.
+            assert!(leaf.contains("    a: None__\n"), "{path}: a ref:\n{leaf}");
+            assert!(leaf.contains("    b: None_\n"), "{path}: b ref:\n{leaf}");
+        }
+    }
+
+    /// Class scope, order independence: the reversed declaration order
+    /// `{None_, None}` must yield the SAME mapping — raw `None_` keeps `None_`,
+    /// raw `None` is forced to `None__`.
+    #[test]
+    fn typevar_collision_is_order_independent_class_scope() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None_"), BaseName::new("None")],
+                name: n,
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("a"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None_")),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("b"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None")),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("class Box(pydantic.BaseModel, typing.Generic[None_, None__]):"),
+            "reversed order changed mapping:\n{leaf}"
+        );
+        assert!(leaf.contains("    a: None_\n"), "a ref:\n{leaf}");
+        assert!(leaf.contains("    b: None__\n"), "b ref:\n{leaf}");
+    }
+
+    /// Free-function scope: a generic free function declaring both
+    /// `None` and `None_` allocates distinct `TypeVar`s and its `.pyi`
+    /// signature references match the declarations.
+    #[test]
+    fn typevar_collision_none_and_none_underscore_diverge_function_scope() {
+        let mut pool: SymbolPool = HashMap::new();
+        let key = cg_name("user", &["lorem"], "echo");
+        pool.insert(
+            key,
+            Symbol::Function(Function {
+                name: BaseName::new("echo"),
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                docstring: None,
+                arguments: vec![FunctionArgument {
+                    name: BaseName::new("value"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                    default: None,
+                }],
+                return_type: type_var(BaseName::new("None_")),
+                throws: None,
+                watchers: vec![],
+                origin: origin("echo.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "bumped decl missing:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("None_ = typing.TypeVar(\"None_\")\n"),
+            "natural decl missing:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("def echo(value: None__, *, _types: dict[str, type]) -> None_: ..."),
+            "signature refs not distinct:\n{pyi}"
+        );
+    }
+
+    /// Method scope: a generic instance method declaring both `None`
+    /// and `None_` allocates distinct `TypeVar`s in its `.pyi` signature.
+    #[test]
+    fn typevar_collision_none_and_none_underscore_diverge_method_scope() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Holder");
+        let mut method = bare_func("pick", "x.baml", 100);
+        method.generic_params = vec![BaseName::new("None"), BaseName::new("None_")];
+        method.arguments = vec![
+            FunctionArgument {
+                name: BaseName::new("self"),
+                docstring: None,
+                ty: class_ty(n.clone(), vec![]),
+                default: None,
+            },
+            FunctionArgument {
+                name: BaseName::new("value"),
+                docstring: None,
+                ty: type_var(BaseName::new("None")),
+                default: None,
+            },
+        ];
+        method.return_type = type_var(BaseName::new("None_"));
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: Vec::new(),
+                name: n,
+                docstring: None,
+                properties: vec![],
+                static_methods: vec![],
+                instance_methods: vec![method],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "bumped decl missing:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("None_ = typing.TypeVar(\"None_\")\n"),
+            "natural decl missing:\n{pyi}"
+        );
+        // The method value param resolves raw `None` → `None__`; the return
+        // resolves raw `None_` → `None_`.
+        assert!(pyi.contains("value: None__"), "param ref:\n{pyi}");
+        assert!(pyi.contains(") -> None_:"), "return ref:\n{pyi}");
+    }
+
+    /// Invariant: a plain no-keyword `TypeVar` scope renders exactly as
+    /// before the collision-aware change — the map path is identity on `T`.
+    #[test]
+    fn nonkeyword_typevar_scope_is_unchanged() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("T")],
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("T")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let leaf = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            leaf.contains("T = typing.TypeVar(\"T\")\n"),
+            "decl:\n{leaf}"
+        );
+        assert!(
+            leaf.contains("class Box(pydantic.BaseModel, typing.Generic[T]):\n"),
+            "base:\n{leaf}"
+        );
+        assert!(leaf.contains("    item: T\n"), "ref:\n{leaf}");
+        // No stray extra underscore leaked into the emitted spelling.
+        assert!(
+            !leaf.contains("T_ = typing.TypeVar"),
+            "spurious escape:\n{leaf}"
+        );
+    }
+
+    // ── Reserved-word codegen: TypeVar allocation and stub aggregation ───────
+
+    /// A leaf that already declares a class named `None__` plus a
+    /// generic `<None, None_>` must bump the keyword `TypeVar` PAST the taken class
+    /// name (`None`→`None_`(raw)→`None__`(class)→`None___`), so no module name is
+    /// declared twice and the `Generic[…]` list never shadows onto the class.
+    #[test]
+    fn typevar_bump_reserves_leaf_class_names() {
+        let mut pool: SymbolPool = HashMap::new();
+        // A source-valid class literally named `None__` (not a hard keyword, so
+        // it emits verbatim and lands in the leaf namespace).
+        let taken = cg_name("user", &["lorem"], "None__");
+        pool.insert(taken.clone(), class_with_fields(taken, &[("a", int_ty())]));
+        // A generic class whose `{None, None_}` twin would, per-scope, bump `None`
+        // onto the already-taken `None__`.
+        let boxn = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            boxn.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                name: boxn,
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("a"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None")),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("b"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("None_")),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("box.baml", 10),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        for path in ["lorem/__init__.py", "lorem/__init__.pyi"] {
+            let leaf = &out[&PathBuf::from(path)];
+            // The class keeps its verbatim name.
+            assert!(
+                leaf.contains("class None__(pydantic.BaseModel):"),
+                "{path}: class None__ def missing:\n{leaf}"
+            );
+            // `None` bumped clear of BOTH the raw `None_` and the class `None__`.
+            assert!(
+                leaf.contains("None___ = typing.TypeVar(\"None___\")\n"),
+                "{path}: keyword TypeVar did not bump past the class name:\n{leaf}"
+            );
+            assert!(
+                leaf.contains("None_ = typing.TypeVar(\"None_\")\n"),
+                "{path}: natural TypeVar decl missing:\n{leaf}"
+            );
+            // Critically: `None__` is NEVER declared as a TypeVar — that name
+            // belongs to the class, so a `None__` TypeVar would collide on import.
+            assert!(
+                !leaf.contains("None__ = typing.TypeVar"),
+                "{path}: TypeVar collided with the leaf class None__:\n{leaf}"
+            );
+            // The generic base lists the bumped + natural params, neither of which
+            // is the class name.
+            assert!(
+                leaf.contains("class Box(pydantic.BaseModel, typing.Generic[None___, None_]):"),
+                "{path}: generic base shadows the class or is not distinct:\n{leaf}"
+            );
+            assert!(leaf.contains("    a: None___\n"), "{path}: a ref:\n{leaf}");
+            assert!(leaf.contains("    b: None_\n"), "{path}: b ref:\n{leaf}");
+        }
+    }
+
+    /// Distinct raw `TypeVar` spellings must never collapse onto one emitted name
+    /// (identical spellings deliberately share one module-level `TypeVar`). A class
+    /// `<None, None_>` with an instance method `<None__>` yields THREE distinct
+    /// emitted `TypeVars`, and the runtime `type_params` (method) and
+    /// `class_type_params` (class) key lists are disjoint.
+    #[test]
+    fn class_and_method_typevars_stay_disjoint() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "MethodCollisionBox");
+        let mut method = bare_func("pick", "x.baml", 100);
+        method.generic_params = vec![BaseName::new("None__")];
+        method.arguments = vec![
+            FunctionArgument {
+                name: BaseName::new("self"),
+                docstring: None,
+                ty: class_ty(n.clone(), vec![]),
+                default: None,
+            },
+            FunctionArgument {
+                name: BaseName::new("other"),
+                docstring: None,
+                ty: type_var(BaseName::new("None__")),
+                default: None,
+            },
+        ];
+        method.return_type = type_var(BaseName::new("None__"));
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("value"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![method],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        // Three DISTINCT emitted names: class `None`→`None___`, class `None_`→
+        // `None_`, method `None__`→`None__`.
+        for decl in [
+            "None___ = typing.TypeVar(\"None___\")\n",
+            "None_ = typing.TypeVar(\"None_\")\n",
+            "None__ = typing.TypeVar(\"None__\")\n",
+        ] {
+            assert!(pyi.contains(decl), "missing decl {decl:?}:\n{pyi}");
+        }
+        // Class binder `None` (→`None___`) is not confused with the method's
+        // distinct `None__` binder.
+        assert!(
+            pyi.contains(
+                "class MethodCollisionBox(pydantic.BaseModel, typing.Generic[None___, None_]):"
+            ),
+            "class generic base:\n{pyi}"
+        );
+        assert!(pyi.contains("    value: None___\n"), "class field:\n{pyi}");
+        assert!(
+            pyi.contains("other: None__,") || pyi.contains("other: None__)"),
+            "method param binder:\n{pyi}"
+        );
+        // Runtime `_types=` keys are disjoint: method binds `None__`, class binds
+        // `None___`/`None_` — no shared string (the runtime half).
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            py.contains("type_params=[\"None__\"], class_type_params=[\"None___\", \"None_\"]"),
+            "runtime _types keys overlap or wrong:\n{py}"
+        );
+    }
+
+    /// A STATIC method whose annotations reference the enclosing
+    /// class's `TypeVars` resolves them through the class map (BAML statics carry
+    /// class generics), so the raw class `None` resolves to the class's emitted
+    /// `None__` — not the stateless `None_`. The runtime `_types=` receiver
+    /// binding is unchanged (statics bind no `class_type_params`).
+    #[test]
+    fn static_method_signature_uses_class_typevar_map() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Factory");
+        let mut make = bare_func("make", "x.baml", 100);
+        make.generic_params = vec![];
+        make.arguments = vec![FunctionArgument {
+            name: BaseName::new("value"),
+            docstring: None,
+            ty: type_var(BaseName::new("None")),
+            default: None,
+        }];
+        make.return_type = type_var(BaseName::new("None"));
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None"), BaseName::new("None_")],
+                name: n,
+                docstring: None,
+                properties: vec![],
+                static_methods: vec![make],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("class Factory(pydantic.BaseModel, typing.Generic[None__, None_]):"),
+            "class generic base:\n{pyi}"
+        );
+        // Static annotation resolves raw class `None` to the class's emitted
+        // `None__` (would be `None_` under the dropped-map bug).
+        assert!(
+            pyi.contains("def make(value: None__) -> None__: ..."),
+            "static sig did not resolve class TypeVar map:\n{pyi}"
+        );
+        // Runtime binding is untouched: a static binds no class_type_params.
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            !py.contains("class_type_params="),
+            "static wrongly bound class_type_params at runtime:\n{py}"
+        );
+    }
+
+    fn optional_callback(param: &str, var: &str) -> Ty {
+        Ty::Function {
+            params: vec![CallableParam {
+                name: Some(BaseName::new(param)),
+                ty: type_var(BaseName::new(var)),
+                mode: CodegenFunctionParamMode::Optional,
+            }],
+            ret: Box::new(type_var(BaseName::new(var))),
+            throws: Box::new(Ty::Never {
+                attr: baml_base::TyAttr::EMPTY,
+            }),
+            attr: baml_base::TyAttr::EMPTY,
+        }
+    }
+
+    fn callback_fn(bare: &str, generics: &[&str], cb: Ty) -> Function {
+        Function {
+            generic_params: generics.iter().map(BaseName::new).collect(),
+            name: BaseName::new(bare),
+            docstring: None,
+            arguments: vec![FunctionArgument {
+                name: BaseName::new("cb"),
+                docstring: None,
+                ty: cb,
+                default: None,
+            }],
+            return_type: int_ty(),
+            throws: None,
+            watchers: vec![],
+            origin: origin("cb.baml", 0),
+        }
+    }
+
+    /// An optional-callback Protocol renders under its generic
+    /// OWNER's map (bumped keyword spelling), not the stateless escape; two owners
+    /// whose callbacks render IDENTICALLY share one Protocol (sharing control),
+    /// while a structurally-different callback gets its own.
+    ///
+    /// Note: under the leaf-global allocation two owners in one leaf always
+    /// spell a shared raw binder identically, so the "incompatible maps" split is
+    /// unreachable within a leaf; distinctness here is driven by the callbacks
+    /// referencing DIFFERENT binders (`None` vs `None_`), which is the reachable
+    /// analog.
+    #[test]
+    fn optional_callback_protocol_uses_owner_map_and_dedups_on_rendering() {
+        let mut pool: SymbolPool = HashMap::new();
+        // fa/fb reference raw `None` (→ owner spelling `None__`) — same rendering,
+        // must share ONE Protocol. fc references raw `None_` (→ `None_`) — distinct.
+        pool.insert(
+            cg_name("user", &["lorem"], "fa"),
+            Symbol::Function(callback_fn(
+                "fa",
+                &["None", "None_"],
+                optional_callback("x", "None"),
+            )),
+        );
+        pool.insert(
+            cg_name("user", &["lorem"], "fb"),
+            Symbol::Function(callback_fn("fb", &["None"], optional_callback("x", "None"))),
+        );
+        pool.insert(
+            cg_name("user", &["lorem"], "fc"),
+            Symbol::Function(callback_fn(
+                "fc",
+                &["None", "None_"],
+                optional_callback("x", "None_"),
+            )),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        // P1: fa's Protocol renders the OWNER spelling `None__` (bug renders `None_`).
+        assert!(
+            pyi.contains("class _fa__cb1(typing.Protocol):\n    def __call__(self, x: None__ = ...) -> None__: ...\n"),
+            "P1 not rendered with owner spelling:\n{pyi}"
+        );
+        // P2: fc's structurally-distinct callback gets its own Protocol at `None_`.
+        assert!(
+            pyi.contains("class _fc__cb1(typing.Protocol):\n    def __call__(self, x: None_ = ...) -> None_: ...\n"),
+            "P2 (distinct callback) missing:\n{pyi}"
+        );
+        // Sharing control: fa AND fb both reference the SAME Protocol; fb never
+        // mints its own.
+        assert!(
+            pyi.contains("def fa(cb: _fa__cb1, *, _types: dict[str, type]) -> int: ..."),
+            "fa signature:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("def fb(cb: _fa__cb1, *, _types: dict[str, type]) -> int: ..."),
+            "fb did not share fa's Protocol:\n{pyi}"
+        );
+        assert!(
+            !pyi.contains("_fb__cb"),
+            "fb minted a redundant Protocol instead of sharing:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("def fc(cb: _fc__cb1, *, _types: dict[str, type]) -> int: ..."),
+            "fc signature:\n{pyi}"
+        );
+    }
+
+    /// A callable-child function that returns a
+    /// root-routed keyword class is rendered into the PARENT stub, so the parent
+    /// `.pyi` must aggregate the child's guarded import. The aggregation is kept
+    /// isolated so it can be reverted as a unit.
+    #[test]
+    fn callable_child_return_import_aggregated_into_parent_stub() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Root-routed keyword class → emitted `None_`.
+        let none = cg_name("user", &[], "None");
+        pool.insert(none.clone(), class(none.clone()));
+        // Parent callable `boundary.id` returns `str` (no None_ import from parent).
+        pool.insert(
+            cg_name("boundary", &[], "id"),
+            zero_arg_func(
+                "id",
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                "core.baml",
+                0,
+            ),
+        );
+        // Child `boundary.id.current` returns the root keyword class — the parent
+        // stub renders `def current(self) -> None_` but historically dropped its
+        // import.
+        pool.insert(
+            cg_name("boundary", &["id"], "current"),
+            zero_arg_func("current", class_ty(none, vec![]), "id.baml", 0),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("vendor/boundary/__init__.pyi")];
+        // The child's return type is spelled in the parent stub …
+        assert!(
+            pyi.contains("def current(self) -> None_: ..."),
+            "child signature not in parent stub:\n{pyi}"
+        );
+        // … and the aggregation now carries its guarded import (parent leaf depth = 3 dots).
+        assert!(
+            pyi.contains("from ... import None_\n"),
+            "parent stub missing aggregated child import:\n{pyi}"
+        );
+    }
+
+    /// A leaf that owns a child package whose
+    /// module name equals a keyword `TypeVar`'s natural escape must bump the
+    /// `TypeVar` PAST the child name. Leaf `lorem` owns generic raw `None` (→
+    /// escapes to `None_`) AND a child submodule `lorem/None_/`; the `TypeVar`
+    /// must allocate `None__`, leaving the lazy child binding `None_` intact so
+    /// `import baml_sdk.lorem.None_` still resolves the module (not the `TypeVar`).
+    #[test]
+    fn keyword_typevar_bumps_past_child_module_name() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Child package `lorem/None_/` (a class in namespace `lorem.None_`).
+        // `None_` is a valid identifier (not a hard keyword), so routing keeps it
+        // verbatim and it becomes an immediate child of `lorem`.
+        let child = cg_name("user", &["lorem", "None_"], "Child");
+        pool.insert(child.clone(), class(child));
+        // Parent leaf `lorem` owns a generic class whose raw binder is `None`.
+        let boxn = cg_name("user", &["lorem"], "Box");
+        pool.insert(
+            boxn.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None")],
+                name: boxn,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("box.baml", 0),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        // The keyword TypeVar bumps PAST the child module name `None_` → `None__`.
+        assert!(
+            py.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "TypeVar did not bump past child module None_:\n{py}"
+        );
+        // `None_` is NEVER a TypeVar — that name belongs to the child module, and
+        // a `None_` TypeVar would overwrite the lazy child binding on import.
+        assert!(
+            !py.contains("None_ = typing.TypeVar"),
+            "TypeVar collided with child module None_:\n{py}"
+        );
+        // The lazy child binding survives in the parent package.
+        assert!(
+            py.contains("_LAZY_CHILDREN = frozenset({\n") && py.contains("    \"None_\",\n"),
+            "child module None_ lazy binding dropped:\n{py}"
+        );
+        // The generic base and field reference the bumped spelling.
+        assert!(
+            py.contains("class Box(pydantic.BaseModel, typing.Generic[None__]):"),
+            "generic base did not use bumped TypeVar:\n{py}"
+        );
+        assert!(py.contains("    item: None__\n"), "field ref:\n{py}");
+        // The `.pyi` cascade re-export `from . import None_` coexists with the
+        // bumped `None__` TypeVar, un-collided.
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("from . import None_\n"),
+            "child re-export missing in stub:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "stub TypeVar not bumped:\n{pyi}"
+        );
+        assert!(
+            !pyi.contains("None_ = typing.TypeVar"),
+            "stub TypeVar collided with child re-export:\n{pyi}"
+        );
+    }
+
+    /// A parent leaf
+    /// owning generic raw `None` whose callable child returns a root KEYWORD class
+    /// (`None`→`None_`). The stub aggregation adds `from ... import None_` into the
+    /// parent stub; the reservation pre-pass reserves that anchor so the `TypeVar`
+    /// bumps to `None__`, leaving `from ... import None_` denoting the imported
+    /// class rather than being rebound to a `TypeVar`. Materializes the composed
+    /// fixture exercising the child-import-anchor and TypeVar-bump interaction
+    /// together.
+    #[test]
+    fn keyword_typevar_bumps_past_aggregated_child_import_anchor() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Root-routed keyword class → emitted `None_`.
+        let none = cg_name("user", &[], "None");
+        pool.insert(none.clone(), class(none.clone()));
+        // Parent callable `boundary.id` returns `str`.
+        pool.insert(
+            cg_name("boundary", &[], "id"),
+            zero_arg_func(
+                "id",
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                "core.baml",
+                0,
+            ),
+        );
+        // Child `boundary.id.current` returns the root keyword class, so the
+        // aggregation adds `from ... import None_` into the parent stub.
+        pool.insert(
+            cg_name("boundary", &["id"], "current"),
+            zero_arg_func("current", class_ty(none, vec![]), "id.baml", 0),
+        );
+        // The SAME parent leaf `vendor/boundary` also owns generic raw `None`,
+        // whose TypeVar would (unreserved) collide with the aggregated `None_`.
+        let boxn = cg_name("boundary", &[], "Box");
+        pool.insert(
+            boxn.clone(),
+            Symbol::Class(Class {
+                generic_params: vec![BaseName::new("None")],
+                name: boxn,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("None")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("box.baml", 5),
+            }),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("vendor/boundary/__init__.pyi")];
+        // Aggregated import retained (child return class), keyword-gate fires
+        // because `None` is a keyword.
+        assert!(
+            pyi.contains("from ... import None_\n"),
+            "aggregated child import anchor dropped:\n{pyi}"
+        );
+        // The generic TypeVar bumped PAST the anchor → `None__`.
+        assert!(
+            pyi.contains("None__ = typing.TypeVar(\"None__\")\n"),
+            "TypeVar did not bump past aggregated import anchor:\n{pyi}"
+        );
+        // `None_` is NOT rebound to a TypeVar — it still denotes the imported class.
+        assert!(
+            !pyi.contains("None_ = typing.TypeVar"),
+            "TypeVar rebound the imported child class None_:\n{pyi}"
+        );
+        // The child annotation resolves to the imported class spelling `None_`.
+        assert!(
+            pyi.contains("def current(self) -> None_: ..."),
+            "child annotation spelling:\n{pyi}"
+        );
+    }
+
+    /// Negative control that makes the restored byte-identity
+    /// universal falsifiable: a KEYWORD-FREE callable child returning ordinary
+    /// root class `Widget` must NOT change the parent stub — the keyword-gate
+    /// suppresses the stub aggregation, so no `import Widget` line appears (byte-
+    /// identical to parent/canary, whose keyword-free unbound-stub bug is a
+    /// disclosed pre-existing follow-up).
+    #[test]
+    fn keyword_free_callable_child_class_return_stays_byte_identical() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Root-routed ORDINARY class (not a keyword).
+        let widget = cg_name("user", &[], "Widget");
+        pool.insert(widget.clone(), class(widget.clone()));
+        // Parent callable `boundary.id` returns `str`.
+        pool.insert(
+            cg_name("boundary", &[], "id"),
+            zero_arg_func(
+                "id",
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                "core.baml",
+                0,
+            ),
+        );
+        // Child `boundary.id.current` returns the ordinary root class.
+        pool.insert(
+            cg_name("boundary", &["id"], "current"),
+            zero_arg_func("current", class_ty(widget, vec![]), "id.baml", 0),
+        );
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let pyi = &out[&PathBuf::from("vendor/boundary/__init__.pyi")];
+        // The child signature is still rendered into the parent stub (pre-existing
+        // behavior, unchanged) …
+        assert!(
+            pyi.contains("def current(self) -> Widget: ..."),
+            "child signature not in parent stub:\n{pyi}"
+        );
+        // … but the keyword-gate suppresses the aggregated import: NO `import
+        // Widget` line. Under an unconditional aggregation this would be
+        // `from ... import Widget`, which is exactly the keyword-free output delta
+        // that broke byte-identity. Its absence pins strict byte-identity for
+        // keyword-free schemas.
+        assert!(
+            !pyi.contains("import Widget"),
+            "keyword-free callable child changed the parent stub (aggregation not gated):\n{pyi}"
+        );
+    }
+
+    /// Generator-side marker emission: the provenance markers the
+    /// bridge encoder consumes are emitted ONLY on keyword-escaped artifacts and
+    /// ONLY in the runtime `.py` (never the `.pyi` stub). A class with ≥1 escaped
+    /// field gets a plain unannotated dunder `__baml_wire_names__` mapping escaped
+    /// attr → raw wire name; an enum with ≥1 escaped member gets a plain dunder
+    /// `__baml_wire_values__`. Keyword-free symbols in the same leaf emit NO
+    /// marker, so their output stays byte-identical.
+    #[test]
+    fn wire_markers_emitted_only_for_escaped_symbols_and_py_only() {
+        let mut pool: SymbolPool = HashMap::new();
+        // Escaped class: field `pass` → `pass_` (alias "pass"); `keep` untouched.
+        let c = cg_name("user", &["lorem"], "C");
+        pool.insert(
+            c.clone(),
+            class_with_fields(c, &[("pass", int_ty()), ("keep", int_ty())]),
+        );
+        // Escaped enum: member `None` → `None_` (wire "None"); `Ok` untouched.
+        let e = cg_name("user", &["lorem"], "E");
+        pool.insert(
+            e.clone(),
+            enum_with_variants(e, &[("None", "None"), ("Ok", "Ok")]),
+        );
+        // Keyword-free class + enum in the SAME leaf: must emit NO marker.
+        let plain_c = cg_name("user", &["lorem"], "Plain");
+        pool.insert(
+            plain_c.clone(),
+            class_with_fields(plain_c, &[("x", int_ty())]),
+        );
+        let plain_e = cg_name("user", &["lorem"], "PlainE");
+        pool.insert(plain_e.clone(), enum_with_variants(plain_e, &[("A", "A")]));
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+
+        // Class marker: exact plain dunder dict of the escaped field only, `.py` only.
+        assert!(
+            py.contains("    __baml_wire_names__ = {\"pass_\": \"pass\"}\n"),
+            "class wire-name marker missing/incorrect:\n{py}"
+        );
+        // Enum marker: exact plain dunder dict of the escaped member only, `.py` only.
+        assert!(
+            py.contains("    __baml_wire_values__ = {\"None_\": \"None\"}\n"),
+            "enum wire-value marker missing/incorrect:\n{py}"
+        );
+        // Exactly ONE of each marker across the whole leaf → keyword-free `Plain`
+        // and `PlainE` emitted none (byte-identity for keyword-free schemas).
+        assert_eq!(
+            py.matches("__baml_wire_names__").count(),
+            1,
+            "expected exactly one class marker (escaped C only):\n{py}"
+        );
+        assert_eq!(
+            py.matches("__baml_wire_values__").count(),
+            1,
+            "expected exactly one enum marker (escaped E only):\n{py}"
+        );
+        // Markers are runtime-only: the stub never carries them.
+        assert!(
+            !pyi.contains("__baml_wire_names__") && !pyi.contains("__baml_wire_values__"),
+            "provenance marker leaked into the .pyi stub:\n{pyi}"
+        );
+    }
+
+    /// A user member (here an instance method) named exactly like the generated
+    /// wire-name marker must not clobber it. On a class that also carries a
+    /// keyword-escaped field (so the marker is emitted), the colliding member is
+    /// bumped one trailing underscore past the marker and the marker survives as a
+    /// plain dunder dict, so the bridge still recovers the raw wire key.
+    #[test]
+    fn wire_name_marker_survives_user_member_named_like_marker() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Collision");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: Vec::new(),
+                name: n,
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("pass"),
+                    docstring: None,
+                    ty: int_ty(),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![method_func(
+                    "__baml_wire_names__",
+                    &["self"],
+                    "x.baml",
+                    100,
+                )],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+
+        // The marker survives as a plain dunder dict of the escaped field.
+        assert!(
+            py.contains("    __baml_wire_names__ = {\"pass_\": \"pass\"}\n"),
+            "wire-name marker missing or clobbered:\n{py}"
+        );
+        // No `_define_function` binding targets the bare marker name (that would
+        // overwrite the dict with a callable at class creation).
+        let binds_marker_name = py.lines().any(|l| {
+            let t = l.trim_start();
+            t.starts_with("__baml_wire_names__ ") && t.contains("_define_function")
+        });
+        assert!(
+            !binds_marker_name,
+            "a method binding still targets the bare marker name:\n{py}"
+        );
+        // The colliding method is bumped one underscore past the marker.
+        let binds_bumped_name = py.lines().any(|l| {
+            let t = l.trim_start();
+            t.starts_with("__baml_wire_names___ ") && t.contains("_define_function")
+        });
+        assert!(
+            binds_bumped_name,
+            "colliding method was not bumped past the marker name:\n{py}"
+        );
+    }
+
+    /// A user FIELD named exactly like the wire-name marker is the import-crash
+    /// case: unlike a colliding method (a bare class-body assignment), a field must
+    /// not keep the marker's leading underscores. A plain trailing-underscore bump
+    /// (`__baml_wire_names___`) still leads with `__`, and
+    /// `__baml_wire_names___: T = pydantic.Field(alias=…)` raises
+    /// `NameError: Fields must not use names with leading underscores` at class
+    /// creation, breaking `import` of the whole leaf. The field is instead projected
+    /// onto a leading-underscore-free spelling (`baml_wire_names___`) while the raw
+    /// `__baml_wire_names__` stays the wire key via the alias and the marker entry,
+    /// so the generated module imports and wire identity is preserved. See the
+    /// import-level companion in `tests/test_reserved_keywords.py`.
+    #[test]
+    fn wire_name_marker_field_collision_projects_off_leading_underscore() {
+        let mut pool: SymbolPool = HashMap::new();
+        let n = cg_name("user", &["lorem"], "Collision");
+        pool.insert(
+            n.clone(),
+            Symbol::Class(Class {
+                generic_params: Vec::new(),
+                name: n,
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("pass"),
+                        docstring: None,
+                        ty: int_ty(),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("__baml_wire_names__"),
+                        docstring: None,
+                        ty: int_ty(),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+
+        // The user field is projected off the marker onto a pydantic-legal,
+        // leading-underscore-free spelling, aliased to its raw wire name.
+        assert!(
+            py.contains(
+                "    baml_wire_names___: int = pydantic.Field(alias=\"__baml_wire_names__\")\n"
+            ),
+            "field not projected off the marker to a legal spelling:\n{py}"
+        );
+        // The import-crashing shape (an ANNOTATED field still leading with `__`)
+        // must not be emitted. `__baml_wire_names___` as a bare assignment (a
+        // bumped METHOD) is fine; only an annotated field crashes, so key on `:`.
+        let crashing_field = py.lines().any(|l| {
+            let t = l.trim_start();
+            t.starts_with("__baml_wire_names___:")
+        });
+        assert!(
+            !crashing_field,
+            "import-crashing leading-underscore annotated field emitted:\n{py}"
+        );
+        // The marker survives as a plain dunder dict and records BOTH the escaped
+        // keyword field and the projected marker field under their raw wire names.
+        assert!(
+            py.contains(
+                "    __baml_wire_names__ = {\"pass_\": \"pass\", \
+                 \"baml_wire_names___\": \"__baml_wire_names__\"}\n"
+            ),
+            "marker missing the projected field's raw wire entry:\n{py}"
+        );
+    }
+
+    /// The class wire-name marker is emitted as a plain dunder assignment, never a
+    /// `typing.ClassVar[dict[str, str]]` annotation. A bare-builtin `dict[...]`
+    /// subscript inside a class-level annotation is shadowable by a user
+    /// `type dict = ...` lowered into the same leaf and breaks
+    /// `typing.get_type_hints`; the plain dunder dict (mirroring the enum marker)
+    /// carries no annotation and is immune.
+    #[test]
+    fn wire_name_marker_is_a_plain_dunder_assignment() {
+        let mut pool: SymbolPool = HashMap::new();
+        let c = cg_name("user", &["lorem"], "C");
+        pool.insert(c.clone(), class_with_fields(c, &[("pass", int_ty())]));
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+
+        // Emitted as a plain dunder dict, identical in shape to the enum marker.
+        assert!(
+            py.contains("    __baml_wire_names__ = {\"pass_\": \"pass\"}\n"),
+            "marker not emitted as a plain dunder dict:\n{py}"
+        );
+        // The shadowable ClassVar-annotated bare-`dict` subscript is gone.
+        assert!(
+            !py.contains("__baml_wire_names__: typing.ClassVar[dict[str, str]]"),
+            "marker still carries the shadowable ClassVar[dict[...]] annotation:\n{py}"
+        );
+        // No bare-builtin `dict[...]` subscript survives on any marker line.
+        assert!(
+            !py.contains("dict[str, str]"),
+            "a bare-builtin dict[...] subscript leaked into the leaf:\n{py}"
         );
     }
 

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
@@ -10,6 +10,7 @@ use baml_codegen_types::{Name, Ty};
 use indexmap::IndexMap;
 
 use crate::{
+    emit::escape_python_keyword,
     py_string,
     routing::{LeafPath, route_class_ref},
 };
@@ -82,7 +83,7 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
                 head
             }
         }
-        Ty::TypeVar(name, _) => name.as_str().to_string(),
+        Ty::TypeVar(name, _) => escape_python_keyword(name.as_str().to_string()),
         Ty::List(inner, _) => format!("typing.List[{}]", translate_ty(inner, ctx)),
         Ty::Map { key, value, .. } => {
             format!(
@@ -206,12 +207,19 @@ fn media_ref(bare: &str, ctx: &TranslateCtx) -> String {
     render_name_ref(&name, ctx)
 }
 
+/// Render a reference to a class / enum / type-alias name. The bare name is
+/// keyword-escaped with the same stateless [`escape_python_keyword`] used at
+/// the definition site (`emit/mod.rs`), so a class declared `None_` is
+/// referenced as `None_` (or `lorem.None_` cross-leaf) — never the raw `None`,
+/// which would `NameError`. Module-path segments are handled separately by the
+/// routing sanitizer and are not escaped here.
 fn render_name_ref(name: &Name, ctx: &TranslateCtx) -> String {
     let routed_leaf = route_class_ref(name);
+    let bare = escape_python_keyword(name.bare_name().to_string());
     if routed_leaf == ctx.current_leaf || routed_leaf.segments.is_empty() {
-        name.bare_name().to_string()
+        bare
     } else {
-        format!("{}.{}", routed_leaf.segments.join("."), name.bare_name())
+        format!("{}.{}", routed_leaf.segments.join("."), bare)
     }
 }
 

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
@@ -10,7 +10,7 @@ use baml_codegen_types::{Name, Ty};
 use indexmap::IndexMap;
 
 use crate::{
-    emit::escape_python_keyword,
+    emit::{TypeVarMap, escape_python_keyword},
     py_string,
     routing::{LeafPath, route_class_ref},
 };
@@ -30,21 +30,97 @@ pub(crate) struct TranslateCtx {
     /// quoted form defers resolution until pydantic walks the alias
     /// later.
     pub(crate) defer_name_refs: bool,
-    /// `.pyi`-only: maps each optional-argument `Ty::Function` in the leaf to
-    /// the name of the `typing.Protocol` emitted for it. A function *type*
-    /// (`typing.Callable[[…], R]`) cannot express per-parameter optionality,
-    /// so a callback with optional params is rendered as a named Protocol
-    /// whose `__call__` carries the precise signature; the type expression for
-    /// such a callable is just that Protocol's name. Absent (`None`) in the
-    /// runtime `.py` path, where callable types fall back to
-    /// `typing.Callable[..., R]` (Protocol classes are stub-only).
-    pub(crate) callback_protocols: Option<std::rc::Rc<IndexMap<Ty, String>>>,
+    /// `.pyi`-only: maps each distinct callback Protocol in the leaf — keyed on
+    /// its RENDERED identity ([`CallbackProtocolKey`]: structural `Ty` + the
+    /// owner-map projection over the `TypeVars` it names) — to the Protocol's
+    /// emitted name. A function *type* (`typing.Callable[[…], R]`) cannot express
+    /// per-parameter optionality, so a callback with optional params is rendered
+    /// as a named Protocol whose `__call__` carries the precise signature; the
+    /// type expression for such a callable is just that Protocol's name. The key
+    /// is re-derived here from `type_var_map` (the owner scope's map), so two
+    /// owners that spell the callback's `TypeVars` differently resolve to distinct
+    /// Protocols. Absent (`None`) in the runtime `.py` path, where callable
+    /// types fall back to `typing.Callable[..., R]` (Protocol classes are
+    /// stub-only).
+    pub(crate) callback_protocols: Option<std::rc::Rc<IndexMap<CallbackProtocolKey, String>>>,
+    /// Raw→emitted `TypeVar` name map for the generic scope whose body is being
+    /// translated (one class, free function, method, or the callback Protocol of
+    /// a generic owner). `Ty::TypeVar` resolves through it so a `{None, None_}`
+    /// twin's references match the distinct `{None__, None_}` declarations. `None`
+    /// when no generic scope is active — resolution then falls back to the
+    /// stateless [`escape_python_keyword`], which is exact for a non-generic
+    /// scope (it has no keyword `TypeVar` twin to disambiguate).
+    pub(crate) type_var_map: Option<std::rc::Rc<TypeVarMap>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SelfRef {
     pub(crate) routed_leaf: LeafPath,
     pub(crate) bare_name: String,
+}
+
+/// De-duplication / lookup key for a callback `typing.Protocol`: the
+/// structural callback `Ty` paired with the owner scope's emitted spelling of
+/// every `TypeVar` that appears in it, in sorted-by-raw-name order. Two owners
+/// whose maps spell the callback's `TypeVars` identically share one Protocol
+/// (keyword-free schemas always do → byte-identical output); owners that spell
+/// them differently (a bumped `{None, None_}` twin) get distinct Protocols. A
+/// callback that names no `TypeVar` has an empty projection, so its identity is
+/// purely structural, exactly as before this change.
+pub(crate) type CallbackProtocolKey = (Ty, Vec<(String, String)>);
+
+/// Build the [`CallbackProtocolKey`] for `ty` under an owner scope's `owner_map`
+/// (or the stateless escape when the owner is non-generic). The projection folds
+/// in only the `TypeVars` that actually appear in `ty`, so an owner's unrelated
+/// generics never fragment otherwise-identical Protocols.
+pub(crate) fn callback_protocol_key(
+    ty: &Ty,
+    owner_map: Option<&TypeVarMap>,
+) -> CallbackProtocolKey {
+    let mut vars: Vec<String> = Vec::new();
+    collect_type_var_names(ty, &mut vars);
+    vars.sort();
+    vars.dedup();
+    let projection = vars
+        .into_iter()
+        .map(|raw| {
+            let emitted = owner_map
+                .and_then(|m| m.get(&raw).cloned())
+                .unwrap_or_else(|| escape_python_keyword(raw.clone()));
+            (raw, emitted)
+        })
+        .collect();
+    (ty.clone(), projection)
+}
+
+/// Collect every `TypeVar` raw name reachable inside `ty` (order irrelevant —
+/// the caller sorts + dedups).
+fn collect_type_var_names(ty: &Ty, out: &mut Vec<String>) {
+    match ty {
+        Ty::TypeVar(name, _) => out.push(name.as_str().to_string()),
+        Ty::List(inner, _) => collect_type_var_names(inner, out),
+        Ty::Map { key, value, .. } => {
+            collect_type_var_names(key, out);
+            collect_type_var_names(value, out);
+        }
+        Ty::Union(items, _) => {
+            for t in items {
+                collect_type_var_names(t, out);
+            }
+        }
+        Ty::Class(_, args, _) => {
+            for a in args {
+                collect_type_var_names(a, out);
+            }
+        }
+        Ty::Function { params, ret, .. } => {
+            for p in params {
+                collect_type_var_names(&p.ty, out);
+            }
+            collect_type_var_names(ret, out);
+        }
+        _ => {}
+    }
 }
 
 pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
@@ -83,7 +159,20 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
                 head
             }
         }
-        Ty::TypeVar(name, _) => escape_python_keyword(name.as_str().to_string()),
+        Ty::TypeVar(name, _) => {
+            // Map wins so a `{None, None_}` twin resolves to the exact spelling
+            // the declaration allocated. The stateless escape is the fallback
+            // only for scopes with no map in `ctx` — non-generic bodies and alias
+            // RHS — which bind no TypeVars and so cannot carry a twin. Callback
+            // Protocol bodies now DO carry the owner scope's map, so a
+            // callback that references a bumped keyword TypeVar resolves through
+            // it here rather than re-escaping statelessly.
+            let raw = name.as_str();
+            ctx.type_var_map
+                .as_ref()
+                .and_then(|m| m.get(raw).cloned())
+                .unwrap_or_else(|| escape_python_keyword(raw.to_string()))
+        }
         Ty::List(inner, _) => format!("typing.List[{}]", translate_ty(inner, ctx)),
         Ty::Map { key, value, .. } => {
             format!(
@@ -126,9 +215,15 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
             if has_optional {
                 // A callback with optional params is emitted as a named
                 // `typing.Protocol` (see `TranslateCtx::callback_protocols`):
-                // the type expression here is just that Protocol's name.
-                if let Some(name) = ctx.callback_protocols.as_ref().and_then(|map| map.get(ty)) {
-                    return name.clone();
+                // the type expression here is just that Protocol's name. The
+                // lookup key folds in the owner scope's spelling of the callback's
+                // TypeVars (`ctx.type_var_map`), so a generic owner resolves to
+                // the Protocol rendered under its own map.
+                if let Some(map) = ctx.callback_protocols.as_ref() {
+                    let key = callback_protocol_key(ty, ctx.type_var_map.as_deref());
+                    if let Some(name) = map.get(&key) {
+                        return name.clone();
+                    }
                 }
                 // Runtime `.py` path (no Protocol map): `typing.Callable` can't
                 // express per-param optionality, so widen the arg list.
@@ -249,6 +344,7 @@ mod tests {
             self_ref: None,
             defer_name_refs: false,
             callback_protocols: None,
+            type_var_map: None,
         }
     }
 
@@ -261,6 +357,7 @@ mod tests {
             current_leaf: leaf(current_segments),
             defer_name_refs: false,
             callback_protocols: None,
+            type_var_map: None,
             self_ref: Some(SelfRef {
                 routed_leaf: leaf(self_segments),
                 bare_name: bare_name.to_string(),
@@ -280,6 +377,7 @@ mod tests {
             current_leaf: leaf(current_segments),
             defer_name_refs: true,
             callback_protocols: None,
+            type_var_map: None,
             self_ref: Some(SelfRef {
                 routed_leaf: leaf(self_segments),
                 bare_name: bare_name.to_string(),

--- a/baml_language/sdks/python/src/baml_bridge/proto.py
+++ b/baml_language/sdks/python/src/baml_bridge/proto.py
@@ -178,14 +178,26 @@ def _set_inbound_value(
     if isinstance(value, enum.Enum):
         ev = inbound_value.enum_value
         ev.name = get_type_map().py_type_to_baml_type(_base_class_for_fqn(type(value)))
-        # Send the member VALUE, not its Python name. Decode is already by
-        # value (`_decode_enum`: `cls(enum_value.value)`), and codegen keeps the
-        # value equal to the BAML wire identity even when the member name is
-        # escaped off a keyword (`None_ = "None"`). For every non-escaped member
-        # name == value, so this is a no-op for existing SDKs; for an escaped
-        # member it puts the raw BAML name (`None`) on the wire instead of the
-        # Python identifier (`None_`) the engine would reject.
-        ev.value = value.value
+        # Codegen escapes an enum MEMBER whose BAML name is a Python keyword
+        # (`None` -> member `None_`, or the collision-bumped `None__` when a
+        # sibling `None_` is also present) and records the raw BAML identity in a
+        # generated `__baml_wire_values__` marker dict on the enum class,
+        # {member name -> raw wire name}, emitted ONLY for enums that carry an
+        # escaped member. Consume that marker as the sole provenance signal:
+        # a marked member wires its raw BAML name (`None_` -> `None`), and a member
+        # with no marker entry wires its member NAME, which is the pre-PR behavior.
+        # An ordinary hand-written or custom enum carries no marker and so takes
+        # this fallback; the lookup is a plain `getattr` by member name, so an enum
+        # that deliberately declares a well-formed marker, or inherits one through
+        # the MRO, is honored on the same path. The `.value` is never forwarded, so
+        # a member whose value is a non-str object cannot reach the string wire
+        # field. Decode is by value (`_decode_enum`: `cls(enum_value.value)`); a
+        # generated escaped member keeps `value == raw name`, so decode still
+        # round-trips.
+        marker = getattr(type(value), "__baml_wire_values__", None)
+        if not isinstance(marker, dict):
+            marker = {}
+        ev.value = marker.get(value.name, value.name)
         return
 
     # bool must precede int — bool is an int subclass in Python.
@@ -325,19 +337,28 @@ def _set_inbound_value(
         # then see them as `Map` instead of `Instance`, so a
         # `Box<Box<int>>` round-trip collapses into bare dicts at the
         # second level.
-        model_fields = type(value).model_fields
+        # Codegen escapes a field whose BAML name is a Python keyword
+        # (`None` -> `None_: T = pydantic.Field(alias="None")`, or the collision-
+        # bumped `None__` when a sibling `None_` is also present) and records the
+        # raw BAML identity in a generated `__baml_wire_names__` marker dict (a
+        # plain unannotated class-body assignment) on the model class, {python attr
+        # -> raw wire name}, emitted ONLY for classes that carry an escaped field.
+        # Consume that marker as the sole
+        # provenance signal: a marked attribute wires its raw BAML name
+        # (`None_` -> `None`), and an attribute with no marker entry wires its
+        # attribute NAME, which is the pre-PR behavior (so an ordinary user field
+        # aliased `wire_label`, and a user field named `None_` aliased `None`, both
+        # send the attribute name). The marker is a plain unannotated class-body
+        # dunder assignment, so it is not a
+        # pydantic field and never appears in `model_json_schema()`, and it is
+        # inherited through the MRO, so a user subclass of a generated model keeps
+        # correct wire identity for free. Decode is by wire name plus
+        # `populate_by_name`, unchanged.
+        wire_names = getattr(type(value), "__baml_wire_names__", None)
+        if not isinstance(wire_names, dict):
+            wire_names = {}
         for k, v in dict(value).items():
-            # Codegen escapes a field whose BAML name is a Python keyword
-            # (`pass` -> `pass_: T = pydantic.Field(alias="pass")`). The engine
-            # keys class fields by the raw BAML name, so put the alias on the
-            # wire when one is present; for every non-escaped field the alias is
-            # None and the wire key is the attribute name unchanged.
-            field_info = model_fields.get(k)
-            wire_key = (
-                field_info.alias
-                if field_info is not None and field_info.alias is not None
-                else k
-            )
+            wire_key = wire_names.get(k, k)
             _set_inbound_map_entry(
                 cv.fields.add(), wire_key, v, kwarg_name=kwarg_name, registered=registered
             )
@@ -376,10 +397,14 @@ def _set_inbound_map_entry(
         # before the `str`/`int` arms would swallow it as a plain scalar key.
         ek = entry.enum_key
         ek.name = get_type_map().py_type_to_baml_type(_base_class_for_fqn(type(key)))
-        # Map-key twin of the enum-value encode above: send the member VALUE so
-        # a keyword-escaped member (`None_ = "None"`) keys the map by its raw
-        # BAML name. No-op when name == value (every non-escaped member).
-        ek.value = key.value
+        # Map-key twin of the scalar-enum marker consumption above: a member listed
+        # in the enum class's generated `__baml_wire_values__` marker wires its raw
+        # BAML name; a member with no marker entry wires its member NAME (the pre-PR
+        # behavior). The `.value` is never forwarded.
+        marker = getattr(type(key), "__baml_wire_values__", None)
+        if not isinstance(marker, dict):
+            marker = {}
+        ek.value = marker.get(key.name, key.name)
     elif isinstance(key, str):
         entry.string_key = key
     elif isinstance(key, int):

--- a/baml_language/sdks/python/src/baml_bridge/proto.py
+++ b/baml_language/sdks/python/src/baml_bridge/proto.py
@@ -178,7 +178,14 @@ def _set_inbound_value(
     if isinstance(value, enum.Enum):
         ev = inbound_value.enum_value
         ev.name = get_type_map().py_type_to_baml_type(_base_class_for_fqn(type(value)))
-        ev.value = value.name
+        # Send the member VALUE, not its Python name. Decode is already by
+        # value (`_decode_enum`: `cls(enum_value.value)`), and codegen keeps the
+        # value equal to the BAML wire identity even when the member name is
+        # escaped off a keyword (`None_ = "None"`). For every non-escaped member
+        # name == value, so this is a no-op for existing SDKs; for an escaped
+        # member it puts the raw BAML name (`None`) on the wire instead of the
+        # Python identifier (`None_`) the engine would reject.
+        ev.value = value.value
         return
 
     # bool must precede int — bool is an int subclass in Python.
@@ -318,9 +325,21 @@ def _set_inbound_value(
         # then see them as `Map` instead of `Instance`, so a
         # `Box<Box<int>>` round-trip collapses into bare dicts at the
         # second level.
+        model_fields = type(value).model_fields
         for k, v in dict(value).items():
+            # Codegen escapes a field whose BAML name is a Python keyword
+            # (`pass` -> `pass_: T = pydantic.Field(alias="pass")`). The engine
+            # keys class fields by the raw BAML name, so put the alias on the
+            # wire when one is present; for every non-escaped field the alias is
+            # None and the wire key is the attribute name unchanged.
+            field_info = model_fields.get(k)
+            wire_key = (
+                field_info.alias
+                if field_info is not None and field_info.alias is not None
+                else k
+            )
             _set_inbound_map_entry(
-                cv.fields.add(), k, v, kwarg_name=kwarg_name, registered=registered
+                cv.fields.add(), wire_key, v, kwarg_name=kwarg_name, registered=registered
             )
         # Private attrs aren't iterated by `dict(value)`. Codegen emits
         # `$rust_type` fields as private attrs (single-underscore names);
@@ -357,7 +376,10 @@ def _set_inbound_map_entry(
         # before the `str`/`int` arms would swallow it as a plain scalar key.
         ek = entry.enum_key
         ek.name = get_type_map().py_type_to_baml_type(_base_class_for_fqn(type(key)))
-        ek.value = key.name
+        # Map-key twin of the enum-value encode above: send the member VALUE so
+        # a keyword-escaped member (`None_ = "None"`) keys the map by its raw
+        # BAML name. No-op when name == value (every non-escaped member).
+        ek.value = key.value
     elif isinstance(key, str):
         entry.string_key = key
     elif isinstance(key, int):

--- a/baml_language/sdks/python/src/baml_bridge/proto.py
+++ b/baml_language/sdks/python/src/baml_bridge/proto.py
@@ -171,14 +171,26 @@ def _set_inbound_value(
     if isinstance(value, enum.Enum):
         ev = inbound_value.enum_value
         ev.name = get_type_map().py_type_to_baml_type(_base_class_for_fqn(type(value)))
-        # Send the member VALUE, not its Python name. Decode is already by
-        # value (`_decode_enum`: `cls(enum_value.value)`), and codegen keeps the
-        # value equal to the BAML wire identity even when the member name is
-        # escaped off a keyword (`None_ = "None"`). For every non-escaped member
-        # name == value, so this is a no-op for existing SDKs; for an escaped
-        # member it puts the raw BAML name (`None`) on the wire instead of the
-        # Python identifier (`None_`) the engine would reject.
-        ev.value = value.value
+        # Codegen escapes an enum MEMBER whose BAML name is a Python keyword
+        # (`None` -> member `None_`, or the collision-bumped `None__` when a
+        # sibling `None_` is also present) and records the raw BAML identity in a
+        # generated `__baml_wire_values__` marker dict on the enum class,
+        # {member name -> raw wire name}, emitted ONLY for enums that carry an
+        # escaped member. Consume that marker as the sole provenance signal:
+        # a marked member wires its raw BAML name (`None_` -> `None`), and a member
+        # with no marker entry wires its member NAME, which is the pre-PR behavior.
+        # An ordinary hand-written or custom enum carries no marker and so takes
+        # this fallback; the lookup is a plain `getattr` by member name, so an enum
+        # that deliberately declares a well-formed marker, or inherits one through
+        # the MRO, is honored on the same path. The `.value` is never forwarded, so
+        # a member whose value is a non-str object cannot reach the string wire
+        # field. Decode is by value (`_decode_enum`: `cls(enum_value.value)`); a
+        # generated escaped member keeps `value == raw name`, so decode still
+        # round-trips.
+        marker = getattr(type(value), "__baml_wire_values__", None)
+        if not isinstance(marker, dict):
+            marker = {}
+        ev.value = marker.get(value.name, value.name)
         return
 
     # bool must precede int — bool is an int subclass in Python.
@@ -321,19 +333,28 @@ def _set_inbound_value(
         # then see them as `Map` instead of `Instance`, so a
         # `Box<Box<int>>` round-trip collapses into bare dicts at the
         # second level.
-        model_fields = type(value).model_fields
+        # Codegen escapes a field whose BAML name is a Python keyword
+        # (`None` -> `None_: T = pydantic.Field(alias="None")`, or the collision-
+        # bumped `None__` when a sibling `None_` is also present) and records the
+        # raw BAML identity in a generated `__baml_wire_names__` marker dict (a
+        # plain unannotated class-body assignment) on the model class, {python attr
+        # -> raw wire name}, emitted ONLY for classes that carry an escaped field.
+        # Consume that marker as the sole
+        # provenance signal: a marked attribute wires its raw BAML name
+        # (`None_` -> `None`), and an attribute with no marker entry wires its
+        # attribute NAME, which is the pre-PR behavior (so an ordinary user field
+        # aliased `wire_label`, and a user field named `None_` aliased `None`, both
+        # send the attribute name). The marker is a plain unannotated class-body
+        # dunder assignment, so it is not a
+        # pydantic field and never appears in `model_json_schema()`, and it is
+        # inherited through the MRO, so a user subclass of a generated model keeps
+        # correct wire identity for free. Decode is by wire name plus
+        # `populate_by_name`, unchanged.
+        wire_names = getattr(type(value), "__baml_wire_names__", None)
+        if not isinstance(wire_names, dict):
+            wire_names = {}
         for k, v in dict(value).items():
-            # Codegen escapes a field whose BAML name is a Python keyword
-            # (`pass` -> `pass_: T = pydantic.Field(alias="pass")`). The engine
-            # keys class fields by the raw BAML name, so put the alias on the
-            # wire when one is present; for every non-escaped field the alias is
-            # None and the wire key is the attribute name unchanged.
-            field_info = model_fields.get(k)
-            wire_key = (
-                field_info.alias
-                if field_info is not None and field_info.alias is not None
-                else k
-            )
+            wire_key = wire_names.get(k, k)
             _set_inbound_map_entry(
                 cv.fields.add(), wire_key, v, kwarg_name=kwarg_name, registered=registered
             )
@@ -372,10 +393,14 @@ def _set_inbound_map_entry(
         # before the `str`/`int` arms would swallow it as a plain scalar key.
         ek = entry.enum_key
         ek.name = get_type_map().py_type_to_baml_type(_base_class_for_fqn(type(key)))
-        # Map-key twin of the enum-value encode above: send the member VALUE so
-        # a keyword-escaped member (`None_ = "None"`) keys the map by its raw
-        # BAML name. No-op when name == value (every non-escaped member).
-        ek.value = key.value
+        # Map-key twin of the scalar-enum marker consumption above: a member listed
+        # in the enum class's generated `__baml_wire_values__` marker wires its raw
+        # BAML name; a member with no marker entry wires its member NAME (the pre-PR
+        # behavior). The `.value` is never forwarded.
+        marker = getattr(type(key), "__baml_wire_values__", None)
+        if not isinstance(marker, dict):
+            marker = {}
+        ek.value = marker.get(key.name, key.name)
     elif isinstance(key, str):
         entry.string_key = key
     elif isinstance(key, int):

--- a/baml_language/sdks/python/src/baml_bridge/proto.py
+++ b/baml_language/sdks/python/src/baml_bridge/proto.py
@@ -171,7 +171,14 @@ def _set_inbound_value(
     if isinstance(value, enum.Enum):
         ev = inbound_value.enum_value
         ev.name = get_type_map().py_type_to_baml_type(_base_class_for_fqn(type(value)))
-        ev.value = value.name
+        # Send the member VALUE, not its Python name. Decode is already by
+        # value (`_decode_enum`: `cls(enum_value.value)`), and codegen keeps the
+        # value equal to the BAML wire identity even when the member name is
+        # escaped off a keyword (`None_ = "None"`). For every non-escaped member
+        # name == value, so this is a no-op for existing SDKs; for an escaped
+        # member it puts the raw BAML name (`None`) on the wire instead of the
+        # Python identifier (`None_`) the engine would reject.
+        ev.value = value.value
         return
 
     # bool must precede int — bool is an int subclass in Python.
@@ -314,9 +321,21 @@ def _set_inbound_value(
         # then see them as `Map` instead of `Instance`, so a
         # `Box<Box<int>>` round-trip collapses into bare dicts at the
         # second level.
+        model_fields = type(value).model_fields
         for k, v in dict(value).items():
+            # Codegen escapes a field whose BAML name is a Python keyword
+            # (`pass` -> `pass_: T = pydantic.Field(alias="pass")`). The engine
+            # keys class fields by the raw BAML name, so put the alias on the
+            # wire when one is present; for every non-escaped field the alias is
+            # None and the wire key is the attribute name unchanged.
+            field_info = model_fields.get(k)
+            wire_key = (
+                field_info.alias
+                if field_info is not None and field_info.alias is not None
+                else k
+            )
             _set_inbound_map_entry(
-                cv.fields.add(), k, v, kwarg_name=kwarg_name, registered=registered
+                cv.fields.add(), wire_key, v, kwarg_name=kwarg_name, registered=registered
             )
         # Private attrs aren't iterated by `dict(value)`. Codegen emits
         # `$rust_type` fields as private attrs (single-underscore names);
@@ -353,7 +372,10 @@ def _set_inbound_map_entry(
         # before the `str`/`int` arms would swallow it as a plain scalar key.
         ek = entry.enum_key
         ek.name = get_type_map().py_type_to_baml_type(_base_class_for_fqn(type(key)))
-        ek.value = key.name
+        # Map-key twin of the enum-value encode above: send the member VALUE so
+        # a keyword-escaped member (`None_ = "None"`) keys the map by its raw
+        # BAML name. No-op when name == value (every non-escaped member).
+        ek.value = key.value
     elif isinstance(key, str):
         entry.string_key = key
     elif isinstance(key, int):

--- a/baml_language/sdks/python/tests/test_bridge_alias_enum_compat.py
+++ b/baml_language/sdks/python/tests/test_bridge_alias_enum_compat.py
@@ -1,0 +1,468 @@
+"""Bridge wire-identity coverage for the generator-provenance marker fix.
+
+Companion to `test_reserved_keywords.py`. The bridge encoder decides the wire
+name of a class field / enum member from a single, explicit signal: a generated
+`__baml_wire_names__` (classes) / `__baml_wire_values__` (enums) marker that the
+codegen stamps on an escaped artifact only. There is NO shape/alias/value
+heuristic anymore (`_is_keyword_escape_of` is deleted). The rule is:
+
+* a name listed in the marker wires its raw BAML name (the keyword the generator
+  escaped, e.g. attr `None_` -> `None`, member `None_` -> `None`), and
+* a name with no marker entry wires its own attribute / member NAME, which is
+  exactly the pre-PR bridge behavior, so an ordinary hand-written model or custom
+  enum, which carries no marker, encodes as it always did; a hand-written type
+  that declares a well-formed marker, or inherits one via the MRO, is honored on
+  the same lookup.
+
+This file pins that contract from both sides:
+
+* MARKER PATH, a generated-shape class/enum carrying the marker wires the raw
+  BAML name (single- and collision-bumped).
+* FALLBACK PATH (marker absent), hand-written models/enums, arbitrary user
+  aliases, custom str/int enums, and an ordinary BAML
+  `None_` identity the old shape heuristic misread as an escape, all wire their
+  attribute / member name. The int-subclass enum value whose `str()` is a
+  keyword can no longer TypeError because `.value` is never forwarded.
+* MARKER HYGIENE, the markers do not pollute the Enum member set, the pydantic
+  field set, or the JSON schema, and they ride the MRO to user subclasses.
+
+Like `test_reserved_keywords.py`, these drive the pure-Python `baml_bridge.proto`
+encode helpers with hand-rolled models/enums, no runtime or typemap is
+initialized. Generated-STYLE fixtures declare the dunder markers by hand exactly
+as the generator emits them; this file does not depend on the
+generator emission itself.
+"""
+
+from __future__ import annotations
+
+import enum
+import typing
+
+import pydantic
+import pytest
+
+from baml_bridge.proto import _set_inbound_value
+from baml_bridge.cffi.v1 import baml_inbound_pb2
+
+
+def _encode(value):
+    inbound = baml_inbound_pb2.InboundValue()
+    _set_inbound_value(inbound, value, kwarg_name="x")
+    return inbound
+
+
+# ---------------------------------------------------------------------------
+# Fixtures, GENERATED-SHAPE (carry the dunder marker) vs HAND-WRITTEN (no marker)
+# ---------------------------------------------------------------------------
+
+
+class _MarkedEscapedFieldModel(pydantic.BaseModel):
+    """Generated shape for `class M { pass int }`: keyword field `pass` renamed to
+    attr `pass_` (alias `pass` for decode) and stamped with the wire-name marker."""
+
+    model_config = pydantic.ConfigDict(extra="forbid", populate_by_name=True)
+    __baml_wire_names__ = {"pass_": "pass"}
+    pass_: int = pydantic.Field(alias="pass")
+
+
+class _MarkedTwinFieldModel(pydantic.BaseModel):
+    """Generated shape for `class C { None, None_ }`: the keyword field `None`
+    collides with a sibling `None_`, so the collision-aware escape double-bumps
+    its attribute to `None__` (marker -> raw `None`); the ordinary sibling `None_`
+    has no marker entry."""
+
+    model_config = pydantic.ConfigDict(extra="forbid", populate_by_name=True)
+    __baml_wire_names__ = {"None__": "None"}
+    None__: int = pydantic.Field(alias="None")
+    None_: int
+
+
+class _MarkedKeywordEnum(str, enum.Enum):
+    """Generated shape for `enum E { None, Ok }`: escaped member `None_` carries a
+    `__baml_wire_values__` marker; the non-keyword member `Ok` has no entry."""
+
+    __baml_wire_values__ = {"None_": "None"}
+    None_ = "None"
+    Ok = "Ok"
+
+
+class _MarkedTwinEnum(str, enum.Enum):
+    """Generated shape for `enum E { None, None_ }`: keyword member `None`
+    double-bumps to `None__` (marker -> raw `None`); the ordinary sibling `None_`
+    has no marker entry and keeps its own name."""
+
+    __baml_wire_values__ = {"None__": "None"}
+    None__ = "None"
+    None_ = "None_"
+
+
+class _HandwrittenNoneAliasedModel(pydantic.BaseModel):
+    """HAND-WRITTEN model for BAML `class C { None_ int }`. The ordinary BAML
+    identifier `None_` maps to Python attr `None_`; the user attaches
+    `Field(alias="None")` for their own reasons. NO marker (not generated), so the
+    bridge must wire the attribute name `None_`, the pre-PR identity. This is the
+    exact runtime shape the deleted shape heuristic misread as a keyword escape and
+    wired as `None`, breaking the call."""
+
+    model_config = pydantic.ConfigDict(extra="forbid", populate_by_name=True)
+    None_: int = pydantic.Field(alias="None")
+
+
+class _HandwrittenNoneValuedEnum(str, enum.Enum):
+    """HAND-WRITTEN enum for BAML `enum E { None_ }`: member `None_` with value
+    `"None"`, NO marker. The bridge must wire the member name `None_` (pre-PR
+    identity), not the value `"None"` (the enum half)."""
+
+    None_ = "None"
+
+
+class _GeneratedModel(pydantic.BaseModel):
+    """Codegen shape for `class Model { value int }`, no escaped field, no marker."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+    value: int
+
+
+class _UserAliasedModel(_GeneratedModel):
+    """User subclass that attaches an ARBITRARY (non-keyword) field alias, a
+    general Pydantic feature unrelated to keyword escaping, and NO marker. Pre-PR
+    the bridge wired the attribute name `value`; the marker-absent fallback
+    restores exactly that."""
+
+    model_config = pydantic.ConfigDict(extra="forbid", populate_by_name=True)
+    value: int = pydantic.Field(alias="wire_label")
+
+
+class _UserSubclassOfMarked(_MarkedEscapedFieldModel):
+    """A user subclass of a marked generated model. It inherits
+    `__baml_wire_names__` through the MRO, so the escaped field still wires under
+    its raw BAML name while a newly-added plain field wires under its own name."""
+
+    extra_field: int = 0
+
+
+class _StringWireEnum(str, enum.Enum):
+    """A custom str enum whose member VALUE diverges from its NAME, NO marker.
+    Pre-PR the bridge wired the member name `Foo`; the fallback restores that."""
+
+    Foo = "wire_label"
+
+
+class _IntegerWireEnum(int, enum.Enum):
+    """An int-backed enum, NO marker. Pre-PR the bridge wired the member name
+    `Foo`; the fallback restores that and never assigns a non-str to the wire."""
+
+    Foo = 7
+
+
+class KeywordStringifyingInt(int):
+    """An int subclass whose `str()` is a Python hard keyword. Exercises the
+    non-str enum-value path: the deleted shape gate evaluated `str(value.value)`
+    and, on the keyword match, forwarded the non-str `value.value` into the
+    protobuf string field, raising `TypeError`. The marker path never touches
+    `.value`, so the member NAME is sent and the TypeError path ceases to exist."""
+
+    def __str__(self) -> str:
+        return "pass"
+
+
+class _StringifyingIntValueEnum(enum.Enum):
+    """Custom enum whose member value is a `KeywordStringifyingInt`; NO marker."""
+
+    pass_ = KeywordStringifyingInt(7)
+
+
+# ---------------------------------------------------------------------------
+# Regression pinned: hand-written `None_`/alias-`None` keeps pre-PR
+# identity (wires `None_`). The hand-written regression, as a test.
+# ---------------------------------------------------------------------------
+
+
+def test_handwritten_none_field_aliased_none_wires_attribute_name():
+    inbound = _encode(_HandwrittenNoneAliasedModel(None_=5))
+    assert inbound.WhichOneof("value") == "class_value"
+    cv = inbound.class_value
+    assert len(cv.fields) == 1
+    # Marker absent -> attribute name `None_`, NOT the alias `None`.
+    assert cv.fields[0].string_key == "None_"
+    assert cv.fields[0].value.int_value == 5
+
+
+def test_handwritten_none_enum_scalar_wires_member_name():
+    inbound = _encode(_HandwrittenNoneValuedEnum.None_)
+    assert inbound.WhichOneof("value") == "enum_value"
+    # Marker absent -> member name `None_`, NOT the value `None`.
+    assert inbound.enum_value.value == "None_"
+
+
+def test_handwritten_none_enum_map_key_wires_member_name():
+    inbound = _encode({_HandwrittenNoneValuedEnum.None_: 1})
+    assert inbound.WhichOneof("value") == "map_value"
+    entry = inbound.map_value.entries[0]
+    assert entry.WhichOneof("key") == "enum_key"
+    assert entry.enum_key.value == "None_"
+    assert entry.value.int_value == 1
+
+
+# ---------------------------------------------------------------------------
+# Marker path: a marked generated artifact wires its raw BAML name,
+# single- and collision-bumped, across the class + both enum sites.
+# ---------------------------------------------------------------------------
+
+
+def test_marker_class_field_wires_raw_baml_name():
+    inbound = _encode(_MarkedEscapedFieldModel(**{"pass": 7}))
+    cv = inbound.class_value
+    assert len(cv.fields) == 1
+    # Marker `{"pass_": "pass"}` -> raw BAML name `pass`.
+    assert cv.fields[0].string_key == "pass"
+    assert cv.fields[0].value.int_value == 7
+
+
+def test_marker_twin_class_field_multibump_wires_raw_baml_name():
+    inbound = _encode(_MarkedTwinFieldModel(None__=7, None_=8))
+    cv = inbound.class_value
+    keys = {f.string_key: f.value.int_value for f in cv.fields}
+    # Double-bumped attr `None__` -> raw `None` via marker; the Python identifier
+    # `None__` must never reach the wire.
+    assert keys["None"] == 7
+    assert "None__" not in keys
+    # Sibling `None_` has no marker entry -> its own name.
+    assert keys["None_"] == 8
+
+
+def test_marker_enum_member_scalar_wires_raw_baml_name():
+    inbound = _encode(_MarkedKeywordEnum.None_)
+    assert inbound.WhichOneof("value") == "enum_value"
+    # Marker `{"None_": "None"}` -> raw BAML variant `None`.
+    assert inbound.enum_value.value == "None"
+
+
+def test_marker_enum_member_map_key_wires_raw_baml_name():
+    inbound = _encode({_MarkedKeywordEnum.None_: 1})
+    entry = inbound.map_value.entries[0]
+    assert entry.WhichOneof("key") == "enum_key"
+    assert entry.enum_key.value == "None"
+    assert entry.value.int_value == 1
+
+
+def test_marker_twin_enum_member_scalar_wires_raw_baml_name():
+    inbound = _encode(_MarkedTwinEnum.None__)
+    assert inbound.WhichOneof("value") == "enum_value"
+    # Double-bumped member `None__` -> raw `None` via marker.
+    assert inbound.enum_value.value == "None"
+
+
+def test_marker_twin_enum_member_map_key_wires_raw_baml_name():
+    inbound = _encode({_MarkedTwinEnum.None__: 1})
+    entry = inbound.map_value.entries[0]
+    assert entry.WhichOneof("key") == "enum_key"
+    assert entry.enum_key.value == "None"
+    assert entry.value.int_value == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression pinned: an int-subclass enum value whose `str()` is a
+# keyword encodes as the member NAME, no TypeError, scalar and map-key.
+# ---------------------------------------------------------------------------
+
+
+def test_keyword_stringifying_int_enum_scalar_wires_member_name():
+    inbound = _encode(_StringifyingIntValueEnum.pass_)
+    assert inbound.WhichOneof("value") == "enum_value"
+    # Member name `pass_`; `.value` (a non-str KeywordStringifyingInt) is never
+    # forwarded, so no `TypeError: bad argument type` on the string wire field.
+    assert inbound.enum_value.value == "pass_"
+
+
+def test_keyword_stringifying_int_enum_map_key_wires_member_name():
+    inbound = _encode({_StringifyingIntValueEnum.pass_: 9})
+    entry = inbound.map_value.entries[0]
+    assert entry.WhichOneof("key") == "enum_key"
+    assert entry.enum_key.value == "pass_"
+    assert entry.value.int_value == 9
+
+
+# ---------------------------------------------------------------------------
+# Marker hygiene: the dunder markers are not Enum members, not pydantic
+# fields, and not in the JSON schema.
+# ---------------------------------------------------------------------------
+
+
+def test_wire_values_marker_is_not_enum_member():
+    # EnumMeta excludes `__dunder__` names from membership, verified, not assumed.
+    assert "__baml_wire_values__" not in _MarkedKeywordEnum.__members__
+    assert "__baml_wire_values__" not in {m.name for m in _MarkedKeywordEnum}
+    # Still reachable as a plain class attribute for the encoder's getattr.
+    assert _MarkedKeywordEnum.__baml_wire_values__ == {"None_": "None"}
+    # Membership is exactly the two declared variants.
+    assert {m.name for m in _MarkedKeywordEnum} == {"None_", "Ok"}
+
+
+def test_wire_names_marker_is_not_pydantic_field_or_in_schema():
+    assert "__baml_wire_names__" not in _MarkedEscapedFieldModel.model_fields
+    schema = _MarkedEscapedFieldModel.model_json_schema()
+    assert "__baml_wire_names__" not in schema.get("properties", {})
+    # Still reachable as a ClassVar for the encoder's getattr.
+    assert _MarkedEscapedFieldModel.__baml_wire_names__ == {"pass_": "pass"}
+
+
+# ---------------------------------------------------------------------------
+# Inheritance: a user subclass of a marked model inherits the marker via
+# MRO and still wires the escaped field correctly.
+# ---------------------------------------------------------------------------
+
+
+def test_user_subclass_of_marked_model_wires_escaped_field():
+    inbound = _encode(_UserSubclassOfMarked(**{"pass": 7}))
+    cv = inbound.class_value
+    keys = {f.string_key: f.value.int_value for f in cv.fields}
+    # Inherited marker still maps `pass_` -> `pass`.
+    assert keys["pass"] == 7
+    assert "pass_" not in keys
+    # A field added by the subclass with no marker entry wires under its own name.
+    assert keys["extra_field"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Non-keyword controls (marker absent OR name not listed) keep pre-PR
+# behavior: attribute name for fields, member NAME for enums.
+# ---------------------------------------------------------------------------
+
+
+def test_user_subclass_arbitrary_alias_wires_attribute_name():
+    inbound = _encode(_UserAliasedModel(value=7))
+    assert inbound.WhichOneof("value") == "class_value"
+    cv = inbound.class_value
+    assert len(cv.fields) == 1
+    # Marker absent -> attribute name `value`, NOT the arbitrary alias `wire_label`.
+    assert cv.fields[0].string_key == "value"
+    assert cv.fields[0].value.int_value == 7
+
+
+def test_custom_string_enum_scalar_wires_member_name():
+    inbound = _encode(_StringWireEnum.Foo)
+    assert inbound.WhichOneof("value") == "enum_value"
+    # Member NAME `Foo`, not the diverging value `wire_label`.
+    assert inbound.enum_value.value == "Foo"
+
+
+def test_custom_string_enum_map_key_wires_member_name():
+    inbound = _encode({_StringWireEnum.Foo: 9})
+    entry = inbound.map_value.entries[0]
+    assert entry.WhichOneof("key") == "enum_key"
+    assert entry.enum_key.value == "Foo"
+    assert entry.value.int_value == 9
+
+
+def test_integer_backed_enum_scalar_wires_member_name():
+    inbound = _encode(_IntegerWireEnum.Foo)
+    assert inbound.WhichOneof("value") == "enum_value"
+    assert inbound.enum_value.value == "Foo"
+
+
+def test_integer_backed_enum_map_key_wires_member_name():
+    inbound = _encode({_IntegerWireEnum.Foo: 9})
+    entry = inbound.map_value.entries[0]
+    assert entry.WhichOneof("key") == "enum_key"
+    assert entry.enum_key.value == "Foo"
+    assert entry.value.int_value == 9
+
+
+def test_marker_present_but_member_not_listed_wires_member_name():
+    # `Ok` is absent from `_MarkedKeywordEnum`'s marker -> its own member name.
+    inbound = _encode(_MarkedKeywordEnum.Ok)
+    assert inbound.enum_value.value == "Ok"
+
+
+def test_marker_twin_enum_sibling_not_listed_wires_member_name():
+    # `None_` is the ordinary sibling, absent from the twin marker -> member name.
+    inbound = _encode(_MarkedTwinEnum.None_)
+    assert inbound.enum_value.value == "None_"
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: a `__baml_wire_names__` attribute that is not a dict (for
+# example a same-named method that shadowed the marker, or a malformed
+# hand-written marker) is ignored rather than `.get`-called, so encode falls
+# back to the attribute name instead of raising.
+# ---------------------------------------------------------------------------
+
+
+class _CallableWireNamesModel(pydantic.BaseModel):
+    """A model whose `__baml_wire_names__` attribute is a callable rather than the
+    marker dict, reproducing the class-creation collision a same-named user method
+    would cause (and any malformed hand-written marker). The bridge must treat a
+    non-dict marker as absent and wire the attribute name `pass_`."""
+
+    model_config = pydantic.ConfigDict(extra="forbid", populate_by_name=True)
+    pass_: int = pydantic.Field(alias="pass")
+
+    def __baml_wire_names__(self):
+        return 1
+
+
+def test_non_dict_wire_names_marker_is_ignored_and_wires_attribute_name():
+    inbound = _encode(_CallableWireNamesModel(**{"pass": 7}))
+    assert inbound.WhichOneof("value") == "class_value"
+    cv = inbound.class_value
+    assert len(cv.fields) == 1
+    # Callable (non-dict) marker ignored -> attribute name `pass_`, no
+    # `AttributeError: 'function' object has no attribute 'get'`.
+    assert cv.fields[0].string_key == "pass_"
+    assert cv.fields[0].value.int_value == 7
+
+
+# ---------------------------------------------------------------------------
+# A generated leaf that lowers a user `type dict = int` into a module-level
+# `dict = int` binding must not carry a bare-builtin `dict[...]` subscript in the
+# wire-name marker annotation, or `typing.get_type_hints` on the escaped class
+# resolves the subscript against the shadowed `dict` and raises. The generator
+# emits a plain, unannotated dunder dict, which is immune.
+# ---------------------------------------------------------------------------
+
+
+def _leaf_module_with_dict_shadow(name: str, marker_line: str):
+    """Build and register an importable module mirroring a generated leaf: the
+    user alias `type dict = int` lowered to `dict = int`, then an escaped-field
+    class carrying the wire-name marker as `marker_line`."""
+    import sys
+    import types
+
+    source = (
+        "from __future__ import annotations\n"
+        "import typing\n"
+        "import pydantic\n"
+        "dict = int\n"
+        "class Victim(pydantic.BaseModel):\n"
+        "    model_config = pydantic.ConfigDict(extra='forbid', populate_by_name=True)\n"
+        f"    {marker_line}\n"
+        "    pass_: int = pydantic.Field(alias='pass')\n"
+    )
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    exec(compile(source, f"<{name}>", "exec"), module.__dict__)
+    return module
+
+
+def test_plain_wire_names_marker_survives_get_type_hints_under_dict_shadow():
+    import sys
+
+    try:
+        plain = _leaf_module_with_dict_shadow(
+            "_leaf_probe_plain_marker", "__baml_wire_names__ = {'pass_': 'pass'}"
+        )
+        # Plain dunder dict carries no annotation, so introspection is unaffected.
+        assert typing.get_type_hints(plain.Victim) == {"pass_": int}
+
+        # The abandoned annotated form is exactly what breaks under the shadow:
+        # the bare `dict[str, str]` subscript resolves against `dict = int`.
+        annotated = _leaf_module_with_dict_shadow(
+            "_leaf_probe_annotated_marker",
+            "__baml_wire_names__: typing.ClassVar[dict[str, str]] = {'pass_': 'pass'}",
+        )
+        with pytest.raises(TypeError):
+            typing.get_type_hints(annotated.Victim)
+    finally:
+        sys.modules.pop("_leaf_probe_plain_marker", None)
+        sys.modules.pop("_leaf_probe_annotated_marker", None)

--- a/baml_language/sdks/python/tests/test_reserved_keywords.py
+++ b/baml_language/sdks/python/tests/test_reserved_keywords.py
@@ -57,9 +57,16 @@ def test_rust_keyword_list_matches_python_kwlist():
 
 
 class _EscapedFieldModel(pydantic.BaseModel):
-    """Mirrors generated codegen for a class with a keyword field `pass`."""
+    """Mirrors generated codegen for a class with a keyword field `pass`.
+
+    Codegen emits the escaped field with a `__baml_wire_names__` marker (a plain
+    unannotated class-body dunder assignment) recording the raw BAML name; that
+    marker is the sole signal the bridge consumes on encode (the `alias` remains
+    only for decode + `populate_by_name`).
+    """
 
     model_config = pydantic.ConfigDict(extra="forbid", populate_by_name=True)
+    __baml_wire_names__ = {"pass_": "pass"}
     pass_: int = pydantic.Field(alias="pass")
 
 
@@ -69,8 +76,14 @@ class _PlainModel(pydantic.BaseModel):
 
 
 class _KeywordEnum(str, enum.Enum):
-    """Mirrors generated codegen for an enum with a keyword member `None`."""
+    """Mirrors generated codegen for an enum with a keyword member `None`.
 
+    Codegen emits the escaped enum with a `__baml_wire_values__` marker (a plain
+    dunder dict, excluded from Enum membership by `EnumMeta`) recording the raw
+    BAML name; that marker is the sole signal the bridge consumes on encode.
+    """
+
+    __baml_wire_values__ = {"None_": "None"}
     None_ = "None"
     Ok = "Ok"
 
@@ -115,3 +128,49 @@ def test_escaped_enum_map_key_encodes_by_raw_value():
     entry = inbound.map_value.entries[0]
     assert entry.enum_key.value == "None"
     assert entry.value.int_value == 1
+
+
+class _MarkerFieldCollisionModel(pydantic.BaseModel):
+    """Mirrors generated codegen for a class whose own field is named exactly like
+    the wire-name marker (`__baml_wire_names__`) alongside a keyword field `pass`.
+
+    A model field cannot lead with `_` (pydantic raises at class creation), so the
+    generator projects the colliding field off the marker to `baml_wire_names___`
+    while the raw `__baml_wire_names__` stays the wire key via the alias and the
+    marker entry. The mere fact that this class body defines without raising is the
+    import-level proof: the pre-fix `__baml_wire_names___: T = pydantic.Field(...)`
+    shape raised `NameError` and broke import of the whole leaf module.
+    """
+
+    model_config = pydantic.ConfigDict(extra="forbid", populate_by_name=True)
+    __baml_wire_names__ = {"pass_": "pass", "baml_wire_names___": "__baml_wire_names__"}
+    pass_: int = pydantic.Field(alias="pass")
+    baml_wire_names___: str = pydantic.Field(alias="__baml_wire_names__")
+
+
+def test_marker_field_collision_model_imports_and_keeps_both_wire_keys():
+    # Import-level: both are real pydantic fields and the marker is a plain dunder.
+    assert set(_MarkerFieldCollisionModel.model_fields) == {"pass_", "baml_wire_names___"}
+    assert isinstance(_MarkerFieldCollisionModel.__baml_wire_names__, dict)
+    inbound = baml_inbound_pb2.InboundValue()
+    _set_inbound_value(
+        inbound,
+        _MarkerFieldCollisionModel(**{"pass": 7, "__baml_wire_names__": "v"}),
+        kwarg_name="x",
+    )
+    cv = inbound.class_value
+    # Both fields wire under their raw BAML names, not the escaped/projected attrs.
+    assert {f.string_key for f in cv.fields} == {"pass", "__baml_wire_names__"}
+
+
+def test_marker_field_collision_leading_underscore_shape_would_crash():
+    # Negative control: documents WHY the projection is required. The naive
+    # trailing-underscore bump keeps the marker's leading `__`, which pydantic
+    # refuses for a model field at class creation.
+    import pytest
+
+    with pytest.raises(NameError):
+
+        class _Crashes(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(populate_by_name=True)
+            __baml_wire_names___: str = pydantic.Field(alias="__baml_wire_names__")

--- a/baml_language/sdks/python/tests/test_reserved_keywords.py
+++ b/baml_language/sdks/python/tests/test_reserved_keywords.py
@@ -1,0 +1,117 @@
+"""Reserved-keyword wire-encoding coverage for issue #4059.
+
+Companion to the pydantic2 generator escape (which renames keyword
+identifiers on the Python side, e.g. field `pass` -> `pass_`, enum member
+`None` -> `None_`) and the `reserved_keywords` sdk-test fixture (which
+exercises the full generate + import + round-trip). These tests pin the
+*bridge* half: an escaped class field or enum member must go on the wire
+under its raw BAML name, not the escaped Python identifier, so the engine
+still recognizes it.
+
+They drive the pure-Python `baml_bridge.proto` encode helpers with
+hand-rolled models/enums, mirroring `test_proto_generics.py`. No runtime
+or typemap is initialized: the encode branches tolerate an empty typemap
+(`py_type_to_baml_type` returns "" for the informational FQN field), and
+what we assert is the field key / enum value placed on the wire.
+"""
+
+from __future__ import annotations
+
+import enum
+import keyword
+
+import pydantic
+
+from baml_bridge.proto import _set_inbound_value
+from baml_bridge.cffi.v1 import baml_inbound_pb2
+
+
+# The 35 CPython hard keywords the generator escapes. MUST stay in lockstep
+# with `PYTHON_HARD_KEYWORDS` in
+# sdks/python/rust/sdkgen_python_pydantic2/src/emit/mod.rs (whose own Rust
+# test `python_hard_keyword_set_is_exactly_the_35_cpython_hard_keywords`
+# asserts the same 35). `keyword.kwlist` is the cross-language anchor.
+_EXPECTED_HARD_KEYWORDS = frozenset(
+    {
+        "False", "None", "True", "and", "as", "assert", "async", "await",
+        "break", "class", "continue", "def", "del", "elif", "else", "except",
+        "finally", "for", "from", "global", "if", "import", "in", "is",
+        "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try",
+        "while", "with", "yield",
+    }
+)
+
+
+def test_rust_keyword_list_matches_python_kwlist():
+    """Cross-check the generator's escape set against CPython's own list.
+
+    Closes the loop the Rust-side test opens: Rust asserts its const equals
+    these 35; this asserts these 35 equal `keyword.kwlist`; together they
+    prove the Rust escape set equals `keyword.kwlist`.
+    """
+    assert set(keyword.kwlist) == _EXPECTED_HARD_KEYWORDS
+    assert len(_EXPECTED_HARD_KEYWORDS) == 35
+    # Soft keywords are valid identifiers and must NEVER be escaped.
+    assert set(keyword.softkwlist) == {"_", "case", "match", "type"}
+    assert _EXPECTED_HARD_KEYWORDS.isdisjoint(keyword.softkwlist)
+
+
+class _EscapedFieldModel(pydantic.BaseModel):
+    """Mirrors generated codegen for a class with a keyword field `pass`."""
+
+    model_config = pydantic.ConfigDict(extra="forbid", populate_by_name=True)
+    pass_: int = pydantic.Field(alias="pass")
+
+
+class _PlainModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+    value: int
+
+
+class _KeywordEnum(str, enum.Enum):
+    """Mirrors generated codegen for an enum with a keyword member `None`."""
+
+    None_ = "None"
+    Ok = "Ok"
+
+
+def test_escaped_class_field_goes_on_wire_under_raw_baml_name():
+    inbound = baml_inbound_pb2.InboundValue()
+    _set_inbound_value(inbound, _EscapedFieldModel(**{"pass": 7}), kwarg_name="x")
+    assert inbound.WhichOneof("value") == "class_value"
+    cv = inbound.class_value
+    assert len(cv.fields) == 1
+    # Raw BAML name `pass` on the wire, not the escaped attribute `pass_`.
+    assert cv.fields[0].string_key == "pass"
+    assert cv.fields[0].value.int_value == 7
+
+
+def test_non_escaped_field_wire_key_unchanged():
+    inbound = baml_inbound_pb2.InboundValue()
+    _set_inbound_value(inbound, _PlainModel(value=3), kwarg_name="x")
+    cv = inbound.class_value
+    assert cv.fields[0].string_key == "value"
+    assert cv.fields[0].value.int_value == 3
+
+
+def test_escaped_enum_member_encodes_by_raw_value():
+    inbound = baml_inbound_pb2.InboundValue()
+    _set_inbound_value(inbound, _KeywordEnum.None_, kwarg_name="x")
+    assert inbound.WhichOneof("value") == "enum_value"
+    # Raw BAML variant `None` on the wire, not the Python member name `None_`.
+    assert inbound.enum_value.value == "None"
+
+
+def test_non_escaped_enum_member_wire_value_unchanged():
+    inbound = baml_inbound_pb2.InboundValue()
+    _set_inbound_value(inbound, _KeywordEnum.Ok, kwarg_name="x")
+    assert inbound.enum_value.value == "Ok"
+
+
+def test_escaped_enum_map_key_encodes_by_raw_value():
+    inbound = baml_inbound_pb2.InboundValue()
+    _set_inbound_value(inbound, {_KeywordEnum.None_: 1}, kwarg_name="x")
+    assert inbound.WhichOneof("value") == "map_value"
+    entry = inbound.map_value.entries[0]
+    assert entry.enum_key.value == "None"
+    assert entry.value.int_value == 1

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/emit/mod.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/emit/mod.rs
@@ -22,6 +22,7 @@ use crate::{
         method::{MethodKind, OptionalArg, RequiredArg, TypeScriptMethodBinding},
         type_alias::TypeScriptTypeAlias,
     },
+    leaf::safe_decl_name,
     routing::{LeafPath, route},
 };
 
@@ -55,6 +56,12 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
         // identifier char, so a `$stream` companion class is emitted as
         // e.g. `Resume$stream` (not stripped to `Resume`). Non-stream
         // symbols are unaffected (their name carries no `$stream`).
+        //
+        // `bare` stays raw. The class / enum / type-alias arms below wrap it in
+        // `safe_decl_name` because those three names bind a module-scope
+        // identifier, where a reserved word is a parse error. Every wire-facing
+        // field on the emitted symbol (`source`, `baml_fqn`, enum member
+        // `value`) keeps the raw spelling.
         let bare = key.name().as_str().to_string();
 
         match symbol {
@@ -82,7 +89,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 out.push((
                     leaf,
                     EmittedSymbol::Class(TypeScriptClass {
-                        name: bare,
+                        name: safe_decl_name(&bare),
                         source: key.clone(),
                         generic_params,
                         docstring: c.docstring.clone(),
@@ -107,7 +114,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 out.push((
                     leaf,
                     EmittedSymbol::Enum(TypeScriptEnum {
-                        name: bare,
+                        name: safe_decl_name(&bare),
                         source: key.clone(),
                         variants,
                         docstring: e.docstring.clone(),
@@ -120,7 +127,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 out.push((
                     leaf,
                     EmittedSymbol::TypeAlias(TypeScriptTypeAlias {
-                        name: bare,
+                        name: safe_decl_name(&bare),
                         source: key.clone(),
                         resolves_to: t.resolves_to.clone(),
                         recursive: t.recursive,

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/leaf.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/leaf.rs
@@ -301,12 +301,17 @@ fn write_enum_doc(out: &mut String, e: &TypeScriptEnum) {
     out.push_str(" */\n");
 }
 
-/// `<T, U>` generic-parameter list, or empty.
+/// `<T, U>` generic-parameter list, or empty. A type-parameter name is a
+/// binding identifier, so it takes the same declaration escape as a class or
+/// enum name; `translate_ty` re-applies that escape at every `Ty::TypeVar` use
+/// site. The raw spellings still reach the runtime through the `$generic`
+/// array and the `typeParams` factory argument, which are string literals.
 fn generic_decl(params: &[String]) -> String {
     if params.is_empty() {
         String::new()
     } else {
-        format!("<{}>", params.join(", "))
+        let escaped: Vec<String> = params.iter().map(|p| safe_decl_name(p.as_str())).collect();
+        format!("<{}>", escaped.join(", "))
     }
 }
 
@@ -315,6 +320,31 @@ fn generic_decl(params: &[String]) -> String {
 /// `(default: V)` becomes `(default_: V)`. The real BAML name still travels in
 /// the `defineFunction` `paramNames` array for marshalling.
 pub(crate) fn safe_param_name(name: &str) -> String {
+    if is_js_reserved(name) {
+        format!("{name}_")
+    } else {
+        name.to_string()
+    }
+}
+
+/// A DECLARATION name binds an identifier in module scope, so unlike an enum
+/// member or a class property (both `IdentifierName`, where reserved words are
+/// legal) it cannot be a reserved word. `export enum import {}` is TS1359, and
+/// because it is a parse error it kills the whole generated file rather than
+/// just that one symbol. Append `_`, the same rule [`safe_param_name`] uses and
+/// the same rule the Python SDK's `escape_python_keyword` uses, so a BAML
+/// `enum import` renders as `export enum import_ {}`.
+///
+/// The escape is deliberately STATELESS. A class / enum / type-alias name has
+/// to be reproducible from the bare BAML `Name` alone at a distance, because
+/// `translate_ty::render_name_ref` re-derives the reference from the IR at
+/// every cross-reference rather than reading the emitted declaration back.
+///
+/// Only the TypeScript identifier moves. Wire identity travels on separate
+/// channels and is untouched: `defineFunction` is handed `baml_fqn`,
+/// `_typemap.ts` is keyed on `TypeScriptClass::source`, and enum member values
+/// are emitted verbatim, so dispatch and marshalling still target `import`.
+pub(crate) fn safe_decl_name(name: &str) -> String {
     if is_js_reserved(name) {
         format!("{name}_")
     } else {
@@ -1095,6 +1125,32 @@ mod tests {
             docstring: None,
             raises_names: Vec::new(),
         })
+    }
+
+    #[test]
+    fn safe_decl_name_escapes_only_reserved_words() {
+        assert_eq!(safe_decl_name("import"), "import_");
+        assert_eq!(safe_decl_name("class"), "class_");
+        assert_eq!(safe_decl_name("interface"), "interface_");
+        assert_eq!(safe_decl_name("Resume"), "Resume");
+        // Companion suffixes survive: `$` is a legal TS identifier character.
+        assert_eq!(safe_decl_name("Resume$stream"), "Resume$stream");
+        // Python keywords that are not reserved in TypeScript stay put, so the
+        // shared `reserved_keywords` fixture keeps per-language spellings
+        // rather than converging on one escaped set.
+        assert_eq!(safe_decl_name("None"), "None");
+        assert_eq!(safe_decl_name("pass"), "pass");
+        assert_eq!(safe_decl_name("lambda"), "lambda");
+    }
+
+    #[test]
+    fn generic_decl_escapes_reserved_type_parameters() {
+        assert_eq!(generic_decl(&[]), "");
+        assert_eq!(generic_decl(&["T".to_string()]), "<T>");
+        assert_eq!(
+            generic_decl(&["package".to_string(), "T".to_string()]),
+            "<package_, T>"
+        );
     }
 
     #[test]

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/lib.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/lib.rs
@@ -393,6 +393,54 @@ mod tests {
     }
 
     #[test]
+    fn reserved_declaration_name_is_escaped_and_wire_identity_is_preserved() {
+        let mut pool = SymbolPool::new();
+        let enum_name = name("user", &["lorem"], "import");
+        pool.insert(enum_name.clone(), enum_sym(&enum_name, 0));
+        let fn_name = name("user", &["lorem"], "pick");
+        pool.insert(
+            fn_name,
+            Symbol::Function(Function {
+                name: BaseName::new("pick"),
+                generic_params: Vec::new(),
+                docstring: None,
+                arguments: Vec::new(),
+                return_type: Ty::Enum(enum_name, baml_base::TyAttr::EMPTY),
+                throws: None,
+                watchers: Vec::new(),
+                origin: origin(1),
+            }),
+        );
+
+        let out = emit_sdk(&pool);
+        let leaf = &out[&PathBuf::from("lorem/index.ts")];
+        // `export enum import {` is TS1359, so the declaration takes the
+        // trailing-underscore escape ...
+        assert!(leaf.contains("export enum import_ {"), "{leaf}");
+        assert!(!leaf.contains("export enum import {"), "{leaf}");
+        // ... the member name is an `IdentifierName` and keeps its source
+        // spelling, as does its wire value ...
+        assert!(leaf.contains("POSITIVE = \"POSITIVE\","), "{leaf}");
+        // ... and the reference re-derives the same escaped spelling from the
+        // IR rather than dangling on the raw name.
+        assert!(leaf.contains("=> import_;"), "{leaf}");
+
+        // Wire identity is untouched: dispatch still names the raw BAML FQN.
+        assert!(
+            leaf.contains("defineFunction(\"user.lorem.pick\", \"sync\", [])"),
+            "{leaf}"
+        );
+        // The type map is still keyed on the raw FQN; only the module-scope
+        // attribute it resolves through moved.
+        let typemap = &out[&PathBuf::from("_typemap.ts")];
+        let entry = typemap
+            .lines()
+            .find(|line| line.contains("\"user.lorem.import\":"))
+            .expect("type map keys the enum on its raw BAML FQN");
+        assert!(entry.ends_with("[\"import_\"],"), "{entry}");
+    }
+
+    #[test]
     fn function_fans_out_sync_and_async() {
         let mut pool = SymbolPool::new();
         let n = name("user", &["lorem"], "extract_resume");

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
@@ -22,6 +22,7 @@ use baml_base::{Literal, MediaKind};
 use baml_codegen_types::{CodegenFunctionParamMode, Name, Ty};
 
 use crate::{
+    leaf::safe_decl_name,
     routing::{LeafPath, route_class_ref},
     ts_string,
 };
@@ -153,11 +154,17 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
         Ty::EnumVariant(name, variant, _) => {
             let mut result = render_name_ref(name, ctx);
             result.expr.push('.');
+            // The MEMBER stays raw. An enum member name is an `IdentifierName`,
+            // so a reserved word is legal both in the declaration
+            // (`{ import = "import" }`) and in this member access
+            // (`Kw.import`); escaping it here would dangle.
             result.expr.push_str(variant.as_str());
             result
         }
         Ty::TypeAlias(name, _) => render_name_ref(name, ctx),
-        Ty::TypeVar(name, _) => TranslatedType::bare(name.as_str().to_string()),
+        // A type parameter is a binding identifier at its declaration site
+        // (`leaf::generic_decl`), so the use site takes the same escape.
+        Ty::TypeVar(name, _) => TranslatedType::bare(safe_decl_name(name.as_str())),
 
         Ty::Function { params, ret, .. } => {
             let ret_t = translate_ty(ret, ctx);
@@ -241,7 +248,8 @@ pub(crate) const ROOT_ALIAS: &str = "_bamlRoot";
 /// The emitted identifier is the BAML name verbatim — including any
 /// `$stream` suffix (spec2: `$` is a valid TS identifier char, and stream
 /// companions live beside their base type rather than in a `stream_types/`
-/// namespace).
+/// namespace), except that a reserved word takes the same trailing-underscore
+/// escape [`crate::leaf::safe_decl_name`] applies to the declaration.
 ///
 /// - Same leaf → bare name, no import.
 /// - Root-namespace symbol referenced from a non-root leaf → `_bamlRoot.Name`
@@ -251,9 +259,13 @@ pub(crate) const ROOT_ALIAS: &str = "_bamlRoot";
 ///   `LeafPath` in `imports`.
 fn render_name_ref(name: &Name, ctx: &TranslateCtx) -> TranslatedType {
     let routed = route_class_ref(name);
-    let ident = name.name().as_str();
+    // Re-derived from the IR `Name`, never read back off the emitted
+    // declaration, so it has to apply the identical stateless escape that
+    // `emit::build_emitted` applied when it named the declaration. Escaping one
+    // side alone produces a dangling reference instead of a fixed file.
+    let ident = safe_decl_name(name.name().as_str());
     if routed == ctx.current_leaf {
-        return TranslatedType::bare(ident.to_string());
+        return TranslatedType::bare(ident);
     }
     let mut imports = BTreeSet::new();
     if routed.segments.is_empty() {
@@ -1009,5 +1021,59 @@ mod tests {
         for case in &cases {
             assert_ty(case);
         }
+    }
+
+    #[test]
+    fn reserved_declaration_names_are_re_escaped_at_reference_sites() {
+        // Same leaf: the bare identifier, escaped exactly as the declaration
+        // was escaped in `emit::build_emitted`.
+        assert_eq!(
+            translate_ty(
+                &enum_ty(name("user", &["lorem"], "import")),
+                &ctx(&["lorem"])
+            )
+            .expr,
+            "import_"
+        );
+        // Cross leaf: only the identifier moves; the routed namespace path is
+        // untouched, because a module path segment is not a binding site.
+        assert_eq!(
+            translate_ty(&enum_ty(name("user", &["lorem"], "import")), &ctx(&[])).expr,
+            "lorem.import_"
+        );
+        // Root-namespace symbol reached from a nested leaf.
+        assert_eq!(
+            translate_ty(
+                &class_ty(name("user", &[], "class"), vec![]),
+                &ctx(&["lorem"])
+            )
+            .expr,
+            "_bamlRoot.class_"
+        );
+        // The enum MEMBER keeps its source spelling: it is an `IdentifierName`
+        // in both the declaration and the member access.
+        assert_eq!(
+            translate_ty(
+                &enum_variant_ty(name("user", &["lorem"], "import"), "default"),
+                &ctx(&["lorem"])
+            )
+            .expr,
+            "import_.default"
+        );
+        // Type parameters are binding identifiers too.
+        assert_eq!(
+            translate_ty(&type_var(BaseName::new("package")), &ctx(&[])).expr,
+            "package_"
+        );
+        // Non-reserved names are untouched, so keyword-free schemas emit
+        // byte-identical output to before this change.
+        assert_eq!(
+            translate_ty(
+                &alias_ty(name("user", &["lorem"], "Json")),
+                &ctx(&["lorem"])
+            )
+            .expr,
+            "Json"
+        );
     }
 }


### PR DESCRIPTION
Fixes #4059.

The generators write BAML declaration names straight into target-language identifier
positions without checking them against that language's reserved words, so a BAML name that
happens to be a keyword produces a generated SDK that does not parse. In TypeScript a BAML
`enum import` emits `export enum import {`, which is TS1359. In C++ an enum member named
`and` emits `and = 0x...ULL` inside an `enum class`, which is not an identifier at all. In
Python a class field named `pass` emits `pass: str` in a class body. This escapes the
identifier in the Python, TypeScript and C++ generators. Only the language spelling moves:
the BAML name still goes on the wire.

| Commit | What it changes |
|---|---|
| `07e49ff` | python generator: escape reserved words in every remaining identifier site |
| `9128520` | python bridge: put BAML names on the wire for escaped fields and enum members |
| `bdb6255` | python: review response, generator-stamped wire-name marker and TypeVar allocator |
| `013fbfe` | typescript generator: escape reserved words in declaration names |
| `044a471` | cpp generator: escape the alternative operator tokens |

Escaping fires only on a name the target language reserves. Every other name is emitted
exactly as it is today, so a schema that names no reserved word of a given language renders
byte-identically in that language.

## Why this is no longer Python only

I opened this as a Python fix and it is still mostly Python: 12 of the 18 files. The
end-to-end fixture is what widened it. `harness_setup`'s `discover_fixtures` enrolls any
directory containing a `baml_src/` across every SDK with no per-SDK opt-out, so
`sdk_tests/fixtures/reserved_keywords/` also ran against the TypeScript and C++ generators,
and both emitted generated code that does not compile.

Those two gaps are pre-existing, not something the fixture introduced. Neither generator
changed behavior to produce them: both write declaration names the same way for any input,
and the escaping each already had was applied to other positions. `reserved_keywords` is the
only fixture under `sdk_tests/fixtures/` that gives a class, enum or type alias a declaration
name reserved in one of these languages, which is why nothing had exercised either gap before.

I would rather fix them here than land a fixture that turns two other generators red. If you
would prefer them split into their own PRs, say so and I will split them. One cost worth
naming so the choice is informed: CI on this fork needs a maintainer to approve each run, so
three PRs means three approvals rather than one.

## TypeScript

`sdkgen_typescript_shared` already had `is_js_reserved` and `JS_RESERVED`, but they were
applied only to parameters, free functions and child-namespace re-exports. Class, enum and
type-alias names were written raw, so a BAML `enum import` emitted `export enum import {`:
`TS1359: Identifier expected. 'import' is a reserved word that cannot be used here`, and the
parse error cascaded through the rest of the file.

The fix adds `safe_decl_name` beside `safe_param_name` and applies it at the two places that
name a binding: `emit::build_emitted`, where an IR name becomes an emitted symbol, and
`translate_ty::render_name_ref`, which re-derives every cross-reference from the IR rather
than reading the declaration back. Escaping one side alone would turn a parse error into a
dangling reference. Type parameters take the same escape in `generic_decl`. Escaping at
`build_emitted` also covers `_typemap.ts`, which indexes the module namespace through a
`Record<string, unknown>` cast; reading that cast, an unescaped symbol would resolve to
`undefined` at runtime with no compile-time signal. That last part is my reading of the code,
not a path I executed.

Only the positions JavaScript actually rejects are touched. Enum members and class properties
are `IdentifierName`, where reserved words are legal, so `enum Kw` still emits
`import = "import"`, `not = "not"`, `try = "try"` and so on, and tsc accepts every one. The
fixture's `class None`, `enum True`, `type False` and `type lambda` are also emitted raw,
because none of those is a JavaScript reserved word.

Wire identity is unchanged. Between the before and after trees, `_typemap.ts` differs by
exactly one line: the key `"user.import"` is untouched and only the symbol it resolves to
moves from `["import"]` to `["import_"]`. Dispatch still names the raw BAML FQN, and enum
member values, marshalling parameter names and the `$generic` / `typeParams` arrays all keep
their source spelling.

## C++

`CPP_KEYWORDS` listed 65 tokens and omitted every alternative token from [lex.digraph].
Per [lex.digraph]/2 those behave as their primary token in all respects except spelling, so
they are not usable as identifiers, and a BAML enum with `and`, `not` or `or` members emitted
`and = 0xe6f79719051ff286ULL,` inside `enum class Kw : uint64_t`. gcc rejects it with
`error: expected identifier before 'and' token`, and because the enum never closes, the rest
of the header goes with it.

The fix adds the 11 alternative tokens plus the 16 other keywords the table was missing (the
four `char*_t` types, the four named casts, `decltype`, `static_assert`, `thread_local`,
`consteval`, `constinit` and the three `co_` keywords), bringing it to the full 92 of C++23:
81 keywords from [lex.key] plus 11 alternative tokens from [lex.digraph]. A test asserts the
count and that the list stays sorted and duplicate-free. No call-site change was needed:
`preferred_token` already projects every `NameRequest` through `project`, which appends an
underscore on a hit.

Wire identity is unaffected. `CppName` stores `wire` separately from `canonical` and derives
it from the BAML FQN. The enumerator values are byte-identical across the change (they are
FNV-1a-64 hashes of the BAML wire string), and the generated codec still round-trips both
directions: `case ::baml_sdk::Kw::and_: return "and";` and
`if (value == "and") return ::baml_sdk::Kw::and_;`.

`import` deliberately stays unescaped in C++: it is not a keyword, it is an identifier with
special meaning only at the start of a module directive. With gcc 13.3.0 on linux/aarch64 I
syntax-checked a translation unit including the generated header at both `-std=c++17` and
`-std=c++20`, so `enum class import` is not a latent break for a consumer building at a newer
standard than the SDK's own `cxx_std_17` pin.

## Python

`escape_python_keyword` already exists in `sdkgen_python_pydantic2` (`emit/mod.rs`) with the
full hard-keyword list, but it only runs on function names and method bindings. Enum
variants, class fields, class/enum/type-alias names and TypeVar names are emitted verbatim.
So BAML like this:

```baml
enum Cell {
    None,
    Filled,
}

class Step {
    pass string,
}
```

generates Python that fails to import with a `SyntaxError`. A field named `lambda` is worse:
`lambda: int` in a class body parses as a lambda expression, so the field silently vanishes
instead of erroring.

Two more things surfaced while fixing it:

- Class methods are emitted as `Callable`-typed property annotations, which bypasses that
  method-binding escape, so keyword method names broke the same way.
- Escaping identifiers is only half of it. Decode (engine to host) matches class fields by
  BAML wire name and enums by value, but encode (host to engine) was emitting the Python
  identifier: `dict(value)` field names and enum `.name`. Renaming `pass` to `pass_` in the
  generator alone would fix imports and outputs while silently breaking inputs.

Same shape as the Go work in #4067: escape the Python spelling, never touch the BAML wire
identity.

**Commit 1 (generator, `sdkgen_python_pydantic2`):**
- Escape every remaining identifier site: enum variants, class properties, class/enum/type-alias
  names (including cross-references through `render_name_ref`, `__init__` re-exports, and
  `.pyi` stubs), and TypeVar names. The typemap and runtime FQNs keep the raw BAML names.
- Escaped enum members keep their value verbatim (`None_ = "None"`), which is what keeps
  decode-by-value working.
- An escaped field renders as `pass_: T = pydantic.Field(alias="pass")`, and any class with an
  escaped field gets `populate_by_name=True`. A class whose fields are all ordinary gains none
  of that field-level machinery: no alias, no `populate_by_name`, and no `__baml_wire_names__`
  marker. The class-name, reference, and `TypeVar` escaping described above still applies
  whenever the class name itself, or a name it references, is a keyword, so only a fully
  keyword-free schema renders byte-identically to today.
- Collisions resolve per scope with a used set (declaring both `pass` and `pass_` yields
  `pass__` and `pass_`), plus a `debug_assert` at the render boundary so a keyword can never
  slip through unescaped.
- Soft keywords (`match`, `case`, `type`) are left alone.

**Commit 2 (bridge, `baml_bridge/proto.py`):**
- Class-field encode sends each field through its alias when present, falling back to the
  field name, so escaped fields go on the wire under the BAML name.
- Enum encode sends `value.value` instead of `value.name`, matching decode (already
  `cls(<wire value>)`). Since name equals value for every non-escaped member, existing SDKs
  see no wire change.

Commit 2 touches the live encode path, so it deserves the closest review. Two structural facts
bound the risk: a generated enum member's value is always the BAML variant name
(`baml_language/crates/baml_project/src/client_codegen.rs:363` hardcodes
`value: v.name.to_string()`, and variant aliases are not applied to codegen), and before this
PR the generator never emitted `Field(alias=...)`, so the alias lookup falls back to the plain
field name across every existing SDK. Commit 2 initially consumed every alias and every enum
value on encode; review showed that regressed hand-written models with their own aliases and
custom enums, so the response commit replaces both paths with an explicit generator-stamped
marker.

**Commit 3 (review response).** One commit folds in the CodeRabbit findings plus three
further review passes I ran against my own branch:

- Root-routed import anchors for keyword classes are escaped, so a non-root leaf emits
  `from .. import None_` instead of the raw keyword (the actual site was `record_name_routing`
  in `leaf.rs`; `render_name_ref` already escaped the annotation, which is why the import line
  diverged from it). Callable-child signature imports are aggregated into the parent `.pyi`
  guarded block only when the referenced class required keyword escaping, so a keyword-free
  callable child leaves the parent stub unchanged.
- TypeVars are allocated once per leaf instead of per scope: distinct raw TypeVar spellings
  never collapse to one emitted name, while identical spellings (the same binder reused across
  scopes, or two independently generic functions both spelling `T`) deliberately share one
  module-level TypeVar, which is sound because each scope is independently generic on it. A
  keyword-escaped TypeVar bumps past every leaf-level class, enum, alias, module import anchor,
  aggregated child-signature import, and child submodule binding it could collide with,
  order-independently; callable-child helper bindings need no reservation because keyword
  bumping only appends trailing underscores and can never produce an underscore-leading name.
  Static-method signatures resolve through the enclosing class map (BAML statics can carry
  class generics), and callback Protocols render under their owner's map and deduplicate on the
  rendered signature. Non-keyword type parameters still map to themselves and the
  callable-child stub aggregation is keyword-gated, so keyword-free schemas render
  byte-identically.
- The bridge now chooses a wire identity only from an explicit provenance marker
  (`__baml_wire_names__` on classes, `__baml_wire_values__` on enums); it no longer infers
  provenance from an alias or enum-value shape. The generator stamps the marker on a class that
  has at least one escaped field, and on an enum that has at least one escaped member, and the
  marker lists only those escaped attribute or member names mapped to their raw BAML names, so
  the container's own name never drives emission. When the bridge finds no marker entry for an
  attribute or member, it wires that attribute or member name, which is the pre-PR behavior;
  ordinary hand-written models and custom enums carry no marker and take this fallback. The
  lookup is a `getattr` that honors only a `dict`-shaped marker (anything else under the marker
  name is ignored and the name fallback applies), so a hand-written type that deliberately
  declares a well-formed marker, or inherits one through the MRO, is honored on the same path.
  Because the marker values are generator-emitted string literals and a member's `.value` is
  never forwarded, an enum member whose value is a non-string object can no longer reach the
  protobuf string field, so the earlier encode-time `TypeError` cannot occur. The runtime shape
  inference (alias for classes, member value for enums) is deleted.
- Corrects a false claim in two of my own earlier comments: BAML admits 24 of the 35 Python
  hard keywords as class/enum/alias names, not only `None`/`True`/`False`. The end-to-end
  fixture now drives lowercase keyword names (`pass`, `import`, `lambda`) through generate,
  import, and the engine.

## Tests

- `sdk_tests/fixtures/reserved_keywords/baml_src/main.baml`: an `enum Kw` whose members are
  keywords in several target languages, a `class Fields` with keyword-named fields, the
  keyword-named types `None`, `True`, `False`, `pass`, `import` and `lambda`, and round-trip
  functions over them. Soft-keyword negative controls included.
- `sdk_tests/crates/python_pydantic2/reserved_keywords/customizable/test_reserved_keywords.py`:
  10 pytest cases round-tripping escaped enum members, class fields and keyword-named types
  through the engine.
- `sdks/python/tests/test_reserved_keywords.py` (8 cases, one cross-checking the Rust keyword
  list against `keyword.kwlist`) and `sdks/python/tests/test_bridge_alias_enum_compat.py`
  (23 cases) pin hand-written models and custom string / integer enums to their pre-PR encode
  behavior, drive the marker consumption path for escaped fields and members including the
  collision-bumped case, and guard against re-regression.
- TypeScript generator crate: `safe_decl_name_escapes_only_reserved_words`,
  `generic_decl_escapes_reserved_type_parameters`,
  `reserved_declaration_name_is_escaped_and_wire_identity_is_preserved`, and
  `reserved_declaration_names_are_re_escaped_at_reference_sites`.
- C++ generator crate: `test_alternative_operator_tokens_are_escaped` and
  `test_cpp_keywords_match_the_standard_table`.
- Python generator crate: the keyword tests loop over all 35 hard keywords for enum members and
  class fields (including the `lambda` presence check), plus name cross-reference, collision,
  soft-keyword and byte-identical controls, and the response commit's tests pin the leaf
  TypeVar allocator, the static and callback map threading, the keyword-gated parent-stub import
  aggregation, the import-anchor escape, and the wire-name marker emission and reservation.

## What I ran, and where

Nothing below is a statement about your CI. Both workflows on this head are still sitting at
`action_required`, so upstream CI has never run on it. Everything here is work I ran myself.

### The fixture on three platforms

I put this PR's exact tree on a branch on my public fork with one extra file, a workflow that
runs the `sdk_tests` harness on `ubuntu-latest`, `windows-latest` and `macos-latest`, and ran
it. That branch is one commit ahead of this PR head and the only file that differs anywhere in
the tree is the workflow YAML, so the results describe this code. Two things to know before the
numbers: it is not your CI configuration (it deliberately carries no mise, no direnv and no
Infisical), and it writes every cell's exit code and every nextest summary to a file instead of
failing the job, so the run's green badge is not the evidence. The numbers below are read out of
those files. Run:
https://github.com/addiplus/baml/actions/runs/31695117485

38 `reserved_keywords` cells passed. No cell produced a compiler or test failure. Two did not
start at all, for the infrastructure reason below.

| Cell | macOS arm64 | Ubuntu x86_64 | Windows x86_64 |
|---|---|---|---|
| cpp `compile`, `run` | pass | pass | did not run, see below |
| typescript `tsc_node`, `esm_node` | pass | pass | pass |
| typescript_web `tsc_web`, `tsc_workers`, `esm_web`, `esm_workers` | pass | pass | pass |
| rust `fmt`, `clippy`, `cargo_test` | pass | pass | pass |
| python_pydantic2 `ruff`, `pyright`, `pytest` | not scheduled | pass | pass |
| swift `swift_test` | pass | not scheduled | not scheduled |

Windows TypeScript is the leg I most wanted, because the fixture had never run there:
`SETUP PASS [864.236s] typescript_pnpm_win` on the Windows-native `setup.ps1` path, then
`esm_node` and `tsc_node`, `2 tests run: 2 passed, 17 skipped`. So `tsc --noEmit` accepts the
generated TypeScript on `x86_64-pc-windows-msvc`.

C++ on Windows did not run, and I am claiming nothing there. The fixture driver shells out to
`bash test.sh compile`, `bash` resolved to WSL's, and the runner reported
`Windows Subsystem for Linux has no installed distributions`. Both cells died in 0.24 seconds,
before any compiler started. The C++ SDK itself built on that leg. Unverified, not failing.

`macos-latest` is arm64, so this gives no x86_64 macOS coverage, and Python is not scheduled on
that leg. Every `build_diagnostics.txt` came back empty on all three legs: zero codegen
soft-failures for any SDK on any platform.

### Generated output is identical across those platforms

I hashed every file under `sdk_tests/crates/*/reserved_keywords/generated/`. macOS arm64
against Ubuntu x86_64: 270 files compared, 270 byte-identical raw, no normalization of any
kind. Against Windows, 229 of the 270 match raw; 37 of the remainder differ only in line
endings and are vendored or scaffold files (C++ SDK headers, protobuf, `Package.swift`,
`tsconfig*.json`), and the last 4 are `package.json` and `pnpm-lock.yaml`, differing in a path
separator inside a local dependency the test harness writes. Every BAML-emitted file is
identical on all three platforms. I did not preserve the aarch64 tree, so I cannot extend that
comparison to a fourth platform.

### Swift

The Swift cell is `#[ignore]`d in the harness, so I forced it with `--run-ignored all` and it
executed rather than being skipped: `PASS [159.297s] sdk_test_swift
reserved_keywords::swift_test`, `1 test run: 1 passed (1 slow), 7 skipped`. `swift test` builds
the package first, so the generated Swift package compiles under Swift 6.3.3 on
arm64-apple-macosx26.0. This PR does not touch the Swift generator; I ran it because the fixture
auto-enrolls there and I wanted to know. One thing worth recording, because it looks wrong at a
glance: the generated Swift carries a bare unescaped `case async` and `public var async:
Swift.Int` in the same file as `func round_trip_fields_async(...) async throws`, and that is
correct, because `async` is contextual in Swift. Four true reserved words are backtick-escaped
and no others. macOS arm64 only.

### The same fixture on linux/aarch64

With gcc 13.3.0, TypeScript 5.9.3 on node 22.23.2 and cargo 1.93.0:

```
PASS [  18.526s] sdk_test_cpp              reserved_keywords::compile
PASS [ 136.543s] sdk_test_cpp              reserved_keywords::run
PASS [   1.438s] sdk_test_typescript       reserved_keywords::tsc_node
PASS [   0.032s] sdk_test_typescript       reserved_keywords::esm_node
PASS [   2.484s] sdk_test_typescript_web   reserved_keywords::tsc_web
PASS [   2.048s] sdk_test_typescript_web   reserved_keywords::tsc_workers
PASS [   0.034s] sdk_test_typescript_web   reserved_keywords::esm_web
PASS [   0.020s] sdk_test_typescript_web   reserved_keywords::esm_workers
PASS [   0.082s] sdk_test_python_pydantic2 reserved_keywords::ruff
PASS [   0.722s] sdk_test_python_pydantic2 reserved_keywords::pytest
PASS [   2.309s] sdk_test_python_pydantic2 reserved_keywords::pyright
```

Package totals in the same run: `sdk_test_cpp` 14/14, `sdk_test_typescript` 19/19,
`sdk_test_typescript_web` 34/34, `sdk_test_python_pydantic2` 20/20, `sdk_test_rust` 20/20.

### A control that fails

A green gate that cannot detect the defect is worth nothing, so I ran the same gates on a
before control at `bdb62555`, the commit that carries the fixture but neither generator fix:

- C++ `test.sh compile` fails with
  `generated/baml_sdk/include/baml_sdk.h:811:3: error: expected identifier before 'and' token`.
- TypeScript, running the exact command the harness issues
  (`tsc --noEmit --project tsconfig.web.json`), fails with
  `web/baml_sdk/index.ts(161,13): error TS1359: Identifier expected. 'import' is a reserved
  word that cannot be used here`. On the fixed tree the same command reports no syntax errors.

### Generator crates and regression sweep, on linux/aarch64

- `cargo check -p sdkgen_typescript_shared -p sdkgen_cpp`: exit 0 on a forced recompile of every
  file the two new commits touch.
- `cargo clippy -p sdkgen_typescript_shared -p sdkgen_cpp --all-targets`: zero warnings.
- `cargo test -p sdkgen_typescript_shared -p sdkgen_cpp`: 69 passed, 0 failed, 1 ignored. That
  ignored test predates this PR.
- `cargo fmt --all -- --check`: exit 0. `cargo check` over the workspace: exit 0, excluding
  `sdk_test_go`, whose codegen step needs `gofmt`, which is not installed on the box I used.
- All six C++ fixtures still compile (`docstrings_etc`, `function_calls`, `llm_functions`,
  `reserved_keywords`, `type_shapes`, `unsupported_only`). The `CPP_KEYWORDS` change is global
  to that generator, so that is the blast radius.
- I swept both generated TypeScript trees, node and web, for any of the 46 ES reserved and
  strict-mode reserved words in declaration position. No matches.

I am not making any claim about the Java, C# or Go generators.

## Not covered here (follow-ups)

- Function and method parameter names. The `_define_function` string lists are both the
  accepted kwargs and the wire keys, and optional host-callable params arrive keyed by the BAML
  name, so renaming params needs a Python-name-to-wire-name map, not a spelling change. Today a
  keyword param breaks only the `.pyi` stub, not the import.
- The module-segment TODO in `routing.rs` (`assert` to `assert_` for leaf paths) is a separate
  concern, untouched.
- One pathological corner: declaring both `None` and `None_` as top-level type names in the
  same namespace. Type NAME escaping is stateless (definition and reference sites resolve
  independently through `render_name_ref`, with no shared state), so that pair collides after
  escaping. Today that source is already unimportable (`class None:` is emitted verbatim), so
  it is not a regression; a full fix needs the Go generator's allocator-style name projection,
  which felt like scope creep here. Field-versus-field and enum-member collisions, and (since
  the response commit) TypeVar collisions, are resolved.
- TypeScript has the same twin corner, and CodeRabbit has flagged it on this PR, so I should
  state where I land. `safe_decl_name` is stateless for the same reason the Python type-name
  escape is: `render_name_ref` re-derives every cross-reference from the IR rather than reading
  the emitted declaration back, so the escaped spelling has to be reproducible from the bare
  BAML name alone. A leaf declaring both `import` and `import_` therefore emits
  `export enum import_` twice. Before this PR that same file emitted `export enum import`,
  which is TS1359 and takes the whole generated file with it, so it is broken before and broken
  after, differently. The half I do think is worth fixing is generic binders: `generic_decl`
  maps each type parameter through the same stateless escape, while the Python side of this PR
  allocates TypeVars leaf-globally against a reserved set. That asymmetry is inside my own diff.
  The fix is mirroring the Python allocator into `generic_decl`, plus a `{package, package_}`
  test. I kept it out of this PR to hold the diff to the cases that break parsing.
- A field and a method whose escaped spellings collide (field `pass` plus method `pass_`, or
  the mirror image) emit two class members with the same name, and the module still imports:
  the later method assignment clobbers the field's `pydantic.Field(alias=...)`, so the raw wire
  key stops validating and the method object silently replaces the field. A static method
  collides the same way. Both spellings pass `baml check`; the same raw name on both members is
  rejected at source, so the trigger is specifically distinct raw names whose escaped spellings
  collide. Neither direction produces working output on the base revision, and the two
  directions differ. Non-keyword field plus keyword method collides identically on the base
  revision, because `expand_methods` already ran method names through `escape_python_keyword`
  there while class properties were emitted raw; this PR does not change that case. Keyword
  field plus non-keyword method does not import at all on the base revision, since the raw
  keyword field is a `SyntaxError`; this PR makes that module import and then be silently wrong,
  which is a worse failure shape even though it is not a regression from working output.
  Confirmed with a generator-level repro plus a real pydantic import. The fix is allocating
  field and method final names against one shared per-class set.
- An ordinary-identifier class that shadows a same-named module TypeVar (`class T` next to a
  generic `<T>` in one leaf) already produces un-importable output on canary today; this PR
  neither fixes nor worsens it, and keyword-escaped TypeVars now bump around such classes.
- A callable child returning an ordinary (non-keyword) root class leaves that class unbound in
  the parent `.pyi` on the base revision today. The stub aggregation is deliberately
  keyword-gated to keep keyword-free output byte-identical, so the ordinary-name case is left as
  a follow-up.
- The same stub aggregation anchors only root-routed keyword classes: a callable child returning
  a keyword-named class that lives on a nested (non-root) module path still emits its escaped
  annotation unbound in the parent `.pyi`, in both bare and dotted reference forms. `baml check`
  and `baml generate` accept the trigger schema. The impact is type-checker-only; the runtime
  `.py` never references the name, so nothing breaks at import or runtime. Confirmed with a
  generator-level repro.
- The source-level reserved-name checks in baml-lib are gated on `GeneratorOutputType`, which
  has no variant for this generator, so nothing fires before emission. Worth naming the tension
  rather than asserting my way past it: #759 asked for exactly this, detection in the static
  analyzer, and #1955 delivered it, but `RESERVED_NAMES_TYPESCRIPT` is empty under a comment
  that TypeScript is flexible about the key names it allows, and the position this PR fixes is a
  declaration name, not a key. I read escaping and source-level detection as complements rather
  than alternatives, and which of them you want is your call.

## Known limitations and disclosures

- Marker values are trusted, not validated. The bridge derives wire identity only from the
  generator-stamped marker. The supported contract is narrow: a class or enum either carries no
  marker and wires its plain attribute or member names, or it carries a `dict[str, str]` mapping
  each escaped Python name to its raw BAML wire name. Generated code only ever emits that second
  form. The bridge checks only that the marker is a `dict` and ignores anything else (the name
  fallback applies); it does not validate the value types, so a hand-crafted dict whose values
  are not strings, which the generator never emits, can still raise or reshape wire keys at
  encode time. Validating the marker values at the bridge boundary is a reasonable future
  hardening; I kept the encode path a guarded dict lookup here.

- The Python SDK test setup refreshes `baml_language/sdks/python/uv.lock`. The checked-in lock
  is stale against `pyproject.toml` (the lock pins `baml-bridge 0.15.0` while the project is at
  `0.16.0`), so running the SDK test setup rewrites it. That staleness is pre-existing and
  present identically on the base revision; this PR leaves that lock file byte-identical to the
  base and does not bundle a lock refresh, and my test gate restores the file after setup. I
  left the refresh out because it would pull an unrelated dependency bump into a
  keyword-escaping change.

- Mixed generator/runtime versions fall back to escaped names. The bridge derives wire identity
  only from the generator-stamped marker, so a client generated before this change carries no
  marker. Pairing such an older generated client with a runtime that includes this change makes
  the encoder fall back to the escaped Python name (`pass_`, `None_`) on the wire, which can
  mismatch the engine's raw BAML name. baml ships the generator and the Python runtime from one
  release and expects them regenerated in lockstep, so after upgrading the runtime you
  regenerate your client and the markers are present. I did not add a cross-version shim,
  because keeping the generated client and the installed runtime on the same release is the
  existing supported path.

Everything above is my own runs, on my own hardware and my own fork. Nothing in this PR has run
on your CI yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SDK generation when BAML classes, enums, fields, aliases, or type variables use language-reserved keywords.
  * Preserved original names and values during encoding, decoding, enum map-key handling, and engine round-trips.
  * Improved handling of naming collisions and generated metadata fields.
  * Added broader reserved-word coverage for Python, TypeScript, and C++ SDKs.
* **Tests**
  * Added comprehensive regression coverage for keyword escaping, aliases, generic types, imports, collisions, and wire compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->