### PR TITLE
fix(sdk-java): gradle from PATH in release workflows (dry-run rehearsal finding)

### DIFF
--- a/.github/workflows/build2-java-sdk.reusable.yaml
+++ b/.github/workflows/build2-java-sdk.reusable.yaml
@@ -195,7 +195,7 @@ jobs:
             ls -la "../../../target/${BAML_TARGET}/release-bridge-java" || true
             exit 1
           fi
-          mise exec -- gradle --no-daemon nativeJar \
+          gradle --no-daemon nativeJar \
             -PbamlVersion="$version" \
             -PbamlNativePlatform="$BAML_NATIVE_PLATFORM" \
             -PbamlNativeLib="$native_lib"
@@ -248,7 +248,7 @@ jobs:
           # JUnit assumeTrue when no cdylib is present); sourcesJar/javadocJar are
           # named explicitly so the release always carries the two Central-
           # required jars regardless of the `assemble` wiring.
-          mise exec -- gradle --no-daemon build sourcesJar javadocJar \
+          gradle --no-daemon build sourcesJar javadocJar \
             -PbamlVersion="$version"
           ls -la build/libs
 

--- a/.github/workflows/publish-gradle-plugin-manual.yml
+++ b/.github/workflows/publish-gradle-plugin-manual.yml
@@ -67,4 +67,4 @@ jobs:
             echo "::error::GRADLE_PUBLISH_KEY / GRADLE_PUBLISH_SECRET secret is empty"
             exit 1
           fi
-          mise exec -- gradle --no-daemon publishPlugins -PbamlVersion="$VERSION"
+          gradle --no-daemon publishPlugins -PbamlVersion="$VERSION"

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -659,7 +659,7 @@ jobs:
           # layout, attaches every downloaded natives-<platform> jar as a
           # classifier artifact (bamlNativeJarsDir), and signs + checksums all of
           # them with the in-memory key.
-          mise exec -- gradle --no-daemon publishMavenPublicationToStagingRepository \
+          gradle --no-daemon publishMavenPublicationToStagingRepository \
             -PbamlVersion="$VERSION" \
             -PbamlNativeJarsDir="$GITHUB_WORKSPACE/dist/natives"
       - name: Stage the signed gradle-plugin into the same Central layout
@@ -681,7 +681,7 @@ jobs:
           # Central bundle below carries both families. publishAllPublications*
           # covers pluginMaven + the marker; both are signed with the in-memory
           # key. The dir is created if baml-bridge was skipped (already on Central).
-          mise exec -- gradle --no-daemon publishAllPublicationsToStagingRepository \
+          gradle --no-daemon publishAllPublicationsToStagingRepository \
             -PbamlVersion="$VERSION" \
             -PbamlStagingDir="$GITHUB_WORKSPACE/baml_language/sdks/java/baml_bridge/build/staging-deploy"
       - name: Upload the Central bundle to the portal (publish automatically)
@@ -813,7 +813,7 @@ jobs:
             echo "::error::GRADLE_PUBLISH_KEY / GRADLE_PUBLISH_SECRET secret is empty"
             exit 1
           fi
-          mise exec -- gradle --no-daemon publishPlugins -PbamlVersion="$VERSION"
+          gradle --no-daemon publishPlugins -PbamlVersion="$VERSION"
 
   publish-toolchain-release:
     name: Publish toolchain release assets


### PR DESCRIPTION
The post-merge `dry_run=true` rehearsal (run 29843145819) caught a provisioning race before any real release: `mise exec -- gradle` auto-installs every missing `mise.toml` tool, and the parallel rustup component installs conflict (`detected conflict: 'bin/cargo'`), failing all java build legs + the manual Portal publish before gradle ever ran.

Fix: invoke `gradle` directly from PATH (setup-mise exports the tool bins) — the exact pattern the java sdk-test legs already prove green on linux/macOS/Windows on every push. Six occurrences across the three release workflows. actionlint clean.

Zero risk: these code paths have never successfully executed (that's what the rehearsal was for); nothing else consumes them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release Improvements**
  * Updated Java SDK, Gradle plugin, and language release workflows to run Gradle commands directly.
  * Maintained existing build outputs, publishing targets, inputs, and artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->