### PR TITLE
perf(compile): parallel check/MIR/emit + inference dedup (0.63s → 0.27s cold, byte-identical)

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "borsh",
  "indexmap",
  "log",
+ "rayon",
  "rustc-hash 2.1.2",
  "salsa",
 ]
@@ -1120,6 +1121,7 @@ dependencies = [
  "bex_vm_types",
  "la-arena",
  "lsp-types",
+ "rayon",
  "salsa",
  "serde",
  "serde_json",
@@ -1175,6 +1177,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
+ "rayon",
  "salsa",
  "serde_json",
  "syn 2.0.117",
@@ -6153,6 +6156,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -211,6 +211,7 @@ prost-build = "0.14.1"
 protoc-bin-vendored = "3"
 quote = { version = "1" }
 ratatui = "0.29"
+rayon = { version = "1.10" }
 regex = { version = "1.10.2" }
 # gitignore-aware directory walking (workspace project discovery in the LSP)
 ignore = { version = "0.4" }

--- a/baml_language/crates/baml_compiler2_emit/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_emit/Cargo.toml
@@ -25,5 +25,6 @@ bex_vm_types = { workspace = true }
 borsh = { workspace = true }
 indexmap = { workspace = true }
 log = { workspace = true }
+rayon = { workspace = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true }

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -280,8 +280,20 @@ struct StackifyCodegen<'ctx, 'obj> {
     enum_object_indices: &'ctx HashMap<String, usize>,
     /// Enum variant mappings (enum name -> variant name -> variant index).
     enum_variants: &'ctx HashMap<String, HashMap<String, usize>>,
-    /// Shared object pool.
+    /// Read-only snapshot of pooled class field metadata (name + type, in
+    /// field order), keyed by every name registered in `class_object_indices`.
+    /// Field lookups resolve through this map instead of reading the object
+    /// pool, so codegen never reads pool contents (parallel emit compiles
+    /// against fragment pools that don't contain the pre-existing objects).
+    class_fields: &'ctx crate::ClassFieldSnapshot,
+    /// Object pool this function's codegen mints into. Serial emit passes the
+    /// whole program pool; parallel emit passes a worker-local fragment pool.
     objects: &'obj mut ObjectPool,
+    /// Program-absolute index of `objects[0]`. Serial emit mints into the
+    /// program pool directly (base 0); parallel workers mint into a fresh
+    /// fragment pool based at the shared watermark, so every index this
+    /// codegen embeds is program-absolute either way.
+    objects_base: usize,
 
     /// Analysis results (classifications, def-use, etc.).
     analysis: AnalysisResult,
@@ -410,7 +422,9 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             class_object_indices: ctx.class_object_indices,
             enum_object_indices: ctx.enum_object_indices,
             enum_variants: ctx.enum_variants,
+            class_fields: ctx.class_fields,
             objects: ctx.objects,
+            objects_base: ctx.objects_base,
             analysis,
             local_slots: HashMap::with_capacity(body.locals.len()),
             real_local_count: 0,
@@ -438,13 +452,23 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         }
     }
 
-    /// Look up a field name from the `ObjectPool` given a class name and field index.
+    /// Append an object to the pool, returning its program-absolute index
+    /// (`objects_base` + local position). The ONLY way codegen adds pool
+    /// objects: parallel emit relies on every minted index being expressed
+    /// relative to the shared watermark.
+    fn mint_object(&mut self, object: Object) -> usize {
+        let idx = self.objects_base + self.objects.len();
+        self.objects.push(object);
+        idx
+    }
+
+    /// Look up a field name from the class-field snapshot given a class name
+    /// and field index.
     fn lookup_class_field_name(&self, class_name: &str, field_idx: usize) -> Option<String> {
-        let &obj_idx = self.class_object_indices.get(class_name)?;
-        match self.objects.get(obj_idx)? {
-            Object::Class(class) => class.fields.get(field_idx).map(|f| f.name.clone()),
-            _ => None,
-        }
+        self.class_fields
+            .get(class_name)?
+            .get(field_idx)
+            .map(|(name, _)| name.clone())
     }
 
     fn class_object_index_for_type_name(&self, tn: &TypeName) -> Option<usize> {
@@ -458,6 +482,18 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                     .copied()
             })
             .or_else(|| self.class_object_indices.get(tn.name().as_str()).copied())
+    }
+
+    /// Class field metadata for a class type name, resolved through the same
+    /// name fallbacks as [`Self::class_object_index_for_type_name`] but
+    /// against the read-only snapshot instead of the pool.
+    fn class_fields_for_type_name(&self, tn: &TypeName) -> Option<&[(String, RuntimeTy)]> {
+        let full_name = tn.render_dotted(false);
+        self.class_fields
+            .get(&full_name)
+            .or_else(|| self.class_fields.get(tn.display_name().as_str()))
+            .or_else(|| self.class_fields.get(tn.name().as_str()))
+            .map(Vec::as_slice)
     }
 
     /// Enum-object index for an enum type name, mirroring
@@ -485,15 +521,10 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             Place::Field { base, field } => {
                 let base_ty = self.resolve_place_type(base)?;
                 match &base_ty {
-                    RuntimeTy::Class(type_name, _, _) => {
-                        let obj_idx = self.class_object_index_for_type_name(type_name)?;
-                        match self.objects.get(obj_idx)? {
-                            Object::Class(class) => {
-                                class.fields.get(*field).map(|f| f.field_type.clone())
-                            }
-                            _ => None,
-                        }
-                    }
+                    RuntimeTy::Class(type_name, _, _) => self
+                        .class_fields_for_type_name(type_name)?
+                        .get(*field)
+                        .map(|(_, field_type)| field_type.clone()),
                     _ => None,
                 }
             }
@@ -1404,8 +1435,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                         let call_site_span = self.current_debug_span;
 
                         // 1. Push event name "$baml_log"
-                        let log_str_idx = self.objects.len();
-                        self.objects.push(Object::String("$baml_log".into()));
+                        let log_str_idx = self.mint_object(Object::String("$baml_log".into()));
                         let log_const_idx = self
                             .add_constant(ConstValue::Object(ObjectIndex::from_raw(log_str_idx)));
                         let inst = self.emit(Instruction::LoadConst(log_const_idx));
@@ -1421,8 +1451,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                             LogLevel::Warn => "warn",
                             LogLevel::Error => "error",
                         };
-                        let level_val_idx = self.objects.len();
-                        self.objects.push(Object::String(level_str.into()));
+                        let level_val_idx = self.mint_object(Object::String(level_str.into()));
                         let level_val_const_idx = self
                             .add_constant(ConstValue::Object(ObjectIndex::from_raw(level_val_idx)));
                         let inst = self.emit(Instruction::LoadConst(level_val_const_idx));
@@ -1435,8 +1464,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                         unwrap_infallible(pull_semantics::walk_call_direct_args(self, args));
 
                         // 4. Push key "level"
-                        let level_key_idx = self.objects.len();
-                        self.objects.push(Object::String("level".into()));
+                        let level_key_idx = self.mint_object(Object::String("level".into()));
                         let level_key_const_idx = self
                             .add_constant(ConstValue::Object(ObjectIndex::from_raw(level_key_idx)));
                         let inst = self.emit(Instruction::LoadConst(level_key_const_idx));
@@ -1446,8 +1474,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                         );
 
                         // 5. Push key "data"
-                        let data_key_idx = self.objects.len();
-                        self.objects.push(Object::String("data".into()));
+                        let data_key_idx = self.mint_object(Object::String("data".into()));
                         let data_key_const_idx = self
                             .add_constant(ConstValue::Object(ObjectIndex::from_raw(data_key_idx)));
                         let inst = self.emit(Instruction::LoadConst(data_key_const_idx));
@@ -1831,9 +1858,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 // reference it via ConstValue::Object so that `to_value()` can
                 // resolve it to a HeapPtr at load time.
                 let operand_str = format!("{v}n");
-                let obj_idx = self.objects.len();
-                self.objects
-                    .push(Object::Bigint(std::sync::Arc::new(v.clone())));
+                let obj_idx = self.mint_object(Object::Bigint(std::sync::Arc::new(v.clone())));
                 let const_idx =
                     self.add_constant(ConstValue::Object(ObjectIndex::from_raw(obj_idx)));
                 let inst = self.emit(Instruction::LoadConst(const_idx));
@@ -1846,8 +1871,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             }
             Constant::String(s) => {
                 let display = Self::display_string_operand(s);
-                let obj_idx = self.objects.len();
-                self.objects.push(Object::String(s.as_str().into()));
+                let obj_idx = self.mint_object(Object::String(s.as_str().into()));
                 let idx = self.add_constant(ConstValue::Object(ObjectIndex::from_raw(obj_idx)));
                 let inst = self.emit(Instruction::LoadConst(idx));
                 self.set_operand(inst, OperandMeta::Const(display));
@@ -1888,20 +1912,27 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                     .get(&name_str)
                     .unwrap_or_else(|| panic!("undefined function: {name_str}"));
                 let gidx = GlobalIndex::from_raw(global_idx);
-                let existing = self.objects.iter().position(|o| {
-                    matches!(o, Object::GenericFunction(gf)
+                // Serial emit scans the whole program pool here, so identical
+                // instantiations minted by EARLIER functions are reused too.
+                // Parallel emit scans only this worker's fragment; the serial
+                // merge replays the cross-function dedup in original function
+                // order (see `merge_function_fragment`), reproducing the exact
+                // serial candidate set and pool layout.
+                let existing = self
+                    .objects
+                    .iter()
+                    .position(|o| {
+                        matches!(o, Object::GenericFunction(gf)
                         if gf.function == gidx && gf.type_args.as_ref() == type_args.as_slice())
-                });
+                    })
+                    .map(|local| self.objects_base + local);
                 let pool_idx = match existing {
                     Some(idx) => idx,
                     None => {
-                        let idx = self.objects.len();
-                        self.objects
-                            .push(Object::GenericFunction(bex_vm_types::GenericFunction {
-                                function: gidx,
-                                type_args: type_args.clone().into_boxed_slice(),
-                            }));
-                        idx
+                        self.mint_object(Object::GenericFunction(bex_vm_types::GenericFunction {
+                            function: gidx,
+                            type_args: type_args.clone().into_boxed_slice(),
+                        }))
                     }
                 };
                 let const_idx =
@@ -3083,8 +3114,7 @@ impl PullSink for StackifyCodegen<'_, '_> {
             write!(display, "\\x{b:02x}").unwrap();
         }
         display.push('"');
-        let obj_idx = self.objects.len();
-        self.objects.push(Object::Uint8Array(bytes.to_vec().into()));
+        let obj_idx = self.mint_object(Object::Uint8Array(bytes.to_vec().into()));
         let idx = self.add_constant(ConstValue::Object(ObjectIndex::from_raw(obj_idx)));
         let inst = self.emit(Instruction::LoadConst(idx));
         self.set_operand(inst, OperandMeta::Const(display));
@@ -3585,6 +3615,7 @@ mod tests {
         let class_object_indices = HashMap::new();
         let enum_object_indices = HashMap::new();
         let enum_variants = HashMap::new();
+        let class_fields = HashMap::new();
         let mut objects = ObjectPool::default();
         let lambda_object_indices = Vec::new();
         let lambda_names = Vec::new();
@@ -3603,7 +3634,9 @@ mod tests {
                 class_object_indices: &class_object_indices,
                 enum_object_indices: &enum_object_indices,
                 enum_variants: &enum_variants,
+                class_fields: &class_fields,
                 objects: &mut objects,
+                objects_base: 0,
                 lambda_object_indices: &lambda_object_indices,
                 lambda_names: &lambda_names,
                 capture_types: &capture_types,

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -794,6 +794,14 @@ fn emitted_function_origin(
     }
 }
 
+/// Read-only snapshot of pooled class field metadata: every name registered in
+/// `class_object_indices` → the class's fields (name + type, in field order).
+/// Built once from the `Object::Class` entries before function bodies are
+/// compiled, so codegen resolves field names/types without reading the object
+/// pool (a hard requirement for parallel emit, whose workers compile against
+/// fragment pools that don't contain the pre-existing objects).
+pub(crate) type ClassFieldSnapshot = HashMap<String, Vec<(String, RuntimeTy)>>;
+
 /// Context for MIR codegen.
 pub(crate) struct MirCodegenContext<'ctx, 'obj> {
     pub globals: &'ctx HashMap<String, usize>,
@@ -801,7 +809,12 @@ pub(crate) struct MirCodegenContext<'ctx, 'obj> {
     pub class_object_indices: &'ctx HashMap<String, usize>,
     pub enum_object_indices: &'ctx HashMap<String, usize>,
     pub enum_variants: &'ctx HashMap<String, HashMap<String, usize>>,
+    pub class_fields: &'ctx ClassFieldSnapshot,
     pub objects: &'obj mut ObjectPool,
+    /// Program-absolute index of `objects[0]`: 0 when `objects` is the whole
+    /// program pool (serial emit), the Stage-B watermark when it is a
+    /// worker-local fragment pool (parallel emit).
+    pub objects_base: usize,
     /// Maps MIR lambda index → `ObjectPool` index of the compiled lambda `Function`.
     /// Parallel to `lambda_names`. Empty for non-lambda functions.
     pub lambda_object_indices: &'ctx [usize],
@@ -2919,218 +2932,61 @@ fn emit_file_group(
         }
     }
 
+    // Read-only snapshot of pooled class field metadata for function-body
+    // codegen, built after Pass 3b so it covers every alias registered in
+    // `class_object_indices` (including classes minted by earlier file
+    // groups). See [`ClassFieldSnapshot`].
+    let class_fields: ClassFieldSnapshot = class_object_indices
+        .iter()
+        .filter_map(|(name, &idx)| match program.objects.get(idx) {
+            Some(Object::Class(class)) => Some((
+                name.clone(),
+                class
+                    .fields
+                    .iter()
+                    .map(|f| (f.name.clone(), f.field_type.clone()))
+                    .collect(),
+            )),
+            _ => None,
+        })
+        .collect();
+
     // --- Pass 4: Compile each function ---
-    for file in files {
-        let rel_path = relative_source_path(db, *file);
-        // A clean file (incremental compile) is not emitted here at all — its
-        // compiled unit is taken verbatim from the cached image by the caller. We
-        // never lower a clean file's bodies (the core B-693 Stage 6 invariant).
-        if let Some(clean) = skip_clean {
-            if clean.contains(&rel_path) {
-                continue;
-            }
-        }
-        // This file's bodies are about to be MIR/bytecode-lowered — record it for
-        // the Stage 6 "only dirty files are lowered" evidence counter.
-        record_lowered_file(&rel_path);
-        let line_starts = build_line_starts(file.text(db));
-        let item_tree = file_item_tree(db, *file);
-        let pkg_info_pass4 = file_package(db, *file);
-        let is_builtin_file = file.path(db).to_string_lossy().starts_with("<builtin>/");
-        let cache_pass4 = &alias_caches[&pkg_info_pass4.package];
-        for (local_id, func_data) in &item_tree.functions {
-            let func_loc = FunctionLoc::new(db, *file, *local_id);
-            let mir = lower_function(db, func_loc, opt);
-            let fq_name = mir.item_ref.to_string();
-
-            let mut compiled_fn = match &mir.kind {
-                MirFunctionKind::Bytecode(body) => {
-                    // Compile lambda children first, collecting their ObjectPool indices.
-                    let source_file = relative_source_path(db, *file);
-                    let empty_capture_types = Vec::new();
-                    let empty_spawn_capture_indices = HashSet::new();
-                    let lambda_info = compile_lambdas_flat(
-                        &mir.lambdas,
-                        Some(body),
-                        &empty_capture_types,
-                        &empty_spawn_capture_indices,
-                        &line_starts,
-                        &source_file,
-                        globals,
-                        classes,
-                        class_object_indices,
-                        enum_object_indices,
-                        enum_variants,
-                        &mut program.objects,
-                        opt,
-                    );
-                    let lambda_obj_indices: Vec<usize> =
-                        lambda_info.iter().map(|(idx, _)| *idx).collect();
-                    let lambda_names_vec: Vec<String> =
-                        lambda_info.iter().map(|(_, name)| name.clone()).collect();
-                    let ctx = MirCodegenContext {
-                        globals,
-                        classes,
-                        class_object_indices,
-                        enum_object_indices,
-                        enum_variants,
-                        objects: &mut program.objects,
-                        lambda_object_indices: &lambda_obj_indices,
-                        lambda_names: &lambda_names_vec,
-                        capture_types: &empty_capture_types,
-                        spawn_capture_indices: &empty_spawn_capture_indices,
-                    };
-                    let mut f =
-                        compile_mir_function(body, mir.arity, mir.span, &line_starts, ctx, opt);
-                    f.name.clone_from(&fq_name);
-                    f.source_file.clone_from(&source_file);
-                    f
-                }
-                MirFunctionKind::Builtin(BuiltinKind::Intrinsic) => {
-                    // Intrinsic functions have no callable body — call sites use
-                    // StatementKind::Intrinsic directly. Skip compilation entirely.
-                    continue;
-                }
-                MirFunctionKind::Builtin(BuiltinKind::AwaitAny) => {
-                    // BEP-034 `__await_any` has no callable body — call sites
-                    // lower to a `Terminator::AwaitAny` suspend point directly.
-                    // Skip compilation entirely (like an intrinsic).
-                    continue;
-                }
-                MirFunctionKind::Builtin(BuiltinKind::Io) => {
-                    let sys_op = bex_vm_types::sys_op_for_path(&fq_name)
-                        .unwrap_or_else(|| panic!("unknown sys_op path: {fq_name}"));
-                    Function {
-                        name: fq_name.clone(),
-                        source_file: String::new(), // builtins have no source file
-                        arity: mir.arity,
-                        real_local_count: 0,
-                        bytecode: Bytecode::default(),
-                        kind: FunctionKind::SysOp(sys_op),
-                        local_names: Vec::new(),
-                        debug_locals: Vec::new(),
-                        span: Span::fake(),
-                        return_type: baml_type::RuntimeTy::Null {
-                            attr: baml_type::TyAttr::default(),
-                        },
-                        param_names: Vec::new(),
-                        param_types: Vec::new(),
-                        param_has_default: Vec::new(),
-                        display_type_params: Vec::new(),
-                        display_param_types: Vec::new(),
-                        display_return_type: "null".to_string(),
-                        throws_type: None,
-                        origin: FunctionOrigin::Builtin,
-                        body_meta: None,
-                        capture: FunctionCaptureProps::disabled(),
-                        function_id: 0, // assigned at engine init (interim provider)
-                    }
-                }
-                MirFunctionKind::Builtin(BuiltinKind::Vm) => Function {
-                    name: fq_name.clone(),
-                    source_file: String::new(), // builtins have no source file
-                    arity: mir.arity,
-                    real_local_count: 0,
-                    bytecode: Bytecode::default(),
-                    kind: FunctionKind::NativeUnresolved,
-                    local_names: Vec::new(),
-                    debug_locals: Vec::new(),
-                    span: Span::fake(),
-                    return_type: baml_type::RuntimeTy::Null {
-                        attr: baml_type::TyAttr::default(),
-                    },
-                    param_names: Vec::new(),
-                    param_types: Vec::new(),
-                    param_has_default: Vec::new(),
-                    display_type_params: Vec::new(),
-                    display_param_types: Vec::new(),
-                    display_return_type: "null".to_string(),
-                    throws_type: None,
-                    origin: FunctionOrigin::Builtin,
-                    body_meta: None,
-                    capture: FunctionCaptureProps::disabled(),
-                    function_id: 0, // assigned at engine init (interim provider)
-                },
-            };
-
-            // Set function metadata from signature
-            let parameter_defaults = baml_compiler2_ppir::function_parameter_defaults(db, func_loc);
-            let signature_metadata = compute_function_metadata_from_item_tree(
-                db,
-                *file,
-                *local_id,
-                func_data,
-                &parameter_defaults,
-                cache_pass4,
-            );
-            compiled_fn.return_type = signature_metadata.return_type;
-            compiled_fn.param_names = signature_metadata.param_names;
-            compiled_fn.param_types = signature_metadata.param_types;
-            compiled_fn.param_has_default = signature_metadata.param_has_default;
-            compiled_fn.display_type_params = signature_metadata.display_type_params;
-            compiled_fn.display_param_types = signature_metadata.display_param_types;
-            compiled_fn.display_return_type = signature_metadata.display_return_type;
-
-            // Set inferred throws type from TIR throw inference
-            compiled_fn.throws_type = compute_throws_type(db, *file, &func_data.name, cache_pass4);
-            compiled_fn.origin =
-                emitted_function_origin(&fq_name, is_builtin_file, func_data.origin);
-
-            // Set LLM-specific body_meta if this is an LLM function
-            if let Some(baml_compiler2_ast::DeclarativeMeta::Llm(llm_meta)) =
-                &func_data.declarative_meta
-            {
-                // NOTE (canary merge): canary removed the runtime `Function.stream_return_type`
-                // field and its plumbing (the pre-existing streaming infra from PRs #3362/#3755).
-                // The stream return type is now carried by the synthesized `$stream` companion's
-                // own `return_type` (see ppir's `companion_stream_return_type`), so the old
-                // emit-side pre-computation block was dropped. BEP-049 M5e stream-path rendering
-                // of `ctx.output_format` should be re-verified against canary's streaming.
-                if let Some(client) = &llm_meta.client {
-                    // New-mode (BEP-049 M5) functions have no Jinja `prompt`
-                    // text — the compiled closure renders it — but they still
-                    // need a registry entry so `get_return_type` /
-                    // `get_stream_return_type` (used by `__make_stream` and the
-                    // streaming `Context`) resolve by name. The empty template
-                    // is never read for them (their `prompt_closure` is non-null,
-                    // so the Jinja `get_jinja_template` branch is skipped).
-                    let prompt_template = llm_meta
-                        .prompt
-                        .as_ref()
-                        .map(|p| p.text.clone())
-                        .unwrap_or_default();
-                    compiled_fn.body_meta = Some(FunctionMeta::Llm {
-                        prompt_template,
-                        client: client.to_string(),
-                    });
-                    compiled_fn.capture = FunctionCaptureProps::disabled()
-                        .with_auto(CaptureCategory::Input)
-                        .with_auto(CaptureCategory::Output)
-                        .with_auto(CaptureCategory::Error);
-                }
-            }
-
-            let fn_obj_idx = program.add_object(Object::Function(Box::new(compiled_fn)));
-            program.function_indices.insert(fq_name.clone(), fn_obj_idx);
-            let val = ConstValue::Object(ObjectIndex::from_raw(fn_obj_idx));
-            if skip_clean.is_some() {
-                // Dirty-only emit: write the function value at its whole-project
-                // (Pass-1) slot rather than appending, so clean-file slot holes are
-                // preserved and every operand slot reverses to the right name.
-                let slot = globals[&fq_name];
-                program.function_global_indices.insert(fq_name, slot);
-                program.globals[slot] = val;
-            } else {
-                let slot = program.globals.len();
-                debug_assert_eq!(
-                    globals.get(&fq_name).copied(),
-                    Some(slot),
-                    "Pass-4 append slot must match the Pass-1 assignment for {fq_name}",
-                );
-                program.function_global_indices.insert(fq_name, slot);
-                program.add_global(val);
-            }
-        }
+    if rayon::current_num_threads() > 1 {
+        // Default: compile function bodies across rayon workers. Byte-identical
+        // to the serial pass — see `emit_functions_parallel` for the
+        // fragment/watermark design. A single-threaded pool (RAYON_NUM_THREADS=1,
+        // or a 1-thread `ThreadPool::install`, as the emit-determinism test uses)
+        // takes the serial path, which is also the reference implementation.
+        emit_functions_parallel(
+            db,
+            files,
+            skip_clean,
+            globals,
+            classes,
+            class_object_indices,
+            enum_object_indices,
+            enum_variants,
+            &class_fields,
+            alias_caches,
+            program,
+            opt,
+        );
+    } else {
+        emit_functions_serial(
+            db,
+            files,
+            skip_clean,
+            globals,
+            classes,
+            class_object_indices,
+            enum_object_indices,
+            enum_variants,
+            &class_fields,
+            alias_caches,
+            program,
+            opt,
+        );
     }
 
     // Stage 6 (`SkipClean`) / design §9 R2: the `$init` / `$init_test` tail is a
@@ -3201,6 +3057,7 @@ fn emit_file_group(
                 class_object_indices,
                 enum_object_indices,
                 enum_variants,
+                &class_fields,
                 &mut *program,
                 opt,
             )?;
@@ -4200,6 +4057,569 @@ fn collect_lambda_capture_infos(
     infos
 }
 
+/// Pass 4, serial (the reference implementation, used on 1-thread pools):
+/// lower and compile every function body,
+/// file by file, straight into the program pool.
+#[allow(clippy::too_many_arguments)]
+fn emit_functions_serial(
+    db: &dyn baml_compiler2_mir::Db,
+    files: &[baml_base::SourceFile],
+    skip_clean: Option<&HashSet<String>>,
+    globals: &HashMap<String, usize>,
+    classes: &HashMap<String, HashMap<String, usize>>,
+    class_object_indices: &HashMap<String, usize>,
+    enum_object_indices: &HashMap<String, usize>,
+    enum_variants: &HashMap<String, HashMap<String, usize>>,
+    class_fields: &ClassFieldSnapshot,
+    alias_caches: &HashMap<Name, ResolvedAliases>,
+    program: &mut Program,
+    opt: OptLevel,
+) {
+    for file in files {
+        let rel_path = relative_source_path(db, *file);
+        // A clean file (incremental compile) is not emitted here at all — its
+        // compiled unit is taken verbatim from the cached image by the caller. We
+        // never lower a clean file's bodies (the core B-693 Stage 6 invariant).
+        if let Some(clean) = skip_clean {
+            if clean.contains(&rel_path) {
+                continue;
+            }
+        }
+        // This file's bodies are about to be MIR/bytecode-lowered — record it for
+        // the Stage 6 "only dirty files are lowered" evidence counter.
+        record_lowered_file(&rel_path);
+        let line_starts = build_line_starts(file.text(db));
+        let item_tree = file_item_tree(db, *file);
+        let pkg_info_pass4 = file_package(db, *file);
+        let is_builtin_file = file.path(db).to_string_lossy().starts_with("<builtin>/");
+        let cache_pass4 = &alias_caches[&pkg_info_pass4.package];
+        for (local_id, func_data) in &item_tree.functions {
+            let func_loc = FunctionLoc::new(db, *file, *local_id);
+            let mir = lower_function(db, func_loc, opt);
+            let fq_name = mir.item_ref.to_string();
+
+            let mut compiled_fn = match &mir.kind {
+                MirFunctionKind::Bytecode(body) => {
+                    // Compile lambda children first, collecting their ObjectPool indices.
+                    let source_file = relative_source_path(db, *file);
+                    let empty_capture_types = Vec::new();
+                    let empty_spawn_capture_indices = HashSet::new();
+                    let lambda_info = compile_lambdas_flat(
+                        &mir.lambdas,
+                        Some(body),
+                        &empty_capture_types,
+                        &empty_spawn_capture_indices,
+                        &line_starts,
+                        &source_file,
+                        globals,
+                        classes,
+                        class_object_indices,
+                        enum_object_indices,
+                        enum_variants,
+                        class_fields,
+                        &mut program.objects,
+                        0,
+                        opt,
+                    );
+                    let lambda_obj_indices: Vec<usize> =
+                        lambda_info.iter().map(|(idx, _)| *idx).collect();
+                    let lambda_names_vec: Vec<String> =
+                        lambda_info.iter().map(|(_, name)| name.clone()).collect();
+                    let ctx = MirCodegenContext {
+                        globals,
+                        classes,
+                        class_object_indices,
+                        enum_object_indices,
+                        enum_variants,
+                        class_fields,
+                        objects: &mut program.objects,
+                        objects_base: 0,
+                        lambda_object_indices: &lambda_obj_indices,
+                        lambda_names: &lambda_names_vec,
+                        capture_types: &empty_capture_types,
+                        spawn_capture_indices: &empty_spawn_capture_indices,
+                    };
+                    let mut f =
+                        compile_mir_function(body, mir.arity, mir.span, &line_starts, ctx, opt);
+                    f.name.clone_from(&fq_name);
+                    f.source_file.clone_from(&source_file);
+                    f
+                }
+                MirFunctionKind::Builtin(kind) => {
+                    match builtin_emit_function(*kind, &fq_name, mir.arity) {
+                        Some(f) => f,
+                        // Intrinsics and `__await_any` have no callable body —
+                        // call sites lower to `StatementKind::Intrinsic` /
+                        // `Terminator::AwaitAny` directly. Skip entirely.
+                        None => continue,
+                    }
+                }
+            };
+
+            attach_function_metadata(
+                db,
+                *file,
+                *local_id,
+                func_data,
+                cache_pass4,
+                is_builtin_file,
+                &fq_name,
+                &mut compiled_fn,
+            );
+            register_compiled_function(
+                program,
+                globals,
+                skip_clean.is_some(),
+                fq_name,
+                compiled_fn,
+            );
+        }
+    }
+}
+
+/// One function's Pass-4 state carried from the serial lowering stage to the
+/// parallel codegen stage and the serial merge stage.
+struct FnWorkItem {
+    file: baml_base::SourceFile,
+    local_id: baml_compiler2_hir::ids::LocalItemId<baml_compiler2_hir::ids::FunctionMarker>,
+    mir: baml_compiler2_mir::MirFunction,
+    fq_name: String,
+    /// Project-relative source path (`relative_source_path`).
+    source_file: String,
+    /// Line index of the item's file, shared by every function in the file.
+    line_starts: std::sync::Arc<[u32]>,
+    is_builtin_file: bool,
+}
+
+/// Pass 4, parallel (`BAML_PARALLEL_EMIT=1`): compile function bodies across
+/// rayon workers, byte-identically to [`emit_functions_serial`].
+///
+/// Three stages:
+///
+/// - **Stage A (serial, salsa)**: lower every function to MIR in exactly the
+///   serial pass's iteration order, collecting owned work items.
+/// - **Stage B (parallel, no salsa)**: pure codegen of every bytecode body.
+///   Each worker mints into a fresh fragment pool based at the shared
+///   watermark `W = program.objects.len()`, so pre-existing absolute indices
+///   (< W: classes/enums/interfaces from Passes 1–3, resolved through frozen
+///   maps and the [`ClassFieldSnapshot`]) stay valid and every worker mint is
+///   fragment-relative (>= W). Workers never touch `program.globals` — every
+///   `GlobalIndex` they embed is a Pass-1 slot read from the frozen `globals`
+///   map — so global operands are absolute in every worker and are never
+///   rewritten at merge time.
+/// - **Stage C (serial merge, original order)**: splice each fragment into
+///   the program pool (replaying cross-function `GenericFunction` interning —
+///   see [`merge_function_fragment`]), then run the unchanged serial tail
+///   (metadata attachment and registration).
+///
+/// Because the serial pool is append-only within Pass 4 and the only
+/// cross-function coupling is the `GenericFunction` interning scan (replayed
+/// exactly by the merge), concatenating fragments in original function order
+/// reproduces the serial pool layout byte for byte.
+#[allow(clippy::too_many_arguments)]
+fn emit_functions_parallel(
+    db: &dyn baml_compiler2_mir::Db,
+    files: &[baml_base::SourceFile],
+    skip_clean: Option<&HashSet<String>>,
+    globals: &HashMap<String, usize>,
+    classes: &HashMap<String, HashMap<String, usize>>,
+    class_object_indices: &HashMap<String, usize>,
+    enum_object_indices: &HashMap<String, usize>,
+    enum_variants: &HashMap<String, HashMap<String, usize>>,
+    class_fields: &ClassFieldSnapshot,
+    alias_caches: &HashMap<Name, ResolvedAliases>,
+    program: &mut Program,
+    opt: OptLevel,
+) {
+    use rayon::prelude::*;
+
+    // --- Stage A: lower every function to MIR (serial: salsa queries) ---
+    let mut work: Vec<FnWorkItem> = Vec::new();
+    for file in files {
+        let rel_path = relative_source_path(db, *file);
+        // Clean files are never lowered (see the serial pass).
+        if let Some(clean) = skip_clean {
+            if clean.contains(&rel_path) {
+                continue;
+            }
+        }
+        record_lowered_file(&rel_path);
+        let line_starts: std::sync::Arc<[u32]> = build_line_starts(file.text(db)).into();
+        let item_tree = file_item_tree(db, *file);
+        let is_builtin_file = file.path(db).to_string_lossy().starts_with("<builtin>/");
+        for local_id in item_tree.functions.keys() {
+            let func_loc = FunctionLoc::new(db, *file, *local_id);
+            let mir = lower_function(db, func_loc, opt);
+            let fq_name = mir.item_ref.to_string();
+            work.push(FnWorkItem {
+                file: *file,
+                local_id: *local_id,
+                mir,
+                fq_name,
+                source_file: rel_path.clone(),
+                line_starts: line_starts.clone(),
+                is_builtin_file,
+            });
+        }
+    }
+
+    // --- Stage B: compile bytecode bodies (parallel: pure codegen) ---
+    let watermark = program.objects.len();
+    let compiled: Vec<Option<(Function, ObjectPool)>> = work
+        .par_iter()
+        .map(|item| {
+            let MirFunctionKind::Bytecode(body) = &item.mir.kind else {
+                // Builtins mint nothing; Stage C constructs them serially.
+                return None;
+            };
+            let mut fragment = ObjectPool::default();
+            let empty_capture_types = Vec::new();
+            let empty_spawn_capture_indices = HashSet::new();
+            let lambda_info = compile_lambdas_flat(
+                &item.mir.lambdas,
+                Some(body),
+                &empty_capture_types,
+                &empty_spawn_capture_indices,
+                &item.line_starts,
+                &item.source_file,
+                globals,
+                classes,
+                class_object_indices,
+                enum_object_indices,
+                enum_variants,
+                class_fields,
+                &mut fragment,
+                watermark,
+                opt,
+            );
+            let lambda_obj_indices: Vec<usize> = lambda_info.iter().map(|(idx, _)| *idx).collect();
+            let lambda_names_vec: Vec<String> =
+                lambda_info.iter().map(|(_, name)| name.clone()).collect();
+            let ctx = MirCodegenContext {
+                globals,
+                classes,
+                class_object_indices,
+                enum_object_indices,
+                enum_variants,
+                class_fields,
+                objects: &mut fragment,
+                objects_base: watermark,
+                lambda_object_indices: &lambda_obj_indices,
+                lambda_names: &lambda_names_vec,
+                capture_types: &empty_capture_types,
+                spawn_capture_indices: &empty_spawn_capture_indices,
+            };
+            let mut f = compile_mir_function(
+                body,
+                item.mir.arity,
+                item.mir.span,
+                &item.line_starts,
+                ctx,
+                opt,
+            );
+            f.name.clone_from(&item.fq_name);
+            f.source_file.clone_from(&item.source_file);
+            Some((f, fragment))
+        })
+        .collect();
+
+    // --- Stage C: merge fragments + serial tail (original function order) ---
+    // Seed the GenericFunction interning table with anything already pooled
+    // below the watermark: the serial scan's candidate set when compiling
+    // function N is {pre-Pass-4 pool} ∪ {mints of functions 1..N-1} ∪ {own
+    // earlier mints}, and the in-order merge replays exactly that set.
+    let mut intern = GenericFunctionInterner::default();
+    for (idx, obj) in program.objects.iter().enumerate() {
+        if let Object::GenericFunction(gf) = obj {
+            intern.insert_if_absent(gf, idx);
+        }
+    }
+    for (item, slot) in work.into_iter().zip(compiled) {
+        let mut compiled_fn = match slot {
+            Some((function, fragment)) => {
+                merge_function_fragment(program, watermark, fragment, function, &mut intern)
+            }
+            None => {
+                let MirFunctionKind::Builtin(kind) = &item.mir.kind else {
+                    unreachable!("Stage B compiles every bytecode function")
+                };
+                match builtin_emit_function(*kind, &item.fq_name, item.mir.arity) {
+                    Some(f) => f,
+                    // Intrinsics and `__await_any` never become callable
+                    // objects (mirrors the serial pass).
+                    None => continue,
+                }
+            }
+        };
+
+        let item_tree = file_item_tree(db, item.file);
+        let func_data = &item_tree.functions[&item.local_id];
+        let pkg_info = file_package(db, item.file);
+        let cache = &alias_caches[&pkg_info.package];
+        attach_function_metadata(
+            db,
+            item.file,
+            item.local_id,
+            func_data,
+            cache,
+            item.is_builtin_file,
+            &item.fq_name,
+            &mut compiled_fn,
+        );
+        register_compiled_function(
+            program,
+            globals,
+            skip_clean.is_some(),
+            item.fq_name,
+            compiled_fn,
+        );
+    }
+}
+
+/// Interning table for pooled `Object::GenericFunction`s, bucketed by target
+/// global slot. Mirrors the serial `emit_constant` scan's equality exactly:
+/// same `function` slot and `==` on the `type_args` slice, first pooled match
+/// wins.
+#[derive(Default)]
+struct GenericFunctionInterner {
+    by_function: HashMap<usize, Vec<InternedGenericFunction>>,
+}
+
+/// One interned instantiation: its type arguments and its final pool index.
+type InternedGenericFunction = (Box<[baml_type::RealizedTy]>, usize);
+
+impl GenericFunctionInterner {
+    fn get(&self, gf: &bex_vm_types::GenericFunction) -> Option<usize> {
+        self.by_function
+            .get(&gf.function.raw())?
+            .iter()
+            .find(|(args, _)| args.as_ref() == gf.type_args.as_ref())
+            .map(|(_, idx)| *idx)
+    }
+
+    fn insert_if_absent(&mut self, gf: &bex_vm_types::GenericFunction, idx: usize) {
+        let bucket = self.by_function.entry(gf.function.raw()).or_default();
+        if !bucket
+            .iter()
+            .any(|(args, _)| args.as_ref() == gf.type_args.as_ref())
+        {
+            bucket.push((gf.type_args.clone(), idx));
+        }
+    }
+}
+
+/// Splice one worker's fragment pool into the program pool and rebase every
+/// fragment-relative object operand (>= `watermark`) in both the fragment's
+/// own objects and the compiled function.
+///
+/// A fragment `Object::GenericFunction` equal to one already pooled (below
+/// the watermark or by an earlier-merged fragment) is dropped and its minted
+/// index mapped to the existing object — exactly the reuse the serial
+/// whole-pool interning scan would have produced. Everything else appends in
+/// mint order, so the merged pool layout is byte-identical to the serial
+/// pass's. `GlobalIndex` operands are Pass-1 slots, absolute in every worker,
+/// and are never rewritten; a `GenericFunction`'s identity (global slot +
+/// type args) is therefore stable across the rewrite.
+fn merge_function_fragment(
+    program: &mut Program,
+    watermark: usize,
+    fragment: ObjectPool,
+    mut compiled_fn: Function,
+    intern: &mut GenericFunctionInterner,
+) -> Function {
+    // Pass 1: append in mint order, building the minted-index → final-index
+    // map. Completed before any operand rewrite so references to later mints
+    // (e.g. a constant pooled after the lambda that uses it) resolve too.
+    let mut index_map: Vec<usize> = Vec::with_capacity(fragment.len());
+    let mut appended: Vec<usize> = Vec::with_capacity(fragment.len());
+    for obj in fragment {
+        let is_generic_function = match &obj {
+            Object::GenericFunction(gf) => {
+                if let Some(existing) = intern.get(gf) {
+                    index_map.push(existing);
+                    continue;
+                }
+                true
+            }
+            _ => false,
+        };
+        let idx = program.add_object(obj);
+        if is_generic_function {
+            if let Object::GenericFunction(gf) = &program.objects[ObjectIndex::from_raw(idx)] {
+                intern.insert_if_absent(gf, idx);
+            }
+        }
+        index_map.push(idx);
+        appended.push(idx);
+    }
+
+    // Pass 2: rewrite fragment-relative operands to their final indices.
+    // Object indices below the watermark (classes/enums/strings from Passes
+    // 1–3) and all global slots are already absolute — left untouched.
+    let rewrite = |operand: bex_vm_types::relink::IndexOperand<'_>| {
+        if let bex_vm_types::relink::IndexOperand::Object(idx) = operand {
+            let raw = idx.raw();
+            if raw >= watermark {
+                let final_idx = *index_map
+                    .get(raw - watermark)
+                    .expect("fragment operand must map to a merged pool index");
+                *idx = ObjectIndex::from_raw(final_idx);
+            }
+        }
+    };
+    for &idx in &appended {
+        bex_vm_types::relink::visit_object_operands(
+            &mut program.objects[ObjectIndex::from_raw(idx)],
+            rewrite,
+        );
+    }
+    bex_vm_types::relink::visit_index_operands(&mut compiled_fn, rewrite);
+    compiled_fn
+}
+
+/// Build the callable `Function` object for a builtin, or `None` for the
+/// kinds that never become callable objects: intrinsics (call sites lower to
+/// `StatementKind::Intrinsic`) and BEP-034 `__await_any` (call sites lower to
+/// a `Terminator::AwaitAny` suspend point).
+fn builtin_emit_function(kind: BuiltinKind, fq_name: &str, arity: usize) -> Option<Function> {
+    let kind = match kind {
+        BuiltinKind::Intrinsic | BuiltinKind::AwaitAny => return None,
+        BuiltinKind::Io => {
+            let sys_op = bex_vm_types::sys_op_for_path(fq_name)
+                .unwrap_or_else(|| panic!("unknown sys_op path: {fq_name}"));
+            FunctionKind::SysOp(sys_op)
+        }
+        BuiltinKind::Vm => FunctionKind::NativeUnresolved,
+    };
+    Some(Function {
+        name: fq_name.to_string(),
+        source_file: String::new(), // builtins have no source file
+        arity,
+        real_local_count: 0,
+        bytecode: Bytecode::default(),
+        kind,
+        local_names: Vec::new(),
+        debug_locals: Vec::new(),
+        span: Span::fake(),
+        return_type: baml_type::RuntimeTy::Null {
+            attr: baml_type::TyAttr::default(),
+        },
+        param_names: Vec::new(),
+        param_types: Vec::new(),
+        param_has_default: Vec::new(),
+        display_type_params: Vec::new(),
+        display_param_types: Vec::new(),
+        display_return_type: "null".to_string(),
+        throws_type: None,
+        origin: FunctionOrigin::Builtin,
+        body_meta: None,
+        capture: FunctionCaptureProps::disabled(),
+        function_id: 0, // assigned at engine init (interim provider)
+    })
+}
+
+/// Fill a compiled function's signature, throws, origin, and LLM metadata
+/// from the item tree — the Pass-4 tail shared by the serial and parallel
+/// passes. Every lookup here is a salsa query, so this always runs on the
+/// serial control thread.
+#[allow(clippy::too_many_arguments)]
+fn attach_function_metadata(
+    db: &dyn baml_compiler2_mir::Db,
+    file: baml_base::SourceFile,
+    local_id: baml_compiler2_hir::ids::LocalItemId<baml_compiler2_hir::ids::FunctionMarker>,
+    func_data: &baml_compiler2_hir::item_tree::Function,
+    cache: &ResolvedAliases,
+    is_builtin_file: bool,
+    fq_name: &str,
+    compiled_fn: &mut Function,
+) {
+    // Set function metadata from signature
+    let func_loc = FunctionLoc::new(db, file, local_id);
+    let parameter_defaults = baml_compiler2_ppir::function_parameter_defaults(db, func_loc);
+    let signature_metadata = compute_function_metadata_from_item_tree(
+        db,
+        file,
+        local_id,
+        func_data,
+        &parameter_defaults,
+        cache,
+    );
+    compiled_fn.return_type = signature_metadata.return_type;
+    compiled_fn.param_names = signature_metadata.param_names;
+    compiled_fn.param_types = signature_metadata.param_types;
+    compiled_fn.param_has_default = signature_metadata.param_has_default;
+    compiled_fn.display_type_params = signature_metadata.display_type_params;
+    compiled_fn.display_param_types = signature_metadata.display_param_types;
+    compiled_fn.display_return_type = signature_metadata.display_return_type;
+
+    // Set inferred throws type from TIR throw inference
+    compiled_fn.throws_type = compute_throws_type(db, file, &func_data.name, cache);
+    compiled_fn.origin = emitted_function_origin(fq_name, is_builtin_file, func_data.origin);
+
+    // Set LLM-specific body_meta if this is an LLM function
+    if let Some(baml_compiler2_ast::DeclarativeMeta::Llm(llm_meta)) = &func_data.declarative_meta {
+        // NOTE (canary merge): canary removed the runtime `Function.stream_return_type`
+        // field and its plumbing (the pre-existing streaming infra from PRs #3362/#3755).
+        // The stream return type is now carried by the synthesized `$stream` companion's
+        // own `return_type` (see ppir's `companion_stream_return_type`), so the old
+        // emit-side pre-computation block was dropped. BEP-049 M5e stream-path rendering
+        // of `ctx.output_format` should be re-verified against canary's streaming.
+        if let Some(client) = &llm_meta.client {
+            // New-mode (BEP-049 M5) functions have no Jinja `prompt`
+            // text — the compiled closure renders it — but they still
+            // need a registry entry so `get_return_type` /
+            // `get_stream_return_type` (used by `__make_stream` and the
+            // streaming `Context`) resolve by name. The empty template
+            // is never read for them (their `prompt_closure` is non-null,
+            // so the Jinja `get_jinja_template` branch is skipped).
+            let prompt_template = llm_meta
+                .prompt
+                .as_ref()
+                .map(|p| p.text.clone())
+                .unwrap_or_default();
+            compiled_fn.body_meta = Some(FunctionMeta::Llm {
+                prompt_template,
+                client: client.to_string(),
+            });
+            compiled_fn.capture = FunctionCaptureProps::disabled()
+                .with_auto(CaptureCategory::Input)
+                .with_auto(CaptureCategory::Output)
+                .with_auto(CaptureCategory::Error);
+        }
+    }
+}
+
+/// Pool the compiled function object and register its global slot — the
+/// final Pass-4 tail shared by the serial and parallel passes.
+fn register_compiled_function(
+    program: &mut Program,
+    globals: &HashMap<String, usize>,
+    dirty_only: bool,
+    fq_name: String,
+    compiled_fn: Function,
+) {
+    let fn_obj_idx = program.add_object(Object::Function(Box::new(compiled_fn)));
+    program.function_indices.insert(fq_name.clone(), fn_obj_idx);
+    let val = ConstValue::Object(ObjectIndex::from_raw(fn_obj_idx));
+    if dirty_only {
+        // Dirty-only emit: write the function value at its whole-project
+        // (Pass-1) slot rather than appending, so clean-file slot holes are
+        // preserved and every operand slot reverses to the right name.
+        let slot = globals[&fq_name];
+        program.function_global_indices.insert(fq_name, slot);
+        program.globals[slot] = val;
+    } else {
+        let slot = program.globals.len();
+        debug_assert_eq!(
+            globals.get(&fq_name).copied(),
+            Some(slot),
+            "Pass-4 append slot must match the Pass-1 assignment for {fq_name}",
+        );
+        program.function_global_indices.insert(fq_name, slot);
+        program.add_global(val);
+    }
+}
+
 /// Compile a flat list of lambda `MirFunction`s into bytecode `Function` objects
 /// and register them in `objects`.  Returns a parallel `Vec<(obj_idx, name)>`
 /// that can be used to build `lambda_object_indices` and `lambda_names` for the
@@ -4221,7 +4641,9 @@ fn compile_lambdas_flat(
     class_object_indices: &HashMap<String, usize>,
     enum_object_indices: &HashMap<String, usize>,
     enum_variants: &HashMap<String, HashMap<String, usize>>,
+    class_fields: &ClassFieldSnapshot,
     objects: &mut ObjectPool,
+    objects_base: usize,
     opt: OptLevel,
 ) -> Vec<(usize, String)> {
     let capture_infos = parent_body.map_or_else(
@@ -4254,7 +4676,9 @@ fn compile_lambdas_flat(
                     class_object_indices,
                     enum_object_indices,
                     enum_variants,
+                    class_fields,
                     objects,
+                    objects_base,
                     opt,
                 );
                 let nested_obj_indices: Vec<usize> =
@@ -4267,7 +4691,9 @@ fn compile_lambdas_flat(
                     class_object_indices,
                     enum_object_indices,
                     enum_variants,
+                    class_fields,
                     objects,
+                    objects_base,
                     lambda_object_indices: &nested_obj_indices,
                     lambda_names: &nested_names,
                     capture_types: &capture_info.capture_types,
@@ -4277,7 +4703,7 @@ fn compile_lambdas_flat(
                     compile_mir_function(body, lambda.arity, lambda.span, line_starts, ctx, opt);
                 f.name.clone_from(&lambda_name);
                 f.source_file = source_file.to_string();
-                let idx = objects.len();
+                let idx = objects_base + objects.len();
                 objects.push(Object::Function(Box::new(f)));
                 idx
             }
@@ -4307,6 +4733,7 @@ fn compile_init_function<'db>(
     class_object_indices: &HashMap<String, usize>,
     enum_object_indices: &HashMap<String, usize>,
     enum_variants: &HashMap<String, HashMap<String, usize>>,
+    class_fields: &ClassFieldSnapshot,
     program: &mut Program,
     opt: OptLevel,
 ) -> Result<Function, LoweringError> {
@@ -4345,7 +4772,9 @@ fn compile_init_function<'db>(
                     class_object_indices,
                     enum_object_indices,
                     enum_variants,
+                    class_fields,
                     &mut program.objects,
+                    0,
                     opt,
                 );
                 let lambda_let_obj_indices: Vec<usize> =
@@ -4358,7 +4787,9 @@ fn compile_init_function<'db>(
                     class_object_indices,
                     enum_object_indices,
                     enum_variants,
+                    class_fields,
                     objects: &mut program.objects,
+                    objects_base: 0,
                     lambda_object_indices: &lambda_let_obj_indices,
                     lambda_names: &lambda_let_names,
                     capture_types: &empty_capture_types,

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -828,7 +828,23 @@ pub(crate) struct MirCodegenContext<'ctx, 'obj> {
 
 /// Database trait for compiler2 emit queries.
 #[salsa::db]
-pub trait Db: baml_compiler2_mir::Db {}
+pub trait Db: baml_compiler2_mir::Db {
+    /// Mint an owned database handle that shares this database's storage, for
+    /// MOVING into a worker thread.
+    ///
+    /// Parallel MIR lowering (Stage A of `emit_functions_parallel`) clones one
+    /// handle per work chunk on the calling thread — the database type is
+    /// expected to be `Send` but not `Sync`, so workers can never share `&db`.
+    /// All clones share one salsa memo table (the rust-analyzer concurrency
+    /// model), so a query computed by one worker is a cache hit for the rest.
+    ///
+    /// The default returns `None`, which keeps every salsa read on the calling
+    /// thread (Stage A stays serial). `ProjectDatabase` overrides this with
+    /// `Clone` (an `Arc` bump).
+    fn parallel_db_handle(&self) -> Option<Box<dyn baml_compiler2_mir::Db + Send>> {
+        None
+    }
+}
 
 /// Compile options.
 pub struct CompileOptions {
@@ -953,7 +969,7 @@ fn fq_to_type_name(fq: &str) -> baml_type::TypeName {
 
 /// Generate bytecode for the entire project (default: `OptLevel::Two`).
 pub fn generate_project_bytecode(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     options: &CompileOptions,
 ) -> Result<Program, LoweringError> {
     generate_project_bytecode_with_opt(db, options, OptLevel::Two)
@@ -961,7 +977,7 @@ pub fn generate_project_bytecode(
 
 /// Generate bytecode for the entire project with a specific optimization level.
 pub fn generate_project_bytecode_with_opt(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     options: &CompileOptions,
     opt: OptLevel,
 ) -> Result<Program, LoweringError> {
@@ -977,7 +993,7 @@ pub fn generate_project_bytecode_with_opt(
 /// compiler build + opt level) that `generate_project_bytecode_with_stdlib`
 /// splices into project compiles.
 pub fn generate_stdlib_program(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     opt: OptLevel,
 ) -> Result<Program, LoweringError> {
     generate_impl(
@@ -1001,7 +1017,7 @@ pub fn generate_stdlib_program(
 /// a full [`generate_project_bytecode_with_opt`] run (asserted by the
 /// `emit_determinism` integration tests).
 pub fn generate_project_bytecode_with_stdlib(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     options: &CompileOptions,
     opt: OptLevel,
     base: &Program,
@@ -1032,7 +1048,7 @@ pub fn generate_project_bytecode_with_stdlib(
 /// incompatible previous units) and propagates any [`LoweringError`] from the
 /// dirty-file emit.
 pub fn generate_project_bytecode_with_reuse_units(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     options: &CompileOptions,
     opt: OptLevel,
     base: &Program,
@@ -1047,7 +1063,7 @@ pub fn generate_project_bytecode_with_reuse_units(
 /// units. Cache-aware callers can persist these directly instead of decomposing
 /// the linked program a second time.
 pub fn generate_project_bytecode_with_reuse_artifacts(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     options: &CompileOptions,
     opt: OptLevel,
     base: &Program,
@@ -1206,7 +1222,7 @@ pub fn reuse_throws_mismatches(
 /// the Stage 2 decomposition does not yet handle (a `$init`/generic-function
 /// tail — see design §9 R1/R2 — or an unattributable pool object).
 pub fn emit_units(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     options: &CompileOptions,
     opt: OptLevel,
 ) -> Result<Vec<CompilationUnit>, LoweringError> {
@@ -2239,7 +2255,7 @@ fn inject_clean_object_placeholders(
 /// whole-project (Pass-1) global slots so the decomposition reverses their
 /// operands to names identically to a full compile. `None` is a full compile.
 fn generate_impl(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     options: &CompileOptions,
     opt: OptLevel,
     base: Option<&Program>,
@@ -2534,7 +2550,7 @@ fn spliced_throws_match(
 /// only by the compiler build) spliceable into any project's compile.
 #[allow(clippy::too_many_arguments)]
 fn emit_file_group(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     files: &[baml_base::SourceFile],
     tables: &mut EmitTables,
     program: &mut Program,
@@ -4177,7 +4193,7 @@ fn emit_functions_serial(
     }
 }
 
-/// One function's Pass-4 state carried from the serial lowering stage to the
+/// One function's Pass-4 state carried from the lowering stage to the
 /// parallel codegen stage and the serial merge stage.
 struct FnWorkItem {
     file: baml_base::SourceFile,
@@ -4191,13 +4207,123 @@ struct FnWorkItem {
     is_builtin_file: bool,
 }
 
-/// Pass 4, parallel (`BAML_PARALLEL_EMIT=1`): compile function bodies across
-/// rayon workers, byte-identically to [`emit_functions_serial`].
+/// Identity of one Pass-4 function before MIR lowering: the [`FnWorkItem`]
+/// fields known from enumeration alone (Stage A's input).
+struct FnSeed {
+    file: baml_base::SourceFile,
+    local_id: baml_compiler2_hir::ids::LocalItemId<baml_compiler2_hir::ids::FunctionMarker>,
+    /// Project-relative source path (`relative_source_path`).
+    source_file: String,
+    /// Line index of the item's file, shared by every function in the file.
+    line_starts: std::sync::Arc<[u32]>,
+    is_builtin_file: bool,
+}
+
+/// Lower one seed's function to MIR on the given database handle.
+///
+/// `FunctionLoc` is minted on the SAME handle the lowering reads from — it is
+/// a `'db`-interned key, and interning is shared storage, so every handle
+/// mints the identical id.
+fn lower_seed(
+    db: &dyn baml_compiler2_mir::Db,
+    seed: &FnSeed,
+    opt: OptLevel,
+) -> baml_compiler2_mir::MirFunction {
+    lower_function(db, FunctionLoc::new(db, seed.file, seed.local_id), opt)
+}
+
+/// Stage A driver: lower every seed's function to MIR, returned in seed order.
+///
+/// `lower_function` reads salsa (PPIR bodies, scope type inference) and
+/// returns an owned [`baml_compiler2_mir::MirFunction`] that is a pure
+/// function of the frozen inputs, and every call is independent — so when the
+/// database mints worker handles ([`Db::parallel_db_handle`]) the seeds are
+/// lowered across rayon workers and the reassembled output is exactly the
+/// serial loop's.
+///
+/// The database type is `Send` but deliberately not `Sync` (each salsa handle
+/// carries thread-confined query-stack state), so — exactly like
+/// `baml_project`'s parallel check — one handle per chunk is cloned on THIS
+/// thread and MOVED into its task; all clones share one memo table, so a
+/// scope inferred by one worker is a cache hit for every other. The first
+/// seed is lowered serially before fanning out to warm the file/package-level
+/// memos every body read reaches. Tiny batches, single-threaded pools, and
+/// databases without handles take the serial loop directly.
+fn lower_seed_mirs(
+    db: &dyn crate::Db,
+    seeds: &[FnSeed],
+    opt: OptLevel,
+) -> Vec<baml_compiler2_mir::MirFunction> {
+    // Small chunks keep rayon's work-stealing effective — bodies vary a lot
+    // in inference cost — while amortizing the per-task handle clone.
+    const CHUNK: usize = 4;
+    // Fan-out pays for itself only past a handful of bodies (mirrors the
+    // parallel-check threshold in `baml_project`).
+    const MIN_PARALLEL: usize = 9;
+
+    if seeds.len() < MIN_PARALLEL || rayon::current_num_threads() <= 1 {
+        return seeds.iter().map(|seed| lower_seed(db, seed, opt)).collect();
+    }
+    let (first, rest) = seeds.split_first().expect("seeds checked non-empty above");
+
+    // Handles are cloned OUTSIDE the rayon scope — a `!Sync` database cannot
+    // be borrowed by the (Send) scope closure — and each chunk's handle is
+    // MOVED into its task. A database that mints no handles keeps Stage A
+    // serial.
+    let chunks: Vec<&[FnSeed]> = rest.chunks(CHUNK).collect();
+    let mut handles: Vec<Box<dyn baml_compiler2_mir::Db + Send>> = Vec::with_capacity(chunks.len());
+    for _ in &chunks {
+        match db.parallel_db_handle() {
+            Some(handle) => handles.push(handle),
+            None => return seeds.iter().map(|seed| lower_seed(db, seed, opt)).collect(),
+        }
+    }
+
+    // Warm the shared file/package-level memos before fanning out, so cold
+    // workers don't all block on the same shared memo slots.
+    let first_mir = lower_seed(db, first, opt);
+
+    let (tx, rx) = std::sync::mpsc::channel::<(usize, Vec<baml_compiler2_mir::MirFunction>)>();
+    rayon::scope(move |s| {
+        // Seed index of the current chunk's first element (`first` is 0).
+        let mut next_start = 1usize;
+        for (chunk, handle) in chunks.into_iter().zip(handles) {
+            let tx = tx.clone();
+            let chunk_start = next_start;
+            next_start += chunk.len();
+            s.spawn(move |_| {
+                let db: &dyn baml_compiler2_mir::Db = &*handle;
+                let out: Vec<baml_compiler2_mir::MirFunction> =
+                    chunk.iter().map(|seed| lower_seed(db, seed, opt)).collect();
+                // Receiver outlives the scope; a send only fails if it
+                // dropped early, which would mean a panic elsewhere.
+                let _ = tx.send((chunk_start, out));
+            });
+        }
+    });
+
+    let mut mirs: Vec<Option<baml_compiler2_mir::MirFunction>> = Vec::with_capacity(seeds.len());
+    mirs.resize_with(seeds.len(), || None);
+    mirs[0] = Some(first_mir);
+    for (chunk_start, out) in rx {
+        for (offset, mir) in out.into_iter().enumerate() {
+            mirs[chunk_start + offset] = Some(mir);
+        }
+    }
+    mirs.into_iter()
+        .map(|mir| mir.expect("every chunk reports exactly its seeds"))
+        .collect()
+}
+
+/// Pass 4, parallel (multi-threaded rayon pools): compile function bodies
+/// across rayon workers, byte-identically to [`emit_functions_serial`].
 ///
 /// Three stages:
 ///
-/// - **Stage A (serial, salsa)**: lower every function to MIR in exactly the
-///   serial pass's iteration order, collecting owned work items.
+/// - **Stage A (parallel, salsa)**: lower every function to MIR across
+///   worker-owned database handles ([`lower_seed_mirs`]), collecting owned
+///   work items in exactly the serial pass's iteration order. Falls back to
+///   the serial loop when the database mints no handles.
 /// - **Stage B (parallel, no salsa)**: pure codegen of every bytecode body.
 ///   Each worker mints into a fresh fragment pool based at the shared
 ///   watermark `W = program.objects.len()`, so pre-existing absolute indices
@@ -4218,7 +4344,7 @@ struct FnWorkItem {
 /// reproduces the serial pool layout byte for byte.
 #[allow(clippy::too_many_arguments)]
 fn emit_functions_parallel(
-    db: &dyn baml_compiler2_mir::Db,
+    db: &dyn crate::Db,
     files: &[baml_base::SourceFile],
     skip_clean: Option<&HashSet<String>>,
     globals: &HashMap<String, usize>,
@@ -4233,8 +4359,13 @@ fn emit_functions_parallel(
 ) {
     use rayon::prelude::*;
 
-    // --- Stage A: lower every function to MIR (serial: salsa queries) ---
-    let mut work: Vec<FnWorkItem> = Vec::new();
+    // --- Stage A: lower every function to MIR (parallel: salsa queries on
+    // pre-cloned handles) ---
+    // Enumeration (clean-file skip, item trees, line indexes) is cheap and
+    // stays serial on `db`; the lowering itself — the expensive half of
+    // Pass 4 — fans out across worker-owned database handles (see
+    // [`lower_seed_mirs`]), reassembled into this exact enumeration order.
+    let mut seeds: Vec<FnSeed> = Vec::new();
     for file in files {
         let rel_path = relative_source_path(db, *file);
         // Clean files are never lowered (see the serial pass).
@@ -4248,20 +4379,29 @@ fn emit_functions_parallel(
         let item_tree = file_item_tree(db, *file);
         let is_builtin_file = file.path(db).to_string_lossy().starts_with("<builtin>/");
         for local_id in item_tree.functions.keys() {
-            let func_loc = FunctionLoc::new(db, *file, *local_id);
-            let mir = lower_function(db, func_loc, opt);
-            let fq_name = mir.item_ref.to_string();
-            work.push(FnWorkItem {
+            seeds.push(FnSeed {
                 file: *file,
                 local_id: *local_id,
-                mir,
-                fq_name,
                 source_file: rel_path.clone(),
                 line_starts: line_starts.clone(),
                 is_builtin_file,
             });
         }
     }
+    let mirs = lower_seed_mirs(db, &seeds, opt);
+    let work: Vec<FnWorkItem> = seeds
+        .into_iter()
+        .zip(mirs)
+        .map(|(seed, mir)| FnWorkItem {
+            file: seed.file,
+            local_id: seed.local_id,
+            fq_name: mir.item_ref.to_string(),
+            mir,
+            source_file: seed.source_file,
+            line_starts: seed.line_starts,
+            is_builtin_file: seed.is_builtin_file,
+        })
+        .collect();
 
     // --- Stage B: compile bytecode bodies (parallel: pure codegen) ---
     let watermark = program.objects.len();

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -93,7 +93,23 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
     // never taint a scope, so unrelated type errors elsewhere in the file are
     // unaffected.
     let tainted = parse_error_tainted_scopes(index, &parse_errors);
-    for (file_scope_idx, scope_id) in index.scope_ids.iter().enumerate() {
+    // Drive inference with PPIR's canonical (post-`$stream`-expansion) ScopeIds,
+    // not HIR's. `ScopeId` is a Salsa *tracked* struct, so HIR's index and
+    // PPIR's expanded index mint distinct Salsa IDs for the same
+    // (file, FileScopeId) pair; keying `infer_scope_types` with HIR IDs here
+    // made every scope in a `$stream`-expanded file get inferred a second time
+    // when TIR/MIR later asked with the PPIR ID. The original file's scopes are
+    // a prefix of the expanded index — the same invariant `infer_scope_types`
+    // relies on when it resolves a `FileScopeId` in the expanded arena — and we
+    // iterate only that prefix, so synthetic `*$stream` scopes are never
+    // visited and diagnostics are unchanged.
+    let ppir_index = baml_compiler2_ppir::file_semantic_index(db, file);
+    for (file_scope_idx, scope_id) in ppir_index
+        .scope_ids
+        .iter()
+        .take(index.scopes.len())
+        .enumerate()
+    {
         if tainted.contains(&file_scope_idx) {
             continue;
         }

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -25,7 +25,7 @@ use baml_base::{FileId, Name, SourceFile, Span};
 use baml_compiler_diagnostics::{
     Diagnostic, DiagnosticId, DiagnosticPhase, ParseError, ToDiagnostic,
 };
-use baml_compiler2_hir::{body::FunctionBody, file_semantic_index, scope::ScopeKind};
+use baml_compiler2_hir::{file_semantic_index, scope::ScopeKind};
 use baml_compiler2_tir::{
     infer_context::{DiagnosticLocation, TirTypeError},
     inference::render_scope_diagnostics,
@@ -222,11 +222,15 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
 
     for (local_id, func_data) in &item_tree.functions {
         let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, *local_id);
-        let body = baml_compiler2_hir::body::function_body(db, func_loc);
-
         // Expression-body functions already have their signatures checked
         // during scope inference (step 3). Only check non-expr bodies here.
-        if matches!(body.as_ref(), FunctionBody::Expr(_)) {
+        // Read the body discriminant straight off the item tree already in
+        // hand — the `function_body` query clones the whole `ExprBody` arena
+        // on execution, far too expensive for a body-kind test.
+        if matches!(
+            func_data.body,
+            Some(baml_compiler2_ast::FunctionBodyDef::Expr(..))
+        ) {
             continue;
         }
 

--- a/baml_language/crates/baml_project/Cargo.toml
+++ b/baml_language/crates/baml_project/Cargo.toml
@@ -35,6 +35,7 @@ baml_workspace = { workspace = true }
 bex_vm_types = { workspace = true }
 la-arena = { workspace = true }
 lsp-types = { workspace = true }
+rayon = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -63,12 +63,75 @@ pub fn collect_diagnostics(db: &ProjectDatabase) -> Vec<Diagnostic> {
 pub fn collect_compiler2_diagnostics(db: &ProjectDatabase) -> Vec<Diagnostic> {
     let source_files = baml_compiler2_hir::compiler2_all_files(db);
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
-    for file in &source_files {
-        diagnostics.extend(lsp2_check_file(db, *file));
+    // Parallel by default; tiny projects skip the pool dispatch overhead.
+    // Thread count follows rayon's global pool (`RAYON_NUM_THREADS` to cap).
+    if source_files.len() > 8 {
+        collect_file_diagnostics_parallel(db, &source_files, &mut diagnostics);
+    } else {
+        for file in &source_files {
+            diagnostics.extend(lsp2_check_file(db, *file));
+        }
     }
     diagnostics.extend(package_level_diagnostics(db, &source_files));
     sort_diagnostics(&mut diagnostics);
     diagnostics
+}
+
+/// Run `check_file` for every file across worker threads.
+///
+/// Every query `check_file` reaches is read-only, and `ProjectDatabase`'s
+/// `Clone` produces a shared-storage salsa handle (the rust-analyzer
+/// concurrency model): workers share one memo table, so a scope inferred by
+/// one thread is a cache hit for every other. Output order does not matter —
+/// the caller sorts diagnostics by (file, span, message) — so workers just
+/// pull the next file off a shared atomic counter (files vary a lot in size;
+/// work-stealing beats fixed chunks).
+///
+/// The first file is checked serially before fanning out: it warms the
+/// package-level queries (package items / resolution context / alias maps)
+/// that every file reads, so cold workers don't all block on the same shared
+/// memo slots.
+fn collect_file_diagnostics_parallel(
+    db: &ProjectDatabase,
+    source_files: &[SourceFile],
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // `ProjectDatabase` is `Send` but deliberately not `Sync` (each salsa
+    // handle carries thread-confined query-stack state), so tasks cannot share
+    // `&db` — every task MOVES its own cloned shared-storage handle instead
+    // (an Arc bump; all clones share one memo table). Small chunks keep
+    // work-stealing effective on rayon's global pool — files vary a lot in
+    // check cost — while amortizing the per-task clone.
+    const CHUNK: usize = 4;
+
+    let Some((first, rest)) = source_files.split_first() else {
+        return;
+    };
+    diagnostics.extend(lsp2_check_file(db, *first));
+
+    let chunks: Vec<&[SourceFile]> = rest.chunks(CHUNK).collect();
+    // Handles are cloned OUTSIDE the rayon scope: a `!Sync` database can't be
+    // borrowed by the (Send) scope closure, so each chunk's handle is created
+    // up front and MOVED into its task.
+    let handles: Vec<ProjectDatabase> = chunks.iter().map(|_| db.clone()).collect();
+    let (tx, rx) = std::sync::mpsc::channel::<Vec<Diagnostic>>();
+    rayon::scope(move |s| {
+        for (chunk, db) in chunks.into_iter().zip(handles) {
+            let tx = tx.clone();
+            s.spawn(move |_| {
+                let mut out = Vec::new();
+                for file in chunk {
+                    out.extend(lsp2_check_file(&db, *file));
+                }
+                // Receiver outlives the scope; a send only fails if it
+                // dropped early, which would mean a panic elsewhere.
+                let _ = tx.send(out);
+            });
+        }
+    });
+    for out in rx {
+        diagnostics.extend(out);
+    }
 }
 
 /// The per-checked-file split alongside the merged, honest-ordered set produced

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -199,27 +199,44 @@ fn package_level_diagnostics(db: &ProjectDatabase, source_files: &[SourceFile]) 
     diagnostics
 }
 
-/// Stable snapshot ordering: by (`file_id`, primary span start, message).
+/// Total, deterministic diagnostic ordering.
+///
+/// The primary key is unchanged — (`file_id`, primary span start, message) —
+/// so any set of diagnostics without exact ties renders exactly as before.
+/// But parallel check ([`collect_file_diagnostics_parallel`]) collects file
+/// chunks in nondeterministic completion order, and a `sort_by` leaves
+/// elements that compare `Equal` in their (now-arbitrary) input order. So two
+/// *distinct* diagnostics sharing the same file/start/message would render in
+/// run-dependent order. The tie-breakers below — span end, then a structural
+/// `Debug` encoding that totally covers the remaining fields (id, severity,
+/// phase, annotations, related info) — give a total order, guaranteeing
+/// byte-identical output regardless of thread scheduling. They only run on
+/// exact (file, start, message) ties, so non-tied output is untouched and the
+/// `Debug` formatting cost is not paid in the common case.
 fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
+    use std::cmp::Ordering;
     diagnostics.sort_by(|a, b| {
         let a_span = a.primary_span();
         let b_span = b.primary_span();
-        match (a_span, b_span) {
-            (Some(sa), Some(sb)) => {
-                let file_cmp = sa.file_id.as_u32().cmp(&sb.file_id.as_u32());
-                if file_cmp != std::cmp::Ordering::Equal {
-                    return file_cmp;
-                }
-                let start_cmp = sa.range.start().cmp(&sb.range.start());
-                if start_cmp != std::cmp::Ordering::Equal {
-                    return start_cmp;
-                }
-                a.message.cmp(&b.message)
-            }
-            (Some(_), None) => std::cmp::Ordering::Less,
-            (None, Some(_)) => std::cmp::Ordering::Greater,
+        let primary = match (a_span, b_span) {
+            (Some(sa), Some(sb)) => sa
+                .file_id
+                .as_u32()
+                .cmp(&sb.file_id.as_u32())
+                .then_with(|| sa.range.start().cmp(&sb.range.start()))
+                .then_with(|| a.message.cmp(&b.message)),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
             (None, None) => a.message.cmp(&b.message),
-        }
+        };
+        primary
+            .then_with(|| match (a_span, b_span) {
+                (Some(sa), Some(sb)) => sa.range.end().cmp(&sb.range.end()),
+                _ => Ordering::Equal,
+            })
+            // Structural catch-all: a stable, total encoding of every remaining
+            // field, so distinct diagnostics never compare Equal.
+            .then_with(|| format!("{a:?}").cmp(&format!("{b:?}")))
     });
 }
 
@@ -291,7 +308,74 @@ impl ProjectDatabase {
 mod tests {
     use std::path::Path;
 
+    use baml_compiler_diagnostics::{Diagnostic, DiagnosticId, DiagnosticPhase, Severity};
+    use baml_db::{FileId, Span};
+    use text_size::TextRange;
+
     use super::*;
+
+    /// `sort_diagnostics` must impose a total order: diagnostics tied on the
+    /// primary key (file, start, message) but differing elsewhere must sort
+    /// into the same sequence regardless of input order, or parallel check
+    /// (which produces them in nondeterministic completion order) would render
+    /// nondeterministically.
+    #[test]
+    fn sort_diagnostics_is_a_total_order_over_ties() {
+        let at = |start: u32, end: u32| Span {
+            file_id: FileId::new(0),
+            range: TextRange::new(start.into(), end.into()),
+        };
+        // All four share (file 0, start 10, message "dup") — the entire primary
+        // key — but differ in span end, id, severity, and phase.
+        let make = |id, sev, end, phase| {
+            let mut d = Diagnostic::new(id, sev, "dup");
+            d = d.with_primary_span(at(10, end)).with_phase(phase);
+            d
+        };
+        let originals = vec![
+            make(
+                DiagnosticId::TypeMismatch,
+                Severity::Error,
+                20,
+                DiagnosticPhase::Type,
+            ),
+            make(
+                DiagnosticId::UnknownType,
+                Severity::Warning,
+                15,
+                DiagnosticPhase::Parse,
+            ),
+            make(
+                DiagnosticId::TypeMismatch,
+                Severity::Warning,
+                20,
+                DiagnosticPhase::Type,
+            ),
+            make(
+                DiagnosticId::UnknownVariable,
+                Severity::Error,
+                20,
+                DiagnosticPhase::Hir,
+            ),
+        ];
+
+        // Sorting any permutation must yield the identical sequence.
+        let mut canonical = originals.clone();
+        sort_diagnostics(&mut canonical);
+        for rotate in 0..originals.len() {
+            let mut perm = originals.clone();
+            perm.rotate_left(rotate);
+            perm.reverse();
+            sort_diagnostics(&mut perm);
+            assert_eq!(
+                format!("{perm:?}"),
+                format!("{canonical:?}"),
+                "sort is not a total order: permutation (rotate {rotate}, reversed) diverged",
+            );
+        }
+        // And the span-end tie-breaker actually ran (the end=15 one sorts first).
+        assert_eq!(canonical[0].primary_span().unwrap().range.end(), 15.into());
+    }
 
     #[test]
     #[ignore = "compiler2: llm_types.baml builtin causes unreachable arm errors from catch expressions"]

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -226,7 +226,16 @@ impl baml_compiler2_tir::Db for ProjectDatabase {}
 impl baml_compiler2_mir::Db for ProjectDatabase {}
 
 #[salsa::db]
-impl baml_compiler2_emit::Db for ProjectDatabase {}
+impl baml_compiler2_emit::Db for ProjectDatabase {
+    fn parallel_db_handle(&self) -> Option<Box<dyn baml_compiler2_mir::Db + Send>> {
+        // A shared-storage salsa handle (an `Arc` bump — the same handle
+        // cloning the parallel check in `check.rs` relies on): the clone is
+        // MOVED into an emit worker thread, and all clones share one memo
+        // table. `ProjectDatabase` is `Send` but deliberately not `Sync`, so
+        // handing out owned handles is the only way workers can read salsa.
+        Some(Box::new(self.clone()))
+    }
+}
 
 #[salsa::db]
 impl baml_lsp2_actions::Db for ProjectDatabase {}

--- a/baml_language/crates/baml_tests/Cargo.toml
+++ b/baml_language/crates/baml_tests/Cargo.toml
@@ -51,6 +51,7 @@ darwin-kperf-events = { workspace = true }
 divan = { workspace = true }
 libc = { workspace = true }
 num-bigint = { workspace = true }
+rayon = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [ "rt-multi-thread", "macros", "net" ] }

--- a/baml_language/crates/baml_tests/tests/emit_determinism.rs
+++ b/baml_language/crates/baml_tests/tests/emit_determinism.rs
@@ -88,6 +88,43 @@ fn baml_src_project_emit_is_deterministic() {
     assert_deterministic(&root, true);
 }
 
+/// The default (parallel) emit must produce byte-identical output to the
+/// serial reference pass: parallel emit compiles each function into a
+/// watermark-based fragment pool and the serial merge replays the exact
+/// serial pool layout (including cross-function `GenericFunction` interning,
+/// which the `ns_instantiation_expr` fixtures in this corpus exercise).
+/// The serial path is selected the same way a user would get it — a
+/// single-threaded rayon pool (`RAYON_NUM_THREADS=1`).
+#[test]
+fn parallel_emit_is_byte_identical_to_serial() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("baml_src");
+    let sources = read_project(&root);
+    let serial = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .expect("build 1-thread rayon pool")
+        .install(|| compile_to_bytes(&root, &sources, true));
+    let parallel = compile_to_bytes(&root, &sources, true);
+
+    if serial != parallel {
+        let diff_at = serial
+            .iter()
+            .zip(parallel.iter())
+            .position(|(a, b)| a != b)
+            .unwrap_or_else(|| serial.len().min(parallel.len()));
+        panic!(
+            "parallel emit diverges from serial for {}: lengths {} vs {}, first difference at \
+             byte {} (context: {:02x?} vs {:02x?})",
+            root.display(),
+            serial.len(),
+            parallel.len(),
+            diff_at,
+            &serial[diff_at.saturating_sub(8)..(diff_at + 8).min(serial.len())],
+            &parallel[diff_at.saturating_sub(8)..(diff_at + 8).min(parallel.len())],
+        );
+    }
+}
+
 fn build_db(root: &Path, sources: &[(PathBuf, String)]) -> ProjectDatabase {
     let mut db = ProjectDatabase::new();
     db.set_project_root(root);

--- a/baml_language/crates/baml_tests/tests/emit_determinism.rs
+++ b/baml_language/crates/baml_tests/tests/emit_determinism.rs
@@ -99,12 +99,20 @@ fn baml_src_project_emit_is_deterministic() {
 fn parallel_emit_is_byte_identical_to_serial() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("baml_src");
     let sources = read_project(&root);
-    let serial = rayon::ThreadPoolBuilder::new()
-        .num_threads(1)
-        .build()
-        .expect("build 1-thread rayon pool")
-        .install(|| compile_to_bytes(&root, &sources, true));
-    let parallel = compile_to_bytes(&root, &sources, true);
+    // Both paths are pinned to explicit pools so the test exercises what it
+    // claims regardless of the ambient pool's size: 1 thread forces the serial
+    // reference emitter, >1 forces `emit_functions_parallel`. (On a single-core
+    // CI runner the default pool is 1 thread, which would otherwise make the
+    // "parallel" call silently take the serial path and test nothing.)
+    let run_with = |threads: usize| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .expect("build rayon pool")
+            .install(|| compile_to_bytes(&root, &sources, true))
+    };
+    let serial = run_with(1);
+    let parallel = run_with(4);
 
     if serial != parallel {
         let diff_at = serial

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -243,6 +243,30 @@ pub trait TypeContext {
     where
         Self: Sized,
     {
+        // Reflexivity fast path: structurally identical spellings canonicalize
+        // to the same form (canonicalization is deterministic and attr-erasure
+        // applies to both sides), and `is_subtype_of` starts with a `self == sup`
+        // fast path — so the two allocation-heavy canonicalization walks below
+        // would only rediscover `true`.
+        if sub == sup {
+            return true;
+        }
+        // Narrow definite-mismatch filter. Unlike `equivalent`, differing heads
+        // do NOT generally refute subtyping (a literal is a subtype of its base,
+        // a member of its union, a class of an interface it implements) — but
+        // those pairs are different `Ty` *variants*, for which
+        // `heads_definitely_differ` already answers `false`. Of the same-variant
+        // nominal pairs it does claim, only interface-to-interface can still be
+        // a subtype under different names (`A <: B` iff `A` requires `B`), so it
+        // is excluded. For the rest the canonical walk below is a foregone
+        // `false`: class heads are preserved by canonicalization and the class
+        // subtype rule requires equal names (generic args are invariant), while
+        // enums and enum variants are nominal with no cross-name rule at all.
+        if !matches!((sub, sup), (Ty::Interface(..), Ty::Interface(..)))
+            && heads_definitely_differ(sub, sup)
+        {
+            return false;
+        }
         let sub = NormalTy::canonical(sub, self);
         let sup = NormalTy::canonical(sup, self);
         sub.is_subtype_of(&sup, self, &mut HashSet::new())


### PR DESCRIPTION
Makes BAML compilation parallel by default — no flags, no env gates. \`RAYON_NUM_THREADS=1\` gives the serial reference path. Plus three single-threaded fixes for redundant work found by profiling.

## Commits

1. **parallel check + parallel emit codegen** — per-file \`check_file\` and per-function stackification on rayon's global pool, cloned shared-storage salsa handles (rust-analyzer model). Emit workers compile into watermark-based fragment pools; the serial merge replays cross-function \`GenericFunction\` interning in original order, reproducing the serial pool layout exactly.
2. **scope-inference dedup** — \`check_file\` drove diagnostics with HIR-minted ScopeIds while TIR/MIR key by PPIR's expanded-index ScopeIds, so every scope in a \`$stream\`-expanded file was inferred twice and re-inferred during emit. Now keyed by PPIR ScopeIds (HIR-prefix gated): \`infer_scope_types\` 13,331 → 8,719 executions.
3. **function_body discriminant** — step 6 deep-cloned every function's ExprBody arena just to test its kind; reads the item tree instead (~2,256 clones gone).
4. **\`is_subtype\` fast paths** — reflexivity + narrow head-mismatch reject (interface/interface pairs excluded — cross-name interface subtyping via \`requires\` is real).
5. **parallel MIR lowering** — the emit \`Db\` trait gains a defaulted \`parallel_db_handle()\`; \`ProjectDatabase\` mints cloned handles so Stage A's \`lower_function\` fans out too.

## Byte-identity

Permanent test \`parallel_emit_is_byte_identical_to_serial\`: full corpus compiled on a 1-thread pool vs the default pool, identical serialized bytes (covers the \`ns_instantiation_expr\` cross-function interning fixtures). Parallel check verified byte-identical diagnostics over two corpora. All suites green: 444/444 lsp2, 1,658/1,658 tir/diagnostics/compiles/emit/mir/instantiation.

## Numbers (cold, disk cache off, medians of 5)

| corpus | serial before | this PR |
|---|---|---|
| baml_tests (77 files, 25k lines) | 0.63 s | **0.265 s** (check 0.18, emit 0.08) |
| agent-tries-baml (53 files, 13k lines, check-only) | 0.21 s | **0.126 s** |

With #4058 merged earlier this week: cold compile 2.39 s → **0.27 s** (~9×).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved compilation and diagnostics performance by parallelizing bytecode emission and per-file diagnostic collection for larger projects.
- **Bug Fixes**
  - Fixed class-field metadata and pooled object index handling to ensure correct field/type resolution during compilation.
  - Improved determinism guarantees so serial and parallel output remains byte-identical.
  - Corrected scope diagnostics to use canonical scope IDs and streamlined function signature checks.
  - Improved subtype compatibility checks with early fast-path decisions.
- **Tests**
  - Added determinism coverage comparing serial vs parallel emit results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->