### PR TITLE
bridge-cpp: static and instance methods

### DIFF
--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_methods_on_classes.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_methods_on_classes.cc
@@ -1,0 +1,38 @@
+// Static + instance method coverage (ns_methods_on_classes.Greeter).
+// Port of function_calls/customizable/test_methods_on_classes.py. Python's
+// bindings-exist reflection test is compile-time in C++ (calling them below
+// proves existence) and needs no runtime port.
+#include <baml_sdk.h>
+#include <baml_test.h>
+
+using baml_sdk::methods_on_classes::Greeter;
+
+BAML_TEST(static_create_round_trips) {
+  const Greeter g = Greeter::create("ada");
+  BAML_ASSERT_EQ(g.name, std::string("ada"));
+}
+
+BAML_TEST(static_create_async_round_trips) {
+  const Greeter g = Greeter::create_async("grace").get();
+  BAML_ASSERT_EQ(g.name, std::string("grace"));
+}
+
+BAML_TEST(instance_who_round_trips) {
+  const Greeter g = Greeter::create("hopper");
+  BAML_ASSERT_EQ(g.who(), std::string("hopper"));
+}
+
+BAML_TEST(instance_who_async_round_trips) {
+  const Greeter g = Greeter::create_async("hopper").get();
+  BAML_ASSERT_EQ(g.who_async().get(), std::string("hopper"));
+}
+
+BAML_TEST(instance_greet_with_arg_round_trips) {
+  const Greeter g = Greeter::create("lovelace");
+  BAML_ASSERT_EQ(g.greet("hi"), std::string("hi"));
+}
+
+BAML_TEST(instance_greet_async_with_arg_round_trips) {
+  const Greeter g = Greeter::create_async("lovelace").get();
+  BAML_ASSERT_EQ(g.greet_async("hi").get(), std::string("hi"));
+}

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_optional_args.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_optional_args.cc
@@ -48,6 +48,19 @@ BAML_TEST(optional_args_async_samples) {
                   .get() == (Probe{1, 5, 9}));
 }
 
+BAML_TEST(opt_box_method_matrix) {
+  using baml_sdk::OptBox;
+  const OptBox box = OptBox::make(10);
+  BAML_ASSERT_EQ(box.base, int64_t{17});
+
+  const OptBox box2 =
+      OptBox::make(10, OptBox::make_opts{}.set_opt1(int64_t{0}));
+  BAML_ASSERT_EQ(box2.base, int64_t{10});
+  BAML_ASSERT(box2.probe(1) == (Probe{10, 1, 5}));
+  BAML_ASSERT(box2.probe(1, OptBox::probe_opts{}.set_opt1(int64_t{8})) ==
+              (Probe{10, 1, 8}));
+}
+
 BAML_TEST(unset_and_null_differ_in_one_call) {
   // unset means "omit this argument"; nullopt means "pass an explicit
   // null". The two must stay distinct within a single call.

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_raises.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_raises.cc
@@ -56,6 +56,16 @@ BAML_TEST(async_sibling_also_has_raises) {
               std::string::npos);
 }
 
+BAML_TEST(method_raises_blocks) {
+  // Methods carry `Raises:` in the header exactly like free functions
+  // (python's .pyi-stub analog): both flavors, both variants.
+  BAML_ASSERT(header_text().find("  /// Raises: ParseError\n"
+                                 "  std::string load(") != std::string::npos);
+  BAML_ASSERT(header_text().find("  /// Raises: TimeoutError\n"
+                                 "  static ::baml_sdk::raises_test::DocLoader "
+                                 "create(") != std::string::npos);
+}
+
 BAML_TEST(non_throwing_function_has_no_raises_block) {
   // The summary line abuts the declaration: no Raises line in between.
   BAML_ASSERT(header_text().find("/// A pure function that never throws.\n"

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_raises.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_raises.cc
@@ -20,6 +20,18 @@ static std::string header_text() {
   return out.str();
 }
 
+BAML_TEST(imports_symbols_reachable) {
+  // Port of python's test_imports: every raises_test symbol is reachable
+  // at its qualified path. Compile-level analog of the import assertions -
+  // the header scrapes below are namespace-blind, so without this a
+  // wrong-namespace regression would pass them.
+  (void)sizeof(baml_sdk::raises_test::DocLoader);
+  (void)&baml_sdk::raises_test::InferredThrow;
+  (void)&baml_sdk::raises_test::LoadDoc;
+  (void)&baml_sdk::raises_test::PureLen;
+  (void)&baml_sdk::raises_test::Reparse;
+}
+
 BAML_TEST(union_throws_lists_all_names) {
   // A multi-member throws union lists every member, unqualified.
   BAML_ASSERT(header_text().find("/// Raises: ParseError, TimeoutError\n"

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
@@ -171,6 +171,54 @@ pub fn to_source_code_with_bytecode(
         }
     }
 
+    // Pass 3: methods, against the final emitted type set (declarations may
+    // reference any emitted class thanks to the forward-declaration block).
+    for emitted in &mut classes {
+        let EmittedType::Class(class) = emitted else {
+            continue;
+        };
+        if class.alias_wrapper {
+            continue;
+        }
+        let Symbol::Class(class_def) = &pool[&class.pool_name] else {
+            unreachable!()
+        };
+        for (methods, is_static) in [
+            (&class_def.static_methods, true),
+            (&class_def.instance_methods, false),
+        ] {
+            for method in methods {
+                if !method.generic_params.is_empty() {
+                    skipped.push(format!(
+                        "{}.{}: generic method (post-step-8)",
+                        class.pool_name, method.name
+                    ));
+                    continue;
+                }
+                let fqn = BamlFqn::member(&class.pool_name, method.name.as_str());
+                match emit_callable(
+                    pool,
+                    &names,
+                    &fqn,
+                    CppNameKind::Method,
+                    method,
+                    &emitted_types,
+                ) {
+                    Ok(emitted_fn) => {
+                        if is_static {
+                            class.static_methods.push(emitted_fn);
+                        } else {
+                            class.instance_methods.push(emitted_fn);
+                        }
+                    }
+                    Err(reason) => {
+                        skipped.push(format!("{}.{}: {reason}", class.pool_name, method.name));
+                    }
+                }
+            }
+        }
+    }
+
     // Pass 4: free functions over the emitted type set.
     let mut fns_by_namespace: BTreeMap<Vec<String>, Vec<EmittedFn>> = BTreeMap::new();
     for name in &pool_names {
@@ -189,6 +237,7 @@ pub fn to_source_code_with_bytecode(
             pool,
             &names,
             &BamlFqn::symbol(name),
+            CppNameKind::Function,
             function,
             &emitted_types,
         ) {
@@ -207,7 +256,7 @@ pub fn to_source_code_with_bytecode(
     );
     out.insert(
         PathBuf::from("src/bindings.cc"),
-        render_bindings(&fns_by_namespace),
+        render_bindings(&classes, &fns_by_namespace),
     );
     out.insert(
         PathBuf::from("src/_inlinedbaml.cc"),
@@ -422,6 +471,19 @@ fn collect_requests(pool: &SymbolPool) -> BTreeSet<NameRequest> {
                         BamlFqn::member(name, prop.name.as_str()),
                         CppNameKind::Field,
                     ));
+                }
+                for method in class_def
+                    .static_methods
+                    .iter()
+                    .chain(&class_def.instance_methods)
+                {
+                    if !method.generic_params.is_empty() {
+                        continue; // generic methods (post-step-8)
+                    }
+                    let method_fqn = BamlFqn::member(name, method.name.as_str());
+                    requests.insert(NameRequest::new(method_fqn.clone(), CppNameKind::Method));
+                    requests.insert(async_request(&method_fqn, method));
+                    request_callable_members(&mut requests, &method_fqn, method);
                 }
             }
             Symbol::Function(function) => {
@@ -651,14 +713,27 @@ struct EmittedField {
 }
 
 struct EmittedClass {
+    /// The pool symbol this class was emitted from (pass 3 looks methods
+    /// back up by it).
+    pool_name: Name,
     ns: Vec<String>,
     name: CppName,
     doc: Option<String>,
     fields: Vec<EmittedField>,
+    static_methods: Vec<EmittedFn>,
+    instance_methods: Vec<EmittedFn>,
     /// A recursive-alias wrapper struct: one `value` field holding the
     /// alias's resolved type, structural codec (aliases have no wire
     /// identity), no methods.
     alias_wrapper: bool,
+}
+
+impl EmittedClass {
+    /// The receiver's C++ spelling inside its own scope (no templates this
+    /// slice, so just the bare class name).
+    fn self_type(&self) -> &str {
+        self.name.declared()
+    }
 }
 
 /// Ok(None) = not emittable *yet* (a field references a class not emitted so
@@ -691,7 +766,28 @@ fn emit_class(
             }
         }
     }
+    // Method optional params become arg<T> fields on opts structs nested in
+    // this class's body, so their types must be complete (= defined
+    // earlier) too. Delay the class while such a dep is merely
+    // not-yet-emitted; once the cycle pass runs (boxed non-empty), stop
+    // blocking -- a dep that still cannot resolve there means pass 3 skips
+    // that method, so no opts struct references it.
+    if boxed.is_empty() {
+        for method in class_def
+            .static_methods
+            .iter()
+            .chain(&class_def.instance_methods)
+        {
+            for arg in method.arguments.iter().filter(|a| a.default.is_some()) {
+                if let Translated::NotYet = translate_ty(pool, names, &arg.ty, emitted_types, boxed)
+                {
+                    return Ok(None);
+                }
+            }
+        }
+    }
     Ok(Some(EmittedClass {
+        pool_name: name.clone(),
         ns: allocated_namespace(names, name),
         name: names
             .get(&NameRequest::new(BamlFqn::symbol(name), CppNameKind::Class))
@@ -706,6 +802,8 @@ fn emit_class(
                 .collect::<Vec<_>>(),
         ),
         fields,
+        static_methods: Vec::new(),
+        instance_methods: Vec::new(),
         alias_wrapper: false,
     }))
 }
@@ -732,6 +830,7 @@ fn emit_alias_wrapper(
         }
     };
     Ok(Some(EmittedClass {
+        pool_name: name.clone(),
         ns: allocated_namespace(names, name),
         name: names
             .get(&NameRequest::new(BamlFqn::symbol(name), CppNameKind::Class))
@@ -741,6 +840,8 @@ fn emit_alias_wrapper(
             name: names.get(&alias_value_field_request(name)).clone(),
             ty: inner,
         }],
+        static_methods: Vec::new(),
+        instance_methods: Vec::new(),
         alias_wrapper: true,
     }))
 }
@@ -831,10 +932,11 @@ fn emit_callable(
     pool: &SymbolPool,
     names: &CppNames,
     fqn: &BamlFqn,
+    kind: CppNameKind,
     function: &Function,
     emitted_types: &BTreeSet<Name>,
 ) -> Result<EmittedFn, String> {
-    let name = names.get(&function_request(&fqn.symbol)).clone();
+    let name = names.get(&NameRequest::new(fqn.clone(), kind)).clone();
 
     let mut params = Vec::new();
     let mut opt_params = Vec::new();
@@ -914,8 +1016,18 @@ fn emit_callable(
         Some(names.get(&opts_request(fqn, function)).clone())
     };
 
+    // The runtime dispatches on the BAML FQN: for methods that is the
+    // class's wire symbol plus the method's source member token, never a
+    // C++ name.
+    let call_fqn = if kind == CppNameKind::Method {
+        let member = fqn.members.last().expect("method identity has a member");
+        format!("{}.{member}", name.wire())
+    } else {
+        name.wire().to_string()
+    };
+
     Ok(EmittedFn {
-        call_fqn: name.wire().to_string(),
+        call_fqn,
         name,
         async_name: names.get(&async_request(fqn, function)).clone(),
         ret,
@@ -1159,12 +1271,18 @@ fn translate_ty(
 // Rendering
 // ---------------------------------------------------------------------------
 
-/// Whether a function renders as its header declaration (defaulted opts
-/// parameter) or its bindings.cc definition (no default repeated).
+/// How a callable renders: a free-function declaration (defaulted opts
+/// parameter) or definition, an in-class method declaration, or an
+/// out-of-line method definition in bindings.cc (owner-qualified, no
+/// default repeated).
 #[derive(Clone, Copy)]
-enum RenderPos {
+enum RenderPos<'a> {
     Decl,
     Def,
+    StaticDecl,
+    InstanceDecl,
+    StaticDef { class: &'a EmittedClass },
+    InstanceDef { class: &'a EmittedClass },
 }
 
 /// Which spelling of a callable renders: the synchronous form or the
@@ -1259,12 +1377,18 @@ fn signature(f: &EmittedFn, pos: RenderPos, variant: FnVariant) -> String {
         .collect();
     if let Some(opts_name) = &f.opts_name {
         let default = match pos {
-            RenderPos::Def => "",
-            RenderPos::Decl => " = {}",
+            RenderPos::Def | RenderPos::StaticDef { .. } | RenderPos::InstanceDef { .. } => "",
+            RenderPos::Decl | RenderPos::StaticDecl | RenderPos::InstanceDecl => " = {}",
+        };
+        // Out-of-line method definitions must qualify the nested opts type.
+        let opts_ty = match pos {
+            RenderPos::StaticDef { class } | RenderPos::InstanceDef { class } => {
+                format!("{}::{}", class.self_type(), opts_name.declared())
+            }
+            _ => opts_name.declared().to_string(),
         };
         params.push(format!(
-            "{opts_name} {opts}{default}",
-            opts_name = opts_name.declared(),
+            "{opts_ty} {opts}{default}",
             opts = GeneratorIdent::OptsParam.token()
         ));
     }
@@ -1272,7 +1396,24 @@ fn signature(f: &EmittedFn, pos: RenderPos, variant: FnVariant) -> String {
         FnVariant::Sync => (f.ret.clone(), f.name.declared()),
         FnVariant::Async => (future_ret(f), f.async_name.declared()),
     };
-    format!("{ret} {name}({params})", params = params.join(", "))
+    let prefix = match pos {
+        RenderPos::StaticDecl => "static ",
+        _ => "",
+    };
+    let owner = match pos {
+        RenderPos::StaticDef { class } | RenderPos::InstanceDef { class } => {
+            format!("{}::", class.self_type())
+        }
+        _ => String::new(),
+    };
+    let constness = match pos {
+        RenderPos::InstanceDecl | RenderPos::InstanceDef { .. } => " const",
+        _ => "",
+    };
+    format!(
+        "{prefix}{ret} {owner}{name}({params}){constness}",
+        params = params.join(", ")
+    )
 }
 
 fn render_opts_struct(buf: &mut String, indent: &str, f: &EmittedFn) {
@@ -1298,10 +1439,18 @@ fn render_opts_struct(buf: &mut String, indent: &str, f: &EmittedFn) {
     let _ = writeln!(buf, "{indent}}};");
 }
 
-/// Emits one binding body: runtime init, required args, set optional args,
-/// then the call (blocking `call_sync`, or `start_call` returning the
-/// in-flight `baml::Future` for the async sibling).
-fn render_body(buf: &mut String, indent: &str, f: &EmittedFn, variant: FnVariant) {
+/// Emits one binding body: runtime init, self (for instance methods),
+/// required args, set optional args, then the call (blocking `call_sync`,
+/// or `start_call` returning the in-flight `baml::future` for the async
+/// sibling). `self_type` is the receiver's C++ spelling for instance
+/// methods.
+fn render_body(
+    buf: &mut String,
+    indent: &str,
+    f: &EmittedFn,
+    variant: FnVariant,
+    self_type: Option<&str>,
+) {
     let args = GeneratorIdent::ArgsLocal.token();
     let w = GeneratorIdent::WriterParam.token();
     let opts = GeneratorIdent::OptsParam.token();
@@ -1312,6 +1461,13 @@ fn render_body(buf: &mut String, indent: &str, f: &EmittedFn, variant: FnVariant
         ensure = GeneratorIdent::EnsureRuntime.token()
     );
     let _ = writeln!(buf, "{indent}::baml::detail::args_encoder {args};");
+    if let Some(self_type) = self_type {
+        let _ = writeln!(
+            buf,
+            "{indent}{args}.add_arg(\"self\", [&](::baml::detail::pb::InboundValue& {w}) {{ \
+             ::baml::codec<{self_type}>::encode({w}, *this); }});",
+        );
+    }
     for p in &f.params {
         let _ = writeln!(
             buf,
@@ -1443,6 +1599,21 @@ fn render_header(
         let _ = writeln!(buf, "struct {} {{", c.name.declared());
         for field in &c.fields {
             let _ = writeln!(buf, "  {} {};", field.ty, field.name.declared());
+        }
+        for f in c.static_methods.iter().chain(&c.instance_methods) {
+            render_opts_struct(&mut buf, "  ", f);
+        }
+        // Declarations only; the bodies live out-of-line in bindings.cc.
+        for (methods, decl_pos) in [
+            (&c.static_methods, RenderPos::StaticDecl),
+            (&c.instance_methods, RenderPos::InstanceDecl),
+        ] {
+            for f in methods {
+                for variant in FN_VARIANTS {
+                    push_doc(&mut buf, "  ", f.doc.as_ref(), &f.raises);
+                    let _ = writeln!(buf, "  {};", signature(f, decl_pos, variant));
+                }
+            }
         }
         let eq_terms: Vec<String> = c
             .fields
@@ -1658,7 +1829,10 @@ fn render_codecs(buf: &mut String, enums: &[EmittedEnum], classes: &[&EmittedCla
     buf.push_str("\n}  // namespace baml\n");
 }
 
-fn render_bindings(fns_by_namespace: &BTreeMap<Vec<String>, Vec<EmittedFn>>) -> String {
+fn render_bindings(
+    types: &[EmittedType],
+    fns_by_namespace: &BTreeMap<Vec<String>, Vec<EmittedFn>>,
+) -> String {
     let mut buf = String::new();
     buf.push_str(
         "// Generated by sdkgen_cpp - do not edit.\n\
@@ -1667,13 +1841,39 @@ fn render_bindings(fns_by_namespace: &BTreeMap<Vec<String>, Vec<EmittedFn>>) -> 
          namespace baml_sdk {\n",
     );
 
+    // Out-of-line method definitions, owner-qualified inside the class's
+    // namespace.
+    for t in types {
+        let EmittedType::Class(c) = t else { continue };
+        if c.static_methods.is_empty() && c.instance_methods.is_empty() {
+            continue;
+        }
+        buf.push('\n');
+        open_namespaces(&mut buf, &c.ns);
+        for (methods, is_instance) in [(&c.static_methods, false), (&c.instance_methods, true)] {
+            for f in methods {
+                let (def_pos, self_type) = if is_instance {
+                    (RenderPos::InstanceDef { class: c }, Some(c.self_type()))
+                } else {
+                    (RenderPos::StaticDef { class: c }, None)
+                };
+                for variant in FN_VARIANTS {
+                    let _ = writeln!(buf, "\n{} {{", signature(f, def_pos, variant));
+                    render_body(&mut buf, "  ", f, variant, self_type);
+                    buf.push_str("}\n");
+                }
+            }
+        }
+        close_namespaces(&mut buf, &c.ns);
+    }
+
     for (ns, fns) in fns_by_namespace {
         buf.push('\n');
         open_namespaces(&mut buf, ns);
         for f in fns {
             for variant in FN_VARIANTS {
                 let _ = writeln!(buf, "\n{} {{", signature(f, RenderPos::Def, variant));
-                render_body(&mut buf, "  ", f, variant);
+                render_body(&mut buf, "  ", f, variant, None);
                 buf.push_str("}\n");
             }
         }

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/naming.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/naming.rs
@@ -128,6 +128,9 @@ impl PartialOrd for BamlFqn {
 pub(crate) enum CppNameKind {
     Namespace,
     Function,
+    /// A static or instance method (class-scoped callable). Wire identity
+    /// is the class symbol; the emitter appends `.member` for dispatch.
+    Method,
     Class,
     Enum,
     EnumVariant,
@@ -147,6 +150,7 @@ impl CppNameKind {
         matches!(
             self,
             CppNameKind::EnumVariant
+                | CppNameKind::Method
                 | CppNameKind::Field
                 | CppNameKind::Parameter
                 | CppNameKind::Setter
@@ -165,6 +169,9 @@ impl CppNameKind {
             CppNameKind::Parameter => 7,
             CppNameKind::OptsStruct => 8,
             CppNameKind::Setter => 9,
+            // New kinds append (typed-hash suffixes embed the tag; existing
+            // numbers must never move).
+            CppNameKind::Method => 10,
         }
     }
 }


### PR DESCRIPTION
Bridge-week step 11, re-landed from `-full` under all the current machinery.

## What

```baml
class Greeter {
  name string
  function create(name: string) -> Greeter { ... }          // static
  function who(self) -> string { ... }                      // instance
}
```

```cpp
Greeter g = Greeter::create("ada");            // static member
std::string n = g.who();                        // const member; *this rides as the self kwarg
auto fut = g.who_async();                       // every method gets its _async sibling
```

- Instance methods encode `*this` as the `self` kwarg (deep-copy semantics, python parity); dispatch = class wire symbol + `.member`.
- Typed throws, opts structs (nested in the class: `OptBox::make_opts`, owner-qualified in the out-of-line bindings.cc definitions), `/// Raises:` doc blocks, and `_async` siblings returning `baml::future<T, variant<...>>` all ride the existing callable machinery — zero runtime changes.
- Naming pool grows `CppNameKind::Method` (tag appended; existing typed-hash tags never move).
- Class emission ordering waits on method optional-param types during the first fixed-point pass, so nested opts structs never reference an undeclared type (the known gotcha from the first landing).

## Tests

- `test_methods_on_classes.cc`: python port, 6 engine round-trip cases (static create, instance who/greet, all async siblings).
- `opt_box_method_matrix` in `test_optional_args.cc`: static + instance methods with opts structs.
- `method_raises_blocks` in `test_raises.cc`: the `Raises:` blocks python pins in its .pyi stubs.

All 12 `sdk_test_cpp` fixture jobs pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The C++ SDK generator now emits both static and instance class methods, including synchronous and asynchronous variants.
  * Method calling supports parameters, optional arguments, and instance receiver handling.
  * Generated C++ documentation now includes method-specific exception (`Raises`) details.

* **Tests**
  * Added C++ tests covering class method creation and invocation, asynchronous results, optional-argument probing, and `Raises` documentation formatting/reachability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->