### PR TITLE
feat(typescript-web): implement browser and Workers runtimes

### DIFF
--- a/baml_language/sdks/typescript/bridge_typescript_web/Cargo.toml
+++ b/baml_language/sdks/typescript/bridge_typescript_web/Cargo.toml
@@ -10,6 +10,8 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 bridge_cffi = { workspace = true, default-features = false }
+sys_wasm = { workspace = true }
+js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 

--- a/baml_language/sdks/typescript/bridge_typescript_web/scripts/prepare-workerd-package.mjs
+++ b/baml_language/sdks/typescript/bridge_typescript_web/scripts/prepare-workerd-package.mjs
@@ -26,6 +26,15 @@ if (workerdSafeProto === workerdProto) {
 }
 writeFileSync(workerdProtoPath, workerdSafeProto);
 
+const workerdIndexPath = resolve(workerd, "index.js");
+const workerdIndex = readFileSync(workerdIndexPath, "utf8");
+writeFileSync(workerdIndexPath, `import { readFileSync } from "node:fs";
+import { installReadFileSync } from "./native.js";
+
+installReadFileSync((path) => readFileSync(path));
+
+${workerdIndex}`);
+
 const browserCoreImport = 'from "./wasm/bridge_web_core.js";';
 const workerdCoreImport = 'from "../workerd-wasm/bridge_web_core.js";';
 const browserNative = readFileSync(resolve(dist, "native.js"), "utf8");

--- a/baml_language/sdks/typescript/bridge_typescript_web/src/lib.rs
+++ b/baml_language/sdks/typescript/bridge_typescript_web/src/lib.rs
@@ -8,10 +8,48 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen(js_name = stageRuntimeBytecode)]
-pub fn stage_runtime_bytecode(_bytecode: &[u8]) -> Result<(), JsError> {
-    Err(JsError::new(
-        "@boundaryml/baml-bridge-web runtime support is not implemented yet",
-    ))
+pub fn stage_runtime_bytecode(bytecode: &[u8]) -> Result<(), JsError> {
+    let sys_ops = sys_wasm::build().map_err(|error| JsError::new(&error))?;
+    bridge_cffi::initialize_runtime_from_bytecode_with_sys_ops(bytecode, sys_ops)
+        .map(|_| ())
+        .map_err(|error| JsError::new(&error.to_string()))
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = configureWebSysops)]
+pub fn configure_web_sysops(fetch_key: u64, read_file_sync_key: u64) -> Result<(), JsError> {
+    sys_wasm::configure_web_sysops(fetch_key, read_file_sync_key)
+        .map_err(|error| JsError::new(&error))
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = registerWebHostCallable)]
+pub fn register_web_host_callable(callable: js_sys::Function) -> u64 {
+    sys_wasm::register_host_callable(callable)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = mintWebHostValueKey)]
+pub fn mint_web_host_value_key() -> u64 {
+    sys_wasm::mint_host_value_key()
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = registerWebHostValueReleaseCallback)]
+pub fn register_web_host_value_release_callback(callback: js_sys::Function) {
+    sys_wasm::register_host_value_release_callback(callback);
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = releaseWebHostCallable)]
+pub fn release_web_host_callable(key: u64) {
+    sys_wasm::release_host_callable(key);
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = completeWebHostCall)]
+pub fn complete_web_host_call(call_id: u32, is_error: i32, content: &[u8]) {
+    sys_wasm::complete_host_call(call_id, is_error, content);
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/baml_language/sdks/typescript/bridge_typescript_web/typescript_src/native.ts
+++ b/baml_language/sdks/typescript/bridge_typescript_web/typescript_src/native.ts
@@ -2,15 +2,136 @@ import initWasm, {
   callFunction as callWasmFunction,
   callFunctionSync as callWasmFunctionSync,
   cancelFunctionCall as cancelWasmFunctionCall,
+  completeWebHostCall,
+  configureWebSysops,
+  mintWebHostValueKey,
   newFunctionCall as newWasmFunctionCall,
+  registerWebHostCallable,
+  registerWebHostValueReleaseCallback,
+  releaseWebHostCallable,
   stageRuntimeBytecode,
 } from "./wasm/bridge_web_core.js";
-
 await initWasm();
 
+interface WebFetchCall {
+  method: string;
+  url: string;
+  headers: Array<[string, string]>;
+  body: Uint8Array;
+  timeoutNanos: bigint;
+}
+
+type WebFetchResult =
+  | { kind: "ok"; statusCode: number; url: string; headers: Array<[string, string]>; body: Uint8Array }
+  | { kind: "io"; message: string }
+  | { kind: "timeout"; message: string };
+
+type WebReadFileResult =
+  | { kind: "ok"; bytes: Uint8Array }
+  | { kind: "io"; message: string }
+  | { kind: "unavailable"; message: string };
+
+type ReadFileSync = (path: string) => Uint8Array;
 type HostCallableDispatchFactory = (callable: (...args: unknown[]) => unknown) => (callId: number, payload: Uint8Array) => void;
 
-export function installHostCallableDispatchFactory(_factory: HostCallableDispatchFactory): void {}
+let readFileSyncImpl: ReadFileSync | undefined;
+let hostCallableDispatchFactory: HostCallableDispatchFactory | undefined;
+let webSysopKeys: { fetch: bigint; readFileSync: bigint } | undefined;
+
+export function installReadFileSync(impl: ReadFileSync): void {
+  readFileSyncImpl = impl;
+}
+
+export function installHostCallableDispatchFactory(factory: HostCallableDispatchFactory): void {
+  hostCallableDispatchFactory = factory;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseFetchCall(value: unknown): WebFetchCall {
+  if (value === null || typeof value !== "object") throw new TypeError("fetch call must be an object");
+  const call = value as Partial<WebFetchCall>;
+  if (typeof call.method !== "string") throw new TypeError("fetch method must be a string");
+  if (typeof call.url !== "string") throw new TypeError("fetch URL must be a string");
+  if (!(call.body instanceof Uint8Array)) throw new TypeError("fetch body must be bytes");
+  if (typeof call.timeoutNanos !== "bigint" || call.timeoutNanos < 0n) throw new TypeError("fetch timeoutNanos must be a non-negative bigint");
+  if (!Array.isArray(call.headers) || !call.headers.every((pair) => Array.isArray(pair) && pair.length === 2 && typeof pair[0] === "string" && typeof pair[1] === "string")) {
+    throw new TypeError("fetch headers must be string pairs");
+  }
+  return call as WebFetchCall;
+}
+
+async function webFetch(value: unknown): Promise<WebFetchResult> {
+  let call: WebFetchCall;
+  try {
+    call = parseFetchCall(value);
+  } catch (error) {
+    return { kind: "io", message: errorMessage(error) };
+  }
+
+  const controller = new AbortController();
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  if (call.timeoutNanos > 0n) {
+    const timeoutMillis = (call.timeoutNanos + 999_999n) / 1_000_000n;
+    const maximumTimerMillis = 2_147_483_647n;
+    timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, Number(timeoutMillis > maximumTimerMillis ? maximumTimerMillis : timeoutMillis));
+  }
+
+  try {
+    const method = call.method.toUpperCase();
+    const requestBody = method === "GET" || method === "HEAD" || call.body.length === 0 ? undefined : new Uint8Array(call.body);
+    const response = await globalThis.fetch(call.url, {
+      method,
+      headers: new Headers(call.headers),
+      body: requestBody,
+      signal: controller.signal,
+    });
+    const body = new Uint8Array(await response.arrayBuffer());
+    return {
+      kind: "ok",
+      statusCode: response.status,
+      url: response.url || call.url,
+      headers: Array.from(response.headers.entries()),
+      body,
+    };
+  } catch (error) {
+    return timedOut
+      ? { kind: "timeout", message: `HTTP request timed out: ${errorMessage(error)}` }
+      : { kind: "io", message: `HTTP request failed: ${errorMessage(error)}` };
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+function webReadFileSync(path: unknown): WebReadFileResult {
+  if (typeof path !== "string") return { kind: "io", message: "readFileSync path must be a string" };
+  if (!readFileSyncImpl) return { kind: "unavailable", message: "fs.readFileSync is not available in this JavaScript runtime" };
+  try {
+    const value = readFileSyncImpl(path);
+    const bytes = new Uint8Array(value.byteLength);
+    bytes.set(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+    return { kind: "ok", bytes };
+  } catch (error) {
+    return { kind: "io", message: `readFileSync failed for ${path}: ${errorMessage(error)}` };
+  }
+}
+
+function ensureWebSysopsConfigured(): void {
+  if (!hostCallableDispatchFactory) throw new Error("Web HOST_VALUE_CALLABLE dispatch is not installed");
+  if (!webSysopKeys) {
+    webSysopKeys = {
+      fetch: registerWebHostCallable(hostCallableDispatchFactory(webFetch)),
+      readFileSync: registerWebHostCallable(hostCallableDispatchFactory(webReadFileSync)),
+    };
+  }
+  configureWebSysops(webSysopKeys.fetch, webSysopKeys.readFileSync);
+}
 
 export interface HandleKey { low: number; high: number; }
 
@@ -78,6 +199,7 @@ export class Collector {
 
 export class BamlRuntime {
   static initializeRuntimeFromBytecode(bytecode: Uint8Array): BamlRuntime {
+    ensureWebSysopsConfigured();
     stageRuntimeBytecode(bytecode);
     runtime = new BamlRuntime();
     return runtime;
@@ -95,7 +217,6 @@ export class BamlRuntime {
 
 let runtime: BamlRuntime | undefined;
 let hostRelease: ((key: HandleKey) => void) | undefined;
-let nextHostValueKey = 1n;
 
 export function getRuntime(): BamlRuntime {
   if (!runtime) throw new Error("BAML runtime has not been initialized");
@@ -105,10 +226,17 @@ export function newFunctionCall(): bigint { return newWasmFunctionCall(); }
 export function cancelFunctionCall(callId: bigint | string): boolean { return cancelWasmFunctionCall(BigInt(callId)); }
 export function flushEvents(): void {}
 export function getVersion(): string { return "0.0.0-web"; }
-export function mintHostValueKey(): HandleKey { return keyFromBigint(nextHostValueKey++); }
-export function registerHostValueReleaseCallback(callback: (key: HandleKey) => void): void { hostRelease = callback; }
-export function registerHostCallable(_callback: (callId: number, args: Uint8Array) => void): HandleKey { return mintHostValueKey(); }
-export function releaseHostCallable(key: HandleKey): void { hostRelease?.(key); }
-export function completeHostCall(_callId: number, _isError: number, _content: Uint8Array): void {}
+export function mintHostValueKey(): HandleKey { return keyFromBigint(mintWebHostValueKey()); }
+export function registerHostValueReleaseCallback(callback: (key: HandleKey) => void): void {
+  hostRelease = callback;
+  registerWebHostValueReleaseCallback((key: bigint) => hostRelease?.(keyFromBigint(key)));
+}
+export function registerHostCallable(callback: (callId: number, args: Uint8Array) => void): HandleKey { return keyFromBigint(registerWebHostCallable(callback)); }
+export function releaseHostCallable(key: HandleKey): void {
+  const value = BigInt.asUintN(64, BigInt(key.high) << 32n | BigInt.asUintN(32, BigInt(key.low)));
+  releaseWebHostCallable(value);
+  hostRelease?.(key);
+}
+export function completeHostCall(callId: number, isError: number, content: Uint8Array): void { completeWebHostCall(callId, isError, content); }
 export function _seedFunctionRefHandle(_globalIndex: number): [HandleKey, number] { throw new Error("test handle seeding is not implemented yet"); }
 export function _seedGenericMediaHandle(): [HandleKey, number] { throw new Error("test handle seeding is not implemented yet"); }

--- a/baml_language/sdks/typescript/bridge_typescript_web/typescript_src/wasm/bridge_web_core.d.ts
+++ b/baml_language/sdks/typescript/bridge_typescript_web/typescript_src/wasm/bridge_web_core.d.ts
@@ -1,6 +1,12 @@
 export default function init(moduleOrPath?: unknown): Promise<unknown>;
 export function stageRuntimeBytecode(bytecode: Uint8Array): void;
+export function configureWebSysops(fetchKey: bigint, readFileSyncKey: bigint): void;
 export function callFunctionSync(functionName: string, encodedArgs: Uint8Array): Uint8Array;
 export function callFunction(functionName: string, encodedArgs: Uint8Array): Promise<Uint8Array>;
 export function newFunctionCall(): bigint;
 export function cancelFunctionCall(callId: bigint): boolean;
+export function registerWebHostCallable(callable: (callId: number, args: Uint8Array) => void): bigint;
+export function mintWebHostValueKey(): bigint;
+export function registerWebHostValueReleaseCallback(callback: (key: bigint) => void): void;
+export function releaseWebHostCallable(key: bigint): void;
+export function completeWebHostCall(callId: number, isError: number, content: Uint8Array): void;


### PR DESCRIPTION
## Summary

- implement the WebAssembly exports and TypeScript runtime plumbing needed by browser and Workers environments
- add workerd package preparation and native runtime bindings
- update bridge declarations and crate configuration for the new runtime surface

## Why

The TypeScript Web bridge needs concrete browser and Workers runtime implementations before higher-level SDK parity can be layered on top.

## Impact

This establishes the low-level Web bridge runtime surface while keeping the change isolated from the later shared-runtime and parity commits in the stack.

## Validation

- Not run in this publishing step