### PR TITLE
fix(bex_events): don't trust the TSC for cross-thread stamps under a hypervisor

### DIFF
--- a/baml_language/crates/bex_events/src/prof/clock.rs
+++ b/baml_language/crates/bex_events/src/prof/clock.rs
@@ -147,8 +147,13 @@ mod imp {
     /// NOT cross-core/cross-socket synchronization. On Linux we therefore
     /// also defer to the kernel, which measures TSC sync across CPUs at
     /// boot and only offers `tsc` as a clocksource when it holds (the same
-    /// check minstant used). Elsewhere the CPUID bit is the best signal
-    /// available; modern single-socket parts ship synchronized.
+    /// check minstant used). Elsewhere we require the invariant bit AND the
+    /// absence of a hypervisor: under virtualization the invariant bit is
+    /// still set, but a vCPU can migrate between physical cores whose TSCs
+    /// are not in lockstep, so `rdtsc` reads backwards across a thread
+    /// hand-off (observed on virtualized Windows CI). Falling back to
+    /// `Instant` there is correct, not just safe: Windows `Instant` is
+    /// `QueryPerformanceCounter`, which the OS keeps system-wide monotonic.
     #[cfg(target_arch = "x86_64")]
     fn tsc_is_trustworthy() -> bool {
         if !has_invariant_tsc() {
@@ -164,8 +169,24 @@ mod imp {
         }
         #[cfg(not(target_os = "linux"))]
         {
-            true
+            !hypervisor_present()
         }
+    }
+
+    /// Whether a hypervisor is present: `CPUID.01H:ECX[31]`, the "hypervisor
+    /// present" bit that is reserved-zero on bare metal and set by every
+    /// mainstream VMM. Used to reject the TSC for cross-thread stamps under
+    /// virtualization, where invariant-TSC no longer implies cross-vCPU
+    /// synchronization. Conservative by design: a guest whose hypervisor
+    /// *does* synchronize the TSC still falls back to `Instant`, trading a
+    /// little per-stamp cost for guaranteed cross-thread monotonicity.
+    #[cfg(all(target_arch = "x86_64", not(target_os = "linux")))]
+    // `__cpuid` is an unsafe fn on the pinned stable toolchain but safe on
+    // newer ones — keep the block, silence the newer toolchains' lint.
+    #[allow(unused_unsafe)]
+    fn hypervisor_present() -> bool {
+        // SAFETY: cpuid leaf 1 is unprivileged and universally available.
+        unsafe { core::arch::x86_64::__cpuid(1).ecx & (1 << 31) != 0 }
     }
 
     /// Invariant-TSC probe: CPUID.80000007H:EDX[8] (constant rate, does not


### PR DESCRIPTION
## Problem

`prof::clock::tests::cross_thread_ordering` fails intermittently on virtualized Windows CI:

```
thread panicked at crates\bex_events\src\prof\clock.rs:637:
cross-thread regression: 1533902163362 -> 1533902163190
```

`prof::clock` stamps profiling records from several OS threads and depends on cross-thread monotonicity. On non-Linux x86_64 it used `rdtsc` whenever the invariant-TSC CPUID bit (`CPUID.80000007H:EDX[8]`) was set. But that bit only guarantees *constant rate*, **not** cross-core synchronization — as the function's own doc comment already noted. Under virtualization the bit stays set while a vCPU can migrate between physical cores whose TSCs aren't in lockstep, so `rdtsc` reads *backwards* across a thread hand-off.

## Fix

Gate the non-Linux TSC path on the **absence of a hypervisor** (`CPUID.01H:ECX[31]`, the conventional "hypervisor present" bit, reserved-zero on bare metal, set by every mainstream VMM). Under a VM the clock falls back to `Instant`, which on Windows is `QueryPerformanceCounter` — the OS's system-wide-monotonic timer — so cross-thread stamps become *correct*, not just non-crashing.

- **Bare-metal x86**: unchanged (`rdtsc`).
- **Linux**: unchanged — its kernel clocksource probe already measures cross-CPU TSC sync at boot.
- **aarch64** (`CNTVCT_EL0`, architecturally synchronized): unaffected.
- Conservative by design: a VM whose hypervisor *does* sync the TSC also falls back to `Instant`, trading a little per-stamp cost for guaranteed cross-thread monotonicity.

## Verification

Compiles on `x86_64-apple-darwin` (non-Linux arm) and `x86_64-unknown-linux-musl` (Linux arm), and all `prof::clock` tests pass natively. The virtualized-Windows path can't be reproduced on non-VM hardware, but the fallback is `Instant`/QPC, which is monotonic by OS design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profiling clock reliability on non-Linux x86_64 systems running in virtualized environments.
  * Automatically falls back to a more dependable timing source when a hypervisor is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->