### PR TITLE
bridge-cpp: async call form - {name}Async siblings, baml::Future, cancellation, co_await

### DIFF
--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/cxx20/test_coawait.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/cxx20/test_coawait.cc
@@ -1,0 +1,161 @@
+// co_await coverage for baml::Future (this file builds as a separate
+// C++20 executable; the C++17 blocking surface is covered by
+// test_cancellation.cc). No python analog: python awaits are event-loop
+// native, while C++20 ships coroutines without a task type - a minimal
+// completion-latch TestTask drives the coroutines here, and the bridge
+// dispatcher thread resumes them.
+//
+// Coroutines take their inputs by value and their outputs via pointers to
+// test-owned locals (never lambda captures: a capturing lambda coroutine
+// dangles once the lambda temporary dies at the end of the launch
+// statement).
+#include <baml_sdk.h>
+#include <baml_test.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <utility>
+#include <variant>
+
+#if !defined(BAML_HAS_COROUTINES)
+#error "the cxx20 test target must enable baml::Future's awaiter"
+#endif
+
+#include <coroutine>
+
+namespace throws_test = baml_sdk::throws_test;
+using baml_sdk::throws_test::MyError;
+
+using SleepFuture = decltype(throws_test::SleepMsAsync(0));
+using IntFuture = decltype(baml_sdk::round_trip_intAsync(0));
+using ThrowFuture = decltype(throws_test::ThrowMyErrorAsync());
+
+namespace {
+
+// Minimal eager coroutine with a completion latch: the test thread blocks
+// in Join() until the coroutine finishes (possibly resumed on the bridge
+// dispatcher thread) and an escaped exception rethrows there.
+struct TestTask {
+  struct Latch {
+    std::mutex mu;
+    std::condition_variable cv;
+    bool done = false;
+    std::exception_ptr error;
+  };
+
+  struct promise_type {
+    std::shared_ptr<Latch> latch = std::make_shared<Latch>();
+    TestTask get_return_object() { return TestTask{latch}; }
+    std::suspend_never initial_suspend() { return {}; }
+    std::suspend_never final_suspend() noexcept { return {}; }
+    void return_void() { Finish(nullptr); }
+    void unhandled_exception() { Finish(std::current_exception()); }
+    void Finish(std::exception_ptr error) {
+      {
+        std::lock_guard<std::mutex> lock(latch->mu);
+        latch->error = std::move(error);
+        latch->done = true;
+      }
+      latch->cv.notify_all();
+    }
+  };
+
+  void Join() {
+    std::unique_lock<std::mutex> lock(latch->mu);
+    latch->cv.wait(lock, [this] { return latch->done; });
+    if (latch->error) {
+      std::rethrow_exception(latch->error);
+    }
+  }
+
+  std::shared_ptr<Latch> latch;
+};
+
+TestTask AwaitSleep(SleepFuture fut, bool* completed) {
+  (void)co_await std::move(fut);
+  *completed = true;
+}
+
+TestTask AwaitInt(IntFuture fut, int64_t* out) {
+  *out = co_await std::move(fut);
+}
+
+TestTask AwaitExpectMyError(ThrowFuture fut, bool* caught) {
+  try {
+    (void)co_await std::move(fut);
+  } catch (const baml::BamlThrown<baml::Union<MyError>>& e) {
+    *caught = e.get<MyError>() == MyError{42, "boom"};
+  }
+}
+
+TestTask AwaitExpectCancelled(SleepFuture fut, bool* cancelled) {
+  try {
+    (void)co_await std::move(fut);
+  } catch (const baml::BamlCancelled&) {
+    *cancelled = true;
+  }
+}
+
+TestTask AwaitUncaught(ThrowFuture fut) { (void)co_await std::move(fut); }
+
+}  // namespace
+
+BAML_TEST(co_await_pending_future_resumes) {
+  // A genuinely in-flight call: the coroutine suspends and the dispatcher
+  // thread resumes it when the envelope lands.
+  bool completed = false;
+  TestTask task = AwaitSleep(throws_test::SleepMsAsync(100), &completed);
+  task.Join();
+  BAML_ASSERT(completed);
+}
+
+BAML_TEST(co_await_yields_the_decoded_value) {
+  int64_t got = 0;
+  TestTask task = AwaitInt(baml_sdk::round_trip_intAsync(7), &got);
+  task.Join();
+  BAML_ASSERT(got == 7);
+}
+
+BAML_TEST(co_await_completed_future_fast_path) {
+  // await_ready() true: no suspension, the coroutine runs straight through.
+  auto fut = baml_sdk::round_trip_intAsync(7);
+  fut.wait();
+  int64_t got = 0;
+  TestTask task = AwaitInt(std::move(fut), &got);
+  task.Join();
+  BAML_ASSERT(got == 7);
+}
+
+BAML_TEST(co_await_throws_typed_into_the_coroutine) {
+  bool caught = false;
+  TestTask task = AwaitExpectMyError(throws_test::ThrowMyErrorAsync(), &caught);
+  task.Join();
+  BAML_ASSERT(caught);
+}
+
+BAML_TEST(co_await_cancelled_call_throws_cancelled) {
+  auto fut = throws_test::SleepMsAsync(2000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  BAML_ASSERT(fut.Cancel());
+  bool cancelled = false;
+  TestTask task = AwaitExpectCancelled(std::move(fut), &cancelled);
+  task.Join();
+  BAML_ASSERT(cancelled);
+}
+
+BAML_TEST(uncaught_coroutine_exception_reaches_join) {
+  TestTask task = AwaitUncaught(throws_test::ThrowMyErrorAsync());
+  bool rethrown = false;
+  try {
+    task.Join();
+  } catch (const baml::BamlThrown<baml::Union<MyError>>&) {
+    rethrown = true;
+  }
+  BAML_ASSERT(rethrown);
+}
+
+BAML_TEST_MAIN()

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/futures_static.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/futures_static.cc
@@ -1,0 +1,32 @@
+// Static shape checks for the baml::Future surface (no python analog;
+// documents the compile-time contract the way unions_static.cc does for
+// baml::Union).
+#include <baml_sdk.h>
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+
+namespace {
+
+using IntFuture = baml::Future<int64_t, baml::Union<std::string, int64_t>>;
+
+// std::future semantics: single consumer, move-only.
+static_assert(std::is_move_constructible<IntFuture>::value,
+              "baml::Future must be movable");
+static_assert(std::is_move_assignable<IntFuture>::value,
+              "baml::Future must be move-assignable");
+static_assert(!std::is_copy_constructible<IntFuture>::value,
+              "baml::Future must not be copyable");
+static_assert(!std::is_copy_assignable<IntFuture>::value,
+              "baml::Future must not be copy-assignable");
+
+// The ThrownU parameter rides baml::Union canonicalization: a reordered
+// spelling of the throws set cannot mint a second Future type.
+static_assert(
+    std::is_same<
+        baml::Future<int64_t, baml::Union<std::string, int64_t>>,
+        baml::Future<int64_t, baml::Union<int64_t, std::string>>>::value,
+    "Future's throws union must be order-canonical");
+
+}  // namespace

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_cancellation.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_cancellation.cc
@@ -75,10 +75,8 @@ BAML_TEST(future_wait_for_times_out_while_in_flight) {
 }
 
 BAML_TEST(future_destruction_detaches) {
-  // Dropping a future neither blocks nor cancels; the abandoned call
-  // completes on its own and later calls are unaffected.
-  {
-    auto fut = throws_test::SleepMsAsync(1);
-  }
+  // The temporary future is dropped at the end of the statement: neither
+  // blocks nor cancels, and later calls are unaffected.
+  (void)throws_test::SleepMsAsync(1);
   BAML_ASSERT(throws_test::SleepMs(1) == std::monostate{});
 }

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_cancellation.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_cancellation.cc
@@ -1,0 +1,84 @@
+// Cancellation coverage. Port of function_calls/test_cancellation.py.
+// Deviations: the asyncio task/TaskGroup/timeout idioms and BamlCallContext
+// have no C++ analog (sync calls are uncancellable; there is no ambient
+// call context) - the portable core is the null-return baseline and
+// engine-side cancellation of an in-flight call via Future::Cancel. The
+// trailing future-semantics cases are C++-specific (python awaitables are
+// single-consume by construction).
+#include <baml_sdk.h>
+#include <baml_test.h>
+
+#include <chrono>
+#include <future>
+#include <thread>
+#include <variant>
+
+namespace throws_test = baml_sdk::throws_test;
+
+BAML_TEST(sync_call_returns_none) {
+  BAML_ASSERT(throws_test::SleepMs(1) == std::monostate{});
+}
+
+BAML_TEST(async_call_returns_none) {
+  BAML_ASSERT(throws_test::SleepMsAsync(1).get() == std::monostate{});
+}
+
+BAML_TEST(async_cancel_via_future_cancel) {
+  const auto start = std::chrono::steady_clock::now();
+  auto fut = throws_test::SleepMsAsync(2000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  BAML_ASSERT(fut.Cancel());
+  bool cancelled = false;
+  try {
+    fut.get();
+  } catch (const baml::BamlCancelled&) {
+    cancelled = true;
+  }
+  BAML_ASSERT(cancelled);
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  BAML_ASSERT(elapsed < std::chrono::milliseconds(500));
+}
+
+BAML_TEST(future_wait_then_get) {
+  auto fut = throws_test::SleepMsAsync(1);
+  BAML_ASSERT(fut.valid());
+  BAML_ASSERT(fut.wait_for(std::chrono::seconds(30)) ==
+              std::future_status::ready);
+  BAML_ASSERT(fut.get() == std::monostate{});
+  BAML_ASSERT(!fut.valid());
+}
+
+BAML_TEST(future_second_get_throws_future_error) {
+  auto fut = throws_test::SleepMsAsync(1);
+  (void)fut.get();
+  bool threw = false;
+  try {
+    (void)fut.get();
+  } catch (const std::future_error&) {
+    threw = true;
+  }
+  BAML_ASSERT(threw);
+}
+
+BAML_TEST(future_wait_for_times_out_while_in_flight) {
+  auto fut = throws_test::SleepMsAsync(2000);
+  BAML_ASSERT(fut.wait_for(std::chrono::milliseconds(1)) ==
+              std::future_status::timeout);
+  BAML_ASSERT(fut.Cancel());
+  bool cancelled = false;
+  try {
+    fut.get();
+  } catch (const baml::BamlCancelled&) {
+    cancelled = true;
+  }
+  BAML_ASSERT(cancelled);
+}
+
+BAML_TEST(future_destruction_detaches) {
+  // Dropping a future neither blocks nor cancels; the abandoned call
+  // completes on its own and later calls are unaffected.
+  {
+    auto fut = throws_test::SleepMsAsync(1);
+  }
+  BAML_ASSERT(throws_test::SleepMs(1) == std::monostate{});
+}

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_errors.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_errors.cc
@@ -74,6 +74,17 @@ BAML_TEST(union_throws_preserves_class_name) {
   }
 }
 
+BAML_TEST(async_sibling_throws_typed) {
+  // C++-specific: the Async sibling's get() surfaces the identical typed
+  // throw as the sync form (python covers this through await semantics).
+  try {
+    baml_sdk::throws_test::ThrowMyErrorAsync().get();
+    baml_test::Fail("ThrowMyErrorAsync did not throw");
+  } catch (const baml::BamlThrown<baml::Union<MyError>>& e) {
+    BAML_ASSERT((e.get<MyError>() == MyError{42, "boom"}));
+  }
+}
+
 BAML_TEST(typed_throw_is_still_a_baml_error) {
   // Backward compatibility: an untyped catch site sees the same throw.
   try {

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_main.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_main.cc
@@ -4,7 +4,8 @@
 #include <baml_test.h>
 
 BAML_TEST(hello_world_returns_literal) {
-  BAML_ASSERT_EQ(baml_sdk::hello_world(), std::string("hello world"));
+  BAML_ASSERT(baml_sdk::hello_world() == BAML_LIT("hello world"){});
+  BAML_ASSERT(BAML_LIT("hello world")::value == "hello world");
 }
 
 BAML_TEST(single_required_arg_round_trips) {

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_optional_args.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_optional_args.cc
@@ -37,6 +37,16 @@ BAML_TEST(optional_args_runtime_matrix) {
               (Probe{1, 8, 9}));
 }
 
+BAML_TEST(optional_args_async_samples) {
+  BAML_ASSERT(baml_sdk::optional_args_probeAsync(1).get() == (Probe{1, 5, 99}));
+  BAML_ASSERT(baml_sdk::optional_args_probeAsync(
+                  1, optional_args_probeOpts{}.set_opt1(std::nullopt))
+                  .get() == (Probe{1, std::nullopt, 99}));
+  BAML_ASSERT(baml_sdk::optional_args_probeAsync(
+                  1, optional_args_probeOpts{}.set_opt2(int64_t{9}))
+                  .get() == (Probe{1, 5, 9}));
+}
+
 BAML_TEST(unset_and_null_differ_in_one_call) {
   // unset means "omit this argument"; nullopt means "pass an explicit
   // null". The two must stay distinct within a single call.

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_raises.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_raises.cc
@@ -2,8 +2,7 @@
 // free-function subset of function_calls/customizable/test_raises.py:
 // Python asserts on runtime __doc__; the C++ surface is the generated
 // header's `/// Raises:` lines (unqualified type names), scraped from the
-// header text. The async-sibling and method/.pyi sub-cases are
-// post-step-8.
+// header text. The method/.pyi sub-cases are post-step-8.
 #include <baml_sdk.h>
 #include <baml_test.h>
 
@@ -43,6 +42,17 @@ BAML_TEST(inferred_contract_without_clause_still_raises) {
   // inferred contract (callable_throws) still surfaces a Raises line.
   BAML_ASSERT(HeaderText().find("/// Raises: ParseError\n"
                                 "std::string InferredThrow(") !=
+              std::string::npos);
+}
+
+BAML_TEST(async_sibling_also_has_raises) {
+  // The Async sibling repeats the full doc block, and its return wraps the
+  // declared throws set as the Future's second parameter.
+  BAML_ASSERT(HeaderText().find(
+                  "/// Raises: ParseError, TimeoutError\n"
+                  "::baml::Future<std::string, "
+                  "::baml::Union<::baml_sdk::raises_test::ParseError, "
+                  "::baml_sdk::raises_test::TimeoutError>> LoadDocAsync(") !=
               std::string::npos);
 }
 

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_complex_models.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_complex_models.cc
@@ -42,7 +42,7 @@ BAML_TEST(
   const ContactMethod phone{"phone", "+1-555-0100", false};
   const Invoice invoice{
       "inv-001",
-      "sent",
+      BAML_LIT("sent"){},
       {LineItem{
           "sdk-pro",
           2,
@@ -55,7 +55,7 @@ BAML_TEST(
   };
   const Invoice wire_invoice{
       "inv-002",
-      "paid",
+      BAML_LIT("paid"){},
       {LineItem{
           "sdk-enterprise",
           1,
@@ -73,9 +73,10 @@ BAML_TEST(
       {home, office},
       {invoice, wire_invoice},
       {
-          AuditEvent{"system", "created", {{"source", "fixture"}}},
-          AuditEvent{
-              "reviewer", "approved", {{"level", "2"}, {"region", "us"}}},
+          AuditEvent{"system", BAML_LIT("created"){}, {{"source", "fixture"}}},
+          AuditEvent{"reviewer",
+                     BAML_LIT("approved"){},
+                     {{"level", "2"}, {"region", "us"}}},
       },
       {{"cohort", "beta"}, {"owner_kind", "internal"}},
       Featured{invoice},

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_enums.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_enums.cc
@@ -22,13 +22,15 @@ BAML_TEST(round_trip_sentiment) {
 }
 
 BAML_TEST(round_trip_sentiment_positive) {
-  // EnumVariant-as-type: the variant tag is dropped during TIR->codegen,
-  // so the C++ type is just Sentiment.
-  BAML_ASSERT(baml_sdk::enums::round_trip_sentiment_positive(
-                  Sentiment::Positive) == Sentiment::Positive);
+  // EnumVariant-as-type is a singleton Lit: only the tagged variant fits,
+  // and the value converts back to the enum implicitly.
+  const Sentiment round_tripped =
+      baml_sdk::enums::round_trip_sentiment_positive(
+          BAML_LIT(Sentiment::Positive){});
+  BAML_ASSERT(round_tripped == Sentiment::Positive);
 }
 
 BAML_TEST(round_trip_enums) {
-  const Enums e{Sentiment::Positive, Sentiment::Positive};
+  const Enums e{Sentiment::Positive, BAML_LIT(Sentiment::Positive){}};
   BAML_ASSERT(baml_sdk::enums::round_trip_enums(e) == e);
 }

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_literals.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_literals.cc
@@ -1,46 +1,95 @@
-// Roundtrip coverage for baml_sdk::literals - literal Ty variants, widened
-// to their base types (spec parity with Python's Literal handling).
-// Port of roundtrip_tests/test_literals.py.
+// Roundtrip coverage for baml_sdk::literals - literal Ty variants as
+// singleton ::baml::Lit types. Port of roundtrip_tests/test_literals.py:
+// python keeps the value set in typing.Literal annotations; C++ makes each
+// value a distinct type, so the round trips construct through the
+// BAML_LIT macro family and read back through Lit's implicit value
+// conversions.
 #include <baml_sdk.h>
 #include <baml_test.h>
 
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
 using baml_sdk::literals::Literals;
 
+// The generated surface is typed per value, not widened.
+static_assert(std::is_same<decltype(baml_sdk::literals::return_literal42()),
+                           BAML_LIT(42)>::value,
+              "int literal return must be a Lit");
+static_assert(std::is_same<decltype(baml_sdk::literals::return_literal_draft()),
+                           BAML_LIT("draft")>::value,
+              "string literal return must be a Lit");
+static_assert(std::is_same<decltype(baml_sdk::literals::return_literal_true()),
+                           BAML_LIT(true)>::value,
+              "bool literal return must be a Lit");
+
 BAML_TEST(return_literals) {
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal42(), 42);
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_neg_one(), -1);
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_draft(),
-                 std::string("draft"));
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_escaped(),
-                 std::string("has \"quotes\""));
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_true(), true);
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_false(), false);
+  BAML_ASSERT(baml_sdk::literals::return_literal42() == BAML_LIT(42){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_neg_one() == BAML_LIT(-1){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_draft() ==
+              BAML_LIT("draft"){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_escaped() ==
+              BAML_LIT("has \"quotes\""){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_true() == BAML_LIT(true){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_false() == BAML_LIT(false){});
+}
+
+BAML_TEST(literal_values_convert_implicitly) {
+  const int64_t n = baml_sdk::literals::return_literal42();
+  BAML_ASSERT(n == 42);
+  const std::string_view s = baml_sdk::literals::return_literal_draft();
+  BAML_ASSERT(s == "draft");
+  const bool b = baml_sdk::literals::return_literal_true();
+  BAML_ASSERT(b);
+  BAML_ASSERT(BAML_LIT("has \"quotes\"")::value == "has \"quotes\"");
 }
 
 BAML_TEST(round_trip_literal42) {
-  BAML_ASSERT_EQ(baml_sdk::literals::round_trip_literal42(42), 42);
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal42(BAML_LIT(42){}) ==
+              BAML_LIT(42){});
 }
 
 BAML_TEST(round_trip_literal_draft) {
-  BAML_ASSERT_EQ(baml_sdk::literals::round_trip_literal_draft("draft"),
-                 std::string("draft"));
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal_draft(
+                  BAML_LIT("draft"){}) == BAML_LIT("draft"){});
 }
 
 BAML_TEST(round_trip_literal_escaped) {
-  BAML_ASSERT_EQ(
-      baml_sdk::literals::round_trip_literal_escaped("has \"quotes\""),
-      std::string("has \"quotes\""));
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal_escaped(BAML_LIT(
+                  "has \"quotes\""){}) == BAML_LIT("has \"quotes\""){});
 }
 
 BAML_TEST(round_trip_literal_true) {
-  BAML_ASSERT_EQ(baml_sdk::literals::round_trip_literal_true(true), true);
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal_true(BAML_LIT(true){}) ==
+              BAML_LIT(true){});
 }
 
 BAML_TEST(round_trip_literal_false) {
-  BAML_ASSERT_EQ(baml_sdk::literals::round_trip_literal_false(false), false);
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal_false(BAML_LIT(false){}) ==
+              BAML_LIT(false){});
 }
 
 BAML_TEST(round_trip_literals) {
-  const Literals lit{42, "draft", "has \"quotes\"", true, false};
+  const Literals lit{BAML_LIT(42){}, BAML_LIT("draft"){},
+                     BAML_LIT("has \"quotes\""){}, BAML_LIT(true){},
+                     BAML_LIT(false){}};
   BAML_ASSERT(baml_sdk::literals::round_trip_literals(lit) == lit);
+}
+
+BAML_TEST(round_trip_flag_mixed_literal_union) {
+  // Mixed-base literal union ("active" | 1 | true): the union codec's
+  // literal pass must route each wire arm to its exact Lit alternative.
+  using baml_sdk::literals::Flag;
+  Flag f = baml_sdk::literals::round_trip_flag(BAML_LIT("active"){});
+  BAML_ASSERT(std::holds_alternative<BAML_LIT("active")>(f));
+  f = baml_sdk::literals::round_trip_flag(BAML_LIT(1){});
+  BAML_ASSERT(std::holds_alternative<BAML_LIT(1)>(f));
+  f = baml_sdk::literals::round_trip_flag(BAML_LIT(true){});
+  const int which = baml::match(
+      f,                                                                    //
+      [](BAML_LIT("active")) { return 0; }, [](BAML_LIT(1)) { return 1; },  //
+      [](BAML_LIT(true)) { return 2; });
+  BAML_ASSERT(which == 2);
 }

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/unions_static.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/unions_static.cc
@@ -26,6 +26,20 @@ static_assert(
                  std::vector<baml::Union<std::string, int64_t>>>::value,
     "canonicalization must hold under std::vector");
 
+// Literal types are ordinary alternatives: the BAML_LIT macro family hits
+// the canonical char-pack / normalized-scalar instantiations, and Lit
+// unions canonicalize like any other.
+static_assert(
+    std::is_same<BAML_LIT("draft"), baml::Lit<'d', 'r', 'a', 'f', 't'>>::value,
+    "BAML_LIT must produce the canonical char pack");
+static_assert(std::is_same<BAML_LIT(1), baml::Lit<int64_t{1}>>::value,
+              "BAML_LIT must normalize ints to int64_t");
+static_assert(std::is_same<BAML_LIT(1), baml::IntLit<1>>::value,
+              "IntLit must agree with BAML_LIT");
+static_assert(std::is_same<baml::Union<BAML_LIT("a"), BAML_LIT("b")>,
+                           baml::Union<BAML_LIT("b"), BAML_LIT("a")>>::value,
+              "Lit unions must be order-canonical");
+
 // Alternatives are a set, not a list: duplicates collapse, so type-based
 // construction and access are never ambiguous.
 static_assert(

--- a/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_literals.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_literals.py
@@ -62,3 +62,13 @@ def test_round_trip_literals():
         literal_false=False,
     )
     assert round_trip_literals(l=lit) == lit
+
+
+def test_round_trip_flag_mixed_literal_union():
+    from baml_sdk.literals import round_trip_flag
+
+    assert round_trip_flag(f="active") == "active"
+    r_int = round_trip_flag(f=1)
+    assert r_int == 1 and not isinstance(r_int, bool)
+    r_bool = round_trip_flag(f=True)
+    assert r_bool is True

--- a/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_literals/types.baml
+++ b/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_literals/types.baml
@@ -63,3 +63,11 @@ function round_trip_literal_false(x: false) -> false {
 function round_trip_literals(l: Literals) -> Literals {
   l
 }
+
+// Mixed-base literal union: every alternative is a literal of a different
+// base type, so hosts with typed literals must dispatch by value.
+type Flag = "active" | 1 | true
+
+function round_trip_flag(f: Flag) -> Flag {
+  f
+}

--- a/baml_language/sdk_tests/harness_setup/src/templates/cpp_test.sh
+++ b/baml_language/sdk_tests/harness_setup/src/templates/cpp_test.sh
@@ -34,6 +34,13 @@ HAVE_TESTS=0
 if compgen -G "tests/*.cc" > /dev/null; then
     HAVE_TESTS=1
 fi
+# tests/cxx20/*.cc need C++20 (co_await coverage); they build as a second
+# executable only when the toolchain has C++20, so the main test binary
+# keeps verifying that the generated SDK compiles as plain C++17.
+HAVE_CXX20_TESTS=0
+if compgen -G "tests/cxx20/*.cc" > /dev/null; then
+    HAVE_CXX20_TESTS=1
+fi
 
 # Consumer-shaped shim project: add_subdirectory over the generated SDK,
 # plus the fixture tests when present.
@@ -49,6 +56,18 @@ mkdir -p "$BUILD_DIR"
         echo 'target_link_libraries(fixture_tests PRIVATE baml::sdk)'
         echo 'if(NOT MSVC)'
         echo '  target_compile_options(fixture_tests PRIVATE -Wall -Wextra)'
+        echo 'endif()'
+    fi
+    if [ "$HAVE_CXX20_TESTS" = 1 ]; then
+        echo 'if("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)'
+        echo "  file(GLOB CXX20_TEST_SOURCES \"$GENERATED/tests/cxx20/*.cc\")"
+        echo '  add_executable(fixture_tests_cxx20 ${CXX20_TEST_SOURCES})'
+        echo '  target_compile_features(fixture_tests_cxx20 PRIVATE cxx_std_20)'
+        echo "  target_include_directories(fixture_tests_cxx20 PRIVATE \"$COMMON_DIR\")"
+        echo '  target_link_libraries(fixture_tests_cxx20 PRIVATE baml::sdk)'
+        echo '  if(NOT MSVC)'
+        echo '    target_compile_options(fixture_tests_cxx20 PRIVATE -Wall -Wextra)'
+        echo '  endif()'
         echo 'endif()'
     fi
 } > "$BUILD_DIR/CMakeLists.txt"
@@ -81,4 +100,12 @@ if [ "$MODE" = run ]; then
     esac
     BAML_RUNTIME_PATH="$WORKSPACE_ROOT/target/debug/$RUNTIME_LIB" \
         "$BUILD_DIR/build/fixture_tests"
+    if [ "$HAVE_CXX20_TESTS" = 1 ]; then
+        if [ -x "$BUILD_DIR/build/fixture_tests_cxx20" ]; then
+            BAML_RUNTIME_PATH="$WORKSPACE_ROOT/target/debug/$RUNTIME_LIB" \
+                "$BUILD_DIR/build/fixture_tests_cxx20"
+        else
+            echo "note: toolchain lacks C++20; tests/cxx20 skipped"
+        fi
+    fi
 fi

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
@@ -13,6 +13,7 @@
 #include <baml/detail/registry.h>
 #include <baml/errors.h>
 #include <baml/future.h>
+#include <baml/lit.h>
 #include <baml/runtime.h>
 #include <baml/union.h>
 

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
@@ -12,6 +12,7 @@
 #include <baml/detail/loader.h>
 #include <baml/detail/registry.h>
 #include <baml/errors.h>
+#include <baml/future.h>
 #include <baml/runtime.h>
 #include <baml/union.h>
 

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/codec.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/codec.h
@@ -12,6 +12,7 @@
 #include <baml/box.h>
 #include <baml/detail/proto.h>
 #include <baml/errors.h>
+#include <baml/lit.h>
 
 #include <cstdint>
 #include <cstdlib>
@@ -259,6 +260,57 @@ struct Codec<std::unordered_map<std::string, T>> {
   }
 };
 
+// BAML literal types (baml::Lit). Encode writes the static value as its
+// plain scalar/enum arm (the engine types the parameter). Decode reuses
+// the base codec for arm handling (plain and literal wire arms alike) and
+// then requires the exact value: a mismatch throws, which inside a union
+// rejects this alternative and lets the next one probe.
+template <auto... Vs>
+struct Codec<Lit<Vs...>> {
+  using L = Lit<Vs...>;
+  static constexpr detail::LitShape kShape =
+      detail::LitShapeOf<decltype(Vs)...>();
+
+  static void Encode(detail::pb::InboundValue& value_msg, const L&) {
+    if constexpr (kShape == detail::LitShape::kString) {
+      value_msg.set_string_value(std::string(L::value));
+    } else if constexpr (kShape == detail::LitShape::kInt) {
+      value_msg.set_int_value(L::value);
+    } else if constexpr (kShape == detail::LitShape::kBool) {
+      value_msg.set_bool_value(L::value);
+    } else {
+      Codec<std::decay_t<decltype(L::value)>>::Encode(value_msg, L::value);
+    }
+  }
+
+  static L Decode(const detail::pb::BamlOutboundValue& raw) {
+    if constexpr (kShape == detail::LitShape::kString) {
+      if (Codec<std::string>::Decode(raw) != L::value) {
+        Mismatch("literal \"" + std::string(L::value) + "\"");
+      }
+    } else if constexpr (kShape == detail::LitShape::kInt) {
+      if (Codec<int64_t>::Decode(raw) != L::value) {
+        Mismatch("literal " + std::to_string(L::value));
+      }
+    } else if constexpr (kShape == detail::LitShape::kBool) {
+      if (Codec<bool>::Decode(raw) != L::value) {
+        Mismatch(L::value ? "literal true" : "literal false");
+      }
+    } else {
+      using E = std::decay_t<decltype(L::value)>;
+      if (Codec<E>::Decode(raw) != L::value) {
+        Mismatch("enum-variant literal");
+      }
+    }
+    return L{};
+  }
+
+ private:
+  [[noreturn]] static void Mismatch(const std::string& expected) {
+    throw BamlError("BAML decode error: expected " + expected);
+  }
+};
+
 // BAML unions (baml::Union<Ts...> = order-canonical std::variant). Encode
 // writes the ACTIVE alternative's value with no union wrapper (the engine
 // types the member; Python parity). Decode receives the union-unwrapped
@@ -266,8 +318,10 @@ struct Codec<std::unordered_map<std::string, T>> {
 // alone -- alternatives are in canonical (sorted) order, so selection is
 // order-independent by construction:
 //
-//   pass 1 (strict): each alternative decodes only its exact wire arms
-//     (int never satisfies a double alternative);
+//   pass 0 (literal): Lit alternatives claim their exact values first, so
+//     Lit<"auto"> beats a std::string sibling for the string "auto";
+//   pass 1 (strict): each non-Lit alternative decodes only its exact wire
+//     arms (int never satisfies a double alternative);
 //   pass 2 (lenient): the engine's int->float coercion is admitted, for
 //     unions with a float arm but no int arm.
 //
@@ -290,9 +344,12 @@ struct Codec<std::variant<Ts...>> {
   static V Decode(const detail::pb::BamlOutboundValue& raw) {
     const auto& v = detail::Unwrap(raw);
     std::optional<V> out;
-    const bool strict = (TryArm<Ts>(v, out, false) || ...);
-    if (!strict) {
-      (TryArm<Ts>(v, out, true) || ...);
+    const bool lit = (TryArm<Ts>(v, out, Pass::kLiteral) || ...);
+    if (!lit) {
+      const bool strict = (TryArm<Ts>(v, out, Pass::kStrict) || ...);
+      if (!strict) {
+        (TryArm<Ts>(v, out, Pass::kLenient) || ...);
+      }
     }
     if (!out.has_value()) {
       detail::KindMismatch("union", v);
@@ -301,6 +358,8 @@ struct Codec<std::variant<Ts...>> {
   }
 
  private:
+  enum class Pass { kLiteral, kStrict, kLenient };
+
   static bool IsIntArm(const detail::pb::BamlOutboundValue& v) {
     if (v.value_case() == detail::pb::BamlOutboundValue::kIntValue) {
       return true;
@@ -312,8 +371,12 @@ struct Codec<std::variant<Ts...>> {
 
   template <class T>
   static bool TryArm(const detail::pb::BamlOutboundValue& v,
-                     std::optional<V>& out, bool lenient) {
-    if (!lenient && std::is_same<T, double>::value && IsIntArm(v)) {
+                     std::optional<V>& out, Pass pass) {
+    if ((pass == Pass::kLiteral) != detail::IsLit<T>::value) {
+      return false;
+    }
+    if (pass == Pass::kStrict && std::is_same<T, double>::value &&
+        IsIntArm(v)) {
       return false;
     }
     try {

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/call.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/call.h
@@ -1,18 +1,21 @@
 #ifndef BAML_DETAIL_CALL_H_
 #define BAML_DETAIL_CALL_H_
 
-// The call driver generated bindings sit on: encode CallFunctionArgs, cross
-// the C ABI once, and block on the result envelope correlated through the
-// registry. (The engine call model is asynchronous; this slice exposes only
-// the synchronous wrapper.)
+// The call drivers generated bindings sit on: encode CallFunctionArgs,
+// cross the C ABI once, and correlate the result envelope through the
+// registry. StartCall returns the in-flight call as a baml::Future; the
+// synchronous form is exactly StartCall + an immediate blocking get(), so
+// both spellings share one code path.
 
 #include <baml/codec.h>
 #include <baml/detail/proto.h>
 #include <baml/detail/registry.h>
+#include <baml/future.h>
 #include <baml_cffi.h>
 
 #include <cstdint>
 #include <string>
+#include <utility>
 
 namespace baml {
 namespace detail {
@@ -21,14 +24,19 @@ namespace detail {
 // when the function declares none): the error arm then surfaces as
 // BamlThrown<ThrownU> instead of an untyped BamlError.
 template <typename Ret, typename ThrownU = void>
-Ret CallSync(const std::string& fqn, ArgsEncoder&& args) {
+Future<Ret, ThrownU> StartCall(const std::string& fqn, ArgsEncoder&& args) {
   CallRegistry::Started started = CallRegistry::Instance().Begin();
   const uint64_t engine_call_id = Api().new_function_call();
   const std::string encoded = args.Finish(engine_call_id);
   Api().call_function(fqn.c_str(),
                       reinterpret_cast<const uint8_t*>(encoded.data()),
                       encoded.size(), started.correlation_id);
-  return DecodeResult<Ret, ThrownU>(started.envelope.get());
+  return Future<Ret, ThrownU>(std::move(started.state), engine_call_id);
+}
+
+template <typename Ret, typename ThrownU = void>
+Ret CallSync(const std::string& fqn, ArgsEncoder&& args) {
+  return StartCall<Ret, ThrownU>(fqn, std::move(args)).get();
 }
 
 }  // namespace detail

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/registry.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/registry.h
@@ -5,9 +5,12 @@
 #include <baml_cffi.h>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
-#include <future>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <utility>
@@ -20,14 +23,63 @@ extern "C" inline void baml_cpp_result_trampoline(uint32_t call_id,
 namespace baml {
 namespace detail {
 
+// Per-call completion state shared between the issuing thread (via
+// baml::Future) and the engine callback thread. A plain mutex/condvar cell
+// rather than std::promise so a continuation can run at fulfillment time:
+// std::future has no completion hook, and the co_await awaiter needs the
+// dispatcher thread to resume the suspended coroutine when the envelope
+// lands. The continuation is a C++17-clean function pointer (the coroutine
+// glue lives behind the feature-gate in future.h).
+struct CallState {
+  std::mutex mu;
+  std::condition_variable cv;
+  bool ready = false;
+  std::vector<uint8_t> envelope;
+  void (*continuation)(void*) = nullptr;
+  void* continuation_arg = nullptr;
+
+  // Called from the engine callback thread. Publishes the envelope, wakes
+  // blocked waiters, and runs the registered continuation (outside the
+  // lock: it may resume a coroutine that immediately touches this state).
+  void Fulfill(const uint8_t* bytes, size_t length) {
+    void (*resume)(void*) = nullptr;
+    void* resume_arg = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      envelope.assign(bytes, bytes + length);
+      ready = true;
+      resume = continuation;
+      resume_arg = continuation_arg;
+    }
+    cv.notify_all();
+    if (resume != nullptr) {
+      resume(resume_arg);
+    }
+  }
+
+  // Blocks until the envelope arrives. The reference stays valid for the
+  // life of this state; only Fulfill writes it, exactly once.
+  const std::vector<uint8_t>& Wait() {
+    std::unique_lock<std::mutex> lock(mu);
+    cv.wait(lock, [this] { return ready; });
+    return envelope;
+  }
+
+  template <class Clock, class Duration>
+  bool WaitUntil(const std::chrono::time_point<Clock, Duration>& deadline) {
+    std::unique_lock<std::mutex> lock(mu);
+    return cv.wait_until(lock, deadline, [this] { return ready; });
+  }
+};
+
 // Correlates async results with in-flight calls. The C ABI has exactly one
-// process-global result callback; this registry owns it and fans results out
-// to per-call promises keyed by a bridge-issued correlation id.
+// process-global result callback; this registry owns it and fans results
+// out to per-call CallState cells keyed by a bridge-issued correlation id.
 class CallRegistry {
  public:
   struct Started {
     uint32_t correlation_id;
-    std::future<std::vector<uint8_t>> envelope;
+    std::shared_ptr<CallState> state;
   };
 
   static CallRegistry& Instance() {
@@ -43,19 +95,18 @@ class CallRegistry {
     if (id == 0) {
       id = next_id_.fetch_add(1, std::memory_order_relaxed);
     }
-    std::promise<std::vector<uint8_t>> promise;
-    std::future<std::vector<uint8_t>> future = promise.get_future();
+    auto state = std::make_shared<CallState>();
     {
       std::lock_guard<std::mutex> lock(mu_);
-      pending_.emplace(id, std::move(promise));
+      pending_.emplace(id, state);
     }
-    return Started{id, std::move(future)};
+    return Started{id, std::move(state)};
   }
 
   // Called from the C callback, on an engine thread. The payload is only
   // valid for the duration of the call, so it is copied out here.
   void Complete(uint32_t call_id, const int8_t* content, size_t length) {
-    std::promise<std::vector<uint8_t>> promise;
+    std::shared_ptr<CallState> state;
     {
       std::lock_guard<std::mutex> lock(mu_);
       auto it = pending_.find(call_id);
@@ -64,18 +115,17 @@ class CallRegistry {
                      call_id);
         return;
       }
-      promise = std::move(it->second);
+      state = std::move(it->second);
       pending_.erase(it);
     }
-    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(content);
-    promise.set_value(std::vector<uint8_t>(bytes, bytes + length));
+    state->Fulfill(reinterpret_cast<const uint8_t*>(content), length);
   }
 
  private:
   CallRegistry() { Api().register_callback(&baml_cpp_result_trampoline); }
 
   std::mutex mu_;
-  std::unordered_map<uint32_t, std::promise<std::vector<uint8_t>>> pending_;
+  std::unordered_map<uint32_t, std::shared_ptr<CallState>> pending_;
   std::atomic<uint32_t> next_id_{1};
 };
 

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/future.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/future.h
@@ -1,0 +1,142 @@
+#ifndef BAML_FUTURE_H_
+#define BAML_FUTURE_H_
+
+// baml::Future<T, ThrownU>: handle to an in-flight async BAML call.
+//
+// get() blocks until the result envelope arrives and decodes it exactly
+// like the synchronous form: the ok arm returns T, declared throws arrive
+// as BamlThrown<ThrownU> (ThrownU is the function's `throws` set as a
+// baml::Union; void when none is declared), panics as BamlPanic. get()
+// consumes the future, std::future-style: a second get() (or a get() on a
+// moved-from future) throws std::future_error.
+//
+// Cancel() requests engine-side cancellation of the in-flight call and
+// returns false if the call is unknown or already completed. The result
+// envelope still arrives - as a baml.panics.Cancelled panic - and get()
+// then throws BamlCancelled. Destruction detaches: it never blocks and
+// never cancels, matching the Python task model.
+//
+// Under C++20 a Future is co_await-able: `co_await std::move(f)` suspends
+// without blocking a thread and resumes when the envelope arrives, with
+// get()'s exact value/throw semantics. The coroutine resumes ON THE BRIDGE
+// DISPATCHER THREAD; code after co_await must not block it (offload long
+// work to your own executor). The awaiter is feature-gated so this header
+// stays C++17-clean.
+//
+// Naming follows STYLE.md carve-out 2: get/wait/wait_for/wait_until/valid
+// mirror std::future and are std-cased; Cancel is our own operation.
+
+#include <baml/codec.h>
+#include <baml/detail/loader.h>
+#include <baml/detail/registry.h>
+
+#include <chrono>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+#if defined(__cpp_impl_coroutine) && __has_include(<coroutine>)
+#include <coroutine>
+#if defined(__cpp_lib_coroutine)
+#define BAML_HAS_COROUTINES 1
+#endif
+#endif
+
+namespace baml {
+
+template <typename T, typename ThrownU = void>
+class Future {
+ public:
+  Future(std::shared_ptr<detail::CallState> state, uint64_t engine_call_id)
+      : state_(std::move(state)), engine_call_id_(engine_call_id) {}
+
+  Future(Future&&) noexcept = default;
+  Future& operator=(Future&&) noexcept = default;
+  Future(const Future&) = delete;
+  Future& operator=(const Future&) = delete;
+
+  // Blocks until the result envelope arrives, then decodes it. Consumes
+  // the future.
+  T get() {
+    std::shared_ptr<detail::CallState> state = TakeState();
+    return detail::DecodeResult<T, ThrownU>(state->Wait());
+  }
+
+  // Blocks until the result arrives without consuming the future.
+  void wait() const {
+    RequireState();
+    state_->Wait();
+  }
+
+  template <class Rep, class Period>
+  std::future_status wait_for(
+      const std::chrono::duration<Rep, Period>& timeout) const {
+    return wait_until(std::chrono::steady_clock::now() + timeout);
+  }
+
+  template <class Clock, class Duration>
+  std::future_status wait_until(
+      const std::chrono::time_point<Clock, Duration>& deadline) const {
+    RequireState();
+    return state_->WaitUntil(deadline) ? std::future_status::ready
+                                       : std::future_status::timeout;
+  }
+
+  bool valid() const noexcept { return state_ != nullptr; }
+
+  // Requests cancellation of the in-flight call. Returns false if the call
+  // is unknown or already completed. The result envelope still arrives (as
+  // a Cancelled panic) and get() reports it.
+  bool Cancel() {
+    return state_ != nullptr &&
+           detail::Api().cancel_function_call(engine_call_id_) == 0;
+  }
+
+  uint64_t call_id() const noexcept { return engine_call_id_; }
+
+#if defined(BAML_HAS_COROUTINES)
+  bool await_ready() const {
+    RequireState();
+    std::lock_guard<std::mutex> lock(state_->mu);
+    return state_->ready;
+  }
+
+  // Registers the coroutine as the completion continuation. Returns false
+  // (resume immediately, no suspension) if the result arrived between the
+  // await_ready check and here.
+  bool await_suspend(std::coroutine_handle<> handle) {
+    std::lock_guard<std::mutex> lock(state_->mu);
+    if (state_->ready) {
+      return false;
+    }
+    state_->continuation = [](void* address) {
+      std::coroutine_handle<>::from_address(address).resume();
+    };
+    state_->continuation_arg = handle.address();
+    return true;
+  }
+
+  T await_resume() { return get(); }
+#endif  // BAML_HAS_COROUTINES
+
+ private:
+  void RequireState() const {
+    if (state_ == nullptr) {
+      throw std::future_error(std::future_errc::no_state);
+    }
+  }
+
+  std::shared_ptr<detail::CallState> TakeState() {
+    RequireState();
+    return std::move(state_);
+  }
+
+  std::shared_ptr<detail::CallState> state_;
+  uint64_t engine_call_id_ = 0;
+};
+
+}  // namespace baml
+
+#endif  // BAML_FUTURE_H_

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
@@ -37,6 +37,13 @@
 // Every Lit carries its value statically: `decltype(x)::value` (also
 // implicitly convertible), so a catch-all match arm can recover the
 // runtime value: `match(u, [](auto l) { return decltype(l)::value; })`.
+//
+// Possible future representation: identity as an FNV-1a-64 hash NTTP
+// (Lit<0x...>) with an emitter-generated hash->string side-table. That
+// would delete the char-pack macro machinery and the length cap, at the
+// cost of unreadable literal types in compiler diagnostics and no ::value
+// for off-schema spellings. Same user-facing API either way; revisit if
+// the char packs become a problem in practice.
 
 #include <cstddef>
 #include <cstdint>

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
@@ -24,8 +24,8 @@
 // C++17 cannot pass a string literal as a template argument (class-type
 // NTTPs are C++20), so BAML_LIT explodes the literal into a char pack via
 // constant-expression indexing (the Boost.Metaparse technique), capped at
-// 64 characters. Generated code never uses the macro: the emitter spells
-// the char packs directly.
+// 256 characters. Generated code never uses the macro: the emitter spells
+// the char packs directly, at any length.
 //
 // A bare integer must NOT be spelled Lit<1>: template identity includes
 // the parameter's TYPE, and `1` deduces `int`, minting a type distinct
@@ -141,7 +141,8 @@ struct IsLit<Lit<Vs...>> : std::true_type {};
 template <std::size_t N, char... Cs>
 struct TrimNulls {
   static_assert(N <= sizeof...(Cs) + 1,
-                "string literal exceeds BAML_LIT's 64-character cap");
+                "string literal exceeds BAML_LIT's 256-character cap (name "
+                "the type via decltype of the generated function instead)");
   static constexpr char arr[] = {Cs...};
   static constexpr std::size_t Length() {
     std::size_t n = 0;
@@ -226,41 +227,29 @@ struct LitSelect<LitArg::kScalar, V, N, Cs...> {
 #define BAML_DETAIL_LIT_CH(s, i) (::baml::detail::LitCharAt((s), (i)))
 
 // clang-format off
+#define BAML_DETAIL_LIT_CH8(s, i)                                            \
+      BAML_DETAIL_LIT_CH(s, (i) + 0), BAML_DETAIL_LIT_CH(s, (i) + 1),        \
+      BAML_DETAIL_LIT_CH(s, (i) + 2), BAML_DETAIL_LIT_CH(s, (i) + 3),        \
+      BAML_DETAIL_LIT_CH(s, (i) + 4), BAML_DETAIL_LIT_CH(s, (i) + 5),        \
+      BAML_DETAIL_LIT_CH(s, (i) + 6), BAML_DETAIL_LIT_CH(s, (i) + 7)
+
+#define BAML_DETAIL_LIT_CH64(s, i)                                           \
+      BAML_DETAIL_LIT_CH8(s, (i) + 0),  BAML_DETAIL_LIT_CH8(s, (i) + 8),     \
+      BAML_DETAIL_LIT_CH8(s, (i) + 16), BAML_DETAIL_LIT_CH8(s, (i) + 24),    \
+      BAML_DETAIL_LIT_CH8(s, (i) + 32), BAML_DETAIL_LIT_CH8(s, (i) + 40),    \
+      BAML_DETAIL_LIT_CH8(s, (i) + 48), BAML_DETAIL_LIT_CH8(s, (i) + 56)
+
+// The 256-character cap applies to this macro only, never to generated
+// code (the emitter spells char packs at any length). Realistically it
+// should never be an issue: literal types are short tag strings, and a
+// 256+ character literal type is a pathological schema. If one ever
+// exists, decltype(the_generated_function()) names its type without the
+// macro, and a `const auto&` match arm catches it.
 #define BAML_LIT(s)                                                          \
   ::baml::detail::LitSelect<::baml::detail::LitArgOf(s),                     \
       ::baml::detail::LitValueOf(s), sizeof(s),                              \
-      BAML_DETAIL_LIT_CH(s, 0),  BAML_DETAIL_LIT_CH(s, 1),                   \
-      BAML_DETAIL_LIT_CH(s, 2),  BAML_DETAIL_LIT_CH(s, 3),                   \
-      BAML_DETAIL_LIT_CH(s, 4),  BAML_DETAIL_LIT_CH(s, 5),                   \
-      BAML_DETAIL_LIT_CH(s, 6),  BAML_DETAIL_LIT_CH(s, 7),                   \
-      BAML_DETAIL_LIT_CH(s, 8),  BAML_DETAIL_LIT_CH(s, 9),                   \
-      BAML_DETAIL_LIT_CH(s, 10), BAML_DETAIL_LIT_CH(s, 11),                  \
-      BAML_DETAIL_LIT_CH(s, 12), BAML_DETAIL_LIT_CH(s, 13),                  \
-      BAML_DETAIL_LIT_CH(s, 14), BAML_DETAIL_LIT_CH(s, 15),                  \
-      BAML_DETAIL_LIT_CH(s, 16), BAML_DETAIL_LIT_CH(s, 17),                  \
-      BAML_DETAIL_LIT_CH(s, 18), BAML_DETAIL_LIT_CH(s, 19),                  \
-      BAML_DETAIL_LIT_CH(s, 20), BAML_DETAIL_LIT_CH(s, 21),                  \
-      BAML_DETAIL_LIT_CH(s, 22), BAML_DETAIL_LIT_CH(s, 23),                  \
-      BAML_DETAIL_LIT_CH(s, 24), BAML_DETAIL_LIT_CH(s, 25),                  \
-      BAML_DETAIL_LIT_CH(s, 26), BAML_DETAIL_LIT_CH(s, 27),                  \
-      BAML_DETAIL_LIT_CH(s, 28), BAML_DETAIL_LIT_CH(s, 29),                  \
-      BAML_DETAIL_LIT_CH(s, 30), BAML_DETAIL_LIT_CH(s, 31),                  \
-      BAML_DETAIL_LIT_CH(s, 32), BAML_DETAIL_LIT_CH(s, 33),                  \
-      BAML_DETAIL_LIT_CH(s, 34), BAML_DETAIL_LIT_CH(s, 35),                  \
-      BAML_DETAIL_LIT_CH(s, 36), BAML_DETAIL_LIT_CH(s, 37),                  \
-      BAML_DETAIL_LIT_CH(s, 38), BAML_DETAIL_LIT_CH(s, 39),                  \
-      BAML_DETAIL_LIT_CH(s, 40), BAML_DETAIL_LIT_CH(s, 41),                  \
-      BAML_DETAIL_LIT_CH(s, 42), BAML_DETAIL_LIT_CH(s, 43),                  \
-      BAML_DETAIL_LIT_CH(s, 44), BAML_DETAIL_LIT_CH(s, 45),                  \
-      BAML_DETAIL_LIT_CH(s, 46), BAML_DETAIL_LIT_CH(s, 47),                  \
-      BAML_DETAIL_LIT_CH(s, 48), BAML_DETAIL_LIT_CH(s, 49),                  \
-      BAML_DETAIL_LIT_CH(s, 50), BAML_DETAIL_LIT_CH(s, 51),                  \
-      BAML_DETAIL_LIT_CH(s, 52), BAML_DETAIL_LIT_CH(s, 53),                  \
-      BAML_DETAIL_LIT_CH(s, 54), BAML_DETAIL_LIT_CH(s, 55),                  \
-      BAML_DETAIL_LIT_CH(s, 56), BAML_DETAIL_LIT_CH(s, 57),                  \
-      BAML_DETAIL_LIT_CH(s, 58), BAML_DETAIL_LIT_CH(s, 59),                  \
-      BAML_DETAIL_LIT_CH(s, 60), BAML_DETAIL_LIT_CH(s, 61),                  \
-      BAML_DETAIL_LIT_CH(s, 62), BAML_DETAIL_LIT_CH(s, 63)>::type
+      BAML_DETAIL_LIT_CH64(s, 0),   BAML_DETAIL_LIT_CH64(s, 64),             \
+      BAML_DETAIL_LIT_CH64(s, 128), BAML_DETAIL_LIT_CH64(s, 192)>::type
 // clang-format on
 
 #endif  // BAML_LIT_H_

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
@@ -1,0 +1,266 @@
+#ifndef BAML_LIT_H_
+#define BAML_LIT_H_
+
+// baml::Lit<Vs...>: BAML literal types as distinct C++ types (C++17).
+//
+// BAML literal types are singleton value types: `"draft"`, `42`, `true`,
+// and enum-variant types like `Sentiment.Positive`. Each distinct value is
+// a distinct C++ type, so literal unions dispatch and exhaustively match
+// at compile time exactly like any other baml::Union:
+//
+//   // status "draft" | "sent" | "paid"
+//   baml::match(invoice.status,
+//     [](BAML_LIT("draft")) { ... },
+//     [](BAML_LIT("sent"))  { ... },
+//     [](BAML_LIT("paid"))  { ... });
+//
+// One macro spells them all -- overloaded constexpr helpers classify the
+// argument and normalize its value at compile time:
+//   BAML_LIT("draft")              string  -> Lit<'d','r','a','f','t'>
+//   BAML_LIT(42)                   int     -> Lit<int64_t{42}>
+//   BAML_LIT(true)                 bool    -> Lit<true>
+//   BAML_LIT(Sentiment::Positive)  enum    -> Lit<Sentiment::Positive>
+//
+// C++17 cannot pass a string literal as a template argument (class-type
+// NTTPs are C++20), so BAML_LIT explodes the literal into a char pack via
+// constant-expression indexing (the Boost.Metaparse technique), capped at
+// 64 characters. Generated code never uses the macro: the emitter spells
+// the char packs directly.
+//
+// A bare integer must NOT be spelled Lit<1>: template identity includes
+// the parameter's TYPE, and `1` deduces `int`, minting a type distinct
+// from the canonical Lit<int64_t{1}>. The shape check rejects it with a
+// pointer to BAML_LIT(1), whose value normalization canonicalizes the
+// type. (baml::IntLit<1> / baml::BoolLit<true> are macro-free alternates
+// with the same normalization.)
+//
+// Every Lit carries its value statically: `decltype(x)::value` (also
+// implicitly convertible), so a catch-all match arm can recover the
+// runtime value: `match(u, [](auto l) { return decltype(l)::value; })`.
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace baml {
+namespace detail {
+
+enum class LitShape { kInvalid, kString, kInt, kBool, kEnum };
+
+// A plain alias (template <class T, class...> using Head = T) does not
+// survive pack expansion into its fixed parameter on clang; a struct
+// specialization does.
+template <class... Ts>
+struct LitHead;
+template <class T, class... Rest>
+struct LitHead<T, Rest...> {
+  using type = T;
+};
+
+template <class... Ts>
+constexpr LitShape LitShapeOf() {
+  if constexpr ((std::is_same<Ts, char>::value && ...)) {
+    // Includes the empty pack: BAML_LIT("") is the empty-string type.
+    return LitShape::kString;
+  } else if constexpr (sizeof...(Ts) == 1) {
+    using T = typename LitHead<Ts...>::type;
+    if (std::is_same<T, int64_t>::value) return LitShape::kInt;
+    if (std::is_same<T, bool>::value) return LitShape::kBool;
+    if (std::is_enum<T>::value) return LitShape::kEnum;
+    return LitShape::kInvalid;
+  } else {
+    return LitShape::kInvalid;
+  }
+}
+
+template <LitShape S, auto... Vs>
+struct LitBase {
+  static_assert(
+      S != LitShape::kInvalid,
+      "unsupported baml::Lit shape. The four literal spellings: "
+      "BAML_LIT(\"...\") for strings; BAML_LIT(n) / baml::IntLit<n> for ints "
+      "(a bare Lit<1> deduces `int`, not int64_t, which would mint a second "
+      "type); BAML_LIT(b) / baml::BoolLit<b> for bools; BAML_LIT(E::V) / "
+      "baml::Lit<E::V> for enum variants");
+};
+
+template <auto... Cs>
+struct LitBase<LitShape::kString, Cs...> {
+  static constexpr char chars[] = {static_cast<char>(Cs)..., '\0'};
+  static constexpr std::string_view value{chars, sizeof...(Cs)};
+  constexpr operator std::string_view() const { return value; }
+};
+
+template <auto V>
+struct LitBase<LitShape::kInt, V> {
+  static constexpr int64_t value = V;
+  constexpr operator int64_t() const { return value; }
+};
+
+template <auto V>
+struct LitBase<LitShape::kBool, V> {
+  static constexpr bool value = V;
+  constexpr operator bool() const { return value; }
+};
+
+template <auto V>
+struct LitBase<LitShape::kEnum, V> {
+  static constexpr decltype(V) value = V;
+  constexpr operator decltype(V)() const { return value; }
+};
+
+}  // namespace detail
+
+template <auto... Vs>
+struct Lit : detail::LitBase<detail::LitShapeOf<decltype(Vs)...>(), Vs...> {
+  // Unit type: two values of the same Lit are always equal (memberwise
+  // equality of generated structs and variant equality both rely on this).
+  friend constexpr bool operator==(Lit, Lit) { return true; }
+  friend constexpr bool operator!=(Lit, Lit) { return false; }
+};
+
+template <int64_t V>
+using IntLit = Lit<V>;
+
+template <bool V>
+using BoolLit = Lit<V>;
+
+namespace detail {
+
+template <class T>
+struct IsLit : std::false_type {};
+template <auto... Vs>
+struct IsLit<Lit<Vs...>> : std::true_type {};
+
+// Strips the '\0' padding BAML_LIT's fixed-arity expansion appends, so
+// every spelling of the same string lands on the same Lit instantiation.
+// N is sizeof(literal) for the cap check; BAML strings never contain
+// embedded NULs, so the first '\0' is the end.
+template <std::size_t N, char... Cs>
+struct TrimNulls {
+  static_assert(N <= sizeof...(Cs) + 1,
+                "string literal exceeds BAML_LIT's 64-character cap");
+  static constexpr char arr[] = {Cs...};
+  static constexpr std::size_t Length() {
+    std::size_t n = 0;
+    while (n < sizeof...(Cs) && arr[n] != '\0') ++n;
+    return n;
+  }
+  template <std::size_t... Is>
+  static Lit<arr[Is]...> Pick(std::index_sequence<Is...>);
+  using type = decltype(Pick(std::make_index_sequence<Length()>{}));
+};
+
+// BAML_LIT(x) argument classification: overload resolution IS the
+// dispatch. Every helper is called in template-argument position, so x
+// must be a literal / constant expression. Bare `char` is deliberately
+// not a literal shape (BAML has no char type; spell the one-char string).
+
+enum class LitArg { kString, kScalar };
+
+template <class T>
+constexpr bool kLitScalarArg =
+    (std::is_integral<T>::value && !std::is_same<T, bool>::value &&
+     !std::is_same<T, char>::value) ||
+    std::is_enum<T>::value;
+
+template <std::size_t N>
+constexpr LitArg LitArgOf(const char (&)[N]) {
+  return LitArg::kString;
+}
+constexpr LitArg LitArgOf(bool) { return LitArg::kScalar; }
+template <class T, std::enable_if_t<kLitScalarArg<T>, int> = 0>
+constexpr LitArg LitArgOf(T) {
+  return LitArg::kScalar;
+}
+
+// The scalar value, normalized: every integral type lands on int64_t so
+// BAML_LIT(42) and BAML_LIT(int64_t{42}) are the same type. An unsigned
+// value above INT64_MAX must not wrap into an aliased identity
+// (BAML_LIT(UINT64_MAX) == BAML_LIT(-1)); reaching the throw during
+// constant evaluation makes the call non-constant, so the out-of-range
+// spelling fails to compile with this message in the diagnostic.
+template <std::size_t N>
+constexpr int64_t LitValueOf(const char (&)[N]) {
+  return 0;  // placeholder; the string path never reads it
+}
+constexpr bool LitValueOf(bool v) { return v; }
+template <class T, std::enable_if_t<std::is_integral<T>::value &&
+                                        !std::is_same<T, bool>::value &&
+                                        !std::is_same<T, char>::value,
+                                    int> = 0>
+constexpr int64_t LitValueOf(T v) {
+  return std::is_signed<T>::value ||
+                 static_cast<uint64_t>(v) <= static_cast<uint64_t>(INT64_MAX)
+             ? static_cast<int64_t>(v)
+             : throw "BAML int literals must be representable in int64_t";
+}
+template <class T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+constexpr T LitValueOf(T v) {
+  return v;
+}
+
+template <std::size_t N>
+constexpr char LitCharAt(const char (&s)[N], std::size_t i) {
+  return i < N ? s[i] : '\0';
+}
+template <class T, std::enable_if_t<!std::is_array<T>::value, int> = 0>
+constexpr char LitCharAt(const T&, std::size_t) {
+  return '\0';
+}
+
+template <LitArg K, auto V, std::size_t N, char... Cs>
+struct LitSelect;
+template <auto V, std::size_t N, char... Cs>
+struct LitSelect<LitArg::kString, V, N, Cs...> : TrimNulls<N, Cs...> {};
+template <auto V, std::size_t N, char... Cs>
+struct LitSelect<LitArg::kScalar, V, N, Cs...> {
+  using type = Lit<V>;
+};
+
+}  // namespace detail
+}  // namespace baml
+
+#define BAML_DETAIL_LIT_CH(s, i) (::baml::detail::LitCharAt((s), (i)))
+
+// clang-format off
+#define BAML_LIT(s)                                                          \
+  ::baml::detail::LitSelect<::baml::detail::LitArgOf(s),                     \
+      ::baml::detail::LitValueOf(s), sizeof(s),                              \
+      BAML_DETAIL_LIT_CH(s, 0),  BAML_DETAIL_LIT_CH(s, 1),                   \
+      BAML_DETAIL_LIT_CH(s, 2),  BAML_DETAIL_LIT_CH(s, 3),                   \
+      BAML_DETAIL_LIT_CH(s, 4),  BAML_DETAIL_LIT_CH(s, 5),                   \
+      BAML_DETAIL_LIT_CH(s, 6),  BAML_DETAIL_LIT_CH(s, 7),                   \
+      BAML_DETAIL_LIT_CH(s, 8),  BAML_DETAIL_LIT_CH(s, 9),                   \
+      BAML_DETAIL_LIT_CH(s, 10), BAML_DETAIL_LIT_CH(s, 11),                  \
+      BAML_DETAIL_LIT_CH(s, 12), BAML_DETAIL_LIT_CH(s, 13),                  \
+      BAML_DETAIL_LIT_CH(s, 14), BAML_DETAIL_LIT_CH(s, 15),                  \
+      BAML_DETAIL_LIT_CH(s, 16), BAML_DETAIL_LIT_CH(s, 17),                  \
+      BAML_DETAIL_LIT_CH(s, 18), BAML_DETAIL_LIT_CH(s, 19),                  \
+      BAML_DETAIL_LIT_CH(s, 20), BAML_DETAIL_LIT_CH(s, 21),                  \
+      BAML_DETAIL_LIT_CH(s, 22), BAML_DETAIL_LIT_CH(s, 23),                  \
+      BAML_DETAIL_LIT_CH(s, 24), BAML_DETAIL_LIT_CH(s, 25),                  \
+      BAML_DETAIL_LIT_CH(s, 26), BAML_DETAIL_LIT_CH(s, 27),                  \
+      BAML_DETAIL_LIT_CH(s, 28), BAML_DETAIL_LIT_CH(s, 29),                  \
+      BAML_DETAIL_LIT_CH(s, 30), BAML_DETAIL_LIT_CH(s, 31),                  \
+      BAML_DETAIL_LIT_CH(s, 32), BAML_DETAIL_LIT_CH(s, 33),                  \
+      BAML_DETAIL_LIT_CH(s, 34), BAML_DETAIL_LIT_CH(s, 35),                  \
+      BAML_DETAIL_LIT_CH(s, 36), BAML_DETAIL_LIT_CH(s, 37),                  \
+      BAML_DETAIL_LIT_CH(s, 38), BAML_DETAIL_LIT_CH(s, 39),                  \
+      BAML_DETAIL_LIT_CH(s, 40), BAML_DETAIL_LIT_CH(s, 41),                  \
+      BAML_DETAIL_LIT_CH(s, 42), BAML_DETAIL_LIT_CH(s, 43),                  \
+      BAML_DETAIL_LIT_CH(s, 44), BAML_DETAIL_LIT_CH(s, 45),                  \
+      BAML_DETAIL_LIT_CH(s, 46), BAML_DETAIL_LIT_CH(s, 47),                  \
+      BAML_DETAIL_LIT_CH(s, 48), BAML_DETAIL_LIT_CH(s, 49),                  \
+      BAML_DETAIL_LIT_CH(s, 50), BAML_DETAIL_LIT_CH(s, 51),                  \
+      BAML_DETAIL_LIT_CH(s, 52), BAML_DETAIL_LIT_CH(s, 53),                  \
+      BAML_DETAIL_LIT_CH(s, 54), BAML_DETAIL_LIT_CH(s, 55),                  \
+      BAML_DETAIL_LIT_CH(s, 56), BAML_DETAIL_LIT_CH(s, 57),                  \
+      BAML_DETAIL_LIT_CH(s, 58), BAML_DETAIL_LIT_CH(s, 59),                  \
+      BAML_DETAIL_LIT_CH(s, 60), BAML_DETAIL_LIT_CH(s, 61),                  \
+      BAML_DETAIL_LIT_CH(s, 62), BAML_DETAIL_LIT_CH(s, 63)>::type
+// clang-format on
+
+#endif  // BAML_LIT_H_

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
@@ -344,6 +344,10 @@ const BRIDGE_HEADERS: &[(&str, &str)] = &[
         include_str!("../../bridge_cpp/include/baml/errors.h"),
     ),
     (
+        "include/baml/future.h",
+        include_str!("../../bridge_cpp/include/baml/future.h"),
+    ),
+    (
         "include/baml/runtime.h",
         include_str!("../../bridge_cpp/include/baml/runtime.h"),
     ),
@@ -376,6 +380,10 @@ const BRIDGE_HEADERS: &[(&str, &str)] = &[
 /// Member name of the synthesized per-callable opts struct within its
 /// callable's identity.
 const OPTS_MEMBER: &str = "opts";
+
+/// Member name of the synthesized async sibling within its callable's
+/// identity.
+const ASYNC_MEMBER: &str = "async";
 
 /// One typed request per identifier any emit pass may need. Mirrors the
 /// pool-level skip filters (`pkg`, `$stream`, `$` companions); symbols that
@@ -419,6 +427,7 @@ fn collect_requests(pool: &SymbolPool) -> BTreeSet<NameRequest> {
                 request_namespace_segments(&mut requests, name);
                 let fqn = BamlFqn::symbol(name);
                 requests.insert(function_request(name));
+                requests.insert(async_request(&fqn, function));
                 request_callable_members(&mut requests, &fqn, function);
             }
             // Non-recursive aliases emit a `using` declaration; recursive
@@ -515,6 +524,18 @@ fn opts_request(callable: &BamlFqn, function: &Function) -> NameRequest {
         // $opts never even mint a type); C++ needs a name only because the
         // struct must be constructible.
         &format!("{}Opts", function.name.as_str()),
+    )
+}
+
+/// The request for a callable's async sibling. Shared between collection
+/// and emission so the lookup key cannot drift. Verbatim source spelling +
+/// "Async" (probe -> probeAsync), following the opts-struct convention:
+/// user names are never re-cased, only suffixed.
+fn async_request(callable: &BamlFqn, function: &Function) -> NameRequest {
+    NameRequest::synthesized(
+        callable.child(ASYNC_MEMBER),
+        CppNameKind::Function,
+        &format!("{}Async", function.name.as_str()),
     )
 }
 
@@ -785,6 +806,8 @@ struct EmittedOptParam {
 
 struct EmittedFn {
     name: CppName,
+    /// The async sibling's allocated name (`{name}Async`).
+    async_name: CppName,
     /// The BAML FQN the runtime call dispatches on (the wire symbol);
     /// never derived from C++ spellings.
     call_fqn: String,
@@ -890,6 +913,7 @@ fn emit_callable(
     Ok(EmittedFn {
         call_fqn: name.wire().to_string(),
         name,
+        async_name: names.get(&async_request(fqn, function)).clone(),
         ret,
         params,
         opt_params,
@@ -1114,6 +1138,26 @@ enum RenderPos {
     Def,
 }
 
+/// Which spelling of a callable renders: the synchronous form or the
+/// `{name}Async` sibling returning a `baml::Future`.
+#[derive(Clone, Copy)]
+enum FnVariant {
+    Sync,
+    Async,
+}
+
+const FN_VARIANTS: [FnVariant; 2] = [FnVariant::Sync, FnVariant::Async];
+
+/// The async sibling's return type: the sync return wrapped in
+/// `baml::Future`, with the declared throws union as the second parameter
+/// when the function has a typed throws set.
+fn future_ret(f: &EmittedFn) -> String {
+    match &f.thrown {
+        Some(u) => format!("::baml::Future<{}, {}>", f.ret, u),
+        None => format!("::baml::Future<{}>", f.ret),
+    }
+}
+
 fn push_doc(buf: &mut String, indent: &str, doc: Option<&String>, raises: &[String]) {
     if let Some(doc) = doc {
         for line in doc.lines() {
@@ -1148,7 +1192,7 @@ fn by_value_or_cref(ty: &str) -> String {
     }
 }
 
-fn signature(f: &EmittedFn, pos: RenderPos) -> String {
+fn signature(f: &EmittedFn, pos: RenderPos, variant: FnVariant) -> String {
     let mut params: Vec<String> = f
         .params
         .iter()
@@ -1165,12 +1209,11 @@ fn signature(f: &EmittedFn, pos: RenderPos) -> String {
             opts = GeneratorIdent::OptsParam.token()
         ));
     }
-    format!(
-        "{ret} {name}({params})",
-        ret = f.ret,
-        name = f.name.declared(),
-        params = params.join(", ")
-    )
+    let (ret, name) = match variant {
+        FnVariant::Sync => (f.ret.clone(), f.name.declared()),
+        FnVariant::Async => (future_ret(f), f.async_name.declared()),
+    };
+    format!("{ret} {name}({params})", params = params.join(", "))
 }
 
 fn render_opts_struct(buf: &mut String, indent: &str, f: &EmittedFn) {
@@ -1197,8 +1240,9 @@ fn render_opts_struct(buf: &mut String, indent: &str, f: &EmittedFn) {
 }
 
 /// Emits one binding body: runtime init, required args, set optional args,
-/// then the synchronous call.
-fn render_body(buf: &mut String, indent: &str, f: &EmittedFn) {
+/// then the call (blocking `CallSync`, or `StartCall` returning the
+/// in-flight `baml::Future` for the async sibling).
+fn render_body(buf: &mut String, indent: &str, f: &EmittedFn, variant: FnVariant) {
     let args = GeneratorIdent::ArgsLocal.token();
     let w = GeneratorIdent::WriterParam.token();
     let opts = GeneratorIdent::OptsParam.token();
@@ -1234,9 +1278,13 @@ fn render_body(buf: &mut String, indent: &str, f: &EmittedFn) {
         Some(u) => format!(", {u}"),
         None => String::new(),
     };
+    let driver = match variant {
+        FnVariant::Sync => "CallSync",
+        FnVariant::Async => "StartCall",
+    };
     let _ = writeln!(
         buf,
-        "{indent}return ::baml::detail::CallSync<{ret}{thrown}>(\"{fqn}\", \
+        "{indent}return ::baml::detail::{driver}<{ret}{thrown}>(\"{fqn}\", \
          std::move({args}));",
         ret = f.ret,
         fqn = f.call_fqn,
@@ -1366,8 +1414,10 @@ fn render_header(
         open_namespaces(&mut buf, ns);
         for f in fns {
             render_opts_struct(&mut buf, "", f);
-            push_doc(&mut buf, "", f.doc.as_ref(), &f.raises);
-            let _ = writeln!(buf, "{};", signature(f, RenderPos::Decl));
+            for variant in FN_VARIANTS {
+                push_doc(&mut buf, "", f.doc.as_ref(), &f.raises);
+                let _ = writeln!(buf, "{};", signature(f, RenderPos::Decl, variant));
+            }
         }
         close_namespaces(&mut buf, ns);
     }
@@ -1562,9 +1612,11 @@ fn render_bindings(fns_by_namespace: &BTreeMap<Vec<String>, Vec<EmittedFn>>) -> 
         buf.push('\n');
         open_namespaces(&mut buf, ns);
         for f in fns {
-            let _ = writeln!(buf, "\n{} {{", signature(f, RenderPos::Def));
-            render_body(&mut buf, "  ", f);
-            buf.push_str("}\n");
+            for variant in FN_VARIANTS {
+                let _ = writeln!(buf, "\n{} {{", signature(f, RenderPos::Def, variant));
+                render_body(&mut buf, "  ", f, variant);
+                buf.push_str("}\n");
+            }
         }
         close_namespaces(&mut buf, ns);
     }

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
@@ -348,6 +348,10 @@ const BRIDGE_HEADERS: &[(&str, &str)] = &[
         include_str!("../../bridge_cpp/include/baml/future.h"),
     ),
     (
+        "include/baml/lit.h",
+        include_str!("../../bridge_cpp/include/baml/lit.h"),
+    ),
+    (
         "include/baml/runtime.h",
         include_str!("../../bridge_cpp/include/baml/runtime.h"),
     ),
@@ -972,15 +976,22 @@ fn translate_ty(
             return Translated::Unsupported("media type (post-step-8)".to_string());
         }
         Ty::Literal(lit, ..) => {
-            // Literal types widen to their base type (Python parity).
+            // Literal types are singleton ::baml::Lit types (each distinct
+            // value a distinct C++ type), spelled as char packs / typed
+            // scalars directly -- the BAML_LIT macro family is user-side
+            // sugar only. Float literals stay widened: float NTTPs are
+            // C++20 and BAML has no float literal types in practice.
             match lit {
-                baml_base::Literal::Int(_) => "int64_t".to_string(),
+                baml_base::Literal::Int(v) => format!("::baml::Lit<{}>", lit_int_spelling(*v)),
                 baml_base::Literal::Bigint(_) => {
                     return Translated::Unsupported("bigint literal (post-step-8)".to_string());
                 }
                 baml_base::Literal::Float(_) => "double".to_string(),
-                baml_base::Literal::String(_) => "std::string".to_string(),
-                baml_base::Literal::Bool(_) => "bool".to_string(),
+                baml_base::Literal::String(s) => {
+                    let chars: Vec<String> = s.bytes().map(lit_char_spelling).collect();
+                    format!("::baml::Lit<{}>", chars.join(", "))
+                }
+                baml_base::Literal::Bool(b) => format!("::baml::Lit<{b}>"),
             }
         }
         Ty::TypeVar(name, _) => {
@@ -1023,9 +1034,7 @@ fn translate_ty(
                     .to_string(),
             );
         }
-        // An enum-variant type (`Sentiment.Positive`) widens to its enum
-        // (Python parity: the variant tag narrows values, not the C++ type).
-        Ty::Enum(name, _) | Ty::EnumVariant(name, _, _) => {
+        Ty::Enum(name, _) => {
             return if emitted_types.contains(name) {
                 Translated::Cpp(
                     names
@@ -1033,6 +1042,26 @@ fn translate_ty(
                         .identifier()
                         .to_string(),
                 )
+            } else {
+                Translated::NotYet
+            };
+        }
+        // An enum-variant type (`Sentiment.Positive`) is a singleton Lit
+        // over the enum value, so unions of variants dispatch and match
+        // per-variant at compile time.
+        Ty::EnumVariant(name, variant, _) => {
+            return if emitted_types.contains(name) {
+                let enum_path = names
+                    .get(&NameRequest::new(BamlFqn::symbol(name), CppNameKind::Enum))
+                    .identifier()
+                    .to_string();
+                let variant_name = names
+                    .get(&NameRequest::new(
+                        BamlFqn::member(name, variant.as_str()),
+                        CppNameKind::EnumVariant,
+                    ))
+                    .declared();
+                Translated::Cpp(format!("::baml::Lit<{enum_path}::{variant_name}>"))
             } else {
                 Translated::NotYet
             };
@@ -1186,10 +1215,40 @@ fn close_namespaces(buf: &mut String, ns: &[String]) {
 }
 
 fn by_value_or_cref(ty: &str) -> String {
+    // Lit types are empty unit structs: by value.
+    if ty.starts_with("::baml::Lit<") {
+        return ty.to_string();
+    }
     match ty {
         "int64_t" | "double" | "bool" | "std::monostate" => ty.to_string(),
         _ => format!("const {ty}&"),
     }
+}
+
+/// Spells one byte of a BAML string literal as a C++ char literal for a
+/// `::baml::Lit` char pack. Bytes, not code points: the pack mirrors the
+/// literal's UTF-8 encoding, matching what `BAML_LIT`'s sizeof-based
+/// expansion produces.
+fn lit_char_spelling(b: u8) -> String {
+    match b {
+        b'\'' => "'\\''".to_string(),
+        b'\\' => "'\\\\'".to_string(),
+        b'\n' => "'\\n'".to_string(),
+        b'\r' => "'\\r'".to_string(),
+        b'\t' => "'\\t'".to_string(),
+        0x20..=0x7e => format!("'{}'", b as char),
+        _ => format!("'\\x{b:02x}'"),
+    }
+}
+
+/// Spells an int literal's value as the canonical `int64_t{...}` template
+/// argument. `i64::MIN` has no valid literal spelling (the unary minus
+/// applies after the out-of-range positive literal), hence the subtraction.
+fn lit_int_spelling(v: i64) -> String {
+    if v == i64::MIN {
+        return "int64_t{-9223372036854775807 - 1}".to_string();
+    }
+    format!("int64_t{{{v}}}")
 }
 
 fn signature(f: &EmittedFn, pos: RenderPos, variant: FnVariant) -> String {


### PR DESCRIPTION
Bridge-week step 10 for C++ (async half; error/panic behavior landed in #4071).

## What

Every generated function gains an **Async sibling** returning `baml::Future<T, ThrownU>`:

```cpp
auto fut = b::ExtractResumeAsync(text);   // returns immediately
fut.Cancel();                             // optional engine-side cancellation
Resume r = fut.get();                     // blocks + decodes; typed throws as BamlThrown<Union<...>>
```

- `get()`/`wait()`/`wait_for()`/`wait_until()`/`valid()` mirror `std::future` (STYLE.md carve-out 2); `Cancel()` and the sibling's `Async` suffix are our vocabulary (Pascal). The suffix follows the opts-struct convention: verbatim BAML spelling + suffix (`probe` -> `probeAsync`), allocated through the naming pool.
- **Cancellation**: `Cancel()` calls the v1 ABI's `cancel_function_call`; the envelope still arrives as a `baml.panics.Cancelled` panic and `get()` throws `BamlCancelled`. Destruction detaches (never blocks, never cancels) - Python task-model parity. No Rust changes.
- **co_await (C++20 only)**: the registry's per-call cell is now a custom `CallState` (mutex + condvar + continuation slot) instead of `std::promise`, so the dispatcher thread can resume a suspended coroutine when the envelope lands. The awaiter is feature-gated (`__cpp_impl_coroutine` + `__cpp_lib_coroutine`); the header stays C++17-clean.
- **One call path**: `CallSync` is now literally `StartCall().get()`.

## Tests

- `test_cancellation.cc`: port of python's `test_cancellation.py` (portable core: null-return baseline + engine-side cancel; asyncio/BamlCallContext idioms documented as deviations) + C++-specific future semantics (consume-once, `wait_for` timeout, detach-on-destroy).
- Async cases added to `test_optional_args.cc` (python parity), `test_raises.cc` (async sibling repeats the doc block), `test_errors.cc` (typed throw through `get()`).
- `futures_static.cc`: move-only + ThrownU order-canonicality static asserts.
- `tests/cxx20/test_coawait.cc`: 6 live co_await cases (pending resume, value, fast path, typed throw into the coroutine, cancellation, escape-to-join) driven by a minimal completion-latch Task. The harness builds `tests/cxx20/*.cc` as a second executable only when the toolchain has C++20, so the main binary keeps proving the SDK compiles as plain C++17.

All 12 `sdk_test_cpp` fixture tests pass locally (26 C++17 + 6 C++20 cases in function_calls).

Note: the size gate is expected to fail until the stale baselines are refreshed - canary has drifted ~600 KB since #4057 and every open PR is at the 3% ceiling (see #4071's report).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dual async C++ SDK bindings (`*Async`) alongside sync calls.
  * Introduced `baml::Future` for in-flight calls, including cancellation and optional C++20 `co_await` support.
  * Added typed singleton literal support via `BAML_LIT(...)` for more precise literal and union typing.
* **Bug Fixes**
  * Improved literal encoding/decoding and union arm selection to preserve exact typed literal values.
  * Enhanced async sibling error propagation and cancellation behavior.
* **Tests**
  * Expanded C++ coverage for futures (including C++20), cancellation, typed throws, optional args, and literal/type-shape checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->