### PR TITLE
bridge-cpp: typed literal types - baml::Lit + one polymorphic BAML_LIT macro

### DIFF
--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_main.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_main.cc
@@ -4,7 +4,8 @@
 #include <baml_test.h>
 
 BAML_TEST(hello_world_returns_literal) {
-  BAML_ASSERT_EQ(baml_sdk::hello_world(), std::string("hello world"));
+  BAML_ASSERT(baml_sdk::hello_world() == BAML_LIT("hello world"){});
+  BAML_ASSERT(BAML_LIT("hello world")::value == "hello world");
 }
 
 BAML_TEST(single_required_arg_round_trips) {

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_complex_models.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_complex_models.cc
@@ -42,7 +42,7 @@ BAML_TEST(
   const ContactMethod phone{"phone", "+1-555-0100", false};
   const Invoice invoice{
       "inv-001",
-      "sent",
+      BAML_LIT("sent"){},
       {LineItem{
           "sdk-pro",
           2,
@@ -55,7 +55,7 @@ BAML_TEST(
   };
   const Invoice wire_invoice{
       "inv-002",
-      "paid",
+      BAML_LIT("paid"){},
       {LineItem{
           "sdk-enterprise",
           1,
@@ -73,9 +73,10 @@ BAML_TEST(
       {home, office},
       {invoice, wire_invoice},
       {
-          AuditEvent{"system", "created", {{"source", "fixture"}}},
-          AuditEvent{
-              "reviewer", "approved", {{"level", "2"}, {"region", "us"}}},
+          AuditEvent{"system", BAML_LIT("created"){}, {{"source", "fixture"}}},
+          AuditEvent{"reviewer",
+                     BAML_LIT("approved"){},
+                     {{"level", "2"}, {"region", "us"}}},
       },
       {{"cohort", "beta"}, {"owner_kind", "internal"}},
       Featured{invoice},

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_enums.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_enums.cc
@@ -22,13 +22,15 @@ BAML_TEST(round_trip_sentiment) {
 }
 
 BAML_TEST(round_trip_sentiment_positive) {
-  // EnumVariant-as-type: the variant tag is dropped during TIR->codegen,
-  // so the C++ type is just Sentiment.
-  BAML_ASSERT(baml_sdk::enums::round_trip_sentiment_positive(
-                  Sentiment::Positive) == Sentiment::Positive);
+  // EnumVariant-as-type is a singleton Lit: only the tagged variant fits,
+  // and the value converts back to the enum implicitly.
+  const Sentiment round_tripped =
+      baml_sdk::enums::round_trip_sentiment_positive(
+          BAML_LIT(Sentiment::Positive){});
+  BAML_ASSERT(round_tripped == Sentiment::Positive);
 }
 
 BAML_TEST(round_trip_enums) {
-  const Enums e{Sentiment::Positive, Sentiment::Positive};
+  const Enums e{Sentiment::Positive, BAML_LIT(Sentiment::Positive){}};
   BAML_ASSERT(baml_sdk::enums::round_trip_enums(e) == e);
 }

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_literals.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_literals.cc
@@ -1,46 +1,95 @@
-// Roundtrip coverage for baml_sdk::literals - literal Ty variants, widened
-// to their base types (spec parity with Python's Literal handling).
-// Port of roundtrip_tests/test_literals.py.
+// Roundtrip coverage for baml_sdk::literals - literal Ty variants as
+// singleton ::baml::Lit types. Port of roundtrip_tests/test_literals.py:
+// python keeps the value set in typing.Literal annotations; C++ makes each
+// value a distinct type, so the round trips construct through the
+// BAML_LIT macro family and read back through Lit's implicit value
+// conversions.
 #include <baml_sdk.h>
 #include <baml_test.h>
 
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
 using baml_sdk::literals::Literals;
 
+// The generated surface is typed per value, not widened.
+static_assert(std::is_same<decltype(baml_sdk::literals::return_literal42()),
+                           BAML_LIT(42)>::value,
+              "int literal return must be a Lit");
+static_assert(std::is_same<decltype(baml_sdk::literals::return_literal_draft()),
+                           BAML_LIT("draft")>::value,
+              "string literal return must be a Lit");
+static_assert(std::is_same<decltype(baml_sdk::literals::return_literal_true()),
+                           BAML_LIT(true)>::value,
+              "bool literal return must be a Lit");
+
 BAML_TEST(return_literals) {
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal42(), 42);
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_neg_one(), -1);
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_draft(),
-                 std::string("draft"));
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_escaped(),
-                 std::string("has \"quotes\""));
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_true(), true);
-  BAML_ASSERT_EQ(baml_sdk::literals::return_literal_false(), false);
+  BAML_ASSERT(baml_sdk::literals::return_literal42() == BAML_LIT(42){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_neg_one() == BAML_LIT(-1){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_draft() ==
+              BAML_LIT("draft"){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_escaped() ==
+              BAML_LIT("has \"quotes\""){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_true() == BAML_LIT(true){});
+  BAML_ASSERT(baml_sdk::literals::return_literal_false() == BAML_LIT(false){});
+}
+
+BAML_TEST(literal_values_convert_implicitly) {
+  const int64_t n = baml_sdk::literals::return_literal42();
+  BAML_ASSERT(n == 42);
+  const std::string_view s = baml_sdk::literals::return_literal_draft();
+  BAML_ASSERT(s == "draft");
+  const bool b = baml_sdk::literals::return_literal_true();
+  BAML_ASSERT(b);
+  BAML_ASSERT(BAML_LIT("has \"quotes\"")::value == "has \"quotes\"");
 }
 
 BAML_TEST(round_trip_literal42) {
-  BAML_ASSERT_EQ(baml_sdk::literals::round_trip_literal42(42), 42);
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal42(BAML_LIT(42){}) ==
+              BAML_LIT(42){});
 }
 
 BAML_TEST(round_trip_literal_draft) {
-  BAML_ASSERT_EQ(baml_sdk::literals::round_trip_literal_draft("draft"),
-                 std::string("draft"));
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal_draft(
+                  BAML_LIT("draft"){}) == BAML_LIT("draft"){});
 }
 
 BAML_TEST(round_trip_literal_escaped) {
-  BAML_ASSERT_EQ(
-      baml_sdk::literals::round_trip_literal_escaped("has \"quotes\""),
-      std::string("has \"quotes\""));
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal_escaped(BAML_LIT(
+                  "has \"quotes\""){}) == BAML_LIT("has \"quotes\""){});
 }
 
 BAML_TEST(round_trip_literal_true) {
-  BAML_ASSERT_EQ(baml_sdk::literals::round_trip_literal_true(true), true);
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal_true(BAML_LIT(true){}) ==
+              BAML_LIT(true){});
 }
 
 BAML_TEST(round_trip_literal_false) {
-  BAML_ASSERT_EQ(baml_sdk::literals::round_trip_literal_false(false), false);
+  BAML_ASSERT(baml_sdk::literals::round_trip_literal_false(BAML_LIT(false){}) ==
+              BAML_LIT(false){});
 }
 
 BAML_TEST(round_trip_literals) {
-  const Literals lit{42, "draft", "has \"quotes\"", true, false};
+  const Literals lit{BAML_LIT(42){}, BAML_LIT("draft"){},
+                     BAML_LIT("has \"quotes\""){}, BAML_LIT(true){},
+                     BAML_LIT(false){}};
   BAML_ASSERT(baml_sdk::literals::round_trip_literals(lit) == lit);
+}
+
+BAML_TEST(round_trip_flag_mixed_literal_union) {
+  // Mixed-base literal union ("active" | 1 | true): the union codec's
+  // literal pass must route each wire arm to its exact Lit alternative.
+  using baml_sdk::literals::Flag;
+  Flag f = baml_sdk::literals::round_trip_flag(BAML_LIT("active"){});
+  BAML_ASSERT(std::holds_alternative<BAML_LIT("active")>(f));
+  f = baml_sdk::literals::round_trip_flag(BAML_LIT(1){});
+  BAML_ASSERT(std::holds_alternative<BAML_LIT(1)>(f));
+  f = baml_sdk::literals::round_trip_flag(BAML_LIT(true){});
+  const int which = baml::match(
+      f,                                                                    //
+      [](BAML_LIT("active")) { return 0; }, [](BAML_LIT(1)) { return 1; },  //
+      [](BAML_LIT(true)) { return 2; });
+  BAML_ASSERT(which == 2);
 }

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/unions_static.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/unions_static.cc
@@ -26,6 +26,20 @@ static_assert(
                  std::vector<baml::Union<std::string, int64_t>>>::value,
     "canonicalization must hold under std::vector");
 
+// Literal types are ordinary alternatives: the BAML_LIT macro family hits
+// the canonical char-pack / normalized-scalar instantiations, and Lit
+// unions canonicalize like any other.
+static_assert(
+    std::is_same<BAML_LIT("draft"), baml::Lit<'d', 'r', 'a', 'f', 't'>>::value,
+    "BAML_LIT must produce the canonical char pack");
+static_assert(std::is_same<BAML_LIT(1), baml::Lit<int64_t{1}>>::value,
+              "BAML_LIT must normalize ints to int64_t");
+static_assert(std::is_same<BAML_LIT(1), baml::IntLit<1>>::value,
+              "IntLit must agree with BAML_LIT");
+static_assert(std::is_same<baml::Union<BAML_LIT("a"), BAML_LIT("b")>,
+                           baml::Union<BAML_LIT("b"), BAML_LIT("a")>>::value,
+              "Lit unions must be order-canonical");
+
 // Alternatives are a set, not a list: duplicates collapse, so type-based
 // construction and access are never ambiguous.
 static_assert(

--- a/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_literals.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_literals.py
@@ -62,3 +62,13 @@ def test_round_trip_literals():
         literal_false=False,
     )
     assert round_trip_literals(l=lit) == lit
+
+
+def test_round_trip_flag_mixed_literal_union():
+    from baml_sdk.literals import round_trip_flag
+
+    assert round_trip_flag(f="active") == "active"
+    r_int = round_trip_flag(f=1)
+    assert r_int == 1 and not isinstance(r_int, bool)
+    r_bool = round_trip_flag(f=True)
+    assert r_bool is True

--- a/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_literals/types.baml
+++ b/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_literals/types.baml
@@ -63,3 +63,11 @@ function round_trip_literal_false(x: false) -> false {
 function round_trip_literals(l: Literals) -> Literals {
   l
 }
+
+// Mixed-base literal union: every alternative is a literal of a different
+// base type, so hosts with typed literals must dispatch by value.
+type Flag = "active" | 1 | true
+
+function round_trip_flag(f: Flag) -> Flag {
+  f
+}

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
@@ -13,6 +13,7 @@
 #include <baml/detail/registry.h>
 #include <baml/errors.h>
 #include <baml/future.h>
+#include <baml/lit.h>
 #include <baml/runtime.h>
 #include <baml/union.h>
 

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/codec.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/codec.h
@@ -12,6 +12,7 @@
 #include <baml/box.h>
 #include <baml/detail/proto.h>
 #include <baml/errors.h>
+#include <baml/lit.h>
 
 #include <cstdint>
 #include <cstdlib>
@@ -259,6 +260,57 @@ struct Codec<std::unordered_map<std::string, T>> {
   }
 };
 
+// BAML literal types (baml::Lit). Encode writes the static value as its
+// plain scalar/enum arm (the engine types the parameter). Decode reuses
+// the base codec for arm handling (plain and literal wire arms alike) and
+// then requires the exact value: a mismatch throws, which inside a union
+// rejects this alternative and lets the next one probe.
+template <auto... Vs>
+struct Codec<Lit<Vs...>> {
+  using L = Lit<Vs...>;
+  static constexpr detail::LitShape kShape =
+      detail::LitShapeOf<decltype(Vs)...>();
+
+  static void Encode(detail::pb::InboundValue& value_msg, const L&) {
+    if constexpr (kShape == detail::LitShape::kString) {
+      value_msg.set_string_value(std::string(L::value));
+    } else if constexpr (kShape == detail::LitShape::kInt) {
+      value_msg.set_int_value(L::value);
+    } else if constexpr (kShape == detail::LitShape::kBool) {
+      value_msg.set_bool_value(L::value);
+    } else {
+      Codec<std::decay_t<decltype(L::value)>>::Encode(value_msg, L::value);
+    }
+  }
+
+  static L Decode(const detail::pb::BamlOutboundValue& raw) {
+    if constexpr (kShape == detail::LitShape::kString) {
+      if (Codec<std::string>::Decode(raw) != L::value) {
+        Mismatch("literal \"" + std::string(L::value) + "\"");
+      }
+    } else if constexpr (kShape == detail::LitShape::kInt) {
+      if (Codec<int64_t>::Decode(raw) != L::value) {
+        Mismatch("literal " + std::to_string(L::value));
+      }
+    } else if constexpr (kShape == detail::LitShape::kBool) {
+      if (Codec<bool>::Decode(raw) != L::value) {
+        Mismatch(L::value ? "literal true" : "literal false");
+      }
+    } else {
+      using E = std::decay_t<decltype(L::value)>;
+      if (Codec<E>::Decode(raw) != L::value) {
+        Mismatch("enum-variant literal");
+      }
+    }
+    return L{};
+  }
+
+ private:
+  [[noreturn]] static void Mismatch(const std::string& expected) {
+    throw BamlError("BAML decode error: expected " + expected);
+  }
+};
+
 // BAML unions (baml::Union<Ts...> = order-canonical std::variant). Encode
 // writes the ACTIVE alternative's value with no union wrapper (the engine
 // types the member; Python parity). Decode receives the union-unwrapped
@@ -266,8 +318,10 @@ struct Codec<std::unordered_map<std::string, T>> {
 // alone -- alternatives are in canonical (sorted) order, so selection is
 // order-independent by construction:
 //
-//   pass 1 (strict): each alternative decodes only its exact wire arms
-//     (int never satisfies a double alternative);
+//   pass 0 (literal): Lit alternatives claim their exact values first, so
+//     Lit<"auto"> beats a std::string sibling for the string "auto";
+//   pass 1 (strict): each non-Lit alternative decodes only its exact wire
+//     arms (int never satisfies a double alternative);
 //   pass 2 (lenient): the engine's int->float coercion is admitted, for
 //     unions with a float arm but no int arm.
 //
@@ -290,9 +344,12 @@ struct Codec<std::variant<Ts...>> {
   static V Decode(const detail::pb::BamlOutboundValue& raw) {
     const auto& v = detail::Unwrap(raw);
     std::optional<V> out;
-    const bool strict = (TryArm<Ts>(v, out, false) || ...);
-    if (!strict) {
-      (TryArm<Ts>(v, out, true) || ...);
+    const bool lit = (TryArm<Ts>(v, out, Pass::kLiteral) || ...);
+    if (!lit) {
+      const bool strict = (TryArm<Ts>(v, out, Pass::kStrict) || ...);
+      if (!strict) {
+        (TryArm<Ts>(v, out, Pass::kLenient) || ...);
+      }
     }
     if (!out.has_value()) {
       detail::KindMismatch("union", v);
@@ -301,6 +358,8 @@ struct Codec<std::variant<Ts...>> {
   }
 
  private:
+  enum class Pass { kLiteral, kStrict, kLenient };
+
   static bool IsIntArm(const detail::pb::BamlOutboundValue& v) {
     if (v.value_case() == detail::pb::BamlOutboundValue::kIntValue) {
       return true;
@@ -312,8 +371,12 @@ struct Codec<std::variant<Ts...>> {
 
   template <class T>
   static bool TryArm(const detail::pb::BamlOutboundValue& v,
-                     std::optional<V>& out, bool lenient) {
-    if (!lenient && std::is_same<T, double>::value && IsIntArm(v)) {
+                     std::optional<V>& out, Pass pass) {
+    if ((pass == Pass::kLiteral) != detail::IsLit<T>::value) {
+      return false;
+    }
+    if (pass == Pass::kStrict && std::is_same<T, double>::value &&
+        IsIntArm(v)) {
       return false;
     }
     try {

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
@@ -1,0 +1,259 @@
+#ifndef BAML_LIT_H_
+#define BAML_LIT_H_
+
+// baml::Lit<Vs...>: BAML literal types as distinct C++ types (C++17).
+//
+// BAML literal types are singleton value types: `"draft"`, `42`, `true`,
+// and enum-variant types like `Sentiment.Positive`. Each distinct value is
+// a distinct C++ type, so literal unions dispatch and exhaustively match
+// at compile time exactly like any other baml::Union:
+//
+//   // status "draft" | "sent" | "paid"
+//   baml::match(invoice.status,
+//     [](BAML_LIT("draft")) { ... },
+//     [](BAML_LIT("sent"))  { ... },
+//     [](BAML_LIT("paid"))  { ... });
+//
+// One macro spells them all -- overloaded constexpr helpers classify the
+// argument and normalize its value at compile time:
+//   BAML_LIT("draft")              string  -> Lit<'d','r','a','f','t'>
+//   BAML_LIT(42)                   int     -> Lit<int64_t{42}>
+//   BAML_LIT(true)                 bool    -> Lit<true>
+//   BAML_LIT(Sentiment::Positive)  enum    -> Lit<Sentiment::Positive>
+//
+// C++17 cannot pass a string literal as a template argument (class-type
+// NTTPs are C++20), so BAML_LIT explodes the literal into a char pack via
+// constant-expression indexing (the Boost.Metaparse technique), capped at
+// 64 characters. Generated code never uses the macro: the emitter spells
+// the char packs directly.
+//
+// A bare integer must NOT be spelled Lit<1>: template identity includes
+// the parameter's TYPE, and `1` deduces `int`, minting a type distinct
+// from the canonical Lit<int64_t{1}>. The shape check rejects it with a
+// pointer to BAML_LIT(1), whose value normalization canonicalizes the
+// type. (baml::IntLit<1> / baml::BoolLit<true> are macro-free alternates
+// with the same normalization.)
+//
+// Every Lit carries its value statically: `decltype(x)::value` (also
+// implicitly convertible), so a catch-all match arm can recover the
+// runtime value: `match(u, [](auto l) { return decltype(l)::value; })`.
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace baml {
+namespace detail {
+
+enum class LitShape { kInvalid, kString, kInt, kBool, kEnum };
+
+// A plain alias (template <class T, class...> using Head = T) does not
+// survive pack expansion into its fixed parameter on clang; a struct
+// specialization does.
+template <class... Ts>
+struct LitHead;
+template <class T, class... Rest>
+struct LitHead<T, Rest...> {
+  using type = T;
+};
+
+template <class... Ts>
+constexpr LitShape LitShapeOf() {
+  if constexpr ((std::is_same<Ts, char>::value && ...)) {
+    // Includes the empty pack: BAML_LIT("") is the empty-string type.
+    return LitShape::kString;
+  } else if constexpr (sizeof...(Ts) == 1) {
+    using T = typename LitHead<Ts...>::type;
+    if (std::is_same<T, int64_t>::value) return LitShape::kInt;
+    if (std::is_same<T, bool>::value) return LitShape::kBool;
+    if (std::is_enum<T>::value) return LitShape::kEnum;
+    return LitShape::kInvalid;
+  } else {
+    return LitShape::kInvalid;
+  }
+}
+
+template <LitShape S, auto... Vs>
+struct LitBase {
+  static_assert(
+      S != LitShape::kInvalid,
+      "unsupported baml::Lit shape. The four literal spellings: "
+      "BAML_LIT(\"...\") for strings; BAML_LIT_INT(n) / baml::IntLit<n> for "
+      "ints (a bare integer deduces `int`, not int64_t, which would mint a "
+      "second type); BAML_LIT_BOOL(b) / baml::Lit<true> for bools; "
+      "BAML_LIT_ENUM(E::V) / baml::Lit<E::V> for enum variants");
+};
+
+template <auto... Cs>
+struct LitBase<LitShape::kString, Cs...> {
+  static constexpr char chars[] = {static_cast<char>(Cs)..., '\0'};
+  static constexpr std::string_view value{chars, sizeof...(Cs)};
+  constexpr operator std::string_view() const { return value; }
+};
+
+template <auto V>
+struct LitBase<LitShape::kInt, V> {
+  static constexpr int64_t value = V;
+  constexpr operator int64_t() const { return value; }
+};
+
+template <auto V>
+struct LitBase<LitShape::kBool, V> {
+  static constexpr bool value = V;
+  constexpr operator bool() const { return value; }
+};
+
+template <auto V>
+struct LitBase<LitShape::kEnum, V> {
+  static constexpr decltype(V) value = V;
+  constexpr operator decltype(V)() const { return value; }
+};
+
+}  // namespace detail
+
+template <auto... Vs>
+struct Lit : detail::LitBase<detail::LitShapeOf<decltype(Vs)...>(), Vs...> {
+  // Unit type: two values of the same Lit are always equal (memberwise
+  // equality of generated structs and variant equality both rely on this).
+  friend constexpr bool operator==(Lit, Lit) { return true; }
+  friend constexpr bool operator!=(Lit, Lit) { return false; }
+};
+
+template <int64_t V>
+using IntLit = Lit<V>;
+
+template <bool V>
+using BoolLit = Lit<V>;
+
+namespace detail {
+
+template <class T>
+struct IsLit : std::false_type {};
+template <auto... Vs>
+struct IsLit<Lit<Vs...>> : std::true_type {};
+
+// Strips the '\0' padding BAML_LIT's fixed-arity expansion appends, so
+// every spelling of the same string lands on the same Lit instantiation.
+// N is sizeof(literal) for the cap check; BAML strings never contain
+// embedded NULs, so the first '\0' is the end.
+template <std::size_t N, char... Cs>
+struct TrimNulls {
+  static_assert(N <= sizeof...(Cs) + 1,
+                "string literal exceeds BAML_LIT's 64-character cap");
+  static constexpr char arr[] = {Cs...};
+  static constexpr std::size_t Length() {
+    std::size_t n = 0;
+    while (n < sizeof...(Cs) && arr[n] != '\0') ++n;
+    return n;
+  }
+  template <std::size_t... Is>
+  static Lit<arr[Is]...> Pick(std::index_sequence<Is...>);
+  using type = decltype(Pick(std::make_index_sequence<Length()>{}));
+};
+
+// BAML_LIT(x) argument classification: overload resolution IS the
+// dispatch. Every helper is called in template-argument position, so x
+// must be a literal / constant expression. Bare `char` is deliberately
+// not a literal shape (BAML has no char type; spell the one-char string).
+
+enum class LitArg { kString, kScalar };
+
+template <class T>
+constexpr bool kLitScalarArg =
+    (std::is_integral<T>::value && !std::is_same<T, bool>::value &&
+     !std::is_same<T, char>::value) ||
+    std::is_enum<T>::value;
+
+template <std::size_t N>
+constexpr LitArg LitArgOf(const char (&)[N]) {
+  return LitArg::kString;
+}
+constexpr LitArg LitArgOf(bool) { return LitArg::kScalar; }
+template <class T, std::enable_if_t<kLitScalarArg<T>, int> = 0>
+constexpr LitArg LitArgOf(T) {
+  return LitArg::kScalar;
+}
+
+// The scalar value, normalized: every integral type lands on int64_t so
+// BAML_LIT(42) and BAML_LIT(int64_t{42}) are the same type.
+template <std::size_t N>
+constexpr int64_t LitValueOf(const char (&)[N]) {
+  return 0;  // placeholder; the string path never reads it
+}
+constexpr bool LitValueOf(bool v) { return v; }
+template <class T, std::enable_if_t<std::is_integral<T>::value &&
+                                        !std::is_same<T, bool>::value &&
+                                        !std::is_same<T, char>::value,
+                                    int> = 0>
+constexpr int64_t LitValueOf(T v) {
+  return static_cast<int64_t>(v);
+}
+template <class T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+constexpr T LitValueOf(T v) {
+  return v;
+}
+
+template <std::size_t N>
+constexpr char LitCharAt(const char (&s)[N], std::size_t i) {
+  return i < N ? s[i] : '\0';
+}
+template <class T, std::enable_if_t<!std::is_array<T>::value, int> = 0>
+constexpr char LitCharAt(const T&, std::size_t) {
+  return '\0';
+}
+
+template <LitArg K, auto V, std::size_t N, char... Cs>
+struct LitSelect;
+template <auto V, std::size_t N, char... Cs>
+struct LitSelect<LitArg::kString, V, N, Cs...> : TrimNulls<N, Cs...> {};
+template <auto V, std::size_t N, char... Cs>
+struct LitSelect<LitArg::kScalar, V, N, Cs...> {
+  using type = Lit<V>;
+};
+
+}  // namespace detail
+}  // namespace baml
+
+#define BAML_DETAIL_LIT_CH(s, i) (::baml::detail::LitCharAt((s), (i)))
+
+// clang-format off
+#define BAML_LIT(s)                                                          \
+  ::baml::detail::LitSelect<::baml::detail::LitArgOf(s),                     \
+      ::baml::detail::LitValueOf(s), sizeof(s),                              \
+      BAML_DETAIL_LIT_CH(s, 0),  BAML_DETAIL_LIT_CH(s, 1),                   \
+      BAML_DETAIL_LIT_CH(s, 2),  BAML_DETAIL_LIT_CH(s, 3),                   \
+      BAML_DETAIL_LIT_CH(s, 4),  BAML_DETAIL_LIT_CH(s, 5),                   \
+      BAML_DETAIL_LIT_CH(s, 6),  BAML_DETAIL_LIT_CH(s, 7),                   \
+      BAML_DETAIL_LIT_CH(s, 8),  BAML_DETAIL_LIT_CH(s, 9),                   \
+      BAML_DETAIL_LIT_CH(s, 10), BAML_DETAIL_LIT_CH(s, 11),                  \
+      BAML_DETAIL_LIT_CH(s, 12), BAML_DETAIL_LIT_CH(s, 13),                  \
+      BAML_DETAIL_LIT_CH(s, 14), BAML_DETAIL_LIT_CH(s, 15),                  \
+      BAML_DETAIL_LIT_CH(s, 16), BAML_DETAIL_LIT_CH(s, 17),                  \
+      BAML_DETAIL_LIT_CH(s, 18), BAML_DETAIL_LIT_CH(s, 19),                  \
+      BAML_DETAIL_LIT_CH(s, 20), BAML_DETAIL_LIT_CH(s, 21),                  \
+      BAML_DETAIL_LIT_CH(s, 22), BAML_DETAIL_LIT_CH(s, 23),                  \
+      BAML_DETAIL_LIT_CH(s, 24), BAML_DETAIL_LIT_CH(s, 25),                  \
+      BAML_DETAIL_LIT_CH(s, 26), BAML_DETAIL_LIT_CH(s, 27),                  \
+      BAML_DETAIL_LIT_CH(s, 28), BAML_DETAIL_LIT_CH(s, 29),                  \
+      BAML_DETAIL_LIT_CH(s, 30), BAML_DETAIL_LIT_CH(s, 31),                  \
+      BAML_DETAIL_LIT_CH(s, 32), BAML_DETAIL_LIT_CH(s, 33),                  \
+      BAML_DETAIL_LIT_CH(s, 34), BAML_DETAIL_LIT_CH(s, 35),                  \
+      BAML_DETAIL_LIT_CH(s, 36), BAML_DETAIL_LIT_CH(s, 37),                  \
+      BAML_DETAIL_LIT_CH(s, 38), BAML_DETAIL_LIT_CH(s, 39),                  \
+      BAML_DETAIL_LIT_CH(s, 40), BAML_DETAIL_LIT_CH(s, 41),                  \
+      BAML_DETAIL_LIT_CH(s, 42), BAML_DETAIL_LIT_CH(s, 43),                  \
+      BAML_DETAIL_LIT_CH(s, 44), BAML_DETAIL_LIT_CH(s, 45),                  \
+      BAML_DETAIL_LIT_CH(s, 46), BAML_DETAIL_LIT_CH(s, 47),                  \
+      BAML_DETAIL_LIT_CH(s, 48), BAML_DETAIL_LIT_CH(s, 49),                  \
+      BAML_DETAIL_LIT_CH(s, 50), BAML_DETAIL_LIT_CH(s, 51),                  \
+      BAML_DETAIL_LIT_CH(s, 52), BAML_DETAIL_LIT_CH(s, 53),                  \
+      BAML_DETAIL_LIT_CH(s, 54), BAML_DETAIL_LIT_CH(s, 55),                  \
+      BAML_DETAIL_LIT_CH(s, 56), BAML_DETAIL_LIT_CH(s, 57),                  \
+      BAML_DETAIL_LIT_CH(s, 58), BAML_DETAIL_LIT_CH(s, 59),                  \
+      BAML_DETAIL_LIT_CH(s, 60), BAML_DETAIL_LIT_CH(s, 61),                  \
+      BAML_DETAIL_LIT_CH(s, 62), BAML_DETAIL_LIT_CH(s, 63)>::type
+// clang-format on
+
+#endif  // BAML_LIT_H_

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
@@ -80,10 +80,10 @@ struct LitBase {
   static_assert(
       S != LitShape::kInvalid,
       "unsupported baml::Lit shape. The four literal spellings: "
-      "BAML_LIT(\"...\") for strings; BAML_LIT_INT(n) / baml::IntLit<n> for "
-      "ints (a bare integer deduces `int`, not int64_t, which would mint a "
-      "second type); BAML_LIT_BOOL(b) / baml::Lit<true> for bools; "
-      "BAML_LIT_ENUM(E::V) / baml::Lit<E::V> for enum variants");
+      "BAML_LIT(\"...\") for strings; BAML_LIT(n) / baml::IntLit<n> for ints "
+      "(a bare Lit<1> deduces `int`, not int64_t, which would mint a second "
+      "type); BAML_LIT(b) / baml::BoolLit<b> for bools; BAML_LIT(E::V) / "
+      "baml::Lit<E::V> for enum variants");
 };
 
 template <auto... Cs>
@@ -177,7 +177,11 @@ constexpr LitArg LitArgOf(T) {
 }
 
 // The scalar value, normalized: every integral type lands on int64_t so
-// BAML_LIT(42) and BAML_LIT(int64_t{42}) are the same type.
+// BAML_LIT(42) and BAML_LIT(int64_t{42}) are the same type. An unsigned
+// value above INT64_MAX must not wrap into an aliased identity
+// (BAML_LIT(UINT64_MAX) == BAML_LIT(-1)); reaching the throw during
+// constant evaluation makes the call non-constant, so the out-of-range
+// spelling fails to compile with this message in the diagnostic.
 template <std::size_t N>
 constexpr int64_t LitValueOf(const char (&)[N]) {
   return 0;  // placeholder; the string path never reads it
@@ -188,7 +192,10 @@ template <class T, std::enable_if_t<std::is_integral<T>::value &&
                                         !std::is_same<T, char>::value,
                                     int> = 0>
 constexpr int64_t LitValueOf(T v) {
-  return static_cast<int64_t>(v);
+  return std::is_signed<T>::value ||
+                 static_cast<uint64_t>(v) <= static_cast<uint64_t>(INT64_MAX)
+             ? static_cast<int64_t>(v)
+             : throw "BAML int literals must be representable in int64_t";
 }
 template <class T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
 constexpr T LitValueOf(T v) {

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
@@ -348,6 +348,10 @@ const BRIDGE_HEADERS: &[(&str, &str)] = &[
         include_str!("../../bridge_cpp/include/baml/future.h"),
     ),
     (
+        "include/baml/lit.h",
+        include_str!("../../bridge_cpp/include/baml/lit.h"),
+    ),
+    (
         "include/baml/runtime.h",
         include_str!("../../bridge_cpp/include/baml/runtime.h"),
     ),
@@ -972,15 +976,22 @@ fn translate_ty(
             return Translated::Unsupported("media type (post-step-8)".to_string());
         }
         Ty::Literal(lit, ..) => {
-            // Literal types widen to their base type (Python parity).
+            // Literal types are singleton ::baml::Lit types (each distinct
+            // value a distinct C++ type), spelled as char packs / typed
+            // scalars directly -- the BAML_LIT macro family is user-side
+            // sugar only. Float literals stay widened: float NTTPs are
+            // C++20 and BAML has no float literal types in practice.
             match lit {
-                baml_base::Literal::Int(_) => "int64_t".to_string(),
+                baml_base::Literal::Int(v) => format!("::baml::Lit<{}>", lit_int_spelling(*v)),
                 baml_base::Literal::Bigint(_) => {
                     return Translated::Unsupported("bigint literal (post-step-8)".to_string());
                 }
                 baml_base::Literal::Float(_) => "double".to_string(),
-                baml_base::Literal::String(_) => "std::string".to_string(),
-                baml_base::Literal::Bool(_) => "bool".to_string(),
+                baml_base::Literal::String(s) => {
+                    let chars: Vec<String> = s.bytes().map(lit_char_spelling).collect();
+                    format!("::baml::Lit<{}>", chars.join(", "))
+                }
+                baml_base::Literal::Bool(b) => format!("::baml::Lit<{b}>"),
             }
         }
         Ty::TypeVar(name, _) => {
@@ -1023,9 +1034,7 @@ fn translate_ty(
                     .to_string(),
             );
         }
-        // An enum-variant type (`Sentiment.Positive`) widens to its enum
-        // (Python parity: the variant tag narrows values, not the C++ type).
-        Ty::Enum(name, _) | Ty::EnumVariant(name, _, _) => {
+        Ty::Enum(name, _) => {
             return if emitted_types.contains(name) {
                 Translated::Cpp(
                     names
@@ -1033,6 +1042,26 @@ fn translate_ty(
                         .identifier()
                         .to_string(),
                 )
+            } else {
+                Translated::NotYet
+            };
+        }
+        // An enum-variant type (`Sentiment.Positive`) is a singleton Lit
+        // over the enum value, so unions of variants dispatch and match
+        // per-variant at compile time.
+        Ty::EnumVariant(name, variant, _) => {
+            return if emitted_types.contains(name) {
+                let enum_path = names
+                    .get(&NameRequest::new(BamlFqn::symbol(name), CppNameKind::Enum))
+                    .identifier()
+                    .to_string();
+                let variant_name = names
+                    .get(&NameRequest::new(
+                        BamlFqn::member(name, variant.as_str()),
+                        CppNameKind::EnumVariant,
+                    ))
+                    .declared();
+                Translated::Cpp(format!("::baml::Lit<{enum_path}::{variant_name}>"))
             } else {
                 Translated::NotYet
             };
@@ -1186,10 +1215,40 @@ fn close_namespaces(buf: &mut String, ns: &[String]) {
 }
 
 fn by_value_or_cref(ty: &str) -> String {
+    // Lit types are empty unit structs: by value.
+    if ty.starts_with("::baml::Lit<") {
+        return ty.to_string();
+    }
     match ty {
         "int64_t" | "double" | "bool" | "std::monostate" => ty.to_string(),
         _ => format!("const {ty}&"),
     }
+}
+
+/// Spells one byte of a BAML string literal as a C++ char literal for a
+/// `::baml::Lit` char pack. Bytes, not code points: the pack mirrors the
+/// literal's UTF-8 encoding, matching what `BAML_LIT`'s sizeof-based
+/// expansion produces.
+fn lit_char_spelling(b: u8) -> String {
+    match b {
+        b'\'' => "'\\''".to_string(),
+        b'\\' => "'\\\\'".to_string(),
+        b'\n' => "'\\n'".to_string(),
+        b'\r' => "'\\r'".to_string(),
+        b'\t' => "'\\t'".to_string(),
+        0x20..=0x7e => format!("'{}'", b as char),
+        _ => format!("'\\x{b:02x}'"),
+    }
+}
+
+/// Spells an int literal's value as the canonical `int64_t{...}` template
+/// argument. `i64::MIN` has no valid literal spelling (the unary minus
+/// applies after the out-of-range positive literal), hence the subtraction.
+fn lit_int_spelling(v: i64) -> String {
+    if v == i64::MIN {
+        return "int64_t{-9223372036854775807 - 1}".to_string();
+    }
+    format!("int64_t{{{v}}}")
 }
 
 fn signature(f: &EmittedFn, pos: RenderPos, variant: FnVariant) -> String {


### PR DESCRIPTION
Stacked on #4078 (retargets to canary when it merges).

BAML literal types stop widening to their base scalars: **each literal value is a distinct C++ type**, so literal unions dispatch and exhaustively match at compile time, and misspellings do not compile. Pure C++17.

## Surface

One macro classifies its argument via overloaded constexpr helpers (overload resolution is the dispatch):

```cpp
BAML_LIT("draft")              // string -> Lit<'d','r','a','f','t'>  (Boost.Metaparse char-pack trick, 64-char cap)
BAML_LIT(42)                   // int    -> Lit<int64_t{42}>  (normalized: a bare int cannot mint a twin type)
BAML_LIT(true)                 // bool   -> Lit<true>
BAML_LIT(Sentiment::Positive)  // enum-variant type (Ty::EnumVariant), no longer widened to the enum
```

```cpp
// status "draft" | "sent" | "paid"
baml::match(invoice.status,
  [](BAML_LIT("draft")) { ... },
  [](BAML_LIT("sent"))  { ... },
  [](BAML_LIT("paid"))  { ... });   // exhaustive; add a value in .baml -> build breaks
```

Every `Lit` carries its value statically (`::value`, plus implicit conversion to `string_view`/`int64_t`/`bool`/enum). Any non-blessed shape (`Lit<1>` int-typed, floats, mixed packs, pointers...) lands on a teaching `static_assert`. Generated code never uses the macro - the emitter spells char packs directly.

## Mechanics

- `lit.h`: `template <auto... Vs> struct Lit` with LitShape tag-dispatch (no partial-spec ambiguity), `TrimNulls` canonicalization so every spelling of a string lands on one instantiation, `IntLit`/`BoolLit` macro-free alternates.
- Codec: encode = the plain scalar/enum arm; decode = base-codec arm handling + exact-value check (mismatch rejects the union arm). Union decode gains a **literal pass** ahead of strict/lenient, so `Lit<"auto">` beats a `std::string` sibling.
- Emitter: `Ty::Literal` + `Ty::EnumVariant` emit `::baml::Lit<...>` (proper char escaping incl. `\xNN` and the `i64::MIN` spelling trick); float literals stay widened (float NTTPs are C++20; BAML has none in practice).
- Lit unions ride the existing order-canonical + dedup `baml::Union` machinery unchanged.

## Tests

- `test_literals.cc` rewritten to typed semantics (returns/round-trips/class-of-literals + implicit-conversion ergonomics + type-level static_asserts).
- New shared-fixture coverage, python-first per ground rules: mixed-base literal union `type Flag = "active" | 1 | true` round trip (`test_round_trip_flag_mixed_literal_union` in python, exact-alternative dispatch + match in C++).
- `test_complex_models.cc`/`test_enums.cc` updated (Invoice.status literal union, EnumVariant-as-type now a singleton Lit).
- `unions_static.cc`: BAML_LIT canonical-identity + int-normalization + Lit-union order-canonicality pins.

cpp fixtures 12/12 locally; python + the rest on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for strongly typed literal values in generated C++ SDKs.
  * Added literal handling for strings, integers, booleans, and enum variants.
  * Added support for mixed literal unions such as `"active"`, `1`, and `true`.
  * Added compile-time validation and exact literal round-trip behavior.

* **Bug Fixes**
  * Improved union value decoding to prioritize exact literal matches before applying broader type conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->