### PR TITLE
TIR + MIR should use ItemTree firewall queries

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -5057,7 +5057,6 @@ mod tests {
     };
 
     use baml_base::{FileId, SourceFile};
-    use baml_compiler2_ast as ast;
     use baml_compiler2_hir::item_tree::{Attribute, AttributeArg};
     use baml_workspace::Project;
 
@@ -5094,12 +5093,6 @@ mod tests {
         fn add_file(&mut self, path: impl Into<PathBuf>, content: &str) -> SourceFile {
             let file_id = FileId::new(self.next_file_id.fetch_add(1, Ordering::SeqCst));
             SourceFile::new(self, content.to_string(), path.into(), file_id)
-        }
-
-        fn init_with_file(&mut self) -> SourceFile {
-            let file = self.add_file("test.baml", "function f() -> int { 1 }");
-            self.project = Some(Project::new(self, PathBuf::from("."), vec![file]));
-            file
         }
     }
 
@@ -5219,51 +5212,26 @@ mod tests {
 
     #[test]
     fn function_metadata_reports_defaulted_params() {
+        // A real parsed function, not a fabricated item tree: the firewall
+        // queries this flows through (`function_in_scope_generic_param_bounds`
+        // → `function_data`) are total over Locs minted from a real tree, and
+        // panic on ids that were never allocated.
         let mut db = TestDb::default();
-        let file = db.init_with_file();
+        let file = db.add_file(
+            "test.baml",
+            "function f(required: int, with_default: int = 1, also_required: int) -> int { 1 }",
+        );
+        db.project = Some(Project::new(&db, PathBuf::from("."), vec![file]));
 
-        let mut defaults = ast::FunctionDefaults::empty();
-        let default_expr = ast::DefaultExprId::new(defaults.exprs.exprs.alloc(ast::Expr::Null));
-        let function_id = baml_compiler2_hir::ids::LocalItemId::<
-            baml_compiler2_hir::ids::FunctionMarker,
-        >::new(1, 0);
-        let default_ref = baml_compiler2_hir::item_tree::DefaultExprRef {
-            function: function_id,
-            expr: default_expr,
-        };
-        let param = |name: &str, default| baml_compiler2_hir::item_tree::FunctionParam {
-            name: baml_base::Name::new(name),
-            type_expr: None,
-            default,
-            span: baml_base::Span::fake().range,
-        };
-        let func_data = baml_compiler2_hir::item_tree::Function {
-            name: baml_base::Name::new("f"),
-            generic_params: Vec::new(),
-            generic_param_bounds: Vec::new(),
-            params: vec![
-                param("required", None),
-                param("with_default", Some(default_ref)),
-                param("also_required", None),
-            ],
-            defaults,
-            return_type: None,
-            throws: None,
-            body: None,
-            declarative_meta: None,
-            origin: ast::FunctionOrigin::UserDefined,
-            docstring: None,
-            is_tagged_template_tag: false,
-            span: baml_base::Span::fake().range,
-        };
-        let parameter_defaults = baml_compiler2_hir::signature::FunctionParameterDefaults {
-            params: func_data
-                .params
-                .iter()
-                .map(|param| param.default.clone())
-                .collect(),
-            defaults: func_data.defaults.clone(),
-        };
+        let item_tree = baml_compiler2_ppir::file_item_tree(&db, file);
+        let (function_id, func_data) = item_tree
+            .functions
+            .iter()
+            .find(|(_, f)| f.name.as_str() == "f")
+            .expect("test file declares `f`");
+        let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(&db, file, *function_id);
+        let parameter_defaults =
+            baml_compiler2_hir::signature::function_parameter_defaults(&db, func_loc);
         let cache = ResolvedAliases {
             aliases: HashMap::new(),
             recursive: HashSet::new(),
@@ -5272,8 +5240,8 @@ mod tests {
         let metadata = compute_function_metadata_from_item_tree(
             &db,
             file,
-            function_id,
-            &func_data,
+            *function_id,
+            func_data,
             &parameter_defaults,
             &cache,
         );

--- a/baml_language/crates/baml_compiler2_hir/src/type_ref.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/type_ref.rs
@@ -149,6 +149,174 @@ impl TypeRefStore {
     pub fn is_empty(&self) -> bool {
         self.types.is_empty()
     }
+
+    /// A [`Display`](std::fmt::Display) view of `id`, rendering BAML source-like text.
+    ///
+    /// Byte-identical to [`ast::TypeExpr`](baml_compiler2_ast::ast::TypeExpr)'s
+    /// `Display`. The arena split moved impl/interface *targets* from spanned
+    /// `TypeExpr`s (which formatted directly) to [`TypeRefId`]s, but the mangled
+    /// `Interface$for$Target` / `Target.method` names built from those targets
+    /// are a cross-module contract — MIR, emit, and the runtime must agree on the
+    /// exact string. Rendering the target here, rather than re-deriving it from
+    /// resolved types, keeps those names identical to the pre-split output.
+    pub fn display(&self, id: TypeRefId) -> TypeRefDisplay<'_> {
+        TypeRefDisplay { store: self, id }
+    }
+}
+
+/// A [`Display`](std::fmt::Display) view of one [`TypeRef`] node, resolving child ids through its
+/// owning [`TypeRefStore`]. Built by [`TypeRefStore::display`].
+///
+/// The formatting mirrors `ast::TypeExprKind`'s `Display` arm-for-arm; the two
+/// must stay in lockstep so mangled names survive the arena split unchanged.
+pub struct TypeRefDisplay<'a> {
+    store: &'a TypeRefStore,
+    id: TypeRefId,
+}
+
+impl std::fmt::Display for TypeRefDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn needs_parens(store: &TypeRefStore, id: TypeRefId) -> bool {
+            matches!(
+                store[id].kind,
+                TypeRefKind::Union { .. } | TypeRefKind::Function { .. }
+            )
+        }
+
+        fn write_postfix_base(
+            store: &TypeRefStore,
+            id: TypeRefId,
+            f: &mut std::fmt::Formatter<'_>,
+        ) -> std::fmt::Result {
+            if needs_parens(store, id) {
+                write!(f, "({})", store.display(id))
+            } else {
+                write!(f, "{}", store.display(id))
+            }
+        }
+
+        let store = self.store;
+        match &store[self.id].kind {
+            TypeRefKind::Path {
+                segments,
+                generic_args,
+                associated_type_bindings,
+            } => {
+                let path = segments
+                    .iter()
+                    .map(Name::as_str)
+                    .collect::<Vec<_>>()
+                    .join(".");
+                write!(f, "{path}")?;
+                if !generic_args.is_empty() || !associated_type_bindings.is_empty() {
+                    write!(f, "<")?;
+                    let mut first = true;
+                    for &arg in generic_args {
+                        if !first {
+                            write!(f, ", ")?;
+                        }
+                        first = false;
+                        write!(f, "{}", store.display(arg))?;
+                    }
+                    for binding in associated_type_bindings {
+                        if !first {
+                            write!(f, ", ")?;
+                        }
+                        first = false;
+                        write!(f, "{} = {}", binding.name, store.display(binding.ty))?;
+                    }
+                    write!(f, ">")?;
+                }
+                Ok(())
+            }
+            TypeRefKind::AssociatedTypeProjection {
+                base,
+                interface,
+                member,
+            } => {
+                if let Some(interface) = interface {
+                    write!(
+                        f,
+                        "({} as {}).{member}",
+                        store.display(*base),
+                        store.display(*interface)
+                    )
+                } else {
+                    write_postfix_base(store, *base, f)?;
+                    write!(f, ".{member}")
+                }
+            }
+            TypeRefKind::Int => write!(f, "int"),
+            TypeRefKind::Bigint => write!(f, "bigint"),
+            TypeRefKind::Float => write!(f, "float"),
+            TypeRefKind::String => write!(f, "string"),
+            TypeRefKind::Bool => write!(f, "bool"),
+            TypeRefKind::Null => write!(f, "null"),
+            TypeRefKind::Never => write!(f, "never"),
+            TypeRefKind::Void => write!(f, "void"),
+            TypeRefKind::Uint8Array => write!(f, "uint8array"),
+            TypeRefKind::Media { kind } => write!(f, "{}", format!("{kind:?}").to_lowercase()),
+            TypeRefKind::Optional { inner } => {
+                write_postfix_base(store, *inner, f)?;
+                write!(f, "?")
+            }
+            TypeRefKind::List { inner } => {
+                write_postfix_base(store, *inner, f)?;
+                write!(f, "[]")
+            }
+            TypeRefKind::Map { key, value } => {
+                write!(f, "map<{}, {}>", store.display(*key), store.display(*value))
+            }
+            TypeRefKind::Union { variants } => {
+                for (i, &v) in variants.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " | ")?;
+                    }
+                    if matches!(store[v].kind, TypeRefKind::Function { .. }) {
+                        write!(f, "({})", store.display(v))?;
+                    } else {
+                        write!(f, "{}", store.display(v))?;
+                    }
+                }
+                Ok(())
+            }
+            TypeRefKind::Literal { value } => write!(f, "{value}"),
+            TypeRefKind::Function {
+                params,
+                ret,
+                throws,
+            } => {
+                write!(f, "(")?;
+                for (i, p) in params.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    if let Some(name) = &p.name {
+                        let optional = if p.optional { "?" } else { "" };
+                        write!(f, "{}{}: {}", name.as_str(), optional, store.display(p.ty))?;
+                    } else {
+                        write!(f, "{}", store.display(p.ty))?;
+                    }
+                }
+                write!(f, ") -> ")?;
+                if matches!(store[*ret].kind, TypeRefKind::Function { .. }) {
+                    write!(f, "({})", store.display(*ret))?;
+                } else {
+                    write!(f, "{}", store.display(*ret))?;
+                }
+                if let Some(throws) = throws {
+                    write!(f, " throws {}", store.display(*throws))?;
+                }
+                Ok(())
+            }
+            TypeRefKind::BuiltinUnknown => write!(f, "unknown"),
+            TypeRefKind::Type => write!(f, "type"),
+            TypeRefKind::Rust => write!(f, "$rust_type"),
+            TypeRefKind::Error => write!(f, "error"),
+            TypeRefKind::Unknown => write!(f, "?"),
+            TypeRefKind::Infer => write!(f, "_"),
+        }
+    }
 }
 
 impl Index<TypeRefId> for TypeRefStore {
@@ -443,5 +611,131 @@ mod tests {
         );
 
         assert_ne!(int_keyed, bool_keyed);
+    }
+
+    /// `TypeRefStore::display` exists so the mangled `Interface$for$Target` /
+    /// `Target.method` names built from impl/interface targets survive the arena
+    /// split unchanged. That only holds if it renders byte-for-byte the same text
+    /// as `ast::TypeExpr`'s `Display` — assert exactly that over the paren- and
+    /// recursion-sensitive shapes (the primitive/literal/media arms are verbatim
+    /// copies, so they need no separate guard).
+    #[test]
+    fn display_is_byte_identical_to_ast() {
+        use baml_compiler2_ast::ast::{AssociatedTypeBinding, FunctionTypeParam};
+
+        let sp = span(0, 0);
+        let prim = |k: TypeExprKind| k.at(sp);
+        let path = |name: &str| {
+            TypeExprKind::Path {
+                segments: name.split('.').map(Name::new).collect(),
+                generic_args: vec![],
+                associated_type_bindings: vec![],
+                attrs: vec![],
+            }
+            .at(sp)
+        };
+        let func = |params, ret, throws| {
+            TypeExprKind::Function {
+                params,
+                ret: Box::new(ret),
+                throws,
+                attrs: vec![],
+            }
+            .at(sp)
+        };
+
+        let cases: Vec<TypeExpr> = vec![
+            prim(TypeExprKind::Int { attrs: vec![] }),
+            prim(TypeExprKind::String { attrs: vec![] }),
+            path("User"),
+            path("baml.http.Request"),
+            // `Stream<int, Item = string>` — generic args plus an assoc binding.
+            TypeExprKind::Path {
+                segments: vec![Name::new("Stream")],
+                generic_args: vec![prim(TypeExprKind::Int { attrs: vec![] })],
+                associated_type_bindings: vec![AssociatedTypeBinding {
+                    name: Name::new("Item"),
+                    ty: Box::new(prim(TypeExprKind::String { attrs: vec![] })),
+                }],
+                attrs: vec![],
+            }
+            .at(sp),
+            // `int?`, `int[]`, `map<string, int[]>`.
+            TypeExprKind::Optional {
+                inner: Box::new(prim(TypeExprKind::Int { attrs: vec![] })),
+                attrs: vec![],
+            }
+            .at(sp),
+            TypeExprKind::List {
+                inner: Box::new(prim(TypeExprKind::Int { attrs: vec![] })),
+                attrs: vec![],
+            }
+            .at(sp),
+            map_of_string_to_int_list(0, vec![]),
+            // `int | string`, and `int | (() -> void)` (union parenthesizes fns).
+            TypeExprKind::Union {
+                variants: vec![
+                    prim(TypeExprKind::Int { attrs: vec![] }),
+                    prim(TypeExprKind::String { attrs: vec![] }),
+                ],
+                attrs: vec![],
+            }
+            .at(sp),
+            TypeExprKind::Union {
+                variants: vec![
+                    prim(TypeExprKind::Int { attrs: vec![] }),
+                    func(vec![], prim(TypeExprKind::Void { attrs: vec![] }), None),
+                ],
+                attrs: vec![],
+            }
+            .at(sp),
+            // `(a: int, b?: string) -> bool throws MyError`.
+            func(
+                vec![
+                    FunctionTypeParam {
+                        name: Some(Name::new("a")),
+                        optional: false,
+                        ty: prim(TypeExprKind::Int { attrs: vec![] }),
+                    },
+                    FunctionTypeParam {
+                        name: Some(Name::new("b")),
+                        optional: true,
+                        ty: prim(TypeExprKind::String { attrs: vec![] }),
+                    },
+                ],
+                prim(TypeExprKind::Bool { attrs: vec![] }),
+                Some(Box::new(path("MyError"))),
+            ),
+            // `() -> (() -> void)` — a function return parenthesizes a function.
+            func(
+                vec![],
+                func(vec![], prim(TypeExprKind::Void { attrs: vec![] }), None),
+                None,
+            ),
+            // `T.Item` and `(T as Iterator).Item`.
+            TypeExprKind::AssociatedTypeProjection {
+                base: Box::new(path("T")),
+                interface: None,
+                member: Name::new("Item"),
+                attrs: vec![],
+            }
+            .at(sp),
+            TypeExprKind::AssociatedTypeProjection {
+                base: Box::new(path("T")),
+                interface: Some(Box::new(path("Iterator"))),
+                member: Name::new("Item"),
+                attrs: vec![],
+            }
+            .at(sp),
+        ];
+
+        for te in &cases {
+            let (store, _, root) = lower(te);
+            assert_eq!(
+                format!("{te}"),
+                format!("{}", store.display(root)),
+                "TypeRef Display must byte-match ast::TypeExpr Display",
+            );
+        }
     }
 }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -631,14 +631,15 @@ fn type_satisfies_bound(
 /// registry's `class_implements` key set (which held an entry per package class). Used to sweep a
 /// package's classes against a blanket impl's bound.
 fn package_class_qtns(db: &dyn crate::Db, pkg_name: &Name) -> Vec<QualifiedTypeName> {
+    use baml_compiler2_ppir::item_data::{class_data, file_classes};
     let mut out = Vec::new();
     for file in compiler2_all_files(db) {
         let pkg_info = file_package(db, file);
         if pkg_info.package != *pkg_name {
             continue;
         }
-        let item_tree = file_item_tree(db, file);
-        for class in item_tree.classes.values() {
+        for class_loc in file_classes(db, file) {
+            let class = class_data(db, *class_loc);
             out.push(QualifiedTypeName::new(
                 pkg_info.package.clone(),
                 pkg_info.namespace_path.clone(),
@@ -675,36 +676,6 @@ fn with_global_ctx<R>(
     f(&ctx)
 }
 
-/// The out-of-body impl block whose method list contains `func_id`, from the unified `impls`
-/// store via the `free_impls` index (replacing the removed `implements_for`).
-fn enclosing_free_impl(
-    item_tree: &baml_compiler2_hir::item_tree::ItemTree,
-    func_id: baml_compiler2_hir::ids::LocalItemId<baml_compiler2_hir::ids::FunctionMarker>,
-) -> Option<&baml_compiler2_hir::item_tree::ImplBlock> {
-    match item_tree.method_owners.get(&func_id)? {
-        baml_compiler2_hir::item_tree::MethodOwner::FreeImpl(impl_id) => {
-            item_tree.impls.get(impl_id)
-        }
-        baml_compiler2_hir::item_tree::MethodOwner::Class(_)
-        | baml_compiler2_hir::item_tree::MethodOwner::Interface(_) => None,
-    }
-}
-
-/// An out-of-body impl block's declared generics as `(param names, each's single optional
-/// bound)` — the legacy flat form (the `ImplBlock` holds the full `&`-bound set per param, of
-/// which only the first is used). Empty for an in-body (`InClass`) block.
-fn free_impl_generics(
-    block: &baml_compiler2_hir::item_tree::ImplBlock,
-) -> (Vec<Name>, Vec<Option<baml_compiler2_ast::TypeExpr>>) {
-    match &block.subject {
-        baml_compiler2_hir::item_tree::ImplSubject::Free { generics, .. } => (
-            generics.iter().map(|g| g.name.clone()).collect(),
-            generics.iter().map(|g| g.bounds.first().cloned()).collect(),
-        ),
-        baml_compiler2_hir::item_tree::ImplSubject::InClass { .. } => (Vec::new(), Vec::new()),
-    }
-}
-
 /// Lower a type expression, treating the `bindings` map's keys as the in-scope type variables,
 /// then substitute those bindings. Threads the in-scope typevar `bounds` so a `T.member`
 /// projection resolves through `T`'s bound rather than erasing to `unknown`. Replaces the
@@ -722,6 +693,40 @@ fn lower_ty_with_bindings(
     let generic_params: Vec<Name> = bindings.keys().cloned().collect();
     let lowered = baml_compiler2_tir::lower_type_expr::lower_type_expr(
         expr,
+        &baml_compiler2_tir::lower_type_expr::ScopeCtx {
+            db,
+            package_items: pkg_items,
+            ns_context: namespace_path,
+            generic_params: &generic_params,
+            bounds,
+            self_ty: None,
+        },
+        diags,
+    );
+    baml_compiler2_tir::generics::substitute_ty(&lowered, bindings)
+}
+
+/// The `TypeRef`-arena twin of [`lower_ty_with_bindings`], for callers holding
+/// firewall data (`*_data(…).type_refs` + a `TypeRefId`) rather than an AST node.
+/// Identical behavior — lowers through `lower_type_ref` instead of `lower_type_expr`.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors the 7-arg lower_ty_with_bindings; the (store, id) pair replaces its one &TypeExpr"
+)]
+fn lower_ref_with_bindings(
+    db: &dyn crate::Db,
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    id: baml_compiler2_hir::type_ref::TypeRefId,
+    pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
+    namespace_path: &[Name],
+    bindings: &FxHashMap<Name, Tir2Ty>,
+    bounds: &baml_compiler2_tir::lower_type_expr::TypeVarBoundsMap,
+    diags: &mut Vec<baml_compiler2_tir::infer_context::TirTypeError>,
+) -> Tir2Ty {
+    let generic_params: Vec<Name> = bindings.keys().cloned().collect();
+    let lowered = baml_compiler2_tir::lower_type_expr::lower_type_ref(
+        store,
+        id,
         &baml_compiler2_tir::lower_type_expr::ScopeCtx {
             db,
             package_items: pkg_items,
@@ -1315,56 +1320,55 @@ fn enum_type_name(ty: &RuntimeTy) -> Option<&TypeName> {
 use baml_compiler2_hir::{
     compiler2_all_files, contributions::Definition, file_package::file_package,
 };
-// Use the PPIR item tree (which includes synthetic *$stream items) rather than
-// the bare HIR item tree. TIR resolves methods using PPIR `LocalItemId`s, so
-// MIR must use the same tree to avoid index mismatches.
-use baml_compiler2_ppir::file_item_tree;
 
 pub fn def_to_item_ref<'db>(db: &'db dyn crate::Db, def: Definition<'db>) -> ItemRef {
-    let file = def.file(db);
-    let pkg_info = file_package(db, file);
-    let item_tree = file_item_tree(db, file);
+    use baml_compiler2_ppir::item_data::{
+        ImplSubjectData, MethodOwner, class_data, client_data, enum_data, function_data,
+        impl_block_data, interface_data, let_data, method_owner, retry_policy_data,
+        template_string_data, test_data, type_alias_data,
+    };
+    let pkg_info = file_package(db, def.file(db));
 
     let name: Name = match def {
-        Definition::Function(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::Class(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::Enum(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::Interface(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::TypeAlias(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::TemplateString(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::Client(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::Test(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::RetryPolicy(loc) => item_tree[loc.id(db)].name.clone(),
-        Definition::Let(loc) => item_tree[loc.id(db)].name.clone(),
+        Definition::Function(loc) => function_data(db, loc).name.clone(),
+        Definition::Class(loc) => class_data(db, loc).name.clone(),
+        Definition::Enum(loc) => enum_data(db, loc).name.clone(),
+        Definition::Interface(loc) => interface_data(db, loc).name.clone(),
+        Definition::TypeAlias(loc) => type_alias_data(db, loc).name.clone(),
+        Definition::TemplateString(loc) => template_string_data(db, loc).name.clone(),
+        Definition::Client(loc) => client_data(db, loc).name.clone(),
+        Definition::Test(loc) => test_data(db, loc).name.clone(),
+        Definition::RetryPolicy(loc) => retry_policy_data(db, loc).name.clone(),
+        Definition::Let(loc) => let_data(db, loc).name.clone(),
     };
 
     // Function definitions: a method needs a Method-shaped ItemRef so it gets a
     // distinct global slot keyed on its owner's name (instead of colliding with
     // same-named free functions in the package).
     if let Definition::Function(func_loc) = def {
-        use baml_compiler2_hir::item_tree::MethodOwner;
-        match item_tree.method_owners.get(&func_loc.id(db)) {
-            Some(MethodOwner::Class(class_id)) => {
-                let class_loc = baml_compiler2_hir::loc::ClassLoc::new(db, file, *class_id);
+        match method_owner(db, func_loc) {
+            Some(MethodOwner::Class(class_loc)) => {
                 return method_item_ref(db, class_loc, func_loc);
             }
-            Some(MethodOwner::Interface(iface_id)) => {
+            Some(MethodOwner::Interface(iface_loc)) => {
                 return ItemRef::Method {
                     package: pkg_info.package.clone(),
                     namespace: pkg_info.namespace_path,
-                    class: item_tree[*iface_id].name.clone(),
+                    class: interface_data(db, iface_loc).name.clone(),
                     name,
                 };
             }
-            Some(MethodOwner::FreeImpl(impl_id)) => {
-                let block = &item_tree.impls[impl_id];
-                if let baml_compiler2_hir::item_tree::ImplSubject::Free { for_target, .. } =
-                    &block.subject
-                {
+            Some(MethodOwner::FreeImpl(impl_loc)) => {
+                let block = impl_block_data(db, impl_loc);
+                if let ImplSubjectData::Free { for_target, .. } = &block.subject {
                     return ItemRef::Method {
                         package: pkg_info.package.clone(),
                         namespace: pkg_info.namespace_path,
-                        class: Name::new(format!("{}$for${}", block.interface_target, for_target)),
+                        class: Name::new(format!(
+                            "{}$for${}",
+                            block.type_refs.display(block.interface_target),
+                            block.type_refs.display(*for_target)
+                        )),
                         name,
                     };
                 }
@@ -1380,15 +1384,19 @@ pub fn def_to_item_ref<'db>(db: &'db dyn crate::Db, def: Definition<'db>) -> Ite
     }
 }
 
-fn scoped_implements_method_name(
-    item_tree: &baml_compiler2_hir::item_tree::ItemTree,
-    func_id: baml_compiler2_hir::ids::LocalItemId<baml_compiler2_hir::ids::FunctionMarker>,
+fn scoped_implements_method_name<'db>(
+    db: &'db dyn crate::Db,
+    func_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
     method_name: &Name,
 ) -> Name {
-    item_tree
-        .method_to_iface_target
-        .get(&func_id)
-        .map(|target| Name::new(format!("{target}.{method_name}")))
+    baml_compiler2_ppir::item_data::method_interface_target(db, func_loc)
+        .as_ref()
+        .map(|target| {
+            Name::new(format!(
+                "{}.{method_name}",
+                target.type_refs.display(target.target)
+            ))
+        })
         .unwrap_or_else(|| method_name.clone())
 }
 
@@ -1397,16 +1405,15 @@ fn method_item_ref<'db>(
     class_loc: baml_compiler2_hir::loc::ClassLoc<'db>,
     func_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
 ) -> ItemRef {
+    use baml_compiler2_ppir::item_data::{class_data, function_data};
     let pkg_info = file_package(db, class_loc.file(db));
-    let item_tree = file_item_tree(db, class_loc.file(db));
-    let class_data = &item_tree[class_loc.id(db)];
-    let func_id = func_loc.id(db);
-    let func_data = &item_tree[func_id];
+    let class = class_data(db, class_loc).name.clone();
+    let method_name = function_data(db, func_loc).name.clone();
     ItemRef::Method {
         package: pkg_info.package,
         namespace: pkg_info.namespace_path,
-        class: class_data.name.clone(),
-        name: scoped_implements_method_name(&item_tree, func_id, &func_data.name),
+        class,
+        name: scoped_implements_method_name(db, func_loc, &method_name),
     }
 }
 
@@ -1422,8 +1429,7 @@ fn resolution_to_item_ref(
     match res {
         MemberResolution::Free { func_loc } => {
             let pkg_info = file_package(db, func_loc.file(db));
-            let item_tree = file_item_tree(db, func_loc.file(db));
-            let func_data = &item_tree[func_loc.id(db)];
+            let func_data = baml_compiler2_ppir::item_data::function_data(db, *func_loc);
             Some(ItemRef::Free {
                 package: pkg_info.package,
                 namespace: pkg_info.namespace_path,
@@ -1442,8 +1448,7 @@ fn resolution_to_item_ref(
             // A virtual interface-method call: the ItemRef names the interface + method, and
             // the runtime dispatches on the receiver's actual impl.
             let pkg_info = file_package(db, iface_loc.file(db));
-            let item_tree = file_item_tree(db, iface_loc.file(db));
-            let iface_data = &item_tree[iface_loc.id(db)];
+            let iface_data = baml_compiler2_ppir::item_data::interface_data(db, *iface_loc);
             Some(ItemRef::Method {
                 package: pkg_info.package,
                 namespace: pkg_info.namespace_path,
@@ -1461,10 +1466,8 @@ fn resolution_to_item_ref(
                 .ok()?;
             let iface_loc = data.interface;
             let pkg_info = file_package(db, iface_loc.file(db));
-            let iface_item_tree = file_item_tree(db, iface_loc.file(db));
-            let iface_data = &iface_item_tree[iface_loc.id(db)];
-            let func_item_tree = file_item_tree(db, func_loc.file(db));
-            let func_data = &func_item_tree[func_loc.id(db)];
+            let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
+            let func_data = baml_compiler2_ppir::item_data::function_data(db, *func_loc);
             Some(ItemRef::Method {
                 package: pkg_info.package,
                 namespace: pkg_info.namespace_path,
@@ -1526,20 +1529,29 @@ type ClassFieldTypes = IndexMap<TypeName, IndexMap<String, RuntimeTy>>;
 type EnumVariantIndices = IndexMap<QualifiedTypeName, IndexMap<String, usize>>;
 type ImplementorsByInterface = IndexMap<TypeName, Vec<TypeName>>;
 type InterfaceTypeView = (TypeName, Vec<Tir2Ty>, Vec<(Name, Tir2Ty)>);
-fn lower_interface_target_args<'db>(
+/// Lower the generic arguments of an interface target held as a `TypeRefId` in
+/// `store` (e.g. the `<int>` in `implements Slot<int>`). Non-`Path` targets
+/// contribute no arguments.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the (store, target) pair plus the name-resolution context sum to 8"
+)]
+fn lower_ref_interface_target_args<'db>(
     db: &'db dyn crate::Db,
-    target: &baml_compiler2_ast::TypeExpr,
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    target: baml_compiler2_hir::type_ref::TypeRefId,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
     namespace_path: &[Name],
     generic_params: &[Name],
     bounds: &baml_compiler2_tir::lower_type_expr::TypeVarBoundsMap,
     diags: &mut Vec<baml_compiler2_tir::infer_context::TirTypeError>,
 ) -> Vec<Tir2Ty> {
-    match &target.kind {
-        baml_compiler2_ast::TypeExprKind::Path { generic_args, .. } => generic_args
+    match &store[target].kind {
+        baml_compiler2_hir::type_ref::TypeRefKind::Path { generic_args, .. } => generic_args
             .iter()
-            .map(|arg| {
-                baml_compiler2_tir::lower_type_expr::lower_type_expr(
+            .map(|&arg| {
+                baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                    store,
                     arg,
                     &baml_compiler2_tir::lower_type_expr::ScopeCtx {
                         db,
@@ -1573,15 +1585,13 @@ fn class_type_name_from_qtn(db: &dyn crate::Db, class_qtn: &QualifiedTypeName) -
 fn interface_type_name_from_loc<'db>(
     db: &'db dyn crate::Db,
     iface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
-) -> Option<TypeName> {
-    let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-    let iface_data = iface_tree.interfaces.get(&iface_loc.id(db))?;
-    let qtn = baml_compiler2_tir::lower_type_expr::qualify_def(
+) -> TypeName {
+    let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
+    baml_compiler2_tir::lower_type_expr::qualify_def(
         db,
         Definition::Interface(iface_loc),
         &iface_data.name,
-    );
-    Some(qtn)
+    )
 }
 
 fn push_unique_interface_implementor(
@@ -1611,9 +1621,8 @@ fn register_class_for_interface_closure<'db>(
             true,
         )
     {
-        if let Some(iface_tn) = interface_type_name_from_loc(db, iface_loc) {
-            push_unique_interface_implementor(interface_implementors, iface_tn, class_tn);
-        }
+        let iface_tn = interface_type_name_from_loc(db, iface_loc);
+        push_unique_interface_implementor(interface_implementors, iface_tn, class_tn);
     }
 }
 
@@ -1723,18 +1732,19 @@ fn class_type_tags_for_project(
     db: &dyn crate::Db,
     _project: baml_workspace::Project,
 ) -> ProjectClassTypeTags {
+    use baml_compiler2_ppir::item_data::{class_data, file_classes};
     let all_files = compiler2_all_files(db);
     let mut tags: IndexMap<TypeName, i64> = IndexMap::new();
 
     for file in &all_files {
-        let item_tree = file_item_tree(db, *file);
         let pkg_info = file_package(db, *file);
 
-        for class_data in item_tree.classes.values() {
+        for class_loc in file_classes(db, *file) {
+            let class = class_data(db, *class_loc);
             let class_qtn = QualifiedTypeName::new(
                 pkg_info.package.clone(),
                 pkg_info.namespace_path.clone(),
-                class_data.name.clone(),
+                class.name.clone(),
             );
             let type_tag = baml_type::typetag::class_type_tag(&class_qtn.render_dotted(false));
             // Use entry to avoid overwriting if the same class appears via multiple paths
@@ -1817,15 +1827,16 @@ fn package_lowering_data<'db>(
                 else {
                     continue;
                 };
-                let itree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-                let Some(iface_data) = itree.interfaces.get(&iface_loc.id(db)) else {
-                    continue;
-                };
+                let iface_data = baml_compiler2_ppir::item_data::interface_data(db, *iface_loc);
                 for sig in &iface_data.required_methods {
                     interface_method_names.insert(sig.name.clone());
                 }
-                for &fn_id in &iface_data.default_methods {
-                    interface_method_names.insert(itree[fn_id].name.clone());
+                for &fn_loc in &iface_data.default_methods {
+                    interface_method_names.insert(
+                        baml_compiler2_ppir::item_data::function_data(db, fn_loc)
+                            .name
+                            .clone(),
+                    );
                 }
             }
         }
@@ -2097,12 +2108,11 @@ impl<'db> LoweringContext<'db> {
     ) -> Option<InterfaceTypeView> {
         let class_tn = class_qtn.clone();
         let class_loc = self.resolve_class_loc_by_type_name(&class_tn)?;
-        let class_tree = file_item_tree(self.db, class_loc.file(self.db));
-        let class_data = &class_tree[class_loc.id(self.db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(self.db, class_loc);
 
         for impl_block in &class_data.implements {
             let view = self.resolve_implements_target_view(
-                &impl_block.target,
+                impl_block.target,
                 &impl_block.associated_type_bindings,
                 class_loc,
             )?;
@@ -2325,8 +2335,7 @@ impl<'db> LoweringContext<'db> {
                 match def {
                     Definition::Class(class_loc) => {
                         let cfile = class_loc.file(db);
-                        let citree = file_item_tree(db, cfile);
-                        let class_data = &citree[class_loc.id(db)];
+                        let class_data = baml_compiler2_ppir::item_data::class_data(db, *class_loc);
 
                         let class_qtn = QualifiedTypeName::new(
                             pkg_name.clone(),
@@ -2343,7 +2352,7 @@ impl<'db> LoweringContext<'db> {
                         let mut idx_counter = 0usize;
                         let mut insert_field =
                             |name: &str,
-                             type_expr: Option<&baml_compiler2_ast::TypeExpr>,
+                             type_ref: Option<baml_compiler2_hir::type_ref::TypeRefId>,
                              generic_params: &[Name],
                              ns: &[Name],
                              fields: &mut IndexMap<String, usize>,
@@ -2356,10 +2365,11 @@ impl<'db> LoweringContext<'db> {
                                 let idx = idx_counter;
                                 fields.insert(name.to_string(), idx);
                                 idx_counter += 1;
-                                let field_ty = type_expr
-                                    .map(|te| {
-                                        let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                                            te,
+                                let field_ty = type_ref
+                                    .map(|id| {
+                                        let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                                            &class_data.type_refs,
+                                            id,
                                             &baml_compiler2_tir::lower_type_expr::ScopeCtx {
                                                 db,
                                                 package_items: pkg_items,
@@ -2382,7 +2392,7 @@ impl<'db> LoweringContext<'db> {
                         for field in &class_data.fields {
                             insert_field(
                                 field.name.as_str(),
-                                field.type_expr.as_ref(),
+                                field.type_ref,
                                 &class_data.generic_params,
                                 &pkg_ns,
                                 &mut fields,
@@ -2398,9 +2408,10 @@ impl<'db> LoweringContext<'db> {
                         // transitively through interface `requires`.
                         for impl_target in &class_data.implements {
                             let Some(iface_loc) =
-                                baml_compiler2_tir::interfaces::resolve_path_to_interface(
+                                baml_compiler2_tir::interfaces::resolve_ref_to_interface(
                                     db,
-                                    &impl_target.target,
+                                    &class_data.type_refs,
+                                    impl_target.target,
                                     pkg_items,
                                     &pkg_ns,
                                 )
@@ -2410,10 +2421,7 @@ impl<'db> LoweringContext<'db> {
                             for iface_loc in baml_compiler2_tir::interfaces::interface_closure_locs(
                                 db, iface_loc,
                             ) {
-                                let Some(iface_tn) = interface_type_name_from_loc(db, iface_loc)
-                                else {
-                                    continue;
-                                };
+                                let iface_tn = interface_type_name_from_loc(db, iface_loc);
                                 let entry = out.interface_implementors.entry(iface_tn).or_default();
                                 if !entry.contains(&tn) {
                                     entry.push(tn.clone());
@@ -2422,9 +2430,7 @@ impl<'db> LoweringContext<'db> {
                         }
                     }
                     Definition::Enum(enum_loc) => {
-                        let efile = enum_loc.file(db);
-                        let eitree = file_item_tree(db, efile);
-                        let enum_data = &eitree[enum_loc.id(db)];
+                        let enum_data = baml_compiler2_ppir::item_data::enum_data(db, *enum_loc);
                         let enum_qtn = QualifiedTypeName::new(
                             pkg_name.clone(),
                             ns_names.clone(),
@@ -2447,12 +2453,9 @@ impl<'db> LoweringContext<'db> {
             if pkg_info.package != *pkg_name {
                 continue;
             }
-            let item_tree = file_item_tree(db, file);
-            for impl_id in &item_tree.free_impls {
-                let Some(imp) = item_tree.impls.get(impl_id) else {
-                    continue;
-                };
-                let baml_compiler2_hir::item_tree::ImplSubject::Free {
+            for impl_loc in baml_compiler2_ppir::item_data::file_free_impls(db, file) {
+                let imp = baml_compiler2_ppir::item_data::impl_block_data(db, *impl_loc);
+                let baml_compiler2_ppir::item_data::ImplSubjectData::Free {
                     for_target,
                     generics,
                 } = &imp.subject
@@ -2461,25 +2464,24 @@ impl<'db> LoweringContext<'db> {
                 };
                 let imp_generic_params: Vec<Name> =
                     generics.iter().map(|g| g.name.clone()).collect();
-                let imp_generic_param_bounds: Vec<Option<baml_compiler2_ast::TypeExpr>> =
-                    generics.iter().map(|g| g.bounds.first().cloned()).collect();
-                let impl_loc = baml_compiler2_hir::loc::ImplLoc::new(db, file, *impl_id);
+                let imp_generic_param_bounds: Vec<Option<baml_compiler2_hir::type_ref::TypeRefId>> =
+                    generics.iter().map(|g| g.bounds.first().copied()).collect();
                 let impl_bounds =
-                    baml_compiler2_tir::lower_type_expr::impl_generic_param_bounds(db, impl_loc);
-                let Some(root_iface_loc) =
-                    baml_compiler2_tir::interfaces::resolve_path_to_interface(
-                        db,
-                        &imp.interface_target,
-                        pkg_items,
-                        &pkg_info.namespace_path,
-                    )
-                else {
+                    baml_compiler2_tir::lower_type_expr::impl_generic_param_bounds(db, *impl_loc);
+                let Some(root_iface_loc) = baml_compiler2_tir::interfaces::resolve_ref_to_interface(
+                    db,
+                    &imp.type_refs,
+                    imp.interface_target,
+                    pkg_items,
+                    &pkg_info.namespace_path,
+                ) else {
                     continue;
                 };
 
                 let mut diags = Vec::new();
-                let target_ty_tir = baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                    for_target,
+                let target_ty_tir = baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                    &imp.type_refs,
+                    *for_target,
                     &baml_compiler2_tir::lower_type_expr::ScopeCtx {
                         db,
                         package_items: pkg_items,
@@ -2500,9 +2502,10 @@ impl<'db> LoweringContext<'db> {
                             .iter()
                             .any(|a| matches!(a, baml_compiler2_tir::ty::Ty::TypeVar(..)))
                         {
-                            let root_iface_args_tir = lower_interface_target_args(
+                            let root_iface_args_tir = lower_ref_interface_target_args(
                                 db,
-                                &imp.interface_target,
+                                &imp.type_refs,
+                                imp.interface_target,
                                 pkg_items,
                                 &pkg_info.namespace_path,
                                 &imp_generic_params,
@@ -2528,8 +2531,9 @@ impl<'db> LoweringContext<'db> {
                             .and_then(|idx| imp_generic_param_bounds.get(idx))
                             .and_then(|bound| bound.as_ref())
                             .map(|bound| {
-                                baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                                    bound,
+                                baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                                    &imp.type_refs,
+                                    *bound,
                                     &baml_compiler2_tir::lower_type_expr::ScopeCtx {
                                         db,
                                         package_items: pkg_items,
@@ -2547,9 +2551,10 @@ impl<'db> LoweringContext<'db> {
                         if !matches!(bound_ty, baml_compiler2_tir::ty::Ty::Interface(..)) {
                             continue;
                         }
-                        let root_iface_args_tir = lower_interface_target_args(
+                        let root_iface_args_tir = lower_ref_interface_target_args(
                             db,
-                            &imp.interface_target,
+                            &imp.type_refs,
+                            imp.interface_target,
                             pkg_items,
                             &pkg_info.namespace_path,
                             &imp_generic_params,
@@ -2597,8 +2602,7 @@ impl<'db> LoweringContext<'db> {
     ) -> Self {
         let file = func_loc.file(db);
 
-        let item_tree = file_item_tree(db, file);
-        let func_data = &item_tree[func_loc.id(db)];
+        let func_data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
         let index = file_semantic_index(db, file);
         // The scope this function opened, from the recorded item↔scope index.
         // Exact — no span match, so companion functions and synthesized `0..0`
@@ -2631,56 +2635,85 @@ impl<'db> LoweringContext<'db> {
         let pkg_id = PackageId::new(db, pkg_info.package.clone());
         let pkg_items_for_bounds = package_items(db, pkg_id);
         let mut bound_param_names = Vec::new();
-        let mut bound_exprs = Vec::new();
-        if let Some(imp) = enclosing_free_impl(&item_tree, func_loc.id(db)) {
-            let (names, bounds) = free_impl_generics(imp);
-            bound_param_names.extend(names);
-            bound_exprs.extend(bounds);
+        // Each source item owns its own `TypeRef` arena, so bounds are collected as
+        // `(store, id)` pairs — index-aligned with `bound_param_names` — and lowered
+        // together below once every sibling param name is in scope (a bound may
+        // reference a sibling type var).
+        let mut bound_refs: Vec<
+            Option<(
+                &baml_compiler2_hir::type_ref::TypeRefStore,
+                baml_compiler2_hir::type_ref::TypeRefId,
+            )>,
+        > = Vec::new();
+        if let Some(baml_compiler2_ppir::item_data::MethodOwner::FreeImpl(impl_loc)) =
+            baml_compiler2_ppir::item_data::method_owner(db, func_loc)
+        {
+            let imp = baml_compiler2_ppir::item_data::impl_block_data(db, impl_loc);
+            if let baml_compiler2_ppir::item_data::ImplSubjectData::Free { generics, .. } =
+                &imp.subject
+            {
+                for g in generics {
+                    bound_param_names.push(g.name.clone());
+                    bound_refs.push(g.bounds.first().copied().map(|id| (&imp.type_refs, id)));
+                }
+            }
         } else if let Some(parent_idx) = func_scope.parent {
             let parent = &index.scopes[parent_idx.index() as usize];
             if matches!(parent.kind, baml_compiler2_hir::scope::ScopeKind::Class)
                 && let Some(type_name) = &parent.name
             {
-                if let Some(class_data) = item_tree
-                    .classes
-                    .values()
-                    .find(|class_data| class_data.name == *type_name)
+                if let Some(class_loc) = baml_compiler2_ppir::item_data::file_classes(db, file)
+                    .iter()
+                    .copied()
+                    .find(|&loc| {
+                        baml_compiler2_ppir::item_data::class_data(db, loc).name == *type_name
+                    })
                 {
+                    let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
                     bound_param_names.extend(class_data.generic_params.iter().cloned());
-                    bound_exprs.extend(class_data.generic_param_bounds.iter().cloned());
-                } else if let Some(iface_data) = item_tree
-                    .interfaces
-                    .values()
-                    .find(|iface_data| iface_data.name == *type_name)
+                    for bound in &class_data.generic_param_bounds {
+                        bound_refs.push(bound.map(|id| (&class_data.type_refs, id)));
+                    }
+                } else if let Some(iface_loc) =
+                    baml_compiler2_ppir::item_data::file_interfaces(db, file)
+                        .iter()
+                        .copied()
+                        .find(|&loc| {
+                            baml_compiler2_ppir::item_data::interface_data(db, loc).name
+                                == *type_name
+                        })
                 {
+                    let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
                     bound_param_names.extend(iface_data.generic_params.iter().cloned());
-                    bound_exprs.extend(iface_data.generic_param_bounds.iter().cloned());
+                    for bound in &iface_data.generic_param_bounds {
+                        bound_refs.push(bound.map(|id| (&iface_data.type_refs, id)));
+                    }
                     bound_param_names.extend(
                         iface_data
                             .associated_types
                             .iter()
                             .map(|assoc| assoc.name.clone()),
                     );
-                    bound_exprs.extend(
-                        iface_data
-                            .associated_types
-                            .iter()
-                            .map(|assoc| assoc.bound.clone()),
-                    );
+                    for assoc in &iface_data.associated_types {
+                        bound_refs.push(assoc.bound.map(|id| (&iface_data.type_refs, id)));
+                    }
                 }
             }
         }
         bound_param_names.extend(func_data.generic_params.iter().cloned());
-        bound_exprs.extend(func_data.generic_param_bounds.iter().cloned());
+        for bound in &func_data.generic_param_bounds {
+            bound_refs.push(bound.map(|id| (&func_data.type_refs, id)));
+        }
         let all_generic_params = bound_param_names.clone();
         let mut generic_param_bounds: FxHashMap<Name, Tir2Ty> = FxHashMap::default();
         for (idx, name) in bound_param_names.iter().enumerate() {
-            let Some(Some(bound_te)) = bound_exprs.get(idx) else {
+            let Some(Some((store, id))) = bound_refs.get(idx).copied() else {
                 continue;
             };
             let mut diags = Vec::new();
-            let bound_ty = baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                bound_te,
+            let bound_ty = baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                store,
+                id,
                 &baml_compiler2_tir::lower_type_expr::ScopeCtx {
                     db,
                     package_items: pkg_items_for_bounds,
@@ -2704,10 +2737,10 @@ impl<'db> LoweringContext<'db> {
         // `self` dispatch through the interface — `interface_dispatch_target_for_tir_ty`
         // already follows type-var bounds — so default methods keep dispatching
         // through the concrete implementor.
-        if let Some(baml_compiler2_hir::item_tree::MethodOwner::Interface(iface_id)) =
-            item_tree.method_owners.get(&func_loc.id(db))
+        if let Some(baml_compiler2_ppir::item_data::MethodOwner::Interface(iface_loc)) =
+            baml_compiler2_ppir::item_data::method_owner(db, func_loc)
         {
-            let iface = &item_tree[*iface_id];
+            let iface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
             if let Some(def) =
                 pkg_items_for_bounds.lookup_type(&pkg_info.namespace_path, &iface.name)
             {
@@ -2830,9 +2863,9 @@ impl<'db> LoweringContext<'db> {
     ) -> Self {
         let file = let_loc.file(db);
 
-        let item_tree = file_item_tree(db, file);
-        let let_data = &item_tree[let_loc.id(db)];
-        let let_name = let_data.name.clone();
+        let let_name = baml_compiler2_ppir::item_data::let_data(db, let_loc)
+            .name
+            .clone();
         let index = file_semantic_index(db, file);
         let let_scope_id = baml_compiler2_ppir::item_data::let_scope(db, let_loc)
             .expect("every item-tree let has a recorded scope")
@@ -3678,21 +3711,16 @@ impl<'db> LoweringContext<'db> {
         baml_compiler2_tir::interfaces::interface_closure_locs(self.db, root_loc)
             .into_iter()
             .any(|iface_loc| {
-                let iface_tree =
-                    baml_compiler2_hir::file_item_tree(self.db, iface_loc.file(self.db));
-                iface_tree
-                    .interfaces
-                    .get(&iface_loc.id(self.db))
-                    .is_some_and(|iface_data| {
-                        iface_data
-                            .required_methods
-                            .iter()
-                            .any(|s| s.name == *method)
-                            || iface_data
-                                .default_methods
-                                .iter()
-                                .any(|&fn_id| iface_tree[fn_id].name == *method)
-                    })
+                use baml_compiler2_ppir::item_data::{function_data, interface_data};
+                let iface_data = interface_data(self.db, iface_loc);
+                iface_data
+                    .required_methods
+                    .iter()
+                    .any(|s| s.name == *method)
+                    || iface_data
+                        .default_methods
+                        .iter()
+                        .any(|&fn_loc| function_data(self.db, fn_loc).name == *method)
             })
     }
 
@@ -3700,6 +3728,7 @@ impl<'db> LoweringContext<'db> {
     /// default methods, not via its `requires` closure. (Unlike
     /// [`Self::mir_interface_declares_method`], which walks the whole closure.)
     fn interface_declares_method_directly(&self, iface_tn: &TypeName, method: &Name) -> bool {
+        use baml_compiler2_ppir::item_data::{function_data, interface_data};
         let pkg_id =
             baml_compiler2_hir::package::PackageId::new(self.db, iface_tn.package().clone());
         let pkg_items = baml_compiler2_hir::package::package_items(self.db, pkg_id);
@@ -3708,20 +3737,15 @@ impl<'db> LoweringContext<'db> {
         else {
             return false;
         };
-        let iface_tree = baml_compiler2_hir::file_item_tree(self.db, loc.file(self.db));
-        iface_tree
-            .interfaces
-            .get(&loc.id(self.db))
-            .is_some_and(|iface_data| {
-                iface_data
-                    .required_methods
-                    .iter()
-                    .any(|s| s.name == *method)
-                    || iface_data
-                        .default_methods
-                        .iter()
-                        .any(|&fn_id| iface_tree[fn_id].name == *method)
-            })
+        let iface_data = interface_data(self.db, loc);
+        iface_data
+            .required_methods
+            .iter()
+            .any(|s| s.name == *method)
+            || iface_data
+                .default_methods
+                .iter()
+                .any(|&fn_loc| function_data(self.db, fn_loc).name == *method)
     }
 
     /// Resolve the interface view that actually *declares* `method`, starting
@@ -3938,21 +3962,19 @@ impl<'db> LoweringContext<'db> {
     /// The associated-type names of the interface whose default method this body is —
     /// `None` when the current function is not an interface default method.
     fn enclosing_interface_assoc_names(&self) -> Option<Vec<baml_base::Name>> {
+        use baml_compiler2_ppir::item_data::{MethodOwner, interface_data, method_owner};
         let fl = self.func_loc?;
-        let item_tree = file_item_tree(self.db, fl.file(self.db));
-        let func_id = fl.id(self.db);
-        let baml_compiler2_hir::item_tree::MethodOwner::Interface(iface_id) =
-            item_tree.method_owners.get(&func_id)?
-        else {
+        let MethodOwner::Interface(iface_loc) = method_owner(self.db, fl)? else {
             return None;
         };
-        Some(&item_tree[*iface_id]).map(|iface_data| {
+        let iface_data = interface_data(self.db, iface_loc);
+        Some(
             iface_data
                 .associated_types
                 .iter()
                 .map(|assoc| assoc.name.clone())
-                .collect()
-        })
+                .collect(),
+        )
     }
 
     /// Rewrite every `Self.X` path (where `X` is one of `assoc_names`) to the bare `X`
@@ -4082,8 +4104,7 @@ impl<'db> LoweringContext<'db> {
 
         // Detect enclosing class for `self` parameter resolution
         let index = file_semantic_index(self.db, self.file);
-        let item_tree = file_item_tree(self.db, self.file);
-        let func_data = &item_tree[func_loc.id(self.db)];
+        let func_data = baml_compiler2_ppir::item_data::function_data(self.db, func_loc);
         let func_span = baml_compiler2_ppir::item_data::function_source_map(self.db, func_loc).span;
         // Set the function-level span on the builder so MirFunction::span is populated.
         self.builder
@@ -4100,7 +4121,12 @@ impl<'db> LoweringContext<'db> {
                 None
             }
         });
-        let enclosing_impl = enclosing_free_impl(&item_tree, func_loc.id(self.db));
+        let enclosing_impl = match baml_compiler2_ppir::item_data::method_owner(self.db, func_loc) {
+            Some(baml_compiler2_ppir::item_data::MethodOwner::FreeImpl(impl_loc)) => Some(
+                baml_compiler2_ppir::item_data::impl_block_data(self.db, impl_loc),
+            ),
+            _ => None,
+        };
 
         // Parameter locals _1..=_n
         // For `self` with no annotation, use the active rule receiver pattern
@@ -4111,15 +4137,17 @@ impl<'db> LoweringContext<'db> {
                     param.ty.kind,
                     baml_compiler2_ast::TypeExprKind::Unknown { .. }
                 ) {
-                if let Some(baml_compiler2_hir::item_tree::ImplSubject::Free {
-                    for_target, ..
-                }) = enclosing_impl.map(|imp| &imp.subject)
+                if let Some(imp) = enclosing_impl
+                    && let baml_compiler2_ppir::item_data::ImplSubjectData::Free {
+                        for_target, ..
+                    } = &imp.subject
                 {
                     let mut diags = Vec::new();
                     let generic_params = self.enclosing_generic_params();
                     let generic_param_bounds = self.enclosing_generic_param_bounds();
-                    let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                        for_target,
+                    let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                        &imp.type_refs,
+                        *for_target,
                         &baml_compiler2_tir::lower_type_expr::ScopeCtx {
                             db: self.db,
                             package_items: pkg_items,
@@ -4211,7 +4239,7 @@ impl<'db> LoweringContext<'db> {
 
     fn lower_default_parameter_prologue(
         &mut self,
-        func_data: &baml_compiler2_hir::item_tree::Function,
+        func_data: &baml_compiler2_ppir::item_data::FunctionData,
         parameter_defaults: &baml_compiler2_hir::signature::FunctionParameterDefaults,
     ) {
         for (index, param) in func_data.params.iter().enumerate() {
@@ -6475,8 +6503,7 @@ impl<'db> LoweringContext<'db> {
             };
         };
 
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-        let class_data = &item_tree[class_loc.id(db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
 
         let field = class_data.fields.iter().find(|f| &f.name == field_name);
         let Some(field) = field else {
@@ -6484,7 +6511,7 @@ impl<'db> LoweringContext<'db> {
                 attr: TyAttr::default(),
             };
         };
-        let Some(ref te) = field.type_expr else {
+        let Some(type_ref) = field.type_ref else {
             return RuntimeTy::Null {
                 attr: TyAttr::default(),
             };
@@ -6493,8 +6520,9 @@ impl<'db> LoweringContext<'db> {
         let pkg_ns =
             baml_compiler2_hir::file_package::file_package(db, class_loc.file(db)).namespace_path;
         let mut diags = Vec::new();
-        let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_expr(
-            te,
+        let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_ref(
+            &class_data.type_refs,
+            type_ref,
             &baml_compiler2_tir::lower_type_expr::ScopeCtx {
                 db,
                 package_items: pkg_items_ref,
@@ -7846,15 +7874,19 @@ impl<'db> LoweringContext<'db> {
         if let AstExpr::Path(segments) = &callee_expr
             && segments.len() == 2
             && self.is_default_receiver_root(segments)
-            && let Some(target_te) = self.implements_block_iface_target()
-            && let baml_compiler2_ast::TypeExprKind::Path { .. } = &target_te.kind
+            && let Some(target) = self.implements_block_iface_target()
+            && matches!(
+                target.type_refs[target.target].kind,
+                baml_compiler2_hir::type_ref::TypeRefKind::Path { .. }
+            )
         {
             let current_pkg = baml_compiler2_hir::file_package::file_package(self.db, self.file);
             let pkg_id = PackageId::new(self.db, current_pkg.package.clone());
             let pkg_items = package_items(self.db, pkg_id);
-            if let Some(iface_loc) = baml_compiler2_tir::interfaces::resolve_path_to_interface(
+            if let Some(iface_loc) = baml_compiler2_tir::interfaces::resolve_ref_to_interface(
                 self.db,
-                &target_te,
+                &target.type_refs,
+                target.target,
                 pkg_items,
                 &current_pkg.namespace_path,
             ) {
@@ -7862,8 +7894,9 @@ impl<'db> LoweringContext<'db> {
                     self.db,
                     iface_loc.file(self.db),
                 );
-                let iface_tree = file_item_tree(self.db, iface_loc.file(self.db));
-                let iface_name = iface_tree[iface_loc.id(self.db)].name.clone();
+                let iface_name = baml_compiler2_ppir::item_data::interface_data(self.db, iface_loc)
+                    .name
+                    .clone();
                 let method_name = segments[1].clone();
                 let item_ref = ItemRef::Method {
                     package: iface_pkg.package.clone(),
@@ -7882,33 +7915,21 @@ impl<'db> LoweringContext<'db> {
                 // `enclosing_generic_params`), so without this an explicit
                 // `default.<method>()` that reads `T` would resolve it to
                 // `unknown` at runtime. Mirrors the interface-dispatch switch.
-                let iface_type_arg_tys: Vec<Tir2Ty> =
-                    if let baml_compiler2_ast::TypeExprKind::Path { generic_args, .. } =
-                        &target_te.kind
-                    {
-                        let generic_params = self.enclosing_generic_params();
-                        let generic_param_bounds = self.enclosing_generic_param_bounds();
-                        let mut diags = Vec::new();
-                        generic_args
-                            .iter()
-                            .map(|arg| {
-                                baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                                    arg,
-                                    &baml_compiler2_tir::lower_type_expr::ScopeCtx {
-                                        db: self.db,
-                                        package_items: pkg_items,
-                                        ns_context: &current_pkg.namespace_path,
-                                        generic_params: &generic_params,
-                                        bounds: &generic_param_bounds,
-                                        self_ty: None,
-                                    },
-                                    &mut diags,
-                                )
-                            })
-                            .collect()
-                    } else {
-                        vec![]
-                    };
+                let iface_type_arg_tys: Vec<Tir2Ty> = {
+                    let generic_params = self.enclosing_generic_params();
+                    let generic_param_bounds = self.enclosing_generic_param_bounds();
+                    let mut diags = Vec::new();
+                    lower_ref_interface_target_args(
+                        self.db,
+                        &target.type_refs,
+                        target.target,
+                        pkg_items,
+                        &current_pkg.namespace_path,
+                        &generic_params,
+                        &generic_param_bounds,
+                        &mut diags,
+                    )
+                };
                 let frame_type_arg_ops = self.emit_frame_type_arg_ops(&iface_type_arg_tys);
                 let ntypeargs = frame_type_arg_ops.len();
                 let mut all_args = frame_type_arg_ops;
@@ -8851,15 +8872,14 @@ impl<'db> LoweringContext<'db> {
         &self,
         func_loc: baml_compiler2_hir::loc::FunctionLoc<'_>,
     ) -> usize {
-        let item_tree = baml_compiler2_ppir::file_item_tree(self.db, func_loc.file(self.db));
-        let func = &item_tree[func_loc.id(self.db)];
+        let func = baml_compiler2_ppir::item_data::function_data(self.db, func_loc);
         let declared_type_value_params = func
             .params
             .iter()
             .filter(|param| {
                 matches!(
-                    param.type_expr.as_ref().map(|ty| &ty.kind),
-                    Some(baml_compiler2_ast::TypeExprKind::Type { .. })
+                    param.type_ref.map(|id| &func.type_refs[id].kind),
+                    Some(baml_compiler2_hir::type_ref::TypeRefKind::Type)
                 )
             })
             .count();
@@ -9122,15 +9142,23 @@ impl LoweringContext<'_> {
     /// method calls prepend receiver class args, and interface dispatch seeds
     /// either static guard args or the matched receiver instance's class args.
     fn enclosing_generic_params(&self) -> Vec<baml_base::Name> {
+        use baml_compiler2_ppir::item_data::{
+            ImplSubjectData, MethodOwner, class_data, function_data, impl_block_data,
+            interface_data, method_owner,
+        };
         let Some(fl) = self.func_loc else {
             return Vec::new();
         };
-        let item_tree = file_item_tree(self.db, fl.file(self.db));
-        let func_id = fl.id(self.db);
-        if let Some(imp) = enclosing_free_impl(&item_tree, func_id) {
-            let (names, _) = free_impl_generics(imp);
-            let mut params = names;
-            params.extend(item_tree[func_id].generic_params.iter().cloned());
+        let owner = method_owner(self.db, fl);
+        if let Some(MethodOwner::FreeImpl(impl_loc)) = owner {
+            let block = impl_block_data(self.db, impl_loc);
+            let mut params: Vec<baml_base::Name> =
+                if let ImplSubjectData::Free { generics, .. } = &block.subject {
+                    generics.iter().map(|g| g.name.clone()).collect()
+                } else {
+                    Vec::new()
+                };
+            params.extend(function_data(self.db, fl).generic_params.iter().cloned());
             return params;
         }
         // BEP-044: interface default methods are lowered as standalone
@@ -9139,10 +9167,8 @@ impl LoweringContext<'_> {
         // class-method convention — interface params first, then fn params — so
         // `TypeVar(T)` lowers to `TypeArgRef(N)` against the frame type args the
         // interface-dispatch switch seeds (see `emit_method_candidate_switch`).
-        if let Some(baml_compiler2_hir::item_tree::MethodOwner::Interface(iface_id)) =
-            item_tree.method_owners.get(&func_id)
-        {
-            let iface_data = &item_tree[*iface_id];
+        if let Some(MethodOwner::Interface(iface_loc)) = owner {
+            let iface_data = interface_data(self.db, iface_loc);
             let mut params = iface_data.generic_params.clone();
             params.extend(
                 iface_data
@@ -9150,22 +9176,18 @@ impl LoweringContext<'_> {
                     .iter()
                     .map(|assoc| assoc.name.clone()),
             );
-            params.extend(item_tree[func_id].generic_params.iter().cloned());
+            params.extend(function_data(self.db, fl).generic_params.iter().cloned());
             return params;
         }
-        let mut params: Vec<baml_base::Name> = match item_tree.method_owners.get(&func_id) {
-            Some(baml_compiler2_hir::item_tree::MethodOwner::Class(class_id)) => {
-                item_tree[*class_id].generic_params.clone()
+        let mut params: Vec<baml_base::Name> = match owner {
+            Some(MethodOwner::Class(class_loc)) => {
+                class_data(self.db, class_loc).generic_params.clone()
             }
             // `Interface` owners are handled by the early return above; a free
             // impl's own generics are not enclosing-type parameters.
-            Some(
-                baml_compiler2_hir::item_tree::MethodOwner::Interface(_)
-                | baml_compiler2_hir::item_tree::MethodOwner::FreeImpl(_),
-            )
-            | None => Vec::new(),
+            Some(MethodOwner::Interface(_) | MethodOwner::FreeImpl(_)) | None => Vec::new(),
         };
-        params.extend(item_tree[func_id].generic_params.iter().cloned());
+        params.extend(function_data(self.db, fl).generic_params.iter().cloned());
         // Inside a (possibly nested) generic lambda body, the lambda's own
         // type params follow the enclosing function's, matching the runtime
         // frame.type_args layout. Empty outside any lambda.
@@ -9190,13 +9212,9 @@ impl LoweringContext<'_> {
                 self.db, fl,
             )
             .clone();
-        let item_tree = file_item_tree(self.db, fl.file(self.db));
-        let func_id = fl.id(self.db);
-        if let Some(baml_compiler2_hir::item_tree::MethodOwner::FreeImpl(impl_id)) =
-            item_tree.method_owners.get(&func_id)
+        if let Some(baml_compiler2_ppir::item_data::MethodOwner::FreeImpl(impl_loc)) =
+            baml_compiler2_ppir::item_data::method_owner(self.db, fl)
         {
-            let impl_loc =
-                baml_compiler2_hir::loc::ImplLoc::new(self.db, fl.file(self.db), *impl_id);
             for (name, conjunction) in
                 baml_compiler2_tir::lower_type_expr::impl_generic_param_bounds(self.db, impl_loc)
             {
@@ -10506,16 +10524,13 @@ impl<'db> LoweringContext<'db> {
 
     /// Resolve `class.method` to a callable `ItemRef` by simple name.
     fn class_method_item_ref_by_name(&self, class_tn: &TypeName, method: &Name) -> Option<ItemRef> {
+        use baml_compiler2_ppir::item_data::{class_data, function_data};
         let class_loc = self.resolve_class_loc_by_type_name(class_tn)?;
-        let item_tree = file_item_tree(self.db, class_loc.file(self.db));
-        let class_data = &item_tree[class_loc.id(self.db)];
-        let func_id = class_data
+        let func_loc = class_data(self.db, class_loc)
             .methods
             .iter()
             .copied()
-            .find(|&id| item_tree[id].name == *method)?;
-        let func_loc =
-            baml_compiler2_hir::loc::FunctionLoc::new(self.db, class_loc.file(self.db), func_id);
+            .find(|&fl| function_data(self.db, fl).name == *method)?;
         Some(method_item_ref(self.db, class_loc, func_loc))
     }
 
@@ -10627,12 +10642,11 @@ impl<'db> LoweringContext<'db> {
         let Some(class_loc) = self.resolve_class_loc_by_type_name(class_tn) else {
             return Vec::new();
         };
-        let class_tree = file_item_tree(self.db, class_loc.file(self.db));
-        let class_data = &class_tree[class_loc.id(self.db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(self.db, class_loc);
         let mut out = Vec::new();
         for impl_block in &class_data.implements {
             if let Some((iface_tn, iface_args, iface_assoc)) = self.resolve_implements_target_view(
-                &impl_block.target,
+                impl_block.target,
                 &impl_block.associated_type_bindings,
                 class_loc,
             ) {
@@ -10716,6 +10730,7 @@ impl<'db> LoweringContext<'db> {
     }
 
     fn interface_method_generic_count(&self, iface_tn: &TypeName, method: &Name) -> Option<usize> {
+        use baml_compiler2_ppir::item_data::{function_data, interface_data};
         let iface_pkg_name = iface_tn.package();
         let iface_pkg_items = self.resolve_class_pkg_items_by_name(iface_pkg_name);
         let iface_ns: Vec<Name> = iface_tn.namespace().clone();
@@ -10724,13 +10739,12 @@ impl<'db> LoweringContext<'db> {
         else {
             return None;
         };
-        let iface_tree = baml_compiler2_hir::file_item_tree(self.db, iface_loc.file(self.db));
-        let iface_data = iface_tree.interfaces.get(&iface_loc.id(self.db))?;
+        let iface_data = interface_data(self.db, iface_loc);
         iface_data
             .default_methods
             .iter()
-            .find_map(|fn_id| {
-                let func = &iface_tree[*fn_id];
+            .find_map(|&fn_loc| {
+                let func = function_data(self.db, fn_loc);
                 (func.name == *method).then_some(func.generic_params.len())
             })
             .or_else(|| {
@@ -10968,9 +10982,7 @@ impl<'db> LoweringContext<'db> {
                 true,
             )
             .into_iter()
-            .filter_map(|(loc, args, assoc)| {
-                Some((interface_type_name_from_loc(self.db, loc)?, args, assoc))
-            })
+            .map(|(loc, args, assoc)| (interface_type_name_from_loc(self.db, loc), args, assoc))
             .collect(),
         )
     }
@@ -10990,52 +11002,42 @@ impl<'db> LoweringContext<'db> {
 
     fn resolve_implements_target_view(
         &self,
-        target: &baml_compiler2_ast::TypeExpr,
-        associated_type_bindings: &[baml_compiler2_ast::AssociatedTypeBindingDef],
+        target: baml_compiler2_hir::type_ref::TypeRefId,
+        associated_type_bindings: &[baml_compiler2_ppir::item_data::AssociatedTypeBindingData],
         class_loc: baml_compiler2_hir::loc::ClassLoc<'db>,
     ) -> Option<InterfaceTypeView> {
         let class_file = class_loc.file(self.db);
         let class_pkg = baml_compiler2_hir::file_package::file_package(self.db, class_file);
         let class_pkg_id = PackageId::new(self.db, class_pkg.package.clone());
         let class_pkg_items = package_items(self.db, class_pkg_id);
-        let target_loc = baml_compiler2_tir::interfaces::resolve_path_to_interface(
+        let class_data = baml_compiler2_ppir::item_data::class_data(self.db, class_loc);
+        // `target` and the class-side `associated_type_bindings` index the class's
+        // own arena; the interface's associated-type defaults index the interface's.
+        let target_store = &class_data.type_refs;
+        let target_loc = baml_compiler2_tir::interfaces::resolve_ref_to_interface(
             self.db,
+            target_store,
             target,
             class_pkg_items,
             &class_pkg.namespace_path,
         )?;
-        let target_tree = baml_compiler2_hir::file_item_tree(self.db, target_loc.file(self.db));
-        let target_data = target_tree.interfaces.get(&target_loc.id(self.db))?;
+        let target_data = baml_compiler2_ppir::item_data::interface_data(self.db, target_loc);
         let target_qtn = baml_compiler2_tir::lower_type_expr::qualify_def(
             self.db,
             Definition::Interface(target_loc),
             &target_data.name,
         );
-        let item_tree = file_item_tree(self.db, class_file);
-        let class_data = &item_tree[class_loc.id(self.db)];
         let mut diags = Vec::new();
-        let target_args = match &target.kind {
-            baml_compiler2_ast::TypeExprKind::Path { generic_args, .. } => generic_args
-                .iter()
-                .map(|arg| {
-                    baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                        arg,
-                        &baml_compiler2_tir::lower_type_expr::ScopeCtx {
-                            db: self.db,
-                            package_items: class_pkg_items,
-                            ns_context: &class_pkg.namespace_path,
-                            generic_params: &class_data.generic_params,
-                            bounds: baml_compiler2_tir::lower_type_expr::class_generic_param_bounds(
-                                self.db, class_loc,
-                            ),
-                            self_ty: None,
-                        },
-                        &mut diags,
-                    )
-                })
-                .collect(),
-            _ => Vec::new(),
-        };
+        let target_args = lower_ref_interface_target_args(
+            self.db,
+            target_store,
+            target,
+            class_pkg_items,
+            &class_pkg.namespace_path,
+            &class_data.generic_params,
+            baml_compiler2_tir::lower_type_expr::class_generic_param_bounds(self.db, class_loc),
+            &mut diags,
+        );
         let target_iface_pkg =
             baml_compiler2_hir::file_package::file_package(self.db, target_loc.file(self.db));
         let mut bindings =
@@ -11052,11 +11054,12 @@ impl<'db> LoweringContext<'db> {
                 if let Some(binding) = associated_type_bindings
                     .iter()
                     .find(|binding| binding.name == assoc.name)
-                    && let Some(type_expr) = &binding.type_expr
+                    && let Some(type_ref) = binding.type_ref
                 {
-                    let ty = lower_ty_with_bindings(
+                    let ty = lower_ref_with_bindings(
                         self.db,
-                        type_expr,
+                        target_store,
+                        type_ref,
                         class_pkg_items,
                         &class_pkg.namespace_path,
                         &bindings,
@@ -11068,9 +11071,10 @@ impl<'db> LoweringContext<'db> {
                     bindings.insert(assoc.name.clone(), ty.clone());
                     return Some((assoc.name.clone(), ty));
                 }
-                assoc.default.as_ref().map(|default| {
-                    let ty = lower_ty_with_bindings(
+                assoc.default.map(|default| {
+                    let ty = lower_ref_with_bindings(
                         self.db,
+                        &target_data.type_refs,
                         default,
                         class_pkg_items,
                         &target_iface_pkg.namespace_path,
@@ -11097,10 +11101,10 @@ impl<'db> LoweringContext<'db> {
         let Some(Definition::Interface(loc)) = pkg_items.lookup_type(&ns, iface_tn.name()) else {
             return false;
         };
-        let tree = file_item_tree(self.db, loc.file(self.db));
-        tree.interfaces
-            .get(&loc.id(self.db))
-            .is_some_and(|data| data.fields.iter().any(|f| &f.name == field))
+        baml_compiler2_ppir::item_data::interface_data(self.db, loc)
+            .fields
+            .iter()
+            .any(|f| &f.name == field)
     }
 
     /// Class-tag dispatch guards for every implementor that satisfies the
@@ -11128,12 +11132,11 @@ impl<'db> LoweringContext<'db> {
             let Some(class_loc) = self.resolve_class_loc_by_type_name(impl_tn) else {
                 continue;
             };
-            let item_tree = file_item_tree(self.db, class_loc.file(self.db));
-            let class_data = &item_tree[class_loc.id(self.db)];
+            let class_data = baml_compiler2_ppir::item_data::class_data(self.db, class_loc);
             for impl_block in &class_data.implements {
                 let Some((target_tn, target_args, target_assoc)) = self
                     .resolve_implements_target_view(
-                        &impl_block.target,
+                        impl_block.target,
                         &impl_block.associated_type_bindings,
                         class_loc,
                     )
@@ -11185,8 +11188,7 @@ impl<'db> LoweringContext<'db> {
         let Some(class_loc) = self.resolve_class_loc_by_type_name(impl_tn) else {
             return Vec::new();
         };
-        let item_tree = file_item_tree(self.db, class_loc.file(self.db));
-        let class_data = &item_tree[class_loc.id(self.db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(self.db, class_loc);
         let Some(requested_views) =
             self.interface_closure_type_name_views(iface_tn, iface_type_args, iface_assoc)
         else {
@@ -11206,7 +11208,7 @@ impl<'db> LoweringContext<'db> {
 
         for impl_block in &class_data.implements {
             let Some((target_tn, target_args, target_assoc)) = self.resolve_implements_target_view(
-                &impl_block.target,
+                impl_block.target,
                 &impl_block.associated_type_bindings,
                 class_loc,
             ) else {
@@ -11309,13 +11311,11 @@ impl<'db> LoweringContext<'db> {
     /// inside an `implements I { ... }` block, return `I`'s target type
     /// expression. `None` for free functions, top-level class methods,
     /// and interface default-method bodies.
-    fn implements_block_iface_target(&self) -> Option<baml_compiler2_ast::TypeExpr> {
+    fn implements_block_iface_target(
+        &self,
+    ) -> Option<&'db baml_compiler2_ppir::item_data::MethodInterfaceTarget> {
         let func_loc = self.func_loc?;
-        let item_tree = file_item_tree(self.db, func_loc.file(self.db));
-        item_tree
-            .method_to_iface_target
-            .get(&func_loc.id(self.db))
-            .cloned()
+        baml_compiler2_ppir::item_data::method_interface_target(self.db, func_loc).as_ref()
     }
 
     fn resolve_class_pkg_items_by_name(
@@ -13074,8 +13074,7 @@ impl LoweringContext<'_> {
 
         let file = class_loc.file(self.db);
         let ns_context = file_package(self.db, file).namespace_path;
-        let item_tree = file_item_tree(self.db, file);
-        let class_data = &item_tree[class_loc.id(self.db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(self.db, class_loc);
         let bindings = baml_compiler2_tir::generics::bind_type_vars(
             &class_data.generic_params,
             class_type_args,
@@ -13085,12 +13084,12 @@ impl LoweringContext<'_> {
         for field in &class_data.fields {
             let mut diags = Vec::new();
             let field_ty = field
-                .type_expr
-                .as_ref()
-                .map(|te| {
+                .type_ref
+                .map(|id| {
                     if bindings.is_empty() {
-                        baml_compiler2_tir::lower_type_expr::lower_type_expr(
-                            te,
+                        baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                            &class_data.type_refs,
+                            id,
                             &baml_compiler2_tir::lower_type_expr::ScopeCtx {
                                 db: self.db,
                                 package_items: pkg_items_for_class,
@@ -13105,9 +13104,10 @@ impl LoweringContext<'_> {
                             &mut diags,
                         )
                     } else {
-                        lower_ty_with_bindings(
+                        lower_ref_with_bindings(
                             self.db,
-                            te,
+                            &class_data.type_refs,
+                            id,
                             pkg_items_for_class,
                             &ns_context,
                             &bindings,
@@ -14605,8 +14605,9 @@ pub fn lower_function<'db>(
                 // `baml_builtins2_codegen` only adds type-arg params for
                 // function-level generics.  We therefore only count the
                 // function's own generic_params here.
-                let item_tree = file_item_tree(db, func_loc.file(db));
-                item_tree[func_loc.id(db)].generic_params.len()
+                baml_compiler2_ppir::item_data::function_data(db, func_loc)
+                    .generic_params
+                    .len()
             } else {
                 0
             };

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -125,18 +125,6 @@ fn baml_iter_interface_qtn(name: &str) -> crate::ty::QualifiedTypeName {
     crate::ty::QualifiedTypeName::new(Name::new("baml"), vec![Name::new("iter")], Name::new(name))
 }
 
-/// A function declaration's generic-param interface bounds, as `TypeExpr`s in
-/// declaration order (`None` for unbounded params). The source of a callee's
-/// bounds for call-site enforcement, since function *values* (realized) no longer
-/// carry bounds on their type.
-fn function_generic_param_bounds_exprs(
-    db: &dyn crate::Db,
-    func_loc: baml_compiler2_hir::loc::FunctionLoc<'_>,
-) -> Vec<Option<TypeExpr>> {
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, func_loc.file(db));
-    item_tree[func_loc.id(db)].generic_param_bounds.clone()
-}
-
 /// Per-callee generic-parameter facts consumed at every call site:
 /// the enclosing class's generic params (empty for free functions), the
 /// callee's user-declared params, their lowered interface bounds, and the
@@ -187,13 +175,14 @@ pub(crate) fn callee_generics_for_func<'db>(
     // `class Box<C>`) regardless of how the class args are supplied — so they
     // must be visible or `C` would resolve to `unknown`.
     let file = func_loc.file(db);
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
     // Enclosing class params via the firewall `method_owner` index (O(1)) rather
     // than an O(classes) `methods.contains` scan — identical result (a class
     // method's owner class's params, else none).
     let class_params: Vec<Name> = match baml_compiler2_ppir::item_data::method_owner(db, func_loc) {
         Some(baml_compiler2_ppir::item_data::MethodOwner::Class(class_loc)) => {
-            item_tree[class_loc.id(db)].generic_params.clone()
+            baml_compiler2_ppir::item_data::class_data(db, class_loc)
+                .generic_params
+                .clone()
         }
         _ => Vec::new(),
     };
@@ -208,9 +197,11 @@ pub(crate) fn callee_generics_for_func<'db>(
     let mut bound_scope = class_params.clone();
     bound_scope.extend(sig.user_generic_params.iter().cloned());
     let mut diags = Vec::new();
-    let user_bounds = lower_generic_param_bounds(
+    let func_data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
+    let user_bounds = lower_generic_param_bound_refs(
         db,
-        &function_generic_param_bounds_exprs(db, func_loc),
+        &func_data.type_refs,
+        &func_data.generic_param_bounds,
         pkg_items,
         &pkg_info.namespace_path,
         &bound_scope,
@@ -226,9 +217,14 @@ pub(crate) fn callee_generics_for_func<'db>(
     }
 }
 
-pub(crate) fn lower_generic_param_bounds(
+/// Lower a declaration's generic-param bounds (`TypeRefId`s into `store`, from
+/// firewall data — `function_data` / `class_data` / …) to their `Ty`s, in
+/// declaration order (`None` for unbounded params).
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn lower_generic_param_bound_refs(
     db: &dyn crate::Db,
-    bounds: &[Option<TypeExpr>],
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    bounds: &[Option<baml_compiler2_hir::type_ref::TypeRefId>],
     pkg_items: &PackageItems<'_>,
     ns_context: &[Name],
     generic_params: &[Name],
@@ -242,10 +238,11 @@ pub(crate) fn lower_generic_param_bounds(
     bounds
         .iter()
         .map(|bound| {
-            bound.as_ref().map(|bound| {
+            bound.map(|bound| {
                 if let Some(bindings) = bindings {
                     crate::generics::substitute_ty(
-                        &crate::lower_type_expr::lower_type_expr(
+                        &crate::lower_type_expr::lower_type_ref(
+                            store,
                             bound,
                             &crate::lower_type_expr::ScopeCtx {
                                 db,
@@ -260,7 +257,8 @@ pub(crate) fn lower_generic_param_bounds(
                         bindings,
                     )
                 } else {
-                    crate::lower_type_expr::lower_type_expr(
+                    crate::lower_type_expr::lower_type_ref(
+                        store,
                         bound,
                         &crate::lower_type_expr::ScopeCtx {
                             db,
@@ -2583,27 +2581,33 @@ impl<'db> TypeInferenceBuilder<'db> {
         func_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
     ) -> (Vec<Name>, Vec<Name>) {
         let db = self.context.db();
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, func_loc.file(db));
-        let func_id = func_loc.id(db);
-        let fn_params = item_tree[func_id].generic_params.clone();
+        let fn_params = baml_compiler2_ppir::item_data::function_data(db, func_loc)
+            .generic_params
+            .clone();
         // The owner's declared generic-param names: an out-of-body impl's block
         // generics, an interface's params for a default method, or the class's.
         let owner_params = match baml_compiler2_ppir::item_data::method_owner(db, func_loc) {
             Some(baml_compiler2_ppir::item_data::MethodOwner::FreeImpl(impl_loc)) => {
-                match &item_tree.impls[&impl_loc.id(db)].subject {
-                    baml_compiler2_hir::item_tree::ImplSubject::Free { generics, .. } => {
+                match &baml_compiler2_ppir::item_data::impl_block_data(db, impl_loc).subject {
+                    baml_compiler2_ppir::item_data::ImplSubjectData::Free { generics, .. } => {
                         generics.iter().map(|g| g.name.clone()).collect()
                     }
-                    baml_compiler2_hir::item_tree::ImplSubject::InClass { .. } => unreachable!(
-                        "MethodOwner::FreeImpl always names an ImplSubject::Free block"
-                    ),
+                    baml_compiler2_ppir::item_data::ImplSubjectData::InClass { .. } => {
+                        unreachable!(
+                            "MethodOwner::FreeImpl always names an ImplSubject::Free block"
+                        )
+                    }
                 }
             }
             Some(baml_compiler2_ppir::item_data::MethodOwner::Interface(iface_loc)) => {
-                item_tree[iface_loc.id(db)].generic_params.clone()
+                baml_compiler2_ppir::item_data::interface_data(db, iface_loc)
+                    .generic_params
+                    .clone()
             }
             Some(baml_compiler2_ppir::item_data::MethodOwner::Class(class_loc)) => {
-                item_tree[class_loc.id(db)].generic_params.clone()
+                baml_compiler2_ppir::item_data::class_data(db, class_loc)
+                    .generic_params
+                    .clone()
             }
             None => Vec::new(),
         };
@@ -2665,7 +2669,10 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     pub fn check_function_parameter_defaults(
         &mut self,
-        params: &[baml_compiler2_hir::item_tree::FunctionParam],
+        params: &[baml_compiler2_ppir::item_data::FunctionParamData],
+        // One span per parameter, parallel to `params`
+        // (`FunctionSourceMap::param_spans`).
+        param_spans: &[text_size::TextRange],
         parameter_defaults: &baml_compiler2_hir::signature::FunctionParameterDefaults,
         param_types: &[(Name, Ty)],
     ) {
@@ -2705,7 +2712,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         TirTypeError::RequiredParamAfterDefault {
                             name: param.name.clone(),
                         },
-                        param.span,
+                        param_spans[index],
                     );
                 }
                 continue;
@@ -5704,11 +5711,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                     && obj_type_args.is_empty()
                     && let Some(class_loc) = self.resolve_class_loc(&class_name)
                 {
-                    let class_tree = baml_compiler2_hir::file_item_tree(
-                        self.context.db(),
-                        class_loc.file(self.context.db()),
-                    );
-                    let class_data = &class_tree[class_loc.id(self.context.db())];
+                    let class_data =
+                        baml_compiler2_ppir::item_data::class_data(self.context.db(), class_loc);
                     if !class_data.generic_params.is_empty() {
                         let field_types: FxHashMap<Name, Ty> = self
                             .class_actual_fields_ordered(&class_name, &[])
@@ -8428,8 +8432,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             return false;
         };
         let db = self.context.db();
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-        !item_tree[class_loc.id(db)].generic_params.is_empty()
+        !baml_compiler2_ppir::item_data::class_data(db, class_loc)
+            .generic_params
+            .is_empty()
     }
 
     /// Does `ty` contain an unknown-like leaf? `count_builtin` decides whether
@@ -9414,8 +9419,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             ) = resolutions.last()
             {
                 let db = self.context.db();
-                let item_tree = baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-                let class_data = &item_tree[class_loc.id(db)];
+                let class_data = baml_compiler2_ppir::item_data::class_data(db, *class_loc);
                 let pkg_info =
                     baml_compiler2_hir::file_package::file_package(db, class_loc.file(db));
                 let ns = &pkg_info.namespace_path;
@@ -10252,7 +10256,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             _ => None,
         };
         let is_tagged = func_loc.is_some_and(|fl| {
-            baml_compiler2_hir::file_item_tree(db, fl.file(db))[fl.id(db)].is_tagged_template_tag
+            baml_compiler2_ppir::item_data::function_data(db, fl).is_tagged_template_tag
         });
 
         // (c) resolves to a function, but it isn't a tagged-string tag.
@@ -10454,9 +10458,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         // params, so the extra entries are inert for runtime args.)
                         let owner_bindings: Vec<(Name, Ty)> = {
                             let db = self.context.db();
-                            let item_tree =
-                                baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-                            item_tree[class_loc.id(db)]
+                            baml_compiler2_ppir::item_data::class_data(db, class_loc)
                                 .generic_params
                                 .iter()
                                 .cloned()
@@ -11104,10 +11106,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 true,
             )
         {
-            let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-            let Some(iface_data) = iface_tree.interfaces.get(&iface_loc.id(db)) else {
-                continue;
-            };
+            let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
             let iface_qtn = crate::lower_type_expr::qualify_def(
                 db,
                 Definition::Interface(iface_loc),
@@ -11632,10 +11631,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
         let db = self.context.db();
         for iface_loc in crate::interfaces::interface_closure_locs(db, root_loc) {
-            let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-            let Some(iface_data) = iface_tree.interfaces.get(&iface_loc.id(db)) else {
-                continue;
-            };
+            let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
             if iface_data
                 .required_methods
                 .iter()
@@ -11643,11 +11639,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             {
                 return true;
             }
-            if iface_data.default_methods.iter().any(|&fn_id| {
-                iface_tree
-                    .functions
-                    .get(&fn_id)
-                    .is_some_and(|f| f.name == *method_name)
+            if iface_data.default_methods.iter().any(|&fn_loc| {
+                baml_compiler2_ppir::item_data::function_data(db, fn_loc).name == *method_name
             }) {
                 return false;
             }
@@ -11666,7 +11659,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// `Self` keyword is resolved at the `TypeExpr` level, before lowering).
     fn fresh_interface_method_receiver_generic(
         &self,
-        iface_data: &baml_compiler2_hir::item_tree::Interface,
+        iface_data: &baml_compiler2_ppir::item_data::InterfaceData<'_>,
         method_generic_params: &[Name],
     ) -> Name {
         let used: FxHashSet<Name> = iface_data
@@ -11691,51 +11684,55 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    /// Whether `ty` references the *bare* `Self` type anywhere — a path of exactly
+    /// Whether `id` references the *bare* `Self` type anywhere — a path of exactly
     /// `[Self]`, recursing structurally. A `Self.Assoc` projection is NOT bare `Self`:
     /// on an existential receiver every associated type is pinned (or defaulted), so the
     /// projection denotes one type shared by every member of the existential — none of
     /// the `Self`-identity problems apply. Both object safety and the interface-field
     /// ban (E0136) key on this: a `value: Self.Item` field is legal (it denotes the
     /// implementor's bound associated type), a `value: Self` field is not.
-    pub(crate) fn type_expr_contains_bare_self(ty: &TypeExpr) -> bool {
-        match &ty.kind {
-            TypeExprKind::Path {
+    pub(crate) fn type_ref_contains_bare_self(
+        store: &baml_compiler2_hir::type_ref::TypeRefStore,
+        id: baml_compiler2_hir::type_ref::TypeRefId,
+    ) -> bool {
+        use baml_compiler2_hir::type_ref::TypeRefKind;
+        match &store[id].kind {
+            TypeRefKind::Path {
                 segments,
                 generic_args,
                 ..
             } => {
                 (segments.len() == 1 && segments[0].as_str() == "Self")
-                    || generic_args.iter().any(Self::type_expr_contains_bare_self)
+                    || generic_args
+                        .iter()
+                        .any(|&arg| Self::type_ref_contains_bare_self(store, arg))
             }
-            TypeExprKind::List { inner, .. } | TypeExprKind::Optional { inner, .. } => {
-                Self::type_expr_contains_bare_self(inner)
+            TypeRefKind::List { inner } | TypeRefKind::Optional { inner } => {
+                Self::type_ref_contains_bare_self(store, *inner)
             }
-            TypeExprKind::Map { key, value, .. } => {
-                Self::type_expr_contains_bare_self(key) || Self::type_expr_contains_bare_self(value)
+            TypeRefKind::Map { key, value } => {
+                Self::type_ref_contains_bare_self(store, *key)
+                    || Self::type_ref_contains_bare_self(store, *value)
             }
-            TypeExprKind::Union { variants, .. } => {
-                variants.iter().any(Self::type_expr_contains_bare_self)
-            }
-            TypeExprKind::Function {
+            TypeRefKind::Union { variants } => variants
+                .iter()
+                .any(|&v| Self::type_ref_contains_bare_self(store, v)),
+            TypeRefKind::Function {
                 params,
                 ret,
                 throws,
-                ..
             } => {
                 params
                     .iter()
-                    .any(|param| Self::type_expr_contains_bare_self(&param.ty))
-                    || Self::type_expr_contains_bare_self(ret)
-                    || throws
-                        .as_ref()
-                        .is_some_and(|throws| Self::type_expr_contains_bare_self(throws))
+                    .any(|param| Self::type_ref_contains_bare_self(store, param.ty))
+                    || Self::type_ref_contains_bare_self(store, *ret)
+                    || throws.is_some_and(|throws| Self::type_ref_contains_bare_self(store, throws))
             }
             _ => false,
         }
     }
 
-    /// Whether `ty` references bare `Self` in an **invariant** position — inside a generic
+    /// Whether `id` references bare `Self` in an **invariant** position — inside a generic
     /// argument, a list/map element, or a function type. Such a `Self` is unsound to
     /// call through an interface-existential receiver: the impl returns a
     /// concretely-tagged container (`Concrete[]`) that is NOT a subtype of the
@@ -11746,43 +11743,45 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// (`dyn I`), which the impl's concrete return subtypes nominally. A `Self.Assoc`
     /// projection is never flagged, even nested (`Self.Item[]`): the existential's pins
     /// make it one concrete type for every member (see
-    /// [`Self::type_expr_contains_bare_self`]). Used for a method's return/throws type;
+    /// [`Self::type_ref_contains_bare_self`]). Used for a method's return/throws type;
     /// parameters use the stricter any-position bare-`Self` check (the multi-`Self`
     /// problem applies in every parameter position).
-    fn type_expr_self_in_invariant_position(ty: &TypeExpr) -> bool {
-        match &ty.kind {
+    pub(crate) fn type_ref_self_in_invariant_position(
+        store: &baml_compiler2_hir::type_ref::TypeRefStore,
+        id: baml_compiler2_hir::type_ref::TypeRefId,
+    ) -> bool {
+        use baml_compiler2_hir::type_ref::TypeRefKind;
+        match &store[id].kind {
             // A class/generic head is invariant in its arguments; a bare `Self` or a
             // `Self.Assoc` projection (the segments) is not itself an invariant nesting.
-            TypeExprKind::Path { generic_args, .. } => {
-                generic_args.iter().any(Self::type_expr_contains_bare_self)
-            }
+            TypeRefKind::Path { generic_args, .. } => generic_args
+                .iter()
+                .any(|&arg| Self::type_ref_contains_bare_self(store, arg)),
             // Invariant containers: any bare `Self` inside is unsound.
-            TypeExprKind::List { inner, .. } => Self::type_expr_contains_bare_self(inner),
-            TypeExprKind::Map { key, value, .. } => {
-                Self::type_expr_contains_bare_self(key) || Self::type_expr_contains_bare_self(value)
+            TypeRefKind::List { inner } => Self::type_ref_contains_bare_self(store, *inner),
+            TypeRefKind::Map { key, value } => {
+                Self::type_ref_contains_bare_self(store, *key)
+                    || Self::type_ref_contains_bare_self(store, *value)
             }
-            TypeExprKind::Function {
+            TypeRefKind::Function {
                 params,
                 ret,
                 throws,
-                ..
             } => {
                 params
                     .iter()
-                    .any(|param| Self::type_expr_contains_bare_self(&param.ty))
-                    || Self::type_expr_contains_bare_self(ret)
-                    || throws
-                        .as_ref()
-                        .is_some_and(|throws| Self::type_expr_contains_bare_self(throws))
+                    .any(|param| Self::type_ref_contains_bare_self(store, param.ty))
+                    || Self::type_ref_contains_bare_self(store, *ret)
+                    || throws.is_some_and(|throws| Self::type_ref_contains_bare_self(store, throws))
             }
             // Covariant-transparent wrappers: recurse, so a bare `Self` under them is
             // fine but a `Self[]` under them is not.
-            TypeExprKind::Optional { inner, .. } => {
-                Self::type_expr_self_in_invariant_position(inner)
+            TypeRefKind::Optional { inner } => {
+                Self::type_ref_self_in_invariant_position(store, *inner)
             }
-            TypeExprKind::Union { variants, .. } => variants
+            TypeRefKind::Union { variants } => variants
                 .iter()
-                .any(Self::type_expr_self_in_invariant_position),
+                .any(|&v| Self::type_ref_self_in_invariant_position(store, v)),
             _ => false,
         }
     }
@@ -11838,9 +11837,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             return out;
         };
         let db = self.context.db();
-        let file = class_loc.file(db);
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-        let class_data = &item_tree[class_loc.id(db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
 
         let resolved = crate::inference::resolve_class_fields(db, class_loc);
 
@@ -11949,8 +11946,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             Some(&source.interface.name),
             "ConcreteFieldSource.iface_loc and .interface must name the same interface",
         );
-        let iface_tree = baml_compiler2_hir::file_item_tree(db, source.iface_loc.file(db));
-        let iface_data = iface_tree.interfaces.get(&source.iface_loc.id(db))?;
+        let iface_data = baml_compiler2_ppir::item_data::interface_data(db, source.iface_loc);
         let field = iface_data.fields.iter().find(|f| f.name == *field_name)?;
         let iface_pkg_items = self.resolve_class_pkg_items(source.interface.name.package())?;
         let iface_ns =
@@ -11963,13 +11959,13 @@ impl<'db> TypeInferenceBuilder<'db> {
         let iface_bounds =
             crate::lower_type_expr::interface_generic_param_bounds(db, source.iface_loc);
         let declared_ty = field
-            .type_expr
-            .as_ref()
-            .map(|te| {
+            .type_ref
+            .map(|type_ref| {
                 let mut diags = Vec::new();
                 let ty = if bindings.is_empty() {
-                    crate::lower_type_expr::lower_type_expr(
-                        te,
+                    crate::lower_type_expr::lower_type_ref(
+                        &iface_data.type_refs,
+                        type_ref,
                         &crate::lower_type_expr::ScopeCtx {
                             db,
                             package_items: iface_pkg_items,
@@ -11983,8 +11979,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 } else {
                     let generic_params: Vec<_> = bindings.keys().cloned().collect();
                     crate::generics::substitute_ty(
-                        &crate::lower_type_expr::lower_type_expr(
-                            te,
+                        &crate::lower_type_expr::lower_type_ref(
+                            &iface_data.type_refs,
+                            type_ref,
                             &crate::lower_type_expr::ScopeCtx {
                                 db,
                                 package_items: iface_pkg_items,
@@ -11998,8 +11995,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                         &bindings,
                     )
                 };
-                for diag in diags {
-                    self.context.report_at_span(diag, te.span);
+                if !diags.is_empty() {
+                    let span =
+                        baml_compiler2_ppir::item_data::interface_source_map(db, source.iface_loc)
+                            .type_refs
+                            .span(type_ref);
+                    for diag in diags {
+                        self.context.report_at_span(diag, span);
+                    }
                 }
                 ty
             })
@@ -12103,8 +12106,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let db = self.context.db();
         let file = class_loc.file(db);
         let ns_context = baml_compiler2_hir::file_package::file_package(db, file).namespace_path;
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-        let class_data = &item_tree[class_loc.id(db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
 
         // `class_data.methods` flattens every `implements I { … }` block's methods together
         // with class-level ones. A name matching more than one can only come from two distinct
@@ -12115,7 +12117,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             .methods
             .iter()
             .copied()
-            .filter(|&mid| item_tree[mid].name == *method_name)
+            .filter(|&method| {
+                baml_compiler2_ppir::item_data::function_data(db, method).name == *method_name
+            })
             .collect();
         if materialized.len() > 1 {
             return None;
@@ -12128,7 +12132,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // member (enumerated by `type_impls`, defaults included). A *class-level* method still
         // shadows interface methods (BEP-044), and a uniquely-provided one keeps the fast path.
         if let [only] = materialized.as_slice()
-            && item_tree.method_to_iface_target.contains_key(only)
+            && baml_compiler2_ppir::item_data::method_interface_target(db, *only).is_some()
         {
             let receiver_args: Vec<Ty> = if class_type_args.is_empty() {
                 class_data
@@ -12155,8 +12159,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         }
 
-        for &method_id in &class_data.methods {
-            let method_data = &item_tree[method_id];
+        for &func_loc in &class_data.methods {
+            let method_data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
             if method_data.name == *method_name {
                 // Build bindings from class-level generic params → concrete args.
                 let mut bindings =
@@ -12176,7 +12180,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                         .or_insert_with(|| Ty::TypeVar(gp.clone(), TyAttr::default()));
                 }
 
-                let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, method_id);
                 let sig = baml_compiler2_ppir::item_data::elaborated_function_data(db, func_loc);
                 let mut diags = Vec::new();
 
@@ -12220,25 +12223,30 @@ impl<'db> TypeInferenceBuilder<'db> {
                     self_ty: Some(class_ty.clone()),
                 };
 
-                if let Some(target) = item_tree.method_to_iface_target.get(&method_id)
-                    && let Some(iface_loc) = crate::interfaces::resolve_path_to_interface(
+                if let Some(target) =
+                    baml_compiler2_ppir::item_data::method_interface_target(db, func_loc)
+                    && let Some(iface_loc) = crate::interfaces::resolve_ref_to_interface(
                         db,
-                        target,
+                        &target.type_refs,
+                        target.target,
                         pkg_items_for_class,
                         &ns_context,
                     )
                 {
-                    let iface_file = iface_loc.file(db);
-                    let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_file);
-                    if let Some(iface_data) = iface_tree.interfaces.get(&iface_loc.id(db)) {
-                        if let baml_compiler2_ast::TypeExprKind::Path { generic_args, .. } =
-                            &target.kind
+                    let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
+                    {
+                        if let baml_compiler2_hir::type_ref::TypeRefKind::Path {
+                            generic_args,
+                            ..
+                        } = &target.type_refs[target.target].kind
                         {
-                            for (param, arg) in iface_data.generic_params.iter().zip(generic_args) {
+                            for (param, &arg) in iface_data.generic_params.iter().zip(generic_args)
+                            {
                                 let ty = {
                                     let generic_params: Vec<_> = bindings.keys().cloned().collect();
                                     crate::generics::substitute_ty(
-                                        &crate::lower_type_expr::lower_type_expr(
+                                        &crate::lower_type_expr::lower_type_ref(
+                                            &target.type_refs,
                                             arg,
                                             &crate::lower_type_expr::ScopeCtx {
                                                 db,
@@ -12259,11 +12267,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             }
                         }
 
-                        let explicit_bindings = item_tree
-                            .method_to_iface_associated_type_bindings
-                            .get(&method_id)
-                            .cloned()
-                            .unwrap_or_default();
+                        let explicit_bindings = &target.associated_type_bindings;
                         for assoc in &iface_data.associated_types {
                             if explicit_bindings.iter().any(|b| b.name == assoc.name) {
                                 continue;
@@ -12290,12 +12294,17 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 bindings.insert(assoc.name.clone(), ty);
                             }
                         }
-                        for binding in &explicit_bindings {
-                            let Some(te) = &binding.type_expr else {
+                        for binding in explicit_bindings {
+                            let Some(type_ref) = binding.type_ref else {
                                 continue;
                             };
                             let ty = crate::generics::substitute_ty(
-                                &crate::lower_type_expr::lower_type_expr(te, &ctx, &mut diags),
+                                &crate::lower_type_expr::lower_type_ref(
+                                    &target.type_refs,
+                                    type_ref,
+                                    &ctx,
+                                    &mut diags,
+                                ),
                                 &bindings,
                             );
                             bindings.insert(binding.name.clone(), ty);
@@ -12482,8 +12491,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let file = class_loc.file(db);
         let stub_pkg = baml_compiler2_hir::file_package::file_package(db, file);
         let stub_ns: &[Name] = &stub_pkg.namespace_path;
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-        let class_data = &item_tree[class_loc.id(db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
         // The stub class's declared parameter bounds, so a `T.member` projection
         // in a member signature resolves `T`'s declaring interface.
         let class_bounds = crate::lower_type_expr::class_generic_param_bounds(db, class_loc);
@@ -12492,8 +12500,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         let mut bindings = crate::generics::bind_type_vars(&class_data.generic_params, type_args);
 
         // Search methods first.
-        for &method_id in &class_data.methods {
-            let method_data = &item_tree[method_id];
+        for &func_loc in &class_data.methods {
+            let method_data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
             if method_data.name == *member_name {
                 // Add method-level generics as TypeVar entries so they survive
                 // lowering and can be resolved by call-site inference.
@@ -12505,7 +12513,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // `bindings` is complete for this method — one snapshot serves
                 // every param and the return type below.
                 let generic_params: Vec<_> = bindings.keys().cloned().collect();
-                let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, method_id);
                 let sig = baml_compiler2_ppir::item_data::elaborated_function_data(db, func_loc);
                 let mut diags = Vec::new();
                 // Build the class type for self parameter resolution.
@@ -12668,13 +12675,13 @@ impl<'db> TypeInferenceBuilder<'db> {
             if field.name == *member_name {
                 let mut diags = Vec::new();
                 let field_ty = field
-                    .type_expr
-                    .as_ref()
-                    .map(|te| {
+                    .type_ref
+                    .map(|type_ref| {
                         let generic_params: Vec<_> = bindings.keys().cloned().collect();
                         crate::generics::substitute_ty(
-                            &crate::lower_type_expr::lower_type_expr(
-                                te,
+                            &crate::lower_type_expr::lower_type_ref(
+                                &class_data.type_refs,
+                                type_ref,
                                 &crate::lower_type_expr::ScopeCtx {
                                     db,
                                     package_items: self.package_items,
@@ -13271,12 +13278,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             return;
         };
         let db = self.context.db();
-        let item_tree = baml_compiler2_hir::file_item_tree(db, class_loc.file(db));
-        let Some(class_data) = item_tree.classes.get(&class_loc.id(db)) else {
-            return;
-        };
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
         self.collect_named_generic_bound_errors(
             &class_data.generic_params,
+            &class_data.type_refs,
             &class_data.generic_param_bounds,
             class_loc.file(db),
             type_args,
@@ -13294,12 +13299,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             return;
         };
         let db = self.context.db();
-        let item_tree = baml_compiler2_hir::file_item_tree(db, interface_loc.file(db));
-        let Some(interface_data) = item_tree.interfaces.get(&interface_loc.id(db)) else {
-            return;
-        };
+        let interface_data = baml_compiler2_ppir::item_data::interface_data(db, interface_loc);
         self.collect_named_generic_bound_errors(
             &interface_data.generic_params,
+            &interface_data.type_refs,
             &interface_data.generic_param_bounds,
             interface_loc.file(db),
             type_args,
@@ -13321,10 +13324,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             return;
         };
         let db = self.context.db();
-        let item_tree = baml_compiler2_hir::file_item_tree(db, interface_loc.file(db));
-        let Some(interface_data) = item_tree.interfaces.get(&interface_loc.id(db)) else {
-            return;
-        };
+        let interface_data = baml_compiler2_ppir::item_data::interface_data(db, interface_loc);
         let missing: Vec<Name> = interface_data
             .associated_types
             .iter()
@@ -13347,7 +13347,8 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn collect_named_generic_bound_errors(
         &mut self,
         generic_params: &[Name],
-        generic_param_bounds: &[Option<TypeExpr>],
+        type_refs: &baml_compiler2_hir::type_ref::TypeRefStore,
+        generic_param_bounds: &[Option<baml_compiler2_hir::type_ref::TypeRefId>],
         file: SourceFile,
         type_args: &[Ty],
         errors: &mut Vec<TirTypeError>,
@@ -13360,8 +13361,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         let pkg_id = PackageId::new(db, pkg_info.package.clone());
         let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
         let mut diags = Vec::new();
-        let lowered_bounds = lower_generic_param_bounds(
+        let lowered_bounds = lower_generic_param_bound_refs(
             db,
+            type_refs,
             generic_param_bounds,
             pkg_items,
             &pkg_info.namespace_path,
@@ -16316,9 +16318,11 @@ impl TypeInferenceBuilder<'_> {
             return Vec::new();
         };
         let db = self.context.db();
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-        let class_data = &item_tree[class_loc.id(db)];
-        class_data.fields.iter().map(|f| f.name.clone()).collect()
+        baml_compiler2_ppir::item_data::class_data(db, class_loc)
+            .fields
+            .iter()
+            .map(|f| f.name.clone())
+            .collect()
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
@@ -560,10 +560,9 @@ fn associated_type_bound_interface(
     self_ty: &Ty,
     member: &Name,
 ) -> Option<baml_type::Interface> {
-    let tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-    let iface = tree.interfaces.get(&iface_loc.id(db))?;
+    let iface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
     let assoc = iface.associated_types.iter().find(|a| &a.name == member)?;
-    let bound_te = assoc.bound.as_ref()?;
+    let bound_ref = assoc.bound?;
 
     let pkg = baml_compiler2_hir::file_package::file_package(db, iface_loc.file(db));
     let pkg_items = baml_compiler2_ppir::package_items(db, PackageId::new(db, pkg.package.clone()));
@@ -634,7 +633,7 @@ fn associated_type_bound_interface(
     // The bound is checked at the interface's declaration; diagnostics are discarded here.
     let mut diags = Vec::new();
     let lowered = crate::generics::substitute_ty(
-        &crate::lower_type_expr::lower_type_expr(bound_te, &scope, &mut diags),
+        &crate::lower_type_expr::lower_type_ref(&iface.type_refs, bound_ref, &scope, &mut diags),
         &bindings,
     );
     lowered.as_interface()
@@ -667,11 +666,10 @@ pub(crate) fn associated_type_declared_bound(
     // over-applied qualifier (`(base as I).member` where `interface I<X>`) is
     // malformed — leave the projection opaque rather than realize a bound against
     // mismatched generics.
-    let tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-    let arity_ok = tree
-        .interfaces
-        .get(&iface_loc.id(db))
-        .is_some_and(|iface| iface.generic_params.len() == interface.generics.len());
+    let arity_ok = baml_compiler2_ppir::item_data::interface_data(db, iface_loc)
+        .generic_params
+        .len()
+        == interface.generics.len();
     if !arity_ok {
         return Vec::new();
     }
@@ -891,13 +889,10 @@ fn interface_declares_member(db: &dyn crate::Db, qtn: &QualifiedTypeName, member
 
 /// Whether the interface at `loc` declares associated type `member` directly.
 fn interface_declares_member_at(db: &dyn crate::Db, loc: InterfaceLoc<'_>, member: &Name) -> bool {
-    let tree = baml_compiler2_hir::file_item_tree(db, loc.file(db));
-    tree.interfaces.get(&loc.id(db)).is_some_and(|iface| {
-        iface
-            .associated_types
-            .iter()
-            .any(|assoc| &assoc.name == member)
-    })
+    baml_compiler2_ppir::item_data::interface_data(db, loc)
+        .associated_types
+        .iter()
+        .any(|assoc| &assoc.name == member)
 }
 
 /// Resolve an interface's qualified name to its declaration location.

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -13,12 +13,11 @@ use baml_type::normalize::TypeContext;
 
 use super::{
     Definition, ExprId, InterfaceBound, MemberAccess, Name, PackageItems, SelfReceiver,
-    TirTypeError, Ty, TyAttr, TypeInferenceBuilder, function_generic_param_bounds_exprs,
-    lower_generic_param_bounds,
+    TirTypeError, Ty, TyAttr, TypeInferenceBuilder, lower_generic_param_bound_refs,
 };
 use crate::{
     infer_context::SelfCallPosition,
-    signature::{DeclaredSignature, lower_signature},
+    signature::{DeclaredSignature, SigTypeRef, lower_signature},
 };
 
 /// One realized interface instantiation to resolve a member against: `loc` reads the declared
@@ -73,65 +72,88 @@ struct MemberLoweringEnv {
 }
 
 /// A positional or keyword interface-method parameter. The `self` receiver is an ordinary
-/// positional `arg`, desugared to `self: Self` (its `ty` is the `Self` path).
+/// positional `arg`, desugared to `self: Self` (its `ty` is [`SigTypeRef::SelfReceiver`]).
 struct InterfaceMethodParam {
     name: Name,
-    ty: baml_compiler2_ast::TypeExpr,
+    ty: SigTypeRef,
 }
 
 /// A normalized interface-method signature: default and required methods both reduce to
 /// this so one builder produces the `Ty::Function`. Interfaces must label their full
 /// contract, so `return_type`/`throws` are required (sourced from the declaration, never
 /// inferred from a body).
-pub(crate) struct InterfaceMethodSpec {
+pub(crate) struct InterfaceMethodSpec<'db> {
+    /// The arena every signature slot (`args`/`kwargs`/`return_type`/`throws`) indexes: the
+    /// elaborated store for a default method, the interface's own store for a required one.
+    sig_refs: &'db baml_compiler2_hir::type_ref::TypeRefStore,
+    /// The arena the `generics` bound ids index. Bounds are never elaborated, so for a
+    /// default method this is the *declaration* store (`FunctionData::type_refs`), distinct
+    /// from `sig_refs`; for a required method the two are one store.
+    bound_refs: &'db baml_compiler2_hir::type_ref::TypeRefStore,
     /// Positional (required) parameters, in declaration order.
     args: Vec<InterfaceMethodParam>,
     /// Keyword/optional parameters (those with a default).
     kwargs: Vec<InterfaceMethodParam>,
-    return_type: baml_compiler2_ast::TypeExpr,
-    throws: baml_compiler2_ast::TypeExpr,
+    return_type: SigTypeRef,
+    throws: SigTypeRef,
     /// Method generic params with their interface-bound *conjunction* (`T extends A & B`),
     /// unified. Currently at most one element per param — the parser surfaces only the first
     /// conjunct — but a list so an override's bounds compare correctly once §3.6 lands.
-    generics: Vec<(Name, Vec<baml_compiler2_ast::TypeExpr>)>,
+    generics: Vec<(Name, Vec<baml_compiler2_hir::type_ref::TypeRefId>)>,
 }
 
-impl InterfaceMethodSpec {
-    pub(crate) fn from_default<'db>(
+impl<'db> InterfaceMethodSpec<'db> {
+    pub(crate) fn from_default(
         db: &'db dyn crate::Db,
         func_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
     ) -> Self {
-        let sig = baml_compiler2_ppir::elaborated_function_signature(db, func_loc);
+        let sig = baml_compiler2_ppir::item_data::elaborated_function_data(db, func_loc);
+        let func_data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
         let (args, kwargs) = split_params(sig.params.iter().map(|p| {
-            // The implicit `self` receiver: name "self" with no declared type.
+            // The implicit `self` receiver: name "self" with no declared type
+            // (elaboration synthesizes an `Unknown` node for it).
             let is_self = p.name.as_str() == "self"
-                && matches!(p.ty.kind, baml_compiler2_ast::TypeExprKind::Unknown { .. });
-            (is_self, p.has_default, p.name.clone(), p.ty.clone())
+                && matches!(
+                    sig.type_refs[p.type_ref].kind,
+                    baml_compiler2_hir::type_ref::TypeRefKind::Unknown
+                );
+            (
+                is_self,
+                p.has_default,
+                p.name.clone(),
+                SigTypeRef::Id(p.type_ref),
+            )
         }));
         let generics = sig
             .user_generic_params
             .iter()
             .cloned()
             .zip(
-                function_generic_param_bounds_exprs(db, func_loc)
-                    .into_iter()
-                    .map(|bound| bound.into_iter().collect()),
+                func_data
+                    .generic_param_bounds
+                    .iter()
+                    .map(|bound| bound.iter().copied().collect()),
             )
             .collect();
         Self {
+            sig_refs: &sig.type_refs,
+            bound_refs: &func_data.type_refs,
             args,
             kwargs,
-            return_type: sig.return_type.clone().unwrap_or_else(unknown_type_expr),
-            throws: sig.throws.clone().unwrap_or_else(unknown_type_expr),
+            return_type: sig.return_type.map_or(SigTypeRef::Missing, SigTypeRef::Id),
+            throws: sig.throws.map_or(SigTypeRef::Missing, SigTypeRef::Id),
             generics,
         }
     }
 
-    pub(crate) fn from_required(sig: &baml_compiler2_hir::item_tree::InterfaceMethodSig) -> Self {
+    pub(crate) fn from_required(
+        iface_data: &'db baml_compiler2_ppir::item_data::InterfaceData<'db>,
+        sig: &baml_compiler2_ppir::item_data::InterfaceMethodSigData,
+    ) -> Self {
         let (args, kwargs) = split_params(sig.params.iter().map(|p| {
-            let is_self = p.name.as_str() == "self" && p.type_expr.is_none();
-            let ty = p.type_expr.clone().unwrap_or_else(unknown_type_expr);
-            (is_self, p.default.is_some(), p.name.clone(), ty)
+            let is_self = p.name.as_str() == "self" && p.type_ref.is_none();
+            let ty = p.type_ref.map_or(SigTypeRef::Missing, SigTypeRef::Id);
+            (is_self, p.has_default, p.name.clone(), ty)
         }));
         let generics = sig
             .generic_params
@@ -140,15 +162,16 @@ impl InterfaceMethodSpec {
             .zip(
                 sig.generic_param_bounds
                     .iter()
-                    .cloned()
-                    .map(|bound| bound.into_iter().collect()),
+                    .map(|bound| bound.iter().copied().collect()),
             )
             .collect();
         Self {
+            sig_refs: &iface_data.type_refs,
+            bound_refs: &iface_data.type_refs,
             args,
             kwargs,
-            return_type: sig.return_type.clone().unwrap_or_else(unknown_type_expr),
-            throws: sig.throws.clone().unwrap_or_else(unknown_type_expr),
+            return_type: sig.return_type.map_or(SigTypeRef::Missing, SigTypeRef::Id),
+            throws: sig.throws.map_or(SigTypeRef::Missing, SigTypeRef::Id),
             generics,
         }
     }
@@ -160,10 +183,16 @@ impl InterfaceMethodSpec {
     }
 
     /// The method's generic parameters paired with their interface-bound conjunction
-    /// (declaration order) — so an override's bounds can be checked against the interface
-    /// method's (an implementation may not add a requirement the interface does not declare).
-    pub(crate) fn generic_bounds(&self) -> &[(Name, Vec<baml_compiler2_ast::TypeExpr>)] {
+    /// (declaration order, ids into [`Self::bound_store`]) — so an override's bounds can be
+    /// checked against the interface method's (an implementation may not add a requirement
+    /// the interface does not declare).
+    pub(crate) fn generic_bounds(&self) -> &[(Name, Vec<baml_compiler2_hir::type_ref::TypeRefId>)] {
         &self.generics
+    }
+
+    /// The arena [`Self::generic_bounds`]' ids index.
+    pub(crate) fn bound_store(&self) -> &'db baml_compiler2_hir::type_ref::TypeRefStore {
+        self.bound_refs
     }
 
     /// Lower this normalized signature to a `Ty::Function` through `ctx` (which resolves `Self`,
@@ -175,40 +204,36 @@ impl InterfaceMethodSpec {
         diags: &mut Vec<TirTypeError>,
     ) -> Ty {
         let signature = DeclaredSignature {
+            type_refs: self.sig_refs,
             positional: self
                 .args
                 .iter()
-                .map(|p| (Some(p.name.clone()), &p.ty))
+                .map(|p| (Some(p.name.clone()), p.ty))
                 .collect(),
             keyword: self
                 .kwargs
                 .iter()
-                .map(|p| (Some(p.name.clone()), &p.ty))
+                .map(|p| (Some(p.name.clone()), p.ty))
                 .collect(),
-            return_type: &self.return_type,
-            throws: &self.throws,
+            return_type: self.return_type,
+            throws: self.throws,
         };
         lower_signature(&signature, ctx, diags).into_ty()
     }
 }
 
-fn unknown_type_expr() -> baml_compiler2_ast::TypeExpr {
-    baml_compiler2_ast::TypeExprKind::Unknown { attrs: vec![] }.at(text_size::TextRange::default())
-}
-
 /// Split `(is_self, has_default, name, ty)` tuples into positional args (no default) and
 /// keyword/optional kwargs (with a default). The `self` receiver desugars to `self: Self`
-/// and stays a positional arg (its declared type is replaced by the `Self` path).
+/// and stays a positional arg (its declared type is replaced by
+/// [`SigTypeRef::SelfReceiver`]).
 fn split_params(
-    params: impl Iterator<Item = (bool, bool, Name, baml_compiler2_ast::TypeExpr)>,
+    params: impl Iterator<Item = (bool, bool, Name, SigTypeRef)>,
 ) -> (Vec<InterfaceMethodParam>, Vec<InterfaceMethodParam>) {
     let mut args = Vec::new();
     let mut kwargs = Vec::new();
     for (is_self, has_default, name, ty) in params {
-        // `self` is syntax sugar for `self: Self` — until `TypeExprKind::Self` exists, desugar
-        // to the `Self` path so the receiver flows through normal param lowering.
         let ty = if is_self {
-            crate::lower_type_expr::type_expr_for_name(Name::new("Self"))
+            SigTypeRef::SelfReceiver
         } else {
             ty
         };
@@ -590,10 +615,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             let Ok(data) = crate::interfaces::impl_data(db, resolved_impl.impl_loc) else {
                 continue;
             };
-            let declares_field = baml_compiler2_hir::file_item_tree(db, data.interface.file(db))
-                .interfaces
-                .get(&data.interface.id(db))
-                .is_some_and(|iface| iface.fields.iter().any(|f| &f.name == field));
+            let declares_field = baml_compiler2_ppir::item_data::interface_data(db, data.interface)
+                .fields
+                .iter()
+                .any(|f| &f.name == field);
             if !declares_field {
                 continue;
             }
@@ -789,19 +814,16 @@ impl<'db> TypeInferenceBuilder<'db> {
         member: &Name,
     ) -> Option<UnionMemberKind> {
         let db = self.context.db();
-        let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-        let iface_data = iface_tree.interfaces.get(&iface_loc.id(db))?;
+        let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
         if iface_data.fields.iter().any(|field| &field.name == member) {
             return Some(UnionMemberKind::Field);
         }
-        if iface_data
-            .default_methods
+        if iface_data.default_methods.iter().any(|&fn_loc| {
+            baml_compiler2_ppir::item_data::function_data(db, fn_loc).name == *member
+        }) || iface_data
+            .required_methods
             .iter()
-            .any(|&fn_id| iface_tree[fn_id].name == *member)
-            || iface_data
-                .required_methods
-                .iter()
-                .any(|sig| &sig.name == member)
+            .any(|sig| &sig.name == member)
         {
             return Some(UnionMemberKind::Method);
         }
@@ -849,9 +871,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         access: &MemberAccess<'_>,
     ) -> Option<Ty> {
         let db = self.context.db();
-        let file = view.loc.file(db);
-        let iface_tree = baml_compiler2_hir::file_item_tree(db, file);
-        let iface_data = iface_tree.interfaces.get(&view.loc.id(db))?;
+        let iface_data = baml_compiler2_ppir::item_data::interface_data(db, view.loc);
 
         // Field lookup: this interface's own fields (no closure).
         for field in &iface_data.fields {
@@ -871,9 +891,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                 });
             }
             let ty = field
-                .type_expr
-                .as_ref()
-                .map(|te| {
+                .type_ref
+                .map(|type_ref| {
                     // A field lowers in the same environment as a method signature — so
                     // `key: Self.Key` resolves through the receiver's pins/impls exactly
                     // as a `-> Self.Key` return would. Fields require a bound receiver
@@ -882,8 +901,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                     let mut diags = env.diags;
                     let ns = view.namespace(db);
                     let ty = crate::generics::substitute_ty(
-                        &crate::lower_type_expr::lower_type_expr(
-                            te,
+                        &crate::lower_type_expr::lower_type_ref(
+                            &iface_data.type_refs,
+                            type_ref,
                             &crate::lower_type_expr::ScopeCtx {
                                 db,
                                 package_items: view.pkg_items(db),
@@ -896,8 +916,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                         ),
                         &env.bindings,
                     );
+                    let span = baml_compiler2_ppir::item_data::interface_source_map(db, view.loc)
+                        .type_refs
+                        .span(type_ref);
                     for diag in diags {
-                        self.context.report_at_span(diag, te.span);
+                        self.context.report_at_span(diag, span);
                     }
                     ty
                 })
@@ -916,12 +939,9 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         // Method lookup: the interface's default body, else its required signature.
         // Both normalize to one `InterfaceMethodSpec` and one builder.
-        if let Some(&fn_id) = iface_data
-            .default_methods
-            .iter()
-            .find(|&&fn_id| iface_tree[fn_id].name == *access.member)
-        {
-            let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, fn_id);
+        if let Some(&func_loc) = iface_data.default_methods.iter().find(|&&fn_loc| {
+            baml_compiler2_ppir::item_data::function_data(db, fn_loc).name == *access.member
+        }) {
             let spec = InterfaceMethodSpec::from_default(db, func_loc);
             return Some(self.build_interface_method_ty(view, recv, &spec, access));
         }
@@ -930,7 +950,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .iter()
             .find(|sig| sig.name == *access.member)
         {
-            let spec = InterfaceMethodSpec::from_required(sig);
+            let spec = InterfaceMethodSpec::from_required(iface_data, sig);
             return Some(self.build_interface_method_ty(view, recv, &spec, access));
         }
         None
@@ -967,10 +987,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 true,
             )
         {
-            let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-            let Some(iface_data) = iface_tree.interfaces.get(&iface_loc.id(db)) else {
-                continue;
-            };
+            let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
             if iface_data.fields.is_empty() {
                 continue;
             }
@@ -997,12 +1014,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                     continue;
                 }
                 let ty = field
-                    .type_expr
-                    .as_ref()
-                    .map(|te| {
+                    .type_ref
+                    .map(|type_ref| {
                         crate::generics::substitute_ty(
-                            &crate::lower_type_expr::lower_type_expr(
-                                te,
+                            &crate::lower_type_expr::lower_type_ref(
+                                &iface_data.type_refs,
+                                type_ref,
                                 &crate::lower_type_expr::ScopeCtx {
                                     db,
                                     package_items: view.pkg_items(db),
@@ -1039,11 +1056,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         receiver_generic: Option<&Name>,
     ) -> MemberLoweringEnv {
         let db = self.context.db();
-        let iface_tree = baml_compiler2_hir::file_item_tree(db, view.loc.file(db));
-        let data = iface_tree
-            .interfaces
-            .get(&view.loc.id(db))
-            .unwrap_or_else(|| unreachable!("the caller resolved this member in the view's data"));
+        let data = baml_compiler2_ppir::item_data::interface_data(db, view.loc);
         let prefer_symbolic = matches!(recv, SelfReceiver::RigidVar(_));
         let mut diags = Vec::new();
 
@@ -1196,7 +1209,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn associated_type_pin(
         &self,
         view: &InterfaceView<'db>,
-        assoc: &baml_compiler2_ast::AssociatedTypeDef,
+        assoc: &baml_compiler2_ppir::item_data::AssociatedTypeData,
         prefer_symbolic: bool,
         prior: &rustc_hash::FxHashMap<Name, Ty>,
     ) -> Option<Ty> {
@@ -1220,11 +1233,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         // pins resolved so far), so a Self-referencing default (`type Items = Self.Item[]`)
         // reduces against them. The default was lowered once (symbolic `Self`) by the shared
         // query; realize substitutes this receiver for `Self` and the realized generic args.
-        let iface_generic_params = baml_compiler2_hir::file_item_tree(db, view.loc.file(db))
-            .interfaces
-            .get(&view.loc.id(db))
-            .map(|iface| iface.generic_params.clone())
-            .unwrap_or_default();
+        let iface_generic_params =
+            &baml_compiler2_ppir::item_data::interface_data(db, view.loc).generic_params;
         let self_ty = Ty::Interface(
             view.realized.name.clone(),
             view.realized.generics.clone(),
@@ -1233,7 +1243,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         );
         let realized = crate::interfaces::realize_associated_default(
             &default,
-            &iface_generic_params,
+            iface_generic_params,
             &view.realized.generics,
             &self_ty,
         );
@@ -1254,11 +1264,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         access: &MemberAccess<'_>,
     ) -> Ty {
         let db = self.context.db();
-        let iface_tree = baml_compiler2_hir::file_item_tree(db, view.loc.file(db));
-        let data = iface_tree
-            .interfaces
-            .get(&view.loc.id(db))
-            .unwrap_or_else(|| unreachable!("the caller resolved this method in the view's data"));
+        let data = baml_compiler2_ppir::item_data::interface_data(db, view.loc);
         let ns = view.namespace(db);
         let pkg_items = view.pkg_items(db);
 
@@ -1310,16 +1316,26 @@ impl<'db> TypeInferenceBuilder<'db> {
         // A `Self.Assoc` projection is exempt in both positions: the existential's pins
         // (or the assoc default) make it one concrete type for every member.
         if matches!(recv, SelfReceiver::Existential(_) | SelfReceiver::Union(_)) && access.bound {
+            let contains_bare_self = |slot: SigTypeRef| match slot {
+                SigTypeRef::Id(id) => Self::type_ref_contains_bare_self(spec.sig_refs, id),
+                // The desugared receiver IS bare `Self` (excluded below by name).
+                SigTypeRef::SelfReceiver => true,
+                SigTypeRef::Missing => false,
+            };
+            let self_in_invariant_position = |slot: SigTypeRef| match slot {
+                SigTypeRef::Id(id) => Self::type_ref_self_in_invariant_position(spec.sig_refs, id),
+                SigTypeRef::SelfReceiver | SigTypeRef::Missing => false,
+            };
             let param_self = spec
                 .args
                 .iter()
                 .chain(&spec.kwargs)
                 .filter(|p| p.name.as_str() != "self")
-                .any(|p| Self::type_expr_contains_bare_self(&p.ty));
+                .any(|p| contains_bare_self(p.ty));
             let position = if param_self {
                 Some(SelfCallPosition::Parameter)
-            } else if Self::type_expr_self_in_invariant_position(&spec.return_type)
-                || Self::type_expr_self_in_invariant_position(&spec.throws)
+            } else if self_in_invariant_position(spec.return_type)
+                || self_in_invariant_position(spec.throws)
             {
                 Some(SelfCallPosition::NestedInReturn)
             } else {
@@ -1362,14 +1378,15 @@ impl<'db> TypeInferenceBuilder<'db> {
         // single-bound; take the first conjunct until that path is retyped to a conjunction
         // (currently a no-op — the parser surfaces at most one). Conformance (E0120) reads the
         // full conjunction via `generic_bounds()`.
-        let bound_exprs: Vec<Option<baml_compiler2_ast::TypeExpr>> = spec
+        let bound_ids: Vec<Option<baml_compiler2_hir::type_ref::TypeRefId>> = spec
             .generics
             .iter()
-            .map(|(_, bound)| bound.first().cloned())
+            .map(|(_, bound)| bound.first().copied())
             .collect();
-        function_generic_param_bounds.extend(lower_generic_param_bounds(
+        function_generic_param_bounds.extend(lower_generic_param_bound_refs(
             db,
-            &bound_exprs,
+            spec.bound_store(),
+            &bound_ids,
             pkg_items,
             &ns,
             &all_generic_params,

--- a/baml_language/crates/baml_compiler2_tir/src/callable.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/callable.rs
@@ -26,20 +26,40 @@ fn join_throw_facts(facts: &BTreeSet<Ty>) -> Ty {
     }
 }
 
+/// Generic parameters of the type declaration enclosing `function` — the
+/// class's for a class method, the interface's for a default method, empty for
+/// top-level functions and free-impl methods (whose generics live on the impl
+/// block). Firewall twin of `ItemTree::enclosing_type_generic_params`.
+fn enclosing_type_generic_params<'db>(
+    db: &'db dyn crate::Db,
+    function: FunctionLoc<'db>,
+) -> Vec<Name> {
+    match baml_compiler2_ppir::item_data::method_owner(db, function) {
+        Some(baml_compiler2_ppir::item_data::MethodOwner::Class(class_loc)) => {
+            baml_compiler2_ppir::item_data::class_data(db, class_loc)
+                .generic_params
+                .clone()
+        }
+        Some(baml_compiler2_ppir::item_data::MethodOwner::Interface(iface_loc)) => {
+            baml_compiler2_ppir::item_data::interface_data(db, iface_loc)
+                .generic_params
+                .clone()
+        }
+        Some(baml_compiler2_ppir::item_data::MethodOwner::FreeImpl(_)) | None => Vec::new(),
+    }
+}
+
 fn lowered_declared_callable_throws<'db>(
     db: &'db dyn crate::Db,
     function: FunctionLoc<'db>,
 ) -> Option<Ty> {
     let file = function.file(db);
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
     let sig = baml_compiler2_ppir::item_data::elaborated_function_data(db, function);
     let pkg_info = file_package::file_package(db, file);
     let pkg_id = PackageId::new(db, pkg_info.package.clone());
     let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
 
-    let mut generic_params = item_tree
-        .enclosing_type_generic_params(function.id(db))
-        .to_vec();
+    let mut generic_params = enclosing_type_generic_params(db, function);
     generic_params.extend(sig.user_generic_params.iter().cloned());
     generic_params.extend(sig.synthetic_effect_params.iter().cloned());
 
@@ -68,15 +88,12 @@ fn signature_cycle_initial_callable_throws<'db>(
     function: FunctionLoc<'db>,
 ) -> Ty {
     let file = function.file(db);
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
     let sig = baml_compiler2_ppir::item_data::elaborated_function_data(db, function);
     let pkg_info = file_package::file_package(db, file);
     let pkg_id = PackageId::new(db, pkg_info.package.clone());
     let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
 
-    let mut generic_params = item_tree
-        .enclosing_type_generic_params(function.id(db))
-        .to_vec();
+    let mut generic_params = enclosing_type_generic_params(db, function);
     generic_params.extend(sig.user_generic_params.iter().cloned());
     generic_params.extend(sig.synthetic_effect_params.iter().cloned());
 
@@ -106,17 +123,16 @@ fn signature_cycle_initial_callable_throws<'db>(
 }
 
 fn callable_short_name<'db>(db: &'db dyn crate::Db, function: FunctionLoc<'db>) -> Name {
-    let file = function.file(db);
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-    let func_data = &item_tree[function.id(db)];
+    let func_data = baml_compiler2_ppir::item_data::function_data(db, function);
 
     // Only a class owner qualifies the name — interface default methods and
     // free-impl methods keep their bare name, preserving the throw-set key
     // format the scan produced.
-    if let Some(baml_compiler2_hir::item_tree::MethodOwner::Class(class_id)) =
-        item_tree.method_owners.get(&function.id(db))
+    if let Some(baml_compiler2_ppir::item_data::MethodOwner::Class(class_loc)) =
+        baml_compiler2_ppir::item_data::method_owner(db, function)
     {
-        Name::new(format!("{}.{}", item_tree[*class_id].name, func_data.name))
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
+        Name::new(format!("{}.{}", class_data.name, func_data.name))
     } else {
         func_data.name.clone()
     }

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -1830,16 +1830,13 @@ fn resolve_related_location<'db>(
                 .map(|range| (func_loc.file(db).file_id(db), range))
         }
         RelatedLocation::ClassField(class_loc, field_name) => {
-            let item_tree = baml_compiler2_hir::file_item_tree(db, class_loc.file(db));
-            let source_map = baml_compiler2_hir::file_item_tree_source_map(db, class_loc.file(db));
-            let class_data = &item_tree[class_loc.id(db)];
+            let class_data = baml_compiler2_ppir::item_data::class_data(db, *class_loc);
             let field_index = class_data
                 .fields
                 .iter()
                 .position(|field| &field.name == field_name)?;
-            let range = source_map
-                .class_field_spans
-                .get(&class_loc.id(db))?
+            let range = baml_compiler2_ppir::item_data::class_source_map(db, *class_loc)
+                .field_name_spans
                 .get(field_index)
                 .copied()?;
             Some((class_loc.file(db).file_id(db), range))

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -51,11 +51,62 @@ pub fn scope_inferences() -> usize {
     SCOPE_INFERENCES.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// One declared `extends` bound, from either bound universe.
+///
+/// Item-tree declarations (functions, classes, interfaces, impl blocks) carry
+/// their bounds as [`TypeRefId`](baml_compiler2_hir::type_ref::TypeRefId)s into
+/// the owning item's arena — firewall data. Expression-body lambdas are not
+/// items: their bounds live in the body AST and stay `ast::TypeExpr`. The env
+/// lowers both identically (`lower_type_ref` is what `lower_type_expr` shims
+/// onto), so which universe a bound came from never affects its meaning.
+#[derive(Debug, Clone)]
+enum BoundSource<'db> {
+    Ref(
+        &'db baml_compiler2_hir::type_ref::TypeRefStore,
+        baml_compiler2_hir::type_ref::TypeRefId,
+    ),
+    /// Transitional. Its last legitimate producer is the lambda path (lambdas
+    /// live in expression bodies, which have no `TypeRefStore` yet); everything
+    /// else is an unconverted item-tree arm. Once bodies store their type
+    /// positions as `TypeRefId`s (the `ExpressionStore` convergence — which also
+    /// fixes the `RawAttribute`-span cutoff leak in body type exprs), this
+    /// variant dies and `BoundSource` collapses to a plain `(store, id)` pair.
+    #[deprecated(
+        note = "transitional: dies with the body TypeRef migration; do not add new producers"
+    )]
+    Ast(ast::TypeExpr),
+}
+
+/// Wrap a declaration's AST bounds for the env. The lambda path's permanent
+/// form; item-tree callers use it only until they hand over firewall ids.
+#[expect(
+    deprecated,
+    reason = "the one sanctioned Ast producer until the body TypeRef migration"
+)]
+fn ast_bounds<'db>(bounds: &[Option<ast::TypeExpr>]) -> Vec<Option<BoundSource<'db>>> {
+    bounds
+        .iter()
+        .map(|bound| bound.clone().map(BoundSource::Ast))
+        .collect()
+}
+
+/// Wrap a firewall item's declared bounds (`TypeRefId`s into its own `store`)
+/// for the env.
+fn ref_bounds<'db>(
+    store: &'db baml_compiler2_hir::type_ref::TypeRefStore,
+    bounds: &[Option<baml_compiler2_hir::type_ref::TypeRefId>],
+) -> Vec<Option<BoundSource<'db>>> {
+    bounds
+        .iter()
+        .map(|bound| bound.map(|id| BoundSource::Ref(store, id)))
+        .collect()
+}
+
 #[derive(Debug, Clone, Default)]
-struct GenericEnv {
+struct GenericEnv<'db> {
     params: Vec<Name>,
     bound_param_names: Vec<Name>,
-    bound_exprs: Vec<Option<ast::TypeExpr>>,
+    bound_exprs: Vec<Option<BoundSource<'db>>>,
     /// Parallel to `bound_param_names`/`bound_exprs`: whether this env's scope
     /// *owns* the bound's declaration. Bound-expr diagnostics (unresolved names,
     /// arity, non-interface bounds) are reported only by the owning scope — an
@@ -70,7 +121,7 @@ struct GenericEnv {
     concrete_bounds: Vec<(Name, baml_type::Interface)>,
 }
 
-impl GenericEnv {
+impl<'db> GenericEnv<'db> {
     fn from_params(params: Vec<Name>) -> Self {
         Self {
             params,
@@ -84,7 +135,7 @@ impl GenericEnv {
     /// Prepend an *enclosing* declaration's parameters (a class's onto a method
     /// env, an impl block's onto its method env). Their bounds are inherited —
     /// diagnosed at the enclosing declaration, not re-reported by this env.
-    fn prepend_declared(&mut self, params: &[Name], bounds: &[Option<ast::TypeExpr>]) {
+    fn prepend_declared(&mut self, params: &[Name], bounds: &[Option<BoundSource<'db>>]) {
         let mut merged_params = params.to_vec();
         merged_params.extend(std::mem::take(&mut self.params));
         self.params = merged_params;
@@ -105,7 +156,7 @@ impl GenericEnv {
     fn add_bounds_for_declared_params(
         &mut self,
         params: &[Name],
-        bounds: &[Option<ast::TypeExpr>],
+        bounds: &[Option<BoundSource<'db>>],
     ) {
         self.bound_param_names.extend(params.iter().cloned());
         self.bound_exprs.extend(
@@ -117,12 +168,12 @@ impl GenericEnv {
         self.owned_bounds.extend(params.iter().map(|_| true));
     }
 
-    fn append_declared(&mut self, params: &[Name], bounds: &[Option<ast::TypeExpr>]) {
+    fn append_declared(&mut self, params: &[Name], bounds: &[Option<BoundSource<'db>>]) {
         self.params.extend(params.iter().cloned());
         self.add_bounds_for_declared_params(params, bounds);
     }
 
-    fn append_unique_declared(&mut self, params: &[Name], bounds: &[Option<ast::TypeExpr>]) {
+    fn append_unique_declared(&mut self, params: &[Name], bounds: &[Option<BoundSource<'db>>]) {
         for (idx, param) in params.iter().enumerate() {
             if self.params.contains(param) {
                 continue;
@@ -197,7 +248,7 @@ pub fn scope_body<'db>(db: &'db dyn crate::Db, scope_id: ScopeId<'db>) -> Option
     let file = scope_id.file(db);
     let index = baml_compiler2_ppir::file_semantic_index(db, file);
     let owner = inference_owner_scope(index, scope_id.file_scope_id(db));
-    let (expr_body, source_map) = fetch_scope_body(db, file, index, owner)?;
+    let (expr_body, source_map) = fetch_scope_body(db, index, owner)?;
     Some(ScopeBody {
         scope: index.scope_ids[owner.index() as usize],
         expr_body,
@@ -220,19 +271,22 @@ pub fn scope_inference_owner<'db>(db: &'db dyn crate::Db, scope_id: ScopeId<'db>
 /// Fetch the `(ExprBody, AstSourceMap)` for an inference-owner scope.
 fn fetch_scope_body<'db>(
     db: &'db dyn crate::Db,
-    file: SourceFile,
     index: &baml_compiler2_hir::semantic_index::FileSemanticIndex<'db>,
     owner: FileScopeId,
 ) -> Option<(ExprBody, AstSourceMap)> {
     let scope = &index.scopes[owner.index() as usize];
     match scope.kind {
         ScopeKind::Function => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-            let (local_id, _) = item_tree
-                .functions
-                .iter()
-                .find(|(_, f)| f.span == scope.range && scope.name.as_ref() == Some(&f.name))?;
-            let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, *local_id);
+            // The recorded item↔scope link, not a `span == range` join (which
+            // could not tell a function from its companions — they share one
+            // span). Template strings also open `ScopeKind::Function` scopes;
+            // their owner is a non-Function item and yields `None` here.
+            let scope_id = index.scope_ids[owner.index() as usize];
+            let Some(baml_compiler2_ppir::item_data::ScopeOwner::Function(func_loc)) =
+                baml_compiler2_ppir::item_data::scope_owner(db, scope_id)
+            else {
+                return None;
+            };
             let body = baml_compiler2_ppir::function_body(db, func_loc);
             let baml_compiler2_hir::body::FunctionBody::Expr(eb) = body.as_ref() else {
                 return None;
@@ -241,12 +295,12 @@ fn fetch_scope_body<'db>(
             Some((eb.clone(), sm))
         }
         ScopeKind::Let => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-            let (local_id, _) = item_tree
-                .lets
-                .iter()
-                .find(|(_, l)| l.span == scope.range && scope.name.as_ref() == Some(&l.name))?;
-            let let_loc = baml_compiler2_hir::loc::LetLoc::new(db, file, *local_id);
+            let scope_id = index.scope_ids[owner.index() as usize];
+            let Some(baml_compiler2_ppir::item_data::ScopeOwner::Let(let_loc)) =
+                baml_compiler2_ppir::item_data::scope_owner(db, scope_id)
+            else {
+                return None;
+            };
             let body = baml_compiler2_hir::body::let_body(db, let_loc);
             let baml_compiler2_hir::body::LetBody::Expr(eb) = body.as_ref() else {
                 return None;
@@ -268,7 +322,7 @@ fn fetch_scope_body<'db>(
                 }
                 parent = index.scopes[p.index() as usize].parent;
             };
-            let (eb, sm) = fetch_scope_body(db, file, index, enclosing)?;
+            let (eb, sm) = fetch_scope_body(db, index, enclosing)?;
             let (_, lambda_body, lambda_sm, _) = find_lambda_by_span(&eb, &sm, scope.range)?;
             Some((lambda_body.clone(), lambda_sm.clone()))
         }
@@ -276,25 +330,32 @@ fn fetch_scope_body<'db>(
     }
 }
 
-fn enclosing_type_generics(
-    item_tree: &baml_compiler2_hir::item_tree::ItemTree,
+fn enclosing_type_generics<'db>(
+    db: &'db dyn crate::Db,
+    file: SourceFile,
     type_name: &Name,
 ) -> Option<(
     crate::infer_context::ShadowedParamOwner,
     Vec<Name>,
-    Vec<Option<ast::TypeExpr>>,
+    Vec<Option<BoundSource<'db>>>,
 )> {
-    for class_data in item_tree.classes.values() {
+    for &class_loc in baml_compiler2_ppir::item_data::file_classes(db, file) {
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
         if class_data.name == *type_name {
             return Some((
                 crate::infer_context::ShadowedParamOwner::Class,
                 class_data.generic_params.clone(),
-                class_data.generic_param_bounds.clone(),
+                class_data
+                    .generic_param_bounds
+                    .iter()
+                    .map(|bound| bound.map(|id| BoundSource::Ref(&class_data.type_refs, id)))
+                    .collect(),
             ));
         }
     }
 
-    for iface_data in item_tree.interfaces.values() {
+    for &iface_loc in baml_compiler2_ppir::item_data::file_interfaces(db, file) {
+        let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
         if iface_data.name == *type_name {
             // Associated types are NOT type-level parameters: a bare associated-type
             // name (`Item`) is illegal and must be written `Self.Item`, so it never
@@ -303,7 +364,11 @@ fn enclosing_type_generics(
             return Some((
                 crate::infer_context::ShadowedParamOwner::Interface,
                 iface_data.generic_params.clone(),
-                iface_data.generic_param_bounds.clone(),
+                iface_data
+                    .generic_param_bounds
+                    .iter()
+                    .map(|bound| bound.map(|id| BoundSource::Ref(&iface_data.type_refs, id)))
+                    .collect(),
             ));
         }
     }
@@ -330,10 +395,8 @@ pub(crate) fn interface_associated_type_names_for_qtn(
     let iface_pkg_items = baml_compiler2_ppir::package_items(db, iface_pkg_id);
 
     let mut names: FxHashSet<Name> = FxHashSet::default();
-    let item_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-    if let Some(iface_data) = item_tree.interfaces.get(&iface_loc.id(db)) {
-        names.extend(iface_data.associated_types.iter().map(|a| a.name.clone()));
-    }
+    let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
+    names.extend(iface_data.associated_types.iter().map(|a| a.name.clone()));
     names.extend(inherited_interface_associated_type_names(
         db,
         iface_loc,
@@ -365,25 +428,24 @@ fn inherited_interface_associated_type_names(
         if !seen.insert((iface_loc.file(db), iface_loc.id(db))) {
             return;
         }
-        let item_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-        let Some(iface_data) = item_tree.interfaces.get(&iface_loc.id(db)) else {
-            return;
-        };
-        for required in &iface_data.requires {
-            let Some(required_loc) =
-                crate::interfaces::resolve_path_to_interface(db, required, pkg_items, ns_context)
-            else {
+        let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
+        for &required in &iface_data.requires {
+            let Some(required_loc) = crate::interfaces::resolve_ref_to_interface(
+                db,
+                &iface_data.type_refs,
+                required,
+                pkg_items,
+                ns_context,
+            ) else {
                 continue;
             };
-            let required_tree = baml_compiler2_hir::file_item_tree(db, required_loc.file(db));
-            if let Some(required_iface) = required_tree.interfaces.get(&required_loc.id(db)) {
-                out.extend(
-                    required_iface
-                        .associated_types
-                        .iter()
-                        .map(|assoc| assoc.name.clone()),
-                );
-            }
+            let required_iface = baml_compiler2_ppir::item_data::interface_data(db, required_loc);
+            out.extend(
+                required_iface
+                    .associated_types
+                    .iter()
+                    .map(|assoc| assoc.name.clone()),
+            );
             let required_pkg =
                 baml_compiler2_hir::file_package::file_package(db, required_loc.file(db));
             let required_pkg_id = PackageId::new(db, required_pkg.package.clone());
@@ -427,21 +489,24 @@ fn lower_env_generic_bound(
     params: &[Name],
     concrete_bounds: &TypeVarBoundsMap,
     self_ty: Option<&Ty>,
-    bound_te: &ast::TypeExpr,
+    bound: &BoundSource<'_>,
     diags: &mut Vec<crate::infer_context::TirTypeError>,
 ) -> Ty {
-    crate::lower_type_expr::lower_type_expr(
-        bound_te,
-        &crate::lower_type_expr::ScopeCtx {
-            db,
-            package_items: pkg_items,
-            ns_context,
-            generic_params: params,
-            bounds: concrete_bounds,
-            self_ty: self_ty.cloned(),
-        },
-        diags,
-    )
+    let ctx = crate::lower_type_expr::ScopeCtx {
+        db,
+        package_items: pkg_items,
+        ns_context,
+        generic_params: params,
+        bounds: concrete_bounds,
+        self_ty: self_ty.cloned(),
+    };
+    match bound {
+        #[expect(deprecated, reason = "consumer of the transitional Ast variant")]
+        BoundSource::Ast(te) => crate::lower_type_expr::lower_type_expr(te, &ctx, diags),
+        BoundSource::Ref(store, id) => {
+            crate::lower_type_expr::lower_type_ref(store, *id, &ctx, diags)
+        }
+    }
 }
 
 /// The lowering view of a [`GenericEnv`]'s concrete constraints: the bounds map
@@ -538,8 +603,11 @@ pub(crate) fn interface_declared_generic_arity(
     else {
         return None;
     };
-    let tree = baml_compiler2_ppir::file_item_tree(db, loc.file(db));
-    Some(tree.interfaces.get(&loc.id(db))?.generic_params.len())
+    Some(
+        baml_compiler2_ppir::item_data::interface_data(db, loc)
+            .generic_params
+            .len(),
+    )
 }
 
 /// Lower one declared interface bound — from a generic parameter's or an
@@ -561,7 +629,7 @@ fn lower_declared_interface_bound(
     params: &[Name],
     bounds: &crate::lower_type_expr::TypeVarBoundsMap,
     self_ty: Option<&Ty>,
-    bound_te: &ast::TypeExpr,
+    bound: &BoundSource<'_>,
     span: TextRange,
     report: bool,
 ) -> Box<[baml_type::Interface]> {
@@ -570,18 +638,21 @@ fn lower_declared_interface_bound(
     // — which is then correctly rejected as a non-interface bound below, rather than
     // failing to resolve and masquerading as an "unresolved type".
     let mut diags = Vec::new();
-    let bound_ty = crate::lower_type_expr::lower_type_expr(
-        bound_te,
-        &crate::lower_type_expr::ScopeCtx {
-            db,
-            package_items: pkg_items,
-            ns_context,
-            generic_params: params,
-            bounds,
-            self_ty: self_ty.cloned(),
-        },
-        &mut diags,
-    );
+    let scope = crate::lower_type_expr::ScopeCtx {
+        db,
+        package_items: pkg_items,
+        ns_context,
+        generic_params: params,
+        bounds,
+        self_ty: self_ty.cloned(),
+    };
+    let bound_ty = match bound {
+        #[expect(deprecated, reason = "consumer of the transitional Ast variant")]
+        BoundSource::Ast(te) => crate::lower_type_expr::lower_type_expr(te, &scope, &mut diags),
+        BoundSource::Ref(store, id) => {
+            crate::lower_type_expr::lower_type_ref(store, *id, &scope, &mut diags)
+        }
+    };
     if report {
         for diag in diags {
             builder.report_at_span(diag, span);
@@ -608,16 +679,34 @@ fn lower_declared_interface_bound(
                 // is the interface's own obligation, checked at its declaration; a
                 // symbolic value resolves at instantiation and fails open. Cycle-safe:
                 // scope inference runs strictly downstream of `impl_data`.
-                if let baml_compiler2_ast::TypeExprKind::Path {
-                    associated_type_bindings,
-                    ..
-                } = &bound_te.kind
+                let written_binding_names: Vec<Name> = match bound {
+                    #[expect(deprecated, reason = "consumer of the transitional Ast variant")]
+                    BoundSource::Ast(te) => match &te.kind {
+                        baml_compiler2_ast::TypeExprKind::Path {
+                            associated_type_bindings,
+                            ..
+                        } => associated_type_bindings
+                            .iter()
+                            .map(|b| b.name.clone())
+                            .collect(),
+                        _ => Vec::new(),
+                    },
+                    BoundSource::Ref(store, id) => match &store[*id].kind {
+                        baml_compiler2_hir::type_ref::TypeRefKind::Path {
+                            associated_type_bindings,
+                            ..
+                        } => associated_type_bindings
+                            .iter()
+                            .map(|b| b.name.clone())
+                            .collect(),
+                        _ => Vec::new(),
+                    },
+                };
                 {
                     let head =
                         baml_type::Interface::new(qtn.clone(), generics.clone(), assoc.clone());
-                    for written in associated_type_bindings {
-                        let Some((_, value)) = assoc.iter().find(|(n, _)| *n == written.name)
-                        else {
+                    for written_name in &written_binding_names {
+                        let Some((_, value)) = assoc.iter().find(|(n, _)| n == written_name) else {
                             // Unknown binding name — lowering reported it already.
                             continue;
                         };
@@ -629,7 +718,7 @@ fn lower_declared_interface_bound(
                             crate::builder::associated_projection::associated_type_declared_bound(
                                 db,
                                 &head,
-                                &written.name,
+                                written_name,
                             )
                         {
                             if !crate::interfaces::normalized_arg_implements_bound(
@@ -640,7 +729,7 @@ fn lower_declared_interface_bound(
                                 builder.report_at_span(
                                     crate::infer_context::TirTypeError::AssociatedTypeBindingViolatesBound {
                                         interface: qtn.clone(),
-                                        name: written.name.clone(),
+                                        name: written_name.clone(),
                                         binding: value.clone(),
                                         bound: declared,
                                     },
@@ -730,28 +819,28 @@ fn apply_generic_env(
 struct GenericLookupContext<'a, 'db> {
     db: &'db dyn crate::Db,
     index: &'a baml_compiler2_hir::semantic_index::FileSemanticIndex<'db>,
-    item_tree: &'a baml_compiler2_hir::item_tree::ItemTree,
+    file: SourceFile,
 }
 
 /// The enclosing class/interface declaration whose type-level parameters a method's
 /// signature env extends — with the declaration kind for shadowing diagnostics.
-struct ParentTypeGenerics {
+struct ParentTypeGenerics<'db> {
     type_name: Name,
     owner: crate::infer_context::ShadowedParamOwner,
     params: Vec<Name>,
-    bounds: Vec<Option<ast::TypeExpr>>,
+    bounds: Vec<Option<BoundSource<'db>>>,
 }
 
-fn parent_type_generic_env(
-    ctx: GenericLookupContext<'_, '_>,
+fn parent_type_generic_env<'db>(
+    ctx: GenericLookupContext<'_, 'db>,
     parent_scope_id: Option<FileScopeId>,
-) -> Option<ParentTypeGenerics> {
+) -> Option<ParentTypeGenerics<'db>> {
     let parent = &ctx.index.scopes[parent_scope_id?.index() as usize];
     if !matches!(parent.kind, ScopeKind::Class) {
         return None;
     }
     let type_name = parent.name.clone()?;
-    let (owner, params, bounds) = enclosing_type_generics(ctx.item_tree, &type_name)?;
+    let (owner, params, bounds) = enclosing_type_generics(ctx.db, ctx.file, &type_name)?;
     Some(ParentTypeGenerics {
         type_name,
         owner,
@@ -760,9 +849,9 @@ fn parent_type_generic_env(
     })
 }
 
-fn prepend_parent_type_generics(
-    ctx: GenericLookupContext<'_, '_>,
-    env: &mut GenericEnv,
+fn prepend_parent_type_generics<'db>(
+    ctx: GenericLookupContext<'_, 'db>,
+    env: &mut GenericEnv<'db>,
     parent_scope_id: Option<FileScopeId>,
 ) -> Option<Name> {
     let parent = parent_type_generic_env(ctx, parent_scope_id)?;
@@ -771,39 +860,49 @@ fn prepend_parent_type_generics(
 }
 
 /// An out-of-body impl block's declared generics as `(param names, each's single optional
-/// bound)`. The legacy flat form the generic env consumes; the `ImplBlock` holds the full
+/// bound)`. The legacy flat form the generic env consumes; the block holds the full
 /// `&`-bound set per param, of which only the first is used here (matching the old single-bound
 /// representation). Empty for an in-body (`InClass`) block.
-fn free_impl_generics(
-    block: &baml_compiler2_hir::item_tree::ImplBlock,
-) -> (Vec<Name>, Vec<Option<baml_compiler2_ast::TypeExpr>>) {
+fn free_impl_generics<'db>(
+    block: &'db baml_compiler2_ppir::item_data::ImplBlockData<'db>,
+) -> (Vec<Name>, Vec<Option<BoundSource<'db>>>) {
     match &block.subject {
-        baml_compiler2_hir::item_tree::ImplSubject::Free { generics, .. } => (
+        baml_compiler2_ppir::item_data::ImplSubjectData::Free { generics, .. } => (
             generics.iter().map(|g| g.name.clone()).collect(),
-            generics.iter().map(|g| g.bounds.first().cloned()).collect(),
+            generics
+                .iter()
+                .map(|g| {
+                    g.bounds
+                        .first()
+                        .map(|&id| BoundSource::Ref(&block.type_refs, id))
+                })
+                .collect(),
         ),
-        baml_compiler2_hir::item_tree::ImplSubject::InClass { .. } => {
+        baml_compiler2_ppir::item_data::ImplSubjectData::InClass { .. } => {
             debug_assert!(false, "Should only be called for a free impl");
             (Vec::new(), Vec::new())
         }
     }
 }
 
-/// The out-of-body `implement … for …` block whose method list contains `func_id`, as its
-/// declared generics, if any. Reads the unified `impls` store via the `free_impls` index.
+/// The out-of-body `implement … for …` block whose method list contains `func_loc`, as its
+/// declared generics, if any.
 ///
-/// Membership is by id. It used to be by source span, which cannot distinguish a function
-/// from its companions — all of `f`, `f$stream` and `f$parse_stream` carry one span.
-fn enclosing_impl_generics_for_func(
-    item_tree: &baml_compiler2_hir::item_tree::ItemTree,
-    func_id: baml_compiler2_hir::ids::LocalItemId<baml_compiler2_hir::ids::FunctionMarker>,
-) -> Option<(Vec<Name>, Vec<Option<baml_compiler2_ast::TypeExpr>>)> {
-    match item_tree.method_owners.get(&func_id)? {
-        baml_compiler2_hir::item_tree::MethodOwner::FreeImpl(impl_id) => {
-            Some(free_impl_generics(&item_tree.impls[impl_id]))
+/// Membership is by the recorded owner link. It used to be by source span, which cannot
+/// distinguish a function from its companions — all of `f`, `f$stream` and `f$parse_stream`
+/// carry one span.
+fn enclosing_impl_generics_for_func<'db>(
+    db: &'db dyn crate::Db,
+    func_loc: FunctionLoc<'db>,
+) -> Option<(Vec<Name>, Vec<Option<BoundSource<'db>>>)> {
+    match baml_compiler2_ppir::item_data::method_owner(db, func_loc)? {
+        baml_compiler2_ppir::item_data::MethodOwner::FreeImpl(impl_loc) => {
+            Some(free_impl_generics(
+                baml_compiler2_ppir::item_data::impl_block_data(db, impl_loc),
+            ))
         }
-        baml_compiler2_hir::item_tree::MethodOwner::Class(_)
-        | baml_compiler2_hir::item_tree::MethodOwner::Interface(_) => None,
+        baml_compiler2_ppir::item_data::MethodOwner::Class(_)
+        | baml_compiler2_ppir::item_data::MethodOwner::Interface(_) => None,
     }
 }
 
@@ -811,17 +910,20 @@ fn generic_env_for_function_data<'db>(
     ctx: GenericLookupContext<'_, 'db>,
     function_scope: &baml_compiler2_hir::scope::Scope,
     func_loc: FunctionLoc<'db>,
-) -> GenericEnv {
-    let func_data = &ctx.item_tree[func_loc.id(ctx.db)];
+) -> GenericEnv<'db> {
+    let func_data = baml_compiler2_ppir::item_data::function_data(ctx.db, func_loc);
     let mut env = GenericEnv::from_params(func_data.generic_params.clone());
-    env.add_bounds_for_declared_params(&func_data.generic_params, &func_data.generic_param_bounds);
+    env.add_bounds_for_declared_params(
+        &func_data.generic_params,
+        &ref_bounds(&func_data.type_refs, &func_data.generic_param_bounds),
+    );
     // A method in a generic `implements<T …> Iface for Target` block sees the
     // block's type params (e.g. `T` in `implements<T extends Comparable>
     // Sortable for T[]`), which live on the impl block rather than a parent
     // scope. Mirror the `ScopeKind::Function` arm: impl generics take the place
     // of parent-type generics so a nested lambda body can resolve them too.
     if let Some((generic_params, generic_param_bounds)) =
-        enclosing_impl_generics_for_func(ctx.item_tree, func_loc.id(ctx.db))
+        enclosing_impl_generics_for_func(ctx.db, func_loc)
     {
         env.prepend_declared(&generic_params, &generic_param_bounds);
     } else {
@@ -830,10 +932,10 @@ fn generic_env_for_function_data<'db>(
     env
 }
 
-fn enclosing_function_generic_env_from_let(
-    ctx: GenericLookupContext<'_, '_>,
+fn enclosing_function_generic_env_from_let<'db>(
+    ctx: GenericLookupContext<'_, 'db>,
     let_scope: &baml_compiler2_hir::scope::Scope,
-) -> Option<GenericEnv> {
+) -> Option<GenericEnv<'db>> {
     let mut current = let_scope.parent;
     while let Some(fsi) = current {
         let scope = &ctx.index.scopes[fsi.index() as usize];
@@ -855,73 +957,49 @@ fn enclosing_function_generic_env_from_let(
     None
 }
 
-struct TypeExprLoweringOptions {
-    span: TextRange,
-    self_ty: Option<Ty>,
-}
-
+/// Lower a firewall type ref through the env's scope and validate its generic
+/// bounds, reporting at `span` (the node's span from the owning item's source
+/// map).
 #[expect(clippy::too_many_arguments)]
-fn lower_type_expr_at_span_in_env(
+fn validate_type_ref_generic_bounds_at_span(
     db: &dyn crate::Db,
     builder: &mut TypeInferenceBuilder<'_>,
     pkg_items: &PackageItems<'_>,
     ns_context: &[Name],
-    env: &GenericEnv,
+    env: &GenericEnv<'_>,
     env_bounds: &crate::lower_type_expr::TypeVarBoundsMap,
-    type_expr: &ast::TypeExpr,
-    options: TypeExprLoweringOptions,
-) -> Ty {
-    // The env's params are the in-scope type variables; `Self` resolves through `self_ty`,
-    // and the env's interface bounds (`env_bounds`, computed once per env via
-    // `env_interface_bounds`) let a `T.member` / `Self.member` projection resolve.
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    id: baml_compiler2_hir::type_ref::TypeRefId,
+    span: TextRange,
+    self_ty: Option<Ty>,
+) {
     let ctx = crate::lower_type_expr::ScopeCtx {
         db,
         package_items: pkg_items,
         ns_context,
         generic_params: &env.params,
         bounds: env_bounds,
-        self_ty: options.self_ty,
+        self_ty,
     };
     let mut diags = Vec::new();
-    let ty = crate::lower_type_expr::lower_type_expr(type_expr, &ctx, &mut diags);
+    let ty = crate::lower_type_expr::lower_type_ref(store, id, &ctx, &mut diags);
     for diag in diags {
-        builder.report_at_span(diag, options.span);
+        builder.report_at_span(diag, span);
     }
-    builder.validate_type_generic_bounds_at_span(options.span, &ty);
-    ty
+    builder.validate_type_generic_bounds_at_span(span, &ty);
 }
 
-#[expect(clippy::too_many_arguments)]
-fn validate_spanned_type_expr_generic_bounds(
-    db: &dyn crate::Db,
-    builder: &mut TypeInferenceBuilder<'_>,
-    pkg_items: &PackageItems<'_>,
-    ns_context: &[Name],
-    env: &GenericEnv,
-    env_bounds: &crate::lower_type_expr::TypeVarBoundsMap,
-    type_expr: &ast::TypeExpr,
-    self_ty: Option<Ty>,
-) {
-    lower_type_expr_at_span_in_env(
-        db,
-        builder,
-        pkg_items,
-        ns_context,
-        env,
-        env_bounds,
-        type_expr,
-        TypeExprLoweringOptions {
-            span: type_expr.span,
-            self_ty,
-        },
-    );
-}
-
-fn extend_env_with_lambda_generics(mut env: GenericEnv, func_def: &FunctionDef) -> GenericEnv {
+fn extend_env_with_lambda_generics<'db>(
+    mut env: GenericEnv<'db>,
+    func_def: &FunctionDef,
+) -> GenericEnv<'db> {
     // The enclosing scope's bounds were already diagnosed there; the lambda's
     // scope reports only its own.
     env.mark_all_bounds_inherited();
-    env.append_unique_declared(&func_def.generic_params, &func_def.generic_param_bounds);
+    env.append_unique_declared(
+        &func_def.generic_params,
+        &ast_bounds(&func_def.generic_param_bounds),
+    );
     env
 }
 
@@ -1708,7 +1786,6 @@ pub fn infer_scope_types<'db>(
             // Find the function by matching scope range AND name against item_tree functions.
             // Both checks are required to disambiguate companion functions that
             // share the parent's span.
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
             // The HIR builder records which item opened each scope, so the owner is
             // read directly rather than recovered by matching `item.span == scope.range`
             // — a join that could not tell a function from its companions, which share
@@ -1717,19 +1794,25 @@ pub fn infer_scope_types<'db>(
             if let Some(baml_compiler2_ppir::item_data::ScopeOwner::Function(func_loc)) =
                 baml_compiler2_ppir::item_data::scope_owner(db, scope_id)
             {
-                let local_id = &func_loc.id(db);
-                let func_data = &item_tree[func_loc.id(db)];
+                let func_data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
                 let func_span =
                     baml_compiler2_ppir::item_data::function_source_map(db, func_loc).span;
                 let body = baml_compiler2_ppir::function_body(db, func_loc);
                 let sig = baml_compiler2_ppir::item_data::elaborated_function_data(db, func_loc);
 
-                let enclosing_impl = match item_tree.method_owners.get(local_id) {
-                    Some(baml_compiler2_hir::item_tree::MethodOwner::FreeImpl(impl_id)) => {
-                        item_tree.impls.get(impl_id)
-                    }
-                    _ => None,
-                };
+                let enclosing_impl =
+                    match baml_compiler2_ppir::item_data::method_owner(db, func_loc) {
+                        Some(baml_compiler2_ppir::item_data::MethodOwner::FreeImpl(impl_loc)) => {
+                            Some(baml_compiler2_ppir::item_data::impl_block_data(
+                                db, impl_loc,
+                            ))
+                        }
+                        Some(
+                            baml_compiler2_ppir::item_data::MethodOwner::Class(_)
+                            | baml_compiler2_ppir::item_data::MethodOwner::Interface(_),
+                        )
+                        | None => None,
+                    };
 
                 let mut env = GenericEnv::from_params(sig.user_generic_params.clone());
                 env.params
@@ -1748,14 +1831,9 @@ pub fn infer_scope_types<'db>(
                         }
                     }
                     env.prepend_declared(&impl_generic_params, &impl_generic_bounds);
-                } else if let Some(parent) = parent_type_generic_env(
-                    GenericLookupContext {
-                        db,
-                        index,
-                        item_tree: &item_tree,
-                    },
-                    scope.parent,
-                ) {
+                } else if let Some(parent) =
+                    parent_type_generic_env(GenericLookupContext { db, index, file }, scope.parent)
+                {
                     for mp in &sig.user_generic_params {
                         if parent.params.iter().any(|cp| cp == mp) {
                             builder.report_at_span(
@@ -1784,14 +1862,13 @@ pub fn infer_scope_types<'db>(
                         }
                         let cn = parent.name.as_ref()?;
                         let def = pkg_items.lookup_type(&pkg_info.namespace_path, cn)?;
-                        if !matches!(
-                            def,
-                            baml_compiler2_hir::contributions::Definition::Interface(_)
-                        ) {
+                        let baml_compiler2_hir::contributions::Definition::Interface(iface_loc) =
+                            def
+                        else {
                             return None;
-                        }
+                        };
                         let qtn = crate::lower_type_expr::qualify_def(db, def, cn);
-                        let iface = item_tree.interfaces.values().find(|i| &i.name == cn)?;
+                        let iface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
                         let args = iface
                             .generic_params
                             .iter()
@@ -1816,7 +1893,7 @@ pub fn infer_scope_types<'db>(
                 }
                 env.add_bounds_for_declared_params(
                     &func_data.generic_params,
-                    &func_data.generic_param_bounds,
+                    &ref_bounds(&func_data.type_refs, &func_data.generic_param_bounds),
                 );
                 apply_generic_env(
                     db,
@@ -1835,8 +1912,10 @@ pub fn infer_scope_types<'db>(
                 // `implements I { ... }` block, attach `I`'s QTN so
                 // `default.<method>(...)` resolves against I's
                 // contract.
-                if let Some(target) = item_tree.method_to_iface_target.get(local_id)
-                    && let baml_compiler2_ast::TypeExprKind::Path { segments, .. } = &target.kind
+                if let Some(target) =
+                    baml_compiler2_ppir::item_data::method_interface_target(db, func_loc)
+                    && let baml_compiler2_hir::type_ref::TypeRefKind::Path { segments, .. } =
+                        &target.type_refs[target.target].kind
                     && let Some((head, name)) = segments
                         .split_last()
                         .map(|(last, head)| (head, last.clone()))
@@ -1878,13 +1957,15 @@ pub fn infer_scope_types<'db>(
                     let self_ty: Option<Ty> = if interface_self_bound.is_some() {
                         Some(crate::self_type::self_type_for_interface_default())
                     } else if let Some(imp) = enclosing_impl
-                        && let baml_compiler2_hir::item_tree::ImplSubject::Free {
-                            for_target, ..
+                        && let baml_compiler2_ppir::item_data::ImplSubjectData::Free {
+                            for_target,
+                            ..
                         } = &imp.subject
                     {
                         let mut diags = Vec::new();
-                        Some(crate::lower_type_expr::lower_type_expr(
-                            for_target,
+                        Some(crate::lower_type_expr::lower_type_ref(
+                            &imp.type_refs,
+                            *for_target,
                             &crate::lower_type_expr::ScopeCtx {
                                 db,
                                 package_items: pkg_items,
@@ -1905,9 +1986,9 @@ pub fn infer_scope_types<'db>(
                             let class_file = class_loc.file(db);
                             let class_pkg =
                                 baml_compiler2_hir::file_package::file_package(db, class_file);
-                            let class_tree = baml_compiler2_hir::file_item_tree(db, class_file);
-                            let class_data = class_tree.classes.get(&class_loc.id(db))?;
-                            Some(crate::self_type::self_type_for_class(
+                            let class_data =
+                                baml_compiler2_ppir::item_data::class_data(db, class_loc);
+                            Some(crate::lower_type_expr::self_type_for_class_data(
                                 class_data,
                                 &class_pkg.namespace_path,
                                 class_pkg.package.clone(),
@@ -1922,30 +2003,45 @@ pub fn infer_scope_types<'db>(
                         baml_compiler2_ppir::elaborated_function_signature_source_map(db, func_loc);
                     let mut type_bindings: FxHashMap<Name, Ty> =
                         type_bindings_for_params(&env.params);
-                    if let Some(target) = item_tree.method_to_iface_target.get(local_id)
-                        && let Some(iface_loc) = crate::interfaces::resolve_path_to_interface(
+                    if let Some(target) =
+                        baml_compiler2_ppir::item_data::method_interface_target(db, func_loc)
+                        && let Some(iface_loc) = crate::interfaces::resolve_ref_to_interface(
                             db,
-                            target,
+                            &target.type_refs,
+                            target.target,
                             pkg_items,
                             &pkg_info.namespace_path,
                         )
                     {
-                        let iface_file = iface_loc.file(db);
-                        let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_file);
-                        if let Some(iface_data) = iface_tree.interfaces.get(&iface_loc.id(db)) {
+                        // Allocated in lockstep with `method_interface_target`, so
+                        // present whenever the target is.
+                        let target_sm =
+                            baml_compiler2_ppir::item_data::method_interface_target_source_map(
+                                db, func_loc,
+                            )
+                            .as_ref()
+                            .unwrap_or_else(|| {
+                                unreachable!("target and its source map share one record")
+                            });
+                        {
+                            let iface_data =
+                                baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
                             let mut iface_type_bindings = type_bindings.clone();
-                            if let baml_compiler2_ast::TypeExprKind::Path { generic_args, .. } =
-                                &target.kind
+                            if let baml_compiler2_hir::type_ref::TypeRefKind::Path {
+                                generic_args,
+                                ..
+                            } = &target.type_refs[target.target].kind
                             {
-                                for (param, arg) in
-                                    iface_data.generic_params.iter().zip(generic_args)
+                                for (param, &arg) in
+                                    iface_data.generic_params.iter().zip(generic_args.iter())
                                 {
                                     let mut arg_diags = Vec::new();
                                     let ty = {
                                         let generic_params: Vec<_> =
                                             type_bindings.keys().cloned().collect();
                                         crate::generics::substitute_ty(
-                                            &crate::lower_type_expr::lower_type_expr(
+                                            &crate::lower_type_expr::lower_type_ref(
+                                                &target.type_refs,
                                                 arg,
                                                 &crate::lower_type_expr::ScopeCtx {
                                                     db,
@@ -1961,21 +2057,20 @@ pub fn infer_scope_types<'db>(
                                         )
                                     };
                                     for diag in arg_diags {
-                                        builder.report_at_span(diag, target.span);
+                                        builder.report_at_span(
+                                            diag,
+                                            target_sm.type_refs.span(target.target),
+                                        );
                                     }
                                     iface_type_bindings.insert(param.clone(), ty.clone());
                                     type_bindings.entry(param.clone()).or_insert(ty);
                                 }
                             }
-                            let explicit_bindings = item_tree
-                                .method_to_iface_associated_type_bindings
-                                .get(local_id)
-                                .cloned()
-                                .unwrap_or_default();
+                            let explicit_bindings = &target.associated_type_bindings;
                             for assoc in &iface_data.associated_types {
                                 if let Some(binding) =
                                     explicit_bindings.iter().find(|b| b.name == assoc.name)
-                                    && let Some(te) = &binding.type_expr
+                                    && let Some(binding_ref) = binding.type_ref
                                 {
                                     // Lower the binding's type through a context that resolves
                                     // `Self`, then substitute the in-scope generics /
@@ -1992,15 +2087,19 @@ pub fn infer_scope_types<'db>(
                                     };
                                     let mut binding_diags = Vec::new();
                                     let ty = crate::generics::substitute_ty(
-                                        &crate::lower_type_expr::lower_type_expr(
-                                            te,
+                                        &crate::lower_type_expr::lower_type_ref(
+                                            &target.type_refs,
+                                            binding_ref,
                                             &binding_ctx,
                                             &mut binding_diags,
                                         ),
                                         &type_bindings,
                                     );
                                     for diag in binding_diags {
-                                        builder.report_at_span(diag, te.span);
+                                        builder.report_at_span(
+                                            diag,
+                                            target_sm.type_refs.span(binding_ref),
+                                        );
                                     }
                                     // Into `iface_type_bindings` only — the binding realizes
                                     // later defaults, but the bare name is NOT in scope
@@ -2133,6 +2232,8 @@ pub fn infer_scope_types<'db>(
                         baml_compiler2_ppir::function_parameter_defaults(db, func_loc);
                     builder.check_function_parameter_defaults(
                         &func_data.params,
+                        &baml_compiler2_ppir::item_data::function_source_map(db, func_loc)
+                            .param_spans,
                         &parameter_defaults,
                         &param_types,
                     );
@@ -2163,17 +2264,19 @@ pub fn infer_scope_types<'db>(
                     }
                 }
             } else {
-                // Template strings create ScopeKind::Function scopes but are
-                // stored in item_tree.template_strings, not item_tree.functions.
-                // They have no expression body to type-check, so skip silently.
-                let is_template_string = item_tree
-                    .template_strings
-                    .values()
-                    .any(|ts| scope.name.as_ref() == Some(&ts.name));
+                // Template strings create ScopeKind::Function scopes but are not
+                // functions. They have no expression body to type-check, so skip
+                // silently.
                 debug_assert!(
-                    is_template_string,
-                    "TIR: no item_tree function matched scope (name={:?}, range={:?})",
-                    scope.name, scope.range
+                    matches!(
+                        baml_compiler2_ppir::item_data::scope_owner(db, scope_id),
+                        Some(baml_compiler2_ppir::item_data::ScopeOwner::TemplateString(
+                            _
+                        ))
+                    ),
+                    "TIR: ScopeKind::Function scope owned by neither a function nor a template string (name={:?}, range={:?})",
+                    scope.name,
+                    scope.range
                 );
             }
         }
@@ -2237,7 +2340,6 @@ pub fn infer_scope_types<'db>(
             // the top-level body (Function or Let) and then locate the lambda
             // expression within it by matching spans.
             let lambda_span = scope.range;
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
 
             // Seed captured variables as Ty::Unknown so that the lambda's builder
             // can resolve references to captures without reporting "unresolved name"
@@ -2335,13 +2437,13 @@ pub fn infer_scope_types<'db>(
                             ancestor_func,
                         )) = ancestor_owner
                         {
-                            let func_data = &item_tree[ancestor_func.id(db)];
-                            // Get the function body from item_tree (includes source map)
-                            if let Some(baml_compiler2_ast::FunctionBodyDef::Expr(
-                                ref func_body,
-                                ref func_sm,
-                            )) = func_data.body
+                            let body = baml_compiler2_ppir::function_body(db, ancestor_func);
+                            if let baml_compiler2_hir::body::FunctionBody::Expr(func_body) =
+                                body.as_ref()
+                                && let Some(func_sm) =
+                                    baml_compiler2_ppir::function_body_source_map(db, ancestor_func)
                             {
+                                let func_sm = &func_sm;
                                 if let Some((func_def, lambda_body, _lambda_sm, _lambda_expr_id)) =
                                     find_lambda_by_span(func_body, func_sm, lambda_span)
                                 {
@@ -2365,11 +2467,7 @@ pub fn infer_scope_types<'db>(
 
                                     let env = extend_env_with_lambda_generics(
                                         generic_env_for_function_data(
-                                            GenericLookupContext {
-                                                db,
-                                                index,
-                                                item_tree: &item_tree,
-                                            },
+                                            GenericLookupContext { db, index, file },
                                             ancestor_scope,
                                             ancestor_func,
                                         ),
@@ -2436,11 +2534,7 @@ pub fn infer_scope_types<'db>(
 
                                     let env = extend_env_with_lambda_generics(
                                         enclosing_function_generic_env_from_let(
-                                            GenericLookupContext {
-                                                db,
-                                                index,
-                                                item_tree: &item_tree,
-                                            },
+                                            GenericLookupContext { db, index, file },
                                             ancestor_scope,
                                         )
                                         .unwrap_or_default(),
@@ -2484,17 +2578,16 @@ pub fn infer_scope_types<'db>(
             }
         }
         ScopeKind::Class => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
             let scope_item = baml_compiler2_ppir::item_data::scope_owner(db, scope_id);
             if let Some(baml_compiler2_ppir::item_data::ScopeOwner::Class(class_loc)) = scope_item {
-                let class_data = &item_tree[class_loc.id(db)];
-                let class_span =
-                    baml_compiler2_ppir::item_data::class_source_map(db, class_loc).span;
+                let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
+                let class_sm = baml_compiler2_ppir::item_data::class_source_map(db, class_loc);
+                let class_span = class_sm.span;
                 report_duplicate_generic_params(&builder, &class_data.generic_params, class_span);
                 let mut env = GenericEnv::from_params(class_data.generic_params.clone());
                 env.add_bounds_for_declared_params(
                     &class_data.generic_params,
-                    &class_data.generic_param_bounds,
+                    &ref_bounds(&class_data.type_refs, &class_data.generic_param_bounds),
                 );
                 apply_generic_env(
                     db,
@@ -2506,29 +2599,31 @@ pub fn infer_scope_types<'db>(
                 );
                 let resolved = resolve_class_fields(db, class_loc);
                 for (field, (_, ty, _)) in class_data.fields.iter().zip(resolved.fields.iter()) {
-                    if let Some(type_expr) = &field.type_expr {
-                        builder.validate_type_generic_bounds_at_span(type_expr.span, ty);
+                    if let Some(id) = field.type_ref {
+                        builder
+                            .validate_type_generic_bounds_at_span(class_sm.type_refs.span(id), ty);
                     }
                 }
             }
             if let Some(baml_compiler2_ppir::item_data::ScopeOwner::Interface(iface_loc)) =
                 scope_item
             {
-                let iface_data = &item_tree[iface_loc.id(db)];
-                let iface_span =
-                    baml_compiler2_ppir::item_data::interface_source_map(db, iface_loc).span;
+                let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
+                let iface_sm = baml_compiler2_ppir::item_data::interface_source_map(db, iface_loc);
+                let iface_span = iface_sm.span;
                 report_duplicate_generic_params(&builder, &iface_data.generic_params, iface_span);
                 // Associated types share the interface's type-level namespace with its
                 // generic parameters (a bare `Assoc` reference lowers as a type variable),
                 // so a name collision — with a parameter or another associated type —
                 // would silently alias the two. Both are declaration errors.
                 for (idx, assoc) in iface_data.associated_types.iter().enumerate() {
+                    let name_span = iface_sm.associated_type_spans[idx].name_span;
                     if iface_data.generic_params.contains(&assoc.name) {
                         builder.report_at_span(
                             crate::infer_context::TirTypeError::AssociatedTypeConflictsWithGenericParam {
                                 name: assoc.name.clone(),
                             },
-                            assoc.name_span,
+                            name_span,
                         );
                     }
                     if iface_data.associated_types[..idx]
@@ -2539,7 +2634,7 @@ pub fn infer_scope_types<'db>(
                             crate::infer_context::TirTypeError::DuplicateAssociatedType {
                                 name: assoc.name.clone(),
                             },
-                            assoc.name_span,
+                            name_span,
                         );
                     }
                 }
@@ -2562,9 +2657,10 @@ pub fn infer_scope_types<'db>(
                 // once the implementor binds the associated type it denotes a concrete field
                 // type (`value: Self.Item` with `type Item = int` is an `int` field).
                 for field in &iface_data.fields {
-                    if let Some(type_expr) = &field.type_expr
-                        && crate::builder::TypeInferenceBuilder::type_expr_contains_bare_self(
-                            type_expr,
+                    if let Some(type_ref) = field.type_ref
+                        && crate::builder::TypeInferenceBuilder::type_ref_contains_bare_self(
+                            &iface_data.type_refs,
+                            type_ref,
                         )
                     {
                         builder.report_at_span(
@@ -2572,7 +2668,7 @@ pub fn infer_scope_types<'db>(
                                 interface: iface_qtn.clone(),
                                 field: field.name.clone(),
                             },
-                            type_expr.span,
+                            iface_sm.type_refs.span(type_ref),
                         );
                     }
                 }
@@ -2586,10 +2682,11 @@ pub fn infer_scope_types<'db>(
                     bounds: &crate::lower_type_expr::TypeVarBoundsMap::default(),
                     self_ty: None,
                 };
-                for requires_te in &iface_data.requires {
-                    if crate::interfaces::resolve_path_to_interface(
+                for &requires_ref in &iface_data.requires {
+                    if crate::interfaces::resolve_ref_to_interface(
                         db,
-                        requires_te,
+                        &iface_data.type_refs,
+                        requires_ref,
                         pkg_items,
                         &pkg_info.namespace_path,
                     )
@@ -2597,9 +2694,11 @@ pub fn infer_scope_types<'db>(
                     {
                         continue;
                     }
+                    let requires_span = iface_sm.type_refs.span(requires_ref);
                     let mut requires_diags = Vec::new();
-                    let lowered = crate::lower_type_expr::lower_type_expr(
-                        requires_te,
+                    let lowered = crate::lower_type_expr::lower_type_ref(
+                        &iface_data.type_refs,
+                        requires_ref,
                         &requires_scope,
                         &mut requires_diags,
                     );
@@ -2609,11 +2708,11 @@ pub fn infer_scope_types<'db>(
                                 interface: iface_qtn.clone(),
                                 target: qtn.name().clone(),
                             },
-                            requires_te.span,
+                            requires_span,
                         ),
                         _ => {
                             for e in requires_diags {
-                                builder.report_at_span(e, requires_te.span);
+                                builder.report_at_span(e, requires_span);
                             }
                         }
                     }
@@ -2626,12 +2725,15 @@ pub fn infer_scope_types<'db>(
                 for (method, throws, span) in iface_data
                     .required_methods
                     .iter()
-                    .map(|s| (&s.name, s.throws.as_ref(), s.span))
-                    .chain(iface_data.default_methods.iter().filter_map(|id| {
-                        item_tree
-                            .functions
-                            .get(id)
-                            .map(|f| (&f.name, f.throws.as_ref(), f.span))
+                    .enumerate()
+                    .map(|(idx, s)| (&s.name, s.throws, iface_sm.required_method_spans[idx].span))
+                    .chain(iface_data.default_methods.iter().map(|&loc| {
+                        let f = baml_compiler2_ppir::item_data::function_data(db, loc);
+                        (
+                            &f.name,
+                            f.throws,
+                            baml_compiler2_ppir::item_data::function_source_map(db, loc).span,
+                        )
                     }))
                 {
                     if throws.is_none() {
@@ -2649,14 +2751,16 @@ pub fn infer_scope_types<'db>(
                 // generics enter the signature-lowering env. The associated-type names are
                 // still collected below, for the method-generic shadowing check.
                 let iface_params = iface_data.generic_params.clone();
-                let iface_bounds = iface_data.generic_param_bounds.clone();
                 let iface_assoc_names: Vec<Name> = iface_data
                     .associated_types
                     .iter()
                     .map(|assoc| assoc.name.clone())
                     .collect();
                 let mut iface_env = GenericEnv::from_params(iface_params.clone());
-                iface_env.add_bounds_for_declared_params(&iface_params, &iface_bounds);
+                iface_env.add_bounds_for_declared_params(
+                    &iface_params,
+                    &ref_bounds(&iface_data.type_refs, &iface_data.generic_param_bounds),
+                );
                 // `Self` in an interface's own signatures is its rigid `Self` type variable,
                 // bounded by the interface itself (as a constraint, no associated pins) — so a
                 // `Self.member` projection in a field or method signature resolves through it,
@@ -2700,7 +2804,7 @@ pub fn infer_scope_types<'db>(
                 // diagnostics — associated types are not type-level params, so nothing is
                 // threaded into the enforcement table.
                 for assoc in &iface_data.associated_types {
-                    if let Some(bound_te) = &assoc.bound {
+                    if let Some(bound_ref) = assoc.bound {
                         let _ = lower_declared_interface_bound(
                             db,
                             &mut builder,
@@ -2709,32 +2813,35 @@ pub fn infer_scope_types<'db>(
                             &iface_env.params,
                             &iface_env_bounds,
                             Some(&self_ty),
-                            bound_te,
-                            bound_te.span,
+                            &BoundSource::Ref(&iface_data.type_refs, bound_ref),
+                            iface_sm.type_refs.span(bound_ref),
                             true,
                         );
                     }
                 }
                 for field in &iface_data.fields {
-                    if let Some(type_expr) = &field.type_expr {
-                        validate_spanned_type_expr_generic_bounds(
+                    if let Some(type_ref) = field.type_ref {
+                        validate_type_ref_generic_bounds_at_span(
                             db,
                             &mut builder,
                             pkg_items,
                             &pkg_info.namespace_path,
                             &iface_env,
                             &iface_env_bounds,
-                            type_expr,
+                            &iface_data.type_refs,
+                            type_ref,
+                            iface_sm.type_refs.span(type_ref),
                             Some(self_ty.clone()),
                         );
                     }
                 }
-                for sig in &iface_data.required_methods {
+                for (sig_idx, sig) in iface_data.required_methods.iter().enumerate() {
+                    let sig_span = iface_sm.required_method_spans[sig_idx].span;
                     // Required methods have no body scope, so the method-generic
                     // hygiene checks that the function arm runs for default methods
                     // happen here: no `<T, T>`, and no shadowing of the interface's
                     // type-level parameters (generics and associated types alike).
-                    report_duplicate_generic_params(&builder, &sig.generic_params, sig.span);
+                    report_duplicate_generic_params(&builder, &sig.generic_params, sig_span);
                     for mp in &sig.generic_params {
                         if iface_params.iter().any(|ip| ip == mp) || iface_assoc_names.contains(mp)
                         {
@@ -2744,7 +2851,7 @@ pub fn infer_scope_types<'db>(
                                     type_name: iface_data.name.clone(),
                                     owner: crate::infer_context::ShadowedParamOwner::Interface,
                                 },
-                                sig.span,
+                                sig_span,
                             );
                         }
                     }
@@ -2753,54 +2860,39 @@ pub fn infer_scope_types<'db>(
                     // interface span; each signature env reports only its
                     // method's own.
                     sig_env.mark_all_bounds_inherited();
-                    sig_env.append_declared(&sig.generic_params, &sig.generic_param_bounds);
+                    sig_env.append_declared(
+                        &sig.generic_params,
+                        &ref_bounds(&iface_data.type_refs, &sig.generic_param_bounds),
+                    );
                     apply_generic_env(
                         db,
                         &mut builder,
                         pkg_items,
                         &pkg_info.namespace_path,
                         &sig_env,
-                        sig.span,
+                        sig_span,
                     );
                     // Once per signature env (the interface's bounds plus this
                     // method's own), shared by its params, return, and throws.
                     let sig_env_bounds =
                         env_interface_bounds(db, pkg_items, &pkg_info.namespace_path, &sig_env);
-                    for param in &sig.params {
-                        if let Some(type_expr) = &param.type_expr {
-                            validate_spanned_type_expr_generic_bounds(
-                                db,
-                                &mut builder,
-                                pkg_items,
-                                &pkg_info.namespace_path,
-                                &sig_env,
-                                &sig_env_bounds,
-                                type_expr,
-                                Some(self_ty.clone()),
-                            );
-                        }
-                    }
-                    if let Some(return_type) = &sig.return_type {
-                        validate_spanned_type_expr_generic_bounds(
+                    for slot in sig
+                        .params
+                        .iter()
+                        .filter_map(|param| param.type_ref)
+                        .chain(sig.return_type)
+                        .chain(sig.throws)
+                    {
+                        validate_type_ref_generic_bounds_at_span(
                             db,
                             &mut builder,
                             pkg_items,
                             &pkg_info.namespace_path,
                             &sig_env,
                             &sig_env_bounds,
-                            return_type,
-                            Some(self_ty.clone()),
-                        );
-                    }
-                    if let Some(throws) = &sig.throws {
-                        validate_spanned_type_expr_generic_bounds(
-                            db,
-                            &mut builder,
-                            pkg_items,
-                            &pkg_info.namespace_path,
-                            &sig_env,
-                            &sig_env_bounds,
-                            throws,
+                            &iface_data.type_refs,
+                            slot,
+                            iface_sm.type_refs.span(slot),
                             Some(self_ty.clone()),
                         );
                     }
@@ -2820,9 +2912,10 @@ pub fn infer_scope_types<'db>(
                     Vec::new(),
                 );
                 for assoc in &iface_data.associated_types {
-                    let Some(default_te) = &assoc.default else {
+                    let Some(default_ref) = assoc.default else {
                         continue;
                     };
+                    let default_span = iface_sm.type_refs.span(default_ref);
                     // The default is lowered once — with a symbolic `Self` — by the shared
                     // query; its lowering diagnostics surface here, at the interface
                     // declaration, the single reporting site, so no referencing site (value
@@ -2837,7 +2930,7 @@ pub fn infer_scope_types<'db>(
                         continue;
                     };
                     for diag in default_diags {
-                        builder.report_at_span(diag, default_te.span);
+                        builder.report_at_span(diag, default_span);
                     }
                     // A bounded default (`type Item extends J = V`) must implement its bound.
                     if assoc.bound.is_none() {
@@ -2863,7 +2956,7 @@ pub fn infer_scope_types<'db>(
                                     default: default_ty.clone(),
                                     bound,
                                 },
-                                default_te.span,
+                                default_span,
                             );
                         }
                     }
@@ -2897,14 +2990,16 @@ pub fn infer_scope_types<'db>(
             }
         }
         ScopeKind::TypeAlias => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
             if let Some(baml_compiler2_ppir::item_data::ScopeOwner::TypeAlias(alias_loc)) =
                 baml_compiler2_ppir::item_data::scope_owner(db, scope_id)
             {
-                let alias_data = &item_tree[alias_loc.id(db)];
+                let alias_data = baml_compiler2_ppir::item_data::type_alias_data(db, alias_loc);
                 let resolved = resolve_type_alias(db, alias_loc);
-                if let Some(type_expr) = &alias_data.type_expr {
-                    builder.validate_type_generic_bounds_at_span(type_expr.span, &resolved.ty);
+                if let Some(id) = alias_data.value {
+                    let span = baml_compiler2_ppir::item_data::type_alias_source_map(db, alias_loc)
+                        .type_refs
+                        .span(id);
+                    builder.validate_type_generic_bounds_at_span(span, &resolved.ty);
                 }
             }
         }
@@ -3018,9 +3113,7 @@ pub fn enum_variants<'db>(
     else {
         return None;
     };
-    let file = enum_loc.file(db);
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-    let enum_data = &item_tree[enum_loc.id(db)];
+    let enum_data = baml_compiler2_ppir::item_data::enum_data(db, enum_loc);
     Some(enum_data.variants.iter().map(|v| v.name.clone()).collect())
 }
 
@@ -3211,12 +3304,12 @@ pub fn resolve_class_fields<'db>(
     class_loc: ClassLoc<'db>,
 ) -> Arc<ResolvedClassFields> {
     let file = class_loc.file(db);
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
     let pkg_id = PackageId::new(db, pkg_info.package.clone());
     let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
 
-    let class_data = &item_tree[class_loc.id(db)];
+    let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
+    let class_spans = baml_compiler2_ppir::item_data::class_source_map(db, class_loc);
     let field_scope = crate::lower_type_expr::ScopeCtx {
         db,
         package_items: pkg_items,
@@ -3231,13 +3324,17 @@ pub fn resolve_class_fields<'db>(
         .iter()
         .map(|f| {
             let ty = f
-                .type_expr
-                .as_ref()
-                .map(|te| {
+                .type_ref
+                .map(|id| {
                     let mut diags = Vec::new();
-                    let ty = crate::lower_type_expr::lower_type_expr(te, &field_scope, &mut diags);
+                    let ty = crate::lower_type_expr::lower_type_ref(
+                        &class_data.type_refs,
+                        id,
+                        &field_scope,
+                        &mut diags,
+                    );
                     for d in diags {
-                        all_diags.push((d, te.span));
+                        all_diags.push((d, class_spans.type_refs.span(id)));
                     }
                     ty
                 })
@@ -3285,20 +3382,20 @@ pub fn resolve_type_alias<'db>(
     alias_loc: TypeAliasLoc<'db>,
 ) -> Arc<ResolvedTypeAlias> {
     let file = alias_loc.file(db);
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
     let pkg_id = PackageId::new(db, pkg_info.package.clone());
     let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
 
-    let alias_data = &item_tree[alias_loc.id(db)];
+    let alias_data = baml_compiler2_ppir::item_data::type_alias_data(db, alias_loc);
+    let alias_spans = baml_compiler2_ppir::item_data::type_alias_source_map(db, alias_loc);
     let mut all_diags = Vec::new();
     let ty = alias_data
-        .type_expr
-        .as_ref()
-        .map(|te| {
+        .value
+        .map(|id| {
             let mut diags = Vec::new();
-            let ty = crate::lower_type_expr::lower_type_expr(
-                te,
+            let ty = crate::lower_type_expr::lower_type_ref(
+                &alias_data.type_refs,
+                id,
                 &crate::lower_type_expr::ScopeCtx {
                     db,
                     package_items: pkg_items,
@@ -3310,7 +3407,7 @@ pub fn resolve_type_alias<'db>(
                 &mut diags,
             );
             for d in diags {
-                all_diags.push((d, te.span));
+                all_diags.push((d, alias_spans.type_refs.span(id)));
             }
             ty
         })
@@ -3347,7 +3444,6 @@ pub fn render_scope_diagnostics<'db>(
     let file_scope = scope_id.file_scope_id(db);
     let index = baml_compiler2_ppir::file_semantic_index(db, file);
     let scope = &index.scopes[file_scope.index() as usize];
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
 
     let source_map = match &scope.kind {
         ScopeKind::Lambda => {
@@ -3364,15 +3460,23 @@ pub fn render_scope_diagnostics<'db>(
                 // The first Function/Let ancestor owns the body the lambda lives in.
                 let body_and_map = match owner {
                     baml_compiler2_ppir::item_data::ScopeOwner::Function(func_loc) => {
-                        match &item_tree[func_loc.id(db)].body {
-                            Some(baml_compiler2_ast::FunctionBodyDef::Expr(body, sm)) => {
-                                Some((body.clone(), sm.clone()))
+                        match baml_compiler2_ppir::function_body(db, func_loc).as_ref() {
+                            baml_compiler2_hir::body::FunctionBody::Expr(body) => {
+                                baml_compiler2_ppir::function_body_source_map(db, func_loc)
+                                    .map(|sm| (body.clone(), sm))
                             }
-                            _ => None,
+                            baml_compiler2_hir::body::FunctionBody::Builtin(_)
+                            | baml_compiler2_hir::body::FunctionBody::Missing => None,
                         }
                     }
                     baml_compiler2_ppir::item_data::ScopeOwner::Let(let_loc) => {
-                        item_tree[let_loc.id(db)].initializer.clone()
+                        match baml_compiler2_hir::body::let_body(db, let_loc).as_ref() {
+                            baml_compiler2_hir::body::LetBody::Expr(body) => {
+                                baml_compiler2_hir::body::let_body_source_map(db, let_loc)
+                                    .map(|sm| (body.clone(), sm))
+                            }
+                            baml_compiler2_hir::body::LetBody::Missing => None,
+                        }
                     }
                     _ => continue,
                 };

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
@@ -765,7 +765,7 @@ pub fn resolve_path_to_interface_identity<'db>(
     current_ns: &[Name],
 ) -> Option<ResolvedInterface<'db>> {
     let mut diagnostics = Vec::new();
-    let Ty::Interface(qtn, _, _, _) = crate::lower_type_expr::lower_type_expr(
+    let ty = crate::lower_type_expr::lower_type_expr(
         target,
         &crate::lower_type_expr::ScopeCtx {
             db,
@@ -776,7 +776,44 @@ pub fn resolve_path_to_interface_identity<'db>(
             self_ty: None,
         },
         &mut diagnostics,
-    ) else {
+    );
+    resolved_interface_from_ty(db, ty)
+}
+
+/// The `TypeRef`-arena twin of [`resolve_path_to_interface_identity`], for
+/// callers holding firewall data (`class_data(…).type_refs` + a `TypeRefId`)
+/// rather than an AST node. Identical resolution — it lowers through
+/// [`lower_type_ref`](crate::lower_type_expr::lower_type_ref) instead of
+/// `lower_type_expr`.
+pub fn resolve_ref_to_interface_identity<'db>(
+    db: &'db dyn crate::Db,
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    target: baml_compiler2_hir::type_ref::TypeRefId,
+    pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
+    current_ns: &[Name],
+) -> Option<ResolvedInterface<'db>> {
+    let mut diagnostics = Vec::new();
+    let ty = crate::lower_type_expr::lower_type_ref(
+        store,
+        target,
+        &crate::lower_type_expr::ScopeCtx {
+            db,
+            package_items: pkg_items,
+            ns_context: current_ns,
+            generic_params: &[],
+            bounds: &crate::lower_type_expr::TypeVarBoundsMap::default(),
+            self_ty: None,
+        },
+        &mut diagnostics,
+    );
+    resolved_interface_from_ty(db, ty)
+}
+
+/// Shared tail of the two `resolve_*_to_interface_identity` functions: a lowered
+/// type is an interface reference iff it lowered to `Ty::Interface`, whose `qtn`
+/// then resolves to a declaration.
+fn resolved_interface_from_ty(db: &dyn crate::Db, ty: Ty) -> Option<ResolvedInterface<'_>> {
+    let Ty::Interface(qtn, _, _, _) = ty else {
         return None;
     };
     let pkg_id = PackageId::new(db, qtn.package().clone());
@@ -797,6 +834,18 @@ pub fn resolve_path_to_interface<'db>(
     current_ns: &[Name],
 ) -> Option<baml_compiler2_hir::loc::InterfaceLoc<'db>> {
     resolve_path_to_interface_identity(db, target, pkg_items, current_ns)
+        .map(|resolved| resolved.loc)
+}
+
+/// The `TypeRef`-arena twin of [`resolve_path_to_interface`].
+pub fn resolve_ref_to_interface<'db>(
+    db: &'db dyn crate::Db,
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    target: baml_compiler2_hir::type_ref::TypeRefId,
+    pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
+    current_ns: &[Name],
+) -> Option<baml_compiler2_hir::loc::InterfaceLoc<'db>> {
+    resolve_ref_to_interface_identity(db, store, target, pkg_items, current_ns)
         .map(|resolved| resolved.loc)
 }
 

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
@@ -41,12 +41,13 @@ type InterfaceClosureQueueEntry<'db> = (
 struct InterfaceTypeAssocLowering<'a, 'db> {
     db: &'db dyn crate::Db,
     iface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
-    iface: &'a baml_compiler2_hir::item_tree::Interface,
+    iface: &'a baml_compiler2_ppir::item_data::InterfaceData<'db>,
     interface_args: &'a [Ty],
-    explicit_associated_bindings: &'a [baml_compiler2_ast::AssociatedTypeBinding],
-    iface_pkg_items: &'a baml_compiler2_hir::package::PackageItems<'db>,
+    explicit_associated_bindings: &'a [baml_compiler2_hir::type_ref::AssociatedTypeBindingRef],
+    /// The arena the explicit bindings' `ty` ids index — the *requiring* item's
+    /// `type_refs` (the bindings are written at the `requires` site).
+    binding_type_refs: &'a baml_compiler2_hir::type_ref::TypeRefStore,
     binding_pkg_items: &'a baml_compiler2_hir::package::PackageItems<'db>,
-    iface_namespace_path: &'a [Name],
     binding_namespace_path: &'a [Name],
     outer_bindings: &'a TypeBindings,
     /// The requiring interface as a constraint (its associated types pinned to the realized
@@ -138,10 +139,13 @@ fn carried_bound_satisfies(
 fn lower_interface_associated_bindings<'db>(
     db: &'db dyn crate::Db,
     iface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
-    iface: &baml_compiler2_hir::item_tree::Interface,
+    iface: &baml_compiler2_ppir::item_data::InterfaceData<'db>,
     interface_args: &[Ty],
     self_ty: &Ty,
-    block_associated_bindings: &[baml_compiler2_ast::AssociatedTypeBindingDef],
+    // The arena the block bindings' `type_ref` ids index — the impl block's own
+    // `type_refs` (the bindings are written in the block's source).
+    binding_type_refs: &baml_compiler2_hir::type_ref::TypeRefStore,
+    block_associated_bindings: &[baml_compiler2_ppir::item_data::AssociatedTypeBindingData],
     binding_pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
     binding_namespace_path: &[Name],
     generic_params: &[Name],
@@ -177,7 +181,7 @@ fn lower_interface_associated_bindings<'db>(
             let ty = if let Some(binding) = block_associated_bindings
                 .iter()
                 .find(|binding| binding.name == assoc.name)
-                && let Some(type_expr) = &binding.type_expr
+                && let Some(type_ref) = binding.type_ref
             {
                 let mut bounds = caller_bounds.clone();
                 if let Some(qtn) = &iface_qtn {
@@ -191,8 +195,9 @@ fn lower_interface_associated_bindings<'db>(
                     );
                 }
                 crate::generics::substitute_ty(
-                    &crate::lower_type_expr::lower_type_expr(
-                        type_expr,
+                    &crate::lower_type_expr::lower_type_ref(
+                        binding_type_refs,
+                        type_ref,
                         &crate::lower_type_expr::ScopeCtx {
                             db,
                             package_items: binding_pkg_items,
@@ -228,7 +233,7 @@ fn lower_interface_associated_bindings<'db>(
 fn complete_interface_associated_bindings_from_tys<'db>(
     db: &'db dyn crate::Db,
     iface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
-    iface: &baml_compiler2_hir::item_tree::Interface,
+    iface: &baml_compiler2_ppir::item_data::InterfaceData<'db>,
     interface_args: &[Ty],
     associated_bindings: &[(Name, Ty)],
     // When false, an unbound associated type is left absent rather than filled
@@ -312,10 +317,9 @@ pub(crate) fn interface_associated_type_default<'db>(
     iface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
     name: Name,
 ) -> Option<(Ty, Vec<crate::infer_context::TirTypeError>)> {
-    let item_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-    let iface = item_tree.interfaces.get(&iface_loc.id(db))?;
+    let iface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
     let assoc = iface.associated_types.iter().find(|a| a.name == name)?;
-    let default = assoc.default.as_ref()?;
+    let default = assoc.default?;
 
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, iface_loc.file(db));
     let pkg_items =
@@ -343,7 +347,8 @@ pub(crate) fn interface_associated_type_default<'db>(
         .collect();
 
     let mut diagnostics = Vec::new();
-    let lowered = crate::lower_type_expr::lower_type_expr(
+    let lowered = crate::lower_type_expr::lower_type_ref(
+        &iface.type_refs,
         default,
         &crate::lower_type_expr::ScopeCtx {
             db,
@@ -397,8 +402,7 @@ pub(crate) fn existential_associated_default(
         return None;
     };
     let (default, _diagnostics) = interface_associated_type_default(db, iface_loc, member.clone())?;
-    let item_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-    let iface = item_tree.interfaces.get(&iface_loc.id(db))?;
+    let iface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
     Some(realize_associated_default(
         &default,
         &iface.generic_params,
@@ -417,13 +421,8 @@ fn lower_interface_type_associated_bindings(
     }
     // The interface's declared parameter bounds, so a `T.member` projection in a
     // binding value or default resolves `T`'s declaring interface.
-    let iface_bounds = crate::lower_type_expr::lower_decl_generic_param_bounds(
-        ctx.db,
-        ctx.iface_pkg_items,
-        ctx.iface_namespace_path,
-        &ctx.iface.generic_params,
-        &ctx.iface.generic_param_bounds,
-    );
+    let iface_bounds =
+        crate::lower_type_expr::interface_generic_param_bounds(ctx.db, ctx.iface_loc);
 
     ctx.iface
         .associated_types
@@ -454,20 +453,26 @@ fn lower_interface_type_associated_bindings(
                         self_ty: Some(Ty::TypeVar(Name::new("Self"), TyAttr::default())),
                     };
                     generics::substitute_ty(
-                        &crate::lower_type_expr::lower_type_expr(&binding.ty, &scope, diagnostics),
+                        &crate::lower_type_expr::lower_type_ref(
+                            ctx.binding_type_refs,
+                            binding.ty,
+                            &scope,
+                            diagnostics,
+                        ),
                         &bindings,
                     )
                 } else {
                     let generic_params: Vec<_> = bindings.keys().cloned().collect();
                     crate::generics::substitute_ty(
-                        &crate::lower_type_expr::lower_type_expr(
-                            &binding.ty,
+                        &crate::lower_type_expr::lower_type_ref(
+                            ctx.binding_type_refs,
+                            binding.ty,
                             &crate::lower_type_expr::ScopeCtx {
                                 db: ctx.db,
                                 package_items: ctx.binding_pkg_items,
                                 ns_context: ctx.binding_namespace_path,
                                 generic_params: &generic_params,
-                                bounds: &iface_bounds,
+                                bounds: iface_bounds,
                                 self_ty: None,
                             },
                             diagnostics,
@@ -860,25 +865,22 @@ pub(crate) fn interface_requires_cycle<'db>(
     root: baml_compiler2_hir::loc::InterfaceLoc<'db>,
 ) -> Option<Vec<Name>> {
     let iface_name = |loc: baml_compiler2_hir::loc::InterfaceLoc<'db>| -> Name {
-        baml_compiler2_hir::file_item_tree(db, loc.file(db))
-            .interfaces
-            .get(&loc.id(db))
-            .map(|i| i.name.clone())
-            .unwrap_or_default()
+        baml_compiler2_ppir::item_data::interface_data(db, loc)
+            .name
+            .clone()
     };
     let required_locs =
         |loc: baml_compiler2_hir::loc::InterfaceLoc<'db>| -> Vec<baml_compiler2_hir::loc::InterfaceLoc<'db>> {
-            let tree = baml_compiler2_hir::file_item_tree(db, loc.file(db));
-            let Some(iface) = tree.interfaces.get(&loc.id(db)) else {
-                return Vec::new();
-            };
+            let iface = baml_compiler2_ppir::item_data::interface_data(db, loc);
             let pkg = baml_compiler2_hir::file_package::file_package(db, loc.file(db));
             let pkg_items =
                 baml_compiler2_ppir::package_items(db, PackageId::new(db, pkg.package.clone()));
             iface
                 .requires
                 .iter()
-                .filter_map(|p| resolve_path_to_interface(db, p, pkg_items, &pkg.namespace_path))
+                .filter_map(|&p| {
+                    resolve_ref_to_interface(db, &iface.type_refs, p, pkg_items, &pkg.namespace_path)
+                })
                 .collect()
         };
     let root_name = iface_name(root);
@@ -923,17 +925,18 @@ pub fn interface_closure_locs<'db>(
             continue;
         }
         out.push(loc);
-        let tree = baml_compiler2_hir::file_item_tree(db, loc.file(db));
-        let Some(iface) = tree.interfaces.get(&loc.id(db)) else {
-            continue;
-        };
+        let iface = baml_compiler2_ppir::item_data::interface_data(db, loc);
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, loc.file(db));
         let pkg_id = PackageId::new(db, pkg_info.package.clone());
         let parent_pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
-        for parent in &iface.requires {
-            if let Some(parent_loc) =
-                resolve_path_to_interface(db, parent, parent_pkg_items, &pkg_info.namespace_path)
-            {
+        for &parent in &iface.requires {
+            if let Some(parent_loc) = resolve_ref_to_interface(
+                db,
+                &iface.type_refs,
+                parent,
+                parent_pkg_items,
+                &pkg_info.namespace_path,
+            ) {
                 queue.push_back(parent_loc);
             }
         }
@@ -975,10 +978,7 @@ pub fn interface_closure_locs_with_args_and_assoc<'db>(
         if ancestors.contains(&loc) {
             continue;
         }
-        let tree = baml_compiler2_hir::file_item_tree(db, loc.file(db));
-        let Some(iface) = tree.interfaces.get(&loc.id(db)) else {
-            continue;
-        };
+        let iface = baml_compiler2_ppir::item_data::interface_data(db, loc);
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, loc.file(db));
         let pkg_id = PackageId::new(db, pkg_info.package.clone());
         let parent_pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
@@ -1012,21 +1012,26 @@ pub fn interface_closure_locs_with_args_and_assoc<'db>(
         // interface.
         let iface_bounds = crate::lower_type_expr::interface_generic_param_bounds(db, loc);
 
-        for parent in &iface.requires {
-            let Some(parent_loc) =
-                resolve_path_to_interface(db, parent, parent_pkg_items, &pkg_info.namespace_path)
-            else {
+        for &parent in &iface.requires {
+            let Some(parent_loc) = resolve_ref_to_interface(
+                db,
+                &iface.type_refs,
+                parent,
+                parent_pkg_items,
+                &pkg_info.namespace_path,
+            ) else {
                 continue;
             };
-            let parent_args = match &parent.kind {
-                baml_compiler2_ast::TypeExprKind::Path { generic_args, .. } => {
+            let parent_args = match &iface.type_refs[parent].kind {
+                baml_compiler2_hir::type_ref::TypeRefKind::Path { generic_args, .. } => {
                     let mut diags = Vec::new();
                     generic_args
                         .iter()
-                        .map(|arg| {
+                        .map(|&arg| {
                             let generic_params: Vec<_> = bindings.keys().cloned().collect();
                             crate::generics::substitute_ty(
-                                &crate::lower_type_expr::lower_type_expr(
+                                &crate::lower_type_expr::lower_type_ref(
+                                    &iface.type_refs,
                                     arg,
                                     &crate::lower_type_expr::ScopeCtx {
                                         db,
@@ -1045,26 +1050,15 @@ pub fn interface_closure_locs_with_args_and_assoc<'db>(
                 }
                 _ => Vec::new(),
             };
-            let parent_tree = baml_compiler2_hir::file_item_tree(db, parent_loc.file(db));
-            let Some(parent_iface) = parent_tree.interfaces.get(&parent_loc.id(db)) else {
-                continue;
-            };
-            let parent_pkg =
-                baml_compiler2_hir::file_package::file_package(db, parent_loc.file(db));
-            let parent_iface_pkg_id = PackageId::new(db, parent_pkg.package.clone());
-            let parent_iface_pkg_items =
-                baml_compiler2_ppir::package_items(db, parent_iface_pkg_id);
+            let parent_iface = baml_compiler2_ppir::item_data::interface_data(db, parent_loc);
             let (parent_explicit_assoc, parent_binding_ns): (
-                &[baml_compiler2_ast::AssociatedTypeBinding],
+                &[baml_compiler2_hir::type_ref::AssociatedTypeBindingRef],
                 &[Name],
-            ) = match &parent.kind {
-                baml_compiler2_ast::TypeExprKind::Path {
+            ) = match &iface.type_refs[parent].kind {
+                baml_compiler2_hir::type_ref::TypeRefKind::Path {
                     associated_type_bindings,
                     ..
-                } => (
-                    associated_type_bindings.as_slice(),
-                    &pkg_info.namespace_path,
-                ),
+                } => (associated_type_bindings, &pkg_info.namespace_path),
                 _ => (&[][..], &pkg_info.namespace_path),
             };
             let parent_assoc = lower_interface_type_associated_bindings(
@@ -1074,9 +1068,8 @@ pub fn interface_closure_locs_with_args_and_assoc<'db>(
                     iface: parent_iface,
                     interface_args: &parent_args,
                     explicit_associated_bindings: parent_explicit_assoc,
-                    iface_pkg_items: parent_iface_pkg_items,
+                    binding_type_refs: &iface.type_refs,
                     binding_pkg_items: parent_pkg_items,
-                    iface_namespace_path: &parent_pkg.namespace_path,
                     binding_namespace_path: parent_binding_ns,
                     outer_bindings: &bindings,
                     self_bound: self_bound.clone(),
@@ -1136,10 +1129,7 @@ pub fn interface_requires<'db>(
         &sub.associated_types,
         true,
     ) {
-        let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-        let Some(iface_data) = iface_tree.interfaces.get(&iface_loc.id(db)) else {
-            continue;
-        };
+        let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
         let iface_qtn = qualify_def(db, Definition::Interface(iface_loc), &iface_data.name);
         if iface_qtn == sup.name
             && iface_args.len() == sup.generics.len()

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -189,9 +189,7 @@ fn package_impls_with_spans<'db>(
         .iter()
         .filter_map(|&loc| {
             let data = impl_data(db, loc).as_ref().ok()?;
-            let span = impl_data_source_map(db, loc)
-                .as_ref()
-                .map(|sm| sm.impl_span)?;
+            let span = impl_data_source_map(db, loc).impl_span;
             Some((data, span))
         })
         .collect()
@@ -666,9 +664,7 @@ fn enum_variant_names(db: &dyn crate::Db, enum_qtn: &TypeName) -> Option<Vec<Nam
     else {
         return None;
     };
-    let file = enum_loc.file(db);
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-    let enum_data = &item_tree[enum_loc.id(db)];
+    let enum_data = baml_compiler2_ppir::item_data::enum_data(db, enum_loc);
     Some(enum_data.variants.iter().map(|v| v.name.clone()).collect())
 }
 

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -8,7 +8,7 @@ use crate::{
     generics::{contains_typevar, substitute_ty},
     interfaces::{
         InterfaceImplOrigin, TypeBindings, lower_interface_associated_bindings, match_ty_patterns,
-        normalized_arg_implements_bound, resolve_path_to_interface,
+        normalized_arg_implements_bound, resolve_ref_to_interface,
     },
     lower_type_expr::qualify_def,
     type_context::AliasEquivCtx,
@@ -144,13 +144,13 @@ pub struct ImplDataSourceMap {
 }
 
 /// The qualified name of a resolved interface loc (head identity for building a
-/// `Ty::Interface`). `None` only if the loc no longer points at an interface.
+/// `Ty::Interface`). Always `Some` for a genuine loc (the firewall lookup is
+/// total); the `Option` shape is kept for its many callers.
 pub fn interface_loc_qtn<'db>(
     db: &'db dyn crate::Db,
     iface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
 ) -> Option<QualifiedTypeName> {
-    let tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-    let data = tree.interfaces.get(&iface_loc.id(db))?;
+    let data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
     Some(qualify_def(
         db,
         Definition::Interface(iface_loc),
@@ -186,19 +186,22 @@ pub enum ImplDataError {
 
 /// Lower one generic param's bounds to its interface constraints, pushing both
 /// the lowering diagnostics and the non-interface-bound (E0142) diagnostics
-/// into `diags`. `generic_param_names` are the in-scope type-var names so a
+/// into `diags`. `store` is the arena the bound ids index (the declaring item's
+/// `type_refs`); `generic_param_names` are the in-scope type-var names so a
 /// bound naming a sibling param doesn't read as an unresolved type.
 fn lower_generic_param_interface_bounds(
     db: &dyn crate::Db,
-    bounds: &[&baml_compiler2_ast::TypeExpr],
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    bounds: &[baml_compiler2_hir::type_ref::TypeRefId],
     pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
     ns: &[Name],
     generic_param_names: &[Name],
     diags: &mut Vec<crate::infer_context::TirTypeError>,
 ) -> Vec<baml_type::Interface> {
     let mut ifaces = Vec::new();
-    for bound in bounds {
-        let ty = crate::lower_type_expr::lower_type_expr(
+    for &bound in bounds {
+        let ty = crate::lower_type_expr::lower_type_ref(
+            store,
             bound,
             &crate::lower_type_expr::ScopeCtx {
                 db,
@@ -279,14 +282,10 @@ pub fn impl_data<'db>(
     db: &'db dyn crate::Db,
     impl_loc: baml_compiler2_hir::loc::ImplLoc<'db>,
 ) -> Result<ImplData<'db>, ImplDataError> {
-    use baml_compiler2_hir::item_tree::ImplSubject;
+    use baml_compiler2_ppir::item_data::{ImplSubjectData, function_data, impl_block_data};
 
     let file = impl_loc.file(db);
-    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
-    let block = item_tree
-        .impls
-        .get(&impl_loc.id(db))
-        .ok_or(ImplDataError::Malformed)?;
+    let block = impl_block_data(db, impl_loc);
 
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
     let pkg_id = PackageId::new(db, pkg_info.package.clone());
@@ -307,13 +306,9 @@ pub fn impl_data<'db>(
         bound_diags,
         origin,
     ) = match &block.subject {
-        ImplSubject::InClass { class, out_of_body } => {
-            let class_data = item_tree
-                .classes
-                .get(class)
-                .ok_or(ImplDataError::Malformed)?;
-            let class_loc = baml_compiler2_hir::loc::ClassLoc::new(db, file, *class);
-            let class_qtn = qualify_def(db, Definition::Class(class_loc), &class_data.name);
+        ImplSubjectData::InClass { class, out_of_body } => {
+            let class_data = baml_compiler2_ppir::item_data::class_data(db, *class);
+            let class_qtn = qualify_def(db, Definition::Class(*class), &class_data.name);
             let for_ty = Ty::Class(
                 class_qtn.clone(),
                 class_data
@@ -335,9 +330,11 @@ pub fn impl_data<'db>(
                 .iter()
                 .zip(class_data.generic_param_bounds.iter())
                 .map(|(name, bound)| {
-                    let bounds: Vec<&baml_compiler2_ast::TypeExpr> = bound.iter().collect();
+                    let bounds: Vec<baml_compiler2_hir::type_ref::TypeRefId> =
+                        bound.iter().copied().collect();
                     let ifaces = lower_generic_param_interface_bounds(
                         db,
+                        &class_data.type_refs,
                         &bounds,
                         pkg_items,
                         ns,
@@ -364,7 +361,7 @@ pub fn impl_data<'db>(
                 },
             )
         }
-        ImplSubject::Free {
+        ImplSubjectData::Free {
             for_target,
             generics,
         } => {
@@ -376,8 +373,9 @@ pub fn impl_data<'db>(
             // `impl_data` via `impls_for_type` regardless of bounds; that cycle is
             // caught by `impl_data`'s `cycle_result` (→ `CyclicHeader`), so such
             // headers are illegal rather than a panic.
-            let for_ty = crate::lower_type_expr::lower_type_expr(
-                for_target,
+            let for_ty = crate::lower_type_expr::lower_type_ref(
+                &block.type_refs,
+                *for_target,
                 &crate::lower_type_expr::ScopeCtx {
                     db,
                     package_items: pkg_items,
@@ -402,10 +400,10 @@ pub fn impl_data<'db>(
             let generic_params = generics
                 .iter()
                 .map(|g| {
-                    let bounds: Vec<&baml_compiler2_ast::TypeExpr> = g.bounds.iter().collect();
                     let ifaces = lower_generic_param_interface_bounds(
                         db,
-                        &bounds,
+                        &block.type_refs,
+                        &g.bounds,
                         pkg_items,
                         ns,
                         &names,
@@ -426,8 +424,9 @@ pub fn impl_data<'db>(
     };
 
     let mut interface_target_diags = Vec::new();
-    let lowered_interface = crate::lower_type_expr::lower_type_expr(
-        &block.interface_target,
+    let lowered_interface = crate::lower_type_expr::lower_type_ref(
+        &block.type_refs,
+        block.interface_target,
         &crate::lower_type_expr::ScopeCtx {
             db,
             package_items: pkg_items,
@@ -448,7 +447,8 @@ pub fn impl_data<'db>(
     // target still surfaces its diagnostics (and the for-target / bound ones).
     // Associated bindings are skipped here — they can't be checked without the
     // interface declaration.
-    let Some(iface_loc) = resolve_path_to_interface(db, &block.interface_target, pkg_items, ns)
+    let Some(iface_loc) =
+        resolve_ref_to_interface(db, &block.type_refs, block.interface_target, pkg_items, ns)
     else {
         // The head didn't name an interface. If it resolved to a named non-interface type, that
         // is a specialized "not an interface" (E0119); otherwise the head is unknown, so the
@@ -481,11 +481,7 @@ pub fn impl_data<'db>(
             .collect();
         return Err(ImplDataError::InterfaceUnresolved { diagnostics });
     };
-    let iface_tree = baml_compiler2_hir::file_item_tree(db, iface_loc.file(db));
-    let iface_data = iface_tree
-        .interfaces
-        .get(&iface_loc.id(db))
-        .ok_or(ImplDataError::Malformed)?;
+    let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
 
     let mut assoc_diags = Vec::new();
     // The impl's own generic bounds, so a `T.member` projection in a binding value
@@ -498,6 +494,7 @@ pub fn impl_data<'db>(
         iface_data,
         &interface_args,
         &for_ty_pattern,
+        &block.type_refs,
         &block.associated_type_bindings,
         pkg_items,
         ns,
@@ -525,12 +522,12 @@ pub fn impl_data<'db>(
         let override_names: Vec<&Name> = block
             .methods
             .iter()
-            .map(|id| &item_tree[*id].name)
+            .map(|loc| &function_data(db, *loc).name)
             .collect();
         let default_names: Vec<&Name> = iface_data
             .default_methods
             .iter()
-            .map(|id| &iface_tree[*id].name)
+            .map(|loc| &function_data(db, *loc).name)
             .collect();
         // E0113: a required method with no override and no inherited default.
         for required in &iface_data.required_methods {
@@ -570,11 +567,10 @@ pub fn impl_data<'db>(
         // well-formedness (E0128/E0129/E0130) runs whenever links are present; field coverage
         // (E0124) runs when the interface declares fields.
         if let InterfaceImplOrigin::InBodyClass { class_qtn } = &origin
-            && let ImplSubject::InClass { class, .. } = &block.subject
+            && let ImplSubjectData::InClass { class, .. } = &block.subject
             && (!block.field_links.is_empty() || !iface_data.fields.is_empty())
         {
-            let class_loc = baml_compiler2_hir::loc::ClassLoc::new(db, file, *class);
-            let class_fields = crate::inference::resolve_class_fields(db, class_loc);
+            let class_fields = crate::inference::resolve_class_fields(db, *class);
             let is_iface_field =
                 |name: &Name| iface_data.fields.iter().any(|fld| fld.name == *name);
             let is_class_field =
@@ -713,10 +709,10 @@ pub fn impl_data<'db>(
         }
         // Bindings written on the `implements` target (`implements I<Item = …>`) instead of in
         // the block are rejected — the block's `type Name = …` is the only binding site.
-        if let baml_compiler2_ast::TypeExprKind::Path {
+        if let baml_compiler2_hir::type_ref::TypeRefKind::Path {
             associated_type_bindings,
             ..
-        } = &block.interface_target.kind
+        } = &block.type_refs[block.interface_target].kind
             && !associated_type_bindings.is_empty()
         {
             conformance_diags.push((
@@ -753,11 +749,7 @@ pub fn impl_data<'db>(
             )
             .collect();
 
-    let methods = block
-        .methods
-        .iter()
-        .map(|id| baml_compiler2_hir::loc::FunctionLoc::new(db, file, *id))
-        .collect();
+    let methods = block.methods.clone();
     let field_links = block
         .field_links
         .iter()
@@ -782,62 +774,68 @@ pub fn impl_data<'db>(
 pub fn impl_data_source_map<'db>(
     db: &'db dyn crate::Db,
     impl_loc: baml_compiler2_hir::loc::ImplLoc<'db>,
-) -> Option<ImplDataSourceMap> {
-    use baml_compiler2_hir::item_tree::ImplSubject;
+) -> ImplDataSourceMap {
+    use baml_compiler2_ppir::item_data::{
+        ImplSubjectData, function_data, function_source_map, impl_block_data, impl_block_source_map,
+    };
 
-    let file = impl_loc.file(db);
-    let file_id = file.file_id(db);
-    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
-    let block = item_tree.impls.get(&impl_loc.id(db))?;
+    let file_id = impl_loc.file(db).file_id(db);
+    let block = impl_block_data(db, impl_loc);
+    let spans = impl_block_source_map(db, impl_loc);
+    let interface_target_range = spans.type_refs.span(block.interface_target);
     // In-body impls attribute to the interface-target span; out-of-body to the
     // whole block span.
     let (impl_range, for_target_span) = match &block.subject {
-        ImplSubject::InClass { .. } => (block.interface_target.span, None),
-        ImplSubject::Free { for_target, .. } => {
-            (block.span, Some(Span::new(file_id, for_target.span)))
-        }
+        ImplSubjectData::InClass { .. } => (interface_target_range, None),
+        ImplSubjectData::Free { for_target, .. } => (
+            spans.span,
+            Some(Span::new(file_id, spans.type_refs.span(*for_target))),
+        ),
     };
     // Group all override spans by name so a same-named duplicate marks every occurrence.
     let mut method_spans: HashMap<Name, Vec<Span>> = HashMap::new();
-    for id in &block.methods {
-        let func = &item_tree[*id];
+    for &func_loc in &block.methods {
         method_spans
-            .entry(func.name.clone())
+            .entry(function_data(db, func_loc).name.clone())
             .or_default()
-            .push(Span::new(file_id, func.span));
+            .push(Span::new(file_id, function_source_map(db, func_loc).span));
     }
     // Group each field link's endpoint spans by name, so a per-name field-link diagnostic
     // (E0128/E0129/E0130) marks every link that mentions that name.
     let mut interface_field_link_spans: HashMap<Name, Vec<Span>> = HashMap::new();
     let mut class_field_link_spans: HashMap<Name, Vec<Span>> = HashMap::new();
-    for link in &block.field_links {
+    for (link, link_spans) in block.field_links.iter().zip(&spans.field_links) {
         interface_field_link_spans
             .entry(link.interface_field.clone())
             .or_default()
-            .push(Span::new(file_id, link.interface_field_span));
+            .push(Span::new(file_id, link_spans.interface_field_span));
         class_field_link_spans
             .entry(link.class_field.clone())
             .or_default()
-            .push(Span::new(file_id, link.class_field_span));
+            .push(Span::new(file_id, link_spans.class_field_span));
     }
     // Group each `type Name = …` binding's name span by name, so a per-name assoc-binding
     // diagnostic (unknown / duplicate / bound violation) marks every binding with that name.
     let mut associated_binding_spans: HashMap<Name, Vec<Span>> = HashMap::new();
-    for binding in &block.associated_type_bindings {
+    for (binding, binding_spans) in block
+        .associated_type_bindings
+        .iter()
+        .zip(&spans.associated_type_bindings)
+    {
         associated_binding_spans
             .entry(binding.name.clone())
             .or_default()
-            .push(Span::new(file_id, binding.name_span));
+            .push(Span::new(file_id, binding_spans.name_span));
     }
-    Some(ImplDataSourceMap {
+    ImplDataSourceMap {
         impl_span: Span::new(file_id, impl_range),
-        interface_target_span: Span::new(file_id, block.interface_target.span),
+        interface_target_span: Span::new(file_id, interface_target_range),
         for_target_span,
         method_spans,
         interface_field_link_spans,
         class_field_link_spans,
         associated_binding_spans,
-    })
+    }
 }
 
 /// Collect every `Ty::TypeVar` name in `ty` (at any depth) into `out` — used to decide which
@@ -901,13 +899,14 @@ fn method_generic_bound_interfaces(
     let empty = crate::lower_type_expr::TypeVarBoundsMap::default();
     spec.generic_bounds()
         .iter()
-        .map(|(name, bound_exprs)| {
-            let conjunction = bound_exprs
+        .map(|(name, bound_ids)| {
+            let conjunction = bound_ids
                 .iter()
-                .filter_map(|te| {
+                .filter_map(|&id| {
                     let mut d = Vec::new();
-                    crate::lower_type_expr::lower_type_expr(
-                        te,
+                    crate::lower_type_expr::lower_type_ref(
+                        spec.bound_store(),
+                        id,
                         &crate::lower_type_expr::ScopeCtx {
                             db,
                             package_items: pkg_items,
@@ -1017,7 +1016,9 @@ pub fn validate_impl_signatures<'db>(
     db: &'db dyn crate::Db,
     impl_loc: baml_compiler2_hir::loc::ImplLoc<'db>,
 ) -> Vec<(crate::infer_context::TirTypeError, ImplDiagnosticLocation)> {
-    use baml_compiler2_hir::item_tree::ImplSubject;
+    use baml_compiler2_ppir::item_data::{
+        ImplSubjectData, function_data, impl_block_data, interface_data,
+    };
 
     use crate::builder::interface_resolution::InterfaceMethodSpec;
 
@@ -1038,10 +1039,7 @@ pub fn validate_impl_signatures<'db>(
         return diags;
     };
     let file = impl_loc.file(db);
-    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
-    let Some(block) = item_tree.impls.get(&impl_loc.id(db)) else {
-        return diags;
-    };
+    let block = impl_block_data(db, impl_loc);
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
     let current_package = pkg_info.package.clone();
     let pkg_id = PackageId::new(db, pkg_info.package);
@@ -1058,10 +1056,7 @@ pub fn validate_impl_signatures<'db>(
         bounds: &bounds,
     };
 
-    let iface_tree = baml_compiler2_hir::file_item_tree(db, data.interface.file(db));
-    let Some(iface_data) = iface_tree.interfaces.get(&data.interface.id(db)) else {
-        return diags;
-    };
+    let iface_data = interface_data(db, data.interface);
     let iface_pkg_info =
         baml_compiler2_hir::file_package::file_package(db, data.interface.file(db));
     let iface_pkg_items =
@@ -1070,10 +1065,9 @@ pub fn validate_impl_signatures<'db>(
     // ── E0116: field-type conformance (in-body impls; out-of-body field impls are E0126). ──
     if !iface_data.fields.is_empty()
         && matches!(data.origin, InterfaceImplOrigin::InBodyClass { .. })
-        && let ImplSubject::InClass { class, .. } = &block.subject
+        && let ImplSubjectData::InClass { class, .. } = &block.subject
     {
-        let class_loc = baml_compiler2_hir::loc::ClassLoc::new(db, file, *class);
-        let class_fields = crate::inference::resolve_class_fields(db, class_loc);
+        let class_fields = crate::inference::resolve_class_fields(db, *class);
         let iface_field_bounds =
             crate::lower_type_expr::interface_generic_param_bounds(db, data.interface);
         // Realize the interface's declared field types at the impl's interface args.
@@ -1085,7 +1079,7 @@ pub fn validate_impl_signatures<'db>(
         let self_bound =
             baml_type::Interface::new(iface_qtn.clone(), data.interface_args.clone(), vec![]);
         for iface_field in &iface_data.fields {
-            let Some(iface_field_te) = &iface_field.type_expr else {
+            let Some(iface_field_ref) = iface_field.type_ref else {
                 continue;
             };
             // The satisfying class field: explicit link, else same name. Absent → E0124 (impl_data).
@@ -1112,7 +1106,12 @@ pub fn validate_impl_signatures<'db>(
                 &data.for_ty_pattern,
                 &iface_bindings,
                 |scope| {
-                    crate::lower_type_expr::lower_type_expr(iface_field_te, scope, &mut lower_diags)
+                    crate::lower_type_expr::lower_type_ref(
+                        &iface_data.type_refs,
+                        iface_field_ref,
+                        scope,
+                        &mut lower_diags,
+                    )
                 },
             );
             // Field types are invariant — the class field must be the same type.
@@ -1203,7 +1202,7 @@ pub fn validate_impl_signatures<'db>(
     let no_bindings = rustc_hash::FxHashMap::<Name, Ty>::default();
 
     for &method_loc in &data.methods {
-        let method_name = item_tree[method_loc.id(db)].name.clone();
+        let method_name = function_data(db, method_loc).name.clone();
 
         // The interface method this override targets: a required sig or a default's function.
         let iface_spec = if let Some(sig) = iface_data
@@ -1211,15 +1210,13 @@ pub fn validate_impl_signatures<'db>(
             .iter()
             .find(|m| m.name == method_name)
         {
-            InterfaceMethodSpec::from_required(sig)
-        } else if let Some(default_id) = iface_data
+            InterfaceMethodSpec::from_required(iface_data, sig)
+        } else if let Some(&default_loc) = iface_data
             .default_methods
             .iter()
-            .find(|id| iface_tree[**id].name == method_name)
+            .find(|loc| function_data(db, **loc).name == method_name)
         {
-            let loc =
-                baml_compiler2_hir::loc::FunctionLoc::new(db, data.interface.file(db), *default_id);
-            InterfaceMethodSpec::from_default(db, loc)
+            InterfaceMethodSpec::from_default(db, default_loc)
         } else {
             continue; // unknown member → E0115 (impl_data)
         };
@@ -1323,7 +1320,7 @@ pub fn validate_impl_signatures<'db>(
     // Cycle-safe here — `implements_interface` re-enters `impl_data`, never this phase-5 query. ──
     {
         let mut d = Vec::new();
-        for required_te in &iface_data.requires {
+        for &required_ref in &iface_data.requires {
             // A `requires` clause may project `Self.member` (`requires I<Item = Self.Item>`), so
             // realize it with `Self` bound to the implemented interface and `Self -> for_ty` last.
             let required = realize_with_symbolic_self(
@@ -1335,7 +1332,14 @@ pub fn validate_impl_signatures<'db>(
                 &self_bound,
                 &for_ty,
                 &iface_bindings,
-                |scope| crate::lower_type_expr::lower_type_expr(required_te, scope, &mut d),
+                |scope| {
+                    crate::lower_type_expr::lower_type_ref(
+                        &iface_data.type_refs,
+                        required_ref,
+                        scope,
+                        &mut d,
+                    )
+                },
             );
             // Reduce any `Self.member` projection in the realized obligation
             // (`(for_ty as I).X` -> the for-type's binding) so the associated pins below are
@@ -1420,8 +1424,8 @@ pub struct ResolvedImpl<'db> {
 
 /// Every `implements` block id declared in a package, as stable
 /// [`ImplLoc`](baml_compiler2_hir::loc::ImplLoc)s.
-/// Uniform over in-body and out-of-body impls (both live in
-/// [`file_item_tree`](baml_compiler2_hir::file_item_tree)`.impls`). Public so MIR can enumerate
+/// Uniform over in-body and out-of-body impls (both enumerated by
+/// [`file_impls`](baml_compiler2_ppir::item_data::file_impls)). Public so MIR can enumerate
 /// a package's impls to rebuild the runtime interface-implementor tables on the L1 substrate.
 ///
 /// Salsa-tracked: this walks *every file in the project* (to find the
@@ -1443,17 +1447,14 @@ pub fn package_impl_locs<'db>(
         if file_pkg != pkg_id {
             continue;
         }
-        let tree = baml_compiler2_hir::file_item_tree(db, file);
-        // The `impls` map is unordered; iterate in source order so the resolver's
+        // `file_impls` yields the blocks in source order, so the resolver's
         // "first full match" is reproducible (coherence guarantees ≤1 match, but
         // a stable order keeps a coherence-violating program from resolving
         // arbitrarily).
-        let mut file_impls: Vec<_> = tree.impls.iter().collect();
-        file_impls.sort_by_key(|(_, block)| block.span.start());
         out.extend(
-            file_impls
-                .into_iter()
-                .map(|(id, _)| baml_compiler2_hir::loc::ImplLoc::new(db, file, *id)),
+            baml_compiler2_ppir::item_data::file_impls(db, file)
+                .iter()
+                .copied(),
         );
     }
     out
@@ -2110,6 +2111,8 @@ impl<'db> ResolvedImpl<'db> {
     /// [`get_implements_block`] before calling here — never passing a
     /// sub-/super-interface of the one that declares the method.
     pub fn get_method(&self, db: &'db dyn crate::Db, method: &Name) -> Option<ResolvedMethod<'db>> {
+        use baml_compiler2_ppir::item_data::{function_data, interface_data};
+
         let data = impl_data(db, self.impl_loc).as_ref().ok()?;
 
         // The impl's own override — a free function, framed by the impl's
@@ -2117,8 +2120,7 @@ impl<'db> ResolvedImpl<'db> {
         // for-type/interface match left unbound (used only in a bound, say)
         // falls back to the top type, matching the prior resolver.
         for &func_loc in &data.methods {
-            let func_tree = baml_compiler2_hir::file_item_tree(db, func_loc.file(db));
-            if func_tree[func_loc.id(db)].name == *method {
+            if function_data(db, func_loc).name == *method {
                 let frame_type_args = data
                     .generic_params
                     .iter()
@@ -2140,21 +2142,16 @@ impl<'db> ResolvedImpl<'db> {
         }
 
         // The interface's default — framed by the realized interface input args.
-        let iface_tree = baml_compiler2_hir::file_item_tree(db, data.interface.file(db));
-        let iface_data = iface_tree.interfaces.get(&data.interface.id(db))?;
-        for &fn_id in &iface_data.default_methods {
-            if iface_tree[fn_id].name == *method {
+        let iface_data = interface_data(db, data.interface);
+        for &fn_loc in &iface_data.default_methods {
+            if function_data(db, fn_loc).name == *method {
                 let frame_type_args = data
                     .interface_args
                     .iter()
                     .map(|arg| substitute_ty(arg, &self.bindings))
                     .collect();
                 return Some(ResolvedMethod {
-                    method: baml_compiler2_hir::loc::FunctionLoc::new(
-                        db,
-                        data.interface.file(db),
-                        fn_id,
-                    ),
+                    method: fn_loc,
                     from_interface_default: true,
                     frame_type_args,
                 });

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -601,12 +601,10 @@ fn lower_path(
                         .map(|&ga| lower_type_ref(store, ga, ctx, diagnostics))
                         .collect();
 
-                    let class_tree = baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-                    let expected_type_args = class_tree
-                        .classes
-                        .get(&class_loc.id(db))
-                        .map(|class| class.generic_params.len())
-                        .unwrap_or(0);
+                    let expected_type_args =
+                        baml_compiler2_ppir::item_data::class_data(db, class_loc)
+                            .generic_params
+                            .len();
                     // A bare generic name (`generic_args.is_empty()`) is left
                     // unchecked here: it is a deliberate wildcard in several
                     // positions (`reflect.type_of<Box>()`, construction
@@ -653,12 +651,8 @@ fn lower_path(
                         .iter()
                         .map(|&ga| lower_type_ref(store, ga, ctx, diagnostics))
                         .collect();
-                    let iface_tree = baml_compiler2_ppir::file_item_tree(db, iface_loc.file(db));
-                    let expected_type_args = iface_tree
-                        .interfaces
-                        .get(&iface_loc.id(db))
-                        .map(|iface| iface.generic_params.len())
-                        .unwrap_or(0);
+                    let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
+                    let expected_type_args = iface_data.generic_params.len();
                     if !generic_args.is_empty() && generic_args.len() != expected_type_args {
                         diagnostics.push(TirTypeError::WrongNumberOfTypeArgs {
                             type_name: short.clone(),
@@ -666,17 +660,11 @@ fn lower_path(
                             got: generic_args.len(),
                         });
                     }
-                    let known_associated_types: FxHashSet<baml_base::Name> = iface_tree
-                        .interfaces
-                        .get(&iface_loc.id(db))
-                        .map(|iface| {
-                            iface
-                                .associated_types
-                                .iter()
-                                .map(|assoc| assoc.name.clone())
-                                .collect()
-                        })
-                        .unwrap_or_default();
+                    let known_associated_types: FxHashSet<baml_base::Name> = iface_data
+                        .associated_types
+                        .iter()
+                        .map(|assoc| assoc.name.clone())
+                        .collect();
                     let iface_qtn = qualify_def(db, def, short);
                     let mut seen_associated_bindings = FxHashSet::default();
                     let lowered_associated_bindings: Vec<(baml_base::Name, Ty)> =
@@ -715,20 +703,12 @@ fn lower_path(
                     // default (`type Items = Self.Item[]`) reduces against them. The
                     // default is lowered once — with a symbolic `Self` — by
                     // `interface_associated_type_default`, and substituted here.
-                    let (iface_generic_params, iface_assoc_names): (Vec<_>, Vec<_>) = iface_tree
-                        .interfaces
-                        .get(&iface_loc.id(db))
-                        .map(|iface| {
-                            (
-                                iface.generic_params.clone(),
-                                iface
-                                    .associated_types
-                                    .iter()
-                                    .map(|assoc| assoc.name.clone())
-                                    .collect(),
-                            )
-                        })
-                        .unwrap_or_default();
+                    let iface_generic_params = iface_data.generic_params.clone();
+                    let iface_assoc_names: Vec<_> = iface_data
+                        .associated_types
+                        .iter()
+                        .map(|assoc| assoc.name.clone())
+                        .collect();
                     let mut associated_bindings = lowered_associated_bindings;
                     for assoc_name in iface_assoc_names {
                         if associated_bindings.iter().any(|(n, _)| *n == assoc_name) {
@@ -822,8 +802,7 @@ fn lower_path(
                     // otherwise `Status.Typo` would silently produce a
                     // bogus `Ty::EnumVariant` and downstream code would
                     // never see `UnresolvedType`.
-                    let item_tree = baml_compiler2_ppir::file_item_tree(db, enum_loc.file(db));
-                    let enum_data = &item_tree[enum_loc.id(db)];
+                    let enum_data = baml_compiler2_ppir::item_data::enum_data(db, enum_loc);
                     if enum_data.variants.iter().any(|v| v.name == *variant) {
                         return Ty::EnumVariant(
                             qualify_def(db, def, enum_short),
@@ -905,25 +884,50 @@ pub fn qualify_def(
     QualifiedTypeName::new(pkg_info.package, pkg_info.namespace_path, name.clone())
 }
 
+/// [`crate::self_type::self_type_for_class`] for callers holding firewall
+/// [`ClassData`](baml_compiler2_ppir::item_data::ClassData) rather than a raw
+/// item-tree `Class` — the same receiver type (declared generics as `TypeVar`
+/// args, builtin-container sugar via
+/// [`receiver_type_for_class_at`](crate::self_type::receiver_type_for_class_at)).
+pub(crate) fn self_type_for_class_data(
+    class_data: &baml_compiler2_ppir::item_data::ClassData<'_>,
+    ns_path: &[baml_base::Name],
+    package: baml_base::Name,
+) -> Ty {
+    let qtn = QualifiedTypeName::new(package, ns_path.to_vec(), class_data.name.clone());
+    let args: Vec<Ty> = class_data
+        .generic_params
+        .iter()
+        .map(|p| Ty::TypeVar(p.clone(), TyAttr::default()))
+        .collect();
+    crate::self_type::receiver_type_for_class_at(qtn, args)
+}
+
 /// Lower a declaration's generic-parameter interface bounds to a [`TypeVarBoundsMap`],
-/// with unbounded parameters omitted. Delegates the per-bound lowering to
-/// [`crate::builder::lower_generic_param_bounds`] (every sibling parameter in scope, so a
-/// bound naming another parameter resolves); bound-lowering diagnostics are discarded — the
-/// declaration's bounds are checked where the declaration is, not here.
+/// with unbounded parameters omitted — for callers holding firewall data
+/// (`class_data` / `interface_data` / `function_data`), whose bounds are
+/// [`TypeRefId`](baml_compiler2_hir::type_ref::TypeRefId)s into the item's own
+/// store. Delegates the per-bound lowering to
+/// [`crate::builder::lower_generic_param_bound_refs`] (every sibling parameter
+/// in scope, so a bound naming another parameter resolves); bound-lowering
+/// diagnostics are discarded — the declaration's bounds are checked where the
+/// declaration is, not here.
 ///
 /// Each bound is kept as a [`baml_type::Interface`] *constraint* (a bare `T extends Iterator`
 /// pins no associated types), never a [`Ty::Interface`] existential; a bound that does not
 /// lower to an interface is dropped.
-pub(crate) fn lower_decl_generic_param_bounds(
+pub(crate) fn lower_decl_generic_param_bound_refs(
     db: &dyn crate::Db,
     package_items: &PackageItems<'_>,
     ns_context: &[baml_base::Name],
     generic_params: &[baml_base::Name],
-    generic_param_bounds: &[Option<TypeExpr>],
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    generic_param_bounds: &[Option<baml_compiler2_hir::type_ref::TypeRefId>],
 ) -> TypeVarBoundsMap {
     let mut diagnostics = Vec::new();
-    crate::builder::lower_generic_param_bounds(
+    crate::builder::lower_generic_param_bound_refs(
         db,
+        store,
         generic_param_bounds,
         package_items,
         ns_context,
@@ -949,18 +953,16 @@ pub fn class_generic_param_bounds<'db>(
     class_loc: baml_compiler2_hir::loc::ClassLoc<'db>,
 ) -> TypeVarBoundsMap {
     let file = class_loc.file(db);
-    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
-    let Some(class) = item_tree.classes.get(&class_loc.id(db)) else {
-        return TypeVarBoundsMap::default();
-    };
+    let class = baml_compiler2_ppir::item_data::class_data(db, class_loc);
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
     let package_items =
         baml_compiler2_ppir::package_items(db, PackageId::new(db, pkg_info.package.clone()));
-    lower_decl_generic_param_bounds(
+    lower_decl_generic_param_bound_refs(
         db,
         package_items,
         &pkg_info.namespace_path,
         &class.generic_params,
+        &class.type_refs,
         &class.generic_param_bounds,
     )
 }
@@ -972,18 +974,16 @@ pub fn interface_generic_param_bounds<'db>(
     interface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
 ) -> TypeVarBoundsMap {
     let file = interface_loc.file(db);
-    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
-    let Some(interface) = item_tree.interfaces.get(&interface_loc.id(db)) else {
-        return TypeVarBoundsMap::default();
-    };
+    let interface = baml_compiler2_ppir::item_data::interface_data(db, interface_loc);
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
     let package_items =
         baml_compiler2_ppir::package_items(db, PackageId::new(db, pkg_info.package.clone()));
-    lower_decl_generic_param_bounds(
+    lower_decl_generic_param_bound_refs(
         db,
         package_items,
         &pkg_info.namespace_path,
         &interface.generic_params,
+        &interface.type_refs,
         &interface.generic_param_bounds,
     )
 }
@@ -999,10 +999,6 @@ pub fn function_in_scope_generic_param_bounds<'db>(
     function_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
 ) -> TypeVarBoundsMap {
     let file = function_loc.file(db);
-    // PPIR's tree is the canonical one (it includes synthesized companions);
-    // reading HIR's here while the owner index reads PPIR's would mix the two.
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-    let function_id = function_loc.id(db);
     let mut bounds = TypeVarBoundsMap::default();
     match baml_compiler2_ppir::item_data::method_owner(db, function_loc) {
         Some(baml_compiler2_ppir::item_data::MethodOwner::Class(class_loc)) => {
@@ -1013,7 +1009,7 @@ pub fn function_in_scope_generic_param_bounds<'db>(
             );
         }
         Some(baml_compiler2_ppir::item_data::MethodOwner::Interface(iface_loc)) => {
-            let interface = &item_tree[iface_loc.id(db)];
+            let interface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
             bounds.extend(
                 interface_generic_param_bounds(db, iface_loc)
                     .iter()
@@ -1055,18 +1051,18 @@ pub fn function_in_scope_generic_param_bounds<'db>(
         }
         None => {}
     }
-    if let Some(function) = item_tree.functions.get(&function_id) {
-        let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
-        let package_items =
-            baml_compiler2_ppir::package_items(db, PackageId::new(db, pkg_info.package.clone()));
-        bounds.extend(lower_decl_generic_param_bounds(
-            db,
-            package_items,
-            &pkg_info.namespace_path,
-            &function.generic_params,
-            &function.generic_param_bounds,
-        ));
-    }
+    let function = baml_compiler2_ppir::item_data::function_data(db, function_loc);
+    let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
+    let package_items =
+        baml_compiler2_ppir::package_items(db, PackageId::new(db, pkg_info.package.clone()));
+    bounds.extend(lower_decl_generic_param_bound_refs(
+        db,
+        package_items,
+        &pkg_info.namespace_path,
+        &function.generic_params,
+        &function.type_refs,
+        &function.generic_param_bounds,
+    ));
     bounds
 }
 
@@ -1583,19 +1579,18 @@ mod tests {
         else {
             panic!("Iterator interface should resolve");
         };
-        let file = iface_loc.file(&db);
-        let tree = baml_compiler2_hir::file_item_tree(&db, file);
-        let iface_data = tree
-            .interfaces
-            .get(&iface_loc.id(&db))
-            .expect("Iterator item-tree data");
-        let fn_id = iface_data
+        let iface_data = baml_compiler2_ppir::item_data::interface_data(&db, iface_loc);
+        let fn_loc = iface_data
             .default_methods
             .iter()
             .copied()
-            .find(|&id| tree[id].name.as_str() == "first")
+            .find(|&loc| {
+                baml_compiler2_ppir::item_data::function_data(&db, loc)
+                    .name
+                    .as_str()
+                    == "first"
+            })
             .expect("`first` default method");
-        let fn_loc = baml_compiler2_hir::loc::FunctionLoc::new(&db, file, fn_id);
         let scope_id = baml_compiler2_ppir::item_data::function_scope(&db, fn_loc)
             .expect("`first`'s body scope");
 

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -290,7 +290,7 @@ struct LoweredClassMethodSignature {
 fn lower_class_method_signature<'db>(
     db: &'db dyn crate::Db,
     pkg_items: &PackageItems<'db>,
-    class_data: &baml_compiler2_hir::item_tree::Class,
+    class_data: &baml_compiler2_ppir::item_data::ClassData<'db>,
     method_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
     ns_path: &[Name],
     diags: &mut Vec<TirTypeError>,
@@ -305,7 +305,7 @@ fn lower_class_method_signature<'db>(
     // `Self` is the enclosing class's full receiver type (`Foo<T>`, or `Array<T>`→`List<T>`
     // for the builtin containers) — resolved through the lowering context, not erased to a
     // bare `Ty::Class` by a name-substitution pre-pass.
-    let self_ty = crate::self_type::self_type_for_class(
+    let self_ty = crate::lower_type_expr::self_type_for_class_data(
         class_data,
         ns_path,
         file_package::file_package(db, method_loc.file(db)).package,
@@ -387,8 +387,7 @@ fn lower_class_export<'db>(
     class_loc: ClassLoc<'db>,
     name: &Name,
 ) -> ExportedType {
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-    let class_data = &item_tree[class_loc.id(db)];
+    let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
     let class_ns = file_package::file_package(db, class_loc.file(db)).namespace_path;
 
     // Lower fields. The class's type-variable bounds let an associated-type
@@ -404,8 +403,13 @@ fn lower_class_export<'db>(
     let mut fields = Vec::new();
     let mut diags = Vec::new();
     for field in &class_data.fields {
-        if let Some(te) = &field.type_expr {
-            let field_ty = crate::lower_type_expr::lower_type_expr(te, &field_scope, &mut diags);
+        if let Some(type_ref) = field.type_ref {
+            let field_ty = crate::lower_type_expr::lower_type_ref(
+                &class_data.type_refs,
+                type_ref,
+                &field_scope,
+                &mut diags,
+            );
             fields.push((field.name.clone(), field_ty));
         } else {
             fields.push((
@@ -419,10 +423,8 @@ fn lower_class_export<'db>(
 
     // Lower methods
     let mut methods = Vec::new();
-    for method_id in &class_data.methods {
-        let method_loc =
-            baml_compiler2_hir::loc::FunctionLoc::new(db, class_loc.file(db), *method_id);
-        let method_data = &item_tree[*method_id];
+    for &method_loc in &class_data.methods {
+        let method_data = baml_compiler2_ppir::item_data::function_data(db, method_loc);
         let lowered = lower_class_method_signature(
             db, pkg_items, class_data, method_loc, &class_ns, &mut diags,
         );
@@ -453,8 +455,7 @@ fn lower_enum_export<'db>(
     enum_loc: EnumLoc<'db>,
     name: &Name,
 ) -> ExportedType {
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, enum_loc.file(db));
-    let enum_data = &item_tree[enum_loc.id(db)];
+    let enum_data = baml_compiler2_ppir::item_data::enum_data(db, enum_loc);
     let qtn = qualify_def(db, Definition::Enum(enum_loc), name);
     ExportedType::Enum {
         qtn,
@@ -469,16 +470,15 @@ fn lower_alias_export<'db>(
     ta_loc: TypeAliasLoc<'db>,
     name: &Name,
 ) -> ExportedType {
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, ta_loc.file(db));
-    let ta_data = &item_tree[ta_loc.id(db)];
+    let ta_data = baml_compiler2_ppir::item_data::type_alias_data(db, ta_loc);
     let ta_ns = file_package::file_package(db, ta_loc.file(db)).namespace_path;
     let mut diags = Vec::new();
     let resolved = ta_data
-        .type_expr
-        .as_ref()
-        .map(|te| {
-            crate::lower_type_expr::lower_type_expr(
-                te,
+        .value
+        .map(|id| {
+            crate::lower_type_expr::lower_type_ref(
+                &ta_data.type_refs,
+                id,
                 &crate::lower_type_expr::ScopeCtx {
                     db,
                     package_items: pkg_items,
@@ -577,14 +577,11 @@ pub fn file_callable_throws_fragment(
     db: &dyn crate::Db,
     file: SourceFile,
 ) -> CallableThrowsFragment {
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
-    let by_id = item_tree
-        .functions
-        .keys()
-        .map(|local_id| {
-            let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, *local_id);
+    let by_id = baml_compiler2_ppir::item_data::file_functions(db, file)
+        .iter()
+        .map(|&func_loc| {
             (
-                local_id.as_u32(),
+                func_loc.id(db).as_u32(),
                 crate::callable::callable_throws(db, func_loc).clone(),
             )
         })
@@ -982,8 +979,7 @@ impl<'db> PackageResolutionContext<'db> {
         let Definition::Class(class_loc) = def else {
             return Vec::new();
         };
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-        let class_data = &item_tree[class_loc.id(db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
         let ns = file_package::file_package(db, class_loc.file(db)).namespace_path;
         let field_scope = crate::lower_type_expr::ScopeCtx {
             db,
@@ -996,9 +992,13 @@ impl<'db> PackageResolutionContext<'db> {
         let mut diags = Vec::new();
         let mut fields = Vec::new();
         for field in &class_data.fields {
-            if let Some(te) = &field.type_expr {
-                let field_ty =
-                    crate::lower_type_expr::lower_type_expr(te, &field_scope, &mut diags);
+            if let Some(type_ref) = field.type_ref {
+                let field_ty = crate::lower_type_expr::lower_type_ref(
+                    &class_data.type_refs,
+                    type_ref,
+                    &field_scope,
+                    &mut diags,
+                );
                 fields.push((field.name.clone(), field_ty));
             } else {
                 fields.push((
@@ -1024,18 +1024,15 @@ impl<'db> PackageResolutionContext<'db> {
         let Definition::Class(class_loc) = def else {
             return None;
         };
-        let item_tree = baml_compiler2_ppir::file_item_tree(db, class_loc.file(db));
-        let class_data = &item_tree[class_loc.id(db)];
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
         let ns = file_package::file_package(db, class_loc.file(db)).namespace_path;
         let mut diags = Vec::new();
 
-        for method_id in &class_data.methods {
-            let method_data = &item_tree[*method_id];
+        for &method_loc in &class_data.methods {
+            let method_data = baml_compiler2_ppir::item_data::function_data(db, method_loc);
             if &method_data.name != method_name {
                 continue;
             }
-            let method_loc =
-                baml_compiler2_hir::loc::FunctionLoc::new(db, class_loc.file(db), *method_id);
             let lowered = lower_class_method_signature(
                 db,
                 &self.own_items,
@@ -1066,26 +1063,18 @@ impl<'db> PackageResolutionContext<'db> {
 /// Convert a Definition to Ty (own-package path).
 fn def_to_ty<'db>(db: &'db dyn crate::Db, def: Definition<'db>) -> Ty {
     let name = match def {
-        Definition::Class(loc) => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, loc.file(db));
-            let data = &item_tree[loc.id(db)];
-            data.name.clone()
-        }
-        Definition::Enum(loc) => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, loc.file(db));
-            let data = &item_tree[loc.id(db)];
-            data.name.clone()
-        }
-        Definition::Interface(loc) => {
-            let item_tree = baml_compiler2_hir::file_item_tree(db, loc.file(db));
-            let data = &item_tree[loc.id(db)];
-            data.name.clone()
-        }
-        Definition::TypeAlias(loc) => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, loc.file(db));
-            let data = &item_tree[loc.id(db)];
-            data.name.clone()
-        }
+        Definition::Class(loc) => baml_compiler2_ppir::item_data::class_data(db, loc)
+            .name
+            .clone(),
+        Definition::Enum(loc) => baml_compiler2_ppir::item_data::enum_data(db, loc)
+            .name
+            .clone(),
+        Definition::Interface(loc) => baml_compiler2_ppir::item_data::interface_data(db, loc)
+            .name
+            .clone(),
+        Definition::TypeAlias(loc) => baml_compiler2_ppir::item_data::type_alias_data(db, loc)
+            .name
+            .clone(),
         _ => {
             return Ty::Unknown {
                 attr: TyAttr::default(),
@@ -1097,8 +1086,7 @@ fn def_to_ty<'db>(db: &'db dyn crate::Db, def: Definition<'db>) -> Ty {
             // Declared generics live on the type as `TypeVar` args, matching
             // `ExportedType::to_ty` so own-package and dependency resolution
             // produce the same `Ty::Class(qtn, [TypeVar…])` shape.
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, loc.file(db));
-            let args = item_tree[loc.id(db)]
+            let args = baml_compiler2_ppir::item_data::class_data(db, loc)
                 .generic_params
                 .iter()
                 .map(|p| Ty::TypeVar(p.clone(), TyAttr::default()))

--- a/baml_language/crates/baml_compiler2_tir/src/resolve.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/resolve.rs
@@ -263,8 +263,7 @@ pub fn resolve_enum_variant(
     let Definition::Enum(enum_loc) = def else {
         return false;
     };
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, enum_loc.file(db));
-    item_tree[enum_loc.id(db)]
+    baml_compiler2_ppir::item_data::enum_data(db, enum_loc)
         .variants
         .iter()
         .any(|v| v.name == *variant)
@@ -291,20 +290,14 @@ pub fn resolve_field(
         return false;
     };
     match def {
-        Definition::Class(loc) => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, loc.file(db));
-            item_tree[loc.id(db)]
-                .fields
-                .iter()
-                .any(|f| f.name == *field)
-        }
-        Definition::Interface(loc) => {
-            let item_tree = baml_compiler2_ppir::file_item_tree(db, loc.file(db));
-            item_tree[loc.id(db)]
-                .fields
-                .iter()
-                .any(|f| f.name == *field)
-        }
+        Definition::Class(loc) => baml_compiler2_ppir::item_data::class_data(db, loc)
+            .fields
+            .iter()
+            .any(|f| f.name == *field),
+        Definition::Interface(loc) => baml_compiler2_ppir::item_data::interface_data(db, loc)
+            .fields
+            .iter()
+            .any(|f| f.name == *field),
         _ => false,
     }
 }

--- a/baml_language/crates/baml_compiler2_tir/src/signature.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/signature.rs
@@ -23,24 +23,38 @@
 //! specialize — never in this lowering.
 
 use baml_base::Name;
-use baml_compiler2_ast::TypeExpr;
+use baml_compiler2_hir::type_ref::{TypeRefBuilder, TypeRefId, TypeRefKind, TypeRefStore};
 
 use crate::{
     infer_context::TirTypeError,
-    lower_type_expr::{TypeExprContext, lower_type_expr},
+    lower_type_expr::{TypeExprContext, lower_type_ref},
     ty::{FunctionParamMode, FunctionParamTy, Ty, TyAttr},
 };
+
+/// One type slot in a [`DeclaredSignature`] — a written type, or one of the two
+/// slots the declaration leaves implicit.
+#[derive(Debug, Clone, Copy)]
+pub enum SigTypeRef {
+    /// A written type: an id into the signature's arena.
+    Id(TypeRefId),
+    /// The `self` receiver, desugared to `self: Self` — lowers as the `Self` path.
+    SelfReceiver,
+    /// No written type — lowers to `unknown`.
+    Missing,
+}
 
 /// A callable's declared, type-bearing signature: positional (required) args, keyword
 /// (optional) args, and the return + throws types. The whole of what the enclosing generic
 /// parameters and `Self` inform.
 pub struct DeclaredSignature<'a> {
+    /// The arena every [`SigTypeRef::Id`] below indexes.
+    pub type_refs: &'a TypeRefStore,
     /// Positional parameters, in declaration order (each required).
-    pub positional: Vec<(Option<Name>, &'a TypeExpr)>,
+    pub positional: Vec<(Option<Name>, SigTypeRef)>,
     /// Keyword parameters (each optional — has a default).
-    pub keyword: Vec<(Option<Name>, &'a TypeExpr)>,
-    pub return_type: &'a TypeExpr,
-    pub throws: &'a TypeExpr,
+    pub keyword: Vec<(Option<Name>, SigTypeRef)>,
+    pub return_type: SigTypeRef,
+    pub throws: SigTypeRef,
 }
 
 /// A function type *constructor* — the same data as a `Ty::Function`, but held in its own type
@@ -82,6 +96,23 @@ pub fn lower_signature(
     ctx: &dyn TypeExprContext<'_>,
     diagnostics: &mut Vec<TirTypeError>,
 ) -> FunctionTypeConstructor {
+    // The two implicit slots, synthesized into a scratch arena so they lower
+    // through the same path as written types (`Self` resolves via the context's
+    // `self_ty`, `unknown` via the ordinary `Unknown` arm).
+    let mut scratch = TypeRefBuilder::new();
+    let self_id = scratch.alloc_synthetic(TypeRefKind::Path {
+        segments: vec![Name::new("Self")],
+        generic_args: Box::new([]),
+        associated_type_bindings: Box::new([]),
+    });
+    let unknown_id = scratch.alloc_synthetic(TypeRefKind::Unknown);
+    let (scratch_store, _) = scratch.finish();
+    let lower = |slot: SigTypeRef, diagnostics: &mut Vec<TirTypeError>| match slot {
+        SigTypeRef::Id(id) => lower_type_ref(sig.type_refs, id, ctx, diagnostics),
+        SigTypeRef::SelfReceiver => lower_type_ref(&scratch_store, self_id, ctx, diagnostics),
+        SigTypeRef::Missing => lower_type_ref(&scratch_store, unknown_id, ctx, diagnostics),
+    };
+
     let params = sig
         .positional
         .iter()
@@ -91,16 +122,16 @@ pub fn lower_signature(
                 .iter()
                 .map(|(name, ty)| (name, ty, FunctionParamMode::Optional)),
         )
-        .map(|(name, ty, mode)| FunctionParamTy {
+        .map(|(name, &ty, mode)| FunctionParamTy {
             name: name.clone(),
-            ty: lower_type_expr(ty, ctx, diagnostics),
+            ty: lower(ty, diagnostics),
             mode,
         })
         .collect();
     FunctionTypeConstructor {
         params,
-        ret: Box::new(lower_type_expr(sig.return_type, ctx, diagnostics)),
-        throws: Box::new(lower_type_expr(sig.throws, ctx, diagnostics)),
+        ret: Box::new(lower(sig.return_type, diagnostics)),
+        throws: Box::new(lower(sig.throws, diagnostics)),
         attr: TyAttr::default(),
     }
 }

--- a/baml_language/crates/baml_compiler2_tir/src/throw_inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throw_inference.rs
@@ -115,35 +115,36 @@ pub fn file_throw_facts(db: &dyn crate::Db, file: baml_base::SourceFile) -> File
     let pkg_id = PackageId::new(db, pkg_info.package.clone());
     let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
     let func_ns = pkg_info.namespace_path;
-    let item_tree = baml_compiler2_ppir::file_item_tree(db, file);
 
     // Class methods (including `implements`-block methods, which
     // `class_data.methods` flattens in) and interface default methods are
     // not top-level solver entries under their own names.
     let mut member_ids = std::collections::HashSet::new();
-    for class_data in item_tree.classes.values() {
+    for class_loc in baml_compiler2_ppir::item_data::file_classes(db, file) {
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, *class_loc);
         member_ids.extend(class_data.methods.iter().copied());
     }
-    for iface_data in item_tree.interfaces.values() {
+    for iface_loc in baml_compiler2_ppir::item_data::file_interfaces(db, file) {
+        let iface_data = baml_compiler2_ppir::item_data::interface_data(db, *iface_loc);
         member_ids.extend(iface_data.default_methods.iter().copied());
     }
     // Out-of-body `implement<…> I for Y { … }` blocks: their methods dispatch
     // through the interface registry and were never solver nodes under their
     // bare names. (In-body `implements` methods are already covered above —
     // `class_data.methods` flattens them in.)
-    for impl_id in &item_tree.free_impls {
-        if let Some(block) = item_tree.impls.get(impl_id) {
-            member_ids.extend(block.methods.iter().copied());
-        }
+    for impl_loc in baml_compiler2_ppir::item_data::file_free_impls(db, file) {
+        let block = baml_compiler2_ppir::item_data::impl_block_data(db, *impl_loc);
+        member_ids.extend(block.methods.iter().copied());
     }
 
     let mut out = Vec::new();
 
-    for (local_id, func_data) in &item_tree.functions {
-        if member_ids.contains(local_id) {
+    for func_loc in baml_compiler2_ppir::item_data::file_functions(db, file) {
+        if member_ids.contains(func_loc) {
             continue;
         }
-        let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, *local_id);
+        let func_loc = *func_loc;
+        let func_data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
         let short_name = &func_data.name;
         let key = function_key(db, func_loc, short_name);
 
@@ -153,6 +154,7 @@ pub fn file_throw_facts(db: &dyn crate::Db, file: baml_base::SourceFile) -> File
             &func_ns,
             func_loc,
             &func_data.generic_params,
+            &func_data.type_refs,
             &func_data.params,
         );
 
@@ -172,12 +174,12 @@ pub fn file_throw_facts(db: &dyn crate::Db, file: baml_base::SourceFile) -> File
         });
     }
 
-    for class_data in item_tree.classes.values() {
+    for class_loc in baml_compiler2_ppir::item_data::file_classes(db, file) {
+        let class_data = baml_compiler2_ppir::item_data::class_data(db, *class_loc);
         let class_name = &class_data.name;
-        for &method_id in &class_data.methods {
-            let method_data = &item_tree[method_id];
+        for &func_loc in &class_data.methods {
+            let method_data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
             let method_name = &method_data.name;
-            let func_loc = baml_compiler2_hir::loc::FunctionLoc::new(db, file, method_id);
             // Key as "ClassName.method_name" (with namespace prefix if any).
             let method_short = Name::new(format!("{class_name}.{method_name}"));
             let key = function_key(db, func_loc, &method_short);
@@ -188,6 +190,7 @@ pub fn file_throw_facts(db: &dyn crate::Db, file: baml_base::SourceFile) -> File
                 &func_ns,
                 func_loc,
                 &method_data.generic_params,
+                &method_data.type_refs,
                 &method_data.params,
             );
 
@@ -341,7 +344,8 @@ fn extract_direct_and_declared<'db>(
     ns_context: &[Name],
     func_loc: baml_compiler2_hir::loc::FunctionLoc<'db>,
     generic_params: &[Name],
-    params: &[baml_compiler2_hir::item_tree::FunctionParam],
+    type_refs: &baml_compiler2_hir::type_ref::TypeRefStore,
+    params: &[baml_compiler2_ppir::item_data::FunctionParamData],
 ) -> (BTreeSet<ThrowFact>, bool) {
     let sig = baml_compiler2_ppir::function_signature(db, func_loc);
     let body = baml_compiler2_ppir::function_body(db, func_loc);
@@ -375,6 +379,7 @@ fn extract_direct_and_declared<'db>(
             ns_context,
             generic_params,
             crate::lower_type_expr::function_in_scope_generic_param_bounds(db, func_loc),
+            type_refs,
             params,
         );
         collect_direct_throws(db, pkg_items, ns_context, func_loc, expr_body, &param_types)
@@ -456,15 +461,17 @@ fn lower_param_types<'db>(
     ns_context: &[Name],
     generic_params: &[Name],
     bounds: &crate::lower_type_expr::TypeVarBoundsMap,
-    params: &[baml_compiler2_hir::item_tree::FunctionParam],
+    type_refs: &baml_compiler2_hir::type_ref::TypeRefStore,
+    params: &[baml_compiler2_ppir::item_data::FunctionParamData],
 ) -> Vec<(Name, Ty)> {
     params
         .iter()
         .filter_map(|param| {
-            let type_expr = param.type_expr.as_ref()?;
+            let type_ref = param.type_ref?;
             let mut diags = Vec::new();
-            let ty = crate::lower_type_expr::lower_type_expr(
-                type_expr,
+            let ty = crate::lower_type_expr::lower_type_ref(
+                type_refs,
+                type_ref,
                 &crate::lower_type_expr::ScopeCtx {
                     db,
                     package_items: pkg_items,

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -429,7 +429,8 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
             let parameter_defaults =
                 baml_compiler2_hir::signature::function_parameter_defaults(db, func_loc);
             builder.check_function_parameter_defaults(
-                &func_data.params,
+                &baml_compiler2_ppir::item_data::function_data(db, func_loc).params,
+                &baml_compiler2_ppir::item_data::function_source_map(db, func_loc).param_spans,
                 &parameter_defaults,
                 &param_types,
             );
@@ -594,13 +595,8 @@ fn check_interfaces(db: &dyn Db, file: SourceFile, file_id: FileId) -> Vec<Diagn
     // `validate_impl_signatures(loc)` (type conformance) each yield
     // `(TirTypeError, ImplDiagnosticLocation)` pairs anchored via the same source
     // map; a `Method` / field-link / binding location may mark several sites.
-    let item_tree = baml_compiler2_hir::file_item_tree(db, file);
-    for impl_id in item_tree.impls.keys() {
-        let impl_loc = baml_compiler2_hir::loc::ImplLoc::new(db, file, *impl_id);
-        let Some(sm) = baml_compiler2_tir::interfaces::impl_data_source_map(db, impl_loc).as_ref()
-        else {
-            continue;
-        };
+    for &impl_loc in baml_compiler2_ppir::item_data::file_impls(db, file) {
+        let sm = baml_compiler2_tir::interfaces::impl_data_source_map(db, impl_loc);
         // `impl_data` owns an impl's structural diagnostics whether or not it
         // fully resolves: an unresolved interface target still carries the
         // diagnostics it lowered (the bad target, the for-target, the bounds). A


### PR DESCRIPTION
Instead of querying the `ItemTree` directly (which will force consumers to fully recompute whenever anything changes), we should use the firewall queries for granular salsa cache invalidation.

This builds on https://github.com/BoundaryML/baml/pull/4064 and will be followed by further PR(s) to complete this migration (eventually making `ItemTree` private to consumers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved generic handling across interfaces, associated types, and method dispatch, using more consistent type metadata throughout compilation.
  * Enhanced type inference and throw/exception analysis reliability, with more accurate source spans and diagnostics.
  * Type display output is now byte-identical to the source syntax for representative types (including unions, generics, function types, and associated-type projections).

* **Tests**
  * Updated default-parameter metadata checks to rely on real parsed input.
  * Expanded type rendering and diagnostic coverage for interface and parameter default scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->