### PR TITLE
perf(cache): warm no-op checks stop re-proving the cache (draft — review before merge)

### DIFF
--- a/baml_language/crates/baml_cli/src/bytecode_cache.rs
+++ b/baml_language/crates/baml_cli/src/bytecode_cache.rs
@@ -671,6 +671,19 @@ pub(crate) struct ReusePlan {
     /// by rel_path. Rehydrated to serve those files' diagnostics without
     /// re-checking, and copied verbatim into the next manifest.
     pub(crate) clean_diagnostics: std::collections::BTreeMap<String, Vec<u8>>,
+    /// Clean files' `CallableThrowsFragment` blobs carried verbatim from the
+    /// previous manifest, by rel_path. The source of the `callable_throws`
+    /// seeds (so seeding needs no unit payloads) and of the next manifest's
+    /// fragment carry.
+    pub(crate) clean_fragments: std::collections::BTreeMap<String, Vec<u8>>,
+    /// True when the dirty partition found nothing changed: no dirty or added
+    /// files, and every manifest entry still present on disk. On this path the
+    /// serve-time throws gate is provably a tautology (the seeds being checked
+    /// are byte-for-byte the values the manifest was stored with, units are
+    /// content-addressed and written before the manifest, and the solve is a
+    /// deterministic pure function), so it is skipped — and unit payloads are
+    /// not loaded at all (nothing will be re-emitted or relinked from them).
+    pub(crate) no_delta: bool,
 }
 
 /// The result of the warm-database preamble ([`CacheContext::prepare_warm_db`]).
@@ -694,6 +707,24 @@ pub(crate) fn prepare_reuse_plan(
     let mut plan = plan?;
     db.set_seeded_throw_facts(std::mem::take(&mut plan.seeded_throw_facts));
     let callable_seeds = std::mem::take(&mut plan.seeded_callable_throws);
+    // No delta ⇒ the gate is a tautology: the seeds just installed are
+    // byte-for-byte the values the manifest was stored with (the store path
+    // persists `file_throw_facts` verbatim and units are content-addressed,
+    // written before the manifest that points at them), and the solve +
+    // runtime conversion the gate would re-run are deterministic pure
+    // functions of those inputs. Comparing a value against itself cannot
+    // demote anything, so skip the compare — it was the dominant cost of a
+    // warm no-op invocation (it derives `package_items`, i.e. re-parses the
+    // project). Any real edit, added or removed file takes the gate below.
+    if plan.no_delta {
+        db.set_seeded_callable_throws(callable_seeds);
+        return Some(plan);
+    }
+    // The gate's runtime-type conversion derives the package alias tables,
+    // which fold every file's semantic index. Prime the per-file indexes
+    // across workers first so that derivation is a cheap fold instead of a
+    // serial parse of the whole project under one salsa memo claim.
+    baml_project::prime_file_indexes_parallel(db);
     let mismatches = reuse_throws_mismatches(db, &plan.prev_units, &plan.clean_files);
     if mismatches.is_empty() {
         db.set_seeded_callable_throws(callable_seeds);
@@ -1348,8 +1379,7 @@ fn compute_dirty_partition(db: &ProjectDatabase, manifest: &ProjectManifest) -> 
 /// empty or fails to decode is skipped — its functions then infer honestly
 /// (degrade, never miscompile). Empty under `BAML_NO_CALLABLE_THROWS_CACHE=1`.
 fn project_callable_throws_seeds(
-    prev_units: &[CompilationUnit],
-    clean_files: &HashSet<String>,
+    clean_fragments: &std::collections::BTreeMap<String, Vec<u8>>,
     root: Option<&PathBuf>,
 ) -> std::collections::BTreeMap<String, std::collections::BTreeMap<u32, baml_type::Ty>> {
     if CacheContext::callable_throws_cache_disabled() {
@@ -1357,27 +1387,25 @@ fn project_callable_throws_seeds(
     }
     use baml_db::baml_compiler2_tir::package_interface::CallableThrowsFragment;
     let mut by_path = std::collections::BTreeMap::new();
-    for unit in prev_units {
-        if !clean_files.contains(&unit.source_file) || unit.callable_throws_fragment.is_empty() {
+    for (rel, fragment_bytes) in clean_fragments {
+        if fragment_bytes.is_empty() {
             continue;
         }
-        let fragment: CallableThrowsFragment =
-            match borsh::from_slice(&unit.callable_throws_fragment) {
-                Ok(f) => f,
-                Err(e) => {
-                    cache_debug(format_args!(
-                        "interface fragment for `{}` undecodable: {e}",
-                        unit.source_file
-                    ));
-                    continue;
-                }
-            };
+        let fragment: CallableThrowsFragment = match borsh::from_slice(fragment_bytes) {
+            Ok(f) => f,
+            Err(e) => {
+                cache_debug(format_args!(
+                    "interface fragment for `{rel}` undecodable: {e}"
+                ));
+                continue;
+            }
+        };
         if fragment.by_id.is_empty() {
             continue;
         }
         let full = root
-            .map(|r| r.join(&unit.source_file).display().to_string())
-            .unwrap_or_else(|| unit.source_file.clone());
+            .map(|r| r.join(rel).display().to_string())
+            .unwrap_or_else(|| rel.clone());
         by_path.insert(full, fragment.by_id);
     }
     by_path
@@ -1422,49 +1450,79 @@ impl CacheContext {
             current,
         } = partition;
 
+        // No dirty or added files, and no manifest entry missing from disk
+        // (a removed file's entry would be neither clean nor current, so the
+        // counts diverge): nothing will be re-emitted or relinked, so unit
+        // payloads are not needed at all — the seeds and diagnostics blobs
+        // are manifest-resident. This skips both the unit read/hash pass and
+        // (in `prepare_reuse_plan`) the serve-time throws gate.
+        let no_delta = dirty_files.is_empty() && clean_files.len() == manifest.files.len();
+
         // Reuse the single file walk `compute_dirty_partition` already made rather
         // than re-listing the source set on the warm hot path.
         let current_files: HashMap<String, SourceFile> =
             current.into_iter().map(|(file, rel)| (rel, file)).collect();
         let mut prev_units = Vec::with_capacity(clean_files.len());
         let mut unit_keys = HashMap::with_capacity(clean_files.len());
-        let mut degraded = Vec::new();
-        for entry in &manifest.files {
-            if !clean_files.contains(&entry.rel_path) {
-                continue;
+        if no_delta {
+            for entry in &manifest.files {
+                unit_keys.insert(entry.rel_path.clone(), entry.unit_key);
             }
-            let key = CacheKey::from_bytes(entry.unit_key);
-            match self.cache.load_unit_shared(&key) {
-                Some(unit)
-                    if unit.source_file == entry.rel_path
-                        && !std::path::Path::new(&unit.source_file).is_absolute() =>
-                {
-                    unit_keys.insert(entry.rel_path.clone(), entry.unit_key);
-                    prev_units.push(unit);
+        } else {
+            // Load clean units across worker threads (read + digest + borsh
+            // decode per unit, sizable at large projects). `par_iter`'s
+            // indexed collect preserves manifest order exactly, so
+            // `prev_units` is byte-for-byte the sequence the serial loop
+            // produced — emit determinism is unaffected.
+            use rayon::prelude::*;
+            let clean_entries: Vec<_> = manifest
+                .files
+                .iter()
+                .filter(|entry| clean_files.contains(&entry.rel_path))
+                .collect();
+            let loaded: Vec<(&str, [u8; 32], Option<CompilationUnit>)> = clean_entries
+                .par_iter()
+                .map(|entry| {
+                    let key = CacheKey::from_bytes(entry.unit_key);
+                    let unit = self.cache.load_unit_shared(&key).filter(|unit| {
+                        unit.source_file == entry.rel_path
+                            && !std::path::Path::new(&unit.source_file).is_absolute()
+                    });
+                    (entry.rel_path.as_str(), entry.unit_key, unit)
+                })
+                .collect();
+            let mut degraded = Vec::new();
+            for (rel, entry_key, unit) in loaded {
+                match unit {
+                    Some(unit) => {
+                        unit_keys.insert(rel.to_string(), entry_key);
+                        prev_units.push(unit);
+                    }
+                    None => degraded.push(rel.to_string()),
                 }
-                _ => degraded.push(entry.rel_path.clone()),
             }
-        }
-        for rel in degraded {
-            cache_debug(format_args!(
-                "unit `{rel}` missing or invalid — degraded to dirty"
-            ));
-            clean_files.remove(&rel);
-            unit_keys.remove(&rel);
-            if let Some(file) = current_files.get(&rel)
-                && !dirty_files.contains(file)
-            {
-                dirty_files.push(*file);
+            for rel in degraded {
+                cache_debug(format_args!(
+                    "unit `{rel}` missing or invalid — degraded to dirty"
+                ));
+                clean_files.remove(&rel);
+                unit_keys.remove(&rel);
+                if let Some(file) = current_files.get(&rel)
+                    && !dirty_files.contains(file)
+                {
+                    dirty_files.push(*file);
+                }
             }
-        }
-        if clean_files.is_empty() {
-            cache_debug(format_args!("all reusable units missing — full compile"));
-            return None;
+            if clean_files.is_empty() {
+                cache_debug(format_args!("all reusable units missing — full compile"));
+                return None;
+            }
         }
         cache_debug(format_args!(
-            "reuse plan: {} clean, {} dirty",
+            "reuse plan: {} clean, {} dirty{}",
             clean_files.len(),
-            dirty_files.len()
+            dirty_files.len(),
+            if no_delta { " (no delta)" } else { "" }
         ));
 
         // Seed throw facts for every file. Clean files' facts come from the
@@ -1492,13 +1550,28 @@ impl CacheContext {
             .collect();
         seeded_throw_facts.extend(fresh_throw_facts);
 
+        // Carry clean files' interface-fragment blobs verbatim (rel-path-keyed):
+        // the `callable_throws` seeds project from these, and the store path
+        // copies them into the next manifest unchanged. Manifest-resident so
+        // seeding never has to read unit payloads.
+        let clean_fragments: std::collections::BTreeMap<String, Vec<u8>> = manifest
+            .files
+            .iter()
+            .filter(|entry| clean_files.contains(&entry.rel_path))
+            .map(|entry| {
+                (
+                    entry.rel_path.clone(),
+                    entry.callable_throws_fragment.clone(),
+                )
+            })
+            .collect();
+
         // Project clean files' cached interface fragments into a per-function
         // `callable_throws` seed (Phase 2): a clean function's throws — and hence
         // any dirty caller's throws-dependent inference over it — are served
         // without walking its body. The throws-taint closure guarantees a seeded
         // function's transitive throw contributors are all unchanged.
-        let seeded_callable_throws =
-            project_callable_throws_seeds(&prev_units, &clean_files, root.as_ref());
+        let seeded_callable_throws = project_callable_throws_seeds(&clean_fragments, root.as_ref());
 
         // Carry clean files' cached diagnostics blobs verbatim (already
         // rel-path-keyed): the gate rehydrates them to serve those files without
@@ -1518,6 +1591,8 @@ impl CacheContext {
             seeded_throw_facts,
             seeded_callable_throws,
             clean_diagnostics,
+            clean_fragments,
+            no_delta,
         })
     }
 
@@ -1662,6 +1737,16 @@ impl CacheContext {
                         .cloned()
                         .or_else(|| plan.and_then(|p| p.clean_diagnostics.get(&rel).cloned()))
                         .unwrap_or_else(crate::diagnostics_cache::empty_blob),
+                    // Verbatim copy of the unit's fragment bytes when this
+                    // compile produced/assembled the unit, else the plan's
+                    // carried manifest copy — the two are byte-identical by
+                    // construction, so the manifest copy can seed without
+                    // reading unit payloads.
+                    callable_throws_fragment: units_by_source
+                        .get(rel.as_str())
+                        .map(|unit| unit.callable_throws_fragment.clone())
+                        .or_else(|| plan.and_then(|p| p.clean_fragments.get(&rel).cloned()))
+                        .unwrap_or_default(),
                     unit_key: unit_keys[&rel],
                     rel_path: rel,
                 }
@@ -1995,19 +2080,20 @@ impl CacheContext {
         let Some(manifest) = self.load_prev_manifest_for_verify() else {
             return Ok(());
         };
-        let prev_units = self.load_prev_units_for_verify(&manifest);
         let Some(root) = db.get_project().map(|p| p.root(db).clone()) else {
             return Ok(());
         };
-        // Exactly the files a served warm compile would have seeded.
+        // Exactly the files a served warm compile would have seeded. The
+        // served artifact is the manifest-resident fragment blob (seeds
+        // project from the manifest, not from unit payloads), so that copy is
+        // what the oracle must compare.
         let clean_files = compute_dirty_partition(db, &manifest).clean_files;
 
-        for unit in &prev_units {
-            if !clean_files.contains(&unit.source_file) || unit.callable_throws_fragment.is_empty()
-            {
+        for entry in &manifest.files {
+            if !clean_files.contains(&entry.rel_path) || entry.callable_throws_fragment.is_empty() {
                 continue;
             }
-            let full = root.join(&unit.source_file);
+            let full = root.join(&entry.rel_path);
             let Some(sf) = db.get_file(&full) else {
                 continue; // file removed — never seeded
             };
@@ -2018,18 +2104,18 @@ impl CacheContext {
             let honest_bytes = borsh::to_vec(honest).map_err(|e| {
                 anyhow::anyhow!(
                     "honest interface fragment for `{}` failed to serialize: {e}",
-                    unit.source_file
+                    entry.rel_path
                 )
             })?;
-            if honest_bytes != unit.callable_throws_fragment {
+            if honest_bytes != entry.callable_throws_fragment {
                 anyhow::bail!(
                     "BAML_CACHE_VERIFY: cached interface fragment for `{}` differs from a fresh \
                      derivation ({} cached vs {} fresh bytes). A clean file's stored fragment is \
                      a stale substitute — the throws-taint closure failed to dirty a file whose \
                      `callable_throws` changed, so the seeded value would be \
                      wrong. Please report this.",
-                    unit.source_file,
-                    unit.callable_throws_fragment.len(),
+                    entry.rel_path,
+                    entry.callable_throws_fragment.len(),
                     honest_bytes.len(),
                 );
             }
@@ -2151,24 +2237,26 @@ impl CacheContext {
             }
         }
 
-        // (2) Served `callable_throws` fragment vs an honest derivation. An
-        // empty fragment seeds nothing, so there is no served artifact to check.
-        if let Some(unit) = plan.prev_units.iter().find(|u| u.source_file == rel)
-            && !unit.callable_throws_fragment.is_empty()
+        // (2) Served `callable_throws` fragment vs an honest derivation. The
+        // served copy is the manifest-resident blob (what the seeds project
+        // from); an empty fragment seeds nothing, so there is no served
+        // artifact to check.
+        if let Some(fragment) = plan.clean_fragments.get(rel)
+            && !fragment.is_empty()
         {
             let honest =
                 baml_db::baml_compiler2_tir::package_interface::file_callable_throws_fragment(
                     honest_db, sf,
                 );
             let honest_bytes = borsh::to_vec(honest)?;
-            if honest_bytes != unit.callable_throws_fragment {
+            if honest_bytes != *fragment {
                 anyhow::bail!(
                     "BAML_CACHE_SAMPLED_VERIFY: the incremental cache served a STALE \
                      callable-throws seed for `{rel}` ({} served vs {} honest bytes). This is a \
                      cache-soundness bug — a warm build would infer different throws than a clean \
                      one. Re-run with BAML_CACHE_VERIFY=1 for the full compare and please report \
                      this (file `{rel}`, artifact: callable-throws fragment).",
-                    unit.callable_throws_fragment.len(),
+                    fragment.len(),
                     honest_bytes.len(),
                 );
             }
@@ -2232,12 +2320,16 @@ impl CacheContext {
             .cache
             .load_unit_shared(&CacheKey::from_bytes(entry.unit_key))
             .expect("unit present");
-        unit.callable_throws_fragment = fragment;
+        unit.callable_throws_fragment = fragment.clone();
         let (key, _) = self
             .cache
             .store_unit_shared(&unit)
             .expect("poisoned unit stored");
         entry.unit_key = *key.as_bytes();
+        // The manifest carries its own verbatim fragment copy (the one seeds
+        // project from) — poison it too so the drift is observable on the
+        // served artifact, matching what a real store-path bug would produce.
+        entry.callable_throws_fragment = fragment;
         let payload = borsh::to_vec(&manifest).expect("manifest serializes");
         self.cache
             .store_raw(&self.manifest_key, &payload)
@@ -3448,6 +3540,16 @@ mod tests {
             ("b.baml", "function b() -> int {\n  2\n}\n"),
             ("c.baml", "function c() -> int {\n  3\n}\n"),
         ];
+        // The second compile edits c.baml: unit validation (and hence missing-
+        // unit degradation) runs only when the partition has a delta — a
+        // no-delta invocation serves entirely from the manifest and never
+        // opens unit payloads (a missing unit there surfaces later as the
+        // relink fallback to a full compile).
+        let edited = [
+            ("a.baml", "function a() -> int {\n  1\n}\n"),
+            ("b.baml", "function b() -> int {\n  2\n}\n"),
+            ("c.baml", "function c() -> int {\n  3 + 0\n}\n"),
+        ];
         let root = bc_root();
         let (_db1, ctx1) = compile_and_store_v1(&root, &files);
 
@@ -3474,23 +3576,24 @@ mod tests {
             .join(format!("{hex}.bexc"));
         std::fs::remove_file(missing_path).expect("remove b unit");
 
-        let r = resolved(&root, &files);
+        let r = resolved(&root, &edited);
         let mut db2 = crate::project_load::build_db_from_sources(&r, |_| {});
         let ctx2 = CacheContext::open(&r, false).expect("cache reopens");
         let pending = ctx2.plan_reuse(&db2).expect("partial reuse survives");
         let dirty = dirty_basenames(&pending.dirty_files, &db2);
-        assert_eq!(dirty, HashSet::from(["b.baml".to_string()]));
         assert_eq!(
-            pending.clean_files,
-            HashSet::from(["a.baml".to_string(), "c.baml".to_string()])
+            dirty,
+            HashSet::from(["b.baml".to_string(), "c.baml".to_string()])
         );
+        assert_eq!(pending.clean_files, HashSet::from(["a.baml".to_string()]));
 
         let plan = prepare_reuse_plan(&mut db2, Some(pending)).expect("reuse plan");
         let _ = baml_db::baml_compiler2_emit::take_lowered_files();
         let relinked =
             compile_program(&db2, &opts(), Some(&ctx2), Some(&plan)).expect("incremental compile");
-        let lowered = baml_db::baml_compiler2_emit::take_lowered_files();
-        assert_eq!(lowered, vec!["b.baml".to_string()]);
+        let mut lowered = baml_db::baml_compiler2_emit::take_lowered_files();
+        lowered.sort();
+        assert_eq!(lowered, vec!["b.baml".to_string(), "c.baml".to_string()]);
 
         let honest_db = crate::project_load::build_db_from_sources(&r, |_| {});
         let full = compile_program(&honest_db, &opts(), Some(&ctx2), None).expect("full compile");
@@ -3888,17 +3991,17 @@ mod tests {
         let Some((root, ctx, mut plan, honest)) = sampled_setup(&files) else {
             return;
         };
-        // Corrupt a.baml's served callable-throws fragment; honest bytes differ.
-        let unit = plan
-            .prev_units
-            .iter_mut()
-            .find(|u| u.source_file == "a.baml")
-            .expect("a.baml unit present in the reuse plan");
+        // Corrupt a.baml's served callable-throws fragment (the manifest-
+        // resident copy the seeds project from); honest bytes differ.
+        let fragment = plan
+            .clean_fragments
+            .get_mut("a.baml")
+            .expect("a.baml fragment present in the reuse plan");
         assert!(
-            !unit.callable_throws_fragment.is_empty(),
+            !fragment.is_empty(),
             "a plain function must carry a non-empty fragment for this test to bite"
         );
-        unit.callable_throws_fragment = vec![0xde, 0xad, 0xbe, 0xef];
+        *fragment = vec![0xde, 0xad, 0xbe, 0xef];
         let err = ctx
             .verify_sampled_artifact(&honest, &plan, "a.baml")
             .expect_err("a stale served fragment must hard-error");

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -102,7 +102,12 @@ fn collect_file_diagnostics_parallel(
 /// thread count. Priming the per-file indexes first keeps all workers busy
 /// on file-local work; the aggregate fold itself is then cheap for whichever
 /// worker claims it.
-fn prime_file_indexes_parallel(db: &ProjectDatabase) {
+///
+/// Public because warm cache paths (the serve-time throws gate, package-level
+/// diagnostics on a no-op check) demand the same aggregates outside any
+/// per-file check fan-out. Priming twice is harmless — the second wave is all
+/// memo hits.
+pub fn prime_file_indexes_parallel(db: &ProjectDatabase) {
     const CHUNK: usize = 4;
     let all_files = baml_compiler2_hir::compiler2_all_files(db);
     let chunks: Vec<&[SourceFile]> = all_files.chunks(CHUNK).collect();
@@ -194,6 +199,12 @@ pub fn collect_compiler2_diagnostics_narrowed(
     precomputed: Vec<Diagnostic>,
 ) -> NarrowedDiagnostics {
     let source_files = baml_compiler2_hir::compiler2_all_files(db);
+    // Even a fully-served (zero-checked-files) collection ends in
+    // `package_level_diagnostics`, which derives the whole-package aggregates
+    // — prime the per-file indexes across workers so that derivation is a
+    // parallel-fed fold, not a serial parse of the project. When the caller
+    // already primed (cache gate, cold fan-out) this is all memo hits.
+    prime_file_indexes_parallel(db);
     // Filter up front (outside any parallel region): `should_check` is a plain
     // `&dyn Fn`, so it never has to be thread-safe.
     let checked: Vec<SourceFile> = source_files

--- a/baml_language/crates/baml_project/src/lib.rs
+++ b/baml_language/crates/baml_project/src/lib.rs
@@ -34,6 +34,7 @@ pub mod testing;
 pub use check::{
     CheckResult, NarrowedDiagnostics, check_files_parallel, collect_compiler2_diagnostics,
     collect_compiler2_diagnostics_narrowed, collect_diagnostics, collect_package_level_diagnostics,
+    prime_file_indexes_parallel,
 };
 pub use client_codegen::build_symbol_pool;
 pub use db::{CursorContext, EventCallback, ProjectDatabase};

--- a/baml_language/crates/bex_cache/src/lib.rs
+++ b/baml_language/crates/bex_cache/src/lib.rs
@@ -219,6 +219,13 @@ pub struct ManifestFile {
     /// interface blob. Because the manifest is written only after a passing
     /// error gate, a clean file's blob holds warnings / info only.
     pub diagnostics: Vec<u8>,
+    /// Opaque borsh blob of this file's `CallableThrowsFragment` — a verbatim
+    /// copy of the same bytes stored in the file's [`CompilationUnit`]. Kept
+    /// in the manifest so the warm path can seed per-function
+    /// `callable_throws` without reading any unit payloads (the units are
+    /// only needed when bytecode is actually relinked). Empty when the file
+    /// contributes no fragment.
+    pub callable_throws_fragment: Vec<u8>,
     /// Content-addressed cache key of this file's serialized [`CompilationUnit`];
     /// the manifest is the sole mutable pointer table for the immutable per-file
     /// unit entries.
@@ -256,8 +263,14 @@ pub fn manifest_key(
 /// The manifest owns reuse policy and points to the exact value produced by the
 /// last successful compile.
 pub fn unit_key(payload: &[u8]) -> CacheKey {
+    unit_key_from_digest(&Sha256::digest(payload).into())
+}
+
+/// [`unit_key`] from an already-computed payload digest (the same digest
+/// entry validation produces), skipping the payload hash.
+fn unit_key_from_digest(digest: &[u8; 32]) -> CacheKey {
     let mut h = keyed_hasher(b"unit");
-    h.update(Sha256::digest(payload));
+    h.update(digest);
     CacheKey(h.finalize().into())
 }
 
@@ -473,12 +486,35 @@ impl BytecodeCache {
         Some(payload.to_vec())
     }
 
+    /// [`Self::load_raw_shared`] that also returns the payload's integrity
+    /// digest (already computed by entry validation), so content-key checks
+    /// derived from that digest need not re-hash the payload.
+    fn load_raw_shared_with_digest(&self, key: &CacheKey) -> Option<(Vec<u8>, [u8; 32])> {
+        let path = self.entry_path(key);
+        if let Ok(data) = fs::read(&path)
+            && let Some((payload, digest)) = check_entry_with_digest(&data, key)
+        {
+            freshen_entry(&path);
+            return Some((payload.to_vec(), digest));
+        }
+        let remote = self.remote.as_ref()?;
+        let entry = remote.get(key)?;
+        let (payload, digest) = check_entry_with_digest(&entry, key)?;
+        let payload = payload.to_vec();
+        self.persist_from_remote(key, &entry);
+        Some((payload, digest))
+    }
+
     /// Load one content-addressed unit through the local/remote read-through
     /// path. Both the entry framing and the unit key's payload hash must agree;
     /// any mismatch is a cache miss.
     pub fn load_unit_shared(&self, key: &CacheKey) -> Option<CompilationUnit> {
-        let payload = self.load_raw_shared(key)?;
-        if unit_key(&payload) != *key {
+        // `check_entry` already verified the header's key echo and the payload
+        // integrity digest, and `unit_key` is derived from that same digest —
+        // so the content-key check here reuses the digest instead of hashing
+        // the (potentially large) payload a second time.
+        let (payload, digest) = self.load_raw_shared_with_digest(key)?;
+        if unit_key_from_digest(&digest) != *key {
             let _ = fs::remove_file(self.entry_path(key));
             return None;
         }
@@ -595,6 +631,13 @@ impl BytecodeCache {
 
 /// Validate an entry's header against `key`; return the payload slice.
 fn check_entry<'a>(data: &'a [u8], key: &CacheKey) -> Option<&'a [u8]> {
+    check_entry_with_digest(data, key).map(|(payload, _)| payload)
+}
+
+/// [`check_entry`] that also hands back the payload digest it computed, so
+/// callers whose content keys derive from that digest (see [`unit_key`]) can
+/// avoid a second full pass over the payload.
+fn check_entry_with_digest<'a>(data: &'a [u8], key: &CacheKey) -> Option<(&'a [u8], [u8; 32])> {
     if data.len() < HEADER_LEN || data[..4] != MAGIC {
         return None;
     }
@@ -611,7 +654,7 @@ fn check_entry<'a>(data: &'a [u8], key: &CacheKey) -> Option<&'a [u8]> {
     if digest != data[48..80] {
         return None;
     }
-    Some(payload)
+    Some((payload, digest))
 }
 
 /// Write via temp file + atomic rename: readers never observe a torn entry,

--- a/baml_language/crates/bex_project/src/seed.rs
+++ b/baml_language/crates/bex_project/src/seed.rs
@@ -749,6 +749,7 @@ mod tests {
                 sig_referenced_names: Vec::new(),
                 throw_facts: Vec::new(), // poison: honest is non-empty
                 diagnostics: Vec::new(),
+                callable_throws_fragment: Vec::new(),
                 unit_key: [0u8; 32], // no unit → callable_throws seed empty
             }],
         };


### PR DESCRIPTION
**Draft on purpose** — this touches cache-soundness invariants; walk through the risk section below before merging. Stacked on #4100.

## The problem

A warm no-op `baml check` at 295k LOC cost 7.2s — identical to a full recompute — because the warm path re-proved its own cache validity from scratch every run: the serve-time throws gate re-parsed every file (via `package_items`) just to convert types for a comparison, and `plan_reuse` read+hashed+decoded 78MB of unit payloads just to extract the tiny throws fragments it seeds from. Profiled: 70% gate, 20% unit loads.

## The fix (adversarially reviewed design)

The naive fix (compare throws in "fact space") was **killed in adversarial review** — it was either circular or unsound (alias-retarget hole). What's implemented is the reviewed survivor:

1. **No-delta gate skip.** When the dirty partition finds zero changed/added/removed files, the gate is provably a tautology: the values it would compare are byte-for-byte what the manifest was stored with (verbatim persist; content-addressed units written before the manifest), and the solve+conversion are deterministic. Comparing a value to itself cannot demote anything. **Every real edit still takes the full runtime-space gate** — the corner the adversary showed the gate genuinely protects (body-only alias retargets) is untouched.
2. **Seeds from manifest, not units.** `ManifestFile` carries a verbatim copy of each unit's throws-fragment blob; seeding reads that. A no-op invocation opens **zero** unit files. Units load (in parallel, order preserved) only when a delta means relink/re-emit will need them.
3. **Prime wave in the gate path** so the `package_items` derivation (still needed on edits and for package-level diagnostics) is a parallel fold, not a serial parse.
4. `bex_cache`: unit content-key is derived from the integrity digest entry-validation already computed — one hash pass per unit instead of two.

## Measured

| warm scenario | before | after |
|---|--:|--:|
| no-op check, 295k LOC | 7.2 s | **2.0 s** (zero unit reads) |
| no-op check, 59k LOC | 0.54 s | **0.30 s** |
| leaf-edit check | ~unchanged | emit-bound (it seeds the cache; the follow-up `run`/`pack` then hit in ~0.7 s at 295k LOC) |

## Risk analysis (what to scrutinize)

- **Where a bug would live:** the no-delta detection (`dirty == added == removed == ∅`) reuses the same dirty-partition logic every warm compile already trusts; a bug there was already a soundness bug before this PR. The new failure surface is *manifest-fragment drift from the unit copy* — mitigated by copying from the same in-memory bytes at store time, and by re-pointing **both** verify oracles (full `BAML_CACHE_VERIFY` compare + always-on 1-in-32 sampled re-derive) at the manifest copy, i.e. exactly what is served.
- **Deliberate behavior change:** a unit file deleted out from under a warm cache is not detected on a *no-op* run (nothing reads it); the next compile that needs it falls back to a byte-identical full compile. Slower once, never wrong.
- **Wire format:** old manifests fail borsh decode → treated as absent → one full recompile re-seeds. No mixed-version reads (manifest key includes compiler fingerprint).

## Verification run

- 66 cache unit tests green (incl. the poison-tripwire tests, re-pointed at the manifest copy; the missing-unit degradation test now exercises the delta path where detection still lives).
- `BAML_CACHE_VERIFY=1` honest-recompile byte-compare: PASS on no-op and after-edit.
- `BAML_CACHE_SAMPLED_VERIFY=1` forced on 7 consecutive warm invocations across edits: PASS.
- Diagnostics byte-identical to the pre-fix binary, cold and warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4oee6wrCHzXH6mM2h8eJo