### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -44,13 +44,13 @@ policy.max_delta_pct = 3.0
 # output).
 # macOS arm64: baseline 19.55 MB file (19_545_088), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 20_131_441
+max_file_bytes = 20_165_687
 # Linux x86_64: baseline 25.27 MB file (25_272_400), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 26_030_572
+max_file_bytes = 26_043_822
 # Windows x86_64: baseline 21.08 MB file (21_075_968), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 21_708_248
+max_file_bytes = 21_739_362
 
 [artifacts.packed-program]
 kind = "pack"
@@ -58,13 +58,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 13.21 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 13_602_990
+max_file_bytes = 13_620_179
 # Linux x86_64: baseline 17.03 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 17_538_033
+max_file_bytes = 17_542_483
 # Windows x86_64: baseline 14.14 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 14_566_773
+max_file_bytes = 14_578_079
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -88,4 +88,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.40 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_534_972
+max_gzip_bytes = 4_534_455

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-20T07:51:49Z"
-git_sha = "fe3304335ff13eb6355233b1f96690b6ede7ae09"
+recorded_at = "2026-07-21T10:07:22Z"
+git_sha = "070b3a3b60721597b31bb1eb9ebf0dc663def3dc"
 
 [artifacts.baml-cli]
-file_bytes = 19545088
-stripped_bytes = 19545136
-gzip_bytes = 9331881
+file_bytes = 19578336
+stripped_bytes = 19578384
+gzip_bytes = 9326991
 
 [artifacts.packed-program]
-file_bytes = 13206786
-gzip_bytes = 6154377
+file_bytes = 13223474
+gzip_bytes = 6153330

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-07-20T07:51:49Z"
-git_sha = "fe3304335ff13eb6355233b1f96690b6ede7ae09"
+recorded_at = "2026-07-21T10:07:22Z"
+git_sha = "070b3a3b60721597b31bb1eb9ebf0dc663def3dc"
 
 [artifacts.bridge_wasm]
-file_bytes = 16160508
-gzip_bytes = 4402885
+file_bytes = 16174902
+gzip_bytes = 4402383

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-20T07:51:49Z"
-git_sha = "fe3304335ff13eb6355233b1f96690b6ede7ae09"
+recorded_at = "2026-07-21T10:07:22Z"
+git_sha = "070b3a3b60721597b31bb1eb9ebf0dc663def3dc"
 
 [artifacts.baml-cli]
-file_bytes = 21075968
-stripped_bytes = 21075968
-gzip_bytes = 9542344
+file_bytes = 21106176
+stripped_bytes = 21106176
+gzip_bytes = 9544410
 
 [artifacts.packed-program]
-file_bytes = 14142498
-gzip_bytes = 6248883
+file_bytes = 14153474
+gzip_bytes = 6248717

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-20T07:51:49Z"
-git_sha = "fe3304335ff13eb6355233b1f96690b6ede7ae09"
+recorded_at = "2026-07-21T10:07:22Z"
+git_sha = "070b3a3b60721597b31bb1eb9ebf0dc663def3dc"
 
 [artifacts.baml-cli]
-file_bytes = 25272400
-stripped_bytes = 25272392
-gzip_bytes = 10732594
+file_bytes = 25285264
+stripped_bytes = 25285256
+gzip_bytes = 10715101
 
 [artifacts.packed-program]
-file_bytes = 17027216
-gzip_bytes = 7039234
+file_bytes = 17031536
+gzip_bytes = 7027724


### PR DESCRIPTION
Adopted from CI run [`070b3a3b60721597b31bb1eb9ebf0dc663def3dc`](https://github.com/BoundaryML/baml/actions/runs/29792124552).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 25.3 MB | 10.7 MB | **file** | 25.3 MB | +12.9 KB (+0.1%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 17.0 MB | 7.0 MB | **file** | 17.0 MB | +4.3 KB (+0.0%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 19.6 MB | 9.3 MB | **file** | 19.5 MB | +33.2 KB (+0.2%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 13.2 MB | 6.2 MB | **file** | 13.2 MB | +16.7 KB (+0.1%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 16.2 MB | 🔒 4.4 MB | **gzip** | 4.4 MB | -502 B (-0.0%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 21.1 MB | 9.5 MB | **file** | 21.1 MB | +30.2 KB (+0.1%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 14.2 MB | 6.2 MB | **file** | 14.1 MB | +11.0 KB (+0.1%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated recorded build metadata and artifact measurements across macOS, Linux, Windows, and WebAssembly builds.
  * Refined size thresholds for command-line and packaged program artifacts.
  * Tightened the WebAssembly compressed-size limit.
  * No user-facing functionality or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->