### PR TITLE
feat(lsp): textDocument/documentHighlight

### DIFF
--- a/baml_language/crates/baml_lsp2_actions/src/definition.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/definition.rs
@@ -110,30 +110,7 @@ fn local_definition_location(
     at_offset: TextSize,
     site: DefinitionSite,
 ) -> Option<Location> {
-    let index = baml_compiler2_hir::file_semantic_index(db, file);
-    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
-
-    // Find the enclosing Function scope to locate the function in the item tree.
-    let scope_id = index.scope_at_offset(at_offset, None);
-    let enclosing_func_scope = index
-        .ancestor_scopes(scope_id)
-        .into_iter()
-        .find(|ancestor_id| {
-            matches!(
-                index.scopes[ancestor_id.index() as usize].kind,
-                baml_compiler2_hir::scope::ScopeKind::Function
-            )
-        })?;
-
-    let func_scope_range = index.scopes[enclosing_func_scope.index() as usize].range;
-
-    // Find the function in the item tree by matching the scope range.
-    let (func_local_id, _) = item_tree
-        .functions
-        .iter()
-        .find(|(_, f)| f.span == func_scope_range)?;
-
-    let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, *func_local_id);
+    let func_loc = utils::enclosing_function_loc(db, file, at_offset)?;
 
     match site {
         DefinitionSite::Statement(stmt_id) => {

--- a/baml_language/crates/baml_lsp2_actions/src/highlights.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/highlights.rs
@@ -1,0 +1,112 @@
+//! `document_highlights_at` — same-file occurrences of the symbol at the
+//! cursor, for `textDocument/documentHighlight`.
+//!
+//! Reuses the `usages` machinery restricted to the request file: the LSP
+//! scopes highlights to one document, and editors re-request them on every
+//! cursor move, so the package-wide scan `usages_at` does would be wasted
+//! work. Unlike `usages_at` — which excludes the definition site by contract —
+//! the declaration occurrence is part of the highlight group, so it is added
+//! back when it lives in the request file.
+//!
+//! All occurrences are returned without a read/write distinction: BAML has no
+//! reassignment, so the LSP `DocumentHighlightKind` split carries no signal.
+
+use baml_base::{Name, SourceFile};
+use baml_compiler_syntax::SyntaxKind;
+use baml_compiler2_hir::semantic_index::BindingKind;
+use text_size::{TextRange, TextSize};
+
+use crate::{Db, definition, usages, utils};
+
+/// Ranges in `file` to highlight for the symbol at `offset`, sorted in
+/// document order.
+///
+/// Regular function (not cached); the expensive work is internally
+/// Salsa-cached (`file_semantic_index`, `syntax_tree`, `function_body`, …).
+/// Returns an empty `Vec` when the cursor is not on an identifier.
+pub fn document_highlights_at(db: &dyn Db, file: SourceFile, offset: TextSize) -> Vec<TextRange> {
+    let Some(token) = utils::find_token_at_offset(db, file, offset) else {
+        return Vec::new();
+    };
+    if token.kind() != SyntaxKind::WORD {
+        return Vec::new();
+    }
+
+    let mut ranges: Vec<TextRange> = usages::same_file_usages_at(db, file, offset)
+        .into_iter()
+        .map(|loc| loc.range)
+        .collect();
+
+    if let Some(decl) = declaration_name_range(db, file, offset, token.text()) {
+        ranges.push(decl);
+    }
+
+    ranges.sort_by_key(|range| range.start());
+    ranges.dedup();
+    ranges
+}
+
+/// The name-token range of the declaration of the symbol at `offset`, when it
+/// lives in `file`.
+///
+/// Locals resolve through the semantic index's recorded `name_range` —
+/// `definition_at` returns the whole `let` statement for a local, which is
+/// too wide to highlight. Both that range (which covers `let name`) and a
+/// parameter's signature span (which covers `name: type`) are narrowed to
+/// their name token. Items and fields fall through to `definition_at`, whose
+/// ranges are already name tokens.
+fn declaration_name_range(
+    db: &dyn Db,
+    file: SourceFile,
+    offset: TextSize,
+    name_text: &str,
+) -> Option<TextRange> {
+    let name = Name::new(name_text);
+
+    if let Some(binding) = usages::local_binding_id_at(db, file, offset, &name) {
+        let declaration_span = match binding.kind {
+            BindingKind::Local(idx) => {
+                let index = baml_compiler2_hir::file_semantic_index(db, file);
+                let bindings = &index.scope_bindings[binding.scope.index() as usize];
+                bindings.bindings[idx as usize].name_range
+            }
+            BindingKind::Parameter(param_idx) => {
+                let func_loc = utils::enclosing_function_loc(db, file, offset)?;
+                let sig_map =
+                    baml_compiler2_hir::signature::function_signature_source_map(db, func_loc);
+                sig_map.param_spans.get(param_idx).copied()?
+            }
+        };
+        return name_token_in_range(db, file, declaration_span, name_text);
+    }
+
+    let def = definition::definition_at(db, file, offset)?;
+    (def.file == file).then_some(def.range)
+}
+
+/// The range of the first `WORD` token inside `range` whose text is
+/// `name_text`.
+fn name_token_in_range(
+    db: &dyn Db,
+    file: SourceFile,
+    range: TextRange,
+    name_text: &str,
+) -> Option<TextRange> {
+    let tree = baml_compiler_parser::syntax_tree(db, file);
+    let node = match tree.covering_element(range) {
+        rowan::NodeOrToken::Token(token) => {
+            return (token.kind() == SyntaxKind::WORD && token.text() == name_text)
+                .then(|| token.text_range());
+        }
+        rowan::NodeOrToken::Node(node) => node,
+    };
+    node.descendants_with_tokens().find_map(|element| {
+        let rowan::NodeOrToken::Token(token) = element else {
+            return None;
+        };
+        (range.contains_range(token.text_range())
+            && token.kind() == SyntaxKind::WORD
+            && token.text() == name_text)
+            .then(|| token.text_range())
+    })
+}

--- a/baml_language/crates/baml_lsp2_actions/src/highlights_tests.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/highlights_tests.rs
@@ -1,0 +1,124 @@
+//! Tests for `document_highlights_at` using cursor-based testing.
+
+#[cfg(test)]
+mod tests {
+    use text_size::{TextRange, TextSize};
+
+    use crate::testing::CursorTest;
+
+    /// Byte ranges of every occurrence of `needle` in the cursor file's text
+    /// (the `<[CURSOR]` marker is already stripped).
+    fn occurrences(test: &CursorTest, needle: &str) -> Vec<TextRange> {
+        let text = test.cursor.file.text(&test.db);
+        text.match_indices(needle)
+            .map(|(start, _)| {
+                TextRange::new(
+                    TextSize::from(u32::try_from(start).unwrap()),
+                    TextSize::from(u32::try_from(start + needle.len()).unwrap()),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn local_variable_highlights_declaration_and_usages() {
+        let test = CursorTest::new(
+            r#"
+function Demo(items: int[]) -> int {
+    let total = items.length()
+    let doubled = <[CURSOR]total + total
+    doubled
+}
+"#,
+        );
+
+        assert_eq!(
+            test.document_highlights(),
+            occurrences(&test, "total"),
+            "declaration + both usages of `total` should highlight"
+        );
+    }
+
+    #[test]
+    fn cursor_on_declaration_highlights_usages_too() {
+        let test = CursorTest::new(
+            r#"
+function Demo() -> int {
+    let <[CURSOR]count = 1
+    count + count
+}
+"#,
+        );
+
+        assert_eq!(
+            test.document_highlights(),
+            occurrences(&test, "count"),
+            "cursor on the declaration should still highlight the usages"
+        );
+    }
+
+    #[test]
+    fn parameter_highlights_declaration_and_usages() {
+        let test = CursorTest::new(
+            r#"
+function Echo(<[CURSOR]word: string) -> string {
+    word + word
+}
+"#,
+        );
+
+        assert_eq!(
+            test.document_highlights(),
+            occurrences(&test, "word"),
+            "param declaration + both body usages should highlight"
+        );
+    }
+
+    #[test]
+    fn top_level_item_highlights_stay_in_the_request_file() {
+        let mut builder = CursorTest::builder();
+        builder.source(
+            "main.baml",
+            r#"
+function Greet(name: string) -> string {
+    name
+}
+
+function Caller() -> string {
+    <[CURSOR]Greet("hi")
+}
+"#,
+        );
+        builder.source(
+            "other.baml",
+            r#"
+function AlsoUses() -> string {
+    Greet("yo")
+}
+"#,
+        );
+        let test = builder.build();
+
+        assert_eq!(
+            test.document_highlights(),
+            occurrences(&test, "Greet"),
+            "definition + same-file usages only; other.baml's call must not leak in"
+        );
+    }
+
+    #[test]
+    fn non_identifier_positions_highlight_nothing() {
+        let test = CursorTest::new(
+            r#"
+function Demo() -> int {
+    1 <[CURSOR]+ 2
+}
+"#,
+        );
+
+        assert!(
+            test.document_highlights().is_empty(),
+            "operators should not highlight"
+        );
+    }
+}

--- a/baml_language/crates/baml_lsp2_actions/src/lib.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/lib.rs
@@ -49,6 +49,7 @@ pub mod describe;
 pub mod env_vars;
 pub mod fixes;
 pub mod grep;
+pub mod highlights;
 pub mod listing;
 pub mod outline;
 pub mod search;
@@ -65,6 +66,8 @@ mod definition_at_tests;
 mod describe_tests;
 #[cfg(test)]
 mod grep_tests;
+#[cfg(test)]
+mod highlights_tests;
 #[cfg(test)]
 mod listing_tests;
 #[cfg(test)]
@@ -101,6 +104,7 @@ pub use describe::{
 pub use env_vars::all_env_var_names;
 pub use fixes::{Fix, FixKind, fixes_at};
 pub use grep::{GrepMode, GrepOptions, GrepResult, MatchAnnotation, TextMatch, grep, list_symbols};
+pub use highlights::document_highlights_at;
 pub use listing::{
     ListingEntry, ResolvedTarget, list_namespace_items, list_package_items, non_user_package_names,
     resolve_target,

--- a/baml_language/crates/baml_lsp2_actions/src/testing.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/testing.rs
@@ -153,6 +153,11 @@ impl CursorTest {
         usages_at(&self.db, self.cursor.file, self.cursor.offset)
     }
 
+    /// Document highlights at the cursor position.
+    pub(crate) fn document_highlights(&self) -> Vec<text_size::TextRange> {
+        crate::highlights::document_highlights_at(&self.db, self.cursor.file, self.cursor.offset)
+    }
+
     /// Format a `Location` as `"filename:line:col"` for assertion messages.
     pub(crate) fn format_location(&self, loc: &Location) -> String {
         let filename = loc

--- a/baml_language/crates/baml_lsp2_actions/src/usages.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/usages.rs
@@ -21,9 +21,7 @@
 use baml_base::{Name, SourceFile};
 use baml_compiler_syntax::SyntaxKind;
 use baml_compiler2_ast::{Expr, ExprBody};
-use baml_compiler2_hir::{
-    body::FunctionBody, loc::FunctionLoc, scope::ScopeKind, semantic_index::BindingId,
-};
+use baml_compiler2_hir::{body::FunctionBody, scope::ScopeKind, semantic_index::BindingId};
 use baml_compiler2_tir::resolve::{ResolvedName, resolve_name_at};
 use rowan::NodeOrToken;
 use text_size::{TextRange, TextSize};
@@ -44,6 +42,27 @@ use crate::{Db, definition::Location, utils};
 /// want "peek references + definition" should call `definition_at` separately
 /// and decide whether to include it.
 pub fn usages_at(db: &dyn Db, file: SourceFile, offset: TextSize) -> Vec<Location> {
+    usages_at_impl(db, file, offset, false)
+}
+
+/// Like [`usages_at`], but scans only `file` itself instead of every source
+/// file in the package. Used by document highlights, which the LSP scopes to
+/// one document and editors re-request on every cursor move — a package-wide
+/// CST scan there would be wasted work.
+pub(crate) fn same_file_usages_at(
+    db: &dyn Db,
+    file: SourceFile,
+    offset: TextSize,
+) -> Vec<Location> {
+    usages_at_impl(db, file, offset, true)
+}
+
+fn usages_at_impl(
+    db: &dyn Db,
+    file: SourceFile,
+    offset: TextSize,
+    current_file_only: bool,
+) -> Vec<Location> {
     // ── Step 1: find and resolve the token at the cursor ─────────────────────
     let Some(token) = utils::find_token_at_offset(db, file, offset) else {
         return Vec::new();
@@ -62,10 +81,16 @@ pub fn usages_at(db: &dyn Db, file: SourceFile, offset: TextSize) -> Vec<Locatio
 
     let resolved = resolve_name_at(db, file, offset, &name);
 
+    let scan_files = if current_file_only {
+        vec![file]
+    } else {
+        collect_source_files(db, file)
+    };
+
     match &resolved {
         ResolvedName::Item(_) | ResolvedName::Builtin(_) => {
-            // Top-level item — scan all source files.
-            find_top_level_usages(db, file, &name_text, &resolved)
+            // Top-level item — scan the in-scope source files.
+            find_top_level_usages(db, &scan_files, &name_text, &resolved)
         }
         ResolvedName::Local {
             definition_site: Some(_),
@@ -78,29 +103,26 @@ pub fn usages_at(db: &dyn Db, file: SourceFile, offset: TextSize) -> Vec<Locatio
         | ResolvedName::Unknown => {
             // Try field-definition usages: if cursor is on a class field definition,
             // find all field access and constructor field sites.
-            find_field_definition_usages(db, file, offset, &name_text)
+            find_field_definition_usages(db, file, offset, &name_text, &scan_files)
         }
     }
 }
 
 // ── top-level usages ──────────────────────────────────────────────────────────
 
-/// Scan all source files for references to a top-level item.
+/// Scan `scan_files` for references to a top-level item.
 ///
 /// Pre-filters each file by checking if the name string appears in the raw
 /// text before walking the CST.
 fn find_top_level_usages(
     db: &dyn Db,
-    current_file: SourceFile,
+    scan_files: &[SourceFile],
     name_text: &str,
     target_resolved: &ResolvedName<'_>,
 ) -> Vec<Location> {
-    // Collect all user source files.
-    let source_files = collect_source_files(db, current_file);
-
     let mut results = Vec::new();
 
-    for sf in source_files {
+    for &sf in scan_files {
         // Optimization: skip files that do not contain the name string at all.
         let text = sf.text(db);
         if !text.contains(name_text) {
@@ -165,38 +187,9 @@ fn find_local_usages(
     name_text: &str,
     target_binding: BindingId,
 ) -> Vec<Location> {
-    let index = baml_compiler2_hir::file_semantic_index(db, file);
-    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
-
-    // Find the enclosing Function scope.
-    let scope_id = index.scope_at_offset(at_offset, None);
-    let enclosing_func_scope = index
-        .ancestor_scopes(scope_id)
-        .into_iter()
-        .find(|ancestor_id| {
-            matches!(
-                index.scopes[ancestor_id.index() as usize].kind,
-                ScopeKind::Function
-            )
-        });
-
-    let Some(enclosing_func_scope) = enclosing_func_scope else {
+    let Some(func_loc) = utils::enclosing_function_loc(db, file, at_offset) else {
         return Vec::new();
     };
-
-    let func_scope_range = index.scopes[enclosing_func_scope.index() as usize].range;
-
-    // Find the function in the item tree by matching its span.
-    let func_entry = item_tree
-        .functions
-        .iter()
-        .find(|(_, f)| f.span == func_scope_range);
-
-    let Some((func_local_id, _)) = func_entry else {
-        return Vec::new();
-    };
-
-    let func_loc = FunctionLoc::new(db, file, *func_local_id);
 
     // We need an expression body and source map.
     let body = baml_compiler2_hir::body::function_body(db, func_loc);
@@ -265,7 +258,7 @@ fn collect_local_path_usages(
     }
 }
 
-fn local_binding_id_at(
+pub(crate) fn local_binding_id_at(
     db: &dyn Db,
     file: SourceFile,
     offset: TextSize,
@@ -296,14 +289,15 @@ fn local_binding_id_at(
 ///
 /// Uses text pre-filter + `ScopeInference` confirmation pattern:
 /// 1. Check that cursor is on a class field definition (Class scope).
-/// 2. Collect all source files.
-/// 3. For each file, scan function scopes for `MemberAccess` and Object constructor
-///    expressions that reference the same field of the same class.
+/// 2. For each file in `scan_files`, scan function scopes for `MemberAccess`
+///    and Object constructor expressions that reference the same field of the
+///    same class.
 fn find_field_definition_usages(
     db: &dyn Db,
     file: SourceFile,
     offset: TextSize,
     field_name_text: &str,
+    scan_files: &[SourceFile],
 ) -> Vec<Location> {
     use baml_compiler2_tir::ty::Ty;
 
@@ -338,12 +332,9 @@ fn find_field_definition_usages(
 
     let class_loc = baml_compiler2_hir::loc::ClassLoc::new(db, file, *class_local_id);
 
-    // Collect all source files
-    let source_files = collect_source_files(db, file);
-
     let mut results = Vec::new();
 
-    for sf in source_files {
+    for &sf in scan_files {
         // Text pre-filter
         let text = sf.text(db);
         if !text.contains(field_name_text) {

--- a/baml_language/crates/baml_lsp2_actions/src/utils.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/utils.rs
@@ -66,6 +66,42 @@ pub fn find_token_at_offset(
     }
 }
 
+// ── enclosing_function_loc ────────────────────────────────────────────────────
+
+/// Find the `FunctionLoc` of the function whose body encloses `offset`, by
+/// walking the semantic-index scope chain to the nearest `Function` scope and
+/// matching its range against the item tree.
+///
+/// Returns `None` when `offset` is not inside a function body, or the scope
+/// has no item-tree counterpart (malformed code).
+pub(crate) fn enclosing_function_loc(
+    db: &dyn Db,
+    file: SourceFile,
+    offset: TextSize,
+) -> Option<baml_compiler2_hir::loc::FunctionLoc<'_>> {
+    let index = baml_compiler2_hir::file_semantic_index(db, file);
+    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
+
+    let scope_id = index.scope_at_offset(offset, None);
+    let func_scope = index.ancestor_scopes(scope_id).into_iter().find(|id| {
+        matches!(
+            index.scopes[id.index() as usize].kind,
+            baml_compiler2_hir::scope::ScopeKind::Function
+        )
+    })?;
+    let func_scope_range = index.scopes[func_scope.index() as usize].range;
+
+    let (func_local_id, _) = item_tree
+        .functions
+        .iter()
+        .find(|(_, f)| f.span == func_scope_range)?;
+    Some(baml_compiler2_hir::loc::FunctionLoc::new(
+        db,
+        file,
+        *func_local_id,
+    ))
+}
+
 // ── definition_span ───────────────────────────────────────────────────────────
 
 /// Map a top-level `Definition` to its source file and name span.

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -85,6 +85,7 @@ pub(super) fn server_capabilities(encoding: PositionEncoding) -> ServerCapabilit
             },
         )),
         document_symbol_provider: Some(lsp_types::OneOf::Left(true)),
+        document_highlight_provider: Some(lsp_types::OneOf::Left(true)),
         workspace_symbol_provider: Some(lsp_types::OneOf::Left(true)),
         workspace: Some(WorkspaceServerCapabilities {
             workspace_folders: Some(WorkspaceFoldersServerCapabilities {
@@ -683,6 +684,33 @@ impl BexLspRequest for BexMulitProject {
             Ok(None)
         } else {
             Ok(Some(references))
+        }
+    }
+
+    fn on_request_text_document_document_highlight(
+        &self,
+        params: lsp_request_params!("textDocument/documentHighlight"),
+    ) -> Result<lsp_request_result!("textDocument/documentHighlight"), LspError> {
+        let highlights: Vec<lsp_types::DocumentHighlight> = self.compute_on_position(
+            &params.text_document_position_params,
+            |db, source_file, offset, encoding| {
+                let codec = PositionCodec::new(source_file.text(db), encoding);
+                baml_lsp2_actions::document_highlights_at(db, source_file, offset)
+                    .into_iter()
+                    .map(|range| lsp_types::DocumentHighlight {
+                        range: codec.byte_range_to_lsp(range),
+                        // BAML has no reassignment, so the read/write kind
+                        // split carries no signal; leave it unspecified.
+                        kind: None,
+                    })
+                    .collect()
+            },
+        )?;
+
+        if highlights.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(highlights))
         }
     }
 


### PR DESCRIPTION
Highlights all same-file occurrences of the symbol under the cursor — declaration + usages for locals, parameters, top-level items, and class fields.

- New `document_highlights_at` in `baml_lsp2_actions` reuses the `usages_at` machinery restricted to the request file: the LSP scopes highlights to one document and editors re-request them on every cursor move, so the package-wide CST scan `usages_at` does would be wasted work. `usages_at` behavior is unchanged (it delegates to the same impl with package-wide scope).
- The declaration occurrence is added back (`usages_at` excludes it by contract), narrowed to its name token — the semantic index's recorded local range covers `let name` and a parameter's signature span covers `name: type`, both too wide to highlight.
- The enclosing-function scope walk that `usages_at` and `definition_at` each had a private copy of is now shared as `utils::enclosing_function_loc`.
- No `DocumentHighlightKind`: BAML has no reassignment, so the read/write split carries no signal.
- Handler + `document_highlight_provider` capability wired in `bex_project`.

Tests: 5 new cursor-marker tests (`highlights_tests.rs`) covering local declaration+usages from both cursor positions, parameters, cross-file isolation, and non-identifier positions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document highlighting for symbols in the current file.
  * Highlights declarations and matching usages for local variables, parameters, and definitions.
  * Advertised document highlighting support through the language server.

* **Bug Fixes**
  * Prevented highlights and usage results from crossing into unrelated files.
  * Improved behavior when the cursor is not positioned on an identifier.

* **Tests**
  * Added coverage for declarations, usages, parameters, cross-file isolation, and non-identifier positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->