### PR TITLE
bridge-cpp: run host callables inline instead of one thread per crossing

### DIFF
--- a/baml_language/crates/sys_native/src/host_dispatch.rs
+++ b/baml_language/crates/sys_native/src/host_dispatch.rs
@@ -83,15 +83,36 @@ pub fn set_dispatch_fn(f: HostDispatchFn) {
 pub fn fire_dispatch(host_value_key: u64, call_id: u32, args: &[u8]) -> bool {
     match HOST_DISPATCH_FN.get() {
         Some(f) => {
-            // The dispatch fn is fire-and-return: every bridge hands the call
-            // off to the host (spawning a task / goroutine / threadsafe-fn
-            // callback) and returns promptly, then later resolves the in-flight
-            // `CompletionHandle` via `complete_host_call`. It never blocks on
-            // the host's response, so we call it directly. A
-            // `tokio::task::block_in_place` wrapper would only be needed for a
-            // blocking callee, and it would panic on a current-thread runtime —
-            // neither applies here.
-            f(host_value_key, call_id, args.as_ptr(), args.len());
+            // Most bridges are fire-and-return: they hand the call off to
+            // the host (spawning a task / goroutine / threadsafe-fn callback)
+            // and return promptly, later resolving the in-flight
+            // `CompletionHandle` via `complete_host_call`.
+            //
+            // A bridge may instead run the host callable *inline* and complete
+            // the call before returning — the C++ bridge does this to avoid
+            // spawning an OS thread per crossing, which dominates its cost.
+            // The inflight entry is installed before this call (see
+            // `host_impls`), so an inline `complete_host_call` resolves a
+            // registered oneshot. Inline dispatch does occupy this worker for
+            // the duration of the callable, so on a multi-thread runtime we
+            // announce the blocking section: `block_in_place` migrates the
+            // remaining tasks off this worker, which keeps the runtime live
+            // even when the callable synchronously re-enters the engine.
+            //
+            // `block_in_place` panics on a current-thread runtime, and is
+            // meaningless outside a runtime context, so both fall back to a
+            // direct call (a fire-and-return bridge never needs it, and an
+            // inline bridge on a current-thread runtime cannot be rescued
+            // here anyway).
+            let call = || f(host_value_key, call_id, args.as_ptr(), args.len());
+            match tokio::runtime::Handle::try_current() {
+                Ok(handle)
+                    if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread =>
+                {
+                    tokio::task::block_in_place(call);
+                }
+                _ => call(),
+            }
             true
         }
         None => {

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/host_value.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/host_value.h
@@ -6,11 +6,21 @@
 // references a type-erased dispatcher in the process-global
 // host_value_registry. When BAML invokes the callable, the engine fires
 // the registered host-dispatch callback; the trampoline here runs the
-// dispatcher on a detached thread (dispatch must be fire-and-return --
-// the engine awaits the completion, so the user callable must not run on
-// the engine's worker), and the dispatcher decodes the BamlToHostCall
-// args, invokes the user function, and resolves the call via
-// complete_host_call. Mirrors bridge_python::host_value.
+// dispatcher INLINE on the engine's worker, decoding the BamlToHostCall
+// args, invoking the user function, and resolving the call via
+// complete_host_call before returning.
+//
+// Inline dispatch is safe because the engine installs the in-flight entry
+// before firing (sys_native `host_impls`), so completing from inside the
+// callback resolves an already-registered oneshot, and because the engine
+// announces the blocking section with `block_in_place` on a multi-thread
+// runtime, which migrates the remaining tasks off this worker and keeps
+// the runtime live even when the user callable re-enters the engine.
+//
+// bridge_python spawns a tokio task here instead. That is ~free in Python;
+// the C++ equivalent was a detached OS thread per crossing, which measured
+// ~29us against ~7us inline on an M-series Mac -- pure overhead on a path
+// hot enough to matter (an embedded game loop issues thousands per second).
 //
 // Host exceptions cross back in two shapes (Python parity):
 //   - baml::host_throw<T>           -> the typed BAML class value itself
@@ -33,7 +43,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
@@ -494,8 +503,7 @@ extern "C" inline void baml_cpp_host_dispatch_trampoline(
   };
   // No C++ exception may cross the C ABI (bridge contract), and every
   // setup fault must still complete the call or the engine awaits forever:
-  // bytes.assign can throw bad_alloc, the registry lock can throw, and the
-  // std::thread constructor throws system_error under thread exhaustion.
+  // bytes.assign can throw bad_alloc and the registry lock can throw.
   try {
     std::vector<uint8_t> bytes;
     if (args != nullptr && length != 0) {
@@ -510,22 +518,19 @@ extern "C" inline void baml_cpp_host_dispatch_trampoline(
                      std::to_string(host_value_key));
       return;
     }
-    // Fire-and-return: the engine awaits the completion, so the user
-    // callable runs on its own thread (the analog of Python's spawned
-    // tokio task). run_host_callable completes the call on every exit
-    // path.
-    std::thread([dispatcher = std::move(dispatcher), bridge_failure, call_id,
-                 bytes = std::move(bytes)]() mutable {
-      try {
-        dispatcher(call_id, std::move(bytes));
-      } catch (...) {
-        bridge_failure(
-            "host callable dispatch failed outside the user callable");
-      }
-    }).detach();
+    // Run inline on the engine's worker (see the header comment for why
+    // this is safe). run_host_callable completes the call on every exit
+    // path; the catch is for a fault in the dispatcher itself, outside the
+    // user callable, which must still complete the call rather than leave
+    // the engine awaiting forever.
+    try {
+      dispatcher(call_id, std::move(bytes));
+    } catch (...) {
+      bridge_failure("host callable dispatch failed outside the user callable");
+    }
   } catch (...) {
     try {
-      bridge_failure("host callable dispatch could not be spawned");
+      bridge_failure("host callable dispatch could not be started");
     } catch (...) {
       // Even the failure path failed (e.g. allocation): swallowing is all
       // the ABI permits -- that call hangs rather than the process


### PR DESCRIPTION
## What

The C++ trampoline spawned a detached `std::thread` for **every** BAML → host callable crossing:

```cpp
std::thread([dispatcher = std::move(dispatcher), ...]() mutable {
  dispatcher(call_id, std::move(bytes));
}).detach();
```

This mirrors `bridge_python::host_value`, which spawns a tokio task. A tokio task is ~free; an OS thread is not. On an M-series Mac `std::thread` spawn+detach alone measures **7.7us**, and a crossing that does no work costs **~29us** — all overhead, on a path hot enough to matter (an embedded game loop issues thousands of these per second).

This PR runs the dispatcher inline on the engine's worker instead.

## Why it's safe

`host_impls` installs the in-flight entry (`InflightGuard::new(call_id)`) *before* calling `fire_dispatch`, so completing from inside the dispatch callback resolves an already-registered oneshot. The awaiting future simply polls ready.

Inline dispatch does occupy the worker for the duration of the callable, which would strand the runtime if the callable synchronously re-enters the engine. So `fire_dispatch` now announces the blocking section with `block_in_place` on a multi-thread runtime, migrating the remaining tasks off this worker.

Sync re-entrancy is not part of the supported contract (`host_dispatch.rs`: "No synchronous re-entrancy"), but it *did* work before this change by accident of the thread spawn — so it is preserved rather than regressed. `block_in_place` panics on a current-thread runtime and is meaningless outside a runtime context, so both fall back to a direct call.

## Measurements

`aarch64-apple-darwin`, a BAML function making 6 crossings, 400 iterations:

| | per crossing |
|---|---|
| before (thread per call) | 29.08 us |
| after (inline + `block_in_place`) | 8.47 us |
| | **3.4x** |

Verified separately, before and after: a host callable that calls back into BAML synchronously returns the correct result. With inline dispatch but *without* the `block_in_place` half, that same test deadlocks — which is what the second half of this change buys.

## Test notes

`cargo test -p sys_native host_dispatch` passes; workspace clippy (`--all-targets --all-features -D warnings`) is clean.

Note that `sdks/cpp/bridge_cpp/tests/run.sh` does not build on `canary` at the moment, independent of this change: `runtime_smoke.cc:42` reads `started.envelope`, but `envelope` is a member of `call_state`, not `call_registry::started`. Untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved host-call dispatch efficiency by reducing unnecessary thread creation overhead.
  * Added safer handling for dispatches running within multi-threaded asynchronous runtimes.

* **Reliability**
  * Improved failure handling during host-call execution to ensure in-flight calls are completed correctly when dispatch errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->