### PR TITLE
bridge-cpp: host callables - std::function crosses the boundary

### DIFF
--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_host_callables.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_host_callables.cc
@@ -1,0 +1,298 @@
+// End-to-end tests for the host-callable round trip.
+// Port of function_calls/customizable/test_host_callables.py. The bridge
+// registers a std::function in its host-value registry and emits a
+// Handle{HOST_VALUE_CALLABLE} wire entry; the engine binds it to an
+// Object::HostClosure; when BAML invokes it the call_host_value sysop
+// fires the dispatch trampoline, which runs the callable on a detached
+// thread and completes the call.
+//
+// Deviations from the Python file: the async-callable tests have no C++
+// analog (there is no coroutine callable; every std::function is the sync
+// path); the release/weakref test is xfail in Python (engine GC heuristic)
+// and has no C++ observation point, so it is not ported; Python's
+// `raise error(ValidationError(...))` is baml::host_throw<ValidationError>;
+// exception identity (`raised is caught`) is observed as same-object
+// rehydration -- the caught exception preserves the original's dynamic
+// type, message, and custom fields.
+#include <baml_sdk.h>
+#include <baml_test.h>
+
+#include <exception>
+#include <string>
+#include <vector>
+
+using baml_sdk::host_callable_tests::Person;
+using baml_sdk::host_callable_tests::ValidationError;
+
+BAML_TEST(simple_sync_callable_returns_string) {
+  const std::string result = baml_sdk::host_callable_tests::call_with_callback(
+      [](int64_t x) { return "got " + std::to_string(x); }, 5);
+  BAML_ASSERT_EQ(result, std::string("got 5"));
+}
+
+BAML_TEST(two_arg_callable_unpacks_positional_args) {
+  const std::string result = baml_sdk::host_callable_tests::call_with_two_args(
+      [](int64_t x, std::string prefix) {
+        return prefix + ":" + std::to_string(x);
+      },
+      7, "answer");
+  BAML_ASSERT_EQ(result, std::string("answer:7"));
+}
+
+BAML_TEST(int_return_callable_round_trip) {
+  const int64_t result = baml_sdk::host_callable_tests::call_int_callback(
+      [](int64_t x) { return x * 2; }, 21);
+  BAML_ASSERT_EQ(result, int64_t{42});
+}
+
+BAML_TEST(throwing_callable_round_trips_original_host_exception) {
+  // A native C++ exception thrown inside a host callable surfaces back to
+  // the caller as the original exception (registry rehydration), not
+  // flattened into a error(HostCallable(...)) wrapper.
+  bool threw = false;
+  try {
+    baml_sdk::host_callable_tests::call_with_callback(
+        [](int64_t) -> std::string { throw std::runtime_error("nope"); }, 1);
+    baml_test::fail("call_with_callback did not throw");
+  } catch (const std::runtime_error& e) {
+    threw = true;
+    BAML_ASSERT_EQ(std::string(e.what()), std::string("nope"));
+  }
+  BAML_ASSERT(threw);
+}
+
+BAML_TEST(throwing_callable_out_of_range_round_trips_with_identity) {
+  // The native-exception rehydration path is class-agnostic: any
+  // exception type round-trips, not just std::runtime_error.
+  bool threw = false;
+  try {
+    baml_sdk::host_callable_tests::call_with_callback(
+        [](int64_t) -> std::string { throw std::out_of_range("missing"); }, 1);
+    baml_test::fail("call_with_callback did not throw");
+  } catch (const std::out_of_range& e) {
+    threw = true;
+    BAML_ASSERT_EQ(std::string(e.what()), std::string("missing"));
+  }
+  BAML_ASSERT(threw);
+}
+
+namespace {
+class MyDomainError : public std::exception {
+ public:
+  MyDomainError(std::string message, int code)
+      : message_(std::move(message)), code(code) {}
+  const char* what() const noexcept override { return message_.c_str(); }
+
+  int code;
+
+ private:
+  std::string message_;
+};
+}  // namespace
+
+BAML_TEST(throwing_callable_custom_host_exception_round_trips_with_identity) {
+  // A user-defined exception subclass round-trips with its custom state
+  // intact -- the same object comes back, so `code` survives even though
+  // the bridge never learned the concrete type.
+  bool threw = false;
+  try {
+    baml_sdk::host_callable_tests::call_with_callback(
+        [](int64_t) -> std::string {
+          throw MyDomainError("custom domain failure", 42);
+        },
+        1);
+    baml_test::fail("call_with_callback did not throw");
+  } catch (const MyDomainError& e) {
+    threw = true;
+    BAML_ASSERT_EQ(std::string(e.what()), std::string("custom domain failure"));
+    BAML_ASSERT_EQ(e.code, 42);
+  }
+  BAML_ASSERT(threw);
+}
+
+BAML_TEST(throwing_callable_hostthrow_codegenned_class_is_caught_in_baml) {
+  // A baml::host_throw<ValidationError> crosses as the real BAML class on
+  // the wire, so the BAML side's typed `catch (e: ValidationError)`
+  // matches structurally and reads e.message as a real field.
+  const std::string result =
+      baml_sdk::host_callable_tests::call_with_typed_throws(
+          [](int64_t) -> std::string {
+            throw baml::host_throw<ValidationError>(ValidationError{
+                4, "bad shape", {"name", "age", "email", "phone"}});
+          },
+          1);
+  BAML_ASSERT_EQ(result, std::string("caught: bad shape"));
+}
+
+BAML_TEST(throwing_callable_hostthrow_propagates_back_with_typed_fields) {
+  // The same host_throw<ValidationError>, when not caught in BAML,
+  // propagates back out as a error whose payload decodes to the
+  // typed ValidationError with all fields preserved.
+  bool threw = false;
+  try {
+    baml_sdk::host_callable_tests::call_with_typed_throws_propagating(
+        [](int64_t) -> std::string {
+          throw baml::host_throw<ValidationError>(
+              ValidationError{7, "propagated through", {"x", "y"}});
+        },
+        1);
+    baml_test::fail("call_with_typed_throws_propagating did not throw");
+  } catch (const baml::error& e) {
+    threw = true;
+    BAML_ASSERT(e.is<ValidationError>());
+    const ValidationError decoded = e.get<ValidationError>();
+    BAML_ASSERT_EQ(decoded.code, int64_t{7});
+    BAML_ASSERT_EQ(decoded.message, std::string("propagated through"));
+    BAML_ASSERT((decoded.fields == std::vector<std::string>{"x", "y"}));
+  }
+  BAML_ASSERT(threw);
+}
+
+BAML_TEST(multiple_throws_in_flight_do_not_collide_in_registry) {
+  // Each host throw mints a fresh host-value key; calls in quick
+  // succession must not see the wrong original exception.
+  bool first_threw = false;
+  try {
+    baml_sdk::host_callable_tests::call_with_callback(
+        [](int64_t) -> std::string { throw std::runtime_error("first"); }, 1);
+  } catch (const std::runtime_error& e) {
+    first_threw = true;
+    BAML_ASSERT_EQ(std::string(e.what()), std::string("first"));
+  }
+  bool second_threw = false;
+  try {
+    baml_sdk::host_callable_tests::call_with_callback(
+        [](int64_t) -> std::string { throw std::runtime_error("second"); }, 2);
+  } catch (const std::runtime_error& e) {
+    second_threw = true;
+    BAML_ASSERT_EQ(std::string(e.what()), std::string("second"));
+  }
+  BAML_ASSERT(first_threw && second_threw);
+}
+
+BAML_TEST(lambda_round_trip) {
+  // A capturing lambda exercises the callable-encoding branch with
+  // closure state.
+  const std::string tag = "lambda";
+  const std::string result = baml_sdk::host_callable_tests::call_with_callback(
+      [tag](int64_t x) { return tag + "-" + std::to_string(x); }, 99);
+  BAML_ASSERT_EQ(result, std::string("lambda-99"));
+}
+
+BAML_TEST(multiple_callable_keys_are_distinct) {
+  // Two separately-registered callables must produce two distinct keys;
+  // invoking one must not call the other.
+  int count_a = 0;
+  int count_b = 0;
+  const std::string a = baml_sdk::host_callable_tests::call_with_callback(
+      [&count_a](int64_t x) {
+        ++count_a;
+        return "a:" + std::to_string(x);
+      },
+      1);
+  const std::string b = baml_sdk::host_callable_tests::call_with_callback(
+      [&count_b](int64_t x) {
+        ++count_b;
+        return "b:" + std::to_string(x);
+      },
+      2);
+  BAML_ASSERT_EQ(a, std::string("a:1"));
+  BAML_ASSERT_EQ(b, std::string("b:2"));
+  BAML_ASSERT(count_a == 1 && count_b == 1);
+}
+
+BAML_TEST(class_callback_round_trips_class_value) {
+  // A user-defined Person crosses the callable boundary: BAML encodes it
+  // for the engine->host call; the dispatcher decodes it into the
+  // codegen-emitted struct; the callback receives a Person.
+  const std::string result =
+      baml_sdk::host_callable_tests::call_with_class_callback(
+          [](Person p) { return p.name + " is " + std::to_string(p.age); },
+          Person{"Ada", 37});
+  BAML_ASSERT_EQ(result, std::string("Ada is 37"));
+}
+
+BAML_TEST(call_repeatedly_invokes_callback_n_times) {
+  // N round-trips through SysOp::BamlHostCallHostValue.
+  std::vector<int64_t> invocations;
+  const std::vector<std::string> results =
+      baml_sdk::host_callable_tests::call_repeatedly(
+          [&invocations](int64_t x) {
+            invocations.push_back(x);
+            return "item-" + std::to_string(x);
+          },
+          5);
+  BAML_ASSERT((results == std::vector<std::string>{"item-0", "item-1", "item-2",
+                                                   "item-3", "item-4"}));
+  BAML_ASSERT((invocations == std::vector<int64_t>{0, 1, 2, 3, 4}));
+}
+
+BAML_TEST(call_repeatedly_with_zero_n_returns_empty_list) {
+  std::vector<int64_t> invocations;
+  const std::vector<std::string> results =
+      baml_sdk::host_callable_tests::call_repeatedly(
+          [&invocations](int64_t x) {
+            invocations.push_back(x);
+            return std::string();
+          },
+          0);
+  BAML_ASSERT(results.empty());
+  BAML_ASSERT(invocations.empty());
+}
+
+BAML_TEST(call_with_throwing_in_baml_catches_host_callable_error) {
+  // The BAML `catch (e)` around a host-callable invocation intercepts a
+  // host-thrown baml.errors.HostCallable; class_name carries the host
+  // exception's (demangled) dynamic type.
+  const std::string result = baml_sdk::host_callable_tests::call_with_throwing(
+      [](int64_t) -> std::string {
+        throw std::runtime_error("boom from host");
+      },
+      1);
+  BAML_ASSERT_EQ(result, std::string("caught:std::runtime_error"));
+}
+
+// ---------------------------------------------------------------------------
+// Optional args x host callables (the combination).
+//
+// A host callable whose own type carries optional parameters
+// (`(x: int, y?: int, z?: int) -> int`). An omitted optional arrives as an
+// unset Arg, so the host's own default is the only source of a value when
+// BAML omits the arg. The callback returns x*100 + y*10 + z so each test
+// can read off exactly which optionals were delivered.
+// ---------------------------------------------------------------------------
+
+static int64_t optional_args_cb(int64_t x, baml::arg<int64_t> y,
+                                baml::arg<int64_t> z) {
+  const int64_t y_val = y.is_set() ? y.value() : 8;
+  const int64_t z_val = z.is_set() ? z.value() : 9;
+  return x * 100 + y_val * 10 + z_val;
+}
+
+BAML_TEST(optional_args_all_unset_apply_host_defaults) {
+  // `callback(x)` supplies neither optional: both arrive unset and the
+  // host defaults fill y/z (8 and 9), yielding 5*100 + 8*10 + 9 = 589.
+  const std::vector<int64_t> results =
+      baml_sdk::host_callable_tests::call_callback_with_optional_args_all_unset(
+          optional_args_cb, 5);
+  BAML_ASSERT((results == std::vector<int64_t>{589}));
+}
+
+BAML_TEST(optional_args_partially_set_deliver_by_name) {
+  // Two calls each supplying exactly one optional by name:
+  // `callback(x, y = 2)` -> 529, then `callback(x, z = 3)` -> 583 --
+  // including the case where the leading optional y is skipped while z
+  // is supplied.
+  const std::vector<int64_t> results = baml_sdk::host_callable_tests::
+      call_callback_with_optional_args_partially_set(optional_args_cb, 5);
+  BAML_ASSERT((results == std::vector<int64_t>{529, 583}));
+}
+
+BAML_TEST(optional_args_all_set_deliver_both) {
+  // `callback(x, y = 2, z = 3)` supplies both optionals; both arrive set
+  // and override the host defaults, yielding 500 + 20 + 3 = 523.
+  const std::vector<int64_t> results =
+      baml_sdk::host_callable_tests::call_callback_with_optional_args_all_set(
+          optional_args_cb, 5);
+  BAML_ASSERT((results == std::vector<int64_t>{523}));
+}

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/baml.h
@@ -9,6 +9,7 @@
 #include <baml/buffer.h>
 #include <baml/codec.h>
 #include <baml/detail/call.h>
+#include <baml/detail/host_value.h>
 #include <baml/detail/loader.h>
 #include <baml/detail/registry.h>
 #include <baml/errors.h>

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/codec.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/codec.h
@@ -10,6 +10,7 @@
 // widens literal values to their base scalar (Python parity).
 
 #include <baml/box.h>
+#include <baml/detail/host_value.h>
 #include <baml/detail/proto.h>
 #include <baml/errors.h>
 #include <baml/lit.h>
@@ -445,6 +446,27 @@ inline std::vector<uint8_t> raw_payload(const pb::BamlOutboundValue& v) {
       is_panic ? result.panic().value() : result.error().value();
   std::string class_name = thrown_class_name(value);
   std::string message = error_message_of(value);
+
+  // A baml.errors.HostCallable wrapping a native host exception carries a
+  // _handle into this process's registry: rethrow the original exception
+  // object instead of a flattened baml::error (Python-identity parity).
+  if (!is_panic && class_name == "baml.errors.HostCallable") {
+    const pb::BamlOutboundValue& v = unwrap(value);
+    if (v.value_case() == pb::BamlOutboundValue::kClassValue) {
+      for (const auto& field : v.class_value().fields()) {
+        if (field.key() == "_handle" &&
+            field.value().value_case() == pb::BamlOutboundValue::kHandleValue &&
+            field.value().handle_value().handle_type() ==
+                pb::HOST_VALUE_OPAQUE) {
+          if (std::exception_ptr original =
+                  host_value_registry::instance().find_exception(
+                      field.value().handle_value().key())) {
+            std::rethrow_exception(original);
+          }
+        }
+      }
+    }
+  }
 
   if (is_panic) {
     if (result.panic().is_exit_panic()) {

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/host_value.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/host_value.h
@@ -1,0 +1,530 @@
+#ifndef BAML_DETAIL_HOST_VALUE_H_
+#define BAML_DETAIL_HOST_VALUE_H_
+
+// Host callables: a std::function passed as a BAML argument crosses the
+// boundary as InboundValue.handle{key, HOST_VALUE_CALLABLE}, where key
+// references a type-erased dispatcher in the process-global
+// host_value_registry. When BAML invokes the callable, the engine fires
+// the registered host-dispatch callback; the trampoline here runs the
+// dispatcher on a detached thread (dispatch must be fire-and-return --
+// the engine awaits the completion, so the user callable must not run on
+// the engine's worker), and the dispatcher decodes the BamlToHostCall
+// args, invokes the user function, and resolves the call via
+// complete_host_call. Mirrors bridge_python::host_value.
+//
+// Host exceptions cross back in two shapes (Python parity):
+//   - baml::host_throw<T>           -> the typed BAML class value itself
+//   - anything else                 -> a baml.errors.HostCallable instance
+//     whose _handle field references the original exception_ptr in this
+//     registry, so the result decoder rehydrates the original exception
+//     on same-process round-trip (see throw_from_result in codec.h).
+
+#include <baml/arg.h>
+#include <baml/detail/loader.h>
+#include <baml/detail/proto.h>
+#include <baml/errors.h>
+#include <baml_cffi.h>
+
+#include <array>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#if !defined(_MSC_VER)
+#include <cxxabi.h>
+
+#include <cstdlib>
+#include <typeinfo>
+#else
+#include <typeinfo>
+#endif
+
+extern "C" inline void baml_cpp_host_dispatch_trampoline(
+    uint64_t host_value_key, uint32_t call_id, const uint8_t* args,
+    size_t length);
+extern "C" inline void baml_cpp_host_release_trampoline(
+    uint64_t host_value_key);
+
+namespace baml {
+
+template <typename T>
+struct codec;
+
+namespace detail {
+
+// Process-wide table of host values handed to BAML: callable dispatchers
+// (registered when a std::function is encoded as an argument) and opaque
+// exception_ptrs (registered when a host callable throws a native
+// exception, so the thrown baml.errors.HostCallable can be rehydrated to
+// the original exception on round-trip). Keys are never 0; entries are
+// removed by the engine-driven release callback when the engine drops its
+// last clone of the corresponding host value.
+class host_value_registry {
+ public:
+  using dispatcher =
+      std::function<void(uint32_t call_id, std::vector<uint8_t> args)>;
+
+  static host_value_registry& instance() {
+    // Intentionally leaked, like call_registry: release callbacks can fire
+    // from engine threads during process teardown.
+    static host_value_registry* registry = new host_value_registry();
+    return *registry;
+  }
+
+  uint64_t add_dispatcher(dispatcher dispatch) {
+    std::lock_guard<std::mutex> lock(mu_);
+    const uint64_t key = next_key_++;
+    table_.emplace(key, entry{std::move(dispatch), nullptr});
+    return key;
+  }
+
+  uint64_t add_exception(std::exception_ptr exception) {
+    std::lock_guard<std::mutex> lock(mu_);
+    const uint64_t key = next_key_++;
+    table_.emplace(key, entry{nullptr, std::move(exception)});
+    return key;
+  }
+
+  void release(uint64_t key) {
+    std::lock_guard<std::mutex> lock(mu_);
+    table_.erase(key);
+  }
+
+  // Copies out under the lock so a concurrent release cannot invalidate
+  // the returned dispatcher mid-call.
+  dispatcher find_dispatcher(uint64_t key) {
+    std::lock_guard<std::mutex> lock(mu_);
+    auto it = table_.find(key);
+    return it == table_.end() ? dispatcher() : it->second.dispatch;
+  }
+
+  std::exception_ptr find_exception(uint64_t key) {
+    std::lock_guard<std::mutex> lock(mu_);
+    auto it = table_.find(key);
+    return it == table_.end() ? nullptr : it->second.exception;
+  }
+
+ private:
+  struct entry {
+    dispatcher dispatch;
+    std::exception_ptr exception;
+  };
+
+  host_value_registry() {
+    api().register_host_dispatch_callback(&baml_cpp_host_dispatch_trampoline);
+    api().register_host_release_callback(&baml_cpp_host_release_trampoline);
+  }
+
+  std::mutex mu_;
+  std::unordered_map<uint64_t, entry> table_;
+  uint64_t next_key_ = 1;
+};
+
+// ---------------------------------------------------------------------------
+// Wire helpers
+// ---------------------------------------------------------------------------
+
+inline void complete_host_success(uint32_t call_id,
+                                  const std::string& inbound_bytes) {
+  api().complete_host_call(
+      call_id, 0, reinterpret_cast<const int8_t*>(inbound_bytes.data()),
+      inbound_bytes.size());
+}
+
+inline void complete_host_error(uint32_t call_id,
+                                const std::string& inbound_bytes) {
+  api().complete_host_call(
+      call_id, 1, reinterpret_cast<const int8_t*>(inbound_bytes.data()),
+      inbound_bytes.size());
+}
+
+// Builds the InboundValue bytes of a baml.errors.HostCallable class value.
+// class_name / message / language are debugging metadata; _handle
+// (required on the wire) references the original exception in the
+// registry for same-process rehydration. traceback is declared nullable
+// but must be present, so it is sent as an explicit null (C++ has no
+// portable traceback).
+inline std::string build_host_callable_inbound(const std::string& class_name,
+                                               const std::string& message,
+                                               uint64_t handle_key) {
+  pb::InboundValue value_msg;
+  pb::InboundClassValue* cls = value_msg.mutable_class_value();
+  const auto string_field = [cls](const char* key, const std::string& v) {
+    pb::InboundMapEntry* field = cls->add_fields();
+    field->set_string_key(key);
+    field->mutable_value()->set_string_value(v);
+  };
+  string_field("message", message);
+  string_field("class_name", class_name);
+  string_field("language", "cpp");
+  {
+    pb::InboundMapEntry* field = cls->add_fields();
+    field->set_string_key("traceback");
+    field->mutable_value();  // present but empty InboundValue = explicit null
+  }
+  {
+    pb::InboundMapEntry* field = cls->add_fields();
+    field->set_string_key("_handle");
+    pb::BamlHandle* handle = field->mutable_value()->mutable_handle();
+    handle->set_key(handle_key);
+    handle->set_handle_type(pb::HOST_VALUE_OPAQUE);
+  }
+  cls->mutable_class_ty()->set_name("baml.errors.HostCallable");
+  return value_msg.SerializeAsString();
+}
+
+// Re-encodes an outbound value as an InboundValue message: the propagation
+// path for a baml::error caught from a nested BAML call and rethrown out
+// of a host callable (the analog of Python re-encoding `BamlError.value`).
+// Class identity round-trips, so the BAML caller's typed catch still
+// matches.
+inline void transcode_outbound_to_inbound(pb::InboundValue& out,
+                                          const pb::BamlOutboundValue& raw) {
+  const pb::BamlOutboundValue& v = unwrap(raw);
+  switch (v.value_case()) {
+    case pb::BamlOutboundValue::VALUE_NOT_SET:
+    case pb::BamlOutboundValue::kNullValue:
+      return;  // absent oneof = null
+    case pb::BamlOutboundValue::kStringValue:
+      out.set_string_value(v.string_value());
+      return;
+    case pb::BamlOutboundValue::kIntValue:
+      out.set_int_value(v.int_value());
+      return;
+    case pb::BamlOutboundValue::kFloatValue:
+      out.set_float_value(v.float_value());
+      return;
+    case pb::BamlOutboundValue::kBoolValue:
+      out.set_bool_value(v.bool_value());
+      return;
+    case pb::BamlOutboundValue::kLiteralValue:
+      switch (v.literal_value().literal_case()) {
+        case pb::BamlLiteralValue::kStringValue:
+          out.set_string_value(v.literal_value().string_value());
+          return;
+        case pb::BamlLiteralValue::kIntValue:
+          out.set_int_value(v.literal_value().int_value());
+          return;
+        case pb::BamlLiteralValue::kBoolValue:
+          out.set_bool_value(v.literal_value().bool_value());
+          return;
+        case pb::BamlLiteralValue::kBigintValue:
+          out.set_bigint_value(v.literal_value().bigint_value());
+          return;
+        default:
+          throw error("cannot transcode this literal value back inbound");
+      }
+    case pb::BamlOutboundValue::kListValue: {
+      pb::InboundListValue* list = out.mutable_list_value();
+      for (const pb::BamlOutboundValue& item : v.list_value().items()) {
+        transcode_outbound_to_inbound(*list->add_values(), item);
+      }
+      return;
+    }
+    case pb::BamlOutboundValue::kMapValue: {
+      pb::InboundMapValue* map = out.mutable_map_value();
+      for (const pb::BamlOutboundMapEntry& e : v.map_value().entries()) {
+        pb::InboundMapEntry* entry = map->add_entries();
+        entry->set_string_key(e.key());
+        transcode_outbound_to_inbound(*entry->mutable_value(), e.value());
+      }
+      return;
+    }
+    case pb::BamlOutboundValue::kClassValue: {
+      pb::InboundClassValue* cls = out.mutable_class_value();
+      for (const pb::BamlOutboundMapEntry& e : v.class_value().fields()) {
+        pb::InboundMapEntry* field = cls->add_fields();
+        field->set_string_key(e.key());
+        transcode_outbound_to_inbound(*field->mutable_value(), e.value());
+      }
+      cls->mutable_class_ty()->set_name(v.class_value().name());
+      return;
+    }
+    case pb::BamlOutboundValue::kEnumValue: {
+      pb::InboundEnumValue* en = out.mutable_enum_value();
+      en->set_name(v.enum_value().name());
+      en->set_value(v.enum_value().value());
+      return;
+    }
+    case pb::BamlOutboundValue::kHandleValue: {
+      pb::BamlHandle* handle = out.mutable_handle();
+      handle->set_key(v.handle_value().key());
+      handle->set_handle_type(v.handle_value().handle_type());
+      return;
+    }
+    case pb::BamlOutboundValue::kUint8ArrayValue:
+      out.set_uint8array_value(v.uint8array_value());
+      return;
+    case pb::BamlOutboundValue::kBigintValue:
+      out.set_bigint_value(v.bigint_value());
+      return;
+    default:
+      throw error("cannot transcode this value back inbound");
+  }
+}
+
+// Best-effort dynamic class name of a host exception, for the
+// baml.errors.HostCallable metadata (Python puts the exception class name
+// there; C++ uses the demangled dynamic type).
+inline std::string exception_class_name(const std::exception& e) {
+#if defined(_MSC_VER)
+  return typeid(e).name();
+#else
+  int status = 0;
+  char* demangled =
+      abi::__cxa_demangle(typeid(e).name(), nullptr, nullptr, &status);
+  std::string out =
+      (status == 0 && demangled != nullptr) ? demangled : typeid(e).name();
+  std::free(demangled);
+  return out;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Typed dispatch
+// ---------------------------------------------------------------------------
+
+template <typename T>
+struct is_arg : std::false_type {};
+template <typename U>
+struct is_arg<::baml::arg<U>> : std::true_type {};
+
+template <typename T>
+struct arg_inner {
+  using type = T;
+};
+template <typename U>
+struct arg_inner<::baml::arg<U>> {
+  using type = U;
+};
+
+template <typename Slot>
+Slot decode_host_slot(const pb::BamlOutboundValue& v) {
+  if constexpr (is_arg<Slot>::value) {
+    return Slot(codec<typename arg_inner<Slot>::type>::decode(v));
+  } else {
+    return codec<Slot>::decode(v);
+  }
+}
+
+// Staging is std::tuple<std::optional<Slot>...>: absent stays disengaged
+// so an omitted optional param materializes as an unset arg.
+template <typename Staging, size_t I>
+void fill_host_slot(Staging& staging, const pb::BamlOutboundValue& v) {
+  using Slot = typename std::tuple_element_t<I, Staging>::value_type;
+  std::get<I>(staging).emplace(decode_host_slot<Slot>(v));
+}
+
+template <typename Staging, size_t... I>
+std::array<void (*)(Staging&, const pb::BamlOutboundValue&), sizeof...(I)>
+make_host_slot_fillers(std::index_sequence<I...>) {
+  return {{&fill_host_slot<Staging, I>...}};
+}
+
+template <typename Slot>
+Slot materialize_host_slot(std::optional<Slot>& staged) {
+  if (staged.has_value()) {
+    return std::move(*staged);
+  }
+  if constexpr (is_arg<Slot>::value) {
+    return Slot();  // omitted optional -> unset
+  } else {
+    throw error("host callable dispatched without a required argument");
+  }
+}
+
+template <typename R, typename Fn, typename Staging, size_t... I>
+R invoke_host_callable(const Fn& fn, Staging& staging,
+                       std::index_sequence<I...>) {
+  return fn(materialize_host_slot<
+            typename std::tuple_element_t<I, Staging>::value_type>(
+      std::get<I>(staging))...);
+}
+
+// Decodes the BamlToHostCall, invokes the user callable, and completes the
+// in-flight call -- exactly once, on every exit path. `names` are the
+// callable's declared BAML parameter names ("" for unnamed required
+// params); supplied optionals are matched to their slot by name, required
+// args by declared order.
+template <typename R, typename... Ps>
+void run_host_callable(const std::function<R(Ps...)>& fn,
+                       const std::array<std::string, sizeof...(Ps)>& names,
+                       uint32_t call_id,
+                       const std::vector<uint8_t>& args_bytes) {
+  try {
+    constexpr size_t n = sizeof...(Ps);
+    using Staging = std::tuple<std::optional<std::decay_t<Ps>>...>;
+    Staging staging;
+    constexpr std::array<bool, n> optional_slot = {
+        {is_arg<std::decay_t<Ps>>::value...}};
+    const auto fillers =
+        make_host_slot_fillers<Staging>(std::make_index_sequence<n>{});
+
+    pb::BamlToHostCall call;
+    if (!call.ParseFromArray(args_bytes.data(),
+                             static_cast<int>(args_bytes.size()))) {
+      throw error("malformed BamlToHostCall payload");
+    }
+    size_t required_cursor = 0;
+    for (const pb::BamlToHostArg& arg : call.args()) {
+      size_t slot = n;
+      if (arg.is_optional_arg()) {
+        for (size_t i = 0; i < n; ++i) {
+          if (names[i] == arg.arg_name()) {
+            slot = i;
+            break;
+          }
+        }
+        if (slot == n) {
+          throw error("host callable received unknown optional argument '" +
+                      arg.arg_name() + "'");
+        }
+      } else {
+        while (required_cursor < n && optional_slot[required_cursor]) {
+          ++required_cursor;
+        }
+        if (required_cursor == n) {
+          throw error(
+              "host callable received more required arguments than "
+              "declared parameters");
+        }
+        slot = required_cursor++;
+      }
+      fillers[slot](staging, arg.value());
+    }
+
+    pb::InboundValue result_msg;
+    if constexpr (std::is_void<R>::value) {
+      invoke_host_callable<void>(fn, staging, std::make_index_sequence<n>{});
+      // void result = BAML null: leave the InboundValue empty.
+    } else {
+      R result =
+          invoke_host_callable<R>(fn, staging, std::make_index_sequence<n>{});
+      codec<R>::encode(result_msg, result);
+    }
+    complete_host_success(call_id, result_msg.SerializeAsString());
+  } catch (const host_throw_base& typed) {
+    pb::InboundValue value_msg;
+    typed.encode_value(value_msg);
+    complete_host_error(call_id, value_msg.SerializeAsString());
+  } catch (const error& e) {
+    // A BAML-originated error rethrown through the callable: transcode
+    // its payload so the class identity survives the round-trip.
+    if (!e.payload().empty()) {
+      try {
+        pb::BamlOutboundValue payload;
+        if (payload.ParseFromArray(e.payload().data(),
+                                   static_cast<int>(e.payload().size()))) {
+          pb::InboundValue value_msg;
+          transcode_outbound_to_inbound(value_msg, payload);
+          complete_host_error(call_id, value_msg.SerializeAsString());
+          return;
+        }
+      } catch (...) {
+        // Untranscodable payload: fall through to the opaque path.
+      }
+    }
+    const uint64_t key =
+        host_value_registry::instance().add_exception(std::current_exception());
+    complete_host_error(
+        call_id,
+        build_host_callable_inbound(exception_class_name(e), e.message(), key));
+  } catch (const std::exception& e) {
+    const uint64_t key =
+        host_value_registry::instance().add_exception(std::current_exception());
+    complete_host_error(call_id, build_host_callable_inbound(
+                                     exception_class_name(e), e.what(), key));
+  } catch (...) {
+    const uint64_t key =
+        host_value_registry::instance().add_exception(std::current_exception());
+    complete_host_error(
+        call_id,
+        build_host_callable_inbound(
+            "unknown", "host callable threw a non-std::exception value", key));
+  }
+}
+
+// Registers `fn` as a host callable and writes the InboundValue handle
+// that references it. Called from generated bindings for callable-typed
+// arguments; `names` are the callable's declared parameter names in
+// declared order (used to key supplied optional args).
+template <typename R, typename... Ps>
+void encode_callable(pb::InboundValue& value_msg, std::function<R(Ps...)> fn,
+                     std::array<std::string, sizeof...(Ps)> names) {
+  auto shared_names =
+      std::make_shared<const std::array<std::string, sizeof...(Ps)>>(
+          std::move(names));
+  const uint64_t key = host_value_registry::instance().add_dispatcher(
+      [fn = std::move(fn), shared_names](uint32_t call_id,
+                                         std::vector<uint8_t> args_bytes) {
+        run_host_callable<R, Ps...>(fn, *shared_names, call_id, args_bytes);
+      });
+  pb::BamlHandle* handle = value_msg.mutable_handle();
+  handle->set_key(key);
+  handle->set_handle_type(pb::HOST_VALUE_CALLABLE);
+}
+
+}  // namespace detail
+}  // namespace baml
+
+extern "C" inline void baml_cpp_host_dispatch_trampoline(
+    uint64_t host_value_key, uint32_t call_id, const uint8_t* args,
+    size_t length) {
+  std::vector<uint8_t> bytes;
+  if (args != nullptr && length != 0) {
+    bytes.assign(args, args + length);
+  }
+  // Bridge-layer faults (not user exceptions) also complete through
+  // complete_host_call -- the C ABI's only completion channel -- as a
+  // HostCallable error whose _handle carries a synthesized baml::error
+  // (the wire shape requires a real handle).
+  const auto bridge_failure = [call_id](const std::string& message) {
+    const uint64_t key =
+        baml::detail::host_value_registry::instance().add_exception(
+            std::make_exception_ptr(baml::error(message)));
+    baml::detail::complete_host_error(
+        call_id, baml::detail::build_host_callable_inbound("BridgeFailure",
+                                                           message, key));
+  };
+  auto dispatcher =
+      baml::detail::host_value_registry::instance().find_dispatcher(
+          host_value_key);
+  if (!dispatcher) {
+    // The engine knows a handle this registry does not: a bridge fault.
+    bridge_failure("no host callable registered for key " +
+                   std::to_string(host_value_key));
+    return;
+  }
+  // Fire-and-return: the engine awaits the completion, so the user
+  // callable runs on its own thread (the analog of Python's spawned tokio
+  // task). run_host_callable completes the call on every exit path.
+  std::thread([dispatcher = std::move(dispatcher), bridge_failure, call_id,
+               bytes = std::move(bytes)]() mutable {
+    try {
+      dispatcher(call_id, std::move(bytes));
+    } catch (...) {
+      bridge_failure("host callable dispatch failed outside the user callable");
+    }
+  }).detach();
+}
+
+extern "C" inline void baml_cpp_host_release_trampoline(
+    uint64_t host_value_key) {
+  // No C++ exception may cross the C ABI (bridge contract).
+  try {
+    baml::detail::host_value_registry::instance().release(host_value_key);
+  } catch (...) {
+  }
+}
+
+#endif  // BAML_DETAIL_HOST_VALUE_H_

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/host_value.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/host_value.h
@@ -480,10 +480,6 @@ void encode_callable(pb::InboundValue& value_msg, std::function<R(Ps...)> fn,
 extern "C" inline void baml_cpp_host_dispatch_trampoline(
     uint64_t host_value_key, uint32_t call_id, const uint8_t* args,
     size_t length) {
-  std::vector<uint8_t> bytes;
-  if (args != nullptr && length != 0) {
-    bytes.assign(args, args + length);
-  }
   // Bridge-layer faults (not user exceptions) also complete through
   // complete_host_call -- the C ABI's only completion channel -- as a
   // HostCallable error whose _handle carries a synthesized baml::error
@@ -496,26 +492,46 @@ extern "C" inline void baml_cpp_host_dispatch_trampoline(
         call_id, baml::detail::build_host_callable_inbound("BridgeFailure",
                                                            message, key));
   };
-  auto dispatcher =
-      baml::detail::host_value_registry::instance().find_dispatcher(
-          host_value_key);
-  if (!dispatcher) {
-    // The engine knows a handle this registry does not: a bridge fault.
-    bridge_failure("no host callable registered for key " +
-                   std::to_string(host_value_key));
-    return;
-  }
-  // Fire-and-return: the engine awaits the completion, so the user
-  // callable runs on its own thread (the analog of Python's spawned tokio
-  // task). run_host_callable completes the call on every exit path.
-  std::thread([dispatcher = std::move(dispatcher), bridge_failure, call_id,
-               bytes = std::move(bytes)]() mutable {
-    try {
-      dispatcher(call_id, std::move(bytes));
-    } catch (...) {
-      bridge_failure("host callable dispatch failed outside the user callable");
+  // No C++ exception may cross the C ABI (bridge contract), and every
+  // setup fault must still complete the call or the engine awaits forever:
+  // bytes.assign can throw bad_alloc, the registry lock can throw, and the
+  // std::thread constructor throws system_error under thread exhaustion.
+  try {
+    std::vector<uint8_t> bytes;
+    if (args != nullptr && length != 0) {
+      bytes.assign(args, args + length);
     }
-  }).detach();
+    auto dispatcher =
+        baml::detail::host_value_registry::instance().find_dispatcher(
+            host_value_key);
+    if (!dispatcher) {
+      // The engine knows a handle this registry does not: a bridge fault.
+      bridge_failure("no host callable registered for key " +
+                     std::to_string(host_value_key));
+      return;
+    }
+    // Fire-and-return: the engine awaits the completion, so the user
+    // callable runs on its own thread (the analog of Python's spawned
+    // tokio task). run_host_callable completes the call on every exit
+    // path.
+    std::thread([dispatcher = std::move(dispatcher), bridge_failure, call_id,
+                 bytes = std::move(bytes)]() mutable {
+      try {
+        dispatcher(call_id, std::move(bytes));
+      } catch (...) {
+        bridge_failure(
+            "host callable dispatch failed outside the user callable");
+      }
+    }).detach();
+  } catch (...) {
+    try {
+      bridge_failure("host callable dispatch could not be spawned");
+    } catch (...) {
+      // Even the failure path failed (e.g. allocation): swallowing is all
+      // the ABI permits -- that call hangs rather than the process
+      // hitting UB.
+    }
+  }
 }
 
 extern "C" inline void baml_cpp_host_release_trampoline(

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/errors.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/errors.h
@@ -7,6 +7,16 @@
 #include <utility>
 #include <vector>
 
+// Forward declaration of the protobuf message host_throw encodes into;
+// including the pb header here would cycle with codec.h/proto.h.
+namespace baml_bridge {
+namespace cffi {
+namespace v1 {
+class InboundValue;
+}  // namespace v1
+}  // namespace cffi
+}  // namespace baml_bridge
+
 namespace baml {
 
 // A value thrown by BAML code (the `error` arm of the result envelope).
@@ -79,6 +89,37 @@ class thrown : public error {
 class cancelled : public panic {
  public:
   using panic::panic;
+};
+
+template <typename T>
+struct codec;
+
+// Thrown from inside a host callable to surface a typed BAML error to the
+// BAML caller: `throw baml::host_throw<ValidationError>{value}` crosses
+// the boundary as a real `ValidationError` class value, so a BAML
+// `catch (e: ValidationError)` matches it structurally (the analog of
+// Python's `raise BamlError(ValidationError(...))`). Any other host
+// exception crosses as an opaque `baml.errors.HostCallable` instead.
+class host_throw_base : public std::exception {
+ public:
+  const char* what() const noexcept override {
+    return "BAML host-callable typed throw";
+  }
+  // Writes the thrown value as an InboundValue message body.
+  virtual void encode_value(
+      ::baml_bridge::cffi::v1::InboundValue& value_msg) const = 0;
+};
+
+template <typename T>
+class host_throw : public host_throw_base {
+ public:
+  explicit host_throw(T value) : value(std::move(value)) {}
+  void encode_value(
+      ::baml_bridge::cffi::v1::InboundValue& value_msg) const override {
+    codec<T>::encode(value_msg, value);
+  }
+
+  T value;
 };
 
 }  // namespace baml

--- a/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
+++ b/baml_language/sdks/cpp/sdkgen_cpp/src/lib.rs
@@ -30,7 +30,9 @@ use std::{
     path::PathBuf,
 };
 
-use baml_codegen_types::{Class, Enum, Function, Name, Symbol, SymbolPool, Ty};
+use baml_codegen_types::{
+    CallableParam, Class, CodegenFunctionParamMode, Enum, Function, Name, Symbol, SymbolPool, Ty,
+};
 
 use crate::naming::{BamlFqn, CppName, CppNameKind, CppNames, GeneratorIdent, NameRequest};
 
@@ -411,6 +413,10 @@ const BRIDGE_HEADERS: &[(&str, &str)] = &[
     (
         "include/baml/detail/call.h",
         include_str!("../../bridge_cpp/include/baml/detail/call.h"),
+    ),
+    (
+        "include/baml/detail/host_value.h",
+        include_str!("../../bridge_cpp/include/baml/detail/host_value.h"),
     ),
     (
         "include/baml/detail/loader.h",
@@ -898,6 +904,11 @@ fn emit_alias_using(
 struct EmittedParam {
     name: CppName,
     ty: String,
+    /// For callable-typed parameters: the callable's declared BAML param
+    /// names in declared order ("" for unnamed required params). Switches
+    /// the binding to `encode_callable` (host-callable registration) and
+    /// keys supplied optional args on dispatch.
+    callable_names: Option<Vec<String>>,
 }
 
 /// An optional parameter, rendered as an `Arg<type>` field on the opts
@@ -941,13 +952,43 @@ fn emit_callable(
     let mut params = Vec::new();
     let mut opt_params = Vec::new();
     for arg in &function.arguments {
-        let ty = match translate_ty(pool, names, &arg.ty, emitted_types, &BTreeSet::new()) {
-            Translated::Cpp(ty) => ty,
-            Translated::NotYet | Translated::Unsupported(_) => {
+        // Top-level callable parameters cross as host callables
+        // (std::function); callables nested in other types stay
+        // unsupported (translate_ty rejects them).
+        let mut callable_names = None;
+        let ty = if let Ty::Function {
+            params: callable_params,
+            ret,
+            ..
+        } = &arg.ty
+        {
+            if arg.default.is_some() {
                 return Err(format!(
-                    "argument `{}` has unsupported type {}",
-                    arg.name, arg.ty
+                    "optional argument `{}` has a callable type (unsupported)",
+                    arg.name
                 ));
+            }
+            match translate_callable_ty(pool, names, callable_params, ret, emitted_types) {
+                Ok((ty, wire_names)) => {
+                    callable_names = Some(wire_names);
+                    ty
+                }
+                Err(reason) => {
+                    return Err(format!(
+                        "argument `{}` has unsupported type {} ({reason})",
+                        arg.name, arg.ty
+                    ));
+                }
+            }
+        } else {
+            match translate_ty(pool, names, &arg.ty, emitted_types, &BTreeSet::new()) {
+                Translated::Cpp(ty) => ty,
+                Translated::NotYet | Translated::Unsupported(_) => {
+                    return Err(format!(
+                        "argument `{}` has unsupported type {}",
+                        arg.name, arg.ty
+                    ));
+                }
             }
         };
         let param_name = names
@@ -966,6 +1007,7 @@ fn emit_callable(
             params.push(EmittedParam {
                 name: param_name,
                 ty,
+                callable_names,
             });
         }
     }
@@ -1038,6 +1080,53 @@ fn emit_callable(
         raises,
         thrown,
     })
+}
+
+/// A callable-typed parameter as `std::function<Ret(Slots...)>` plus its
+/// declared BAML param names ("" for unnamed). Optional callable params
+/// (`y?: int`) become `arg` slots, so an argument BAML omits materializes
+/// as an unset `arg` and the host's own default applies.
+fn translate_callable_ty(
+    pool: &SymbolPool,
+    names: &CppNames,
+    callable_params: &[CallableParam],
+    ret: &Ty,
+    emitted_types: &BTreeSet<Name>,
+) -> Result<(String, Vec<String>), String> {
+    let mut slots = Vec::new();
+    let mut wire_names = Vec::new();
+    for p in callable_params {
+        let slot = match translate_ty(pool, names, &p.ty, emitted_types, &BTreeSet::new()) {
+            Translated::Cpp(t) => t,
+            Translated::NotYet | Translated::Unsupported(_) => {
+                return Err(format!("callable param type {}", p.ty));
+            }
+        };
+        slots.push(match p.mode {
+            CodegenFunctionParamMode::Required => slot,
+            CodegenFunctionParamMode::Optional => format!("::baml::arg<{slot}>"),
+        });
+        wire_names.push(
+            p.name
+                .as_ref()
+                .map(|n| n.as_str().to_string())
+                .unwrap_or_default(),
+        );
+    }
+    let ret_ty = if matches!(ret, Ty::Void { .. }) {
+        "void".to_string()
+    } else {
+        match translate_ty(pool, names, ret, emitted_types, &BTreeSet::new()) {
+            Translated::Cpp(t) => t,
+            Translated::NotYet | Translated::Unsupported(_) => {
+                return Err(format!("callable return type {ret}"));
+            }
+        }
+    };
+    Ok((
+        format!("std::function<{ret_ty}({})>", slots.join(", ")),
+        wire_names,
+    ))
 }
 
 fn unqualified_leaf_name(ty: &Ty) -> String {
@@ -1469,6 +1558,23 @@ fn render_body(
         );
     }
     for p in &f.params {
+        if let Some(callable_names) = &p.callable_names {
+            let names_array = callable_names
+                .iter()
+                .map(|n| format!("std::string(\"{n}\")"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let _ = writeln!(
+                buf,
+                "{indent}{args}.add_arg(\"{wire}\", [&](::baml::detail::pb::InboundValue& {w}) {{ \
+                 ::baml::detail::encode_callable({w}, {value}, \
+                 std::array<std::string, {n}>{{{{{names_array}}}}}); }});",
+                wire = p.name.wire(),
+                value = p.name.identifier(),
+                n = callable_names.len(),
+            );
+            continue;
+        }
         let _ = writeln!(
             buf,
             "{indent}{args}.add_arg(\"{wire}\", [&](::baml::detail::pb::InboundValue& {w}) {{ \
@@ -1516,7 +1622,9 @@ fn render_header(
         "// Generated by sdkgen_cpp - do not edit.\n\
          #ifndef BAML_SDK_H_\n\
          #define BAML_SDK_H_\n\n\
+         #include <array>\n\
          #include <cstdint>\n\
+         #include <functional>\n\
          #include <unordered_map>\n\
          #include <optional>\n\
          #include <string>\n\


### PR DESCRIPTION
Bridge-week step 12. Re-landed from `-full` with the wire layer rewritten against protobuf.

## What

```baml
function run_agent(query: string, tool: (string) -> string) -> string { tool(query) }
```

```cpp
std::string out = b::run_agent("hi", [](std::string q) { return q + "!"; }, ...);
```

- A callable argument registers a type-erased dispatcher in the process-global `host_value_registry` and rides as `InboundValue.handle{HOST_VALUE_CALLABLE}`. The engine's dispatch callback runs it **fire-and-return on a detached thread**, decoding `BamlToHostCall` args (required by declared order, supplied optionals by name into `arg<T>` slots) and completing via `complete_host_call` on every exit path.
- **Exception rehydration by identity** (python parity): a native exception thrown in your callback comes back to you as the *original exception object* — custom types and fields survive (`MyDomainError.code == 42` after the round trip). `baml::host_throw<ValidationError>` crosses as the real typed BAML class, structurally caught by BAML's `catch (e: ValidationError)`. A `baml::error` rethrown through a callable transcodes its payload so class identity survives.
- Emitter: top-level `Ty::Function` params become `std::function<Ret(Slots...)>` with optional callable params as `arg<T>` slots; `encode_callable` carries the declared wire names for by-name optional dispatch. Nested callables stay unsupported.
- Zero Rust changes: `register_host_dispatch_callback` / `register_host_release_callback` / `complete_host_call` were already in the v1 ABI table.

## Deviations from python (documented in the test header)

- No async callables: C++ has no runtime awaitable detection; every `std::function` is the sync path (blocking its dispatch thread is fine — dispatches are concurrent).
- The release/weakref test is xfail in python and has no C++ observation point.

## Tests

`test_host_callables.cc`: 17 engine round-trip cases — simple/multi-arg/int/class-value callables, capturing lambdas, distinct registry keys, repeated invocation (incl. zero-N), native-exception identity round trips (std::runtime_error, std::out_of_range, custom type with fields), `host_throw` caught in BAML and propagating back typed, BAML-side catch of HostCallable with demangled class_name, and the optional-args-in-callables matrix (all-unset host defaults / by-name partial / all-set).

All 12 `sdk_test_cpp` fixture jobs pass locally. Parity workflow to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added C++ SDK support for passing callable functions into BAML workflows, including multi-argument callbacks, return values, captured state, and structured argument payloads.
  - Added optional callable-argument delivery semantics (host defaults, partial named overrides, full named overrides).
  - Introduced typed host-callable exception support so thrown errors preserve type and payload across the C++/BAML boundary.
- **Tests**
  - Added an end-to-end C++ test suite covering host-callable round-tripping, exception propagation, and callable invocation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->