### PR TITLE
bridge-cpp: adopt std-library naming (Core Guidelines NL.10)

### DIFF
--- a/baml_language/sdk_tests/crates/cpp/common/baml_test.h
+++ b/baml_language/sdk_tests/crates/cpp/common/baml_test.h
@@ -15,37 +15,37 @@
 
 namespace baml_test {
 
-struct Case {
+struct test_case {
   const char* name;
   void (*fn)();
 };
 
-inline std::vector<Case>& Registry() {
-  static std::vector<Case> cases;
+inline std::vector<test_case>& registry() {
+  static std::vector<test_case> cases;
   return cases;
 }
 
-struct Register {
-  Register(const char* name, void (*fn)()) {
-    Registry().push_back(Case{name, fn});
+struct registrar {
+  registrar(const char* name, void (*fn)()) {
+    registry().push_back(test_case{name, fn});
   }
 };
 
-struct Failure {
+struct failure {
   std::string message;
 };
 
-[[noreturn]] inline void Fail(std::string message) {
-  throw Failure{std::move(message)};
+[[noreturn]] inline void fail(std::string message) {
+  throw failure{std::move(message)};
 }
 
-inline int RunAll() {
+inline int run_all() {
   int failed = 0;
-  for (const Case& c : Registry()) {
+  for (const test_case& c : registry()) {
     try {
       c.fn();
       std::printf("PASS %s\n", c.name);
-    } catch (const Failure& f) {
+    } catch (const failure& f) {
       std::printf("FAIL %s: %s\n", c.name, f.message.c_str());
       ++failed;
     } catch (const std::exception& e) {
@@ -56,16 +56,16 @@ inline int RunAll() {
       ++failed;
     }
   }
-  std::printf("%zu tests, %d failed\n", Registry().size(), failed);
+  std::printf("%zu tests, %d failed\n", registry().size(), failed);
   return failed == 0 ? 0 : 1;
 }
 
 }  // namespace baml_test
 
-#define BAML_TEST(name)                                                      \
-  static void baml_test_case_##name();                                       \
-  static ::baml_test::Register baml_test_reg_##name{#name,                   \
-                                                    &baml_test_case_##name}; \
+#define BAML_TEST(name)                                                       \
+  static void baml_test_case_##name();                                        \
+  static ::baml_test::registrar baml_test_reg_##name{#name,                   \
+                                                     &baml_test_case_##name}; \
   static void baml_test_case_##name()
 
 #define BAML_STRINGIZE_INNER(x) #x
@@ -74,7 +74,7 @@ inline int RunAll() {
 #define BAML_ASSERT(cond)                                        \
   do {                                                           \
     if (!(cond)) {                                               \
-      ::baml_test::Fail(std::string(__FILE__ ":" BAML_STRINGIZE( \
+      ::baml_test::fail(std::string(__FILE__ ":" BAML_STRINGIZE( \
                             __LINE__) ": assertion failed: ") +  \
                         #cond);                                  \
     }                                                            \
@@ -83,13 +83,13 @@ inline int RunAll() {
 #define BAML_ASSERT_EQ(lhs, rhs)                                 \
   do {                                                           \
     if (!((lhs) == (rhs))) {                                     \
-      ::baml_test::Fail(std::string(__FILE__ ":" BAML_STRINGIZE( \
+      ::baml_test::fail(std::string(__FILE__ ":" BAML_STRINGIZE( \
                             __LINE__) ": assertion failed: ") +  \
                         #lhs " == " #rhs);                       \
     }                                                            \
   } while (0)
 
 #define BAML_TEST_MAIN() \
-  int main() { return ::baml_test::RunAll(); }
+  int main() { return ::baml_test::run_all(); }
 
 #endif  // BAML_TEST_H_

--- a/baml_language/sdk_tests/crates/cpp/docstrings_etc/customizable/tests/test_main.cc
+++ b/baml_language/sdk_tests/crates/cpp/docstrings_etc/customizable/tests/test_main.cc
@@ -11,10 +11,10 @@
 
 using baml_sdk::docs::Priority;
 
-static std::string HeaderText() {
+static std::string header_text() {
   std::ifstream in("baml_sdk/include/baml_sdk.h");
   if (!in) {
-    baml_test::Fail("cannot open baml_sdk/include/baml_sdk.h");
+    baml_test::fail("cannot open baml_sdk/include/baml_sdk.h");
   }
   std::ostringstream out;
   out << in.rdbuf();
@@ -42,7 +42,7 @@ BAML_TEST(class_doc_summary_and_attributes_section) {
       "///     title: Title shown in lists and search results.\n"
       "///     body: Free-form body text.\n"
       "struct Doc {";
-  BAML_ASSERT(HeaderText().find(expected) != std::string::npos);
+  BAML_ASSERT(header_text().find(expected) != std::string::npos);
 }
 
 BAML_TEST(undocumented_field_listed_as_bare_name_under_attributes) {
@@ -60,7 +60,7 @@ BAML_TEST(undocumented_field_listed_as_bare_name_under_attributes) {
       "///     id: Stable identifier \u2014 surfaces in URLs.\n"
       "///     text\n"
       "struct Note {";
-  BAML_ASSERT(HeaderText().find(expected) != std::string::npos);
+  BAML_ASSERT(header_text().find(expected) != std::string::npos);
 }
 
 BAML_TEST(enum_doc_summary_and_members_section) {
@@ -74,11 +74,11 @@ BAML_TEST(enum_doc_summary_and_members_section) {
       "///     NEUTRAL\n"
       "// Enumerator values: FNV-1a-64 of the wire value (reorder-stable).\n"
       "enum class Sentiment : uint64_t {";
-  BAML_ASSERT(HeaderText().find(expected) != std::string::npos);
+  BAML_ASSERT(header_text().find(expected) != std::string::npos);
 }
 
 BAML_TEST(enum_summary_only_omits_members_section) {
-  const std::string text = HeaderText();
+  const std::string text = header_text();
   // The class-level summary is present verbatim with NO Members: rollup
   // between it and the declaration (python parity: exact __doc__
   // equality for the summary-only case).
@@ -98,11 +98,11 @@ BAML_TEST(enum_summary_only_omits_members_section) {
   const std::string body = text.substr(body_start, body_end - body_start);
   BAML_ASSERT_EQ(CountOccurrences(body, "="), size_t{3});
   // ...with these wire values.
-  BAML_ASSERT_EQ(std::string(baml::Codec<Priority>::ToWire(Priority::HIGH)),
+  BAML_ASSERT_EQ(std::string(baml::codec<Priority>::ToWire(Priority::HIGH)),
                  std::string("HIGH"));
-  BAML_ASSERT_EQ(std::string(baml::Codec<Priority>::ToWire(Priority::MEDIUM)),
+  BAML_ASSERT_EQ(std::string(baml::codec<Priority>::ToWire(Priority::MEDIUM)),
                  std::string("MEDIUM"));
-  BAML_ASSERT_EQ(std::string(baml::Codec<Priority>::ToWire(Priority::LOW)),
+  BAML_ASSERT_EQ(std::string(baml::codec<Priority>::ToWire(Priority::LOW)),
                  std::string("LOW"));
   BAML_ASSERT(Priority::HIGH != Priority::LOW);
 }
@@ -110,7 +110,7 @@ BAML_TEST(enum_summary_only_omits_members_section) {
 BAML_TEST(no_inline_field_or_variant_doc_artifacts) {
   // Field/variant /// docs live exclusively in the parent's rollup, never
   // inline per field: each doc line appears exactly once, on the parent.
-  const std::string text = HeaderText();
+  const std::string text = header_text();
   BAML_ASSERT_EQ(CountOccurrences(text, "Title shown in lists"), size_t{1});
   BAML_ASSERT_EQ(CountOccurrences(text, "Smiling face."), size_t{1});
 }

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/cxx20/test_coawait.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/cxx20/test_coawait.cc
@@ -1,8 +1,8 @@
-// co_await coverage for baml::Future (this file builds as a separate
+// co_await coverage for baml::future (this file builds as a separate
 // C++20 executable; the C++17 blocking surface is covered by
 // test_cancellation.cc). No python analog: python awaits are event-loop
 // native, while C++20 ships coroutines without a task type - a minimal
-// completion-latch TestTask drives the coroutines here, and the bridge
+// completion-latch test_task drives the coroutines here, and the bridge
 // dispatcher thread resumes them.
 //
 // Coroutines take their inputs by value and their outputs via pointers to
@@ -22,7 +22,7 @@
 #include <variant>
 
 #if !defined(BAML_HAS_COROUTINES)
-#error "the cxx20 test target must enable baml::Future's awaiter"
+#error "the cxx20 test target must enable baml::future's awaiter"
 #endif
 
 #include <coroutine>
@@ -30,17 +30,17 @@
 namespace throws_test = baml_sdk::throws_test;
 using baml_sdk::throws_test::MyError;
 
-using SleepFuture = decltype(throws_test::SleepMsAsync(0));
-using IntFuture = decltype(baml_sdk::round_trip_intAsync(0));
-using ThrowFuture = decltype(throws_test::ThrowMyErrorAsync());
+using sleep_future = decltype(throws_test::SleepMs_async(0));
+using int_future = decltype(baml_sdk::round_trip_int_async(0));
+using throw_future = decltype(throws_test::ThrowMyError_async());
 
 namespace {
 
 // Minimal eager coroutine with a completion latch: the test thread blocks
-// in Join() until the coroutine finishes (possibly resumed on the bridge
+// in join() until the coroutine finishes (possibly resumed on the bridge
 // dispatcher thread) and an escaped exception rethrows there.
-struct TestTask {
-  struct Latch {
+struct test_task {
+  struct completion_latch {
     std::mutex mu;
     std::condition_variable cv;
     bool done = false;
@@ -48,13 +48,14 @@ struct TestTask {
   };
 
   struct promise_type {
-    std::shared_ptr<Latch> latch = std::make_shared<Latch>();
-    TestTask get_return_object() { return TestTask{latch}; }
+    std::shared_ptr<completion_latch> latch =
+        std::make_shared<completion_latch>();
+    test_task get_return_object() { return test_task{latch}; }
     std::suspend_never initial_suspend() { return {}; }
     std::suspend_never final_suspend() noexcept { return {}; }
-    void return_void() { Finish(nullptr); }
-    void unhandled_exception() { Finish(std::current_exception()); }
-    void Finish(std::exception_ptr error) {
+    void return_void() { finish(nullptr); }
+    void unhandled_exception() { finish(std::current_exception()); }
+    void finish(std::exception_ptr error) {
       {
         std::lock_guard<std::mutex> lock(latch->mu);
         latch->error = std::move(error);
@@ -64,7 +65,7 @@ struct TestTask {
     }
   };
 
-  void Join() {
+  void join() {
     std::unique_lock<std::mutex> lock(latch->mu);
     latch->cv.wait(lock, [this] { return latch->done; });
     if (latch->error) {
@@ -72,35 +73,35 @@ struct TestTask {
     }
   }
 
-  std::shared_ptr<Latch> latch;
+  std::shared_ptr<completion_latch> latch;
 };
 
-TestTask AwaitSleep(SleepFuture fut, bool* completed) {
+test_task await_sleep(sleep_future fut, bool* completed) {
   (void)co_await std::move(fut);
   *completed = true;
 }
 
-TestTask AwaitInt(IntFuture fut, int64_t* out) {
+test_task await_int(int_future fut, int64_t* out) {
   *out = co_await std::move(fut);
 }
 
-TestTask AwaitExpectMyError(ThrowFuture fut, bool* caught) {
+test_task await_expect_my_error(throw_future fut, bool* caught) {
   try {
     (void)co_await std::move(fut);
-  } catch (const baml::BamlThrown<baml::Union<MyError>>& e) {
+  } catch (const baml::thrown<baml::variant<MyError>>& e) {
     *caught = e.get<MyError>() == MyError{42, "boom"};
   }
 }
 
-TestTask AwaitExpectCancelled(SleepFuture fut, bool* cancelled) {
+test_task await_expect_cancelled(sleep_future fut, bool* cancelled) {
   try {
     (void)co_await std::move(fut);
-  } catch (const baml::BamlCancelled&) {
+  } catch (const baml::cancelled&) {
     *cancelled = true;
   }
 }
 
-TestTask AwaitUncaught(ThrowFuture fut) { (void)co_await std::move(fut); }
+test_task await_uncaught(throw_future fut) { (void)co_await std::move(fut); }
 
 }  // namespace
 
@@ -108,51 +109,52 @@ BAML_TEST(co_await_pending_future_resumes) {
   // A genuinely in-flight call: the coroutine suspends and the dispatcher
   // thread resumes it when the envelope lands.
   bool completed = false;
-  TestTask task = AwaitSleep(throws_test::SleepMsAsync(100), &completed);
-  task.Join();
+  test_task task = await_sleep(throws_test::SleepMs_async(100), &completed);
+  task.join();
   BAML_ASSERT(completed);
 }
 
 BAML_TEST(co_await_yields_the_decoded_value) {
   int64_t got = 0;
-  TestTask task = AwaitInt(baml_sdk::round_trip_intAsync(7), &got);
-  task.Join();
+  test_task task = await_int(baml_sdk::round_trip_int_async(7), &got);
+  task.join();
   BAML_ASSERT(got == 7);
 }
 
 BAML_TEST(co_await_completed_future_fast_path) {
   // await_ready() true: no suspension, the coroutine runs straight through.
-  auto fut = baml_sdk::round_trip_intAsync(7);
+  auto fut = baml_sdk::round_trip_int_async(7);
   fut.wait();
   int64_t got = 0;
-  TestTask task = AwaitInt(std::move(fut), &got);
-  task.Join();
+  test_task task = await_int(std::move(fut), &got);
+  task.join();
   BAML_ASSERT(got == 7);
 }
 
 BAML_TEST(co_await_throws_typed_into_the_coroutine) {
   bool caught = false;
-  TestTask task = AwaitExpectMyError(throws_test::ThrowMyErrorAsync(), &caught);
-  task.Join();
+  test_task task =
+      await_expect_my_error(throws_test::ThrowMyError_async(), &caught);
+  task.join();
   BAML_ASSERT(caught);
 }
 
 BAML_TEST(co_await_cancelled_call_throws_cancelled) {
-  auto fut = throws_test::SleepMsAsync(2000);
+  auto fut = throws_test::SleepMs_async(2000);
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  BAML_ASSERT(fut.Cancel());
+  BAML_ASSERT(fut.cancel());
   bool cancelled = false;
-  TestTask task = AwaitExpectCancelled(std::move(fut), &cancelled);
-  task.Join();
+  test_task task = await_expect_cancelled(std::move(fut), &cancelled);
+  task.join();
   BAML_ASSERT(cancelled);
 }
 
 BAML_TEST(uncaught_coroutine_exception_reaches_join) {
-  TestTask task = AwaitUncaught(throws_test::ThrowMyErrorAsync());
+  test_task task = await_uncaught(throws_test::ThrowMyError_async());
   bool rethrown = false;
   try {
-    task.Join();
-  } catch (const baml::BamlThrown<baml::Union<MyError>>&) {
+    task.join();
+  } catch (const baml::thrown<baml::variant<MyError>>&) {
     rethrown = true;
   }
   BAML_ASSERT(rethrown);

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/futures_static.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/futures_static.cc
@@ -1,6 +1,6 @@
-// Static shape checks for the baml::Future surface (no python analog;
+// Static shape checks for the baml::future surface (no python analog;
 // documents the compile-time contract the way unions_static.cc does for
-// baml::Union).
+// baml::variant).
 #include <baml_sdk.h>
 
 #include <cstdint>
@@ -9,24 +9,24 @@
 
 namespace {
 
-using IntFuture = baml::Future<int64_t, baml::Union<std::string, int64_t>>;
+using int_future = baml::future<int64_t, baml::variant<std::string, int64_t>>;
 
 // std::future semantics: single consumer, move-only.
-static_assert(std::is_move_constructible<IntFuture>::value,
-              "baml::Future must be movable");
-static_assert(std::is_move_assignable<IntFuture>::value,
-              "baml::Future must be move-assignable");
-static_assert(!std::is_copy_constructible<IntFuture>::value,
-              "baml::Future must not be copyable");
-static_assert(!std::is_copy_assignable<IntFuture>::value,
-              "baml::Future must not be copy-assignable");
+static_assert(std::is_move_constructible<int_future>::value,
+              "baml::future must be movable");
+static_assert(std::is_move_assignable<int_future>::value,
+              "baml::future must be move-assignable");
+static_assert(!std::is_copy_constructible<int_future>::value,
+              "baml::future must not be copyable");
+static_assert(!std::is_copy_assignable<int_future>::value,
+              "baml::future must not be copy-assignable");
 
-// The ThrownU parameter rides baml::Union canonicalization: a reordered
+// The ThrownU parameter rides baml::variant canonicalization: a reordered
 // spelling of the throws set cannot mint a second Future type.
 static_assert(
     std::is_same<
-        baml::Future<int64_t, baml::Union<std::string, int64_t>>,
-        baml::Future<int64_t, baml::Union<int64_t, std::string>>>::value,
+        baml::future<int64_t, baml::variant<std::string, int64_t>>,
+        baml::future<int64_t, baml::variant<int64_t, std::string>>>::value,
     "Future's throws union must be order-canonical");
 
 }  // namespace

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/optional_args_static.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/optional_args_static.cc
@@ -44,9 +44,9 @@ struct has_set_opt3<
 static_assert(
     ProbeInvocable<int64_t>(0),
     "optional_args_probe(x) must be callable with the required arg alone");
-static_assert(ProbeInvocable<int64_t, baml_sdk::optional_args_probeOpts>(0),
+static_assert(ProbeInvocable<int64_t, baml_sdk::optional_args_probe_opts>(0),
               "optional_args_probe(x, opts) must be callable");
-static_assert(has_set_opt1<baml_sdk::optional_args_probeOpts>::value,
+static_assert(has_set_opt1<baml_sdk::optional_args_probe_opts>::value,
               "opts must expose set_opt1");
 
 // optional_args_probe()  -- missing required arg.
@@ -59,7 +59,7 @@ static_assert(!ProbeInvocable<int64_t, int>(0),
               "a positional value must not convert to the opts struct");
 
 // optional_args_probe(1, opt3=1)  -- unknown optional arg.
-static_assert(!has_set_opt3<baml_sdk::optional_args_probeOpts>::value,
+static_assert(!has_set_opt3<baml_sdk::optional_args_probe_opts>::value,
               "opts must not expose a setter for an undeclared optional");
 
 // optional_args_probe("x")  -- wrong type for the required arg.
@@ -67,7 +67,7 @@ static_assert(!ProbeInvocable<const char*>(0),
               "a string must not convert to the int-typed required arg");
 
 // optional_args_probe(1, opt1="x")  -- wrong type for an optional arg.
-static_assert(!std::is_constructible<::baml::Arg<std::optional<int64_t>>,
+static_assert(!std::is_constructible<::baml::arg<std::optional<int64_t>>,
                                      const char*>::value,
               "a string must not convert to an int-typed optional arg");
 

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_cancellation.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_cancellation.cc
@@ -20,18 +20,18 @@ BAML_TEST(sync_call_returns_none) {
 }
 
 BAML_TEST(async_call_returns_none) {
-  BAML_ASSERT(throws_test::SleepMsAsync(1).get() == std::monostate{});
+  BAML_ASSERT(throws_test::SleepMs_async(1).get() == std::monostate{});
 }
 
 BAML_TEST(async_cancel_via_future_cancel) {
   const auto start = std::chrono::steady_clock::now();
-  auto fut = throws_test::SleepMsAsync(2000);
+  auto fut = throws_test::SleepMs_async(2000);
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  BAML_ASSERT(fut.Cancel());
+  BAML_ASSERT(fut.cancel());
   bool cancelled = false;
   try {
     fut.get();
-  } catch (const baml::BamlCancelled&) {
+  } catch (const baml::cancelled&) {
     cancelled = true;
   }
   BAML_ASSERT(cancelled);
@@ -40,7 +40,7 @@ BAML_TEST(async_cancel_via_future_cancel) {
 }
 
 BAML_TEST(future_wait_then_get) {
-  auto fut = throws_test::SleepMsAsync(1);
+  auto fut = throws_test::SleepMs_async(1);
   BAML_ASSERT(fut.valid());
   BAML_ASSERT(fut.wait_for(std::chrono::seconds(30)) ==
               std::future_status::ready);
@@ -49,7 +49,7 @@ BAML_TEST(future_wait_then_get) {
 }
 
 BAML_TEST(future_second_get_throws_future_error) {
-  auto fut = throws_test::SleepMsAsync(1);
+  auto fut = throws_test::SleepMs_async(1);
   (void)fut.get();
   bool threw = false;
   try {
@@ -61,14 +61,14 @@ BAML_TEST(future_second_get_throws_future_error) {
 }
 
 BAML_TEST(future_wait_for_times_out_while_in_flight) {
-  auto fut = throws_test::SleepMsAsync(2000);
+  auto fut = throws_test::SleepMs_async(2000);
   BAML_ASSERT(fut.wait_for(std::chrono::milliseconds(1)) ==
               std::future_status::timeout);
-  BAML_ASSERT(fut.Cancel());
+  BAML_ASSERT(fut.cancel());
   bool cancelled = false;
   try {
     fut.get();
-  } catch (const baml::BamlCancelled&) {
+  } catch (const baml::cancelled&) {
     cancelled = true;
   }
   BAML_ASSERT(cancelled);
@@ -77,6 +77,6 @@ BAML_TEST(future_wait_for_times_out_while_in_flight) {
 BAML_TEST(future_destruction_detaches) {
   // The temporary future is dropped at the end of the statement: neither
   // blocks nor cancels, and later calls are unaffected.
-  (void)throws_test::SleepMsAsync(1);
+  (void)throws_test::SleepMs_async(1);
   BAML_ASSERT(throws_test::SleepMs(1) == std::monostate{});
 }

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_errors.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_errors.cc
@@ -1,9 +1,9 @@
 // Typed error-union delivery. Port of the union-relevant subset of
 // function_calls/customizable/test_errors.py (panic / cancellation /
 // os-exit / traceback-splicing coverage stays post-step-8):
-// - a declared throw surfaces as BamlThrown<baml::Union<...>> carrying the
+// - a declared throw surfaces as thrown<baml::variant<...>> carrying the
 //   decoded value, readable with baml::match (the analog of Python's
-//   BamlError.value), while catch(BamlError&) keeps working;
+//   error.value), while catch(error&) keeps working;
 // - single-member and multi-member `throws` agree on class_name (the
 //   engine wraps multi-member throws in union_variant_value);
 // - the untyped is<T>()/get<T>() probes still work on the same exception.
@@ -18,13 +18,13 @@ using baml_sdk::raises_test::TimeoutError;
 using baml_sdk::throws_test::MyError;
 
 BAML_TEST(stdlib_error_surfaces_typed) {
-  // `baml.json.parse` on bad input -> BamlThrown whose value decodes to a
+  // `baml.json.parse` on bad input -> thrown whose value decodes to a
   // JsonParseError (a plain generated struct). Proves stdlib error classes
   // surface structured, independent of any user `throws` clause.
   try {
     baml_sdk::throws_test::ParseJson("{not valid json");
-    baml_test::Fail("ParseJson did not throw");
-  } catch (const baml::BamlThrown<baml::Union<JsonParseError>>& e) {
+    baml_test::fail("ParseJson did not throw");
+  } catch (const baml::thrown<baml::variant<JsonParseError>>& e) {
     BAML_ASSERT(std::holds_alternative<JsonParseError>(e.value));
   }
 }
@@ -34,8 +34,8 @@ BAML_TEST(user_throw_surfaces_declared_instance) {
   // itself, typed.
   try {
     baml_sdk::throws_test::ThrowMyError();
-    baml_test::Fail("ThrowMyError did not throw");
-  } catch (const baml::BamlThrown<baml::Union<MyError>>& e) {
+    baml_test::fail("ThrowMyError did not throw");
+  } catch (const baml::thrown<baml::variant<MyError>>& e) {
     const MyError got = baml::match(e.value,  //
                                     [](const MyError& m) { return m; });
     BAML_ASSERT((got == MyError{42, "boom"}));
@@ -53,16 +53,16 @@ BAML_TEST(union_throws_preserves_class_name) {
   std::string single_name;
   try {
     baml_sdk::raises_test::Reparse("x");
-    baml_test::Fail("Reparse did not throw");
-  } catch (const baml::BamlThrown<baml::Union<ParseError>>& e) {
+    baml_test::fail("Reparse did not throw");
+  } catch (const baml::thrown<baml::variant<ParseError>>& e) {
     single_name = e.class_name();
   }
   try {
     baml_sdk::raises_test::LoadDoc("x");
-    baml_test::Fail("LoadDoc did not throw");
-  } catch (const baml::BamlThrown<baml::Union<TimeoutError, ParseError>>& e) {
+    baml_test::fail("LoadDoc did not throw");
+  } catch (const baml::thrown<baml::variant<TimeoutError, ParseError>>& e) {
     // NOTE: the catch spells the union REVERSED from the declaration
-    // (throws ParseError | TimeoutError) -- baml::Union is order-canonical,
+    // (throws ParseError | TimeoutError) -- baml::variant is order-canonical,
     // so both spellings are the same catchable type.
     BAML_ASSERT_EQ(single_name, std::string("user.raises_test.ParseError"));
     BAML_ASSERT_EQ(e.class_name(), single_name);
@@ -78,9 +78,9 @@ BAML_TEST(async_sibling_throws_typed) {
   // C++-specific: the Async sibling's get() surfaces the identical typed
   // throw as the sync form (python covers this through await semantics).
   try {
-    baml_sdk::throws_test::ThrowMyErrorAsync().get();
-    baml_test::Fail("ThrowMyErrorAsync did not throw");
-  } catch (const baml::BamlThrown<baml::Union<MyError>>& e) {
+    baml_sdk::throws_test::ThrowMyError_async().get();
+    baml_test::fail("ThrowMyError_async did not throw");
+  } catch (const baml::thrown<baml::variant<MyError>>& e) {
     BAML_ASSERT((e.get<MyError>() == MyError{42, "boom"}));
   }
 }
@@ -89,8 +89,8 @@ BAML_TEST(typed_throw_is_still_a_baml_error) {
   // Backward compatibility: an untyped catch site sees the same throw.
   try {
     baml_sdk::throws_test::ThrowMyError();
-    baml_test::Fail("ThrowMyError did not throw");
-  } catch (const baml::BamlError& e) {
+    baml_test::fail("ThrowMyError did not throw");
+  } catch (const baml::error& e) {
     BAML_ASSERT_EQ(e.class_name(), std::string("user.throws_test.MyError"));
     BAML_ASSERT(e.is<MyError>());
     BAML_ASSERT((e.get<MyError>() == MyError{42, "boom"}));

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_optional_args.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_optional_args.cc
@@ -5,56 +5,57 @@
 #include <baml_sdk.h>
 #include <baml_test.h>
 
-using baml_sdk::optional_args_probeOpts;
+using baml_sdk::optional_args_probe_opts;
 
 using Probe = std::vector<std::optional<int64_t>>;
 
 BAML_TEST(optional_args_runtime_matrix) {
   BAML_ASSERT(baml_sdk::optional_args_probe(1) == (Probe{1, 5, 99}));
-  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probeOpts{}
+  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probe_opts{}
                                                    .set_opt1(baml::unset)
                                                    .set_opt2(baml::unset)) ==
               (Probe{1, 5, 99}));
   BAML_ASSERT(baml_sdk::optional_args_probe(
-                  1, optional_args_probeOpts{}.set_opt1(std::nullopt)) ==
+                  1, optional_args_probe_opts{}.set_opt1(std::nullopt)) ==
               (Probe{1, std::nullopt, 99}));
   BAML_ASSERT(baml_sdk::optional_args_probe(
-                  1, optional_args_probeOpts{}.set_opt1(int64_t{8})) ==
+                  1, optional_args_probe_opts{}.set_opt1(int64_t{8})) ==
               (Probe{1, 8, 99}));
   BAML_ASSERT(baml_sdk::optional_args_probe(
-                  1, optional_args_probeOpts{}.set_opt2(std::nullopt)) ==
+                  1, optional_args_probe_opts{}.set_opt2(std::nullopt)) ==
               (Probe{1, 5, std::nullopt}));
   BAML_ASSERT(baml_sdk::optional_args_probe(
-                  1, optional_args_probeOpts{}.set_opt2(int64_t{9})) ==
+                  1, optional_args_probe_opts{}.set_opt2(int64_t{9})) ==
               (Probe{1, 5, 9}));
-  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probeOpts{}
+  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probe_opts{}
                                                    .set_opt1(std::nullopt)
                                                    .set_opt2(std::nullopt)) ==
               (Probe{1, std::nullopt, std::nullopt}));
-  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probeOpts{}
+  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probe_opts{}
                                                    .set_opt1(int64_t{8})
                                                    .set_opt2(int64_t{9})) ==
               (Probe{1, 8, 9}));
 }
 
 BAML_TEST(optional_args_async_samples) {
-  BAML_ASSERT(baml_sdk::optional_args_probeAsync(1).get() == (Probe{1, 5, 99}));
-  BAML_ASSERT(baml_sdk::optional_args_probeAsync(
-                  1, optional_args_probeOpts{}.set_opt1(std::nullopt))
+  BAML_ASSERT(baml_sdk::optional_args_probe_async(1).get() ==
+              (Probe{1, 5, 99}));
+  BAML_ASSERT(baml_sdk::optional_args_probe_async(
+                  1, optional_args_probe_opts{}.set_opt1(std::nullopt))
                   .get() == (Probe{1, std::nullopt, 99}));
-  BAML_ASSERT(baml_sdk::optional_args_probeAsync(
-                  1, optional_args_probeOpts{}.set_opt2(int64_t{9}))
+  BAML_ASSERT(baml_sdk::optional_args_probe_async(
+                  1, optional_args_probe_opts{}.set_opt2(int64_t{9}))
                   .get() == (Probe{1, 5, 9}));
 }
 
 BAML_TEST(unset_and_null_differ_in_one_call) {
   // unset means "omit this argument"; nullopt means "pass an explicit
   // null". The two must stay distinct within a single call.
-  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probeOpts{}
+  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probe_opts{}
                                                    .set_opt1(baml::unset)
                                                    .set_opt2(std::nullopt)) ==
               (Probe{1, 5, std::nullopt}));
-  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probeOpts{}
+  BAML_ASSERT(baml_sdk::optional_args_probe(1, optional_args_probe_opts{}
                                                    .set_opt1(std::nullopt)
                                                    .set_opt2(baml::unset)) ==
               (Probe{1, std::nullopt, 99}));

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_raises.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_raises.cc
@@ -10,10 +10,10 @@
 #include <sstream>
 #include <string>
 
-static std::string HeaderText() {
+static std::string header_text() {
   std::ifstream in("baml_sdk/include/baml_sdk.h");
   if (!in) {
-    baml_test::Fail("cannot open baml_sdk/include/baml_sdk.h");
+    baml_test::fail("cannot open baml_sdk/include/baml_sdk.h");
   }
   std::ostringstream out;
   out << in.rdbuf();
@@ -22,42 +22,42 @@ static std::string HeaderText() {
 
 BAML_TEST(union_throws_lists_all_names) {
   // A multi-member throws union lists every member, unqualified.
-  BAML_ASSERT(HeaderText().find("/// Raises: ParseError, TimeoutError\n"
-                                "std::string LoadDoc(") != std::string::npos);
+  BAML_ASSERT(header_text().find("/// Raises: ParseError, TimeoutError\n"
+                                 "std::string LoadDoc(") != std::string::npos);
 }
 
 BAML_TEST(single_throws) {
-  BAML_ASSERT(HeaderText().find("/// Raises: ParseError\n"
-                                "std::string Reparse(") != std::string::npos);
+  BAML_ASSERT(header_text().find("/// Raises: ParseError\n"
+                                 "std::string Reparse(") != std::string::npos);
 }
 
 BAML_TEST(summary_precedes_raises_block) {
-  BAML_ASSERT(HeaderText().find("/// Load a document from a path.\n"
-                                "/// Raises: ParseError, TimeoutError\n"
-                                "std::string LoadDoc(") != std::string::npos);
+  BAML_ASSERT(header_text().find("/// Load a document from a path.\n"
+                                 "/// Raises: ParseError, TimeoutError\n"
+                                 "std::string LoadDoc(") != std::string::npos);
 }
 
 BAML_TEST(inferred_contract_without_clause_still_raises) {
   // No written `throws` clause, but the body throws ParseError -- the
   // inferred contract (callable_throws) still surfaces a Raises line.
-  BAML_ASSERT(HeaderText().find("/// Raises: ParseError\n"
-                                "std::string InferredThrow(") !=
+  BAML_ASSERT(header_text().find("/// Raises: ParseError\n"
+                                 "std::string InferredThrow(") !=
               std::string::npos);
 }
 
 BAML_TEST(async_sibling_also_has_raises) {
   // The Async sibling repeats the full doc block, and its return wraps the
   // declared throws set as the Future's second parameter.
-  BAML_ASSERT(HeaderText().find(
+  BAML_ASSERT(header_text().find(
                   "/// Raises: ParseError, TimeoutError\n"
-                  "::baml::Future<std::string, "
-                  "::baml::Union<::baml_sdk::raises_test::ParseError, "
-                  "::baml_sdk::raises_test::TimeoutError>> LoadDocAsync(") !=
+                  "::baml::future<std::string, "
+                  "::baml::variant<::baml_sdk::raises_test::ParseError, "
+                  "::baml_sdk::raises_test::TimeoutError>> LoadDoc_async(") !=
               std::string::npos);
 }
 
 BAML_TEST(non_throwing_function_has_no_raises_block) {
   // The summary line abuts the declaration: no Raises line in between.
-  BAML_ASSERT(HeaderText().find("/// A pure function that never throws.\n"
-                                "int64_t PureLen(") != std::string::npos);
+  BAML_ASSERT(header_text().find("/// A pure function that never throws.\n"
+                                 "int64_t PureLen(") != std::string::npos);
 }

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_aliases.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_aliases.cc
@@ -3,7 +3,7 @@
 // Non-recursive aliases emit `using` declarations; recursive aliases emit
 // named wrapper structs whose self-references are boxed, so
 // `RecList = int | RecList[]` is
-// `struct RecList { baml::Union<int64_t, vector<Box<RecList>>> value; }`.
+// `struct RecList { baml::variant<int64_t, vector<Box<RecList>>> value; }`.
 #include <baml_sdk.h>
 #include <baml_test.h>
 
@@ -15,7 +15,7 @@ namespace aliases = baml_sdk::aliases;
 using aliases::AliasContainer;
 using aliases::MaybeRec;
 using aliases::RecList;
-using RecChildren = std::vector<baml::Box<RecList>>;
+using RecChildren = std::vector<baml::box<RecList>>;
 
 BAML_TEST(round_trip_string_list) {
   // StringList is a generated `using` alias; the codegen pool preserves
@@ -34,10 +34,10 @@ BAML_TEST(round_trip_rec_list) {
 
   // [1, [2, 3]]
   const RecList nested{RecChildren{
-      baml::Box<RecList>(RecList{int64_t{1}}),
-      baml::Box<RecList>(RecList{RecChildren{
-          baml::Box<RecList>(RecList{int64_t{2}}),
-          baml::Box<RecList>(RecList{int64_t{3}}),
+      baml::box<RecList>(RecList{int64_t{1}}),
+      baml::box<RecList>(RecList{RecChildren{
+          baml::box<RecList>(RecList{int64_t{2}}),
+          baml::box<RecList>(RecList{int64_t{3}}),
       }}),
   }};
   BAML_ASSERT(aliases::round_trip_rec_list(nested) == nested);
@@ -47,9 +47,9 @@ BAML_TEST(round_trip_alias_container) {
   const AliasContainer c{
       {"x"},  // list_field: StringList
       RecList{RecChildren{
-          baml::Box<RecList>(RecList{int64_t{1}}),
-          baml::Box<RecList>(RecList{RecChildren{
-              baml::Box<RecList>(RecList{int64_t{2}}),
+          baml::box<RecList>(RecList{int64_t{1}}),
+          baml::box<RecList>(RecList{RecChildren{
+              baml::box<RecList>(RecList{int64_t{2}}),
           }}),
       }},  // rec_field: [1, [2]]
   };
@@ -58,9 +58,9 @@ BAML_TEST(round_trip_alias_container) {
 
 BAML_TEST(round_trip_maybe_rec) {
   // C++-specific: a nullable recursive-alias reference folds the null into
-  // the box (OptionalBox<RecList>; optional<Box<T>> needs a complete T).
+  // the box (optional_box<RecList>; optional<Box<T>> needs a complete T).
   const MaybeRec none{{}};
   BAML_ASSERT(aliases::round_trip_maybe_rec(none) == none);
-  const MaybeRec some{baml::OptionalBox<RecList>(RecList{int64_t{6}})};
+  const MaybeRec some{baml::optional_box<RecList>(RecList{int64_t{6}})};
   BAML_ASSERT(aliases::round_trip_maybe_rec(some) == some);
 }

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_complex_models.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_complex_models.cc
@@ -2,10 +2,10 @@
 // Port of type_shapes/customizable/test_complex_models.py. Deviations:
 // - Keyword construction becomes aggregate init in field declaration order
 //   (matching the generated header).
-// - Union-typed fields (Invoice.payment, ComplexProfile.featured, flags
-//   elements) spell a baml::Union alternative explicitly; the spellings
+// - variant-typed fields (Invoice.payment, ComplexProfile.featured, flags
+//   elements) spell a baml::variant alternative explicitly; the spellings
 //   below deliberately use the python declaration order, which is legal
-//   because baml::Union is order-canonical.
+//   because baml::variant is order-canonical.
 #include <baml_sdk.h>
 #include <baml_test.h>
 
@@ -24,9 +24,9 @@ using complex_models::PostalAddress;
 using complex_models::ProfileOwner;
 using complex_models::WirePayment;
 
-using Payment = baml::Union<CardPayment, WirePayment>;
-using Featured = baml::Union<Invoice, PostalAddress, std::string>;
-using Flag = baml::Union<int64_t, std::string, bool>;
+using Payment = baml::variant<CardPayment, WirePayment>;
+using Featured = baml::variant<Invoice, PostalAddress, std::string>;
+using Flag = baml::variant<int64_t, std::string, bool>;
 
 BAML_TEST(
     round_trip_complex_profile_preserves_deeply_nested_mixed_shape_class) {

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_forward_refs.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_forward_refs.cc
@@ -12,8 +12,8 @@ namespace forward_refs = baml_sdk::forward_refs;
 using forward_refs::Other;
 using forward_refs::RecList;
 using forward_refs::RecListWithOther;
-using RecItems = std::vector<baml::Box<RecList>>;
-using RecWOItems = std::vector<baml::Box<RecListWithOther>>;
+using RecItems = std::vector<baml::box<RecList>>;
+using RecWOItems = std::vector<baml::box<RecListWithOther>>;
 
 BAML_TEST(round_trip_other) {
   const Other o{7};
@@ -27,7 +27,7 @@ BAML_TEST(round_trip_node_symbol_exists) {
 }
 
 BAML_TEST(round_trip_rec_list) {
-  // Union-bodied recursive alias in the forward_refs namespace (distinct
+  // variant-bodied recursive alias in the forward_refs namespace (distinct
   // from ns_aliases' RecList; exercises forward-ref quoting): [1, [2, 3]].
   const RecList r{RecItems{
       RecList{int64_t{1}},

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_lists.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_lists.cc
@@ -4,7 +4,7 @@
 #include <baml_test.h>
 
 using baml_sdk::lists::ListContainer;
-using IntOrString = baml::Union<int64_t, std::string>;
+using IntOrString = baml::variant<int64_t, std::string>;
 
 BAML_TEST(round_trip_ints) {
   const std::vector<int64_t> xs{1, 2, 3};

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_literals.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_literals.cc
@@ -1,5 +1,5 @@
 // Roundtrip coverage for baml_sdk::literals - literal Ty variants as
-// singleton ::baml::Lit types. Port of roundtrip_tests/test_literals.py:
+// singleton ::baml::lit types. Port of roundtrip_tests/test_literals.py:
 // python keeps the value set in typing.Literal annotations; C++ makes each
 // value a distinct type, so the round trips construct through the
 // BAML_LIT macro family and read back through Lit's implicit value

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_optional.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_optional.cc
@@ -26,7 +26,7 @@ BAML_TEST(round_trip_resume) {
 }
 
 BAML_TEST(round_trip_optional_union) {
-  using U = baml::Union<int64_t, std::string>;
+  using U = baml::variant<int64_t, std::string>;
   BAML_ASSERT(baml_sdk::optional::round_trip_optional_union(U{int64_t{3}}) ==
               U{int64_t{3}});
   BAML_ASSERT(baml_sdk::optional::round_trip_optional_union(
@@ -37,9 +37,9 @@ BAML_TEST(round_trip_optional_union) {
 
 BAML_TEST(round_trip_optional_container) {
   const OptionalContainer c{
-      std::nullopt,                                         // optional_int
-      Resume{"x"},                                          // optional_class
-      baml::Union<int64_t, std::string>{std::string("y")},  // optional_union
+      std::nullopt,                                           // optional_int
+      Resume{"x"},                                            // optional_class
+      baml::variant<int64_t, std::string>{std::string("y")},  // optional_union
   };
   BAML_ASSERT(baml_sdk::optional::round_trip_optional_container(c) == c);
 }

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_recursion.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_recursion.cc
@@ -1,6 +1,6 @@
 // Roundtrip coverage for baml_sdk::recursion - recursive classes / SCCs.
 // Port of roundtrip_tests/test_recursion.py. Recursive children are
-// baml::OptionalBox<T>; finite values terminate with std::nullopt.
+// baml::optional_box<T>; finite values terminate with std::nullopt.
 #include <baml_sdk.h>
 #include <baml_test.h>
 

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_unions.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/test_unions.cc
@@ -1,6 +1,6 @@
 // Roundtrip coverage for baml_sdk::unions - union normalization variants.
 // Port of roundtrip_tests/test_unions.py, plus the C++-only canonical-form
-// guarantees: baml::Union is an order-canonical std::variant alias
+// guarantees: baml::variant is an order-canonical std::variant alias
 // (variant<A, B> and variant<B, A> are the SAME type, matching BAML's
 // set-semantic unions), readable with baml::match and every std::variant
 // API.
@@ -13,19 +13,20 @@
 
 using baml_sdk::unions::T;
 using baml_sdk::unions::UnionContainer;
-using IntOrString = baml::Union<int64_t, std::string>;
+using IntOrString = baml::variant<int64_t, std::string>;
 
 // Canonicalization: both spellings resolve to one instantiation, singles
 // collapse to plain variants, and the generated field type is reachable
 // from either spelling.
-static_assert(std::is_same<baml::Union<int64_t, std::string>,
-                           baml::Union<std::string, int64_t>>::value,
-              "baml::Union must be order-canonical");
-static_assert(std::is_same<baml::Union<T, std::string>,
-                           baml::Union<std::string, T>>::value,
-              "baml::Union must be order-canonical for generated types");
-static_assert(std::is_same<baml::Union<int64_t>, std::variant<int64_t>>::value,
-              "a one-alternative baml::Union is a plain std::variant");
+static_assert(std::is_same<baml::variant<int64_t, std::string>,
+                           baml::variant<std::string, int64_t>>::value,
+              "baml::variant must be order-canonical");
+static_assert(std::is_same<baml::variant<T, std::string>,
+                           baml::variant<std::string, T>>::value,
+              "baml::variant must be order-canonical for generated types");
+static_assert(
+    std::is_same<baml::variant<int64_t>, std::variant<int64_t>>::value,
+    "a one-alternative baml::variant is a plain std::variant");
 
 BAML_TEST(round_trip_null_to_end) {
   using U = std::optional<IntOrString>;
@@ -50,7 +51,7 @@ BAML_TEST(round_trip_singleton_unwrap) {
 }
 
 BAML_TEST(round_trip_optional_plus_null) {
-  using TOrString = baml::Union<T, std::string>;
+  using TOrString = baml::variant<T, std::string>;
   using U = std::optional<TOrString>;
   BAML_ASSERT(baml_sdk::unions::round_trip_optional_plus_null(
                   U{TOrString{T{1}}}) == U{TOrString{T{1}}});
@@ -66,11 +67,11 @@ BAML_TEST(round_trip_t) {
 
 BAML_TEST(round_trip_union_container) {
   const UnionContainer c{
-      std::nullopt,                       // null_to_end
-      IntOrString{std::string("d")},      // dedup
-      5,                                  // singleton_unwrap
-      baml::Union<std::string, T>{T{2}},  // optional_plus_null:
-                                          // reversed spelling on purpose
+      std::nullopt,                         // null_to_end
+      IntOrString{std::string("d")},        // dedup
+      5,                                    // singleton_unwrap
+      baml::variant<std::string, T>{T{2}},  // optional_plus_null:
+                                            // reversed spelling on purpose
   };
   BAML_ASSERT(baml_sdk::unions::round_trip_union_container(c) == c);
 }
@@ -98,6 +99,6 @@ BAML_TEST(union_is_a_plain_std_variant) {
   BAML_ASSERT(std::holds_alternative<int64_t>(u));
   BAML_ASSERT_EQ(std::get<int64_t>(u), int64_t{9});
   // Assign across spellings: same type, plain copy.
-  baml::Union<std::string, int64_t> v = u;
+  baml::variant<std::string, int64_t> v = u;
   BAML_ASSERT_EQ(std::get<int64_t>(v), int64_t{9});
 }

--- a/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/unions_static.cc
+++ b/baml_language/sdk_tests/crates/cpp/type_shapes/customizable/tests/unions_static.cc
@@ -1,4 +1,4 @@
-// Static shape checks for the baml::Union surface (no python analog;
+// Static shape checks for the baml::variant surface (no python analog;
 // documents the compile-time contract the way optional_args_static.cc does
 // for opts structs). Each "must not compile" shape is pinned as a negative
 // trait assertion rather than a commented-out snippet.
@@ -10,59 +10,59 @@
 
 namespace {
 
-using IntOrString = baml::Union<int64_t, std::string>;
+using IntOrString = baml::variant<int64_t, std::string>;
 
 // Canonicalization is total: every permutation of an alternative set is
 // one instantiation, including through nesting in std containers.
-static_assert(std::is_same<baml::Union<int64_t, std::string>,
-                           baml::Union<std::string, int64_t>>::value,
-              "baml::Union must be order-canonical");
+static_assert(std::is_same<baml::variant<int64_t, std::string>,
+                           baml::variant<std::string, int64_t>>::value,
+              "baml::variant must be order-canonical");
 static_assert(
-    std::is_same<std::optional<baml::Union<int64_t, std::string>>,
-                 std::optional<baml::Union<std::string, int64_t>>>::value,
+    std::is_same<std::optional<baml::variant<int64_t, std::string>>,
+                 std::optional<baml::variant<std::string, int64_t>>>::value,
     "canonicalization must hold under std::optional");
 static_assert(
-    std::is_same<std::vector<baml::Union<int64_t, std::string>>,
-                 std::vector<baml::Union<std::string, int64_t>>>::value,
+    std::is_same<std::vector<baml::variant<int64_t, std::string>>,
+                 std::vector<baml::variant<std::string, int64_t>>>::value,
     "canonicalization must hold under std::vector");
 
 // Literal types are ordinary alternatives: the BAML_LIT macro family hits
 // the canonical char-pack / normalized-scalar instantiations, and Lit
 // unions canonicalize like any other.
 static_assert(
-    std::is_same<BAML_LIT("draft"), baml::Lit<'d', 'r', 'a', 'f', 't'>>::value,
+    std::is_same<BAML_LIT("draft"), baml::lit<'d', 'r', 'a', 'f', 't'>>::value,
     "BAML_LIT must produce the canonical char pack");
-static_assert(std::is_same<BAML_LIT(1), baml::Lit<int64_t{1}>>::value,
+static_assert(std::is_same<BAML_LIT(1), baml::lit<int64_t{1}>>::value,
               "BAML_LIT must normalize ints to int64_t");
-static_assert(std::is_same<BAML_LIT(1), baml::IntLit<1>>::value,
-              "IntLit must agree with BAML_LIT");
-static_assert(std::is_same<baml::Union<BAML_LIT("a"), BAML_LIT("b")>,
-                           baml::Union<BAML_LIT("b"), BAML_LIT("a")>>::value,
+static_assert(std::is_same<BAML_LIT(1), baml::int_lit<1>>::value,
+              "int_lit must agree with BAML_LIT");
+static_assert(std::is_same<baml::variant<BAML_LIT("a"), BAML_LIT("b")>,
+                           baml::variant<BAML_LIT("b"), BAML_LIT("a")>>::value,
               "Lit unions must be order-canonical");
 
 // Alternatives are a set, not a list: duplicates collapse, so type-based
 // construction and access are never ambiguous.
-static_assert(
-    std::is_same<baml::Union<int64_t, int64_t>, baml::Union<int64_t>>::value,
-    "baml::Union must deduplicate repeated alternatives");
-static_assert(std::is_same<baml::Union<int64_t, std::string, int64_t>,
-                           baml::Union<std::string, int64_t>>::value,
+static_assert(std::is_same<baml::variant<int64_t, int64_t>,
+                           baml::variant<int64_t>>::value,
+              "baml::variant must deduplicate repeated alternatives");
+static_assert(std::is_same<baml::variant<int64_t, std::string, int64_t>,
+                           baml::variant<std::string, int64_t>>::value,
               "deduplication must compose with order canonicalization");
 
-// A Union IS a std::variant instantiation (alias, not a wrapper).
+// A baml::variant IS a std::variant instantiation (alias, not a wrapper).
 static_assert(
     std::is_same<
         IntOrString,
         std::variant<typename std::variant_alternative<0, IntOrString>::type,
                      typename std::variant_alternative<1, IntOrString>::type>>::
         value,
-    "baml::Union must be a plain std::variant instantiation");
+    "baml::variant must be a plain std::variant instantiation");
 
 // match exhaustiveness: an arm set missing an alternative is not invocable
 // with that alternative, which is exactly what makes baml::match (std::visit
 // underneath) reject it at compile time.
 const auto int_only = [](int64_t) { return 0; };
-using IntOnlyArms = baml::detail::Overloaded<std::decay_t<decltype(int_only)>>;
+using IntOnlyArms = baml::detail::overloaded<std::decay_t<decltype(int_only)>>;
 static_assert(std::is_invocable<IntOnlyArms, int64_t>::value,
               "sanity: the int arm must accept int64_t");
 static_assert(!std::is_invocable<IntOnlyArms, const std::string&>::value,
@@ -71,7 +71,7 @@ static_assert(!std::is_invocable<IntOnlyArms, const std::string&>::value,
 // The const auto& catch-all restores invocability for every alternative.
 const auto catch_all = [](const auto&) { return 0; };
 using WithCatchAll =
-    baml::detail::Overloaded<std::decay_t<decltype(int_only)>,
+    baml::detail::overloaded<std::decay_t<decltype(int_only)>,
                              std::decay_t<decltype(catch_all)>>;
 static_assert(std::is_invocable<WithCatchAll, const std::string&>::value,
               "a const auto& arm must catch remaining alternatives");

--- a/baml_language/sdks/cpp/.clang-tidy
+++ b/baml_language/sdks/cpp/.clang-tidy
@@ -1,0 +1,18 @@
+# Naming enforcement for the std-style convention documented in STYLE.md.
+# Layout is clang-format's job (BasedOnStyle: Google); identifiers are
+# checked here. Generated code (generated/, pb/, baml_cffi.h) is excluded
+# by not being run through clang-tidy.
+Checks: 'readability-identifier-naming'
+CheckOptions:
+  readability-identifier-naming.ClassCase: lower_case
+  readability-identifier-naming.StructCase: lower_case
+  readability-identifier-naming.EnumCase: lower_case
+  readability-identifier-naming.EnumConstantCase: lower_case
+  readability-identifier-naming.FunctionCase: lower_case
+  readability-identifier-naming.VariableCase: lower_case
+  readability-identifier-naming.ParameterCase: lower_case
+  readability-identifier-naming.GlobalConstantCase: lower_case
+  readability-identifier-naming.PrivateMemberSuffix: '_'
+  readability-identifier-naming.TemplateParameterCase: CamelCase
+  readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
+  readability-identifier-naming.MacroDefinitionIgnoredRegexp: '^(WIN32_LEAN_AND_MEAN)$'

--- a/baml_language/sdks/cpp/STYLE.md
+++ b/baml_language/sdks/cpp/STYLE.md
@@ -1,41 +1,49 @@
 # C++ style
 
-This SDK follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
-Headers use `.h`, sources use `.cc`, include guards use the Google
-`BAML_..._H_` form, and formatting is clang-format with
-`BasedOnStyle: Google` (see `.clang-format`).
+Layout is Google; naming is the C++ standard library's.
 
-## Carve-outs
+- **Formatting**: clang-format with `BasedOnStyle: Google` (see
+  `.clang-format`). Headers use `.h`, sources use `.cc`, include guards
+  use the `BAML_..._H_` form.
+- **Naming**: std-library convention, per the C++ Core Guidelines
+  ([NL.10](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#nl10-prefer-underscore_style-names):
+  prefer `underscore_style`, consistent with the ISO standard library) --
+  the same convention Boost uses. Enforced by clang-tidy
+  `readability-identifier-naming` (see `.clang-tidy`).
 
-Functions are PascalCase except the following, all sanctioned by the Google
-guide itself:
+## The naming rules
 
-1. Accessors returning stored state keep snake_case: `message()`,
-   `class_name()`, `baml_trace()`, `payload()`, `bytes()`, `code()`, and
-   `detail::OwnedBuffer`'s `empty()`/`to_string()`. Generated opts
-   setters are `set_<param>` -- the guide's own mutator convention.
-2. The vocabulary rule (Abseil's practice: structure is Google-cased,
-   vocabulary is std-cased). Types stay PascalCase (`Union`, `Box`,
-   `Arg`, `Unset`; lowercase `union` is a C++ keyword regardless), but
-   API that a user's muscle memory or generic code treats as
-   optional/variant-shaped keeps std spelling, exactly as
-   `absl::optional::has_value` / `absl::visit` / `absl::nullopt` do:
-   `baml::match` (mirrors `std::visit`), `baml::unset` (mirrors
-   `std::nullopt`), `Arg::is_set`/`is_unset`/`value`,
-   `Box`/`OptionalBox::has_value`, `BamlError::is<T>`/`get<T>` (mirror
-   `std::holds_alternative`/`std::get`).
-3. Type traits keep std spelling: `is_std_optional`, `has_set_opt1`,
-   `has_set_opt3`.
-4. `extern "C"` symbols keep snake_case (C ABI): `baml_cpp_result_trampoline`.
-5. Generated identifiers derived from BAML source names are unchanged,
-   including derived names: the opts struct for function `probe` is
-   `probeOpts` (source casing preserved, never re-cased)
-   (functions, classes, fields, params in generated `baml_sdk` code).
+| Entity | Case | Examples |
+|---|---|---|
+| types | `snake_case` | `baml::variant`, `baml::future`, `baml::lit`, `baml::error`, `baml::thrown<U>`, `detail::call_state` |
+| functions and methods | `snake_case` | `baml::match`, `future::cancel`, `codec<T>::encode`, `detail::call_sync` |
+| constants | `snake_case` | `baml::unset` (type `baml::unset_t`, the `nullopt`/`nullopt_t` pattern) |
+| enumerators | `snake_case` | `lit_shape::integer` (`int`/`bool`/`enum` are keywords; spell them out) |
+| template parameters | `CamelCase` | `T`, `Ret`, `ThrownU`, `WriteValue` |
+| macros | `BAML_UPPER` | `BAML_LIT`, `BAML_TEST` |
+| private members | trailing `_` | `state_`, `engine_call_id_` |
 
-## Deliberate deviations
+`baml::variant` is the one vocabulary drift from BAML's own terminology:
+lowercase `union` is a C++ keyword, and `variant` is the std name for the
+same shape.
 
-- Exceptions are used deliberately: the `BamlError` contract is the bridge's
-  error surface. This is a knowing deviation from the Google guide's
-  no-exceptions rule.
-- Generated code approximates Google style (2-space indent) but is not
+## Exceptions to the rules
+
+1. `extern "C"` symbols and everything in the C ABI header
+   (`baml_cffi.h`: `BamlApiV1`, `BamlBuffer`, ...) keep their contract
+   spellings.
+2. Generated protobuf code (`pb/`) keeps protoc's conventions.
+3. Generated identifiers derived from BAML source names are spelled
+   exactly as the BAML author wrote them, never re-cased (`SleepMs` stays
+   `SleepMs`). Suffixes the generator adds are snake and follow the other
+   bridges: the async sibling of `SleepMs` is `SleepMs_async` (python
+   parity), the opts struct for `probe` is `probe_opts`, setters are
+   `set_<param>`.
+
+## Deliberate deviations from the Google guide
+
+- Exceptions are used deliberately: the `baml::error` contract is the
+  bridge's error surface. This is a knowing deviation from the Google
+  guide's no-exceptions rule.
+- Generated code approximates the layout (2-space indent) but is not
   clang-formatted.

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/arg.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/arg.h
@@ -9,17 +9,17 @@
 
 namespace baml {
 
-// The BAML `null` unit type is std::monostate. Union-with-null is
+// The BAML `null` unit type is std::monostate. variant-with-null is
 // std::optional, so nullability uses only std vocabulary:
 //   null         -> std::monostate
 //   T | null     -> std::optional<T>
 
 // Explicit spelling for the unset state of an optional argument (Python's
 // UNSET analog). Omitting the setter is equivalent.
-struct Unset {
-  explicit constexpr Unset() = default;
+struct unset_t {
+  explicit constexpr unset_t() = default;
 };
-inline constexpr Unset unset{};
+inline constexpr unset_t unset{};
 
 namespace detail {
 
@@ -33,40 +33,40 @@ struct is_std_optional<std::optional<U>> : std::true_type {};
 // Two-state optional-argument holder: unset (omitted; the engine evaluates
 // the declared BAML default) or a value of the argument's normalized type.
 // Nullability lives in T itself: a `string?` argument is
-// Arg<std::optional<std::string>>, so std::nullopt is a *value* that is null,
-// and a non-nullable `int` argument (Arg<int64_t>) rejects null at compile
+// arg<std::optional<std::string>>, so std::nullopt is a *value* that is null,
+// and a non-nullable `int` argument (arg<int64_t>) rejects null at compile
 // time.
 template <typename T>
-class Arg {
+class arg {
  public:
-  Arg() = default;
-  Arg(Unset) {}
+  arg() = default;
+  arg(unset_t) {}
 
   // Converting constructor so e.g. a string literal reaches
-  // Arg<std::optional<std::string>> in one user-defined conversion
-  // (generated setters take Arg<T> by value).
+  // arg<std::optional<std::string>> in one user-defined conversion
+  // (generated setters take arg<T> by value).
   template <typename U,
             typename = std::enable_if_t<
                 std::is_constructible<T, U&&>::value &&
-                !std::is_same<std::decay_t<U>, Arg>::value &&
-                !std::is_same<std::decay_t<U>, Unset>::value &&
+                !std::is_same<std::decay_t<U>, arg>::value &&
+                !std::is_same<std::decay_t<U>, unset_t>::value &&
                 !(std::is_same<std::decay_t<U>, std::monostate>::value &&
                   detail::is_std_optional<T>::value)>>
-  Arg(U&& value) : value_(std::in_place, std::forward<U>(value)) {}
+  arg(U&& value) : value_(std::in_place, std::forward<U>(value)) {}
 
   // A value of the null type is a null: std::monostate{} sets a nullable
   // argument to null. Excluded when T itself is the bare null type, where
   // the converting constructor already treats monostate as the value.
   template <typename U = T,
             typename = std::enable_if_t<detail::is_std_optional<U>::value>>
-  Arg(std::monostate) : value_(std::in_place, std::nullopt) {}
+  arg(std::monostate) : value_(std::in_place, std::nullopt) {}
 
   bool is_unset() const { return !value_.has_value(); }
   bool is_set() const { return value_.has_value(); }
 
   const T& value() const {
     if (!is_set()) {
-      throw std::logic_error("baml::Arg::value() called while unset");
+      throw std::logic_error("baml::arg::value() called while unset");
     }
     return *value_;
   }

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
@@ -15,6 +15,6 @@
 #include <baml/future.h>
 #include <baml/lit.h>
 #include <baml/runtime.h>
-#include <baml/union.h>
+#include <baml/variant.h>
 
 #endif  // BAML_BAML_H_

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/box.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/box.h
@@ -12,54 +12,54 @@ namespace baml {
 // copyable, and unlike std::optional it may hold an incomplete type.
 // Never null except in the moved-from state.
 template <typename T>
-class Box {
+class box {
  public:
-  Box(T value) : ptr_(new T(std::move(value))) {}
+  box(T value) : ptr_(new T(std::move(value))) {}
 
-  Box(const Box& other) : ptr_(new T(*other.ptr_)) {}
-  Box(Box&&) noexcept = default;
-  Box& operator=(const Box& other) {
+  box(const box& other) : ptr_(new T(*other.ptr_)) {}
+  box(box&&) noexcept = default;
+  box& operator=(const box& other) {
     if (this != &other) {
       ptr_ = std::unique_ptr<T>(new T(*other.ptr_));
     }
     return *this;
   }
-  Box& operator=(Box&&) noexcept = default;
+  box& operator=(box&&) noexcept = default;
 
   T& operator*() { return *ptr_; }
   const T& operator*() const { return *ptr_; }
   T* operator->() { return ptr_.get(); }
   const T* operator->() const { return ptr_.get(); }
 
-  friend bool operator==(const Box& a, const Box& b) {
+  friend bool operator==(const box& a, const box& b) {
     return *a.ptr_ == *b.ptr_;
   }
-  friend bool operator!=(const Box& a, const Box& b) { return !(a == b); }
+  friend bool operator!=(const box& a, const box& b) { return !(a == b); }
 
  private:
   std::unique_ptr<T> ptr_;
 };
 
 // Nullable deep-copying heap box: the spelling of `T | null` when T is a
-// recursive class (std::optional requires a complete T; OptionalBox, like
-// Box, only needs the forward declaration). Empty = BAML null.
+// recursive class (std::optional requires a complete T; optional_box, like
+// box, only needs the forward declaration). Empty = BAML null.
 template <typename T>
-class OptionalBox {
+class optional_box {
  public:
-  OptionalBox() = default;
-  OptionalBox(std::nullopt_t) {}
-  OptionalBox(T value) : ptr_(new T(std::move(value))) {}
+  optional_box() = default;
+  optional_box(std::nullopt_t) {}
+  optional_box(T value) : ptr_(new T(std::move(value))) {}
 
-  OptionalBox(const OptionalBox& other)
+  optional_box(const optional_box& other)
       : ptr_(other.ptr_ ? new T(*other.ptr_) : nullptr) {}
-  OptionalBox(OptionalBox&&) noexcept = default;
-  OptionalBox& operator=(const OptionalBox& other) {
+  optional_box(optional_box&&) noexcept = default;
+  optional_box& operator=(const optional_box& other) {
     if (this != &other) {
       ptr_ = other.ptr_ ? std::unique_ptr<T>(new T(*other.ptr_)) : nullptr;
     }
     return *this;
   }
-  OptionalBox& operator=(OptionalBox&&) noexcept = default;
+  optional_box& operator=(optional_box&&) noexcept = default;
 
   bool has_value() const { return ptr_ != nullptr; }
   explicit operator bool() const { return has_value(); }
@@ -68,13 +68,13 @@ class OptionalBox {
   T* operator->() { return ptr_.get(); }
   const T* operator->() const { return ptr_.get(); }
 
-  friend bool operator==(const OptionalBox& a, const OptionalBox& b) {
+  friend bool operator==(const optional_box& a, const optional_box& b) {
     if (a.has_value() != b.has_value()) {
       return false;
     }
     return !a.has_value() || *a.ptr_ == *b.ptr_;
   }
-  friend bool operator!=(const OptionalBox& a, const OptionalBox& b) {
+  friend bool operator!=(const optional_box& a, const optional_box& b) {
     return !(a == b);
   }
 

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/buffer.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/buffer.h
@@ -10,14 +10,14 @@ namespace baml {
 namespace detail {
 
 // RAII owner for a BamlBuffer returned by the C ABI. Frees with free_buffer().
-class OwnedBuffer {
+class owned_buffer {
  public:
-  explicit OwnedBuffer(BamlBuffer buf) : buf_(buf) {}
+  explicit owned_buffer(BamlBuffer buf) : buf_(buf) {}
 
-  OwnedBuffer(OwnedBuffer&& other) noexcept : buf_(other.buf_) {
+  owned_buffer(owned_buffer&& other) noexcept : buf_(other.buf_) {
     other.buf_ = BamlBuffer{nullptr, 0};
   }
-  OwnedBuffer& operator=(OwnedBuffer&& other) noexcept {
+  owned_buffer& operator=(owned_buffer&& other) noexcept {
     if (this != &other) {
       Release();
       buf_ = other.buf_;
@@ -25,10 +25,10 @@ class OwnedBuffer {
     }
     return *this;
   }
-  OwnedBuffer(const OwnedBuffer&) = delete;
-  OwnedBuffer& operator=(const OwnedBuffer&) = delete;
+  owned_buffer(const owned_buffer&) = delete;
+  owned_buffer& operator=(const owned_buffer&) = delete;
 
-  ~OwnedBuffer() { Release(); }
+  ~owned_buffer() { Release(); }
 
   bool empty() const { return buf_.ptr == nullptr || buf_.len == 0; }
 
@@ -41,7 +41,7 @@ class OwnedBuffer {
  private:
   void Release() {
     if (buf_.ptr != nullptr) {
-      Api().free_buffer(buf_);
+      api().free_buffer(buf_);
       buf_ = BamlBuffer{nullptr, 0};
     }
   }

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/codec.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/codec.h
@@ -1,12 +1,12 @@
 #ifndef BAML_CODEC_H_
 #define BAML_CODEC_H_
 
-// Codec<T>: the typed boundary layer. `Encode` fills an InboundValue
-// message; `Decode` converts a BamlOutboundValue into T, throwing BamlError
+// codec<T>: the typed boundary layer. `encode` fills an InboundValue
+// message; `decode` converts a BamlOutboundValue into T, throwing error
 // on arm mismatches. Generated code adds specializations for its
 // classes/enums; this header owns the primitive and container instances.
 //
-// Decode sees values through detail::Unwrap (union metadata dropped) and
+// decode sees values through detail::unwrap (union metadata dropped) and
 // widens literal values to their base scalar (Python parity).
 
 #include <baml/box.h>
@@ -27,25 +27,25 @@
 namespace baml {
 
 template <typename T>
-struct Codec;  // primary template intentionally undefined
+struct codec;  // primary template intentionally undefined
 
 namespace detail {
 
-[[noreturn]] inline void KindMismatch(const char* expected,
-                                      const pb::BamlOutboundValue& got) {
-  throw BamlError(std::string("BAML decode error: expected ") + expected +
-                  ", got " + ArmName(got.value_case()));
+[[noreturn]] inline void kind_mismatch(const char* expected,
+                                       const pb::BamlOutboundValue& got) {
+  throw error(std::string("BAML decode error: expected ") + expected +
+              ", got " + arm_name(got.value_case()));
 }
 
 }  // namespace detail
 
 template <>
-struct Codec<int64_t> {
-  static void Encode(detail::pb::InboundValue& value_msg, int64_t v) {
+struct codec<int64_t> {
+  static void encode(detail::pb::InboundValue& value_msg, int64_t v) {
     value_msg.set_int_value(v);
   }
-  static int64_t Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static int64_t decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() == detail::pb::BamlOutboundValue::kIntValue) {
       return v.int_value();
     }
@@ -54,17 +54,17 @@ struct Codec<int64_t> {
             detail::pb::BamlLiteralValue::kIntValue) {
       return v.literal_value().int_value();
     }
-    detail::KindMismatch("int", v);
+    detail::kind_mismatch("int", v);
   }
 };
 
 template <>
-struct Codec<double> {
-  static void Encode(detail::pb::InboundValue& value_msg, double v) {
+struct codec<double> {
+  static void encode(detail::pb::InboundValue& value_msg, double v) {
     value_msg.set_float_value(v);
   }
-  static double Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static double decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     switch (v.value_case()) {
       case detail::pb::BamlOutboundValue::kFloatValue:
         return v.float_value();
@@ -73,31 +73,31 @@ struct Codec<double> {
         return static_cast<double>(v.int_value());
       case detail::pb::BamlOutboundValue::kLiteralValue:
         // Float literals ride as source text; malformed text surfaces as
-        // a BamlError, never a bare std:: exception.
+        // a error, never a bare std:: exception.
         if (v.literal_value().literal_case() ==
             detail::pb::BamlLiteralValue::kFloatValue) {
           try {
             return std::stod(v.literal_value().float_value());
           } catch (const std::exception&) {
-            throw BamlError("BAML decode error: malformed float literal '" +
-                            v.literal_value().float_value() + "'");
+            throw error("BAML decode error: malformed float literal '" +
+                        v.literal_value().float_value() + "'");
           }
         }
         break;
       default:
         break;
     }
-    detail::KindMismatch("float", v);
+    detail::kind_mismatch("float", v);
   }
 };
 
 template <>
-struct Codec<bool> {
-  static void Encode(detail::pb::InboundValue& value_msg, bool v) {
+struct codec<bool> {
+  static void encode(detail::pb::InboundValue& value_msg, bool v) {
     value_msg.set_bool_value(v);
   }
-  static bool Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static bool decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() == detail::pb::BamlOutboundValue::kBoolValue) {
       return v.bool_value();
     }
@@ -106,18 +106,18 @@ struct Codec<bool> {
             detail::pb::BamlLiteralValue::kBoolValue) {
       return v.literal_value().bool_value();
     }
-    detail::KindMismatch("bool", v);
+    detail::kind_mismatch("bool", v);
   }
 };
 
 template <>
-struct Codec<std::string> {
-  static void Encode(detail::pb::InboundValue& value_msg,
+struct codec<std::string> {
+  static void encode(detail::pb::InboundValue& value_msg,
                      const std::string& v) {
     value_msg.set_string_value(v);
   }
-  static std::string Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static std::string decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() == detail::pb::BamlOutboundValue::kStringValue) {
       return v.string_value();
     }
@@ -126,21 +126,21 @@ struct Codec<std::string> {
             detail::pb::BamlLiteralValue::kStringValue) {
       return v.literal_value().string_value();
     }
-    detail::KindMismatch("string", v);
+    detail::kind_mismatch("string", v);
   }
 };
 
 template <>
-struct Codec<std::vector<uint8_t>> {
-  static void Encode(detail::pb::InboundValue& value_msg,
+struct codec<std::vector<uint8_t>> {
+  static void encode(detail::pb::InboundValue& value_msg,
                      const std::vector<uint8_t>& v) {
     value_msg.set_uint8array_value(
         std::string(reinterpret_cast<const char*>(v.data()), v.size()));
   }
-  static std::vector<uint8_t> Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static std::vector<uint8_t> decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() != detail::pb::BamlOutboundValue::kUint8ArrayValue) {
-      detail::KindMismatch("uint8array", v);
+      detail::kind_mismatch("uint8array", v);
     }
     const std::string& bytes = v.uint8array_value();
     return std::vector<uint8_t>(bytes.begin(), bytes.end());
@@ -148,15 +148,15 @@ struct Codec<std::vector<uint8_t>> {
 };
 
 template <>
-struct Codec<std::monostate> {
-  static void Encode(detail::pb::InboundValue&, std::monostate) {
+struct codec<std::monostate> {
+  static void encode(detail::pb::InboundValue&, std::monostate) {
     // BAML null = absent InboundValue oneof: set nothing.
   }
-  static std::monostate Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static std::monostate decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() != detail::pb::BamlOutboundValue::kNullValue &&
         v.value_case() != detail::pb::BamlOutboundValue::VALUE_NOT_SET) {
-      detail::KindMismatch("null", v);
+      detail::kind_mismatch("null", v);
     }
     return std::monostate{};
   }
@@ -165,162 +165,162 @@ struct Codec<std::monostate> {
 // Boxes are transparent on the wire: the box exists only to break C++
 // type-recursion cycles.
 template <typename T>
-struct Codec<Box<T>> {
-  static void Encode(detail::pb::InboundValue& value_msg, const Box<T>& v) {
-    Codec<T>::Encode(value_msg, *v);
+struct codec<box<T>> {
+  static void encode(detail::pb::InboundValue& value_msg, const box<T>& v) {
+    codec<T>::encode(value_msg, *v);
   }
-  static Box<T> Decode(const detail::pb::BamlOutboundValue& v) {
-    return Box<T>(Codec<T>::Decode(v));
+  static box<T> decode(const detail::pb::BamlOutboundValue& v) {
+    return box<T>(codec<T>::decode(v));
   }
 };
 
 template <typename T>
-struct Codec<OptionalBox<T>> {
-  static void Encode(detail::pb::InboundValue& value_msg,
-                     const OptionalBox<T>& v) {
+struct codec<optional_box<T>> {
+  static void encode(detail::pb::InboundValue& value_msg,
+                     const optional_box<T>& v) {
     if (v.has_value()) {
-      Codec<T>::Encode(value_msg, *v);
+      codec<T>::encode(value_msg, *v);
     }
     // empty = BAML null = absent oneof: set nothing.
   }
-  static OptionalBox<T> Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static optional_box<T> decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() == detail::pb::BamlOutboundValue::kNullValue ||
         v.value_case() == detail::pb::BamlOutboundValue::VALUE_NOT_SET) {
-      return OptionalBox<T>();
+      return optional_box<T>();
     }
-    return OptionalBox<T>(Codec<T>::Decode(v));
+    return optional_box<T>(codec<T>::decode(v));
   }
 };
 
 template <typename T>
-struct Codec<std::optional<T>> {
-  static void Encode(detail::pb::InboundValue& value_msg,
+struct codec<std::optional<T>> {
+  static void encode(detail::pb::InboundValue& value_msg,
                      const std::optional<T>& v) {
     if (v.has_value()) {
-      Codec<T>::Encode(value_msg, *v);
+      codec<T>::encode(value_msg, *v);
     }
     // nullopt = BAML null = absent oneof: set nothing.
   }
-  static std::optional<T> Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static std::optional<T> decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() == detail::pb::BamlOutboundValue::kNullValue ||
         v.value_case() == detail::pb::BamlOutboundValue::VALUE_NOT_SET) {
       return std::nullopt;
     }
-    return Codec<T>::Decode(v);
+    return codec<T>::decode(v);
   }
 };
 
 template <typename T>
-struct Codec<std::vector<T>> {
-  static void Encode(detail::pb::InboundValue& value_msg,
+struct codec<std::vector<T>> {
+  static void encode(detail::pb::InboundValue& value_msg,
                      const std::vector<T>& v) {
     detail::pb::InboundListValue* list = value_msg.mutable_list_value();
     for (const T& item : v) {
-      Codec<T>::Encode(*list->add_values(), item);
+      codec<T>::encode(*list->add_values(), item);
     }
   }
-  static std::vector<T> Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static std::vector<T> decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() != detail::pb::BamlOutboundValue::kListValue) {
-      detail::KindMismatch("list", v);
+      detail::kind_mismatch("list", v);
     }
     std::vector<T> out;
     out.reserve(static_cast<size_t>(v.list_value().items_size()));
     for (const auto& item : v.list_value().items()) {
-      out.push_back(Codec<T>::Decode(item));
+      out.push_back(codec<T>::decode(item));
     }
     return out;
   }
 };
 
 template <typename T>
-struct Codec<std::unordered_map<std::string, T>> {
-  static void Encode(detail::pb::InboundValue& value_msg,
+struct codec<std::unordered_map<std::string, T>> {
+  static void encode(detail::pb::InboundValue& value_msg,
                      const std::unordered_map<std::string, T>& v) {
     detail::pb::InboundMapValue* map = value_msg.mutable_map_value();
     for (const auto& entry : v) {
       detail::pb::InboundMapEntry* e = map->add_entries();
       e->set_string_key(entry.first);
-      Codec<T>::Encode(*e->mutable_value(), entry.second);
+      codec<T>::encode(*e->mutable_value(), entry.second);
     }
   }
-  static std::unordered_map<std::string, T> Decode(
+  static std::unordered_map<std::string, T> decode(
       const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+    const auto& v = detail::unwrap(raw);
     if (v.value_case() != detail::pb::BamlOutboundValue::kMapValue) {
-      detail::KindMismatch("map", v);
+      detail::kind_mismatch("map", v);
     }
     std::unordered_map<std::string, T> out;
     for (const auto& entry : v.map_value().entries()) {
-      out.emplace(entry.key(), Codec<T>::Decode(entry.value()));
+      out.emplace(entry.key(), codec<T>::decode(entry.value()));
     }
     return out;
   }
 };
 
-// BAML literal types (baml::Lit). Encode writes the static value as its
-// plain scalar/enum arm (the engine types the parameter). Decode reuses
+// BAML literal types (baml::lit). encode writes the static value as its
+// plain scalar/enum arm (the engine types the parameter). decode reuses
 // the base codec for arm handling (plain and literal wire arms alike) and
 // then requires the exact value: a mismatch throws, which inside a union
 // rejects this alternative and lets the next one probe.
 template <auto... Vs>
-struct Codec<Lit<Vs...>> {
-  using L = Lit<Vs...>;
-  static constexpr detail::LitShape kShape =
-      detail::LitShapeOf<decltype(Vs)...>();
+struct codec<lit<Vs...>> {
+  using L = lit<Vs...>;
+  static constexpr detail::lit_shape shape =
+      detail::lit_shape_of<decltype(Vs)...>();
 
-  static void Encode(detail::pb::InboundValue& value_msg, const L&) {
-    if constexpr (kShape == detail::LitShape::kString) {
+  static void encode(detail::pb::InboundValue& value_msg, const L&) {
+    if constexpr (shape == detail::lit_shape::string) {
       value_msg.set_string_value(std::string(L::value));
-    } else if constexpr (kShape == detail::LitShape::kInt) {
+    } else if constexpr (shape == detail::lit_shape::integer) {
       value_msg.set_int_value(L::value);
-    } else if constexpr (kShape == detail::LitShape::kBool) {
+    } else if constexpr (shape == detail::lit_shape::boolean) {
       value_msg.set_bool_value(L::value);
     } else {
-      Codec<std::decay_t<decltype(L::value)>>::Encode(value_msg, L::value);
+      codec<std::decay_t<decltype(L::value)>>::encode(value_msg, L::value);
     }
   }
 
-  static L Decode(const detail::pb::BamlOutboundValue& raw) {
-    if constexpr (kShape == detail::LitShape::kString) {
-      if (Codec<std::string>::Decode(raw) != L::value) {
-        Mismatch("literal \"" + std::string(L::value) + "\"");
+  static L decode(const detail::pb::BamlOutboundValue& raw) {
+    if constexpr (shape == detail::lit_shape::string) {
+      if (codec<std::string>::decode(raw) != L::value) {
+        mismatch("literal \"" + std::string(L::value) + "\"");
       }
-    } else if constexpr (kShape == detail::LitShape::kInt) {
-      if (Codec<int64_t>::Decode(raw) != L::value) {
-        Mismatch("literal " + std::to_string(L::value));
+    } else if constexpr (shape == detail::lit_shape::integer) {
+      if (codec<int64_t>::decode(raw) != L::value) {
+        mismatch("literal " + std::to_string(L::value));
       }
-    } else if constexpr (kShape == detail::LitShape::kBool) {
-      if (Codec<bool>::Decode(raw) != L::value) {
-        Mismatch(L::value ? "literal true" : "literal false");
+    } else if constexpr (shape == detail::lit_shape::boolean) {
+      if (codec<bool>::decode(raw) != L::value) {
+        mismatch(L::value ? "literal true" : "literal false");
       }
     } else {
       using E = std::decay_t<decltype(L::value)>;
-      if (Codec<E>::Decode(raw) != L::value) {
-        Mismatch("enum-variant literal");
+      if (codec<E>::decode(raw) != L::value) {
+        mismatch("enum-variant literal");
       }
     }
     return L{};
   }
 
  private:
-  [[noreturn]] static void Mismatch(const std::string& expected) {
-    throw BamlError("BAML decode error: expected " + expected);
+  [[noreturn]] static void mismatch(const std::string& expected) {
+    throw error("BAML decode error: expected " + expected);
   }
 };
 
-// BAML unions (baml::Union<Ts...> = order-canonical std::variant). Encode
+// BAML unions (baml::variant<Ts...> = order-canonical std::variant). encode
 // writes the ACTIVE alternative's value with no union wrapper (the engine
-// types the member; Python parity). Decode receives the union-unwrapped
+// types the member; Python parity). decode receives the union-unwrapped
 // inner value and must pick an alternative from the concrete wire arm
 // alone -- alternatives are in canonical (sorted) order, so selection is
 // order-independent by construction:
 //
-//   pass 0 (literal): Lit alternatives claim their exact values first, so
-//     Lit<"auto"> beats a std::string sibling for the string "auto";
-//   pass 1 (strict): each non-Lit alternative decodes only its exact wire
+//   pass 0 (literal): lit alternatives claim their exact values first, so
+//     lit<"auto"> beats a std::string sibling for the string "auto";
+//   pass 1 (strict): each non-lit alternative decodes only its exact wire
 //     arms (int never satisfies a double alternative);
 //   pass 2 (lenient): the engine's int->float coercion is admitted, for
 //     unions with a float arm but no int arm.
@@ -329,38 +329,38 @@ struct Codec<Lit<Vs...>> {
 // codecs; structurally ambiguous alternatives (two lists) resolve by
 // probing elements.
 template <class... Ts>
-struct Codec<std::variant<Ts...>> {
+struct codec<std::variant<Ts...>> {
   using V = std::variant<Ts...>;
 
-  static void Encode(detail::pb::InboundValue& value_msg, const V& v) {
+  static void encode(detail::pb::InboundValue& value_msg, const V& v) {
     std::visit(
         [&value_msg](const auto& alt) {
           using T = std::decay_t<decltype(alt)>;
-          Codec<T>::Encode(value_msg, alt);
+          codec<T>::encode(value_msg, alt);
         },
         v);
   }
 
-  static V Decode(const detail::pb::BamlOutboundValue& raw) {
-    const auto& v = detail::Unwrap(raw);
+  static V decode(const detail::pb::BamlOutboundValue& raw) {
+    const auto& v = detail::unwrap(raw);
     std::optional<V> out;
-    const bool lit = (TryArm<Ts>(v, out, Pass::kLiteral) || ...);
+    const bool lit = (try_arm<Ts>(v, out, pass::literal) || ...);
     if (!lit) {
-      const bool strict = (TryArm<Ts>(v, out, Pass::kStrict) || ...);
+      const bool strict = (try_arm<Ts>(v, out, pass::strict) || ...);
       if (!strict) {
-        (TryArm<Ts>(v, out, Pass::kLenient) || ...);
+        (try_arm<Ts>(v, out, pass::lenient) || ...);
       }
     }
     if (!out.has_value()) {
-      detail::KindMismatch("union", v);
+      detail::kind_mismatch("union", v);
     }
     return std::move(*out);
   }
 
  private:
-  enum class Pass { kLiteral, kStrict, kLenient };
+  enum class pass { literal, strict, lenient };
 
-  static bool IsIntArm(const detail::pb::BamlOutboundValue& v) {
+  static bool is_int_arm(const detail::pb::BamlOutboundValue& v) {
     if (v.value_case() == detail::pb::BamlOutboundValue::kIntValue) {
       return true;
     }
@@ -370,19 +370,19 @@ struct Codec<std::variant<Ts...>> {
   }
 
   template <class T>
-  static bool TryArm(const detail::pb::BamlOutboundValue& v,
-                     std::optional<V>& out, Pass pass) {
-    if ((pass == Pass::kLiteral) != detail::IsLit<T>::value) {
+  static bool try_arm(const detail::pb::BamlOutboundValue& v,
+                      std::optional<V>& out, pass pass) {
+    if ((pass == pass::literal) != detail::is_lit<T>::value) {
       return false;
     }
-    if (pass == Pass::kStrict && std::is_same<T, double>::value &&
-        IsIntArm(v)) {
+    if (pass == pass::strict && std::is_same<T, double>::value &&
+        is_int_arm(v)) {
       return false;
     }
     try {
-      out.emplace(std::in_place_type<T>, Codec<T>::Decode(v));
+      out.emplace(std::in_place_type<T>, codec<T>::decode(v));
       return true;
-    } catch (const BamlError&) {
+    } catch (const error&) {
       return false;
     }
   }
@@ -393,8 +393,8 @@ namespace detail {
 // Extracts a human-readable message from a thrown BAML value: the `message`
 // field of an error class when present, else the class FQN, else the
 // value's arm name.
-inline std::string ErrorMessageOf(const pb::BamlOutboundValue& raw) {
-  const pb::BamlOutboundValue& v = Unwrap(raw);
+inline std::string error_message_of(const pb::BamlOutboundValue& raw) {
+  const pb::BamlOutboundValue& v = unwrap(raw);
   if (v.value_case() == pb::BamlOutboundValue::kClassValue) {
     const pb::BamlValueClass& cls = v.class_value();
     for (const auto& field : cls.fields()) {
@@ -408,10 +408,10 @@ inline std::string ErrorMessageOf(const pb::BamlOutboundValue& raw) {
   if (v.value_case() == pb::BamlOutboundValue::kStringValue) {
     return v.string_value();
   }
-  return ArmName(v.value_case());
+  return arm_name(v.value_case());
 }
 
-inline std::string JoinTrace(
+inline std::string join_trace(
     const google::protobuf::RepeatedPtrField<std::string>& trace) {
   std::string out;
   for (const std::string& line : trace) {
@@ -424,26 +424,27 @@ inline std::string JoinTrace(
 }
 
 // The FQN of a thrown class value, for class_name() routing.
-inline std::string ThrownClassName(const pb::BamlOutboundValue& raw) {
-  const pb::BamlOutboundValue& v = Unwrap(raw);
+inline std::string thrown_class_name(const pb::BamlOutboundValue& raw) {
+  const pb::BamlOutboundValue& v = unwrap(raw);
   return v.value_case() == pb::BamlOutboundValue::kClassValue
              ? v.class_value().name()
              : std::string();
 }
 
-// The re-encoded thrown value, kept on the exception so BamlError::get<T>()
+// The re-encoded thrown value, kept on the exception so error::get<T>()
 // can decode it as a typed value later.
-inline std::vector<uint8_t> RawPayload(const pb::BamlOutboundValue& v) {
+inline std::vector<uint8_t> raw_payload(const pb::BamlOutboundValue& v) {
   const std::string bytes = v.SerializeAsString();
   return std::vector<uint8_t>(bytes.begin(), bytes.end());
 }
 
-[[noreturn]] inline void ThrowFromResult(const pb::BamlOutboundResult& result) {
+[[noreturn]] inline void throw_from_result(
+    const pb::BamlOutboundResult& result) {
   const bool is_panic = result.result_case() == pb::BamlOutboundResult::kPanic;
   const pb::BamlOutboundValue& value =
       is_panic ? result.panic().value() : result.error().value();
-  std::string class_name = ThrownClassName(value);
-  std::string message = ErrorMessageOf(value);
+  std::string class_name = thrown_class_name(value);
+  std::string message = error_message_of(value);
 
   if (is_panic) {
     if (result.panic().is_exit_panic()) {
@@ -451,69 +452,71 @@ inline std::vector<uint8_t> RawPayload(const pb::BamlOutboundValue& v) {
       // (parity with Python's os._exit path).
       std::_Exit(static_cast<int>(result.panic().exit_code()));
     }
-    std::string trace = JoinTrace(result.panic().trace());
+    std::string trace = join_trace(result.panic().trace());
     if (class_name == "baml.panics.Cancelled") {
-      throw BamlCancelled(std::move(message), class_name, std::move(trace),
-                          RawPayload(value));
+      throw cancelled(std::move(message), class_name, std::move(trace),
+                      raw_payload(value));
     }
-    throw BamlPanic(std::move(message), class_name, std::move(trace),
-                    RawPayload(value));
+    throw panic(std::move(message), class_name, std::move(trace),
+                raw_payload(value));
   }
-  throw BamlError(std::move(message), class_name,
-                  JoinTrace(result.error().trace()), RawPayload(value));
+  throw error(std::move(message), class_name,
+              join_trace(result.error().trace()), raw_payload(value));
 }
 
-inline pb::BamlOutboundResult ParseResultEnvelope(
+inline pb::BamlOutboundResult parse_result_envelope(
     const std::vector<uint8_t>& envelope) {
   pb::BamlOutboundResult result;
   if (!result.ParseFromArray(envelope.data(),
                              static_cast<int>(envelope.size()))) {
-    throw BamlError("BAML decode error: malformed result envelope");
+    throw error("BAML decode error: malformed result envelope");
   }
   if (result.result_case() == pb::BamlOutboundResult::RESULT_NOT_SET) {
-    throw BamlError("BAML decode error: result envelope has no arm");
+    throw error("BAML decode error: result envelope has no arm");
   }
   return result;
 }
 
 // The typed error path: when the error arm's value decodes into the
-// function's declared `throws` union, throw BamlThrown<ThrownU> carrying
+// function's declared `throws` union, throw thrown<ThrownU> carrying
 // the typed payload. Anything else (undeclared throw, panic, exit) falls
-// through to the untyped ThrowFromResult.
+// through to the untyped throw_from_result.
 template <typename ThrownU>
-[[noreturn]] void ThrowFromResultTyped(const pb::BamlOutboundResult& result) {
+[[noreturn]] void throw_from_result_typed(
+    const pb::BamlOutboundResult& result) {
   if (result.result_case() == pb::BamlOutboundResult::kError) {
     const pb::BamlOutboundValue& value = result.error().value();
     std::optional<ThrownU> decoded;
     try {
-      decoded.emplace(Codec<ThrownU>::Decode(value));
-    } catch (const BamlError&) {
+      decoded.emplace(codec<ThrownU>::decode(value));
+    } catch (const error&) {
       // Not in the declared set: untyped fallback below.
     }
     if (decoded.has_value()) {
-      throw BamlThrown<ThrownU>(
-          std::move(*decoded), ErrorMessageOf(value), ThrownClassName(value),
-          JoinTrace(result.error().trace()), RawPayload(value));
+      throw thrown<ThrownU>(std::move(*decoded), error_message_of(value),
+                            thrown_class_name(value),
+                            join_trace(result.error().trace()),
+                            raw_payload(value));
     }
   }
-  ThrowFromResult(result);
+  throw_from_result(result);
 }
 
 // Decodes a BamlOutboundResult envelope into T. Non-ok arms throw:
-// BamlThrown<ThrownU> for declared throws (when ThrownU is not void),
-// else BamlError / BamlPanic / BamlCancelled.
+// thrown<ThrownU> for declared throws (when ThrownU is not void),
+// else error / panic / cancelled.
 template <typename T, typename ThrownU = void>
-T DecodeResult(const std::vector<uint8_t>& envelope) {
-  pb::BamlOutboundResult result = ParseResultEnvelope(envelope);
+T decode_result(const std::vector<uint8_t>& envelope) {
+  pb::BamlOutboundResult result = parse_result_envelope(envelope);
   if (result.result_case() != pb::BamlOutboundResult::kOk) {
     if constexpr (std::is_void<ThrownU>::value) {
-      ThrowFromResult(result);
+      throw_from_result(result);
     } else {
-      ThrowFromResultTyped<ThrownU>(result);
+      throw_from_result_typed<ThrownU>(result);
     }
   }
   if constexpr (!std::is_void<T>::value) {
-    return Codec<T>::Decode(result.ok());
+    return codec<T>::decode(result.ok());
   }
 }
 
@@ -523,21 +526,21 @@ T DecodeResult(const std::vector<uint8_t>& envelope) {
 // envelope carried. Declared in errors.h; defined here because decoding
 // needs the codec.
 template <typename T>
-T BamlError::get() const {
+T error::get() const {
   detail::pb::BamlOutboundValue value;
   if (!value.ParseFromArray(payload().data(),
                             static_cast<int>(payload().size()))) {
-    throw BamlError("BAML decode error: malformed error payload");
+    throw error("BAML decode error: malformed error payload");
   }
-  return Codec<T>::Decode(value);
+  return codec<T>::decode(value);
 }
 
 template <typename T>
-bool BamlError::is() const {
+bool error::is() const {
   try {
     (void)get<T>();
     return true;
-  } catch (const BamlError&) {
+  } catch (const error&) {
     return false;
   }
 }

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/call.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/call.h
@@ -3,8 +3,8 @@
 
 // The call drivers generated bindings sit on: encode CallFunctionArgs,
 // cross the C ABI once, and correlate the result envelope through the
-// registry. StartCall returns the in-flight call as a baml::Future; the
-// synchronous form is exactly StartCall + an immediate blocking get(), so
+// registry. start_call returns the in-flight call as a baml::future; the
+// synchronous form is exactly start_call + an immediate blocking get(), so
 // both spellings share one code path.
 
 #include <baml/codec.h>
@@ -20,23 +20,23 @@
 namespace baml {
 namespace detail {
 
-// ThrownU is the function's declared `throws` set as a baml::Union (void
+// ThrownU is the function's declared `throws` set as a baml::variant (void
 // when the function declares none): the error arm then surfaces as
-// BamlThrown<ThrownU> instead of an untyped BamlError.
+// thrown<ThrownU> instead of an untyped error.
 template <typename Ret, typename ThrownU = void>
-Future<Ret, ThrownU> StartCall(const std::string& fqn, ArgsEncoder&& args) {
-  CallRegistry::Started started = CallRegistry::Instance().Begin();
-  const uint64_t engine_call_id = Api().new_function_call();
-  const std::string encoded = args.Finish(engine_call_id);
-  Api().call_function(fqn.c_str(),
+future<Ret, ThrownU> start_call(const std::string& fqn, args_encoder&& args) {
+  call_registry::started started = call_registry::instance().begin();
+  const uint64_t engine_call_id = api().new_function_call();
+  const std::string encoded = args.finish(engine_call_id);
+  api().call_function(fqn.c_str(),
                       reinterpret_cast<const uint8_t*>(encoded.data()),
                       encoded.size(), started.correlation_id);
-  return Future<Ret, ThrownU>(std::move(started.state), engine_call_id);
+  return future<Ret, ThrownU>(std::move(started.state), engine_call_id);
 }
 
 template <typename Ret, typename ThrownU = void>
-Ret CallSync(const std::string& fqn, ArgsEncoder&& args) {
-  return StartCall<Ret, ThrownU>(fqn, std::move(args)).get();
+Ret call_sync(const std::string& fqn, args_encoder&& args) {
+  return start_call<Ret, ThrownU>(fqn, std::move(args)).get();
 }
 
 }  // namespace detail

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/loader.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/loader.h
@@ -6,7 +6,7 @@
 // contract. Every C-ABI call goes through the returned BamlApiV1 table.
 //
 // Resolution order (contract "Canonical runtime-resolution algorithm"):
-//   1. Programmatic path set via baml::SetRuntimePath before first load.
+//   1. Programmatic path set via baml::set_runtime_path before first load.
 //   2. BAML_RUNTIME_PATH (compatibility alias: BAML_LIBRARY_PATH; both set
 //      to different values is BAML_RUNTIME_CONFIG_CONFLICT).
 //   3. Executable-adjacent library (application-bundled delivery).
@@ -46,10 +46,10 @@ namespace baml {
 // Structured runtime-loading failure (contract "Standard error and
 // remediation contract"). code() is the stable machine identity; what()
 // carries the rendered message with searched paths and remediation.
-class RuntimeError : public BamlError {
+class runtime_error : public error {
  public:
-  RuntimeError(std::string code, const std::string& message)
-      : BamlError(code + ": " + message), code_(std::move(code)) {}
+  runtime_error(std::string code, const std::string& message)
+      : error(code + ": " + message), code_(std::move(code)) {}
 
   const std::string& code() const { return code_; }
 
@@ -60,7 +60,7 @@ class RuntimeError : public BamlError {
 namespace detail {
 
 // The canonical target triple this translation unit was compiled for.
-inline const char* CanonicalTarget() {
+inline const char* canonical_target() {
 #if defined(__APPLE__) && defined(__aarch64__)
   return "aarch64-apple-darwin";
 #elif defined(__APPLE__) && defined(__x86_64__)
@@ -88,7 +88,7 @@ inline const char* CanonicalTarget() {
 
 // The canonical runtime filename for this platform (contract "Native
 // filenames").
-inline const char* RuntimeFilename() {
+inline const char* runtime_filename() {
 #if defined(_WIN32)
   return "bridge_cffi.dll";
 #elif defined(__APPLE__)
@@ -98,13 +98,13 @@ inline const char* RuntimeFilename() {
 #endif
 }
 
-inline std::string EnvOrEmpty(const char* name) {
+inline std::string env_or_empty(const char* name) {
   const char* v = std::getenv(name);
   return v == nullptr ? std::string() : std::string(v);
 }
 
 // Directory containing the running executable, or empty when undeterminable.
-inline std::string ExecutableDir() {
+inline std::string executable_dir() {
 #if defined(_WIN32)
   char buf[MAX_PATH];
   const DWORD n = GetModuleFileNameA(nullptr, buf, MAX_PATH);
@@ -132,7 +132,7 @@ inline std::string ExecutableDir() {
   return slash == std::string::npos ? std::string() : path.substr(0, slash);
 }
 
-inline bool FileExists(const std::string& path) {
+inline bool file_exists(const std::string& path) {
 #if defined(_WIN32)
   const DWORD attrs = GetFileAttributesA(path.c_str());
   return attrs != INVALID_FILE_ATTRIBUTES &&
@@ -143,11 +143,11 @@ inline bool FileExists(const std::string& path) {
 }
 
 // Shared runtime cache path for `version` (contract "Runtime cache layout").
-inline std::string CachePath(const std::string& version) {
-  std::string root = EnvOrEmpty("BAML_RUNTIME_CACHE_DIR");
-  const std::string alias = EnvOrEmpty("BAML_CACHE_DIR");
+inline std::string cache_path(const std::string& version) {
+  std::string root = env_or_empty("BAML_RUNTIME_CACHE_DIR");
+  const std::string alias = env_or_empty("BAML_CACHE_DIR");
   if (!root.empty() && !alias.empty() && root != alias) {
-    throw RuntimeError(
+    throw runtime_error(
         "BAML_RUNTIME_CONFIG_CONFLICT",
         "BAML_RUNTIME_CACHE_DIR and BAML_CACHE_DIR are both set and differ");
   }
@@ -155,12 +155,12 @@ inline std::string CachePath(const std::string& version) {
     root = alias;
   }
   if (root.empty()) {
-    std::string home = EnvOrEmpty("BAML_HOME");
+    std::string home = env_or_empty("BAML_HOME");
     if (home.empty()) {
 #if defined(_WIN32)
-      home = EnvOrEmpty("USERPROFILE");
+      home = env_or_empty("USERPROFILE");
 #else
-      home = EnvOrEmpty("HOME");
+      home = env_or_empty("HOME");
 #endif
       if (home.empty()) {
         return std::string();
@@ -169,23 +169,23 @@ inline std::string CachePath(const std::string& version) {
     }
     root = home + "/runtimes";
   }
-  return root + "/prod/" + version + "/abi-v1/" + CanonicalTarget() + "/" +
-         RuntimeFilename();
+  return root + "/prod/" + version + "/abi-v1/" + canonical_target() + "/" +
+         runtime_filename();
 }
 
 // Programmatic runtime path (contract precedence step 2, after one-way env
 // safety controls). Set-before-load only.
-inline std::string& ProgrammaticPathStorage() {
+inline std::string& programmatic_path_storage() {
   static std::string path;
   return path;
 }
 
-inline bool& ApiLoadedFlag() {
+inline bool& api_loaded_flag() {
   static bool loaded = false;
   return loaded;
 }
 
-inline void* OpenLibrary(const std::string& path, std::string& error) {
+inline void* open_library(const std::string& path, std::string& error) {
 #if defined(_WIN32)
   HMODULE handle = LoadLibraryA(path.c_str());
   if (handle == nullptr) {
@@ -202,7 +202,7 @@ inline void* OpenLibrary(const std::string& path, std::string& error) {
 #endif
 }
 
-inline void* ResolveSymbol(void* library, const char* name) {
+inline void* resolve_symbol(void* library, const char* name) {
 #if defined(_WIN32)
   return reinterpret_cast<void*>(
       GetProcAddress(reinterpret_cast<HMODULE>(library), name));
@@ -211,14 +211,14 @@ inline void* ResolveSymbol(void* library, const char* name) {
 #endif
 }
 
-struct LoadedApi {
+struct loaded_api {
   const BamlApiV1* table = nullptr;
 };
 
 // Loads the runtime and resolves the v1 table. Runs once; throws
-// RuntimeError on every failure path.
-inline const LoadedApi& LoadApi() {
-  static const LoadedApi loaded = [] {
+// runtime_error on every failure path.
+inline const loaded_api& load_api() {
+  static const loaded_api loaded = [] {
     // Candidate paths in contract order. The version used for the cache
     // path is the SDK's expected version when registration has provided
     // one; before that the cache probe is skipped (steps 1-3 don't need
@@ -226,11 +226,11 @@ inline const LoadedApi& LoadApi() {
     std::vector<std::string> searched;
     std::string chosen;
 
-    const std::string programmatic = ProgrammaticPathStorage();
-    const std::string env_path = EnvOrEmpty("BAML_RUNTIME_PATH");
-    const std::string alias_path = EnvOrEmpty("BAML_LIBRARY_PATH");
+    const std::string programmatic = programmatic_path_storage();
+    const std::string env_path = env_or_empty("BAML_RUNTIME_PATH");
+    const std::string alias_path = env_or_empty("BAML_LIBRARY_PATH");
     if (!env_path.empty() && !alias_path.empty() && env_path != alias_path) {
-      throw RuntimeError(
+      throw runtime_error(
           "BAML_RUNTIME_CONFIG_CONFLICT",
           "BAML_RUNTIME_PATH and BAML_LIBRARY_PATH are both set and differ");
     }
@@ -240,21 +240,21 @@ inline const LoadedApi& LoadApi() {
     } else if (!env_path.empty() || !alias_path.empty()) {
       chosen = env_path.empty() ? alias_path : env_path;
     } else {
-      const std::string exe_dir = ExecutableDir();
+      const std::string exe_dir = executable_dir();
       if (!exe_dir.empty()) {
-        const std::string adjacent = exe_dir + "/" + RuntimeFilename();
-        if (FileExists(adjacent)) {
+        const std::string adjacent = exe_dir + "/" + runtime_filename();
+        if (file_exists(adjacent)) {
           chosen = adjacent;
         } else {
           searched.push_back(adjacent);
         }
       }
       if (chosen.empty()) {
-        const std::string version = EnvOrEmpty("BAML_RUNTIME_VERSION");
+        const std::string version = env_or_empty("BAML_RUNTIME_VERSION");
         if (!version.empty()) {
-          const std::string cached = CachePath(version);
+          const std::string cached = cache_path(version);
           if (!cached.empty()) {
-            if (FileExists(cached)) {
+            if (file_exists(cached)) {
               chosen = cached;
             } else {
               searched.push_back(cached);
@@ -266,7 +266,7 @@ inline const LoadedApi& LoadApi() {
 
     if (chosen.empty()) {
       std::string message = "no BAML runtime found for target " +
-                            std::string(CanonicalTarget()) + ".";
+                            std::string(canonical_target()) + ".";
       if (searched.empty()) {
         message += " No candidate locations were configured.";
       } else {
@@ -278,21 +278,21 @@ inline const LoadedApi& LoadApi() {
       message +=
           "\nRun `baml runtime install`, set BAML_RUNTIME_PATH, or bundle "
           "the runtime next to the executable.";
-      throw RuntimeError("BAML_RUNTIME_NOT_FOUND", message);
+      throw runtime_error("BAML_RUNTIME_NOT_FOUND", message);
     }
 
     std::string load_error;
-    void* library = OpenLibrary(chosen, load_error);
+    void* library = open_library(chosen, load_error);
     if (library == nullptr) {
-      throw RuntimeError("BAML_RUNTIME_LOAD_FAILED",
-                         chosen + ": " + load_error);
+      throw runtime_error("BAML_RUNTIME_LOAD_FAILED",
+                          chosen + ": " + load_error);
     }
 
-    using GetApiFn = const BamlApiV1* (*)();
-    auto get_api =
-        reinterpret_cast<GetApiFn>(ResolveSymbol(library, "baml_get_api_v1"));
+    using get_api_fn = const BamlApiV1* (*)();
+    auto get_api = reinterpret_cast<get_api_fn>(
+        resolve_symbol(library, "baml_get_api_v1"));
     if (get_api == nullptr) {
-      throw RuntimeError(
+      throw runtime_error(
           "BAML_RUNTIME_ABI_MISMATCH",
           chosen +
               " does not export baml_get_api_v1; it is not a BAML "
@@ -301,45 +301,45 @@ inline const LoadedApi& LoadApi() {
     const BamlApiV1* table = get_api();
     if (table == nullptr || table->abi_version != 1 ||
         table->struct_size < sizeof(BamlApiV1)) {
-      throw RuntimeError("BAML_RUNTIME_ABI_MISMATCH",
-                         "expected ABI v1 table of at least " +
-                             std::to_string(sizeof(BamlApiV1)) +
-                             " bytes from " + chosen);
+      throw runtime_error("BAML_RUNTIME_ABI_MISMATCH",
+                          "expected ABI v1 table of at least " +
+                              std::to_string(sizeof(BamlApiV1)) +
+                              " bytes from " + chosen);
     }
 
-    ApiLoadedFlag() = true;
+    api_loaded_flag() = true;
     // The library handle is deliberately dropped: the runtime is never
     // dlclosed (engine threads may outlive any unload point).
-    return LoadedApi{table};
+    return loaded_api{table};
   }();
   return loaded;
 }
 
 // The resolved v1 function table. Loads the runtime on first use.
-inline const BamlApiV1& Api() { return *LoadApi().table; }
+inline const BamlApiV1& api() { return *load_api().table; }
 
 // Registers this bridge (language + canonical SDK version) with the loaded
 // runtime; the contract-required first semantic operation. Idempotent.
 // A non-empty diagnostic from the runtime (version mismatch, conflicting
 // registration) throws with the runtime's shared message preserved.
-inline void EnsureRegistered(const char* sdk_version) {
+inline void ensure_registered(const char* sdk_version) {
   static std::once_flag flag;
   std::call_once(flag, [sdk_version] {
-    const BamlApiV1& api = Api();
+    const BamlApiV1& table = api();
     const std::string version(sdk_version);
     BamlBridgeInfoV1 info;
     info.struct_size = sizeof(BamlBridgeInfoV1);
     info.language = BAML_BRIDGE_LANGUAGE_CPP;
     info.sdk_version = reinterpret_cast<const uint8_t*>(version.data());
     info.sdk_version_len = version.size();
-    BamlBuffer diagnostic = api.register_bridge(&info);
+    BamlBuffer diagnostic = table.register_bridge(&info);
     if (diagnostic.ptr != nullptr && diagnostic.len != 0) {
       std::string message(reinterpret_cast<const char*>(diagnostic.ptr),
                           diagnostic.len);
-      api.free_buffer(diagnostic);
-      throw RuntimeError("BAML_RUNTIME_VERSION_MISMATCH", message);
+      table.free_buffer(diagnostic);
+      throw runtime_error("BAML_RUNTIME_VERSION_MISMATCH", message);
     }
-    api.free_buffer(diagnostic);
+    table.free_buffer(diagnostic);
   });
 }
 
@@ -347,12 +347,12 @@ inline void EnsureRegistered(const char* sdk_version) {
 
 // Points the loader at an explicit runtime library. Must be called before
 // the first BAML operation; afterwards the configuration is frozen.
-inline void SetRuntimePath(const std::string& path) {
-  if (detail::ApiLoadedFlag()) {
-    throw RuntimeError("BAML_RUNTIME_ALREADY_LOADED",
-                       "SetRuntimePath called after the runtime was loaded");
+inline void set_runtime_path(const std::string& path) {
+  if (detail::api_loaded_flag()) {
+    throw runtime_error("BAML_RUNTIME_ALREADY_LOADED",
+                        "set_runtime_path called after the runtime was loaded");
   }
-  detail::ProgrammaticPathStorage() = path;
+  detail::programmatic_path_storage() = path;
 }
 
 }  // namespace baml

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/proto.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/proto.h
@@ -3,9 +3,9 @@
 
 // The typed wire layer over the generated protobuf-lite bindings for the
 // bridge_ctypes CFFI schemas (checked-in under bridge_cpp/pb/, pinned to
-// the repo's vendored protoc). ArgsEncoder builds one CallFunctionArgs;
+// the repo's vendored protoc). args_encoder builds one CallFunctionArgs;
 // the helpers here normalize outbound values (union unwrap, arm naming)
-// for the Codec layer. Copies are deliberate and visible (contract:
+// for the codec layer. Copies are deliberate and visible (contract:
 // coarse-grained boundary, measurable copies).
 
 #include <cstdint>
@@ -20,7 +20,7 @@ namespace detail {
 namespace pb = ::baml_bridge::cffi::v1;
 
 // Human-readable arm name for decode diagnostics.
-inline const char* ArmName(pb::BamlOutboundValue::ValueCase c) {
+inline const char* arm_name(pb::BamlOutboundValue::ValueCase c) {
   switch (c) {
     case pb::BamlOutboundValue::kNullValue:
     case pb::BamlOutboundValue::VALUE_NOT_SET:
@@ -61,10 +61,10 @@ inline const char* ArmName(pb::BamlOutboundValue::ValueCase c) {
   return "?";
 }
 
-// Union variants carry metadata the C++ surface drops (Python parity):
+// variant variants carry metadata the C++ surface drops (Python parity):
 // resolve to the innermost non-union value. A variant with no inner value
 // resolves to the default instance, whose arm is VALUE_NOT_SET (= null).
-inline const pb::BamlOutboundValue& Unwrap(const pb::BamlOutboundValue& v) {
+inline const pb::BamlOutboundValue& unwrap(const pb::BamlOutboundValue& v) {
   const pb::BamlOutboundValue* cur = &v;
   while (cur->value_case() == pb::BamlOutboundValue::kUnionVariantValue) {
     cur = &cur->union_variant_value().value();
@@ -73,19 +73,19 @@ inline const pb::BamlOutboundValue& Unwrap(const pb::BamlOutboundValue& v) {
 }
 
 // Builds one CallFunctionArgs message: kwargs entries are filled via the
-// value-writer callbacks that Codec<T>::Encode provides, then Finish()
+// value-writer callbacks that codec<T>::encode provides, then finish()
 // stamps the engine call id and serializes.
-class ArgsEncoder {
+class args_encoder {
  public:
   // `write_value` fills the InboundValue for this argument.
   template <typename WriteValue>
-  void AddArg(const std::string& name, WriteValue&& write_value) {
+  void add_arg(const std::string& name, WriteValue&& write_value) {
     pb::InboundMapEntry* entry = args_.add_kwargs();
     entry->set_string_key(name);
     write_value(*entry->mutable_value());
   }
 
-  std::string Finish(uint64_t call_id) {
+  std::string finish(uint64_t call_id) {
     args_.set_call_id(call_id);
     return args_.SerializeAsString();
   }

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/registry.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/registry.h
@@ -24,13 +24,13 @@ namespace baml {
 namespace detail {
 
 // Per-call completion state shared between the issuing thread (via
-// baml::Future) and the engine callback thread. A plain mutex/condvar cell
+// baml::future) and the engine callback thread. A plain mutex/condvar cell
 // rather than std::promise so a continuation can run at fulfillment time:
 // std::future has no completion hook, and the co_await awaiter needs the
 // dispatcher thread to resume the suspended coroutine when the envelope
 // lands. The continuation is a C++17-clean function pointer (the coroutine
 // glue lives behind the feature-gate in future.h).
-struct CallState {
+struct call_state {
   std::mutex mu;
   std::condition_variable cv;
   bool ready = false;
@@ -41,7 +41,7 @@ struct CallState {
   // Called from the engine callback thread. Publishes the envelope, wakes
   // blocked waiters, and runs the registered continuation (outside the
   // lock: it may resume a coroutine that immediately touches this state).
-  void Fulfill(const uint8_t* bytes, size_t length) {
+  void fulfill(const uint8_t* bytes, size_t length) {
     void (*resume)(void*) = nullptr;
     void* resume_arg = nullptr;
     {
@@ -58,15 +58,15 @@ struct CallState {
   }
 
   // Blocks until the envelope arrives. The reference stays valid for the
-  // life of this state; only Fulfill writes it, exactly once.
-  const std::vector<uint8_t>& Wait() {
+  // life of this state; only fulfill writes it, exactly once.
+  const std::vector<uint8_t>& wait() {
     std::unique_lock<std::mutex> lock(mu);
     cv.wait(lock, [this] { return ready; });
     return envelope;
   }
 
   template <class Clock, class Duration>
-  bool WaitUntil(const std::chrono::time_point<Clock, Duration>& deadline) {
+  bool wait_until(const std::chrono::time_point<Clock, Duration>& deadline) {
     std::unique_lock<std::mutex> lock(mu);
     return cv.wait_until(lock, deadline, [this] { return ready; });
   }
@@ -74,39 +74,39 @@ struct CallState {
 
 // Correlates async results with in-flight calls. The C ABI has exactly one
 // process-global result callback; this registry owns it and fans results
-// out to per-call CallState cells keyed by a bridge-issued correlation id.
-class CallRegistry {
+// out to per-call call_state cells keyed by a bridge-issued correlation id.
+class call_registry {
  public:
-  struct Started {
+  struct started {
     uint32_t correlation_id;
-    std::shared_ptr<CallState> state;
+    std::shared_ptr<call_state> state;
   };
 
-  static CallRegistry& Instance() {
+  static call_registry& instance() {
     // Intentionally leaked (never destroyed): engine callback threads may
     // fire during process teardown, after static destructors would have
     // run a function-local static's destructor.
-    static CallRegistry* registry = new CallRegistry();
+    static call_registry* registry = new call_registry();
     return *registry;
   }
 
-  Started Begin() {
+  started begin() {
     uint32_t id = next_id_.fetch_add(1, std::memory_order_relaxed);
     if (id == 0) {
       id = next_id_.fetch_add(1, std::memory_order_relaxed);
     }
-    auto state = std::make_shared<CallState>();
+    auto state = std::make_shared<call_state>();
     {
       std::lock_guard<std::mutex> lock(mu_);
       pending_.emplace(id, state);
     }
-    return Started{id, std::move(state)};
+    return started{id, std::move(state)};
   }
 
   // Called from the C callback, on an engine thread. The payload is only
   // valid for the duration of the call, so it is copied out here.
-  void Complete(uint32_t call_id, const int8_t* content, size_t length) {
-    std::shared_ptr<CallState> state;
+  void complete(uint32_t call_id, const int8_t* content, size_t length) {
+    std::shared_ptr<call_state> state;
     {
       std::lock_guard<std::mutex> lock(mu_);
       auto it = pending_.find(call_id);
@@ -118,14 +118,14 @@ class CallRegistry {
       state = std::move(it->second);
       pending_.erase(it);
     }
-    state->Fulfill(reinterpret_cast<const uint8_t*>(content), length);
+    state->fulfill(reinterpret_cast<const uint8_t*>(content), length);
   }
 
  private:
-  CallRegistry() { Api().register_callback(&baml_cpp_result_trampoline); }
+  call_registry() { api().register_callback(&baml_cpp_result_trampoline); }
 
   std::mutex mu_;
-  std::unordered_map<uint32_t, std::shared_ptr<CallState>> pending_;
+  std::unordered_map<uint32_t, std::shared_ptr<call_state>> pending_;
   std::atomic<uint32_t> next_id_{1};
 };
 
@@ -137,7 +137,7 @@ extern "C" inline void baml_cpp_result_trampoline(uint32_t call_id,
                                                   size_t length) {
   // No C++ exception may cross the C ABI (bridge contract).
   try {
-    baml::detail::CallRegistry::Instance().Complete(call_id, content, length);
+    baml::detail::call_registry::instance().complete(call_id, content, length);
   } catch (...) {
   }
 }

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/errors.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/errors.h
@@ -12,13 +12,13 @@ namespace baml {
 // A value thrown by BAML code (the `error` arm of the result envelope).
 // what() carries the rendered message plus the BAML trace; the thrown value
 // itself rides along as encoded bytes and decodes via is<T>() / get<T>().
-class BamlError : public std::runtime_error {
+class error : public std::runtime_error {
  public:
-  explicit BamlError(std::string message)
-      : BamlError(std::move(message), std::string(), std::string(), {}) {}
+  explicit error(std::string message)
+      : error(std::move(message), std::string(), std::string(), {}) {}
 
-  BamlError(std::string message, std::string class_name, std::string baml_trace,
-            std::vector<uint8_t> payload)
+  error(std::string message, std::string class_name, std::string baml_trace,
+        std::vector<uint8_t> payload)
       : std::runtime_error(Render(message, baml_trace)),
         message_(std::move(message)),
         class_name_(std::move(class_name)),
@@ -50,35 +50,35 @@ class BamlError : public std::runtime_error {
 };
 
 // The `panic` arm: an engine invariant failure, not a user-thrown value.
-class BamlPanic : public BamlError {
+class panic : public error {
  public:
-  using BamlError::BamlError;
+  using error::error;
 };
 
 // A thrown BAML value decoded into the function's declared `throws` set:
-// generated bindings throw BamlThrown<baml::Union<A, B>> when the error
+// generated bindings throw thrown<baml::variant<A, B>> when the error
 // arm decodes into that set, so a catch site reads the typed payload with
 // baml::match instead of probing is<T>()/get<T>(). The template argument
-// is order-canonical (baml::Union), so BamlThrown<Union<A, B>> and
-// BamlThrown<Union<B, A>> are the same catchable type. Derives BamlError:
+// is order-canonical (baml::variant), so thrown<variant<A, B>> and
+// thrown<variant<B, A>> are the same catchable type. Derives error:
 // untyped catch sites keep working, and an undeclared thrown value (one
-// outside the declared set) still surfaces as a plain BamlError.
+// outside the declared set) still surfaces as a plain error.
 template <class U>
-class BamlThrown : public BamlError {
+class thrown : public error {
  public:
-  BamlThrown(U thrown, std::string message, std::string class_name,
-             std::string baml_trace, std::vector<uint8_t> payload)
-      : BamlError(std::move(message), std::move(class_name),
-                  std::move(baml_trace), std::move(payload)),
+  thrown(U thrown, std::string message, std::string class_name,
+         std::string baml_trace, std::vector<uint8_t> payload)
+      : error(std::move(message), std::move(class_name), std::move(baml_trace),
+              std::move(payload)),
         value(std::move(thrown)) {}
 
   U value;
 };
 
 // Cancellation surfaces as the engine panic `baml.panics.Cancelled`.
-class BamlCancelled : public BamlPanic {
+class cancelled : public panic {
  public:
-  using BamlPanic::BamlPanic;
+  using panic::panic;
 };
 
 }  // namespace baml

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/future.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/future.h
@@ -1,30 +1,30 @@
 #ifndef BAML_FUTURE_H_
 #define BAML_FUTURE_H_
 
-// baml::Future<T, ThrownU>: handle to an in-flight async BAML call.
+// baml::future<T, ThrownU>: handle to an in-flight async BAML call.
 //
 // get() blocks until the result envelope arrives and decodes it exactly
 // like the synchronous form: the ok arm returns T, declared throws arrive
-// as BamlThrown<ThrownU> (ThrownU is the function's `throws` set as a
-// baml::Union; void when none is declared), panics as BamlPanic. get()
+// as thrown<ThrownU> (ThrownU is the function's `throws` set as a
+// baml::variant; void when none is declared), panics as panic. get()
 // consumes the future, std::future-style: a second get() (or a get() on a
 // moved-from future) throws std::future_error.
 //
-// Cancel() requests engine-side cancellation of the in-flight call and
+// cancel() requests engine-side cancellation of the in-flight call and
 // returns false if the call is unknown or already completed. The result
 // envelope still arrives - as a baml.panics.Cancelled panic - and get()
-// then throws BamlCancelled. Destruction detaches: it never blocks and
+// then throws cancelled. Destruction detaches: it never blocks and
 // never cancels, matching the Python task model.
 //
-// Under C++20 a Future is co_await-able: `co_await std::move(f)` suspends
+// Under C++20 a future is co_await-able: `co_await std::move(f)` suspends
 // without blocking a thread and resumes when the envelope arrives, with
 // get()'s exact value/throw semantics. The coroutine resumes ON THE BRIDGE
 // DISPATCHER THREAD; code after co_await must not block it (offload long
 // work to your own executor). The awaiter is feature-gated so this header
 // stays C++17-clean.
 //
-// Naming follows STYLE.md carve-out 2: get/wait/wait_for/wait_until/valid
-// mirror std::future and are std-cased; Cancel is our own operation.
+// The surface mirrors std::future (get/wait/wait_for/wait_until/valid)
+// plus cancel and call_id.
 
 #include <baml/codec.h>
 #include <baml/detail/loader.h>
@@ -47,27 +47,27 @@
 namespace baml {
 
 template <typename T, typename ThrownU = void>
-class Future {
+class future {
  public:
-  Future(std::shared_ptr<detail::CallState> state, uint64_t engine_call_id)
+  future(std::shared_ptr<detail::call_state> state, uint64_t engine_call_id)
       : state_(std::move(state)), engine_call_id_(engine_call_id) {}
 
-  Future(Future&&) noexcept = default;
-  Future& operator=(Future&&) noexcept = default;
-  Future(const Future&) = delete;
-  Future& operator=(const Future&) = delete;
+  future(future&&) noexcept = default;
+  future& operator=(future&&) noexcept = default;
+  future(const future&) = delete;
+  future& operator=(const future&) = delete;
 
   // Blocks until the result envelope arrives, then decodes it. Consumes
   // the future.
   T get() {
-    std::shared_ptr<detail::CallState> state = TakeState();
-    return detail::DecodeResult<T, ThrownU>(state->Wait());
+    std::shared_ptr<detail::call_state> state = take_state();
+    return detail::decode_result<T, ThrownU>(state->wait());
   }
 
   // Blocks until the result arrives without consuming the future.
   void wait() const {
-    RequireState();
-    state_->Wait();
+    require_state();
+    state_->wait();
   }
 
   template <class Rep, class Period>
@@ -79,9 +79,9 @@ class Future {
   template <class Clock, class Duration>
   std::future_status wait_until(
       const std::chrono::time_point<Clock, Duration>& deadline) const {
-    RequireState();
-    return state_->WaitUntil(deadline) ? std::future_status::ready
-                                       : std::future_status::timeout;
+    require_state();
+    return state_->wait_until(deadline) ? std::future_status::ready
+                                        : std::future_status::timeout;
   }
 
   bool valid() const noexcept { return state_ != nullptr; }
@@ -89,16 +89,16 @@ class Future {
   // Requests cancellation of the in-flight call. Returns false if the call
   // is unknown or already completed. The result envelope still arrives (as
   // a Cancelled panic) and get() reports it.
-  bool Cancel() {
+  bool cancel() {
     return state_ != nullptr &&
-           detail::Api().cancel_function_call(engine_call_id_) == 0;
+           detail::api().cancel_function_call(engine_call_id_) == 0;
   }
 
   uint64_t call_id() const noexcept { return engine_call_id_; }
 
 #if defined(BAML_HAS_COROUTINES)
   bool await_ready() const {
-    RequireState();
+    require_state();
     std::lock_guard<std::mutex> lock(state_->mu);
     return state_->ready;
   }
@@ -122,18 +122,18 @@ class Future {
 #endif  // BAML_HAS_COROUTINES
 
  private:
-  void RequireState() const {
+  void require_state() const {
     if (state_ == nullptr) {
       throw std::future_error(std::future_errc::no_state);
     }
   }
 
-  std::shared_ptr<detail::CallState> TakeState() {
-    RequireState();
+  std::shared_ptr<detail::call_state> take_state() {
+    require_state();
     return std::move(state_);
   }
 
-  std::shared_ptr<detail::CallState> state_;
+  std::shared_ptr<detail::call_state> state_;
   uint64_t engine_call_id_ = 0;
 };
 

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/lit.h
@@ -1,12 +1,12 @@
 #ifndef BAML_LIT_H_
 #define BAML_LIT_H_
 
-// baml::Lit<Vs...>: BAML literal types as distinct C++ types (C++17).
+// baml::lit<Vs...>: BAML literal types as distinct C++ types (C++17).
 //
 // BAML literal types are singleton value types: `"draft"`, `42`, `true`,
 // and enum-variant types like `Sentiment.Positive`. Each distinct value is
 // a distinct C++ type, so literal unions dispatch and exhaustively match
-// at compile time exactly like any other baml::Union:
+// at compile time exactly like any other baml::variant:
 //
 //   // status "draft" | "sent" | "paid"
 //   baml::match(invoice.status,
@@ -16,10 +16,10 @@
 //
 // One macro spells them all -- overloaded constexpr helpers classify the
 // argument and normalize its value at compile time:
-//   BAML_LIT("draft")              string  -> Lit<'d','r','a','f','t'>
-//   BAML_LIT(42)                   int     -> Lit<int64_t{42}>
-//   BAML_LIT(true)                 bool    -> Lit<true>
-//   BAML_LIT(Sentiment::Positive)  enum    -> Lit<Sentiment::Positive>
+//   BAML_LIT("draft")              string  -> lit<'d','r','a','f','t'>
+//   BAML_LIT(42)                   int     -> lit<int64_t{42}>
+//   BAML_LIT(true)                 bool    -> lit<true>
+//   BAML_LIT(Sentiment::Positive)  enum    -> lit<Sentiment::Positive>
 //
 // C++17 cannot pass a string literal as a template argument (class-type
 // NTTPs are C++20), so BAML_LIT explodes the literal into a char pack via
@@ -27,19 +27,19 @@
 // 256 characters. Generated code never uses the macro: the emitter spells
 // the char packs directly, at any length.
 //
-// A bare integer must NOT be spelled Lit<1>: template identity includes
+// A bare integer must NOT be spelled lit<1>: template identity includes
 // the parameter's TYPE, and `1` deduces `int`, minting a type distinct
-// from the canonical Lit<int64_t{1}>. The shape check rejects it with a
+// from the canonical lit<int64_t{1}>. The shape check rejects it with a
 // pointer to BAML_LIT(1), whose value normalization canonicalizes the
-// type. (baml::IntLit<1> / baml::BoolLit<true> are macro-free alternates
+// type. (baml::int_lit<1> / baml::bool_lit<true> are macro-free alternates
 // with the same normalization.)
 //
-// Every Lit carries its value statically: `decltype(x)::value` (also
+// Every lit carries its value statically: `decltype(x)::value` (also
 // implicitly convertible), so a catch-all match arm can recover the
 // runtime value: `match(u, [](auto l) { return decltype(l)::value; })`.
 //
 // Possible future representation: identity as an FNV-1a-64 hash NTTP
-// (Lit<0x...>) with an emitter-generated hash->string side-table. That
+// (lit<0x...>) with an emitter-generated hash->string side-table. That
 // would delete the char-pack macro machinery and the length cap, at the
 // cost of unreadable literal types in compiler diagnostics and no ::value
 // for off-schema spellings. Same user-facing API either way; revisit if
@@ -54,66 +54,66 @@
 namespace baml {
 namespace detail {
 
-enum class LitShape { kInvalid, kString, kInt, kBool, kEnum };
+enum class lit_shape { invalid, string, integer, boolean, enumeration };
 
 // A plain alias (template <class T, class...> using Head = T) does not
 // survive pack expansion into its fixed parameter on clang; a struct
 // specialization does.
 template <class... Ts>
-struct LitHead;
+struct lit_head;
 template <class T, class... Rest>
-struct LitHead<T, Rest...> {
+struct lit_head<T, Rest...> {
   using type = T;
 };
 
 template <class... Ts>
-constexpr LitShape LitShapeOf() {
+constexpr lit_shape lit_shape_of() {
   if constexpr ((std::is_same<Ts, char>::value && ...)) {
     // Includes the empty pack: BAML_LIT("") is the empty-string type.
-    return LitShape::kString;
+    return lit_shape::string;
   } else if constexpr (sizeof...(Ts) == 1) {
-    using T = typename LitHead<Ts...>::type;
-    if (std::is_same<T, int64_t>::value) return LitShape::kInt;
-    if (std::is_same<T, bool>::value) return LitShape::kBool;
-    if (std::is_enum<T>::value) return LitShape::kEnum;
-    return LitShape::kInvalid;
+    using T = typename lit_head<Ts...>::type;
+    if (std::is_same<T, int64_t>::value) return lit_shape::integer;
+    if (std::is_same<T, bool>::value) return lit_shape::boolean;
+    if (std::is_enum<T>::value) return lit_shape::enumeration;
+    return lit_shape::invalid;
   } else {
-    return LitShape::kInvalid;
+    return lit_shape::invalid;
   }
 }
 
-template <LitShape S, auto... Vs>
-struct LitBase {
+template <lit_shape S, auto... Vs>
+struct lit_base {
   static_assert(
-      S != LitShape::kInvalid,
-      "unsupported baml::Lit shape. The four literal spellings: "
-      "BAML_LIT(\"...\") for strings; BAML_LIT(n) / baml::IntLit<n> for ints "
-      "(a bare Lit<1> deduces `int`, not int64_t, which would mint a second "
-      "type); BAML_LIT(b) / baml::BoolLit<b> for bools; BAML_LIT(E::V) / "
-      "baml::Lit<E::V> for enum variants");
+      S != lit_shape::invalid,
+      "unsupported baml::lit shape. The four literal spellings: "
+      "BAML_LIT(\"...\") for strings; BAML_LIT(n) / baml::int_lit<n> for ints "
+      "(a bare lit<1> deduces `int`, not int64_t, which would mint a second "
+      "type); BAML_LIT(b) / baml::bool_lit<b> for bools; BAML_LIT(E::V) / "
+      "baml::lit<E::V> for enum variants");
 };
 
 template <auto... Cs>
-struct LitBase<LitShape::kString, Cs...> {
+struct lit_base<lit_shape::string, Cs...> {
   static constexpr char chars[] = {static_cast<char>(Cs)..., '\0'};
   static constexpr std::string_view value{chars, sizeof...(Cs)};
   constexpr operator std::string_view() const { return value; }
 };
 
 template <auto V>
-struct LitBase<LitShape::kInt, V> {
+struct lit_base<lit_shape::integer, V> {
   static constexpr int64_t value = V;
   constexpr operator int64_t() const { return value; }
 };
 
 template <auto V>
-struct LitBase<LitShape::kBool, V> {
+struct lit_base<lit_shape::boolean, V> {
   static constexpr bool value = V;
   constexpr operator bool() const { return value; }
 };
 
 template <auto V>
-struct LitBase<LitShape::kEnum, V> {
+struct lit_base<lit_shape::enumeration, V> {
   static constexpr decltype(V) value = V;
   constexpr operator decltype(V)() const { return value; }
 };
@@ -121,44 +121,44 @@ struct LitBase<LitShape::kEnum, V> {
 }  // namespace detail
 
 template <auto... Vs>
-struct Lit : detail::LitBase<detail::LitShapeOf<decltype(Vs)...>(), Vs...> {
-  // Unit type: two values of the same Lit are always equal (memberwise
+struct lit : detail::lit_base<detail::lit_shape_of<decltype(Vs)...>(), Vs...> {
+  // Unit type: two values of the same lit are always equal (memberwise
   // equality of generated structs and variant equality both rely on this).
-  friend constexpr bool operator==(Lit, Lit) { return true; }
-  friend constexpr bool operator!=(Lit, Lit) { return false; }
+  friend constexpr bool operator==(lit, lit) { return true; }
+  friend constexpr bool operator!=(lit, lit) { return false; }
 };
 
 template <int64_t V>
-using IntLit = Lit<V>;
+using int_lit = lit<V>;
 
 template <bool V>
-using BoolLit = Lit<V>;
+using bool_lit = lit<V>;
 
 namespace detail {
 
 template <class T>
-struct IsLit : std::false_type {};
+struct is_lit : std::false_type {};
 template <auto... Vs>
-struct IsLit<Lit<Vs...>> : std::true_type {};
+struct is_lit<lit<Vs...>> : std::true_type {};
 
 // Strips the '\0' padding BAML_LIT's fixed-arity expansion appends, so
-// every spelling of the same string lands on the same Lit instantiation.
+// every spelling of the same string lands on the same lit instantiation.
 // N is sizeof(literal) for the cap check; BAML strings never contain
 // embedded NULs, so the first '\0' is the end.
 template <std::size_t N, char... Cs>
-struct TrimNulls {
+struct trim_nulls {
   static_assert(N <= sizeof...(Cs) + 1,
                 "string literal exceeds BAML_LIT's 256-character cap (name "
                 "the type via decltype of the generated function instead)");
   static constexpr char arr[] = {Cs...};
-  static constexpr std::size_t Length() {
+  static constexpr std::size_t length() {
     std::size_t n = 0;
     while (n < sizeof...(Cs) && arr[n] != '\0') ++n;
     return n;
   }
   template <std::size_t... Is>
-  static Lit<arr[Is]...> Pick(std::index_sequence<Is...>);
-  using type = decltype(Pick(std::make_index_sequence<Length()>{}));
+  static lit<arr[Is]...> pick(std::index_sequence<Is...>);
+  using type = decltype(pick(std::make_index_sequence<length()>{}));
 };
 
 // BAML_LIT(x) argument classification: overload resolution IS the
@@ -166,22 +166,22 @@ struct TrimNulls {
 // must be a literal / constant expression. Bare `char` is deliberately
 // not a literal shape (BAML has no char type; spell the one-char string).
 
-enum class LitArg { kString, kScalar };
+enum class lit_arg { string, scalar };
 
 template <class T>
-constexpr bool kLitScalarArg =
+constexpr bool lit_scalar_arg_v =
     (std::is_integral<T>::value && !std::is_same<T, bool>::value &&
      !std::is_same<T, char>::value) ||
     std::is_enum<T>::value;
 
 template <std::size_t N>
-constexpr LitArg LitArgOf(const char (&)[N]) {
-  return LitArg::kString;
+constexpr lit_arg lit_arg_of(const char (&)[N]) {
+  return lit_arg::string;
 }
-constexpr LitArg LitArgOf(bool) { return LitArg::kScalar; }
-template <class T, std::enable_if_t<kLitScalarArg<T>, int> = 0>
-constexpr LitArg LitArgOf(T) {
-  return LitArg::kScalar;
+constexpr lit_arg lit_arg_of(bool) { return lit_arg::scalar; }
+template <class T, std::enable_if_t<lit_scalar_arg_v<T>, int> = 0>
+constexpr lit_arg lit_arg_of(T) {
+  return lit_arg::scalar;
 }
 
 // The scalar value, normalized: every integral type lands on int64_t so
@@ -191,47 +191,47 @@ constexpr LitArg LitArgOf(T) {
 // constant evaluation makes the call non-constant, so the out-of-range
 // spelling fails to compile with this message in the diagnostic.
 template <std::size_t N>
-constexpr int64_t LitValueOf(const char (&)[N]) {
+constexpr int64_t lit_value_of(const char (&)[N]) {
   return 0;  // placeholder; the string path never reads it
 }
-constexpr bool LitValueOf(bool v) { return v; }
+constexpr bool lit_value_of(bool v) { return v; }
 template <class T, std::enable_if_t<std::is_integral<T>::value &&
                                         !std::is_same<T, bool>::value &&
                                         !std::is_same<T, char>::value,
                                     int> = 0>
-constexpr int64_t LitValueOf(T v) {
+constexpr int64_t lit_value_of(T v) {
   return std::is_signed<T>::value ||
                  static_cast<uint64_t>(v) <= static_cast<uint64_t>(INT64_MAX)
              ? static_cast<int64_t>(v)
              : throw "BAML int literals must be representable in int64_t";
 }
 template <class T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
-constexpr T LitValueOf(T v) {
+constexpr T lit_value_of(T v) {
   return v;
 }
 
 template <std::size_t N>
-constexpr char LitCharAt(const char (&s)[N], std::size_t i) {
+constexpr char lit_char_at(const char (&s)[N], std::size_t i) {
   return i < N ? s[i] : '\0';
 }
 template <class T, std::enable_if_t<!std::is_array<T>::value, int> = 0>
-constexpr char LitCharAt(const T&, std::size_t) {
+constexpr char lit_char_at(const T&, std::size_t) {
   return '\0';
 }
 
-template <LitArg K, auto V, std::size_t N, char... Cs>
-struct LitSelect;
+template <lit_arg K, auto V, std::size_t N, char... Cs>
+struct lit_select;
 template <auto V, std::size_t N, char... Cs>
-struct LitSelect<LitArg::kString, V, N, Cs...> : TrimNulls<N, Cs...> {};
+struct lit_select<lit_arg::string, V, N, Cs...> : trim_nulls<N, Cs...> {};
 template <auto V, std::size_t N, char... Cs>
-struct LitSelect<LitArg::kScalar, V, N, Cs...> {
-  using type = Lit<V>;
+struct lit_select<lit_arg::scalar, V, N, Cs...> {
+  using type = lit<V>;
 };
 
 }  // namespace detail
 }  // namespace baml
 
-#define BAML_DETAIL_LIT_CH(s, i) (::baml::detail::LitCharAt((s), (i)))
+#define BAML_DETAIL_LIT_CH(s, i) (::baml::detail::lit_char_at((s), (i)))
 
 // clang-format off
 #define BAML_DETAIL_LIT_CH8(s, i)                                            \
@@ -253,8 +253,8 @@ struct LitSelect<LitArg::kScalar, V, N, Cs...> {
 // exists, decltype(the_generated_function()) names its type without the
 // macro, and a `const auto&` match arm catches it.
 #define BAML_LIT(s)                                                          \
-  ::baml::detail::LitSelect<::baml::detail::LitArgOf(s),                     \
-      ::baml::detail::LitValueOf(s), sizeof(s),                              \
+  ::baml::detail::lit_select<::baml::detail::lit_arg_of(s),                     \
+      ::baml::detail::lit_value_of(s), sizeof(s),                              \
       BAML_DETAIL_LIT_CH64(s, 0),   BAML_DETAIL_LIT_CH64(s, 64),             \
       BAML_DETAIL_LIT_CH64(s, 128), BAML_DETAIL_LIT_CH64(s, 192)>::type
 // clang-format on

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/runtime.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/runtime.h
@@ -12,8 +12,8 @@
 namespace baml {
 
 // Canonical BAML version of the loaded native runtime.
-inline std::string Version() {
-  detail::OwnedBuffer buf{detail::Api().version()};
+inline std::string version() {
+  detail::owned_buffer buf{detail::api().version()};
   return buf.to_string();
 }
 
@@ -21,14 +21,14 @@ inline std::string Version() {
 // payload generated SDKs embed). Registers this bridge (language + SDK
 // canonical version) first -- the contract-required ordering -- then boots.
 // Replaces any previously initialized runtime.
-inline void InitializeRuntimeFromBytecode(const uint8_t* bytecode,
-                                          size_t length,
-                                          const char* sdk_version) {
-  detail::EnsureRegistered(sdk_version);
-  detail::OwnedBuffer error{
-      detail::Api().initialize_runtime_from_bytecode(bytecode, length)};
-  if (!error.empty()) {
-    throw BamlError("BAML_RUNTIME_INITIALIZATION_FAILED: " + error.to_string());
+inline void initialize_runtime_from_bytecode(const uint8_t* bytecode,
+                                             size_t length,
+                                             const char* sdk_version) {
+  detail::ensure_registered(sdk_version);
+  detail::owned_buffer failure{
+      detail::api().initialize_runtime_from_bytecode(bytecode, length)};
+  if (!failure.empty()) {
+    throw error("BAML_RUNTIME_INITIALIZATION_FAILED: " + failure.to_string());
   }
 }
 

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/variant.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/variant.h
@@ -1,17 +1,17 @@
-#ifndef BAML_UNION_H_
-#define BAML_UNION_H_
+#ifndef BAML_VARIANT_H_
+#define BAML_VARIANT_H_
 
-// baml::Union<Ts...>: BAML's union type as an order-canonical
+// baml::variant<Ts...>: BAML's union type as an order-canonical
 // std::variant.
 //
 // BAML unions are sets (`string | int` == `int | string`, `int | int` ==
 // `int`), but std::variant<A, B> and std::variant<B, A> are distinct C++
-// types. baml::Union sorts its alternatives at compile time (by a per-type
+// types. baml::variant sorts its alternatives at compile time (by a per-type
 // constexpr name) and drops duplicates, so every spelling of the same
 // alternative set resolves to the SAME std::variant instantiation. It is an
-// alias, not a wrapper class: a baml::Union value is a plain std::variant and
+// alias, not a wrapper class: a baml::variant value is a plain std::variant and
 // works with std::get, std::holds_alternative, std::visit, and every other
-// variant API. (Lowercase `union` is a C++ keyword; Union follows the guide's
+// variant API. (Lowercase `union` is a C++ keyword; variant follows the guide's
 // type-alias casing, while match mirrors std::visit per the vocabulary
 // rule in STYLE.md.)
 //
@@ -20,8 +20,8 @@
 // under canonical ordering). std::visit enforces exhaustiveness at compile
 // time; a `[](const auto&) { ... }` arm is the explicit catch-all.
 //
-// Nullability is NOT spelled with Union: `T | null` is std::optional<T>
-// and `A | B | null` is std::optional<Union<A, B>> (see codec.h).
+// Nullability is NOT spelled with variant: `T | null` is std::optional<T>
+// and `A | B | null` is std::optional<variant<A, B>> (see codec.h).
 
 #include <array>
 #include <cstddef>
@@ -37,7 +37,7 @@ namespace detail {
 // function name embeds the fully-qualified type; uniqueness and a stable
 // order per compiler are all that matters, not the exact spelling.
 template <class T>
-constexpr std::string_view TypeName() {
+constexpr std::string_view type_name() {
 #if defined(_MSC_VER)
   return __FUNCSIG__;
 #else
@@ -51,14 +51,14 @@ constexpr std::string_view TypeName() {
 // function cannot return a runtime-sized array. Insertion sort because
 // constexpr std::sort is C++20 and this is C++17.
 template <std::size_t N>
-struct CanonIndices {
+struct canon_indices {
   std::array<std::size_t, N> idx;
   std::size_t count;
 };
 
 template <class... Ts>
-constexpr CanonIndices<sizeof...(Ts)> SortedUniqueIndices() {
-  std::array<std::string_view, sizeof...(Ts)> names{TypeName<Ts>()...};
+constexpr canon_indices<sizeof...(Ts)> sorted_unique_indices() {
+  std::array<std::string_view, sizeof...(Ts)> names{type_name<Ts>()...};
   std::array<std::size_t, sizeof...(Ts)> idx{};
   for (std::size_t i = 0; i < idx.size(); ++i) idx[i] = i;
   for (std::size_t i = 1; i < idx.size(); ++i)
@@ -76,13 +76,13 @@ constexpr CanonIndices<sizeof...(Ts)> SortedUniqueIndices() {
 // Reorders the pack into canonical order via the sorted, deduplicated
 // indices.
 template <class... Ts>
-struct CanonSort {
-  static constexpr CanonIndices<sizeof...(Ts)> canon =
-      SortedUniqueIndices<Ts...>();
+struct canon_sort {
+  static constexpr canon_indices<sizeof...(Ts)> canon =
+      sorted_unique_indices<Ts...>();
   template <std::size_t... Is>
   static std::variant<std::tuple_element_t<canon.idx[Is], std::tuple<Ts...>>...>
-      Helper(std::index_sequence<Is...>);
-  using type = decltype(Helper(std::make_index_sequence<canon.count>{}));
+      helper(std::index_sequence<Is...>);
+  using type = decltype(helper(std::make_index_sequence<canon.count>{}));
 };
 
 }  // namespace detail
@@ -90,29 +90,29 @@ struct CanonSort {
 // Alias, not a class: every alternative-set spelling resolves to the same
 // std::variant instantiation.
 template <class... Ts>
-using Union = typename detail::CanonSort<Ts...>::type;
+using variant = typename detail::canon_sort<Ts...>::type;
 
 namespace detail {
 
 template <class... Fs>
-struct Overloaded : Fs... {
+struct overloaded : Fs... {
   using Fs::operator()...;
 };
 template <class... Fs>
-Overloaded(Fs...) -> Overloaded<Fs...>;
+overloaded(Fs...) -> overloaded<Fs...>;
 
 }  // namespace detail
 
-// Pattern matching over a baml::Union (or any std::variant): one callable per
+// Pattern matching over a baml::variant (or any std::variant): one callable per
 // alternative, dispatched by type. A missing arm is a compile error;
 // `[](const auto&) { ... }` is the explicit catch-all (spell the parameter
 // `const auto&`, not `auto&&`, or it out-competes the exact arms).
 template <class V, class... Fs>
 decltype(auto) match(V&& v, Fs&&... fs) {
-  return std::visit(detail::Overloaded{std::forward<Fs>(fs)...},
+  return std::visit(detail::overloaded{std::forward<Fs>(fs)...},
                     std::forward<V>(v));
 }
 
 }  // namespace baml
 
-#endif  // BAML_UNION_H_
+#endif  // BAML_VARIANT_H_

--- a/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
@@ -1,6 +1,6 @@
 // Bridge-core smoke test: exercises the header-only runtime layer against
 // the real cdylib - version, bytecode-init error surface, call registry
-// fan-out, Arg semantics, and buffer moves. End-to-end typed calls are
+// fan-out, arg semantics, and buffer moves. End-to-end typed calls are
 // covered by the generated-SDK fixtures (sdk_tests/crates/cpp), which embed
 // real bytecode.
 #include <baml/baml.h>
@@ -14,7 +14,7 @@
 #include <vector>
 
 static void TestVersion() {
-  const std::string v = baml::Version();
+  const std::string v = baml::version();
   assert(!v.empty());
   std::printf("version: %s\n", v.c_str());
 }
@@ -25,9 +25,9 @@ static void TestBytecodeInitRejectsGarbage() {
   const uint8_t garbage[] = {0xde, 0xad, 0xbe, 0xef};
   bool threw = false;
   try {
-    const std::string v = baml::Version();
-    baml::InitializeRuntimeFromBytecode(garbage, sizeof(garbage), v.c_str());
-  } catch (const baml::BamlError&) {
+    const std::string v = baml::version();
+    baml::initialize_runtime_from_bytecode(garbage, sizeof(garbage), v.c_str());
+  } catch (const baml::error&) {
     threw = true;
   }
   assert(threw);
@@ -35,7 +35,7 @@ static void TestBytecodeInitRejectsGarbage() {
 }
 
 static void TestCallRegistryRoundTrip() {
-  auto started = baml::detail::CallRegistry::Instance().Begin();
+  auto started = baml::detail::call_registry::instance().begin();
   const std::vector<int8_t> payload = {1, 2, 3, 4};
   baml_cpp_result_trampoline(started.correlation_id, payload.data(),
                              payload.size());
@@ -48,35 +48,35 @@ static void TestCallRegistryRoundTrip() {
 
 static void TestArgTwoState() {
   // Non-nullable optional argument (BAML `count: int = 5`).
-  baml::Arg<int64_t> unset_arg;
+  baml::arg<int64_t> unset_arg;
   assert(unset_arg.is_unset() && !unset_arg.is_set());
 
-  baml::Arg<int64_t> explicit_unset = baml::unset;
+  baml::arg<int64_t> explicit_unset = baml::unset;
   assert(explicit_unset.is_unset());
 
-  baml::Arg<int64_t> value_arg = int64_t{42};
+  baml::arg<int64_t> value_arg = int64_t{42};
   assert(value_arg.is_set() && value_arg.value() == 42);
 
   // Null is not in a non-nullable argument's type: rejected at compile time.
   static_assert(
-      !std::is_constructible<baml::Arg<int64_t>, std::nullopt_t>::value,
+      !std::is_constructible<baml::arg<int64_t>, std::nullopt_t>::value,
       "null must not be passable to a non-nullable argument");
   static_assert(
-      !std::is_constructible<baml::Arg<int64_t>, std::monostate>::value,
+      !std::is_constructible<baml::arg<int64_t>, std::monostate>::value,
       "null must not be passable to a non-nullable argument");
 
   // Nullable optional argument (BAML `lang: string? = "en"`).
-  baml::Arg<std::optional<std::string>> lang_value = std::string("fr");
+  baml::arg<std::optional<std::string>> lang_value = std::string("fr");
   assert(lang_value.is_set() && lang_value.value().has_value());
 
-  baml::Arg<std::optional<std::string>> lang_null = std::nullopt;
+  baml::arg<std::optional<std::string>> lang_null = std::nullopt;
   assert(lang_null.is_set() && !lang_null.value().has_value());
 
-  baml::Arg<std::optional<std::string>> lang_null2 = std::monostate{};
+  baml::arg<std::optional<std::string>> lang_null2 = std::monostate{};
   assert(lang_null2.is_set() && !lang_null2.value().has_value());
 
   // Bare-null-typed argument: monostate is the VALUE there.
-  baml::Arg<std::monostate> null_typed_arg = std::monostate{};
+  baml::arg<std::monostate> null_typed_arg = std::monostate{};
   assert(null_typed_arg.is_set());
 
   bool threw = false;
@@ -87,10 +87,10 @@ static void TestArgTwoState() {
   }
   assert(threw);
 
-  // Setters take Arg<T> by value; a string literal must convert in one hop.
+  // Setters take arg<T> by value; a string literal must convert in one hop.
   struct Opts {
-    baml::Arg<std::optional<std::string>> lang;
-    Opts& set_lang(baml::Arg<std::optional<std::string>> v) {
+    baml::arg<std::optional<std::string>> lang;
+    Opts& set_lang(baml::arg<std::optional<std::string>> v) {
       lang = std::move(v);
       return *this;
     }
@@ -104,9 +104,9 @@ static void TestArgTwoState() {
 }
 
 static void TestOwnedBufferMove() {
-  baml::detail::OwnedBuffer a{baml::detail::Api().version()};
+  baml::detail::owned_buffer a{baml::detail::api().version()};
   assert(!a.empty());
-  baml::detail::OwnedBuffer b = std::move(a);
+  baml::detail::owned_buffer b = std::move(a);
   assert(a.empty() && !b.empty());
   std::printf("owned buffer move ok\n");
 }

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
@@ -1,9 +1,9 @@
 //! C++ SDK emitter, scoped to the packaging/publishing slice (bridge-week
 //! steps 1-8): the single-header layout, namespace routing, free functions
 //! with required + optional arguments (per-function opts structs, spec D4),
-//! classes + enums with generated `Codec<T>` specializations, transparent
+//! classes + enums with generated `codec<T>` specializations, transparent
 //! and recursive type aliases, and recursion via `baml::Box` cycle-breaking.
-//! multi-member unions as order-canonical `::baml::Union` aliases, and
+//! multi-member unions as order-canonical `::baml::variant` aliases, and
 //! typed error unions via `BamlThrown`.
 //! Post-step-8 features (async, methods, callbacks, generics, streaming
 //! companions, media/handles) are skipped and reported in a trailing
@@ -356,8 +356,8 @@ const BRIDGE_HEADERS: &[(&str, &str)] = &[
         include_str!("../../bridge_cpp/include/baml/runtime.h"),
     ),
     (
-        "include/baml/union.h",
-        include_str!("../../bridge_cpp/include/baml/union.h"),
+        "include/baml/variant.h",
+        include_str!("../../bridge_cpp/include/baml/variant.h"),
     ),
     (
         "include/baml/detail/call.h",
@@ -527,7 +527,7 @@ fn opts_request(callable: &BamlFqn, function: &Function) -> NameRequest {
         // bridges never re-case user names (Python kwargs and TS's inline
         // $opts never even mint a type); C++ needs a name only because the
         // struct must be constructible.
-        &format!("{}Opts", function.name.as_str()),
+        &format!("{}_opts", function.name.as_str()),
     )
 }
 
@@ -539,7 +539,7 @@ fn async_request(callable: &BamlFqn, function: &Function) -> NameRequest {
     NameRequest::synthesized(
         callable.child(ASYNC_MEMBER),
         CppNameKind::Function,
-        &format!("{}Async", function.name.as_str()),
+        &format!("{}_async", function.name.as_str()),
     )
 }
 
@@ -753,7 +753,7 @@ enum EmittedType {
 }
 
 /// A non-recursive type alias as a `using` declaration. A `using` is a pure
-/// synonym, so no codec is emitted: `Codec<Alias>` *is* `Codec<Target>`.
+/// synonym, so no codec is emitted: `codec<Alias>` *is* `codec<Target>`.
 struct EmittedUsing {
     ns: Vec<String>,
     name: CppName,
@@ -822,8 +822,8 @@ struct EmittedFn {
     opts_name: Option<CppName>,
     doc: Option<String>,
     raises: Vec<String>,
-    /// The declared throws set as a `::baml::Union<...>` spelling, when
-    /// every member translates; `None` uses the untyped `BamlError` path.
+    /// The declared throws set as a `::baml::variant<...>` spelling, when
+    /// every member translates; `None` uses the untyped `error` path.
     thrown: Option<String>,
 }
 
@@ -891,17 +891,17 @@ fn emit_callable(
     };
 
     // The declared throws set as a C++ type for the typed error path:
-    // always spelled as a ::baml::Union (a single thrown type wraps into a
+    // always spelled as a ::baml::variant (a single thrown type wraps into a
     // one-alternative Union) so every catch site reads uniformly via
     // baml::match. A throws set this slice cannot translate falls back to
-    // the untyped BamlError path (None -> CallSync's ThrownU = void).
+    // the untyped untyped error path (None -> call_sync's ThrownU = void).
     let thrown = function.throws.as_ref().and_then(|ty| {
         match translate_ty(pool, names, ty, emitted_types, &BTreeSet::new()) {
             Translated::Cpp(t) => {
-                if t.starts_with("::baml::Union<") {
+                if t.starts_with("::baml::variant<") {
                     Some(t)
                 } else {
-                    Some(format!("::baml::Union<{t}>"))
+                    Some(format!("::baml::variant<{t}>"))
                 }
             }
             Translated::NotYet | Translated::Unsupported(_) => None,
@@ -976,22 +976,22 @@ fn translate_ty(
             return Translated::Unsupported("media type (post-step-8)".to_string());
         }
         Ty::Literal(lit, ..) => {
-            // Literal types are singleton ::baml::Lit types (each distinct
+            // Literal types are singleton ::baml::lit types (each distinct
             // value a distinct C++ type), spelled as char packs / typed
             // scalars directly -- the BAML_LIT macro family is user-side
             // sugar only. Float literals stay widened: float NTTPs are
             // C++20 and BAML has no float literal types in practice.
             match lit {
-                baml_base::Literal::Int(v) => format!("::baml::Lit<{}>", lit_int_spelling(*v)),
+                baml_base::Literal::Int(v) => format!("::baml::lit<{}>", lit_int_spelling(*v)),
                 baml_base::Literal::Bigint(_) => {
                     return Translated::Unsupported("bigint literal (post-step-8)".to_string());
                 }
                 baml_base::Literal::Float(_) => "double".to_string(),
                 baml_base::Literal::String(s) => {
                     let chars: Vec<String> = s.bytes().map(lit_char_spelling).collect();
-                    format!("::baml::Lit<{}>", chars.join(", "))
+                    format!("::baml::lit<{}>", chars.join(", "))
                 }
-                baml_base::Literal::Bool(b) => format!("::baml::Lit<{b}>"),
+                baml_base::Literal::Bool(b) => format!("::baml::lit<{b}>"),
             }
         }
         Ty::TypeVar(name, _) => {
@@ -1017,7 +1017,7 @@ fn translate_ty(
                     return Translated::NotYet;
                 };
                 if boxed.contains(name) {
-                    return Translated::Cpp(format!("::baml::Box<{base}>"));
+                    return Translated::Cpp(format!("::baml::box<{base}>"));
                 }
                 return Translated::Cpp(base);
             }
@@ -1061,7 +1061,7 @@ fn translate_ty(
                         CppNameKind::EnumVariant,
                     ))
                     .declared();
-                Translated::Cpp(format!("::baml::Lit<{enum_path}::{variant_name}>"))
+                Translated::Cpp(format!("::baml::lit<{enum_path}::{variant_name}>"))
             } else {
                 Translated::NotYet
             };
@@ -1085,7 +1085,7 @@ fn translate_ty(
                 return Translated::NotYet;
             };
             if boxed.contains(name) {
-                return Translated::Cpp(format!("::baml::Box<{base}>"));
+                return Translated::Cpp(format!("::baml::box<{base}>"));
             }
             return Translated::Cpp(base);
         }
@@ -1123,7 +1123,7 @@ fn translate_ty(
                     other => return other,
                 }
             }
-            // Multi-member unions spell ::baml::Union<...>, an
+            // Multi-member unions spell ::baml::variant<...>, an
             // order-canonical std::variant alias: the C++ type system
             // dedups spellings (Union<A, B> == Union<B, A>), so
             // declaration order is fine here; sorting the rendered text
@@ -1132,17 +1132,17 @@ fn translate_ty(
             let inner = match alternatives.as_slice() {
                 [] => return Translated::Unsupported("empty union".to_string()),
                 [single] => single.clone(),
-                many => format!("::baml::Union<{}>", many.join(", ")),
+                many => format!("::baml::variant<{}>", many.join(", ")),
             };
             if had_null {
                 // A nullable boxed recursive edge cannot be optional<Box<T>>
                 // (std::optional needs a complete T at instantiation);
                 // OptionalBox folds the null into the box itself.
                 if let Some(boxed_inner) = inner
-                    .strip_prefix("::baml::Box<")
+                    .strip_prefix("::baml::box<")
                     .and_then(|rest| rest.strip_suffix('>'))
                 {
-                    format!("::baml::OptionalBox<{boxed_inner}>")
+                    format!("::baml::optional_box<{boxed_inner}>")
                 } else {
                     format!("std::optional<{inner}>")
                 }
@@ -1182,8 +1182,8 @@ const FN_VARIANTS: [FnVariant; 2] = [FnVariant::Sync, FnVariant::Async];
 /// when the function has a typed throws set.
 fn future_ret(f: &EmittedFn) -> String {
     match &f.thrown {
-        Some(u) => format!("::baml::Future<{}, {}>", f.ret, u),
-        None => format!("::baml::Future<{}>", f.ret),
+        Some(u) => format!("::baml::future<{}, {}>", f.ret, u),
+        None => format!("::baml::future<{}>", f.ret),
     }
 }
 
@@ -1216,7 +1216,7 @@ fn close_namespaces(buf: &mut String, ns: &[String]) {
 
 fn by_value_or_cref(ty: &str) -> String {
     // Lit types are empty unit structs: by value.
-    if ty.starts_with("::baml::Lit<") {
+    if ty.starts_with("::baml::lit<") {
         return ty.to_string();
     }
     match ty {
@@ -1226,7 +1226,7 @@ fn by_value_or_cref(ty: &str) -> String {
 }
 
 /// Spells one byte of a BAML string literal as a C++ char literal for a
-/// `::baml::Lit` char pack. Bytes, not code points: the pack mirrors the
+/// `::baml::lit` char pack. Bytes, not code points: the pack mirrors the
 /// literal's UTF-8 encoding, matching what `BAML_LIT`'s sizeof-based
 /// expansion produces.
 fn lit_char_spelling(b: u8) -> String {
@@ -1283,7 +1283,7 @@ fn render_opts_struct(buf: &mut String, indent: &str, f: &EmittedFn) {
     let _ = writeln!(buf, "{indent}struct {opts_name} {{");
     for p in &f.opt_params {
         let name = p.name.declared();
-        let arg_ty = format!("::baml::Arg<{}>", p.ty);
+        let arg_ty = format!("::baml::arg<{}>", p.ty);
         let _ = writeln!(buf, "{indent}  {arg_ty} {name};");
         let _ = writeln!(
             buf,
@@ -1299,7 +1299,7 @@ fn render_opts_struct(buf: &mut String, indent: &str, f: &EmittedFn) {
 }
 
 /// Emits one binding body: runtime init, required args, set optional args,
-/// then the call (blocking `CallSync`, or `StartCall` returning the
+/// then the call (blocking `call_sync`, or `start_call` returning the
 /// in-flight `baml::Future` for the async sibling).
 fn render_body(buf: &mut String, indent: &str, f: &EmittedFn, variant: FnVariant) {
     let args = GeneratorIdent::ArgsLocal.token();
@@ -1311,12 +1311,12 @@ fn render_body(buf: &mut String, indent: &str, f: &EmittedFn, variant: FnVariant
         detail = GeneratorIdent::DetailNamespace.token(),
         ensure = GeneratorIdent::EnsureRuntime.token()
     );
-    let _ = writeln!(buf, "{indent}::baml::detail::ArgsEncoder {args};");
+    let _ = writeln!(buf, "{indent}::baml::detail::args_encoder {args};");
     for p in &f.params {
         let _ = writeln!(
             buf,
-            "{indent}{args}.AddArg(\"{wire}\", [&](::baml::detail::pb::InboundValue& {w}) {{ \
-             ::baml::Codec<{ty}>::Encode({w}, {value}); }});",
+            "{indent}{args}.add_arg(\"{wire}\", [&](::baml::detail::pb::InboundValue& {w}) {{ \
+             ::baml::codec<{ty}>::encode({w}, {value}); }});",
             wire = p.name.wire(),
             ty = p.ty,
             value = p.name.identifier()
@@ -1327,8 +1327,8 @@ fn render_body(buf: &mut String, indent: &str, f: &EmittedFn, variant: FnVariant
         let _ = writeln!(
             buf,
             "{indent}if ({opts}.{field}.is_set()) {{\n{indent}  \
-             {args}.AddArg(\"{wire}\", [&](::baml::detail::pb::InboundValue& {w}) {{ \
-             ::baml::Codec<{ty}>::Encode({w}, {opts}.{field}.value()); }});\n{indent}}}",
+             {args}.add_arg(\"{wire}\", [&](::baml::detail::pb::InboundValue& {w}) {{ \
+             ::baml::codec<{ty}>::encode({w}, {opts}.{field}.value()); }});\n{indent}}}",
             wire = p.name.wire(),
             ty = p.ty
         );
@@ -1338,8 +1338,8 @@ fn render_body(buf: &mut String, indent: &str, f: &EmittedFn, variant: FnVariant
         None => String::new(),
     };
     let driver = match variant {
-        FnVariant::Sync => "CallSync",
-        FnVariant::Async => "StartCall",
+        FnVariant::Sync => "call_sync",
+        FnVariant::Async => "start_call",
     };
     let _ = writeln!(
         buf,
@@ -1495,7 +1495,7 @@ fn render_header(
     buf
 }
 
-/// Codec<T> specializations for the generated enums and classes. Emitted in
+/// codec<T> specializations for the generated enums and classes. Emitted in
 /// the header (inline) so they are visible from any translation unit.
 fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedClass]) {
     buf.push_str("\nnamespace baml {\n");
@@ -1505,17 +1505,17 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
         let fqn = e.name.wire();
         let _ = writeln!(
             buf,
-            "\ntemplate <>\nstruct Codec<{q}> {{\n  \
-             static void Encode(detail::pb::InboundValue& value_msg, {q} v) {{\n    \
+            "\ntemplate <>\nstruct codec<{q}> {{\n  \
+             static void encode(detail::pb::InboundValue& value_msg, {q} v) {{\n    \
              auto* e = value_msg.mutable_enum_value();\n    \
              e->set_name(\"{fqn}\");\n    \
              e->set_value(ToWire(v));\n  }}\n  \
-             static {q} Decode(const detail::pb::BamlOutboundValue& raw) {{\n    \
-             const auto& v = detail::Unwrap(raw);\n    \
+             static {q} decode(const detail::pb::BamlOutboundValue& raw) {{\n    \
+             const auto& v = detail::unwrap(raw);\n    \
              if (v.value_case() != detail::pb::BamlOutboundValue::kEnumValue ||\n      \
              (!v.enum_value().name().empty() &&\n       \
              v.enum_value().name() != \"{fqn}\")) {{\n      \
-             detail::KindMismatch(\"enum {fqn}\", v);\n    }}\n    \
+             detail::kind_mismatch(\"enum {fqn}\", v);\n    }}\n    \
              return FromWire(v.enum_value().value());\n  }}",
         );
         buf.push_str("  static const char* ToWire(");
@@ -1527,7 +1527,7 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
                 variant = variant.declared()
             );
         }
-        buf.push_str("    }\n    throw BamlError(\"invalid enum value\");\n  }\n");
+        buf.push_str("    }\n    throw error(\"invalid enum value\");\n  }\n");
         let _ = writeln!(buf, "  static {q} FromWire(const std::string& value) {{");
         for (variant, value) in &e.variants {
             let _ = writeln!(
@@ -1538,7 +1538,7 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
         }
         let _ = writeln!(
             buf,
-            "    throw BamlError(\"unknown variant '\" + value + \"' for enum {fqn}\");\n  \
+            "    throw error(\"unknown variant '\" + value + \"' for enum {fqn}\");\n  \
              }}\n}};",
         );
     }
@@ -1556,11 +1556,11 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
             buf.push_str("\ntemplate <>\n");
             let _ = writeln!(
                 buf,
-                "struct Codec<{q}> {{\n  \
-                 static void Encode(detail::pb::InboundValue& value_msg, const {q}& v) {{\n    \
-                 Codec<{inner}>::Encode(value_msg, v.{field});\n  }}\n  \
-                 static {q} Decode(const detail::pb::BamlOutboundValue& v) {{\n    \
-                 return {q}{{Codec<{inner}>::Decode(v)}};\n  }}\n}};"
+                "struct codec<{q}> {{\n  \
+                 static void encode(detail::pb::InboundValue& value_msg, const {q}& v) {{\n    \
+                 codec<{inner}>::encode(value_msg, v.{field});\n  }}\n  \
+                 static {q} decode(const detail::pb::BamlOutboundValue& v) {{\n    \
+                 return {q}{{codec<{inner}>::decode(v)}};\n  }}\n}};"
             );
             continue;
         }
@@ -1568,10 +1568,10 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
         let fqn = c.name.wire();
 
         buf.push_str("\ntemplate <>\n");
-        let _ = writeln!(buf, "struct Codec<{q}> {{");
+        let _ = writeln!(buf, "struct codec<{q}> {{");
         let _ = writeln!(
             buf,
-            "  static void Encode(detail::pb::InboundValue& value_msg, const {q}& v) {{\n    \
+            "  static void encode(detail::pb::InboundValue& value_msg, const {q}& v) {{\n    \
              auto* cls = value_msg.mutable_class_value();"
         );
         for field in &c.fields {
@@ -1579,7 +1579,7 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
                 buf,
                 "    {{\n      auto* entry = cls->add_fields();\n      \
                  entry->set_string_key(\"{wire}\");\n      \
-                 Codec<{ty}>::Encode(*entry->mutable_value(), v.{name});\n    }}",
+                 codec<{ty}>::encode(*entry->mutable_value(), v.{name});\n    }}",
                 wire = field.name.wire(),
                 ty = field.ty,
                 name = field.name.identifier()
@@ -1595,12 +1595,12 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
         // non-default-constructible field types (baml::Box) work.
         let _ = writeln!(
             buf,
-            "  static {q} Decode(const detail::pb::BamlOutboundValue& raw) {{\n    \
-             const auto& v = detail::Unwrap(raw);\n    \
+            "  static {q} decode(const detail::pb::BamlOutboundValue& raw) {{\n    \
+             const auto& v = detail::unwrap(raw);\n    \
              if (v.value_case() != detail::pb::BamlOutboundValue::kClassValue ||\n      \
              (!v.class_value().name().empty() &&\n       \
              v.class_value().name() != \"{fqn}\")) {{\n      \
-             detail::KindMismatch(\"class {fqn}\", v);\n    }}",
+             detail::kind_mismatch(\"class {fqn}\", v);\n    }}",
         );
         for field in &c.fields {
             let _ = writeln!(
@@ -1618,7 +1618,7 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
             let _ = writeln!(
                 buf,
                 "      {kw} (field.key() == \"{wire}\") {{\n        \
-                 field_{name} = Codec<{ty}>::Decode(field.value());",
+                 field_{name} = codec<{ty}>::decode(field.value());",
                 wire = field.name.wire(),
                 ty = field.ty,
                 name = field.name.declared()
@@ -1631,14 +1631,14 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
         }
         let _ = writeln!(
             buf,
-            "        throw BamlError(\"unexpected field '\" + field.key() + \"' on {fqn}\");\n      \
+            "        throw error(\"unexpected field '\" + field.key() + \"' on {fqn}\");\n      \
              }}\n    }}",
         );
         for field in &c.fields {
             let _ = writeln!(
                 buf,
                 "    if (!field_{name}.has_value()) {{\n      \
-                 throw BamlError(\"missing field '{wire}' on {fqn}\");\n    }}",
+                 throw error(\"missing field '{wire}' on {fqn}\");\n    }}",
                 name = field.name.declared(),
                 wire = field.name.wire()
             );
@@ -1775,7 +1775,7 @@ fn render_inlinedbaml(user_baml_files: &[UserBamlFile], baml_bytecode: &[u8]) ->
          for (const BamlBytecodeChunk& chunk : kBamlBytecodeChunks) {{\n      \
          bytecode.append(chunk.data, chunk.len);\n    \
          }}\n    \
-         ::baml::InitializeRuntimeFromBytecode(\n        \
+         ::baml::initialize_runtime_from_bytecode(\n        \
          reinterpret_cast<const uint8_t*>(bytecode.data()), bytecode.size(),\n        \
          \"{version}\");\n  \
          }});\n\

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/naming.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/naming.rs
@@ -306,7 +306,7 @@ impl GeneratorIdent {
             GeneratorIdent::WriterParam => "w",
             GeneratorIdent::SetterValueParam => "v",
             GeneratorIdent::OptsParam => "opts",
-            GeneratorIdent::EnsureRuntime => "EnsureRuntime",
+            GeneratorIdent::EnsureRuntime => "ensure_runtime",
             GeneratorIdent::DetailNamespace => "detail",
         }
     }


### PR DESCRIPTION
Layout stays Google; **naming goes to the C++ standard library's convention** ([Core Guidelines NL.10](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#nl10-prefer-underscore_style-names), = Boost = std), machine-enforced by a new `.clang-tidy` `readability-identifier-naming` config. The bridge's public vocabulary was already std-mirroring, so the style now matches what the types are.

## The surface

```cpp
baml::variant<A, B>                  // was baml::Union (lowercase union is a keyword)
baml::match(v, ...)                  // unchanged
baml::lit<...> / BAML_LIT(...)       // was Lit; int_lit/bool_lit alternates
baml::future<T, U>                   // was Future; fut.cancel() joins get/wait_for as snake
baml::box / baml::optional_box       // was Box/OptionalBox
baml::arg + baml::unset_t / unset    // the nullopt_t/nullopt pattern
baml::error / thrown<U> / panic / cancelled / runtime_error   // was Baml*-prefixed
baml::codec<T>::encode / decode      // was Codec::Encode/Decode
```

No more mixed casing on one object (`wait_for` next to `Cancel` is gone), no more vocabulary carve-out list -- STYLE.md collapses to one rule with the Core Guidelines as the cited authority.

## Generated code

Names mirroring BAML source stay exactly as the author wrote them (`SleepMs` stays Pascal -- true in every bridge, python identical). Generator-added suffixes go snake with the convention: **`SleepMs_async`** (now exact python sibling parity) and **`probe_opts`**. `union.h` -> `variant.h`.

## Enforcement

- `.clang-tidy`: 11-line `readability-identifier-naming` config (snake types/functions/constants/enumerators, CamelCase template params, `BAML_` UPPER macros, trailing-`_` members). clang-format cannot check naming; this can.
- C-ABI spellings (`BamlApiV1`, extern-C trampolines) and protoc output keep their contract conventions.

All 23 `sdk_test_cpp` + `sdkgen_cpp` tests pass locally (12 fixture jobs incl. the 6 live co_await cases).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a consistent lower-case C++ SDK API for variants, futures, errors, runtime initialization, codecs, optional arguments, and boxed values.
  * Added improved coroutine support terminology and cancellation handling.
* **Documentation**
  * Updated C++ naming guidance and generated API documentation.
* **Chores**
  * Added clang-tidy naming rules to help enforce the updated C++ style.
* **Compatibility**
  * Existing C++ integrations using previous type and method names must update to the new API names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->