### PR TITLE
perf: linear cold compiles, and one warm cache for check/run/pack

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -6883,6 +6883,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -303,7 +303,10 @@ rand_xoshiro = "0.6"
 num-bigint = { version = "0.4", features = [ "rand", "serde" ] }
 num-traits = { version = "0.2" }
 rsa = { version = "0.9", default-features = false, features = [ "std", "pem" ] }
-sha2 = { version = "0.10", features = [ "oid" ] }
+# `asm` enables the hardware SHA-2 backend (SHA-NI / ARMv8 crypto extensions,
+# runtime-detected). Without it the warm bytecode-cache path software-hashes
+# ~hundreds of MB of unit payloads per run.
+sha2 = { version = "0.10", features = [ "oid", "asm" ] }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -303,10 +303,11 @@ rand_xoshiro = "0.6"
 num-bigint = { version = "0.4", features = [ "rand", "serde" ] }
 num-traits = { version = "0.2" }
 rsa = { version = "0.9", default-features = false, features = [ "std", "pem" ] }
-# `asm` enables the hardware SHA-2 backend (SHA-NI / ARMv8 crypto extensions,
-# runtime-detected). Without it the warm bytecode-cache path software-hashes
-# ~hundreds of MB of unit payloads per run.
-sha2 = { version = "0.10", features = [ "oid", "asm" ] }
+# The hardware SHA-2 backend (`asm`: SHA-NI / ARMv8 crypto extensions,
+# runtime-detected) is enabled per-target in `bex_cache` — the `asm` feature
+# does not build under MSVC (sha2-asm ships GAS `.S` sources), so it must not
+# be turned on here unconditionally.
+sha2 = { version = "0.10", features = [ "oid" ] }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -34,21 +34,30 @@ impl CheckArgs {
         let mut db = build_db_from_sources(&resolved, |_| {});
         let cache = CacheContext::open(&resolved, false);
 
-        // Check is a read-only cache consumer. It can use the immutable stdlib
-        // interface and the last successful compile's reuse seeds, but cannot
-        // advance the manifest without emitting matching Program/unit entries.
-        // The stdlib-interface-hit flag is only useful to run/test (which write),
-        // so a read-only check discards it.
-        let reuse_plan = match &cache {
-            Some(ctx) => ctx.prepare_warm_db(&mut db).reuse_plan,
-            None => None,
+        // The manifest can only advance alongside emitted Program/unit entries,
+        // so a clean check *seeds* the cache below by running the same
+        // emit-and-store path as run/test (gated to checks that actually have
+        // something to advance). That turns a check-only workflow warm instead
+        // of leaving it on the full-compile path forever.
+        let (reuse_plan, stdlib_interface_hit) = match &cache {
+            Some(ctx) => {
+                let prep = ctx.prepare_warm_db(&mut db);
+                (prep.reuse_plan, prep.stdlib_interface_hit)
+            }
+            None => (None, false),
         };
 
         reporter.spin("Checking", format!("{file_count} file(s)"));
-        let diagnostics = cache.as_ref().map_or_else(
-            || baml_project::collect_diagnostics(&db),
-            |cache| cache.collect_diagnostics_for_check(&db, reuse_plan.as_ref()),
-        );
+        // With a cache, collect through the incremental collector so the fresh
+        // per-file blobs are available for seeding below; its merged set is
+        // identical to the read-only collector's.
+        let (diagnostics, fresh_diagnostics) = match &cache {
+            Some(ctx) => {
+                let incremental = ctx.collect_diagnostics_incremental(&db, reuse_plan.as_ref());
+                (incremental.merged, Some(incremental.fresh_by_file))
+            }
+            None => (baml_project::collect_diagnostics(&db), None),
+        };
         if let Some(cache) = &cache {
             cache.verify_diagnostics(&db)?;
             cache.verify_stdlib_diagnostics(&db)?;
@@ -92,6 +101,48 @@ impl CheckArgs {
         if error_count > 0 {
             reporter.abandon();
             return Ok(crate::ExitCode::Other);
+        }
+
+        // Seed the bytecode cache from this clean check — the same
+        // emit-and-store path run/test use — but only when it advances the
+        // manifest: no reuse plan (missing/stale manifest) or a plan with
+        // dirty files. A fully-current manifest (zero dirty files) has
+        // nothing to store, and skipping keeps the no-op check emit-free.
+        // Seeding is an optimization: a failed emit on a diagnostics-clean
+        // project is logged, never surfaced as a check failure.
+        if let Some(ctx) = &cache {
+            let should_seed = reuse_plan
+                .as_ref()
+                .is_none_or(|plan| !plan.dirty_files.is_empty());
+            if should_seed {
+                match crate::bytecode_cache::compile_program_artifacts(
+                    &db,
+                    &baml_db::baml_compiler2_emit::CompileOptions {
+                        emit_test_cases: false,
+                    },
+                    cache.as_ref(),
+                    reuse_plan.as_ref(),
+                ) {
+                    Ok(compiled) => {
+                        let fresh = fresh_diagnostics
+                            .as_ref()
+                            .expect("a cache is present, so fresh diagnostics were computed");
+                        ctx.verify_and_store(
+                            &db,
+                            &compiled,
+                            fresh,
+                            reuse_plan.as_ref(),
+                            stdlib_interface_hit,
+                            || build_db_from_sources(&resolved, |_| {}),
+                        )?;
+                    }
+                    Err(err) => {
+                        crate::bytecode_cache::cache_debug(format_args!(
+                            "check: cache seeding skipped (emit failed): {err:?}"
+                        ));
+                    }
+                }
+            }
         }
 
         reporter.finish("Finished", format!("checked {file_count} file(s)"));

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -40,7 +40,7 @@ use sys_native::SysOpsExt;
 
 use crate::{
     commands::release_version,
-    project_load::{load_project_for_build, resolve_standalone_file, validate_file_from_flags},
+    project_load::{resolve_standalone_file, validate_file_from_flags},
     reporter::Reporter,
 };
 
@@ -237,44 +237,118 @@ impl PackArgs {
     }
 
     fn load_and_compile(&self, reporter: &Reporter) -> Result<(ProjectDatabase, Program, bool)> {
-        let (db, needs_format_hint) = if let Some(file) = self.file.as_deref() {
-            self.load_standalone(file)?
-        } else {
-            self.load_project(reporter)?
+        if let Some(file) = self.file.as_deref() {
+            // Standalone `--file` mode has no project root, so there is no
+            // cache seam — always a cold compile, same as `baml run --file`.
+            let (db, needs_format_hint) = self.load_standalone(file)?;
+            check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
+            let program = baml_compiler2_emit::generate_project_bytecode(
+                &db,
+                &baml_compiler2_emit::CompileOptions {
+                    emit_test_cases: false,
+                },
+            )
+            .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
+            return Ok((db, program, needs_format_hint));
+        }
+        self.load_and_compile_project(reporter)
+    }
+
+    /// Project-mode load + compile through the bytecode cache — the same warm
+    /// flow as `baml run` (`run_command::load_and_compile`): whole-program hit
+    /// when nothing changed, per-file unit reuse on a dirty edit, full compile
+    /// otherwise. Pack compiles with `emit_test_cases: false`, so it shares
+    /// run/check's exact cache key space — a pack right after a run (or a
+    /// re-pack) serves the identical `Program`. The packaged bytecode is
+    /// target-independent (the `--target` triple only selects the host binary
+    /// bytes), and emit determinism guarantees a reused image is byte-identical
+    /// to a fresh compile, so serving from cache never changes the artifact.
+    fn load_and_compile_project(
+        &self,
+        reporter: &Reporter,
+    ) -> Result<(ProjectDatabase, Program, bool)> {
+        let resolved = crate::project_load::resolve_project_sources(self.from.as_deref())?;
+        if resolved.files.is_empty() {
+            anyhow::bail!("No .baml files found in {}", resolved.root.display());
+        }
+        // Mirror `baml run`'s per-file format check: probe each source through
+        // the formatter and emit a single advisory if any file would change.
+        let needs_format_hint = resolved
+            .files
+            .iter()
+            .any(|(_, source)| crate::run_command::source_needs_format_hint(source));
+
+        // Building the database only sets salsa inputs — the expensive work
+        // (typecheck, emit) happens lazily below, which a cache hit skips.
+        let mut db = crate::project_load::build_db_from_sources(&resolved, |_| {});
+
+        let cache =
+            crate::bytecode_cache::CacheContext::open(&resolved, /* emit_test_cases */ false);
+        if !crate::bytecode_cache::CacheContext::verify_enabled()
+            && let Some(ctx) = &cache
+            && let Some(program) = ctx.load()
+        {
+            crate::bytecode_cache::cache_debug(format_args!(
+                "pack: bytecode cache hit — skipping compile"
+            ));
+            return Ok((db, program, needs_format_hint));
+        }
+
+        // Seed the stdlib typed interface and prepare the per-file reuse plan —
+        // the same warm-database setup run/check/test use.
+        let (reuse_plan, stdlib_interface_hit) = match &cache {
+            Some(ctx) => {
+                let prep = ctx.prepare_warm_db(&mut db);
+                (prep.reuse_plan, prep.stdlib_interface_hit)
+            }
+            None => (None, false),
         };
 
         // Keep `baml pack` quiet during compilation. Its visible progress is
         // packaging/downloading/output-oriented; compile/count status belongs
         // to `check` and `generate`.
-        check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
+        //
+        // With a cache, gate diagnostics through the incremental collector: it
+        // checks only the reuse plan's dirty files and serves clean files from
+        // their cached blobs, returning the fresh per-file blobs to persist.
+        // Without a cache, run the honest full check (no blobs to store).
+        let fresh_diagnostics = if let Some(ctx) = &cache {
+            let incremental = ctx.collect_diagnostics_incremental(&db, reuse_plan.as_ref());
+            bail_on_error_diagnostics(
+                &db,
+                &incremental.merged,
+                "Cannot pack: compilation errors found",
+                reporter,
+            )?;
+            Some(incremental.fresh_by_file)
+        } else {
+            check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
+            None
+        };
 
-        let program = baml_compiler2_emit::generate_project_bytecode(
+        let compiled = crate::bytecode_cache::compile_program_artifacts(
             &db,
             &baml_compiler2_emit::CompileOptions {
                 emit_test_cases: false,
             },
+            cache.as_ref(),
+            reuse_plan.as_ref(),
         )
         .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
-
-        Ok((db, program, needs_format_hint))
-    }
-
-    fn load_project(&self, reporter: &Reporter) -> Result<(ProjectDatabase, bool)> {
-        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), reporter, false)?;
-        if baml_files.is_empty() {
-            anyhow::bail!("No .baml files found in {}", from.display());
+        if let Some(ctx) = &cache {
+            let fresh = fresh_diagnostics
+                .as_ref()
+                .expect("a cache is present, so fresh diagnostics were computed");
+            ctx.verify_and_store(
+                &db,
+                &compiled,
+                fresh,
+                reuse_plan.as_ref(),
+                stdlib_interface_hit,
+                || crate::project_load::build_db_from_sources(&resolved, |_| {}),
+            )?;
         }
-        // Mirror `baml run`'s per-file format check: probe each source
-        // through the formatter and emit a single advisory if any file
-        // would change. Cheap enough at compile time (we already read
-        // each file from disk during discovery) and matches the
-        // warning surfaces `baml run` already provides.
-        let needs_format_hint = baml_files.iter().any(|path| {
-            std::fs::read_to_string(path)
-                .map(|source| crate::run_command::source_needs_format_hint(&source))
-                .unwrap_or(false)
-        });
-        Ok((db, needs_format_hint))
+        Ok((db, compiled.program, needs_format_hint))
     }
 
     fn load_standalone(&self, file_path: &Path) -> Result<(ProjectDatabase, bool)> {
@@ -405,15 +479,25 @@ fn label_for(targets: &[ResolvedPackTarget]) -> String {
 }
 
 /// Collect diagnostics; render errors to stderr and bail with `ctx`.
+fn check_diagnostics(db: &ProjectDatabase, ctx: &str, reporter: &Reporter) -> Result<()> {
+    let diagnostics = baml_project::collect_diagnostics(db);
+    bail_on_error_diagnostics(db, &diagnostics, ctx, reporter)
+}
+
+/// Render any `Error`-severity entries in an already-collected diagnostics
+/// list and bail with `ctx`; no-op when the list is error-free.
 ///
 /// When `reporter` has an active spinner, abandon it before printing so
 /// the multi-line ariadne block lands cleanly instead of getting
 /// interleaved with the tick character.
-fn check_diagnostics(db: &ProjectDatabase, ctx: &str, reporter: &Reporter) -> Result<()> {
+fn bail_on_error_diagnostics(
+    db: &ProjectDatabase,
+    diagnostics: &[baml_db::baml_compiler_diagnostics::Diagnostic],
+    ctx: &str,
+    reporter: &Reporter,
+) -> Result<()> {
     use baml_db::baml_compiler_diagnostics::render;
 
-    let source_files = db.get_source_files();
-    let diagnostics = baml_project::collect_diagnostics(db);
     let errors: Vec<_> = diagnostics
         .iter()
         .filter(|d| d.severity == Severity::Error)
@@ -421,6 +505,7 @@ fn check_diagnostics(db: &ProjectDatabase, ctx: &str, reporter: &Reporter) -> Re
     if errors.is_empty() {
         return Ok(());
     }
+    let source_files = db.get_source_files();
     let mut sources = HashMap::new();
     let mut file_paths = HashMap::new();
     for sf in &source_files {
@@ -1146,9 +1231,9 @@ mod tests {
         assert_eq!(name, "DoesNotExist");
     }
 
-    // ── load_project / load_standalone error paths ────────────────────
+    // ── project / load_standalone error paths ─────────────────────────
 
-    /// An empty directory has no `.baml` files → `load_project` errors
+    /// An empty directory has no `.baml` files → project loading errors
     /// before ever reaching compilation.
     #[test]
     fn test_load_project_empty_dir_errors() {
@@ -1165,7 +1250,7 @@ mod tests {
         let mut args = pack_args();
         args.from = Some(tmp.path().to_path_buf());
         let reporter = Reporter::new();
-        let err = args.load_project(&reporter).unwrap_err();
+        let err = args.load_and_compile_project(&reporter).unwrap_err();
         assert!(
             format!("{err}").contains("No .baml files"),
             "expected no-files error; got: {err}",

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -193,6 +193,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
         file_id,
         &item_tree,
         pkg_items,
+        &pkg_info.package,
         &pkg_info.namespace_path,
         source_text,
     ));
@@ -1214,10 +1215,33 @@ fn check_jinja_templates(
     file_id: FileId,
     item_tree: &baml_compiler2_hir::item_tree::ItemTree,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
+    package: &Name,
     namespace_path: &[Name],
     source_text: &str,
 ) -> Vec<Diagnostic> {
-    let base_types = build_jinja_types(db, pkg_items, namespace_path);
+    // Files with no LLM prompts and no template_string bodies have nothing to
+    // validate. Return before touching the package-wide Jinja environment so
+    // such files never pay for (or depend on) it at all.
+    let has_prompts = item_tree.functions.values().any(|func_data| {
+        matches!(
+            &func_data.declarative_meta,
+            Some(baml_compiler2_ast::DeclarativeMeta::Llm(llm)) if llm.prompt.is_some()
+        )
+    });
+    let has_templates = item_tree
+        .template_strings
+        .values()
+        .any(|template| template.body.is_some());
+    if !has_prompts && !has_templates {
+        return Vec::new();
+    }
+
+    let ns_id = baml_compiler2_hir::namespace::NamespaceId::new(
+        db,
+        package.clone(),
+        namespace_path.to_vec(),
+    );
+    let base_types = jinja_base_types(db, ns_id);
     let mut diagnostics = Vec::new();
 
     for func_data in item_tree.functions.values() {
@@ -1227,7 +1251,7 @@ fn check_jinja_templates(
             func_data,
             pkg_items,
             namespace_path,
-            &base_types,
+            base_types,
             source_text,
         ));
     }
@@ -1297,6 +1321,31 @@ fn check_llm_prompt_template(
         &prompt.text,
         sys_jinja_types::validate_template(func_data.name.as_str(), &prompt.text, &mut types),
     )
+}
+
+/// Package-wide Jinja type environment (classes, enums, aliases, and
+/// `template_strings` visible from a namespace), memoized per
+/// (package, namespace path).
+///
+/// `build_jinja_types` walks every type in the package, so before this was a
+/// Salsa query it re-ran O(package items) work once per checked file — the
+/// dominant quadratic term in whole-project checks (and it ran a second time
+/// per file inside `get_bytecode`'s error gate). As a tracked function the
+/// walk runs once per (package, namespace, revision) and every later
+/// `check_file` in the same revision gets a memo hit; `PredefinedTypes`'s
+/// `PartialEq` gives Salsa backdating, so edits that leave the environment
+/// unchanged don't invalidate downstream prompt checks.
+#[salsa::tracked(returns(ref))]
+fn jinja_base_types<'db>(
+    db: &'db dyn Db,
+    ns_id: baml_compiler2_hir::namespace::NamespaceId<'db>,
+) -> sys_jinja_types::PredefinedTypes {
+    let pkg_id = baml_compiler2_hir::package::PackageId::new(db, ns_id.package(db));
+    // Match the call-site environment exactly: `check_file` resolves items via
+    // `package_resolution_context(...).own_items`, which is ppir's
+    // `package_items` — use the same query here so the env is identical.
+    let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
+    build_jinja_types(db, pkg_items, &ns_id.path(db))
 }
 
 fn build_jinja_types(

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -163,9 +163,26 @@ pub fn collect_compiler2_diagnostics_narrowed(
     precomputed: Vec<Diagnostic>,
 ) -> NarrowedDiagnostics {
     let source_files = baml_compiler2_hir::compiler2_all_files(db);
+    // Filter up front (outside any parallel region): `should_check` is a plain
+    // `&dyn Fn`, so it never has to be thread-safe.
+    let checked: Vec<SourceFile> = source_files
+        .iter()
+        .copied()
+        .filter(|file| should_check(*file))
+        .collect();
     let mut fresh: Vec<Diagnostic> = Vec::new();
-    for file in &source_files {
-        if should_check(*file) {
+    // Same parallel-by-default policy as [`collect_compiler2_diagnostics`]. On
+    // a cold check `should_check` is all-true and `checked` is the whole
+    // project, so a serial loop here would leave every core but one idle; on a
+    // warm incremental check the dirty set is small and stays on the serial
+    // arm. Cross-file collection order is not part of the contract: `merged`
+    // gets the total-order sort below, and `fresh` consumers group by owner
+    // file (per-file order is preserved — each file's diagnostics come from
+    // one `lsp2_check_file` call, appended contiguously).
+    if checked.len() > 8 {
+        collect_file_diagnostics_parallel(db, &checked, &mut fresh);
+    } else {
+        for file in &checked {
             fresh.extend(lsp2_check_file(db, *file));
         }
     }
@@ -174,6 +191,15 @@ pub fn collect_compiler2_diagnostics_narrowed(
     merged.extend(package_level_diagnostics(db, &source_files));
     sort_diagnostics(&mut merged);
     NarrowedDiagnostics { merged, fresh }
+}
+
+/// Public wrapper over [`package_level_diagnostics`] for callers that assemble
+/// per-file diagnostics themselves (the LSP's candidate builder): these
+/// cross-file diagnostics come from `package_items`, not `check_file`, so a
+/// per-file sweep alone silently misses them.
+pub fn collect_package_level_diagnostics(db: &ProjectDatabase) -> Vec<Diagnostic> {
+    let source_files = baml_compiler2_hir::compiler2_all_files(db);
+    package_level_diagnostics(db, &source_files)
 }
 
 /// Package-level diagnostics (cross-file name conflicts and namespace shadows),

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -193,7 +193,7 @@ pub fn collect_compiler2_diagnostics_narrowed(
     NarrowedDiagnostics { merged, fresh }
 }
 
-/// Public wrapper over [`package_level_diagnostics`] for callers that assemble
+/// Public wrapper over the private `package_level_diagnostics` for callers that assemble
 /// per-file diagnostics themselves (the LSP's candidate builder): these
 /// cross-file diagnostics come from `package_items`, not `check_file`, so a
 /// per-file sweep alone silently misses them.

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -160,11 +160,18 @@ pub struct ProjectDatabase {
     /// long-lived `ProjectDatabase`).
     seeded_callable_throws: Option<baml_workspace::SeededCallableThrows>,
     /// Maps file paths to their `SourceFile` handles (user files only).
-    file_map: HashMap<std::path::PathBuf, SourceFile>,
+    ///
+    /// `Arc`-wrapped (with `Arc::make_mut` at the mutation sites) so cloning a
+    /// database handle stays O(1): the parallel check and emit drivers mint a
+    /// shared-storage handle per work chunk, and a deep per-clone copy of an
+    /// N-entry `PathBuf` map made every clone O(files) — quadratic CPU and
+    /// peak RSS across a whole compile.
+    file_map: Arc<HashMap<std::path::PathBuf, SourceFile>>,
     /// Maps file paths to compiler2-only `SourceFile` handles.
     compiler2_file_map: HashMap<std::path::PathBuf, SourceFile>,
-    /// Maps `FileId` to file path for reverse lookup (all files including v2 stubs).
-    file_id_to_path: HashMap<FileId, std::path::PathBuf>,
+    /// Maps `FileId` to file path for reverse lookup (all files including v2
+    /// stubs). `Arc`-wrapped for the same reason as `file_map`.
+    file_id_to_path: Arc<HashMap<FileId, std::path::PathBuf>>,
     /// `SourceFile` inputs of removed paths. Salsa never frees inputs, so a
     /// delete/recreate cycle (branch switch, codegen rewriting `.baml`
     /// files) would mint a new immortal input per cycle; instead the input
@@ -292,9 +299,9 @@ impl ProjectDatabase {
             seeded_throw_facts: None,
             seeded_stdlib_interface: None,
             seeded_callable_throws: None,
-            file_map: HashMap::new(),
+            file_map: Arc::new(HashMap::new()),
             compiler2_file_map: HashMap::new(),
-            file_id_to_path: HashMap::new(),
+            file_id_to_path: Arc::new(HashMap::new()),
             removed_file_tombstones: HashMap::new(),
         };
         db.seeded_throw_facts = Some(baml_workspace::SeededThrowFacts::new(
@@ -453,8 +460,8 @@ impl ProjectDatabase {
             };
             let file_id = file.file_id(self);
 
-            self.file_map.insert(canonical_path.clone(), file);
-            self.file_id_to_path.insert(file_id, canonical_path);
+            Arc::make_mut(&mut self.file_map).insert(canonical_path.clone(), file);
+            Arc::make_mut(&mut self.file_id_to_path).insert(file_id, canonical_path);
 
             // Update project files list if project is set
             if let Some(project) = self.project {
@@ -476,9 +483,9 @@ impl ProjectDatabase {
     pub fn remove_file(&mut self, path: &std::path::Path) {
         let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
-        if let Some(file) = self.file_map.remove(&canonical_path) {
+        if let Some(file) = Arc::make_mut(&mut self.file_map).remove(&canonical_path) {
             let file_id = file.file_id(self);
-            self.file_id_to_path.remove(&file_id);
+            Arc::make_mut(&mut self.file_id_to_path).remove(&file_id);
 
             // Remove from project files list
             if let Some(project) = self.project {
@@ -544,7 +551,7 @@ impl ProjectDatabase {
             let file = self.add_file_internal(&path, builtin.contents);
             let file_id = file.file_id(self);
 
-            self.file_id_to_path.insert(file_id, path.clone());
+            Arc::make_mut(&mut self.file_id_to_path).insert(file_id, path.clone());
             self.compiler2_file_map.insert(path, file);
 
             v2_builtin_files.push(file);
@@ -632,6 +639,20 @@ impl ProjectDatabase {
         if error_count > 0 {
             return Err(baml_compiler2_emit::LoweringError::ProjectHasErrors { error_count });
         }
+        self.get_bytecode_unchecked()
+    }
+
+    /// [`Self::get_bytecode`] without the error gate: goes straight to codegen.
+    ///
+    /// Only for callers that have already run a full-project check (per-file
+    /// `check_file` sweep **plus** package-level diagnostics) at the current
+    /// revision and found no user-file errors — the gate in `get_bytecode`
+    /// would re-derive exactly that result. Calling this on an error-bearing
+    /// project can panic in the runtime-conversion boundary (see the gate
+    /// comment above).
+    pub fn get_bytecode_unchecked(
+        &self,
+    ) -> Result<bex_vm_types::Program, baml_compiler2_emit::LoweringError> {
         let opts = baml_compiler2_emit::CompileOptions {
             emit_test_cases: false,
         };
@@ -1265,7 +1286,7 @@ impl ProjectDatabase {
             return Some(sf);
         }
         // Fallback: match by file name suffix (handles Monaco's relative paths)
-        for (stored_path, sf) in &self.file_map {
+        for (stored_path, sf) in self.file_map.iter() {
             if stored_path.ends_with(file_path)
                 || file_path.ends_with(stored_path.to_string_lossy().as_ref())
             {

--- a/baml_language/crates/baml_project/src/lib.rs
+++ b/baml_language/crates/baml_project/src/lib.rs
@@ -33,7 +33,7 @@ pub mod testing;
 
 pub use check::{
     CheckResult, NarrowedDiagnostics, collect_compiler2_diagnostics,
-    collect_compiler2_diagnostics_narrowed, collect_diagnostics,
+    collect_compiler2_diagnostics_narrowed, collect_diagnostics, collect_package_level_diagnostics,
 };
 pub use client_codegen::build_symbol_pool;
 pub use db::{CursorContext, EventCallback, ProjectDatabase};

--- a/baml_language/crates/bex_cache/Cargo.toml
+++ b/baml_language/crates/bex_cache/Cargo.toml
@@ -16,6 +16,16 @@ baml_version = { workspace = true }
 bex_vm_types = { workspace = true }
 borsh = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking", "rustls" ] }
+
+# The warm bytecode-cache path hashes every cached unit payload per run
+# (~230MB at a 295k LOC project), so enable sha2's hardware backend (`asm`:
+# SHA-NI / ARMv8 crypto extensions, runtime-detected) wherever it builds.
+# MSVC is the exception: sha2-asm ships GAS `.S` sources that cl.exe cannot
+# assemble, so MSVC targets keep the portable implementation.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+sha2 = { workspace = true, features = [ "asm" ] }
+
+[target.'cfg(target_env = "msvc")'.dependencies]
 sha2 = { workspace = true }
 
 [dev-dependencies]

--- a/baml_language/crates/bex_project/src/project.rs
+++ b/baml_language/crates/bex_project/src/project.rs
@@ -243,6 +243,34 @@ pub(crate) fn collect_diagnostic_candidate(guard: &SourceGuard<'_>) -> Diagnosti
         });
     }
 
+    // Package-level diagnostics (cross-file name conflicts and namespace
+    // shadows) come from `package_items`, not `check_file`, so the per-file
+    // sweep above misses them: without this the candidate under-reports
+    // errors relative to `get_bytecode`'s gate, and cross-file conflicts
+    // never reach the editor at all. Bucket each onto its primary-span
+    // file's document; only user-file spans count toward `has_errors`
+    // (matching the gate's filter).
+    let package_diags = baml_project::collect_package_level_diagnostics(db);
+    if !package_diags.is_empty() {
+        let doc_index: HashMap<std::path::PathBuf, usize> = documents
+            .iter()
+            .enumerate()
+            .map(|(idx, doc)| (doc.path.clone(), idx))
+            .collect();
+        for diag in package_diags {
+            let Some(span) = diag.primary_span() else {
+                continue;
+            };
+            let Some((path, _)) = file_texts.get(&span.file_id) else {
+                continue;
+            };
+            has_errors |= diag.severity == baml_compiler_diagnostics::Severity::Error;
+            if let Some(&idx) = doc_index.get(path) {
+                documents[idx].diagnostics.push(diag);
+            }
+        }
+    }
+
     DiagnosticCandidate {
         source_revision: guard.revision(),
         file_texts,
@@ -806,7 +834,10 @@ impl BexProject {
         if diagnostics.has_errors {
             return CompilationOutcome::BlockedByDiagnostics(diagnostics);
         }
-        match guard.db().get_bytecode() {
+        // The candidate above is a full-project check (per-file sweep plus
+        // package-level diagnostics), so `get_bytecode`'s error gate would
+        // re-derive exactly what `has_errors` just proved — skip it.
+        match guard.db().get_bytecode_unchecked() {
             Ok(program) => CompilationOutcome::Ready(
                 Box::new(CompiledCandidate {
                     source_revision: guard.revision(),

--- a/baml_language/crates/sys_jinja_types/src/evaluate_type/mod.rs
+++ b/baml_language/crates/sys_jinja_types/src/evaluate_type/mod.rs
@@ -15,7 +15,7 @@ use minijinja::machinery::{Span, ast::Expr};
 pub use self::types::{EnumDefinition, EnumValueDefinition, JinjaContext, PredefinedTypes, Type};
 pub(crate) use self::{expr::evaluate_type, stmt::get_variable_types};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TypeError {
     message: String,
     span: Span,

--- a/baml_language/crates/sys_jinja_types/src/evaluate_type/types.rs
+++ b/baml_language/crates/sys_jinja_types/src/evaluate_type/types.rs
@@ -14,13 +14,13 @@ use minijinja::machinery::{
 
 use super::TypeError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EnumDefinition {
     pub name: String,
     pub values: Vec<EnumValueDefinition>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EnumValueDefinition {
     pub name: String,
     pub alias: Option<String>,
@@ -300,7 +300,7 @@ impl BitOr for Type {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 enum Scope {
     CodeBlock(IndexMap<String, Type>),
     Branch(IndexMap<String, Type>, IndexMap<String, Type>, bool),
@@ -311,7 +311,7 @@ enum Scope {
     Narrowing(IndexMap<String, Type>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PredefinedTypes {
     functions: IndexMap<String, (Type, Vec<(String, Type)>)>,
     classes: HashMap<String, IndexMap<String, Type>>,


### PR DESCRIPTION
## What this does

Six fixes that came out of benchmarking the BAML compiler head-to-head against tsgo (native TypeScript) and `go build` on generated, semantically-identical corpora from 1.5k to 295k LOC.

**Compiler core**
1. **Jinja type env memoized** (`jinja_base_types` salsa query per package+namespace) + skipped for files with no prompts/`template_strings`. It was rebuilt per checked file — O(N²) — and twice per compile via `get_bytecode`'s error gate. This was ~95% of the quadratic CPU.
2. **`ProjectDatabase` handle clones O(files) → O(1)** (Arc-wrapped file maps). The parallel drivers clone a handle per work chunk (~1.55N per compile); the deep map copies were the second quadratic (CPU + peak RSS).
3. **Cache-path check collector parallelized** — `check`/`run` routed through a serial loop while the identical parallel machinery sat next to it (only reachable with the cache disabled).
4. **`get_bytecode` no longer re-checks the whole project inside emit** — the LSP proves errors once and calls `get_bytecode_unchecked`. To keep that sound, the LSP diagnostics candidate now includes package-level diagnostics (cross-file name conflicts / namespace shadows), which previously **never reached the editor at all**.

**CLI cache surface**
5. **`baml pack` now uses the bytecode cache** (it never opened one — every pack was fully cold). Whole-program hit / per-file reuse / store, sharing run+check's key space. Packed `Program` is target-independent; emit determinism keeps reused images byte-identical.
6. **`baml check` now seeds the cache** after a clean check (only when it advances the manifest — no-op checks stay emit-free; a failed emit is logged, never a check failure). Check-only workflows finally reach the warm path.

Plus `sha2/asm` (hardware SHA for the ~230MB of unit hashing per warm run at large sizes; target-gated, wasm unaffected).

## End-user impact (measured, Apple Silicon, hyperfine medians)

**Cold compiles scale linearly now** (was ~quadratic: 5× the code cost 33× the CPU):

| project size | `check` before | `check` after | `run` before | `run` after | `pack` before | `pack` after |
|--:|--:|--:|--:|--:|--:|--:|
| 59k LOC | 1.56 s | **1.01 s** | 2.30 s | **1.04 s** | 1.75 s | **1.06 s** |
| 295k LOC | 21–46 s | **7.1 s** | 27–35 s | **7.3 s** | 40.5 s | **7.2 s** |

At 295k LOC: user CPU **125.7 s → 8.9 s (14×)**, peak RSS **5.3 GB → 3.6 GB**.

**One warm cache now serves every command** (59k LOC project):

```
baml check   1.0 s    (cold, seeds the cache)
baml check   0.5 s    (warm)
baml run     0.10 s   (whole-program hit)
baml pack    0.13 s   (hit — was a full cold compile, every time)
```

Re-pack of a 295k LOC project: **40.5 s → 0.61 s** (packed binary verified to execute).

For context at 59k LOC: cold check+emit+cache-store now lands at classic `tsc --noEmit` speed (1.01 vs 1.00 s) and ahead of `go build` (1.23 s); tsgo remains far ahead (0.13 s) — closing that further is warm-floor work (tracked below), not this PR.

**Trade-off made deliberately:** cold `check` at mid-size projects (~15–30k LOC) is ~10% slower than before because it now emits + stores once to warm the cache; every subsequent check/run/pack is then served warm.

**Editor fix riding along:** cross-file duplicate-name / namespace-shadow errors now appear in editor diagnostics (they were silently dropped by the LSP's per-file sweep).

## Not in this PR (known, profiled, next)

- The warm-path O(project) floor: the throws-gate safety compare re-parses every file, and `check` loads all unit bytes it doesn't need (~90% of warm no-op cost at 295k LOC). Design for fixing it (TIR-space throws compare + manifest-resident unit metadata) is under adversarial review.
- LSP single-sweep / changed-file-first publish.
- `baml test`'s separate `emit_test_cases` keyspace still doesn't share this cache.

Letting CI run the test suites for verification; diagnostics output was verified byte-identical (cold + warm) against the pre-fix binary on an error-heavy corpus during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4oee6wrCHzXH6mM2h8eJo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Faster repeated project checks and packaging using bytecode caching with incremental, fresh diagnostics reused for later runs.
  - Improved hashing throughput on supported platforms with runtime-detected hardware-accelerated SHA-2, while keeping MSVC builds on the portable path.
  - Faster Jinja template validation via memoized, package-aware type information and early exits for irrelevant files.

- **Bug Fixes**
  - More complete cross-file package diagnostics (e.g., namespace conflicts) surfaced during compilation.
  - More consistent error-only diagnostic reporting.

- **Developer Experience**
  - More robust handling of empty project directories during project-mode compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->