### PR TITLE
Rng interface

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1456,6 +1456,9 @@ dependencies = [
  "indexmap",
  "log",
  "num-bigint",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
  "serde",
  "serde_json",
  "smallvec",
@@ -1698,6 +1701,7 @@ dependencies = [
  "bytes",
  "console_error_panic_hook",
  "futures",
+ "getrandom 0.3.4",
  "indexmap",
  "js-sys",
  "log",
@@ -6132,6 +6136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7373,6 +7386,7 @@ dependencies = [
  "bridge_ctypes",
  "bytes",
  "futures",
+ "getrandom 0.2.17",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -288,6 +288,10 @@ wasm-logger = "0.2.0"
 web-time = "1.1.0"
 getrandom = { version = "0.2" }
 getrandom_03 = { package = "getrandom", version = "0.3", features = [ "wasm_js" ] }
+# Pinned to the rand 0.8-era ecosystem (rand_core 0.6) to share the `RngCore`
+# trait with `num-bigint`'s `rand` feature below, so the `baml.random`
+# generators can drive `num-bigint` sampling (future `bigint.random`). Bumping
+# to rand_core 0.9 would fork that trait and is deliberately avoided.
 rand_core = "0.6"
 rand_chacha = "0.3"
 rand_xoshiro = "0.6"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -288,6 +288,9 @@ wasm-logger = "0.2.0"
 web-time = "1.1.0"
 getrandom = { version = "0.2" }
 getrandom_03 = { package = "getrandom", version = "0.3", features = [ "wasm_js" ] }
+rand_core = "0.6"
+rand_chacha = "0.3"
+rand_xoshiro = "0.6"
 num-bigint = { version = "0.4", features = [ "rand", "serde" ] }
 num-traits = { version = "0.2" }
 rsa = { version = "0.9", default-features = false, features = [ "std", "pem" ] }

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_random/random.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_random/random.baml
@@ -15,13 +15,26 @@ interface Rng {
     ///   (for example, if the underlying system random number generator is unavailable)
     function random(self, bytes: int) -> uint8array throws never
 
-    /// Returns a uniformly random `int`.
+    /// Returns a uniformly random `int` over the full `[int.min_value(),
+    /// int.max_value()]` range.
     ///
-    /// Since BAML `int` is 63-bit, this may discard a single bit of entropy.
-    /// This may be relevant when using deterministic PRNGs.
+    /// BAML `int` is 63-bit, so this discards a single bit of the 64 drawn (the
+    /// top bit of the first byte). The remaining 63 bits give a uniform value:
+    /// the low 62 bits form the magnitude and the 63rd is the sign.
     function random_int(self) -> int throws never {
         let bytes = self.random(8);
-        ((bytes[0] & 127) << 7) | (bytes[1] << 6) | (bytes[2] << 5) | (bytes[3] << 4) | (bytes[4] << 3) | (bytes[5] << 2) | (bytes[6] << 1) | bytes[7]
+        // A uniform 62-bit magnitude in `[0, int.max_value()]`. The first byte
+        // is masked to 6 bits (`& 63`) so its top contribution lands at bit 61,
+        // never bit 62 — the i63 sign bit — which would overflow.
+        let magnitude = ((bytes[0] & 63) << 56) | (bytes[1] << 48) | (bytes[2] << 40) | (bytes[3] << 32) | (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7];
+        // Use bit 6 of the first byte as a sign bit. `0 - magnitude - 1` maps
+        // `[0, 2^62)` onto `[int.min_value(), -1]`, so the two branches together
+        // tile the whole signed range with no overlap or overflow.
+        if ((bytes[0] & 64) == 0) {
+            magnitude
+        } else {
+            0 - magnitude - 1
+        }
     }
 }
 

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_random/random.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_random/random.baml
@@ -1,9 +1,16 @@
+/// A source of random bytes.
+///
+/// Three implementations are provided by the standard library:
+/// - `SystemRandom` is a secure singleton provider that calls out to the system's entropy source
+/// - `Xoshiro256PlusPlus` is a fast seedable PRNG
+/// - `ChaCha20` is a secure seedable PRNG
 interface Rng {
     /// Produces `bytes` uniformly random bytes.
     ///
     /// ## Panics
     ///
     /// - If `bytes` is negative.
+    /// - If `bytes` bytes cannot be allocated (`baml.panics.AllocFailure`).
     /// - If the implementation fails to produce the requested number of bytes
     ///   (for example, if the underlying system random number generator is unavailable)
     function random(self, bytes: int) -> uint8array throws never
@@ -18,6 +25,10 @@ interface Rng {
     }
 }
 
+/// A cryptographically secure generator backed by the operating system's
+/// entropy source (a CSPRNG). Draws fresh entropy on every call and is not
+/// seedable, so it is non-deterministic and suitable for security-sensitive
+/// randomness such as keys, tokens, and nonces.
 class SystemRandom {
     /// Returns a new `SystemRandom` instance using the global system random number generator.
     function get() -> SystemRandom throws never {
@@ -34,6 +45,13 @@ class SystemRandom {
     }
 }
 
+/// A fast, seedable, deterministic PRNG (xoshiro256++). Given the same seed it
+/// always reproduces the same stream, which makes it ideal for tests,
+/// simulations, and sampling.
+///
+/// NOT cryptographically secure: its output is predictable from observed draws.
+/// Never use it for keys, tokens, nonces, or any security-sensitive value — use
+/// `SystemRandom` or a well-seeded `ChaCha20` instead.
 class Xoshiro256PlusPlus {
     /// Opaque, mutex-guarded generator state owned by the Rust runtime.
     _state: $rust_type
@@ -68,6 +86,11 @@ class Xoshiro256PlusPlus {
     }
 }
 
+/// A seedable, deterministic CSPRNG (ChaCha20). Given the same seed it always
+/// reproduces the same stream. It is cryptographically secure *only* when seeded
+/// with high-entropy input — e.g. 32 bytes drawn from `SystemRandom` (the
+/// default when no seed is given). A low-entropy or attacker-known seed makes
+/// its output predictable.
 class ChaCha20 {
     /// Opaque, mutex-guarded generator state owned by the Rust runtime.
     _state: $rust_type

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_random/random.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_random/random.baml
@@ -1,0 +1,103 @@
+interface Rng {
+    /// Produces `bytes` uniformly random bytes.
+    ///
+    /// ## Panics
+    ///
+    /// - If `bytes` is negative.
+    /// - If the implementation fails to produce the requested number of bytes
+    ///   (for example, if the underlying system random number generator is unavailable)
+    function random(self, bytes: int) -> uint8array throws never
+
+    /// Returns a uniformly random `int`.
+    ///
+    /// Since BAML `int` is 63-bit, this may discard a single bit of entropy.
+    /// This may be relevant when using deterministic PRNGs.
+    function random_int(self) -> int throws never {
+        let bytes = self.random(8);
+        ((bytes[0] & 127) << 7) | (bytes[1] << 6) | (bytes[2] << 5) | (bytes[3] << 4) | (bytes[4] << 3) | (bytes[5] << 2) | (bytes[6] << 1) | bytes[7]
+    }
+}
+
+class SystemRandom {
+    /// Returns a new `SystemRandom` instance using the global system random number generator.
+    function get() -> SystemRandom throws never {
+        SystemRandom {}
+    }
+
+    implements Rng {
+        function random(self, bytes: int) -> uint8array throws never {
+            $rust_io_function
+        }
+        function random_int(self) -> int throws never {
+            $rust_io_function
+        }
+    }
+}
+
+class Xoshiro256PlusPlus {
+    /// Opaque, mutex-guarded generator state owned by the Rust runtime.
+    _state: $rust_type
+
+    /// Creates a new `Xoshiro256PlusPlus` pseudo-random number generator.
+    ///
+    /// ## Parameters
+    /// - `seed`: The seed for the random number generator.
+    ///   If no seed is provided, a random seed is generated using the system random number generator.
+    ///   The seed must be at least 32 bytes long.
+    ///
+    /// ## Panics
+    /// If `seed` is shorter than 32 bytes.
+    //baml:mut_vm
+    //baml:fallible
+    function new(
+        seed: uint8array = Rng.random(SystemRandom.get(), 32),
+    ) -> Xoshiro256PlusPlus throws never {
+        $rust_function
+    }
+
+    implements Rng {
+        //baml:vm
+        //baml:fallible
+        function random(self, bytes: int) -> uint8array throws never {
+            $rust_function
+        }
+        //baml:vm
+        function random_int(self) -> int throws never {
+            $rust_function
+        }
+    }
+}
+
+class ChaCha20 {
+    /// Opaque, mutex-guarded generator state owned by the Rust runtime.
+    _state: $rust_type
+
+    /// Creates a new `ChaCha20` pseudo-random number generator.
+    ///
+    /// ## Parameters
+    /// - `seed`: The seed for the random number generator.
+    ///   If no seed is provided, a random seed is generated using the system random number generator.
+    ///   The seed must be at least 32 bytes long.
+    ///
+    /// ## Panics
+    /// If `seed` is shorter than 32 bytes.
+    //baml:mut_vm
+    //baml:fallible
+    function new(
+        seed: uint8array = Rng.random(SystemRandom.get(), 32),
+    ) -> ChaCha20 throws never {
+        $rust_function
+    }
+
+    implements Rng {
+        //baml:vm
+        //baml:fallible
+        function random(self, bytes: int) -> uint8array throws never {
+            $rust_function
+        }
+        //baml:vm
+        function random_int(self) -> int throws never {
+            $rust_function
+        }
+    }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_random/random.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_random/random.baml
@@ -78,11 +78,18 @@ class Xoshiro256PlusPlus {
     ///
     /// ## Panics
     /// If `seed` is shorter than 32 bytes.
+    function new(
+        seed: uint8array = SystemRandom.get().random(32),
+    ) -> Xoshiro256PlusPlus throws never {
+        // A `$rust_function` builtin can't fill omitted default args, so this
+        // thin wrapper resolves the default seed and forwards to `_new` (whose
+        // `seed` is required) — the `net.TcpStream.connect`/`_connect` convention.
+        Xoshiro256PlusPlus._new(seed)
+    }
+
     //baml:mut_vm
     //baml:fallible
-    function new(
-        seed: uint8array = Rng.random(SystemRandom.get(), 32),
-    ) -> Xoshiro256PlusPlus throws never {
+    function _new(seed: uint8array) -> Xoshiro256PlusPlus throws never {
         $rust_function
     }
 
@@ -117,11 +124,18 @@ class ChaCha20 {
     ///
     /// ## Panics
     /// If `seed` is shorter than 32 bytes.
+    function new(
+        seed: uint8array = SystemRandom.get().random(32),
+    ) -> ChaCha20 throws never {
+        // A `$rust_function` builtin can't fill omitted default args, so this
+        // thin wrapper resolves the default seed and forwards to `_new` (whose
+        // `seed` is required) — the `net.TcpStream.connect`/`_connect` convention.
+        ChaCha20._new(seed)
+    }
+
     //baml:mut_vm
     //baml:fallible
-    function new(
-        seed: uint8array = Rng.random(SystemRandom.get(), 32),
-    ) -> ChaCha20 throws never {
+    function _new(seed: uint8array) -> ChaCha20 throws never {
         $rust_function
     }
 

--- a/baml_language/crates/baml_builtins2/src/lib.rs
+++ b/baml_language/crates/baml_builtins2/src/lib.rs
@@ -131,6 +131,7 @@ pub const ALL: &[BuiltinFile] = &[
     builtin!("baml", "ns_time/zoneddatetime.baml"),
     builtin!("baml", "ns_ops/comparison.baml"),
     builtin!("baml", "ns_ops/math.baml"),
+    builtin!("baml", "ns_random/random.baml"),
     // --- boundary package ---
     builtin!("boundary", "core.baml"),
     builtin!("boundary", "ns_id/id.baml"),

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -141,27 +141,37 @@ fn build_namespace_tree(builtins: &[NativeBuiltin]) -> NamespaceNode<'_> {
     for b in builtins {
         let rest = b.path.strip_prefix("baml.").unwrap_or(&b.path);
         let segments: Vec<&str> = rest.split('.').collect();
-        let baml_method_name = segments.last().unwrap().to_string();
-        let rust_method_name = camel_to_snake(&baml_method_name);
+        let last_idx = segments.len() - 1;
+
+        // The class is the first uppercase segment before the final method
+        // segment (if any). Everything after the class is the dispatch key:
+        // a method declared inside an `implements I { ... }` block keeps the
+        // interface segment in its runtime path (`...{Class}.I.method`), so the
+        // class dispatch must match on `I.method`. The Rust method name comes
+        // from the final segment alone so it stays a valid identifier.
+        let class_idx = segments[..last_idx]
+            .iter()
+            .position(|s| s.starts_with(|c: char| c.is_uppercase()));
+
+        let (ns_segments, class_name, baml_method_name): (Vec<&str>, Option<&str>, String) =
+            match class_idx {
+                Some(ci) => (
+                    segments[..ci].to_vec(),
+                    Some(segments[ci]),
+                    segments[ci + 1..].join("."),
+                ),
+                None => (
+                    segments[..last_idx].to_vec(),
+                    None,
+                    segments[last_idx].to_string(),
+                ),
+            };
 
         let entry = BuiltinEntry {
             builtin: b,
             baml_method_name,
-            rust_method_name,
+            rust_method_name: camel_to_snake(segments[last_idx]),
         };
-
-        let prefix_segments = &segments[..segments.len() - 1];
-
-        let mut ns_segments: Vec<&str> = Vec::new();
-        let mut class_name: Option<&str> = None;
-
-        for &seg in prefix_segments {
-            if seg.starts_with(|c: char| c.is_uppercase()) {
-                class_name = Some(seg);
-                break;
-            }
-            ns_segments.push(seg);
-        }
 
         let node = root.get_or_create_namespace(&ns_segments);
 

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::types::{BamlType, NativeBuiltin, NativeClassDef};
+use crate::types::{BamlType, NativeBuiltin, NativeClassDef, Receiver};
 
 // ============================================================================
 // Path configuration for generated code
@@ -80,6 +80,24 @@ fn io_namespace_name(builtin: &NativeBuiltin) -> &str {
 /// Extract the method name (last segment) from an IO builtin path.
 fn io_method_name(builtin: &NativeBuiltin) -> &str {
     builtin.path.rsplit('.').next().unwrap_or("")
+}
+
+/// The class-dispatch match key for an IO method: the path portion after
+/// `...{ClassName}.`.
+///
+/// A method declared inside an `implements I { ... }` block keeps the interface
+/// segment in its runtime path (`...{Class}.I.method`), so the key is
+/// `I.method`; a direct method is just `method`. The clean trait method name
+/// and glue still use the final segment (`io_method_name`).
+fn io_class_dispatch_key(builtin: &NativeBuiltin) -> String {
+    builtin
+        .receiver
+        .as_ref()
+        .and_then(|r| builtin.path.split_once(&format!(".{}.", r.class_name)))
+        .map_or_else(
+            || io_method_name(builtin).to_string(),
+            |(_, rest)| rest.to_string(),
+        )
 }
 
 fn build_io_namespace_tree<'a>(
@@ -705,6 +723,28 @@ fn class_trait_ident(ns: &str, class: &str) -> syn::Ident {
     format_ident!("IoClass{}{}", capitalize_first(ns), class)
 }
 
+/// Whether the clean trait method and glue thread an *extracted* receiver value
+/// to the impl.
+///
+/// True for a non-static receiver on an instance-backed (field-carrying) class:
+/// the receiver is materialized as an `owned::{ns}::{Class}` and passed through.
+///
+/// A fieldless marker class (e.g. `random.SystemRandom`) still takes `self` in
+/// BAML so it can satisfy an interface, but it carries no data and has no
+/// generated `owned::`/`view::` struct. Its `self` arg slot is still consumed
+/// by the glue (the VM pushes it), but the value is ignored and the clean
+/// method takes no receiver parameter. `consumes_self_slot` covers that case.
+fn receiver_is_extracted(receiver: &Receiver) -> bool {
+    !receiver.receiver_type.is_static() && receiver.instance_backed
+}
+
+/// Whether the method consumes a leading `self` arg slot on the operand stack.
+/// True for any non-static receiver, including fieldless marker classes whose
+/// receiver value is consumed but ignored.
+fn consumes_self_slot(receiver: &Receiver) -> bool {
+    !receiver.receiver_type.is_static()
+}
+
 // ============================================================================
 // Generate SysOp Enum
 // ============================================================================
@@ -1305,12 +1345,12 @@ fn emit_one_class_trait(
                     compile_error!(concat!("missing receiver for method ", stringify!(#method_ident)));
                 };
             };
-            let receiver_param = if receiver.receiver_type.is_static() {
-                None
-            } else {
+            let receiver_param = if receiver_is_extracted(receiver) {
                 let receiver_param_ident = format_ident!("{}", class_name.to_lowercase());
                 let receiver_ty = quote! { #owned::#ns_ident::#class_ident };
                 Some(quote! { #receiver_param_ident: #receiver_ty,})
+            } else {
+                None
             };
 
             let extra_params: Vec<TokenStream> = m
@@ -1359,7 +1399,7 @@ fn emit_one_class_trait(
     let dispatch_arms: Vec<TokenStream> = methods
         .iter()
         .map(|m| {
-            let method_name_str = io_method_name(m);
+            let method_name_str = io_class_dispatch_key(m);
             let glue_ident = format_ident!("__glue_{}", m.fn_name);
             quote! {
                 #method_name_str => Some(self.#glue_ident(heap, permit, args, ctx, call_id))
@@ -1413,10 +1453,14 @@ fn emit_glue_method(
     let class_ident = format_ident!("{}", class_name);
 
     // Arg extraction lets
-    let arg_self = if receiver.receiver_type.is_static() {
+    let arg_self = if !consumes_self_slot(receiver) {
         None
-    } else {
+    } else if receiver_is_extracted(receiver) {
         Some(quote! { let __arg_self = __args.next().unwrap(); })
+    } else {
+        // Fieldless marker receiver: consume the `self` slot but discard it —
+        // the clean method takes no receiver and there is no `view::` struct.
+        Some(quote! { let _ = __args.next().unwrap(); })
     };
 
     let arg_idents: Vec<syn::Ident> = (0..builtin.params.len())
@@ -1439,14 +1483,14 @@ fn emit_glue_method(
         .map(|id| quote! { let #id = __args.next().unwrap(); })
         .collect();
 
-    let receiver_extraction = if receiver.receiver_type.is_static() {
-        None
-    } else {
+    let receiver_extraction = if receiver_is_extracted(receiver) {
         Some(quote! {
             let __receiver = __arg_self
                 .as_builtin_class::<#view::#ns_ident::#class_ident>(heap.as_ref(), permit)?
                 .into_owned(heap.as_ref(), permit)?;
         })
+    } else {
+        None
     };
 
     // Extraction inside gc protection
@@ -1476,10 +1520,10 @@ fn emit_glue_method(
         .collect();
 
     // Tuple elements for Ok return
-    let receiver_ident = if receiver.receiver_type.is_static() {
-        None
-    } else {
+    let receiver_ident = if receiver_is_extracted(receiver) {
         Some(quote! { __receiver, })
+    } else {
+        None
     };
     let tuple_idents: Vec<syn::Ident> = builtin
         .params
@@ -2127,7 +2171,19 @@ fn emit_runtime_io_handles(
     let mut handles = Vec::new();
 
     for (ns, node) in tree {
-        for class_name in node.classes.keys() {
+        for (class_name, methods) in &node.classes {
+            // Fieldless marker classes (e.g. `random.SystemRandom`) have no
+            // generated `owned::` struct, so there is nothing to wrap in a
+            // handle and `from_external` would not resolve. They are never used
+            // as a receiver handle in the `RuntimeIo` trait either (see
+            // `emit_runtime_io_trait`), so skip them entirely.
+            let instance_backed = methods
+                .first()
+                .and_then(|m| m.receiver.as_ref())
+                .is_none_or(|r| r.instance_backed);
+            if !instance_backed {
+                continue;
+            }
             let handle_ident = handle_type_name(ns, class_name);
 
             // Find the class def to get non-opaque fields.
@@ -2216,12 +2272,16 @@ fn emit_runtime_io_trait(
 
         let mut params: Vec<TokenStream> = Vec::new();
 
-        // For class methods, the first param is a handle reference.
+        // For class methods, the first param is a handle reference. Fieldless
+        // marker receivers (e.g. `random.SystemRandom`) have no handle type, so
+        // they take no receiver param — the adapter synthesizes their `self`.
         if let Some(ref receiver) = builtin.receiver {
-            let ns = io_namespace_name(builtin);
-            let handle = handle_type_name(ns, &receiver.class_name);
-            let param_ident = format_ident!("{}", receiver.class_name.to_lowercase());
-            params.push(quote! { #param_ident: &#handle });
+            if receiver.instance_backed {
+                let ns = io_namespace_name(builtin);
+                let handle = handle_type_name(ns, &receiver.class_name);
+                let param_ident = format_ident!("{}", receiver.class_name.to_lowercase());
+                params.push(quote! { #param_ident: &#handle });
+            }
         }
 
         for p in &builtin.params {
@@ -2360,11 +2420,23 @@ fn emit_adapter_impl(
 
         if let Some(ref receiver) = builtin.receiver {
             let ns = io_namespace_name(builtin);
-            let handle = handle_type_name(ns, &receiver.class_name);
-            let param_ident = format_ident!("{}", receiver.class_name.to_lowercase());
-            params.push(quote! { #param_ident: &#handle });
-            ext_bindings.push(quote! { let __recv_raw = #param_ident.raw.clone(); });
-            arg_exprs.push(quote! { BexValue::ExternalValue(&__recv_raw) });
+            if receiver.instance_backed {
+                let handle = handle_type_name(ns, &receiver.class_name);
+                let param_ident = format_ident!("{}", receiver.class_name.to_lowercase());
+                params.push(quote! { #param_ident: &#handle });
+                ext_bindings.push(quote! { let __recv_raw = #param_ident.raw.clone(); });
+                arg_exprs.push(quote! { BexValue::ExternalValue(&__recv_raw) });
+            } else if !receiver.receiver_type.is_static() {
+                // Fieldless marker receiver: the SysOpFn glue still consumes a
+                // leading `self` slot, so synthesize an empty instance for it.
+                // The `RuntimeIo` method itself takes no receiver param.
+                let class_fqn = format!("baml.{}.{}", ns, receiver.class_name);
+                ext_bindings.push(quote! {
+                    let __recv_raw =
+                        BexExternalValue::instance(#class_fqn, indexmap::IndexMap::new());
+                });
+                arg_exprs.push(quote! { BexValue::ExternalValue(&__recv_raw) });
+            }
         }
 
         for (i, p) in builtin.params.iter().enumerate() {

--- a/baml_language/crates/baml_builtins2_codegen/src/extract.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/extract.rs
@@ -209,7 +209,21 @@ fn extract_from_class(
         .map(|n| n.as_str().to_string())
         .collect();
 
-    for method in &class_def.methods {
+    // Builtin methods may be declared directly on the class or inside an
+    // `implements I { ... }` block (BEP-044) — e.g. the `random.Rng`
+    // implementors put their `$rust_function` / `$rust_io_function` methods in
+    // an `implements Rng { ... }` block. A method inside `implements I` is named
+    // `{ns}.{Class}.{I}.{method}` at runtime (matching MIR's
+    // `scoped_implements_method_name`), so it carries the interface qualifier; a
+    // direct method is just `{ns}.{Class}.{method}`.
+    let direct = class_def.methods.iter().map(|m| (m, None));
+    let in_impl = class_def.implements.iter().flat_map(|b| {
+        // The interface `TypeExpr`'s `Display` is the exact form MIR uses to
+        // build the method's fully-qualified name, so reuse it verbatim.
+        let iface = b.target.to_string();
+        b.methods.iter().map(move |m| (m, Some(iface.clone())))
+    });
+    for (method, iface_qualifier) in direct.chain(in_impl) {
         let Some(pipeline) = extract_builtin_pipeline(method) else {
             continue;
         };
@@ -227,7 +241,15 @@ fn extract_from_class(
             }
         }
 
-        let path = format!("{namespace_prefix}.{class_name}.{}", method.name.as_str());
+        let path = match &iface_qualifier {
+            Some(iface) => {
+                format!(
+                    "{namespace_prefix}.{class_name}.{iface}.{}",
+                    method.name.as_str()
+                )
+            }
+            None => format!("{namespace_prefix}.{class_name}.{}", method.name.as_str()),
+        };
         let fn_name = path_to_fn_name(&path);
 
         let has_self = method

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -259,10 +259,10 @@ class            baml.panics.SdkPanic             <builtin>/baml/ns_panics/panic
 class            baml.panics.HostContractViolation <builtin>/baml/ns_panics/panics.baml:90
 class            baml.panics.IntegerOverflow      <builtin>/baml/ns_panics/panics.baml:100
 type             baml.panics.Panic                <builtin>/baml/ns_panics/panics.baml:104
-interface        baml.random.Rng                  <builtin>/baml/ns_random/random.baml:9
-class            baml.random.SystemRandom         <builtin>/baml/ns_random/random.baml:34
-class            baml.random.Xoshiro256PlusPlus   <builtin>/baml/ns_random/random.baml:57
-class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:96
+interface        baml.random.Rng                  <builtin>/baml/ns_random/random.baml:7
+class            baml.random.SystemRandom         <builtin>/baml/ns_random/random.baml:45
+class            baml.random.Xoshiro256PlusPlus   <builtin>/baml/ns_random/random.baml:68
+class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:107
 class            baml.spawn.SpawnParams           <builtin>/baml/ns_spawn/spawn.baml:19
 class            baml.spawn.TaskGroup             <builtin>/baml/ns_spawn/spawn.baml:31
 class            baml.spawn.CancelToken           <builtin>/baml/ns_spawn/spawn.baml:85

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -259,6 +259,10 @@ class            baml.panics.SdkPanic             <builtin>/baml/ns_panics/panic
 class            baml.panics.HostContractViolation <builtin>/baml/ns_panics/panics.baml:90
 class            baml.panics.IntegerOverflow      <builtin>/baml/ns_panics/panics.baml:100
 type             baml.panics.Panic                <builtin>/baml/ns_panics/panics.baml:104
+interface        baml.random.Rng                  <builtin>/baml/ns_random/random.baml:1
+class            baml.random.SystemRandom         <builtin>/baml/ns_random/random.baml:21
+class            baml.random.Xoshiro256PlusPlus   <builtin>/baml/ns_random/random.baml:37
+class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:71
 class            baml.spawn.SpawnParams           <builtin>/baml/ns_spawn/spawn.baml:19
 class            baml.spawn.TaskGroup             <builtin>/baml/ns_spawn/spawn.baml:31
 class            baml.spawn.CancelToken           <builtin>/baml/ns_spawn/spawn.baml:85

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -259,10 +259,10 @@ class            baml.panics.SdkPanic             <builtin>/baml/ns_panics/panic
 class            baml.panics.HostContractViolation <builtin>/baml/ns_panics/panics.baml:90
 class            baml.panics.IntegerOverflow      <builtin>/baml/ns_panics/panics.baml:100
 type             baml.panics.Panic                <builtin>/baml/ns_panics/panics.baml:104
-interface        baml.random.Rng                  <builtin>/baml/ns_random/random.baml:1
-class            baml.random.SystemRandom         <builtin>/baml/ns_random/random.baml:21
-class            baml.random.Xoshiro256PlusPlus   <builtin>/baml/ns_random/random.baml:37
-class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:71
+interface        baml.random.Rng                  <builtin>/baml/ns_random/random.baml:9
+class            baml.random.SystemRandom         <builtin>/baml/ns_random/random.baml:34
+class            baml.random.Xoshiro256PlusPlus   <builtin>/baml/ns_random/random.baml:57
+class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:96
 class            baml.spawn.SpawnParams           <builtin>/baml/ns_spawn/spawn.baml:19
 class            baml.spawn.TaskGroup             <builtin>/baml/ns_spawn/spawn.baml:31
 class            baml.spawn.CancelToken           <builtin>/baml/ns_spawn/spawn.baml:85

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -262,7 +262,7 @@ type             baml.panics.Panic                <builtin>/baml/ns_panics/panic
 interface        baml.random.Rng                  <builtin>/baml/ns_random/random.baml:7
 class            baml.random.SystemRandom         <builtin>/baml/ns_random/random.baml:45
 class            baml.random.Xoshiro256PlusPlus   <builtin>/baml/ns_random/random.baml:68
-class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:107
+class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:114
 class            baml.spawn.SpawnParams           <builtin>/baml/ns_spawn/spawn.baml:19
 class            baml.spawn.TaskGroup             <builtin>/baml/ns_spawn/spawn.baml:31
 class            baml.spawn.CancelToken           <builtin>/baml/ns_spawn/spawn.baml:85

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -549,6 +549,17 @@ pub enum TirTypeError {
         interface: crate::ty::QualifiedTypeName,
         method: Name,
     },
+    /// A `$rust_io_function` (sys-op) method inside an `implements` block has
+    /// method-level generic parameters. An impl-block method is reached only
+    /// through interface (virtual) dispatch, which does not reconstruct the
+    /// synthetic type-argument slots a generic sys-op's glue reads off the
+    /// stack — so such a call would fail at runtime. (A generic sys-op declared
+    /// directly on a class is fine: it lowers to a direct `SysOp` instruction,
+    /// which does supply those slots.) Impl conformance.
+    GenericSysOpMethodInInterfaceImpl {
+        interface: crate::ty::QualifiedTypeName,
+        method: Name,
+    },
     /// An interface that declares fields is implemented out-of-body
     /// (`implement I for T`). A field-bearing interface can only be implemented in the
     /// class body, where its fields are satisfied by the class's own fields (E0126).
@@ -1431,6 +1442,15 @@ impl fmt::Display for TirTypeError {
                 write!(
                     f,
                     "missing implementation of method `{method}` required by interface `{}`",
+                    interface.render_user_facing()
+                )
+            }
+            TirTypeError::GenericSysOpMethodInInterfaceImpl { interface, method } => {
+                write!(
+                    f,
+                    "`$rust_io_function` method `{method}` implementing interface `{}` may not \
+                     declare its own generic parameters: a sys-op reached through interface \
+                     dispatch cannot carry method-level type arguments",
                     interface.render_user_facing()
                 )
             }

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -1204,6 +1204,31 @@ pub fn validate_impl_signatures<'db>(
     for &method_loc in &data.methods {
         let method_name = function_data(db, method_loc).name.clone();
 
+        // A `$rust_io_function` (sys-op) override with method-level generics can't
+        // be dispatched through interface (virtual) dispatch — the only way an
+        // impl-block method is reached. Virtual dispatch does not reconstruct the
+        // synthetic type-argument slots a generic sys-op's glue reads off the
+        // stack, so such a call would fail at runtime; reject it at declaration.
+        // (A generic sys-op declared directly on a class lowers to a direct
+        // `SysOp` instruction, which supplies those slots, so it is fine.)
+        if !function_data(db, method_loc).generic_params.is_empty()
+            && matches!(
+                baml_compiler2_ppir::function_body(db, method_loc).as_ref(),
+                baml_compiler2_hir::body::FunctionBody::Builtin(
+                    baml_compiler2_ast::BuiltinKind::Io
+                )
+            )
+        {
+            diags.push((
+                crate::infer_context::TirTypeError::GenericSysOpMethodInInterfaceImpl {
+                    interface: iface_qtn.clone(),
+                    method: method_name.clone(),
+                },
+                ImplDiagnosticLocation::Method(method_name.clone()),
+            ));
+            continue;
+        }
+
         // The interface method this override targets: a required sig or a default's function.
         let iface_spec = if let Some(sig) = iface_data
             .required_methods

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -3364,6 +3364,63 @@ function needs<T extends Marker>(x: T) -> int throws never {
     }
 
     #[test]
+    fn generic_sysop_method_in_implements_block_is_rejected() {
+        // A `$rust_io_function` override with method-level generics is only reachable
+        // through interface dispatch, which cannot supply the sys-op's synthetic
+        // type-argument slots — rejected at the declaration (E0146). (`$rust_io_function`
+        // outside a builtin file also draws the builtin-only-syntax diagnostic, but that
+        // travels the HIR channel and does not gate body lowering, so the impl-conformance
+        // guard under test still sees a sys-op body here.)
+        let diags = impl_diagnostics(
+            "interface Codec {\n  function decode<T>(self, raw: string) -> T throws never\n}\n\
+             class Wire {\n  implements Codec {\n    \
+             function decode<T>(self, raw: string) -> T throws never { $rust_io_function }\n  }\n}\n",
+        );
+        assert!(
+            diags.iter().any(|e| matches!(
+                e,
+                TirTypeError::GenericSysOpMethodInInterfaceImpl { method, .. }
+                    if method.as_str() == "decode"
+            )),
+            "expected GenericSysOpMethodInInterfaceImpl for `decode`, got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn non_generic_sysop_method_in_implements_block_is_accepted() {
+        // A sys-op override with no method-level generics dispatches fine virtually
+        // (its arity already counts the receiver) — e.g. `SystemRandom`'s `Rng` impl.
+        let diags = impl_diagnostics(
+            "interface Source {\n  function read(self, n: int) -> string throws never\n}\n\
+             class Device {\n  implements Source {\n    \
+             function read(self, n: int) -> string throws never { $rust_io_function }\n  }\n}\n",
+        );
+        assert!(
+            !diags
+                .iter()
+                .any(|e| matches!(e, TirTypeError::GenericSysOpMethodInInterfaceImpl { .. })),
+            "a non-generic sys-op override must not be rejected, got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn generic_vm_builtin_method_in_implements_block_is_not_flagged_as_sysop() {
+        // The guard is specific to `$rust_io_function` (sys-ops); a `$rust_function`
+        // VM builtin with method generics is a different dispatch mechanism.
+        let diags = impl_diagnostics(
+            "interface Codec {\n  function decode<T>(self, raw: string) -> T throws never\n}\n\
+             class Wire {\n  implements Codec {\n    \
+             function decode<T>(self, raw: string) -> T throws never { $rust_function }\n  }\n}\n",
+        );
+        assert!(
+            !diags
+                .iter()
+                .any(|e| matches!(e, TirTypeError::GenericSysOpMethodInInterfaceImpl { .. })),
+            "a $rust_function override must not draw the sys-op diagnostic, got {diags:?}"
+        );
+    }
+
+    #[test]
     fn out_of_body_impl_of_field_interface_is_reported() {
         // A field-bearing interface can only be implemented in the class body (E0126). A simple
         // `implement HasField for Holder` is merged onto `Holder` for resolution but is written

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -3367,7 +3367,7 @@ function needs<T extends Marker>(x: T) -> int throws never {
     fn generic_sysop_method_in_implements_block_is_rejected() {
         // A `$rust_io_function` override with method-level generics is only reachable
         // through interface dispatch, which cannot supply the sys-op's synthetic
-        // type-argument slots — rejected at the declaration (E0146). (`$rust_io_function`
+        // type-argument slots — rejected at the declaration (E0153). (`$rust_io_function`
         // outside a builtin file also draws the builtin-only-syntax diagnostic, but that
         // travels the HIR channel and does not gate body lowering, so the impl-conformance
         // guard under test still sees a sys-op body here.)

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -233,7 +233,7 @@ pub enum DiagnosticId {
     // Wildcard `_` type in a non-inferable position (E0147)
     WildcardTypeNotAllowed,
 
-    // Interface diagnostics (BEP-044; E0112-E0120)
+    // Interface diagnostics (BEP-044)
     /// `implements I {}` references an interface that does not exist.
     UnknownInterface,
     /// A class is missing the body of a required interface method.
@@ -553,7 +553,7 @@ impl DiagnosticId {
             DiagnosticId::FromJsonMustImplementInterface => "E0143",
             DiagnosticId::CleanupMagicMethodSignature => "E0144",
             DiagnosticId::GenericBoundNotInterface => "E0145",
-            DiagnosticId::GenericSysOpMethodInInterfaceImpl => "E0146",
+            DiagnosticId::GenericSysOpMethodInInterfaceImpl => "E0153",
 
             // Aliasing lints
             DiagnosticId::ArrayFilledAliasing => "E0148",

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -253,6 +253,11 @@ pub enum DiagnosticId {
     /// A method body in `implements I {}` has a signature that doesn't match
     /// the interface's declared signature for that method.
     InterfaceMethodSignatureMismatch,
+    /// A `$rust_io_function` (sys-op) method in an `implements` block declares
+    /// its own generic parameters. Such a method is reached only through
+    /// interface (virtual) dispatch, which cannot carry the sys-op's
+    /// method-level type arguments.
+    GenericSysOpMethodInInterfaceImpl,
     /// Two `implements` blocks on the same class declare methods with the
     /// same name — unqualified calls would be ambiguous (BEP-044
     /// §"Method Disambiguation").
@@ -548,6 +553,7 @@ impl DiagnosticId {
             DiagnosticId::FromJsonMustImplementInterface => "E0143",
             DiagnosticId::CleanupMagicMethodSignature => "E0144",
             DiagnosticId::GenericBoundNotInterface => "E0145",
+            DiagnosticId::GenericSysOpMethodInInterfaceImpl => "E0146",
 
             // Aliasing lints
             DiagnosticId::ArrayFilledAliasing => "E0148",

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -1979,6 +1979,9 @@ fn tir_type_error_to_diagnostic_id(
         // Interface impl conformance (BEP-044, E0113–E0139): tir2 owns these and
         // check.rs surfaces them via `check_interfaces`.
         TirTypeError::MissingInterfaceMethod { .. } => DiagnosticId::MissingInterfaceMethod,
+        TirTypeError::GenericSysOpMethodInInterfaceImpl { .. } => {
+            DiagnosticId::GenericSysOpMethodInInterfaceImpl
+        }
         TirTypeError::OutOfBodyImplementsFieldInterface { .. } => {
             DiagnosticId::OutOfBodyImplementsFieldInterface
         }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1382,6 +1382,30 @@ class baml.panics.UserPanic {
 }
 type baml.panics.Panic = baml.panics.DivisionByZero | baml.panics.IndexOutOfBounds | baml.panics.InvalidFieldAccess | baml.panics.MapKeyNotFound | baml.panics.StackOverflow | baml.panics.AssertionFailed | baml.panics.Unreachable | baml.panics.Cancelled | baml.panics.UserPanic | baml.panics.Exit | baml.panics.AllocFailure | baml.panics.HostUnavailable | baml.panics.NegativeBitShift | baml.panics.SdkPanic | baml.panics.HostContractViolation | baml.panics.IntegerOverflow
 
+--- <builtin>/baml/ns_random/random.baml ---
+class baml.random.ChaCha20 {
+  _state: $rust_type
+}
+class baml.random.SystemRandom {
+}
+class baml.random.Xoshiro256PlusPlus {
+  _state: $rust_type
+}
+function baml.random.get() -> baml.random.SystemRandom  [expr] {
+  {  } baml.random.SystemRandom {  }
+}
+function baml.random.new(seed: uint8array = Rng.random(SystemRandom.get(), 32)) -> baml.random.ChaCha20  [builtin]
+function baml.random.new(seed: uint8array = Rng.random(SystemRandom.get(), 32)) -> baml.random.Xoshiro256PlusPlus  [builtin]
+function baml.random.random(self: ?, bytes: int) -> uint8array  [builtin]
+function baml.random.random(self: ?, bytes: int) -> uint8array  [builtin]
+function baml.random.random(self: ?, bytes: int) -> uint8array  [builtin]
+function baml.random.random_int(self: ?) -> int  [builtin]
+function baml.random.random_int(self: ?) -> int  [builtin]
+function baml.random.random_int(self: ?) -> int  [expr] {
+  { let bytes = self.random(8) } bytes[0] BitAnd 127 Shl 7 BitOr bytes[1] Shl 6 BitOr bytes[2] Shl 5 BitOr bytes[3] Shl 4 BitOr bytes[4] Shl 3 BitOr bytes[5] Shl 2 BitOr bytes[6] Shl 1 BitOr bytes[7]
+}
+function baml.random.random_int(self: ?) -> int  [builtin]
+
 --- <builtin>/baml/ns_spawn/spawn.baml ---
 class baml.spawn.CancelToken {
   _handle: $rust_type

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1391,19 +1391,25 @@ class baml.random.SystemRandom {
 class baml.random.Xoshiro256PlusPlus {
   _state: $rust_type
 }
+function baml.random._new(seed: uint8array) -> baml.random.ChaCha20  [builtin]
+function baml.random._new(seed: uint8array) -> baml.random.Xoshiro256PlusPlus  [builtin]
 function baml.random.get() -> baml.random.SystemRandom  [expr] {
   {  } baml.random.SystemRandom {  }
 }
-function baml.random.new(seed: uint8array = Rng.random(SystemRandom.get(), 32)) -> baml.random.ChaCha20  [builtin]
-function baml.random.new(seed: uint8array = Rng.random(SystemRandom.get(), 32)) -> baml.random.Xoshiro256PlusPlus  [builtin]
+function baml.random.new(seed: uint8array = SystemRandom.get().random(32)) -> baml.random.ChaCha20  [expr] {
+  {  } ChaCha20._new(seed)
+}
+function baml.random.new(seed: uint8array = SystemRandom.get().random(32)) -> baml.random.Xoshiro256PlusPlus  [expr] {
+  {  } Xoshiro256PlusPlus._new(seed)
+}
 function baml.random.random(self: ?, bytes: int) -> uint8array  [builtin]
 function baml.random.random(self: ?, bytes: int) -> uint8array  [builtin]
 function baml.random.random(self: ?, bytes: int) -> uint8array  [builtin]
-function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [expr] {
   { let bytes = self.random(8); let magnitude = bytes[0] BitAnd 63 Shl 56 BitOr bytes[1] Shl 48 BitOr bytes[2] Shl 40 BitOr bytes[3] Shl 32 BitOr bytes[4] Shl 24 BitOr bytes[5] Shl 16 BitOr bytes[6] Shl 8 BitOr bytes[7] } if (bytes[0] BitAnd 64 Eq 0) {  } magnitude else {  } 0 Sub magnitude Sub 1
 }
+function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [builtin]
 
 --- <builtin>/baml/ns_spawn/spawn.baml ---

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_hir.snap
@@ -1402,7 +1402,7 @@ function baml.random.random(self: ?, bytes: int) -> uint8array  [builtin]
 function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [expr] {
-  { let bytes = self.random(8) } bytes[0] BitAnd 127 Shl 7 BitOr bytes[1] Shl 6 BitOr bytes[2] Shl 5 BitOr bytes[3] Shl 4 BitOr bytes[4] Shl 3 BitOr bytes[5] Shl 2 BitOr bytes[6] Shl 1 BitOr bytes[7]
+  { let bytes = self.random(8); let magnitude = bytes[0] BitAnd 63 Shl 56 BitOr bytes[1] Shl 48 BitOr bytes[2] Shl 40 BitOr bytes[3] Shl 32 BitOr bytes[4] Shl 24 BitOr bytes[5] Shl 16 BitOr bytes[6] Shl 8 BitOr bytes[7] } if (bytes[0] BitAnd 64 Eq 0) {  } magnitude else {  } 0 Sub magnitude Sub 1
 }
 function baml.random.random_int(self: ?) -> int  [builtin]
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -8539,6 +8539,132 @@ fn baml.ops.Subtract<float>$for$int.sub = builtin(vm)
 
 fn baml.ops.Subtract<bigint>$for$int.sub = builtin(vm)
 
+fn baml.random.SystemRandom.get() -> baml.random.SystemRandom {
+    // Locals:
+    let _0: baml.random.SystemRandom // _0 // return
+
+    bb0: {
+        _0 = baml.random.SystemRandom {  };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.random.ChaCha20.new = builtin(vm)
+
+fn baml.random.Xoshiro256PlusPlus.new = builtin(vm)
+
+fn baml.random.ChaCha20.Rng.random = builtin(vm)
+
+fn baml.random.Xoshiro256PlusPlus.Rng.random = builtin(vm)
+
+fn baml.random.SystemRandom.Rng.random = builtin(io)
+
+fn baml.random.Xoshiro256PlusPlus.Rng.random_int = builtin(vm)
+
+fn baml.random.SystemRandom.Rng.random_int = builtin(io)
+
+fn baml.random.Rng.random_int(self: baml.random.Rng) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: baml.random.Rng // self // param
+    let _2: uint8array // bytes
+    let _3: int
+    let _4: int
+    let _5: int
+    let _6: int
+    let _7: int
+    let _8: int
+    let _9: int
+    let _10: int
+    let _11: int
+    let _12: uint8array
+    let _13: 0
+    let _14: int
+    let _15: int
+    let _16: uint8array
+    let _17: 1
+    let _18: int
+    let _19: int
+    let _20: uint8array
+    let _21: 2
+    let _22: int
+    let _23: int
+    let _24: uint8array
+    let _25: 3
+    let _26: int
+    let _27: int
+    let _28: uint8array
+    let _29: 4
+    let _30: int
+    let _31: int
+    let _32: uint8array
+    let _33: 5
+    let _34: int
+    let _35: int
+    let _36: uint8array
+    let _37: 6
+    let _38: int
+    let _39: uint8array
+    let _40: 7
+
+    bb0: {
+        _2 = virtual_call random as baml.random.Rng(copy _1, const 8_i64) -> [bb1];
+    }
+
+    bb1: {
+        _12 = copy _2;
+        _13 = const 0_i64;
+        _11 = copy _12[_13];
+        _10 = copy _11 & const 127_i64;
+        _9 = copy _10 << const 7_i64;
+        _16 = copy _2;
+        _17 = const 1_i64;
+        _15 = copy _16[_17];
+        _14 = copy _15 << const 6_i64;
+        _8 = copy _9 | copy _14;
+        _20 = copy _2;
+        _21 = const 2_i64;
+        _19 = copy _20[_21];
+        _18 = copy _19 << const 5_i64;
+        _7 = copy _8 | copy _18;
+        _24 = copy _2;
+        _25 = const 3_i64;
+        _23 = copy _24[_25];
+        _22 = copy _23 << const 4_i64;
+        _6 = copy _7 | copy _22;
+        _28 = copy _2;
+        _29 = const 4_i64;
+        _27 = copy _28[_29];
+        _26 = copy _27 << const 3_i64;
+        _5 = copy _6 | copy _26;
+        _32 = copy _2;
+        _33 = const 5_i64;
+        _31 = copy _32[_33];
+        _30 = copy _31 << const 2_i64;
+        _4 = copy _5 | copy _30;
+        _36 = copy _2;
+        _37 = const 6_i64;
+        _35 = copy _36[_37];
+        _34 = copy _35 << const 1_i64;
+        _3 = copy _4 | copy _34;
+        _39 = copy _2;
+        _40 = const 7_i64;
+        _38 = copy _39[_40];
+        _0 = copy _3 | copy _38;
+        goto -> bb2;
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.random.ChaCha20.Rng.random_int = builtin(vm)
+
 fn baml.spawn.TaskGroup.active_count = builtin(vm)
 
 fn baml.spawn.CancelToken.any = builtin(vm)

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -8572,7 +8572,7 @@ fn baml.random.Rng.random_int(self: baml.random.Rng) -> int {
     let _0: int // _0 // return
     let _1: baml.random.Rng // self // param
     let _2: uint8array // bytes
-    let _3: int
+    let _3: int // magnitude
     let _4: int
     let _5: int
     let _6: int
@@ -8581,84 +8581,109 @@ fn baml.random.Rng.random_int(self: baml.random.Rng) -> int {
     let _9: int
     let _10: int
     let _11: int
-    let _12: uint8array
-    let _13: 0
-    let _14: int
+    let _12: int
+    let _13: uint8array
+    let _14: 0
     let _15: int
-    let _16: uint8array
-    let _17: 1
-    let _18: int
+    let _16: int
+    let _17: uint8array
+    let _18: 1
     let _19: int
-    let _20: uint8array
-    let _21: 2
-    let _22: int
+    let _20: int
+    let _21: uint8array
+    let _22: 2
     let _23: int
-    let _24: uint8array
-    let _25: 3
-    let _26: int
+    let _24: int
+    let _25: uint8array
+    let _26: 3
     let _27: int
-    let _28: uint8array
-    let _29: 4
-    let _30: int
+    let _28: int
+    let _29: uint8array
+    let _30: 4
     let _31: int
-    let _32: uint8array
-    let _33: 5
-    let _34: int
+    let _32: int
+    let _33: uint8array
+    let _34: 5
     let _35: int
-    let _36: uint8array
-    let _37: 6
-    let _38: int
-    let _39: uint8array
-    let _40: 7
+    let _36: int
+    let _37: uint8array
+    let _38: 6
+    let _39: int
+    let _40: uint8array
+    let _41: 7
+    let _42: bool
+    let _43: int
+    let _44: int
+    let _45: uint8array
+    let _46: 0
+    let _47: int
+    let _48: int
 
     bb0: {
         _2 = virtual_call random as baml.random.Rng(copy _1, const 8_i64) -> [bb1];
     }
 
     bb1: {
-        _12 = copy _2;
-        _13 = const 0_i64;
-        _11 = copy _12[_13];
-        _10 = copy _11 & const 127_i64;
-        _9 = copy _10 << const 7_i64;
-        _16 = copy _2;
-        _17 = const 1_i64;
-        _15 = copy _16[_17];
-        _14 = copy _15 << const 6_i64;
-        _8 = copy _9 | copy _14;
-        _20 = copy _2;
-        _21 = const 2_i64;
-        _19 = copy _20[_21];
-        _18 = copy _19 << const 5_i64;
-        _7 = copy _8 | copy _18;
-        _24 = copy _2;
-        _25 = const 3_i64;
-        _23 = copy _24[_25];
-        _22 = copy _23 << const 4_i64;
-        _6 = copy _7 | copy _22;
-        _28 = copy _2;
-        _29 = const 4_i64;
-        _27 = copy _28[_29];
-        _26 = copy _27 << const 3_i64;
-        _5 = copy _6 | copy _26;
-        _32 = copy _2;
-        _33 = const 5_i64;
-        _31 = copy _32[_33];
-        _30 = copy _31 << const 2_i64;
-        _4 = copy _5 | copy _30;
-        _36 = copy _2;
-        _37 = const 6_i64;
-        _35 = copy _36[_37];
-        _34 = copy _35 << const 1_i64;
-        _3 = copy _4 | copy _34;
-        _39 = copy _2;
-        _40 = const 7_i64;
-        _38 = copy _39[_40];
-        _0 = copy _3 | copy _38;
-        goto -> bb2;
+        _13 = copy _2;
+        _14 = const 0_i64;
+        _12 = copy _13[_14];
+        _11 = copy _12 & const 63_i64;
+        _10 = copy _11 << const 56_i64;
+        _17 = copy _2;
+        _18 = const 1_i64;
+        _16 = copy _17[_18];
+        _15 = copy _16 << const 48_i64;
+        _9 = copy _10 | copy _15;
+        _21 = copy _2;
+        _22 = const 2_i64;
+        _20 = copy _21[_22];
+        _19 = copy _20 << const 40_i64;
+        _8 = copy _9 | copy _19;
+        _25 = copy _2;
+        _26 = const 3_i64;
+        _24 = copy _25[_26];
+        _23 = copy _24 << const 32_i64;
+        _7 = copy _8 | copy _23;
+        _29 = copy _2;
+        _30 = const 4_i64;
+        _28 = copy _29[_30];
+        _27 = copy _28 << const 24_i64;
+        _6 = copy _7 | copy _27;
+        _33 = copy _2;
+        _34 = const 5_i64;
+        _32 = copy _33[_34];
+        _31 = copy _32 << const 16_i64;
+        _5 = copy _6 | copy _31;
+        _37 = copy _2;
+        _38 = const 6_i64;
+        _36 = copy _37[_38];
+        _35 = copy _36 << const 8_i64;
+        _4 = copy _5 | copy _35;
+        _40 = copy _2;
+        _41 = const 7_i64;
+        _39 = copy _40[_41];
+        _3 = copy _4 | copy _39;
+        _45 = copy _2;
+        _46 = const 0_i64;
+        _44 = copy _45[_46];
+        _43 = copy _44 & const 64_i64;
+        _42 = copy _43 == const 0_i64;
+        branch copy _42 -> [bb3, bb2];
     }
 
     bb2: {
+        _48 = copy _3;
+        _47 = const 0_i64 - copy _48;
+        _0 = copy _47 - const 1_i64;
+        goto -> bb4;
+    }
+
+    bb3: {
+        _0 = copy _3;
+        goto -> bb4;
+    }
+
+    bb4: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -8539,6 +8539,10 @@ fn baml.ops.Subtract<float>$for$int.sub = builtin(vm)
 
 fn baml.ops.Subtract<bigint>$for$int.sub = builtin(vm)
 
+fn baml.random.ChaCha20._new = builtin(vm)
+
+fn baml.random.Xoshiro256PlusPlus._new = builtin(vm)
+
 fn baml.random.SystemRandom.get() -> baml.random.SystemRandom {
     // Locals:
     let _0: baml.random.SystemRandom // _0 // return
@@ -8553,9 +8557,63 @@ fn baml.random.SystemRandom.get() -> baml.random.SystemRandom {
     }
 }
 
-fn baml.random.ChaCha20.new = builtin(vm)
+fn baml.random.ChaCha20.new(seed: uint8array) -> baml.random.ChaCha20 {
+    // Locals:
+    let _0: baml.random.ChaCha20 // _0 // return
+    let _1: uint8array // seed // param
+    let _2: bool
+    let _3: baml.random.SystemRandom
 
-fn baml.random.Xoshiro256PlusPlus.new = builtin(vm)
+    bb0: {
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb3];
+    }
+
+    bb1: {
+        _3 = call const fn baml.random.SystemRandom.get() -> [bb2];
+    }
+
+    bb2: {
+        _1 = virtual_call random as baml.random.Rng(copy _3, const 32_i64) -> [bb3];
+    }
+
+    bb3: {
+        _0 = call const fn baml.random.ChaCha20._new(copy _1) -> [bb4];
+    }
+
+    bb4: {
+        return;
+    }
+}
+
+fn baml.random.Xoshiro256PlusPlus.new(seed: uint8array) -> baml.random.Xoshiro256PlusPlus {
+    // Locals:
+    let _0: baml.random.Xoshiro256PlusPlus // _0 // return
+    let _1: uint8array // seed // param
+    let _2: bool
+    let _3: baml.random.SystemRandom
+
+    bb0: {
+        _2 = copy _1 == const <omitted>;
+        branch copy _2 -> [bb1, bb3];
+    }
+
+    bb1: {
+        _3 = call const fn baml.random.SystemRandom.get() -> [bb2];
+    }
+
+    bb2: {
+        _1 = virtual_call random as baml.random.Rng(copy _3, const 32_i64) -> [bb3];
+    }
+
+    bb3: {
+        _0 = call const fn baml.random.Xoshiro256PlusPlus._new(copy _1) -> [bb4];
+    }
+
+    bb4: {
+        return;
+    }
+}
 
 fn baml.random.ChaCha20.Rng.random = builtin(vm)
 
@@ -8564,8 +8622,6 @@ fn baml.random.Xoshiro256PlusPlus.Rng.random = builtin(vm)
 fn baml.random.SystemRandom.Rng.random = builtin(io)
 
 fn baml.random.Xoshiro256PlusPlus.Rng.random_int = builtin(vm)
-
-fn baml.random.SystemRandom.Rng.random_int = builtin(io)
 
 fn baml.random.Rng.random_int(self: baml.random.Rng) -> int {
     // Locals:
@@ -8687,6 +8743,8 @@ fn baml.random.Rng.random_int(self: baml.random.Rng) -> int {
         return;
     }
 }
+
+fn baml.random.SystemRandom.Rng.random_int = builtin(io)
 
 fn baml.random.ChaCha20.Rng.random_int = builtin(vm)
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -2799,6 +2799,35 @@ class baml.panics.IntegerOverflow$stream {
 }
 type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.IndexOutOfBounds$stream | baml.panics.InvalidFieldAccess$stream | baml.panics.MapKeyNotFound$stream | baml.panics.StackOverflow$stream | baml.panics.AssertionFailed$stream | baml.panics.Unreachable$stream | baml.panics.Cancelled$stream | baml.panics.UserPanic$stream | baml.panics.Exit$stream | baml.panics.AllocFailure$stream | baml.panics.HostUnavailable$stream | baml.panics.NegativeBitShift$stream | baml.panics.SdkPanic$stream | baml.panics.HostContractViolation$stream | baml.panics.IntegerOverflow$stream
 
+--- <builtin>/baml/ns_random/random.baml ---
+function baml.random.Rng.random_int(self: baml.random.Rng) -> int throws never {
+  { : int
+    let bytes = self.random(8) : uint8array
+    bytes[0] & 127 << 7 | bytes[1] << 6 | bytes[2] << 5 | bytes[3] << 4 | bytes[4] << 3 | bytes[5] << 2 | bytes[6] << 1 | bytes[7] : int
+  }
+}
+class baml.random.SystemRandom {
+}
+function baml.random.SystemRandom.get() -> baml.random.SystemRandom throws never {
+  { : baml.random.SystemRandom
+    SystemRandom {  } : baml.random.SystemRandom
+  }
+}
+class baml.random.Xoshiro256PlusPlus {
+  _state: $rust_type
+}
+class baml.random.ChaCha20 {
+  _state: $rust_type
+}
+class baml.random.SystemRandom$stream {
+}
+class baml.random.Xoshiro256PlusPlus$stream {
+  _state: $rust_type
+}
+class baml.random.ChaCha20$stream {
+  _state: $rust_type
+}
+
 --- <builtin>/baml/ns_spawn/spawn.baml ---
 class baml.spawn.SpawnParams {
   body: () -> T throws E

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -2824,8 +2824,18 @@ function baml.random.SystemRandom.get() -> baml.random.SystemRandom throws never
 class baml.random.Xoshiro256PlusPlus {
   _state: $rust_type
 }
+function baml.random.Xoshiro256PlusPlus.new(seed: uint8array = SystemRandom.get().random(32)) -> baml.random.Xoshiro256PlusPlus throws never {
+  { : baml.random.Xoshiro256PlusPlus
+    Xoshiro256PlusPlus._new(seed) : baml.random.Xoshiro256PlusPlus
+  }
+}
 class baml.random.ChaCha20 {
   _state: $rust_type
+}
+function baml.random.ChaCha20.new(seed: uint8array = SystemRandom.get().random(32)) -> baml.random.ChaCha20 throws never {
+  { : baml.random.ChaCha20
+    ChaCha20._new(seed) : baml.random.ChaCha20
+  }
 }
 class baml.random.SystemRandom$stream {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -2803,7 +2803,15 @@ type baml.panics.Panic$stream = baml.panics.DivisionByZero$stream | baml.panics.
 function baml.random.Rng.random_int(self: baml.random.Rng) -> int throws never {
   { : int
     let bytes = self.random(8) : uint8array
-    bytes[0] & 127 << 7 | bytes[1] << 6 | bytes[2] << 5 | bytes[3] << 4 | bytes[4] << 3 | bytes[5] << 2 | bytes[6] << 1 | bytes[7] : int
+    let magnitude = bytes[0] & 63 << 56 | bytes[1] << 48 | bytes[2] << 40 | bytes[3] << 32 | bytes[4] << 24 | bytes[5] << 16 | bytes[6] << 8 | bytes[7] : int
+    if (bytes[0] & 64 == 0 : bool) : int
+      { : int
+        magnitude : int
+      }
+    else
+      { : int
+        0 - magnitude - 1 : int
+      }
   }
 }
 class baml.random.SystemRandom {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -6034,50 +6034,73 @@ function baml.random.Rng.random_int(self: baml.random.Rng) -> int {
     load_var bytes
     load_const 0
     load_array_element
-    load_const 127
+    load_const 63
     bin_op &
-    load_const 7
+    load_const 56
     bin_op <<
     load_var bytes
     load_const 1
     load_array_element
-    load_const 6
+    load_const 48
     bin_op <<
     bin_op |
     load_var bytes
     load_const 2
     load_array_element
-    load_const 5
+    load_const 40
     bin_op <<
     bin_op |
     load_var bytes
     load_const 3
     load_array_element
-    load_const 4
+    load_const 32
     bin_op <<
     bin_op |
     load_var bytes
     load_const 4
     load_array_element
-    load_const 3
+    load_const 24
     bin_op <<
     bin_op |
     load_var bytes
     load_const 5
     load_array_element
-    load_const 2
+    load_const 16
     bin_op <<
     bin_op |
     load_var bytes
     load_const 6
     load_array_element
-    load_const 1
+    load_const 8
     bin_op <<
     bin_op |
     load_var bytes
     load_const 7
     load_array_element
     bin_op |
+    store_var magnitude
+    load_var bytes
+    load_const 0
+    load_array_element
+    load_const 64
+    bin_op &
+    load_const 0
+    cmp_int_op ==
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const 0
+    load_var magnitude
+    sub_int
+    load_const 1
+    sub_int
+    jump L2
+
+  L1:
+    load_var magnitude
+
+  L2:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -6015,6 +6015,92 @@ function baml.ops.__union_sub(a: unknown, b: unknown) -> unknown {
 function baml.ops.equals_equals(a: unknown, b: unknown) -> bool {
 }
 
+function baml.random.ChaCha20.Rng.random(self: baml.random.ChaCha20, bytes: int) -> uint8array {
+}
+
+function baml.random.ChaCha20.Rng.random_int(self: baml.random.ChaCha20) -> int {
+}
+
+function baml.random.ChaCha20.new(seed: uint8array) -> baml.random.ChaCha20 {
+}
+
+function baml.random.Rng.random_int(self: baml.random.Rng) -> int {
+    load_var self
+    load_const 8
+    load_type baml.random.Rng
+    load_const "random"
+    virtual_call nargs=2 ntypeargs=0
+    store_var bytes
+    load_var bytes
+    load_const 0
+    load_array_element
+    load_const 127
+    bin_op &
+    load_const 7
+    bin_op <<
+    load_var bytes
+    load_const 1
+    load_array_element
+    load_const 6
+    bin_op <<
+    bin_op |
+    load_var bytes
+    load_const 2
+    load_array_element
+    load_const 5
+    bin_op <<
+    bin_op |
+    load_var bytes
+    load_const 3
+    load_array_element
+    load_const 4
+    bin_op <<
+    bin_op |
+    load_var bytes
+    load_const 4
+    load_array_element
+    load_const 3
+    bin_op <<
+    bin_op |
+    load_var bytes
+    load_const 5
+    load_array_element
+    load_const 2
+    bin_op <<
+    bin_op |
+    load_var bytes
+    load_const 6
+    load_array_element
+    load_const 1
+    bin_op <<
+    bin_op |
+    load_var bytes
+    load_const 7
+    load_array_element
+    bin_op |
+    return
+}
+
+function baml.random.SystemRandom.Rng.random(self: baml.random.SystemRandom, bytes: int) -> uint8array {
+}
+
+function baml.random.SystemRandom.Rng.random_int(self: baml.random.SystemRandom) -> int {
+}
+
+function baml.random.SystemRandom.get() -> baml.random.SystemRandom {
+    alloc_instance baml.random.SystemRandom
+    return
+}
+
+function baml.random.Xoshiro256PlusPlus.Rng.random(self: baml.random.Xoshiro256PlusPlus, bytes: int) -> uint8array {
+}
+
+function baml.random.Xoshiro256PlusPlus.Rng.random_int(self: baml.random.Xoshiro256PlusPlus) -> int {
+}
+
+function baml.random.Xoshiro256PlusPlus.new(seed: uint8array) -> baml.random.Xoshiro256PlusPlus {
+}
+
 function baml.spawn.CancelToken.any(tokens: baml.spawn.CancelToken[]) -> baml.spawn.CancelToken {
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -6021,7 +6021,25 @@ function baml.random.ChaCha20.Rng.random(self: baml.random.ChaCha20, bytes: int)
 function baml.random.ChaCha20.Rng.random_int(self: baml.random.ChaCha20) -> int {
 }
 
+function baml.random.ChaCha20._new(seed: uint8array) -> baml.random.ChaCha20 {
+}
+
 function baml.random.ChaCha20.new(seed: uint8array) -> baml.random.ChaCha20 {
+    load_var seed
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    call baml.random.SystemRandom.get
+    load_const 32
+    load_type baml.random.Rng
+    load_const "random"
+    virtual_call nargs=2 ntypeargs=0
+    store_var seed
+
+  L0:
+    load_var seed
+    call baml.random.ChaCha20._new
+    return
 }
 
 function baml.random.Rng.random_int(self: baml.random.Rng) -> int {
@@ -6121,7 +6139,25 @@ function baml.random.Xoshiro256PlusPlus.Rng.random(self: baml.random.Xoshiro256P
 function baml.random.Xoshiro256PlusPlus.Rng.random_int(self: baml.random.Xoshiro256PlusPlus) -> int {
 }
 
+function baml.random.Xoshiro256PlusPlus._new(seed: uint8array) -> baml.random.Xoshiro256PlusPlus {
+}
+
 function baml.random.Xoshiro256PlusPlus.new(seed: uint8array) -> baml.random.Xoshiro256PlusPlus {
+    load_var seed
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    call baml.random.SystemRandom.get
+    load_const 32
+    load_type baml.random.Rng
+    load_const "random"
+    virtual_call nargs=2 ntypeargs=0
+    store_var seed
+
+  L0:
+    load_var seed
+    call baml.random.Xoshiro256PlusPlus._new
+    return
 }
 
 function baml.spawn.CancelToken.any(tokens: baml.spawn.CancelToken[]) -> baml.spawn.CancelToken {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -278,6 +278,11 @@ namespace baml.panics:
   class StackOverflow { methods: [] }
   class Unreachable { methods: [] }
   class UserPanic { methods: [] }
+namespace baml.random:
+  class ChaCha20 { methods: [new, random, random_int] }
+  type Rng
+  class SystemRandom { methods: [get, random, random_int] }
+  class Xoshiro256PlusPlus { methods: [new, random, random_int] }
 namespace baml.spawn:
   class CancelToken { methods: [new, any, cancel, is_cancelled] }
   class SpawnParams<T, E> { methods: [] }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -279,10 +279,10 @@ namespace baml.panics:
   class Unreachable { methods: [] }
   class UserPanic { methods: [] }
 namespace baml.random:
-  class ChaCha20 { methods: [new, random, random_int] }
+  class ChaCha20 { methods: [new, _new, random, random_int] }
   type Rng
   class SystemRandom { methods: [get, random, random_int] }
-  class Xoshiro256PlusPlus { methods: [new, random, random_int] }
+  class Xoshiro256PlusPlus { methods: [new, _new, random, random_int] }
 namespace baml.spawn:
   class CancelToken { methods: [new, any, cancel, is_cancelled] }
   class SpawnParams<T, E> { methods: [] }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 758 ntypeargs=0   (assert.format_operand)
+       26   call 768 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 758 ntypeargs=0   (assert.format_operand)
+       29   call 768 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 758 ntypeargs=0   (assert.format_operand)
+       32   call 768 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 758 ntypeargs=0   (assert.format_operand)
+       35   call 768 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 758 ntypeargs=0   (assert.format_operand)
+       8    call 768 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 758 ntypeargs=0   (assert.format_operand)
+       11   call 768 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -170,7 +170,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1352 0   
+  101   0   make_closure 1370 0   
         1   return                
 }
 
@@ -195,7 +195,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1365 1    
+       17   make_closure 1383 1    
        18   return                 
 }
 
@@ -234,7 +234,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1383 2    
+       29   make_closure 1401 2    
        30   return                 
 }
 
@@ -253,12 +253,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1374 1    
+       11   make_closure 1392 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1356 0   
+  95   0   make_closure 1374 0   
        1   return                
 }
 
@@ -556,11 +556,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   198   22   load_var2 1 5                      
-        23   call 735 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 745 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   199   25   load_var 1                         (self)
-        26   call 718 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 728 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   203   28   load_type 5                        
@@ -597,7 +597,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   206   58   load_var2 9 2                      
-        59   call 723 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 733 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   209   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -671,7 +671,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 717 ntypeargs=0   (testing.select_names)
+        2   call 727 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -688,9 +688,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 733 ntypeargs=0   (testing.testset_children)
+        1   call 743 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 711 ntypeargs=0   (testing.run_testset)
+        3   call 721 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -714,24 +714,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   16   load_var2 1 2          
         17   load_var 3             (exclude)
-        18   call 717 ntypeargs=0   (testing.select_names)
+        18   call 727 ntypeargs=0   (testing.select_names)
         19   store_var 6            (_9)
         20   load_var2 1 6          
-        21   call 708 ntypeargs=0   (testing.TestRegistry.run_selected)
+        21   call 718 ntypeargs=0   (testing.TestRegistry.run_selected)
         22   jump +3                (to 25)
 
   180   23   load_var 1             (self)
-        24   call 730 ntypeargs=0   (testing.TestRegistry.run_all)
+        24   call 740 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   25   call 746 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   25   call 756 ntypeargs=0   (testing.flatten_with_tolerated)
         26   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 714 ntypeargs=0   (testing.testset_children_selected)
+        1   call 724 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 711 ntypeargs=0   (testing.run_testset)
+        3   call 721 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -764,7 +764,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 745 ntypeargs=0               (testing.run_test)
+        26   call 755 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   140   28   load_type 5                        
@@ -801,7 +801,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   144   58   load_var2 9 2                      
-        59   call 722 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 732 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   147   61   load_const 12                      ("Test not found: ")
@@ -836,11 +836,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   153   22   load_var2 1 5                      
-        23   call 735 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 733 ntypeargs=0               (testing.testset_children)
+        23   call 745 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 743 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 711 ntypeargs=0               (testing.run_testset)
+        27   call 721 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   156   29   load_type 5                        
@@ -877,7 +877,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   159   59   load_var2 9 2                      
-        60   call 726 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 736 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   162   62   load_const 12                      ("TestSet not found: ")
@@ -968,7 +968,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         69   store_var 10                       (_27)
 
   119   70   load_var 9                         (sub)
-        71   call 718 ntypeargs=0               (testing.TestRegistry.serialize)
+        71   call 728 ntypeargs=0               (testing.TestRegistry.serialize)
         72   store_var 11                       (_28)
 
   117   73   load_var2 2 10                     
@@ -1245,13 +1245,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   16   load_field 0                       (func_pat)
         17   load_var 2                         (function_name)
-        18   call 731 ntypeargs=0               (testing.filter_match)
+        18   call 741 ntypeargs=0               (testing.filter_match)
         19   jump_if_false +6                   (to 25)
         20   pop 1                              
         21   load_var 6                         (p)
         22   load_field 1                       (test_pat)
         23   load_var 3                         (test_name)
-        24   call 731 ntypeargs=0               (testing.filter_match)
+        24   call 741 ntypeargs=0               (testing.filter_match)
         25   pop_jump_if_false -20              (to 5)
 
   527   26   load_const 5                       (true)
@@ -1285,7 +1285,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         19   load_var 5                         (r)
         20   load_field 5                       (results)
         21   load_var 2                         (out)
-        22   call 724 ntypeargs=0               (testing.collect_leaf_messages)
+        22   call 734 ntypeargs=0               (testing.collect_leaf_messages)
         23   pop 1                              
         24   jump -19                           (to 5)
         25   load_var 5                         (r)
@@ -1377,7 +1377,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   567   40   load_var2 1 6                      
 
-  566   41   call 736 ntypeargs=0               (testing.collect_subtree_names)
+  566   41   call 746 ntypeargs=0               (testing.collect_subtree_names)
 
   567   42   load_type 10                       
         43   load_const 11                      ("iter")
@@ -1405,8 +1405,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 735 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 719 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 745 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 729 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +20               (to 23)
         4    load_var 3             (e)
         5    type_tag               
@@ -1521,7 +1521,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   71    load_var 11                        (tsr)
         72    load_field 5                       (results)
         73    load_var 12                        (ft)
-        74    call 721 ntypeargs=0               (testing.count_leaves)
+        74    call 731 ntypeargs=0               (testing.count_leaves)
         75    store_var 10                       (delta)
         76    jump +30                           (to 106)
 
@@ -1616,7 +1616,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 729 ntypeargs=0   (testing.glob_match)
+        6   call 739 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -1671,7 +1671,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   37   load_var 1             (report)
         38   load_field 5           (results)
         39   load_var 2             (top_tolerated)
-        40   call 721 ntypeargs=0   (testing.count_leaves)
+        40   call 731 ntypeargs=0   (testing.count_leaves)
         41   store_var 3            (counts)
 
   645   42   load_type 2            
@@ -1681,7 +1681,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   45   load_var 1             (report)
         46   load_field 5           (results)
         47   load_var 5             (messages)
-        48   call 724 ntypeargs=0   (testing.collect_leaf_messages)
+        48   call 734 ntypeargs=0   (testing.collect_leaf_messages)
         49   pop 1                  
 
   648   50   load_var 1             (report)
@@ -1835,14 +1835,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 741 ntypeargs=0   (testing.split_top)
+        1    call 751 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 743 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 753 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +17               (to 26)
 
@@ -1859,7 +1859,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         19   load_field 0           (head)
         20   load_var 4             (split)
         21   load_field 1           (tail)
-        22   call 743 ntypeargs=0   (testing.any_pattern_matches)
+        22   call 753 ntypeargs=0   (testing.any_pattern_matches)
         23   jump +4                (to 27)
 
   541   24   load_const 1           (true)
@@ -1972,7 +1972,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   370   25   load_var 5                         (child)
-        26   make_closure 1298 1                
+        26   make_closure 1316 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   spawn                              
@@ -1994,7 +1994,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   375   43   load_const 9                       ("unexpected test child failure")
         44   call 244 ntypeargs=0               (baml.sys.panic)
 
-  377   45   call 715 ntypeargs=0               (testing.aggregate_reports)
+  377   45   call 725 ntypeargs=0               (testing.aggregate_reports)
         46   return                             
 }
 
@@ -2053,11 +2053,11 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         46   pop_jump_if_false -38              (to 8)
 
   116   47   load_var 3                         (named_results)
-        48   call 715 ntypeargs=0               (testing.aggregate_reports)
+        48   call 725 ntypeargs=0               (testing.aggregate_reports)
         49   jump +3                            (to 52)
 
   121   50   load_var 3                         (named_results)
-        51   call 715 ntypeargs=0               (testing.aggregate_reports)
+        51   call 725 ntypeargs=0               (testing.aggregate_reports)
         52   return                             
 }
 
@@ -2067,7 +2067,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1346 1    
+        4    make_closure 1364 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -2099,17 +2099,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   418   8    load_var 1             (children)
-        9    call 728 ntypeargs=0   (testing.run_children_parallel)
+        9    call 738 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0    load_var 2                         (include)
-        1    call 716 ntypeargs=0               (testing.parse_filter_patterns)
+        1    call 726 ntypeargs=0               (testing.parse_filter_patterns)
         2    store_var 4                        (inc)
 
   550   3    load_var 3                         (exclude)
-        4    call 716 ntypeargs=0               (testing.parse_filter_patterns)
+        4    call 726 ntypeargs=0               (testing.parse_filter_patterns)
         5    store_var 5                        (exc)
 
   551   6    load_type 0                        
@@ -2117,7 +2117,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8    store_var 6                        (out)
 
   552   9    load_var 1                         (registry)
-        10   call 719 ntypeargs=0               (testing.collect_leaf_names)
+        10   call 729 ntypeargs=0               (testing.collect_leaf_names)
         11   load_type 1                        
         12   load_const 2                       ("iter")
         13   virtual_call nargs=1 ntypeargs=0   
@@ -2135,7 +2135,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         25   store_var_load_var 9               (name)
 
   553   26   load_var2 4 5                      
-        27   call 744 ntypeargs=0               (testing.leaf_selected)
+        27   call 754 ntypeargs=0               (testing.leaf_selected)
         28   pop_jump_if_false -13              (to 15)
 
   554   29   load_var2 6 9                      
@@ -2192,7 +2192,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1317 2   
+        8    make_closure 1335 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -2209,7 +2209,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1335 2   
+        9    make_closure 1353 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -2230,7 +2230,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1350 3   
+        13   make_closure 1368 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -2264,7 +2264,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 734 ntypeargs=0               (testing.test_child)
+        26   call 744 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_var2 2 6                      
         29   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2290,7 +2290,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   238   48   load_var2 1 8                      
 
-  237   49   call 742 ntypeargs=0               (testing.testset_child)
+  237   49   call 752 ntypeargs=0               (testing.testset_child)
         50   store_var 9                        (_21)
 
   238   51   load_var2 2 9                      
@@ -2328,7 +2328,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 738 ntypeargs=0               (testing._name_selected)
+        23   call 748 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   247   25   load_var 6                         (t)
@@ -2337,7 +2337,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 734 ntypeargs=0               (testing.test_child)
+        31   call 744 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_var2 3 7                      
         34   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2365,12 +2365,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 720 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 730 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   259   59   load_var2 1 10                     
         60   load_var 2                         (names)
-        61   call 747 ntypeargs=0               (testing.testset_child_selected)
+        61   call 757 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 11                       (_26)
         63   load_var2 3 11                     
         64   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2390,7 +2390,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 761 ntypeargs=0   (user.score)
+       7    call 771 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 768 ntypeargs=0   (assert.format_operand)
+       26   call 770 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 768 ntypeargs=0   (assert.format_operand)
+       29   call 770 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 768 ntypeargs=0   (assert.format_operand)
+       32   call 770 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 768 ntypeargs=0   (assert.format_operand)
+       35   call 770 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 768 ntypeargs=0   (assert.format_operand)
+       8    call 770 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 768 ntypeargs=0   (assert.format_operand)
+       11   call 770 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -170,7 +170,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1370 0   
+  101   0   make_closure 1374 0   
         1   return                
 }
 
@@ -195,7 +195,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1383 1    
+       17   make_closure 1387 1    
        18   return                 
 }
 
@@ -234,7 +234,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1401 2    
+       29   make_closure 1405 2    
        30   return                 
 }
 
@@ -253,12 +253,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1392 1    
+       11   make_closure 1396 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1374 0   
+  95   0   make_closure 1378 0   
        1   return                
 }
 
@@ -556,11 +556,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   198   22   load_var2 1 5                      
-        23   call 745 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 747 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   199   25   load_var 1                         (self)
-        26   call 728 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 730 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   203   28   load_type 5                        
@@ -597,7 +597,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   206   58   load_var2 9 2                      
-        59   call 733 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 735 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   209   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -671,7 +671,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 727 ntypeargs=0   (testing.select_names)
+        2   call 729 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -688,9 +688,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 743 ntypeargs=0   (testing.testset_children)
+        1   call 745 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 721 ntypeargs=0   (testing.run_testset)
+        3   call 723 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -714,24 +714,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   16   load_var2 1 2          
         17   load_var 3             (exclude)
-        18   call 727 ntypeargs=0   (testing.select_names)
+        18   call 729 ntypeargs=0   (testing.select_names)
         19   store_var 6            (_9)
         20   load_var2 1 6          
-        21   call 718 ntypeargs=0   (testing.TestRegistry.run_selected)
+        21   call 720 ntypeargs=0   (testing.TestRegistry.run_selected)
         22   jump +3                (to 25)
 
   180   23   load_var 1             (self)
-        24   call 740 ntypeargs=0   (testing.TestRegistry.run_all)
+        24   call 742 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   25   call 756 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   25   call 758 ntypeargs=0   (testing.flatten_with_tolerated)
         26   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 724 ntypeargs=0   (testing.testset_children_selected)
+        1   call 726 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 721 ntypeargs=0   (testing.run_testset)
+        3   call 723 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -764,7 +764,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 755 ntypeargs=0               (testing.run_test)
+        26   call 757 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   140   28   load_type 5                        
@@ -801,7 +801,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   144   58   load_var2 9 2                      
-        59   call 732 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 734 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   147   61   load_const 12                      ("Test not found: ")
@@ -836,11 +836,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   153   22   load_var2 1 5                      
-        23   call 745 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 743 ntypeargs=0               (testing.testset_children)
+        23   call 747 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 745 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 721 ntypeargs=0               (testing.run_testset)
+        27   call 723 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   156   29   load_type 5                        
@@ -877,7 +877,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   159   59   load_var2 9 2                      
-        60   call 736 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 738 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   162   62   load_const 12                      ("TestSet not found: ")
@@ -968,7 +968,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         69   store_var 10                       (_27)
 
   119   70   load_var 9                         (sub)
-        71   call 728 ntypeargs=0               (testing.TestRegistry.serialize)
+        71   call 730 ntypeargs=0               (testing.TestRegistry.serialize)
         72   store_var 11                       (_28)
 
   117   73   load_var2 2 10                     
@@ -1245,13 +1245,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   16   load_field 0                       (func_pat)
         17   load_var 2                         (function_name)
-        18   call 741 ntypeargs=0               (testing.filter_match)
+        18   call 743 ntypeargs=0               (testing.filter_match)
         19   jump_if_false +6                   (to 25)
         20   pop 1                              
         21   load_var 6                         (p)
         22   load_field 1                       (test_pat)
         23   load_var 3                         (test_name)
-        24   call 741 ntypeargs=0               (testing.filter_match)
+        24   call 743 ntypeargs=0               (testing.filter_match)
         25   pop_jump_if_false -20              (to 5)
 
   527   26   load_const 5                       (true)
@@ -1285,7 +1285,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         19   load_var 5                         (r)
         20   load_field 5                       (results)
         21   load_var 2                         (out)
-        22   call 734 ntypeargs=0               (testing.collect_leaf_messages)
+        22   call 736 ntypeargs=0               (testing.collect_leaf_messages)
         23   pop 1                              
         24   jump -19                           (to 5)
         25   load_var 5                         (r)
@@ -1377,7 +1377,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   567   40   load_var2 1 6                      
 
-  566   41   call 746 ntypeargs=0               (testing.collect_subtree_names)
+  566   41   call 748 ntypeargs=0               (testing.collect_subtree_names)
 
   567   42   load_type 10                       
         43   load_const 11                      ("iter")
@@ -1405,8 +1405,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 745 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 729 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 747 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 731 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +20               (to 23)
         4    load_var 3             (e)
         5    type_tag               
@@ -1521,7 +1521,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   71    load_var 11                        (tsr)
         72    load_field 5                       (results)
         73    load_var 12                        (ft)
-        74    call 731 ntypeargs=0               (testing.count_leaves)
+        74    call 733 ntypeargs=0               (testing.count_leaves)
         75    store_var 10                       (delta)
         76    jump +30                           (to 106)
 
@@ -1616,7 +1616,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 739 ntypeargs=0   (testing.glob_match)
+        6   call 741 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -1671,7 +1671,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   37   load_var 1             (report)
         38   load_field 5           (results)
         39   load_var 2             (top_tolerated)
-        40   call 731 ntypeargs=0   (testing.count_leaves)
+        40   call 733 ntypeargs=0   (testing.count_leaves)
         41   store_var 3            (counts)
 
   645   42   load_type 2            
@@ -1681,7 +1681,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   45   load_var 1             (report)
         46   load_field 5           (results)
         47   load_var 5             (messages)
-        48   call 734 ntypeargs=0   (testing.collect_leaf_messages)
+        48   call 736 ntypeargs=0   (testing.collect_leaf_messages)
         49   pop 1                  
 
   648   50   load_var 1             (report)
@@ -1835,14 +1835,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 751 ntypeargs=0   (testing.split_top)
+        1    call 753 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 753 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 755 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +17               (to 26)
 
@@ -1859,7 +1859,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         19   load_field 0           (head)
         20   load_var 4             (split)
         21   load_field 1           (tail)
-        22   call 753 ntypeargs=0   (testing.any_pattern_matches)
+        22   call 755 ntypeargs=0   (testing.any_pattern_matches)
         23   jump +4                (to 27)
 
   541   24   load_const 1           (true)
@@ -1972,7 +1972,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   370   25   load_var 5                         (child)
-        26   make_closure 1316 1                
+        26   make_closure 1320 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   spawn                              
@@ -1994,7 +1994,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   375   43   load_const 9                       ("unexpected test child failure")
         44   call 244 ntypeargs=0               (baml.sys.panic)
 
-  377   45   call 725 ntypeargs=0               (testing.aggregate_reports)
+  377   45   call 727 ntypeargs=0               (testing.aggregate_reports)
         46   return                             
 }
 
@@ -2053,11 +2053,11 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         46   pop_jump_if_false -38              (to 8)
 
   116   47   load_var 3                         (named_results)
-        48   call 725 ntypeargs=0               (testing.aggregate_reports)
+        48   call 727 ntypeargs=0               (testing.aggregate_reports)
         49   jump +3                            (to 52)
 
   121   50   load_var 3                         (named_results)
-        51   call 725 ntypeargs=0               (testing.aggregate_reports)
+        51   call 727 ntypeargs=0               (testing.aggregate_reports)
         52   return                             
 }
 
@@ -2067,7 +2067,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1364 1    
+        4    make_closure 1368 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -2099,17 +2099,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   418   8    load_var 1             (children)
-        9    call 738 ntypeargs=0   (testing.run_children_parallel)
+        9    call 740 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0    load_var 2                         (include)
-        1    call 726 ntypeargs=0               (testing.parse_filter_patterns)
+        1    call 728 ntypeargs=0               (testing.parse_filter_patterns)
         2    store_var 4                        (inc)
 
   550   3    load_var 3                         (exclude)
-        4    call 726 ntypeargs=0               (testing.parse_filter_patterns)
+        4    call 728 ntypeargs=0               (testing.parse_filter_patterns)
         5    store_var 5                        (exc)
 
   551   6    load_type 0                        
@@ -2117,7 +2117,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8    store_var 6                        (out)
 
   552   9    load_var 1                         (registry)
-        10   call 729 ntypeargs=0               (testing.collect_leaf_names)
+        10   call 731 ntypeargs=0               (testing.collect_leaf_names)
         11   load_type 1                        
         12   load_const 2                       ("iter")
         13   virtual_call nargs=1 ntypeargs=0   
@@ -2135,7 +2135,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         25   store_var_load_var 9               (name)
 
   553   26   load_var2 4 5                      
-        27   call 754 ntypeargs=0               (testing.leaf_selected)
+        27   call 756 ntypeargs=0               (testing.leaf_selected)
         28   pop_jump_if_false -13              (to 15)
 
   554   29   load_var2 6 9                      
@@ -2192,7 +2192,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1335 2   
+        8    make_closure 1339 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -2209,7 +2209,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1353 2   
+        9    make_closure 1357 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -2230,7 +2230,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1368 3   
+        13   make_closure 1372 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -2264,7 +2264,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 744 ntypeargs=0               (testing.test_child)
+        26   call 746 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_var2 2 6                      
         29   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2290,7 +2290,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   238   48   load_var2 1 8                      
 
-  237   49   call 752 ntypeargs=0               (testing.testset_child)
+  237   49   call 754 ntypeargs=0               (testing.testset_child)
         50   store_var 9                        (_21)
 
   238   51   load_var2 2 9                      
@@ -2328,7 +2328,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 748 ntypeargs=0               (testing._name_selected)
+        23   call 750 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   247   25   load_var 6                         (t)
@@ -2337,7 +2337,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 744 ntypeargs=0               (testing.test_child)
+        31   call 746 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_var2 3 7                      
         34   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2365,12 +2365,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 730 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 732 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   259   59   load_var2 1 10                     
         60   load_var 2                         (names)
-        61   call 757 ntypeargs=0               (testing.testset_child_selected)
+        61   call 759 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 11                       (_26)
         63   load_var2 3 11                     
         64   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2390,7 +2390,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 771 ntypeargs=0   (user.score)
+       7    call 773 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 758 ntypeargs=0   (assert.format_operand)
+       26   call 768 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 758 ntypeargs=0   (assert.format_operand)
+       29   call 768 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 758 ntypeargs=0   (assert.format_operand)
+       32   call 768 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 758 ntypeargs=0   (assert.format_operand)
+       35   call 768 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 758 ntypeargs=0   (assert.format_operand)
+       8    call 768 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 758 ntypeargs=0   (assert.format_operand)
+       11   call 768 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -170,7 +170,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1352 0   
+  101   0   make_closure 1370 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -197,7 +197,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1365 1    
+       17   make_closure 1383 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -238,7 +238,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1383 2    
+       29   make_closure 1401 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -259,14 +259,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1374 1    
+       11   make_closure 1392 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1356 0   
+  95   0   make_closure 1374 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -576,11 +576,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   198   22   load_var2 1 5                      
-        23   call 735 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 745 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   199   25   load_var 1                         (self)
-        26   call 718 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 728 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   203   28   load_type 5                        
@@ -617,7 +617,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   206   58   load_var2 9 2                      
-        59   call 723 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 733 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   209   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -695,7 +695,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 717 ntypeargs=0   (testing.select_names)
+        2   call 727 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -714,9 +714,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 733 ntypeargs=0   (testing.testset_children)
+        1   call 743 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 711 ntypeargs=0   (testing.run_testset)
+        3   call 721 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -740,24 +740,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   16   load_var2 1 2          
         17   load_var 3             (exclude)
-        18   call 717 ntypeargs=0   (testing.select_names)
+        18   call 727 ntypeargs=0   (testing.select_names)
         19   store_var 6            (_9)
         20   load_var2 1 6          
-        21   call 708 ntypeargs=0   (testing.TestRegistry.run_selected)
+        21   call 718 ntypeargs=0   (testing.TestRegistry.run_selected)
         22   jump +3                (to 25)
 
   180   23   load_var 1             (self)
-        24   call 730 ntypeargs=0   (testing.TestRegistry.run_all)
+        24   call 740 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   25   call 746 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   25   call 756 ntypeargs=0   (testing.flatten_with_tolerated)
         26   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 714 ntypeargs=0   (testing.testset_children_selected)
+        1   call 724 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 711 ntypeargs=0   (testing.run_testset)
+        3   call 721 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -790,7 +790,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 745 ntypeargs=0               (testing.run_test)
+        26   call 755 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   140   28   load_type 5                        
@@ -827,7 +827,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   144   58   load_var2 9 2                      
-        59   call 722 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 732 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   147   61   load_const 12                      ("Test not found: ")
@@ -862,11 +862,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   153   22   load_var2 1 5                      
-        23   call 735 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 733 ntypeargs=0               (testing.testset_children)
+        23   call 745 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 743 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 711 ntypeargs=0               (testing.run_testset)
+        27   call 721 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   156   29   load_type 5                        
@@ -903,7 +903,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   159   59   load_var2 9 2                      
-        60   call 726 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 736 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   162   62   load_const 12                      ("TestSet not found: ")
@@ -995,7 +995,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 12                       (_27)
 
   119   72   load_var 11                        (sub)
-        73   call 718 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 728 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 13                       (_28)
 
   117   75   load_var2 3 12                     
@@ -1291,13 +1291,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   16   load_field 0                       (func_pat)
         17   load_var 2                         (function_name)
-        18   call 731 ntypeargs=0               (testing.filter_match)
+        18   call 741 ntypeargs=0               (testing.filter_match)
         19   jump_if_false +6                   (to 25)
         20   pop 1                              
         21   load_var 6                         (p)
         22   load_field 1                       (test_pat)
         23   load_var 3                         (test_name)
-        24   call 731 ntypeargs=0               (testing.filter_match)
+        24   call 741 ntypeargs=0               (testing.filter_match)
         25   pop_jump_if_false -20              (to 5)
 
   527   26   load_const 5                       (true)
@@ -1333,7 +1333,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   673   21   load_field 5                       (results)
         22   load_var 2                         (out)
-        23   call 724 ntypeargs=0               (testing.collect_leaf_messages)
+        23   call 734 ntypeargs=0               (testing.collect_leaf_messages)
         24   pop 1                              
         25   jump -20                           (to 5)
 
@@ -1432,7 +1432,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         43   store_var 9                        (ts)
 
   567   44   load_var2 1 9                      
-        45   call 736 ntypeargs=0               (testing.collect_subtree_names)
+        45   call 746 ntypeargs=0               (testing.collect_subtree_names)
         46   load_type 10                       
         47   load_const 11                      ("iter")
         48   virtual_call nargs=1 ntypeargs=0   
@@ -1462,8 +1462,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 735 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 719 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 745 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 729 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +20               (to 23)
         4    load_var 3             (e)
         5    type_tag               
@@ -1578,7 +1578,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   71    load_var 12                        (tsr)
         72    load_field 5                       (results)
         73    load_var 13                        (ft)
-        74    call 721 ntypeargs=0               (testing.count_leaves)
+        74    call 731 ntypeargs=0               (testing.count_leaves)
         75    store_var 10                       (delta)
         76    jump +31                           (to 107)
 
@@ -1676,7 +1676,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 729 ntypeargs=0   (testing.glob_match)
+        6   call 739 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -1731,7 +1731,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   37   load_var 1             (report)
         38   load_field 5           (results)
         39   load_var 2             (top_tolerated)
-        40   call 721 ntypeargs=0   (testing.count_leaves)
+        40   call 731 ntypeargs=0   (testing.count_leaves)
         41   store_var 3            (counts)
 
   645   42   load_type 2            
@@ -1741,7 +1741,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   45   load_var 1             (report)
         46   load_field 5           (results)
         47   load_var 5             (messages)
-        48   call 724 ntypeargs=0   (testing.collect_leaf_messages)
+        48   call 734 ntypeargs=0   (testing.collect_leaf_messages)
         49   pop 1                  
 
   648   50   load_var 1             (report)
@@ -1896,14 +1896,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 741 ntypeargs=0   (testing.split_top)
+        1    call 751 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 743 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 753 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +17               (to 26)
 
@@ -1920,7 +1920,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         19   load_field 0           (head)
         20   load_var 4             (split)
         21   load_field 1           (tail)
-        22   call 743 ntypeargs=0   (testing.any_pattern_matches)
+        22   call 753 ntypeargs=0   (testing.any_pattern_matches)
         23   jump +4                (to 27)
 
   541   24   load_const 1           (true)
@@ -2035,7 +2035,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   370   25   load_var 5                         (child)
-        26   make_closure 1298 1                
+        26   make_closure 1316 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   spawn                              
@@ -2057,7 +2057,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   375   43   load_const 9                       ("unexpected test child failure")
         44   call 244 ntypeargs=0               (baml.sys.panic)
 
-  377   45   call 715 ntypeargs=0               (testing.aggregate_reports)
+  377   45   call 725 ntypeargs=0               (testing.aggregate_reports)
         46   return                             
 }
 
@@ -2123,11 +2123,11 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         50   pop_jump_if_false -42              (to 8)
 
   116   51   load_var 3                         (named_results)
-        52   call 715 ntypeargs=0               (testing.aggregate_reports)
+        52   call 725 ntypeargs=0               (testing.aggregate_reports)
         53   jump +3                            (to 56)
 
   121   54   load_var 3                         (named_results)
-        55   call 715 ntypeargs=0               (testing.aggregate_reports)
+        55   call 725 ntypeargs=0               (testing.aggregate_reports)
         56   return                             
 }
 
@@ -2137,7 +2137,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1346 1    
+        4    make_closure 1364 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -2173,17 +2173,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   418   10   load_var 1             (children)
-        11   call 728 ntypeargs=0   (testing.run_children_parallel)
+        11   call 738 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0    load_var 2                         (include)
-        1    call 716 ntypeargs=0               (testing.parse_filter_patterns)
+        1    call 726 ntypeargs=0               (testing.parse_filter_patterns)
         2    store_var 5                        (inc)
 
   550   3    load_var 3                         (exclude)
-        4    call 716 ntypeargs=0               (testing.parse_filter_patterns)
+        4    call 726 ntypeargs=0               (testing.parse_filter_patterns)
         5    store_var 6                        (exc)
 
   551   6    load_type 0                        
@@ -2191,7 +2191,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8    store_var 7                        (out)
 
   552   9    load_var 1                         (registry)
-        10   call 719 ntypeargs=0               (testing.collect_leaf_names)
+        10   call 729 ntypeargs=0               (testing.collect_leaf_names)
         11   load_type 1                        
         12   load_const 2                       ("iter")
         13   virtual_call nargs=1 ntypeargs=0   
@@ -2209,7 +2209,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         25   store_var_load_var 10              (name)
 
   553   26   load_var2 5 6                      
-        27   call 744 ntypeargs=0               (testing.leaf_selected)
+        27   call 754 ntypeargs=0               (testing.leaf_selected)
         28   pop_jump_if_false -13              (to 15)
 
   554   29   load_var2 7 10                     
@@ -2268,7 +2268,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1317 2   
+        8    make_closure 1335 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -2287,7 +2287,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1335 2   
+        9    make_closure 1353 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -2310,7 +2310,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1350 3   
+        13   make_closure 1368 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -2346,7 +2346,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 734 ntypeargs=0               (testing.test_child)
+        26   call 744 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_var2 3 7                      
         29   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2373,7 +2373,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         49   store_var 10                       (ts)
 
   238   50   load_var2 1 10                     
-        51   call 742 ntypeargs=0               (testing.testset_child)
+        51   call 752 ntypeargs=0               (testing.testset_child)
         52   store_var 11                       (_21)
         53   load_var2 3 11                     
         54   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2412,7 +2412,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 738 ntypeargs=0               (testing._name_selected)
+        23   call 748 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   247   25   load_var 7                         (t)
@@ -2421,7 +2421,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 734 ntypeargs=0               (testing.test_child)
+        31   call 744 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_var2 4 8                      
         34   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2449,12 +2449,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 720 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 730 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   259   59   load_var2 1 11                     
         60   load_var 2                         (names)
-        61   call 747 ntypeargs=0               (testing.testset_child_selected)
+        61   call 757 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 12                       (_26)
         63   load_var2 4 12                     
         64   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2476,7 +2476,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 761 ntypeargs=0   (user.score)
+       7    call 771 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 768 ntypeargs=0   (assert.format_operand)
+       26   call 770 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 768 ntypeargs=0   (assert.format_operand)
+       29   call 770 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 768 ntypeargs=0   (assert.format_operand)
+       32   call 770 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 768 ntypeargs=0   (assert.format_operand)
+       35   call 770 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 768 ntypeargs=0   (assert.format_operand)
+       8    call 770 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 768 ntypeargs=0   (assert.format_operand)
+       11   call 770 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -170,7 +170,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1370 0   
+  101   0   make_closure 1374 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -197,7 +197,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1383 1    
+       17   make_closure 1387 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -238,7 +238,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1401 2    
+       29   make_closure 1405 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -259,14 +259,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1392 1    
+       11   make_closure 1396 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1374 0   
+  95   0   make_closure 1378 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -576,11 +576,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   198   22   load_var2 1 5                      
-        23   call 745 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 747 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   199   25   load_var 1                         (self)
-        26   call 728 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 730 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   203   28   load_type 5                        
@@ -617,7 +617,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   206   58   load_var2 9 2                      
-        59   call 733 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 735 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   209   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -695,7 +695,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 727 ntypeargs=0   (testing.select_names)
+        2   call 729 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -714,9 +714,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 743 ntypeargs=0   (testing.testset_children)
+        1   call 745 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 721 ntypeargs=0   (testing.run_testset)
+        3   call 723 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -740,24 +740,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   16   load_var2 1 2          
         17   load_var 3             (exclude)
-        18   call 727 ntypeargs=0   (testing.select_names)
+        18   call 729 ntypeargs=0   (testing.select_names)
         19   store_var 6            (_9)
         20   load_var2 1 6          
-        21   call 718 ntypeargs=0   (testing.TestRegistry.run_selected)
+        21   call 720 ntypeargs=0   (testing.TestRegistry.run_selected)
         22   jump +3                (to 25)
 
   180   23   load_var 1             (self)
-        24   call 740 ntypeargs=0   (testing.TestRegistry.run_all)
+        24   call 742 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   25   call 756 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   25   call 758 ntypeargs=0   (testing.flatten_with_tolerated)
         26   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 724 ntypeargs=0   (testing.testset_children_selected)
+        1   call 726 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 721 ntypeargs=0   (testing.run_testset)
+        3   call 723 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -790,7 +790,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 755 ntypeargs=0               (testing.run_test)
+        26   call 757 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   140   28   load_type 5                        
@@ -827,7 +827,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   144   58   load_var2 9 2                      
-        59   call 732 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 734 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   147   61   load_const 12                      ("Test not found: ")
@@ -862,11 +862,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   153   22   load_var2 1 5                      
-        23   call 745 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 743 ntypeargs=0               (testing.testset_children)
+        23   call 747 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 745 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 721 ntypeargs=0               (testing.run_testset)
+        27   call 723 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   156   29   load_type 5                        
@@ -903,7 +903,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   159   59   load_var2 9 2                      
-        60   call 736 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 738 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   162   62   load_const 12                      ("TestSet not found: ")
@@ -995,7 +995,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 12                       (_27)
 
   119   72   load_var 11                        (sub)
-        73   call 728 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 730 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 13                       (_28)
 
   117   75   load_var2 3 12                     
@@ -1291,13 +1291,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   16   load_field 0                       (func_pat)
         17   load_var 2                         (function_name)
-        18   call 741 ntypeargs=0               (testing.filter_match)
+        18   call 743 ntypeargs=0               (testing.filter_match)
         19   jump_if_false +6                   (to 25)
         20   pop 1                              
         21   load_var 6                         (p)
         22   load_field 1                       (test_pat)
         23   load_var 3                         (test_name)
-        24   call 741 ntypeargs=0               (testing.filter_match)
+        24   call 743 ntypeargs=0               (testing.filter_match)
         25   pop_jump_if_false -20              (to 5)
 
   527   26   load_const 5                       (true)
@@ -1333,7 +1333,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   673   21   load_field 5                       (results)
         22   load_var 2                         (out)
-        23   call 734 ntypeargs=0               (testing.collect_leaf_messages)
+        23   call 736 ntypeargs=0               (testing.collect_leaf_messages)
         24   pop 1                              
         25   jump -20                           (to 5)
 
@@ -1432,7 +1432,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         43   store_var 9                        (ts)
 
   567   44   load_var2 1 9                      
-        45   call 746 ntypeargs=0               (testing.collect_subtree_names)
+        45   call 748 ntypeargs=0               (testing.collect_subtree_names)
         46   load_type 10                       
         47   load_const 11                      ("iter")
         48   virtual_call nargs=1 ntypeargs=0   
@@ -1462,8 +1462,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 745 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 729 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 747 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 731 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +20               (to 23)
         4    load_var 3             (e)
         5    type_tag               
@@ -1578,7 +1578,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   71    load_var 12                        (tsr)
         72    load_field 5                       (results)
         73    load_var 13                        (ft)
-        74    call 731 ntypeargs=0               (testing.count_leaves)
+        74    call 733 ntypeargs=0               (testing.count_leaves)
         75    store_var 10                       (delta)
         76    jump +31                           (to 107)
 
@@ -1676,7 +1676,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 739 ntypeargs=0   (testing.glob_match)
+        6   call 741 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -1731,7 +1731,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   37   load_var 1             (report)
         38   load_field 5           (results)
         39   load_var 2             (top_tolerated)
-        40   call 731 ntypeargs=0   (testing.count_leaves)
+        40   call 733 ntypeargs=0   (testing.count_leaves)
         41   store_var 3            (counts)
 
   645   42   load_type 2            
@@ -1741,7 +1741,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   45   load_var 1             (report)
         46   load_field 5           (results)
         47   load_var 5             (messages)
-        48   call 734 ntypeargs=0   (testing.collect_leaf_messages)
+        48   call 736 ntypeargs=0   (testing.collect_leaf_messages)
         49   pop 1                  
 
   648   50   load_var 1             (report)
@@ -1896,14 +1896,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 751 ntypeargs=0   (testing.split_top)
+        1    call 753 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 753 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 755 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +17               (to 26)
 
@@ -1920,7 +1920,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         19   load_field 0           (head)
         20   load_var 4             (split)
         21   load_field 1           (tail)
-        22   call 753 ntypeargs=0   (testing.any_pattern_matches)
+        22   call 755 ntypeargs=0   (testing.any_pattern_matches)
         23   jump +4                (to 27)
 
   541   24   load_const 1           (true)
@@ -2035,7 +2035,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   370   25   load_var 5                         (child)
-        26   make_closure 1316 1                
+        26   make_closure 1320 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   spawn                              
@@ -2057,7 +2057,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   375   43   load_const 9                       ("unexpected test child failure")
         44   call 244 ntypeargs=0               (baml.sys.panic)
 
-  377   45   call 725 ntypeargs=0               (testing.aggregate_reports)
+  377   45   call 727 ntypeargs=0               (testing.aggregate_reports)
         46   return                             
 }
 
@@ -2123,11 +2123,11 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         50   pop_jump_if_false -42              (to 8)
 
   116   51   load_var 3                         (named_results)
-        52   call 725 ntypeargs=0               (testing.aggregate_reports)
+        52   call 727 ntypeargs=0               (testing.aggregate_reports)
         53   jump +3                            (to 56)
 
   121   54   load_var 3                         (named_results)
-        55   call 725 ntypeargs=0               (testing.aggregate_reports)
+        55   call 727 ntypeargs=0               (testing.aggregate_reports)
         56   return                             
 }
 
@@ -2137,7 +2137,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1364 1    
+        4    make_closure 1368 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -2173,17 +2173,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   418   10   load_var 1             (children)
-        11   call 738 ntypeargs=0   (testing.run_children_parallel)
+        11   call 740 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0    load_var 2                         (include)
-        1    call 726 ntypeargs=0               (testing.parse_filter_patterns)
+        1    call 728 ntypeargs=0               (testing.parse_filter_patterns)
         2    store_var 5                        (inc)
 
   550   3    load_var 3                         (exclude)
-        4    call 726 ntypeargs=0               (testing.parse_filter_patterns)
+        4    call 728 ntypeargs=0               (testing.parse_filter_patterns)
         5    store_var 6                        (exc)
 
   551   6    load_type 0                        
@@ -2191,7 +2191,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8    store_var 7                        (out)
 
   552   9    load_var 1                         (registry)
-        10   call 729 ntypeargs=0               (testing.collect_leaf_names)
+        10   call 731 ntypeargs=0               (testing.collect_leaf_names)
         11   load_type 1                        
         12   load_const 2                       ("iter")
         13   virtual_call nargs=1 ntypeargs=0   
@@ -2209,7 +2209,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         25   store_var_load_var 10              (name)
 
   553   26   load_var2 5 6                      
-        27   call 754 ntypeargs=0               (testing.leaf_selected)
+        27   call 756 ntypeargs=0               (testing.leaf_selected)
         28   pop_jump_if_false -13              (to 15)
 
   554   29   load_var2 7 10                     
@@ -2268,7 +2268,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1335 2   
+        8    make_closure 1339 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -2287,7 +2287,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1353 2   
+        9    make_closure 1357 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -2310,7 +2310,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1368 3   
+        13   make_closure 1372 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -2346,7 +2346,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 744 ntypeargs=0               (testing.test_child)
+        26   call 746 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_var2 3 7                      
         29   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2373,7 +2373,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         49   store_var 10                       (ts)
 
   238   50   load_var2 1 10                     
-        51   call 752 ntypeargs=0               (testing.testset_child)
+        51   call 754 ntypeargs=0               (testing.testset_child)
         52   store_var 11                       (_21)
         53   load_var2 3 11                     
         54   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2412,7 +2412,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 748 ntypeargs=0               (testing._name_selected)
+        23   call 750 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   247   25   load_var 7                         (t)
@@ -2421,7 +2421,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 744 ntypeargs=0               (testing.test_child)
+        31   call 746 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_var2 4 8                      
         34   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2449,12 +2449,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 730 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 732 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   259   59   load_var2 1 11                     
         60   load_var 2                         (names)
-        61   call 757 ntypeargs=0               (testing.testset_child_selected)
+        61   call 759 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 12                       (_26)
         63   load_var2 4 12                     
         64   call 9 ntypeargs=0                 (baml.Array.push)
@@ -2476,7 +2476,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 771 ntypeargs=0   (user.score)
+       7    call 773 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/crates/bex_engine/tests/random.rs
+++ b/baml_language/crates/bex_engine/tests/random.rs
@@ -119,12 +119,6 @@ function main() -> int {
     .unwrap();
 }
 
-// IGNORED: a concrete generator in the user package can't be upcast to the
-// stdlib interface `baml.random.Rng` — `package_implements_registry` is
-// per-package, so the user package doesn't see the `baml` package's
-// `Xoshiro256PlusPlus implements Rng` entry. Re-enable once class→interface
-// upcast resolves implementors across packages.
-#[ignore = "cross-package class->interface upcast not yet supported"]
 #[tokio::test]
 async fn rng_dispatches_through_interface() {
     // A concrete generator assigned to a `Rng`-typed parameter dispatches to
@@ -144,6 +138,51 @@ function main(seed: uint8array) -> bool {
         entry: "main",
         inputs: seed_input(),
         expected: Ok(BexExternalValue::Bool(true)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn sysop_dispatches_through_interface_typed_param() {
+    // A `$rust_io_function` impl method reached through an `Rng`-typed
+    // parameter: the `VirtualCall` resolves `SystemRandom`'s impl at runtime
+    // and the call funnel yields the sys-op to the engine — the analogue of
+    // `rng_dispatches_through_interface` for the IO (sys-op) dispatch kind.
+    let source = r#"
+function draw(rng: baml.random.Rng) -> int {
+    rng.random(24).length()
+}
+function main() -> int {
+    draw(baml.random.SystemRandom.get().as<baml.random.Rng>)
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        expected: Ok(BexExternalValue::Int(24)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn sysop_bound_method_value_invokes() {
+    // Tearing a `$rust_io_function` impl method off its receiver as a value
+    // and calling it indirectly routes the same call funnel into the sys-op
+    // yield — the value analogue of the virtual call above.
+    let source = r#"
+function main() -> int {
+    let f = baml.random.SystemRandom.get().random;
+    f(16).length()
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        expected: Ok(BexExternalValue::Int(16)),
         ..Default::default()
     })
     .await

--- a/baml_language/crates/bex_engine/tests/random.rs
+++ b/baml_language/crates/bex_engine/tests/random.rs
@@ -94,16 +94,12 @@ function main() -> int {
     .unwrap();
 }
 
-// IGNORED: native (`$rust_function`) builtins don't yet substitute parameter
-// defaults. The `seed` default-arg prologue is only generated for bytecode
-// function bodies (`lower_default_parameter_prologue`), so `new()` reaches the
-// native constructor with `seed = OmittedArg`. Re-enable once native builtins
-// support parameter defaults (needed for `int.random(rng: Rng = ...)` too).
-#[ignore = "native builtins don't substitute parameter defaults yet"]
 #[tokio::test]
 async fn new_without_seed_uses_system_entropy() {
-    // No explicit seed → the default arg `Rng.random(SystemRandom.get(), 32)`
-    // runs, exercising the IO seeding path through interface dispatch.
+    // No explicit seed → `ChaCha20.new`'s BAML wrapper fills the default arg
+    // `Rng.random(SystemRandom.get(), 32)` (the native `$rust_function` `_new`
+    // it forwards to takes a required seed), exercising the IO seeding path
+    // through interface dispatch.
     let source = r#"
 function main() -> int {
     baml.random.ChaCha20.new().random(8).length()

--- a/baml_language/crates/bex_engine/tests/random.rs
+++ b/baml_language/crates/bex_engine/tests/random.rs
@@ -120,6 +120,45 @@ function main() -> int {
 }
 
 #[tokio::test]
+async fn default_random_int_spans_full_signed_range_without_overflow() {
+    // The `Rng.random_int` default body — inherited by any user implementor that
+    // provides only `random`. All-`0xFF` bytes assemble the maximum magnitude
+    // with the sign bit set: exactly the input that overflowed the old
+    // `(bytes[0] & 127) << 56` form. It must land on `int.min_value()`, and
+    // all-zero bytes on `0`, confirming the full signed range with no overflow.
+    let source = r#"
+class AllOnes {
+    implements baml.random.Rng {
+        function random(self, bytes: int) -> uint8array throws never {
+            let data = b"\xff\xff\xff\xff\xff\xff\xff\xff";
+            data
+        }
+    }
+}
+class AllZeros {
+    implements baml.random.Rng {
+        function random(self, bytes: int) -> uint8array throws never {
+            let data = b"\x00\x00\x00\x00\x00\x00\x00\x00";
+            data
+        }
+    }
+}
+function main() -> bool {
+    (AllOnes {}).random_int() == baml.Int.min_value()
+        && (AllZeros {}).random_int() == 0
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        expected: Ok(BexExternalValue::Bool(true)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
 async fn rng_dispatches_through_interface() {
     // A concrete generator assigned to a `Rng`-typed parameter dispatches to
     // the right implementor — the same value as calling it directly.

--- a/baml_language/crates/bex_engine/tests/random.rs
+++ b/baml_language/crates/bex_engine/tests/random.rs
@@ -1,0 +1,151 @@
+//! End-to-end tests for the `baml.random` generators, run through the engine
+//! with the real native `SysOps` (so `SystemRandom` draws real OS entropy and
+//! the `$rust_io_function` dispatch path is exercised).
+
+mod common;
+
+use bex_engine::BexExternalValue;
+use common::{EngineProgram, assert_engine_executes};
+
+/// A fixed 32-byte seed passed as the entry function's `uint8array` argument.
+fn seed_input() -> Vec<BexExternalValue> {
+    vec![BexExternalValue::Uint8Array((0u8..32).collect())]
+}
+
+#[tokio::test]
+async fn xoshiro_is_deterministic_and_advances() {
+    // Two generators seeded identically agree draw-for-draw, and successive
+    // draws from one generator differ (the state advances under the mutex).
+    let source = r#"
+function main(seed: uint8array) -> bool {
+    let a = baml.random.Xoshiro256PlusPlus.new(seed = seed);
+    let b = baml.random.Xoshiro256PlusPlus.new(seed = seed);
+    let a1 = a.random_int();
+    let b1 = b.random_int();
+    let a2 = a.random_int();
+    a1 == b1 && a1 != a2
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        inputs: seed_input(),
+        expected: Ok(BexExternalValue::Bool(true)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn chacha_is_deterministic() {
+    let source = r#"
+function main(seed: uint8array) -> bool {
+    let a = baml.random.ChaCha20.new(seed = seed);
+    let b = baml.random.ChaCha20.new(seed = seed);
+    a.random_int() == b.random_int()
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        inputs: seed_input(),
+        expected: Ok(BexExternalValue::Bool(true)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn random_returns_requested_byte_count() {
+    let source = r#"
+function main(seed: uint8array) -> int {
+    baml.random.Xoshiro256PlusPlus.new(seed = seed).random(16).length()
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        inputs: seed_input(),
+        expected: Ok(BexExternalValue::Int(16)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn system_random_draws_through_native_sysops() {
+    // Exercises the `$rust_io_function` path end-to-end: `SystemRandom.random`
+    // is dispatched to `sys_native` and must return the requested bytes.
+    let source = r#"
+function main() -> int {
+    baml.random.SystemRandom.get().random(24).length()
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        expected: Ok(BexExternalValue::Int(24)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}
+
+// IGNORED: native (`$rust_function`) builtins don't yet substitute parameter
+// defaults. The `seed` default-arg prologue is only generated for bytecode
+// function bodies (`lower_default_parameter_prologue`), so `new()` reaches the
+// native constructor with `seed = OmittedArg`. Re-enable once native builtins
+// support parameter defaults (needed for `int.random(rng: Rng = ...)` too).
+#[ignore = "native builtins don't substitute parameter defaults yet"]
+#[tokio::test]
+async fn new_without_seed_uses_system_entropy() {
+    // No explicit seed → the default arg `Rng.random(SystemRandom.get(), 32)`
+    // runs, exercising the IO seeding path through interface dispatch.
+    let source = r#"
+function main() -> int {
+    baml.random.ChaCha20.new().random(8).length()
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        expected: Ok(BexExternalValue::Int(8)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}
+
+// IGNORED: a concrete generator in the user package can't be upcast to the
+// stdlib interface `baml.random.Rng` — `package_implements_registry` is
+// per-package, so the user package doesn't see the `baml` package's
+// `Xoshiro256PlusPlus implements Rng` entry. Re-enable once class→interface
+// upcast resolves implementors across packages.
+#[ignore = "cross-package class->interface upcast not yet supported"]
+#[tokio::test]
+async fn rng_dispatches_through_interface() {
+    // A concrete generator assigned to a `Rng`-typed parameter dispatches to
+    // the right implementor — the same value as calling it directly.
+    let source = r#"
+function draw(rng: baml.random.Rng) -> int {
+    rng.random_int()
+}
+function main(seed: uint8array) -> bool {
+    let direct = baml.random.Xoshiro256PlusPlus.new(seed = seed).random_int();
+    let via_iface = draw(baml.random.Xoshiro256PlusPlus.new(seed = seed).as<baml.random.Rng>);
+    direct == via_iface
+}
+"#;
+    assert_engine_executes(EngineProgram {
+        source,
+        entry: "main",
+        inputs: seed_input(),
+        expected: Ok(BexExternalValue::Bool(true)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+}

--- a/baml_language/crates/bex_vm/Cargo.toml
+++ b/baml_language/crates/bex_vm/Cargo.toml
@@ -30,6 +30,9 @@ getrandom = { workspace = true }
 indexmap = { workspace = true }
 log = { workspace = true }
 num-bigint = { workspace = true }
+rand_chacha = { workspace = true }
+rand_core = { workspace = true }
+rand_xoshiro = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -34,6 +34,7 @@ mod map;
 mod media;
 mod ops;
 mod ops_math;
+mod random;
 mod resolve;
 pub(crate) use resolve::{realize_frame, resolve_implements_rule, type_implements};
 mod root;

--- a/baml_language/crates/bex_vm/src/package_baml/random.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/random.rs
@@ -1,0 +1,141 @@
+//! `baml.random` seedable pseudo-random generators (`$rust_function`).
+//!
+//! The cryptographic [`SystemRandom`] generator is host-backed and lives in the
+//! sys-ops path (`sys_native` / `bridge_wasm`); the seedable PRNGs implemented
+//! here run inline in the VM.
+//!
+//! Each generator stores its state behind an `Arc<Mutex<_>>` in the instance's
+//! opaque `_state` field. The mutex is what makes drawing sound: a generator
+//! value is shared as an immutable `Object::RustData`, so advancing its state
+//! requires interior mutability, and concurrent draws from the same generator
+//! across `spawn` fibers must be serialized rather than racing on the backing
+//! `RngCore` state.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use bex_vm_types::types::Value;
+use rand_chacha::ChaCha20Rng;
+use rand_core::{RngCore, SeedableRng};
+use rand_xoshiro::Xoshiro256PlusPlus as XoshiroRng;
+
+use super::{
+    BamlClassRandomChaCha20, BamlClassRandomXoshiro256PlusPlus, BamlNamespaceRandom,
+    PackageBamlImpl, copy, view,
+};
+use crate::{
+    BexVm,
+    errors::{VmPanic, VmRustFnError},
+};
+
+/// Minimum seed length, in bytes, for the seedable PRNGs.
+const SEED_LEN: usize = 32;
+
+/// Materialize a 32-byte seed from a BAML `uint8array`, panicking if it is too
+/// short. Bytes beyond the first 32 are ignored.
+fn seed_array(seed: &[u8]) -> Result<[u8; SEED_LEN], VmRustFnError> {
+    let head = seed.get(..SEED_LEN).ok_or_else(|| {
+        VmRustFnError::Panic(VmPanic::UserPanic {
+            message: format!(
+                "Rng seed must be at least {SEED_LEN} bytes, got {}",
+                seed.len()
+            ),
+        })
+    })?;
+    let mut arr = [0u8; SEED_LEN];
+    arr.copy_from_slice(head);
+    Ok(arr)
+}
+
+/// Convert a `bytes` count into a buffer length, panicking if it is negative
+/// (per the `Rng.random` contract).
+fn byte_count(bytes: i64) -> Result<usize, VmRustFnError> {
+    usize::try_from(bytes).map_err(|_| {
+        VmRustFnError::Panic(VmPanic::UserPanic {
+            message: format!("Rng.random: byte count must be non-negative, got {bytes}"),
+        })
+    })
+}
+
+/// Draw `n` random bytes from a locked generator.
+fn fill<R: RngCore>(mutex: &Mutex<R>, n: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; n];
+    mutex
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .fill_bytes(&mut buf);
+    buf
+}
+
+/// Draw a uniformly random BAML `int` (i63) from a locked generator.
+///
+/// `next_u64` is uniform over all 64 bits; reinterpreting it as `i64` and
+/// arithmetic-shifting right by one maps it uniformly onto `[INT_MIN, INT_MAX]`
+/// (every i63 value has exactly two u64 preimages), which always fits in
+/// `Value::int`.
+fn next_i63<R: RngCore>(mutex: &Mutex<R>) -> i64 {
+    let r = mutex
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .next_u64();
+    r.cast_signed() >> 1
+}
+
+// =========================================================================
+// Xoshiro256PlusPlus
+// =========================================================================
+
+#[expect(
+    clippy::used_underscore_items,
+    reason = "the `_state` view accessor is generated from the private BAML field"
+)]
+impl BamlClassRandomXoshiro256PlusPlus for PackageBamlImpl {
+    fn new(vm: &mut BexVm, seed: &[u8]) -> Result<Value, VmRustFnError> {
+        let rng = XoshiroRng::from_seed(seed_array(seed)?);
+        let state: Arc<dyn std::any::Any + Send + Sync> = Arc::new(Mutex::new(rng));
+        Ok(copy::random::Xoshiro256PlusPlus { _state: state }.to_value(vm))
+    }
+
+    fn random(
+        vm: &BexVm,
+        rng: &view::random::Xoshiro256PlusPlus<'_>,
+        bytes: i64,
+    ) -> Result<Vec<u8>, VmRustFnError> {
+        let n = byte_count(bytes)?;
+        Ok(fill(rng._state::<Mutex<XoshiroRng>>(vm), n))
+    }
+
+    fn random_int(vm: &BexVm, rng: &view::random::Xoshiro256PlusPlus<'_>) -> i64 {
+        next_i63(rng._state::<Mutex<XoshiroRng>>(vm))
+    }
+}
+
+// =========================================================================
+// ChaCha20
+// =========================================================================
+
+#[expect(
+    clippy::used_underscore_items,
+    reason = "the `_state` view accessor is generated from the private BAML field"
+)]
+impl BamlClassRandomChaCha20 for PackageBamlImpl {
+    fn new(vm: &mut BexVm, seed: &[u8]) -> Result<Value, VmRustFnError> {
+        let rng = ChaCha20Rng::from_seed(seed_array(seed)?);
+        let state: Arc<dyn std::any::Any + Send + Sync> = Arc::new(Mutex::new(rng));
+        Ok(copy::random::ChaCha20 { _state: state }.to_value(vm))
+    }
+
+    fn random(
+        vm: &BexVm,
+        rng: &view::random::ChaCha20<'_>,
+        bytes: i64,
+    ) -> Result<Vec<u8>, VmRustFnError> {
+        let n = byte_count(bytes)?;
+        Ok(fill(rng._state::<Mutex<ChaCha20Rng>>(vm), n))
+    }
+
+    fn random_int(vm: &BexVm, rng: &view::random::ChaCha20<'_>) -> i64 {
+        next_i63(rng._state::<Mutex<ChaCha20Rng>>(vm))
+    }
+}
+
+impl BamlNamespaceRandom for PackageBamlImpl {}

--- a/baml_language/crates/bex_vm/src/package_baml/random.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/random.rs
@@ -97,7 +97,7 @@ fn next_i63<R: RngCore>(mutex: &Mutex<R>) -> i64 {
     reason = "the `_state` view accessor is generated from the private BAML field"
 )]
 impl BamlClassRandomXoshiro256PlusPlus for PackageBamlImpl {
-    fn new(vm: &mut BexVm, seed: &[u8]) -> Result<Value, VmRustFnError> {
+    fn _new(vm: &mut BexVm, seed: &[u8]) -> Result<Value, VmRustFnError> {
         let rng = XoshiroRng::from_seed(seed_array(seed)?);
         let state: Arc<dyn std::any::Any + Send + Sync> = Arc::new(Mutex::new(rng));
         Ok(copy::random::Xoshiro256PlusPlus { _state: state }.to_value(vm))
@@ -126,7 +126,7 @@ impl BamlClassRandomXoshiro256PlusPlus for PackageBamlImpl {
     reason = "the `_state` view accessor is generated from the private BAML field"
 )]
 impl BamlClassRandomChaCha20 for PackageBamlImpl {
-    fn new(vm: &mut BexVm, seed: &[u8]) -> Result<Value, VmRustFnError> {
+    fn _new(vm: &mut BexVm, seed: &[u8]) -> Result<Value, VmRustFnError> {
         let rng = ChaCha20Rng::from_seed(seed_array(seed)?);
         let state: Arc<dyn std::any::Any + Send + Sync> = Arc::new(Mutex::new(rng));
         Ok(copy::random::ChaCha20 { _state: state }.to_value(vm))

--- a/baml_language/crates/bex_vm/src/package_baml/random.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/random.rs
@@ -57,13 +57,21 @@ fn byte_count(bytes: i64) -> Result<usize, VmRustFnError> {
 }
 
 /// Draw `n` random bytes from a locked generator.
-fn fill<R: RngCore>(mutex: &Mutex<R>, n: usize) -> Vec<u8> {
-    let mut buf = vec![0u8; n];
+///
+/// Allocates fallibly (`try_reserve`) so an unsatisfiable request surfaces as a
+/// catchable [`VmPanic::AllocFailure`] rather than aborting the host process via
+/// the global allocator's OOM handler.
+fn fill<R: RngCore>(mutex: &Mutex<R>, n: usize) -> Result<Vec<u8>, VmRustFnError> {
+    let mut buf = Vec::new();
+    buf.try_reserve(n).map_err(|_| VmPanic::AllocFailure {
+        message: format!("Rng.random: allocation of {n} bytes failed"),
+    })?;
+    buf.resize(n, 0u8);
     mutex
         .lock()
         .unwrap_or_else(PoisonError::into_inner)
         .fill_bytes(&mut buf);
-    buf
+    Ok(buf)
 }
 
 /// Draw a uniformly random BAML `int` (i63) from a locked generator.
@@ -101,7 +109,7 @@ impl BamlClassRandomXoshiro256PlusPlus for PackageBamlImpl {
         bytes: i64,
     ) -> Result<Vec<u8>, VmRustFnError> {
         let n = byte_count(bytes)?;
-        Ok(fill(rng._state::<Mutex<XoshiroRng>>(vm), n))
+        fill(rng._state::<Mutex<XoshiroRng>>(vm), n)
     }
 
     fn random_int(vm: &BexVm, rng: &view::random::Xoshiro256PlusPlus<'_>) -> i64 {
@@ -130,7 +138,7 @@ impl BamlClassRandomChaCha20 for PackageBamlImpl {
         bytes: i64,
     ) -> Result<Vec<u8>, VmRustFnError> {
         let n = byte_count(bytes)?;
-        Ok(fill(rng._state::<Mutex<ChaCha20Rng>>(vm), n))
+        fill(rng._state::<Mutex<ChaCha20Rng>>(vm), n)
     }
 
     fn random_int(vm: &BexVm, rng: &view::random::ChaCha20<'_>) -> i64 {

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -4219,6 +4219,84 @@ impl BexVm {
         }
     }
 
+    /// Drain a sys-op's arguments off the eval stack and produce the
+    /// [`VmExecState::SysOp`] yield that hands control to the engine.
+    ///
+    /// This is the single implementation of "run a `$rust_io_function`",
+    /// shared by the dedicated `OpCode::SysOp` handler (a statically-known
+    /// direct call) and the general call funnel
+    /// ([`Self::execute_call_from_locals_offset`], reached when a sys-op is
+    /// invoked as a callable value — virtual/interface dispatch or a
+    /// bound-method value). Both present the op's `arity` arguments as the top
+    /// of the stack, so a sys-op is dispatched identically however it is
+    /// reached.
+    ///
+    /// `callee_fn_ptr` must point at an `Object::Function` whose kind is
+    /// [`FunctionKind::SysOp`]; the mismatch arms are defensive.
+    fn dispatch_sysop_yield(
+        &mut self,
+        callee_fn_ptr: HeapPtr,
+        runtime_id: Option<Value>,
+        frame_idx: usize,
+    ) -> Result<VmExecState, VmError> {
+        let (sys_op, function_id, arity, capture, param_names) = {
+            let obj = self.get_object(callee_fn_ptr);
+            let Object::Function(f) = obj else {
+                return Err(VmInternalError::TypeError {
+                    expected: FunctionType::SysOp.into(),
+                    got: ObjectType::of(obj).into(),
+                }
+                .into());
+            };
+            let FunctionKind::SysOp(sys_op) = f.kind else {
+                return Err(VmInternalError::TypeError {
+                    expected: FunctionType::SysOp.into(),
+                    got: FunctionType::from(&f.kind).into(),
+                }
+                .into());
+            };
+            (sys_op, f.function_id, f.arity, f.capture, f.param_names.clone())
+        };
+        let args_offset = self
+            .stack
+            .len()
+            .checked_sub(arity)
+            .ok_or(VmInternalError::NotEnoughItemsOnStack(arity))?;
+        let args_offset = StackIndex::from_raw(args_offset);
+        let call_args: Vec<Value> = self.stack.drain(args_offset..).collect();
+        // PR4b: sys-op calls (LLM calls included) appear on the timeline as a
+        // CallFunction here; the engine emits the matching EndFunction once the
+        // op completes.
+        let call_site_source = self.call_site_source_for_frame(frame_idx, self.cur_pc);
+        let capture_mask = VmCaptureMask::from_props(capture, self.value_capture_auto_enabled);
+        let explicit_local_id = runtime_id
+            .map(|value| self.consume_local_id_value(value))
+            .transpose()?;
+        let capture_mask = explicit_local_id
+            .as_ref()
+            .map_or(capture_mask, |id| capture_mask.with_overrides(id.capture));
+        let call_id = self.prof_enter_sysop(function_id, call_site_source, capture_mask);
+        if let Some(explicit_local_id) = &explicit_local_id {
+            self.install_consumed_local_id_for_sysop(call_id, explicit_local_id);
+        }
+        let entries: Vec<(String, Value)> = call_args
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                let name = param_names
+                    .get(index)
+                    .cloned()
+                    .unwrap_or_else(|| format!("arg{index}"));
+                (name, *value)
+            })
+            .collect();
+        self.maybe_capture_named_inputs(call_id, &entries, capture_mask);
+        Ok(VmExecState::SysOp {
+            operation: sys_op,
+            args: call_args,
+        })
+    }
+
     fn execute_call_from_locals_offset(
         &mut self,
         callee_ptr: HeapPtr,
@@ -5901,66 +5979,14 @@ impl BexVm {
                     };
                     let callee = bex_vm_types::GlobalIndex::from_raw(raw as usize);
                     let callee_value = self.globals.get(self.proof(), callee);
-                    let expected_type = FunctionType::SysOp;
-                    let callee_ptr = self.as_object_ptr(callee_value, expected_type.into())?;
-                    let Object::Function(callable_future) = self.get_object(callee_ptr) else {
-                        return Err(VmInternalError::TypeError {
-                            expected: expected_type.into(),
-                            got: ObjectType::of(self.get_object(callee_ptr)).into(),
-                        }
-                        .into());
-                    };
-                    let FunctionKind::SysOp(sys_op) = callable_future.kind else {
-                        return Err(VmInternalError::TypeError {
-                            expected: FunctionType::SysOp.into(),
-                            got: FunctionType::from(&callable_future.kind).into(),
-                        }
-                        .into());
-                    };
-                    let sysop_function_id = callable_future.function_id;
-                    let sysop_arity = callable_future.arity;
-                    let sysop_capture = callable_future.capture;
-                    let sysop_param_names = callable_future.param_names.clone();
-                    let args_offset = self
-                        .stack
-                        .len()
-                        .checked_sub(sysop_arity)
-                        .ok_or(VmInternalError::NotEnoughItemsOnStack(sysop_arity))?;
-                    let args_offset = StackIndex::from_raw(args_offset);
-                    let call_args: Vec<Value> = self.stack.drain(args_offset..).collect();
-                    // PR4b: sys-op calls (LLM calls included) appear on the
-                    // timeline as a CallFunction here; the engine emits the
-                    // matching EndFunction once the op completes.
-                    let call_site_source = self.call_site_source_for_frame(*frame_idx, self.cur_pc);
-                    let capture_mask =
-                        VmCaptureMask::from_props(sysop_capture, self.value_capture_auto_enabled);
-                    let explicit_local_id = runtime_id
-                        .map(|value| self.consume_local_id_value(value))
-                        .transpose()?;
-                    let capture_mask = explicit_local_id
-                        .as_ref()
-                        .map_or(capture_mask, |id| capture_mask.with_overrides(id.capture));
-                    let call_id =
-                        self.prof_enter_sysop(sysop_function_id, call_site_source, capture_mask);
-                    if let Some(explicit_local_id) = &explicit_local_id {
-                        self.install_consumed_local_id_for_sysop(call_id, explicit_local_id);
-                    }
-                    let entries: Vec<(String, Value)> = call_args
-                        .iter()
-                        .enumerate()
-                        .map(|(index, value)| {
-                            let name = sysop_param_names
-                                .get(index)
-                                .cloned()
-                                .unwrap_or_else(|| format!("arg{index}"));
-                            (name, *value)
-                        })
-                        .collect();
-                    self.maybe_capture_named_inputs(call_id, &entries, capture_mask);
-                    return Ok(Some(VmExecState::SysOp {
-                        operation: sys_op,
-                        args: call_args,
-                    }));
+                    // `as_object_ptr` asserts the global is a `FunctionType::SysOp`
+                    // function; `dispatch_sysop_yield` drains the args and yields.
+                    let callee_ptr = self.as_object_ptr(callee_value, FunctionType::SysOp.into())?;
+                    return Ok(Some(self.dispatch_sysop_yield(
+                        callee_ptr,
+                        runtime_id,
+                        *frame_idx,
+                    )?));
                 }
 
                 // ── Spawn (BEP-034) ────────────────────────────────────────────

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -4255,7 +4255,13 @@ impl BexVm {
                 }
                 .into());
             };
-            (sys_op, f.function_id, f.arity, f.capture, f.param_names.clone())
+            (
+                sys_op,
+                f.function_id,
+                f.arity,
+                f.capture,
+                f.param_names.clone(),
+            )
         };
         let args_offset = self
             .stack
@@ -4380,7 +4386,7 @@ impl BexVm {
         // `Object::Function` itself (unwrapped from any Closure/BoundMethod/
         // GenericFunction), carried on call notifications so the engine can map
         // it to a `FunctionId` without a name lookup.
-        let (callee, _callee_fn_ptr) = match self.get_object(callee_ptr) {
+        let (callee, callee_fn_ptr) = match self.get_object(callee_ptr) {
             Object::Function(f) => (f, callee_ptr),
             Object::Closure(c) => {
                 // SAFETY: closure.function is a compile-time or TLAB-allocated
@@ -4707,14 +4713,19 @@ impl BexVm {
             }
 
             FunctionKind::SysOp(_) => {
-                log::error!(
-                    "[VM] tried to CALL SysOp function '{callee_name}' via bytecode — SysOps must go through the engine yield path"
-                );
-                return Err(VmInternalError::TypeError {
-                    expected: FunctionType::Callable.into(),
-                    got: FunctionType::from(&callee_kind).into(),
-                }
-                .into());
+                // A sys-op reached as a callable value — virtual/interface
+                // dispatch or a bound-method value — runs through the same
+                // engine yield as a direct `OpCode::SysOp`: drain its args and
+                // suspend. The resolved sys-op `Function`'s arity already counts
+                // the receiver, so the top-of-stack args are exactly what the
+                // op's glue expects. On resume the engine pushes the result and
+                // the caller's post-call store binds it, identically to a
+                // returning bytecode callee.
+                return Ok(Some(self.dispatch_sysop_yield(
+                    callee_fn_ptr,
+                    runtime_id,
+                    *frame_idx,
+                )?));
             }
 
             FunctionKind::NativeUnresolved => {
@@ -5981,12 +5992,11 @@ impl BexVm {
                     let callee_value = self.globals.get(self.proof(), callee);
                     // `as_object_ptr` asserts the global is a `FunctionType::SysOp`
                     // function; `dispatch_sysop_yield` drains the args and yields.
-                    let callee_ptr = self.as_object_ptr(callee_value, FunctionType::SysOp.into())?;
-                    return Ok(Some(self.dispatch_sysop_yield(
-                        callee_ptr,
-                        runtime_id,
-                        *frame_idx,
-                    )?));
+                    let callee_ptr =
+                        self.as_object_ptr(callee_value, FunctionType::SysOp.into())?;
+                    return Ok(Some(
+                        self.dispatch_sysop_yield(callee_ptr, runtime_id, *frame_idx)?,
+                    ));
                 }
 
                 // ── Spawn (BEP-034) ────────────────────────────────────────────

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -4226,13 +4226,16 @@ impl BexVm {
     /// shared by the dedicated `OpCode::SysOp` handler (a statically-known
     /// direct call) and the general call funnel
     /// ([`Self::execute_call_from_locals_offset`], reached when a sys-op is
-    /// invoked as a callable value — virtual/interface dispatch or a
-    /// bound-method value). Both present the op's `arity` arguments as the top
-    /// of the stack, so a sys-op is dispatched identically however it is
-    /// reached.
+    /// invoked as a callable value — virtual/interface dispatch, a bound-method
+    /// value, or a callback handed to a native higher-order builtin). Both
+    /// present the op's `arity` arguments as the top of the stack, so a sys-op
+    /// is dispatched identically however it is reached.
     ///
     /// `callee_fn_ptr` must point at an `Object::Function` whose kind is
-    /// [`FunctionKind::SysOp`]; the mismatch arms are defensive.
+    /// [`FunctionKind::SysOp`]. The kind check below is genuinely load-bearing
+    /// for the `OpCode::SysOp` caller (its `as_object_ptr` does not verify the
+    /// kind — see there); the funnel caller has already matched on the kind, so
+    /// for it the check is redundant. Do not delete it.
     fn dispatch_sysop_yield(
         &mut self,
         callee_fn_ptr: HeapPtr,
@@ -4714,13 +4717,37 @@ impl BexVm {
 
             FunctionKind::SysOp(_) => {
                 // A sys-op reached as a callable value — virtual/interface
-                // dispatch or a bound-method value — runs through the same
-                // engine yield as a direct `OpCode::SysOp`: drain its args and
-                // suspend. The resolved sys-op `Function`'s arity already counts
-                // the receiver, so the top-of-stack args are exactly what the
-                // op's glue expects. On resume the engine pushes the result and
-                // the caller's post-call store binds it, identically to a
-                // returning bytecode callee.
+                // dispatch, a bound-method value, or a callback handed to a
+                // native higher-order builtin — runs through the same engine
+                // yield as a direct `OpCode::SysOp`: drain its args and suspend.
+                // The resolved sys-op `Function`'s arity already counts the
+                // receiver, so the top-of-stack args are exactly what the op's
+                // glue expects. On resume the engine pushes the result and the
+                // caller's post-call store binds it, identically to a returning
+                // bytecode callee.
+                //
+                // `dispatch_sysop_yield` drains `stack.len() - arity`; every
+                // funnel caller positions the args as the exact top of stack, so
+                // that window is `locals_offset`. Assert it rather than thread
+                // `locals_offset` through the shared helper.
+                debug_assert_eq!(
+                    self.stack.len().checked_sub(callee_arity),
+                    Some(locals_offset.raw()),
+                    "sysop dispatch: args must be the top {callee_arity} stack slots \
+                     (len {}, locals_offset {})",
+                    self.stack.len(),
+                    locals_offset.raw(),
+                );
+                // Sys-ops do not thread type arguments: a method-level-generic
+                // sys-op is rejected at compile time (E0153), and class/interface
+                // generics are type-erased for the op's glue. Any type args here
+                // would be silently dropped, so fail closed in debug.
+                debug_assert!(
+                    closure_type_args.is_empty()
+                        && bound_method_class_type_args.is_empty()
+                        && gf_type_args.is_empty(),
+                    "sysop dispatch received type args, which it cannot thread to the op",
+                );
                 return Ok(Some(self.dispatch_sysop_yield(
                     callee_fn_ptr,
                     runtime_id,
@@ -5990,8 +6017,11 @@ impl BexVm {
                     };
                     let callee = bex_vm_types::GlobalIndex::from_raw(raw as usize);
                     let callee_value = self.globals.get(self.proof(), callee);
-                    // `as_object_ptr` asserts the global is a `FunctionType::SysOp`
-                    // function; `dispatch_sysop_yield` drains the args and yields.
+                    // `as_object_ptr` only unwraps the value to a heap pointer
+                    // (the `FunctionType` argument is error-message metadata, not
+                    // an assertion). `dispatch_sysop_yield`'s own kind check is
+                    // therefore the load-bearing validation on this path — it
+                    // rejects a non-sys-op global before draining and yields.
                     let callee_ptr =
                         self.as_object_ptr(callee_value, FunctionType::SysOp.into())?;
                     return Ok(Some(

--- a/baml_language/crates/bridge_wasm/Cargo.toml
+++ b/baml_language/crates/bridge_wasm/Cargo.toml
@@ -25,6 +25,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 console_error_panic_hook = { workspace = true, optional = true }
 futures = { workspace = true }
+getrandom_03 = { workspace = true }
 indexmap = { workspace = true }
 js-sys = { workspace = true }
 log = { workspace = true }

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -60,6 +60,7 @@ mod wasm_io_fs;
 mod wasm_io_glob;
 mod wasm_lsp;
 mod wasm_playground;
+mod wasm_random;
 mod wasm_sys;
 mod wasm_time;
 
@@ -756,6 +757,7 @@ impl BamlWasmRuntime {
                 std::sync::Arc::clone(&wasm_vfs_arc),
             )))
             .with_time_instance(std::sync::Arc::new(wasm_time::WasmTime))
+            .with_random_instance(std::sync::Arc::new(wasm_random::WasmRandom))
             // One `WasmHost` per runtime, holding *this* runtime's JS
             // `host_dispatch` callback so a BAML→host call dispatches through
             // the correct wrapper (a process-global callback would let a second

--- a/baml_language/crates/bridge_wasm/src/wasm_random.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_random.rs
@@ -22,11 +22,19 @@ impl io::IoClassRandomSystemRandom for WasmRandom {
         _ctx: &SysOpContext,
     ) -> SysOpOutput<Vec<u8>> {
         let Ok(n) = usize::try_from(bytes) else {
-            return SysOpOutput::err(VmPanic::AllocFailure {
-                message: "Cannot allocate negative size array".to_string(),
+            return SysOpOutput::err(VmPanic::UserPanic {
+                message: format!("Rng.random: byte count must be non-negative, got {bytes}"),
             });
         };
-        let mut buf = vec![0u8; n];
+        // Allocate fallibly so an unsatisfiable request is a catchable
+        // `AllocFailure` panic, not a wasm-instance trap.
+        let mut buf = Vec::new();
+        if buf.try_reserve(n).is_err() {
+            return SysOpOutput::err(VmPanic::AllocFailure {
+                message: format!("Rng.random: allocation of {n} bytes failed"),
+            });
+        }
+        buf.resize(n, 0u8);
         match getrandom_03::fill(&mut buf) {
             Ok(()) => SysOpOutput::ok(buf),
             Err(e) => SysOpOutput::err(VmPanic::HostUnavailable {

--- a/baml_language/crates/bridge_wasm/src/wasm_random.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_random.rs
@@ -1,0 +1,58 @@
+//! WASM `baml.random` namespace implementation.
+//!
+//! `SystemRandom` draws fresh entropy from the host CSPRNG. On wasm that is the
+//! Web Crypto API (`crypto.getRandomValues`), reached through `getrandom`'s
+//! `wasm_js` backend — no JS callback is needed, so `WasmRandom` is a unit
+//! struct (mirroring `WasmTime`).
+
+use std::sync::Arc;
+
+use sys_ops::io::{self, CallId, SysOpContext, SysOpOutput, VmPanic};
+use sys_types::BexHeap;
+
+/// WASM implementation of the `baml.random` namespace.
+pub(crate) struct WasmRandom;
+
+impl io::IoClassRandomSystemRandom for WasmRandom {
+    fn random(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        bytes: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<Vec<u8>> {
+        let Ok(n) = usize::try_from(bytes) else {
+            return SysOpOutput::err(VmPanic::AllocFailure {
+                message: "Cannot allocate negative size array".to_string(),
+            });
+        };
+        let mut buf = vec![0u8; n];
+        match getrandom_03::fill(&mut buf) {
+            Ok(()) => SysOpOutput::ok(buf),
+            Err(e) => SysOpOutput::err(VmPanic::HostUnavailable {
+                resource: "randomness".to_string(),
+                message: format!("SystemRandom.random: system entropy unavailable: {e}"),
+            }),
+        }
+    }
+
+    fn random_int(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<i64> {
+        let mut buf = [0u8; 8];
+        match getrandom_03::fill(&mut buf) {
+            // Arithmetic shift right by one maps the uniform 64-bit draw onto
+            // the BAML i63 range `[INT_MIN, INT_MAX]`.
+            Ok(()) => SysOpOutput::ok(i64::from_le_bytes(buf) >> 1),
+            Err(e) => SysOpOutput::err(VmPanic::HostUnavailable {
+                resource: "randomness".to_string(),
+                message: format!("SystemRandom.random_int: system entropy unavailable: {e}"),
+            }),
+        }
+    }
+}
+
+impl io::IoNamespaceRandom for WasmRandom {}

--- a/baml_language/crates/sys_native/Cargo.toml
+++ b/baml_language/crates/sys_native/Cargo.toml
@@ -45,6 +45,7 @@ sys_ops = { workspace = true }
 sys_types = { workspace = true }
 bytes = { workspace = true, optional = true }
 futures = { workspace = true }
+getrandom = { workspace = true }
 http-body-util = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 hyper-util = { workspace = true, optional = true }

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -7,11 +7,9 @@
 use std::sync::{Arc, OnceLock};
 
 use bex_heap::{BexExternalValue, BexHeap};
-// Only the non-`bundle-http` HTTP stubs use `VmPanic` (to surface an
-// unsupported-platform panic); under `bundle-http` the real impls run instead.
-#[cfg(not(feature = "bundle-http"))]
-use sys_ops::io::VmPanic;
-use sys_ops::io::{self, CallId, SysOpContext, SysOpOutput, VmBamlError, VmRustFnError, owned};
+use sys_ops::io::{
+    self, CallId, SysOpContext, SysOpOutput, VmBamlError, VmPanic, VmRustFnError, owned,
+};
 
 // Process-level shared BufReader for stdin, preventing data loss when
 // BufReader over-reads into its internal buffer across multiple io.input() calls.
@@ -163,6 +161,54 @@ impl io::IoNamespaceTime for NativeSysOps {
         }
     }
 }
+
+// ============================================================================
+// Random (operating-system entropy)
+// ============================================================================
+
+impl io::IoClassRandomSystemRandom for NativeSysOps {
+    fn random(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        bytes: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<Vec<u8>> {
+        let Ok(n) = usize::try_from(bytes) else {
+            return SysOpOutput::err(VmPanic::AllocFailure {
+                message: "Cannot allocate negative size array".to_string(),
+            });
+        };
+        let mut buf = vec![0u8; n];
+        match getrandom::getrandom(&mut buf) {
+            Ok(()) => SysOpOutput::ok(buf),
+            Err(e) => SysOpOutput::err(VmPanic::HostUnavailable {
+                resource: "randomness".to_string(),
+                message: format!("SystemRandom.random: system entropy unavailable: {e}"),
+            }),
+        }
+    }
+
+    fn random_int(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<i64> {
+        let mut buf = [0u8; 8];
+        match getrandom::getrandom(&mut buf) {
+            // Arithmetic shift right by one maps the uniform 64-bit draw onto
+            // the BAML i63 range `[INT_MIN, INT_MAX]`.
+            Ok(()) => SysOpOutput::ok(i64::from_le_bytes(buf) >> 1),
+            Err(e) => SysOpOutput::err(VmPanic::HostUnavailable {
+                resource: "randomness".to_string(),
+                message: format!("SystemRandom.random_int: system entropy unavailable: {e}"),
+            }),
+        }
+    }
+}
+
+impl io::IoNamespaceRandom for NativeSysOps {}
 
 // ============================================================================
 // IO (stdin input)

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -175,11 +175,19 @@ impl io::IoClassRandomSystemRandom for NativeSysOps {
         _ctx: &SysOpContext,
     ) -> SysOpOutput<Vec<u8>> {
         let Ok(n) = usize::try_from(bytes) else {
-            return SysOpOutput::err(VmPanic::AllocFailure {
-                message: "Cannot allocate negative size array".to_string(),
+            return SysOpOutput::err(VmPanic::UserPanic {
+                message: format!("Rng.random: byte count must be non-negative, got {bytes}"),
             });
         };
-        let mut buf = vec![0u8; n];
+        // Allocate fallibly so an unsatisfiable request is a catchable
+        // `AllocFailure` panic, not a host-process abort.
+        let mut buf = Vec::new();
+        if buf.try_reserve(n).is_err() {
+            return SysOpOutput::err(VmPanic::AllocFailure {
+                message: format!("Rng.random: allocation of {n} bytes failed"),
+            });
+        }
+        buf.resize(n, 0u8);
         match getrandom::getrandom(&mut buf) {
             Ok(()) => SysOpOutput::ok(buf),
             Err(e) => SysOpOutput::err(VmPanic::HostUnavailable {

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -1746,6 +1746,29 @@ impl io::IoNamespaceTime for DefaultIoOps {
     }
 }
 
+impl io::IoClassRandomSystemRandom for DefaultIoOps {
+    fn random(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _bytes: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<Vec<u8>> {
+        SysOpOutput::err(VmPanic::HostUnavailable {
+            resource: "randomness".to_string(),
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
+    fn random_int(&self, _h: &Arc<BexHeap>, _c: CallId, _ctx: &SysOpContext) -> SysOpOutput<i64> {
+        SysOpOutput::err(VmPanic::HostUnavailable {
+            resource: "randomness".to_string(),
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
+}
+
+impl io::IoNamespaceRandom for DefaultIoOps {}
+
 impl io::IoPackageBaml for DefaultIoOps {}
 
 /// Builder for composing an [`io::SysOps`] table by overriding namespaces.
@@ -2308,6 +2331,34 @@ impl IoSysOpsBuilder {
     pub fn with_time<T: io::IoNamespaceTime + Default + Send + Sync + 'static>(self) -> Self {
         self.with_time_instance(Arc::new(T::default()))
     }
+
+    /// Override the `random` namespace (`SystemRandom.random` / `random_int`)
+    /// with a pre-built instance.
+    #[must_use]
+    pub fn with_random_instance(
+        mut self,
+        instance: Arc<dyn io::IoNamespaceRandom + Send + Sync + 'static>,
+    ) -> Self {
+        self.inner.baml_random_systemrandom_rng_random = {
+            let t = instance.clone();
+            Arc::new(move |heap, permit, args, ctx, call_id| {
+                t.__glue_baml_random_systemrandom_rng_random(heap, permit, args, ctx, call_id)
+            })
+        };
+        self.inner.baml_random_systemrandom_rng_random_int = {
+            let t = instance;
+            Arc::new(move |heap, permit, args, ctx, call_id| {
+                t.__glue_baml_random_systemrandom_rng_random_int(heap, permit, args, ctx, call_id)
+            })
+        };
+        self
+    }
+
+    /// Override the `random` namespace with a default-constructible type.
+    #[must_use]
+    pub fn with_random<T: io::IoNamespaceRandom + Default + Send + Sync + 'static>(self) -> Self {
+        self.with_random_instance(Arc::new(T::default()))
+    }
 }
 
 impl Default for IoSysOpsBuilder {
@@ -2324,6 +2375,7 @@ use ::sys_types::{
     VmBamlError, VmRustFnError,
 };
 pub use io::SysOps;
+use sys_types::VmPanic;
 
 /// Builder for composing a [`SysOps`] table by overriding namespaces.
 ///

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -2372,10 +2372,9 @@ use ::std::sync::Arc;
 // Re-export io::SysOps as the primary SysOps type.
 use ::sys_types::{
     AsBexExternalValue as _, CallId, FunctionRef, LlmFunctionInfo, SysOpContext, SysOpOutput,
-    VmBamlError, VmRustFnError,
+    VmBamlError, VmPanic, VmRustFnError,
 };
 pub use io::SysOps;
-use sys_types::VmPanic;
 
 /// Builder for composing a [`SysOps`] table by overriding namespaces.
 ///


### PR DESCRIPTION
Adds the `baml.random.Rng` interface which represents a randomness source.
Includes three standard library implementors:
- `baml.random.SystemRandom` fetches a secure random value from the OS/browser/etc (typically requires leaving the process but is secure; good for seeding PRNGs)
- `baml.random.Xoshiro256PlusPlus` is a widely used fast PRNG (not suitable for security-dependent uses)
- `baml.random.ChaCha20` is a widely used cryptographically secure PRNG

Also makes sysop `$rust_io_function`s work in `implements` blocks including for indirect/virtual calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standard random module with secure system randomness and seedable Xoshiro and ChaCha20 generators.
  - Added byte generation and uniformly distributed integer generation.
  - Added native and WebAssembly runtime support for secure randomness.
  - Added interface-based random generator dispatch.

- **Bug Fixes**
  - Improved method dispatch for interface implementations.
  - Added diagnostics for unsupported generic system-operation methods in interface implementations.

- **Tests**
  - Added coverage for deterministic output, entropy-backed randomness, interface dispatch, and boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->