### PR TITLE
perf: linear cold compiles, one warm cache for every command, flat editor latency

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "libsui",
  "mimalloc",
  "object 0.36.3",
+ "rayon",
  "regex",
  "reqwest",
  "sdkgen_cpp",

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -6953,6 +6953,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -314,10 +314,11 @@ rand_xoshiro = "0.6"
 num-bigint = { version = "0.4", features = [ "rand", "serde" ] }
 num-traits = { version = "0.2" }
 rsa = { version = "0.9", default-features = false, features = [ "std", "pem" ] }
-# `asm` enables the hardware SHA-2 backend (SHA-NI / ARMv8 crypto extensions,
-# runtime-detected). Without it the warm bytecode-cache path software-hashes
-# ~hundreds of MB of unit payloads per run.
-sha2 = { version = "0.10", features = [ "oid", "asm" ] }
+# The hardware SHA-2 backend (`asm`: SHA-NI / ARMv8 crypto extensions,
+# runtime-detected) is enabled per-target in `bex_cache` — the `asm` feature
+# does not build under MSVC (sha2-asm ships GAS `.S` sources), so it must not
+# be turned on here unconditionally.
+sha2 = { version = "0.10", features = [ "oid" ] }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -314,7 +314,10 @@ rand_xoshiro = "0.6"
 num-bigint = { version = "0.4", features = [ "rand", "serde" ] }
 num-traits = { version = "0.2" }
 rsa = { version = "0.9", default-features = false, features = [ "std", "pem" ] }
-sha2 = { version = "0.10", features = [ "oid" ] }
+# `asm` enables the hardware SHA-2 backend (SHA-NI / ARMv8 crypto extensions,
+# runtime-detected). Without it the warm bytecode-cache path software-hashes
+# ~hundreds of MB of unit payloads per run.
+sha2 = { version = "0.10", features = [ "oid", "asm" ] }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -52,6 +52,7 @@ indicatif = { workspace = true }
 libsui = { workspace = true }
 mimalloc = { workspace = true }
 object = { workspace = true }
+rayon = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking", "json", "rustls" ] }
 serde = { workspace = true }

--- a/baml_language/crates/baml_cli/src/bytecode_cache.rs
+++ b/baml_language/crates/baml_cli/src/bytecode_cache.rs
@@ -1785,11 +1785,7 @@ impl CacheContext {
     /// the identical warm-database setup `run`, `test`, and `check` each run
     /// before the diagnostics gate. `check` discards `stdlib_interface_hit`.
     pub(crate) fn prepare_warm_db(&self, db: &mut ProjectDatabase) -> WarmPrep {
-        let stdlib_interface_hit = !Self::verify_enabled()
-            && self
-                .load_stdlib_interface()
-                .map(|by_package| db.set_seeded_stdlib_interface(by_package))
-                .is_some();
+        let stdlib_interface_hit = self.seed_stdlib_interface(db);
         let reuse_plan = prepare_reuse_plan(db, self.plan_reuse(db));
         WarmPrep {
             reuse_plan,
@@ -2275,6 +2271,17 @@ impl CacheContext {
             }
         }
         Ok(())
+    }
+
+    /// Install the immutable stdlib typed-interface seed (a per-toolchain
+    /// build constant). Returns whether the seed was served; gated off under
+    /// `BAML_CACHE_VERIFY` so the oracle exercises the honest path.
+    pub(crate) fn seed_stdlib_interface(&self, db: &mut ProjectDatabase) -> bool {
+        !Self::verify_enabled()
+            && self
+                .load_stdlib_interface()
+                .map(|by_package| db.set_seeded_stdlib_interface(by_package))
+                .is_some()
     }
 
     /// Test hook: overwrite one file's cached diagnostics with an empty blob,

--- a/baml_language/crates/baml_cli/src/bytecode_cache.rs
+++ b/baml_language/crates/baml_cli/src/bytecode_cache.rs
@@ -671,6 +671,19 @@ pub(crate) struct ReusePlan {
     /// by rel_path. Rehydrated to serve those files' diagnostics without
     /// re-checking, and copied verbatim into the next manifest.
     pub(crate) clean_diagnostics: std::collections::BTreeMap<String, Vec<u8>>,
+    /// Clean files' `CallableThrowsFragment` blobs carried verbatim from the
+    /// previous manifest, by rel_path. The source of the `callable_throws`
+    /// seeds (so seeding needs no unit payloads) and of the next manifest's
+    /// fragment carry.
+    pub(crate) clean_fragments: std::collections::BTreeMap<String, Vec<u8>>,
+    /// True when the dirty partition found nothing changed: no dirty or added
+    /// files, and every manifest entry still present on disk. On this path the
+    /// serve-time throws gate is provably a tautology (the seeds being checked
+    /// are byte-for-byte the values the manifest was stored with, units are
+    /// content-addressed and written before the manifest, and the solve is a
+    /// deterministic pure function), so it is skipped — and unit payloads are
+    /// not loaded at all (nothing will be re-emitted or relinked from them).
+    pub(crate) no_delta: bool,
 }
 
 /// The result of the warm-database preamble ([`CacheContext::prepare_warm_db`]).
@@ -694,6 +707,24 @@ pub(crate) fn prepare_reuse_plan(
     let mut plan = plan?;
     db.set_seeded_throw_facts(std::mem::take(&mut plan.seeded_throw_facts));
     let callable_seeds = std::mem::take(&mut plan.seeded_callable_throws);
+    // No delta ⇒ the gate is a tautology: the seeds just installed are
+    // byte-for-byte the values the manifest was stored with (the store path
+    // persists `file_throw_facts` verbatim and units are content-addressed,
+    // written before the manifest that points at them), and the solve +
+    // runtime conversion the gate would re-run are deterministic pure
+    // functions of those inputs. Comparing a value against itself cannot
+    // demote anything, so skip the compare — it was the dominant cost of a
+    // warm no-op invocation (it derives `package_items`, i.e. re-parses the
+    // project). Any real edit, added or removed file takes the gate below.
+    if plan.no_delta {
+        db.set_seeded_callable_throws(callable_seeds);
+        return Some(plan);
+    }
+    // The gate's runtime-type conversion derives the package alias tables,
+    // which fold every file's semantic index. Prime the per-file indexes
+    // across workers first so that derivation is a cheap fold instead of a
+    // serial parse of the whole project under one salsa memo claim.
+    baml_project::prime_file_indexes_parallel(db);
     let mismatches = reuse_throws_mismatches(db, &plan.prev_units, &plan.clean_files);
     if mismatches.is_empty() {
         db.set_seeded_callable_throws(callable_seeds);
@@ -1361,8 +1392,7 @@ fn compute_dirty_partition(db: &ProjectDatabase, manifest: &ProjectManifest) -> 
 /// empty or fails to decode is skipped — its functions then infer honestly
 /// (degrade, never miscompile). Empty under `BAML_NO_CALLABLE_THROWS_CACHE=1`.
 fn project_callable_throws_seeds(
-    prev_units: &[CompilationUnit],
-    clean_files: &HashSet<String>,
+    clean_fragments: &std::collections::BTreeMap<String, Vec<u8>>,
     root: Option<&PathBuf>,
 ) -> std::collections::BTreeMap<String, std::collections::BTreeMap<u32, baml_type::Ty>> {
     if CacheContext::callable_throws_cache_disabled() {
@@ -1370,27 +1400,25 @@ fn project_callable_throws_seeds(
     }
     use baml_db::baml_compiler2_tir::package_interface::CallableThrowsFragment;
     let mut by_path = std::collections::BTreeMap::new();
-    for unit in prev_units {
-        if !clean_files.contains(&unit.source_file) || unit.callable_throws_fragment.is_empty() {
+    for (rel, fragment_bytes) in clean_fragments {
+        if fragment_bytes.is_empty() {
             continue;
         }
-        let fragment: CallableThrowsFragment =
-            match borsh::from_slice(&unit.callable_throws_fragment) {
-                Ok(f) => f,
-                Err(e) => {
-                    cache_debug(format_args!(
-                        "interface fragment for `{}` undecodable: {e}",
-                        unit.source_file
-                    ));
-                    continue;
-                }
-            };
+        let fragment: CallableThrowsFragment = match borsh::from_slice(fragment_bytes) {
+            Ok(f) => f,
+            Err(e) => {
+                cache_debug(format_args!(
+                    "interface fragment for `{rel}` undecodable: {e}"
+                ));
+                continue;
+            }
+        };
         if fragment.by_id.is_empty() {
             continue;
         }
         let full = root
-            .map(|r| r.join(&unit.source_file).display().to_string())
-            .unwrap_or_else(|| unit.source_file.clone());
+            .map(|r| r.join(rel).display().to_string())
+            .unwrap_or_else(|| rel.clone());
         by_path.insert(full, fragment.by_id);
     }
     by_path
@@ -1435,49 +1463,79 @@ impl CacheContext {
             current,
         } = partition;
 
+        // No dirty or added files, and no manifest entry missing from disk
+        // (a removed file's entry would be neither clean nor current, so the
+        // counts diverge): nothing will be re-emitted or relinked, so unit
+        // payloads are not needed at all — the seeds and diagnostics blobs
+        // are manifest-resident. This skips both the unit read/hash pass and
+        // (in `prepare_reuse_plan`) the serve-time throws gate.
+        let no_delta = dirty_files.is_empty() && clean_files.len() == manifest.files.len();
+
         // Reuse the single file walk `compute_dirty_partition` already made rather
         // than re-listing the source set on the warm hot path.
         let current_files: HashMap<String, SourceFile> =
             current.into_iter().map(|(file, rel)| (rel, file)).collect();
         let mut prev_units = Vec::with_capacity(clean_files.len());
         let mut unit_keys = HashMap::with_capacity(clean_files.len());
-        let mut degraded = Vec::new();
-        for entry in &manifest.files {
-            if !clean_files.contains(&entry.rel_path) {
-                continue;
+        if no_delta {
+            for entry in &manifest.files {
+                unit_keys.insert(entry.rel_path.clone(), entry.unit_key);
             }
-            let key = CacheKey::from_bytes(entry.unit_key);
-            match self.cache.load_unit_shared(&key) {
-                Some(unit)
-                    if unit.source_file == entry.rel_path
-                        && !std::path::Path::new(&unit.source_file).is_absolute() =>
-                {
-                    unit_keys.insert(entry.rel_path.clone(), entry.unit_key);
-                    prev_units.push(unit);
+        } else {
+            // Load clean units across worker threads (read + digest + borsh
+            // decode per unit, sizable at large projects). `par_iter`'s
+            // indexed collect preserves manifest order exactly, so
+            // `prev_units` is byte-for-byte the sequence the serial loop
+            // produced — emit determinism is unaffected.
+            use rayon::prelude::*;
+            let clean_entries: Vec<_> = manifest
+                .files
+                .iter()
+                .filter(|entry| clean_files.contains(&entry.rel_path))
+                .collect();
+            let loaded: Vec<(&str, [u8; 32], Option<CompilationUnit>)> = clean_entries
+                .par_iter()
+                .map(|entry| {
+                    let key = CacheKey::from_bytes(entry.unit_key);
+                    let unit = self.cache.load_unit_shared(&key).filter(|unit| {
+                        unit.source_file == entry.rel_path
+                            && !std::path::Path::new(&unit.source_file).is_absolute()
+                    });
+                    (entry.rel_path.as_str(), entry.unit_key, unit)
+                })
+                .collect();
+            let mut degraded = Vec::new();
+            for (rel, entry_key, unit) in loaded {
+                match unit {
+                    Some(unit) => {
+                        unit_keys.insert(rel.to_string(), entry_key);
+                        prev_units.push(unit);
+                    }
+                    None => degraded.push(rel.to_string()),
                 }
-                _ => degraded.push(entry.rel_path.clone()),
             }
-        }
-        for rel in degraded {
-            cache_debug(format_args!(
-                "unit `{rel}` missing or invalid — degraded to dirty"
-            ));
-            clean_files.remove(&rel);
-            unit_keys.remove(&rel);
-            if let Some(file) = current_files.get(&rel)
-                && !dirty_files.contains(file)
-            {
-                dirty_files.push(*file);
+            for rel in degraded {
+                cache_debug(format_args!(
+                    "unit `{rel}` missing or invalid — degraded to dirty"
+                ));
+                clean_files.remove(&rel);
+                unit_keys.remove(&rel);
+                if let Some(file) = current_files.get(&rel)
+                    && !dirty_files.contains(file)
+                {
+                    dirty_files.push(*file);
+                }
             }
-        }
-        if clean_files.is_empty() {
-            cache_debug(format_args!("all reusable units missing — full compile"));
-            return None;
+            if clean_files.is_empty() {
+                cache_debug(format_args!("all reusable units missing — full compile"));
+                return None;
+            }
         }
         cache_debug(format_args!(
-            "reuse plan: {} clean, {} dirty",
+            "reuse plan: {} clean, {} dirty{}",
             clean_files.len(),
-            dirty_files.len()
+            dirty_files.len(),
+            if no_delta { " (no delta)" } else { "" }
         ));
 
         // Seed throw facts for every file. Clean files' facts come from the
@@ -1505,13 +1563,28 @@ impl CacheContext {
             .collect();
         seeded_throw_facts.extend(fresh_throw_facts);
 
+        // Carry clean files' interface-fragment blobs verbatim (rel-path-keyed):
+        // the `callable_throws` seeds project from these, and the store path
+        // copies them into the next manifest unchanged. Manifest-resident so
+        // seeding never has to read unit payloads.
+        let clean_fragments: std::collections::BTreeMap<String, Vec<u8>> = manifest
+            .files
+            .iter()
+            .filter(|entry| clean_files.contains(&entry.rel_path))
+            .map(|entry| {
+                (
+                    entry.rel_path.clone(),
+                    entry.callable_throws_fragment.clone(),
+                )
+            })
+            .collect();
+
         // Project clean files' cached interface fragments into a per-function
         // `callable_throws` seed (Phase 2): a clean function's throws — and hence
         // any dirty caller's throws-dependent inference over it — are served
         // without walking its body. The throws-taint closure guarantees a seeded
         // function's transitive throw contributors are all unchanged.
-        let seeded_callable_throws =
-            project_callable_throws_seeds(&prev_units, &clean_files, root.as_ref());
+        let seeded_callable_throws = project_callable_throws_seeds(&clean_fragments, root.as_ref());
 
         // Carry clean files' cached diagnostics blobs verbatim (already
         // rel-path-keyed): the gate rehydrates them to serve those files without
@@ -1531,6 +1604,8 @@ impl CacheContext {
             seeded_throw_facts,
             seeded_callable_throws,
             clean_diagnostics,
+            clean_fragments,
+            no_delta,
         })
     }
 
@@ -1675,6 +1750,16 @@ impl CacheContext {
                         .cloned()
                         .or_else(|| plan.and_then(|p| p.clean_diagnostics.get(&rel).cloned()))
                         .unwrap_or_else(crate::diagnostics_cache::empty_blob),
+                    // Verbatim copy of the unit's fragment bytes when this
+                    // compile produced/assembled the unit, else the plan's
+                    // carried manifest copy — the two are byte-identical by
+                    // construction, so the manifest copy can seed without
+                    // reading unit payloads.
+                    callable_throws_fragment: units_by_source
+                        .get(rel.as_str())
+                        .map(|unit| unit.callable_throws_fragment.clone())
+                        .or_else(|| plan.and_then(|p| p.clean_fragments.get(&rel).cloned()))
+                        .unwrap_or_default(),
                     unit_key: unit_keys[&rel],
                     rel_path: rel,
                 }
@@ -2008,19 +2093,20 @@ impl CacheContext {
         let Some(manifest) = self.load_prev_manifest_for_verify() else {
             return Ok(());
         };
-        let prev_units = self.load_prev_units_for_verify(&manifest);
         let Some(root) = db.get_project().map(|p| p.root(db).clone()) else {
             return Ok(());
         };
-        // Exactly the files a served warm compile would have seeded.
+        // Exactly the files a served warm compile would have seeded. The
+        // served artifact is the manifest-resident fragment blob (seeds
+        // project from the manifest, not from unit payloads), so that copy is
+        // what the oracle must compare.
         let clean_files = compute_dirty_partition(db, &manifest).clean_files;
 
-        for unit in &prev_units {
-            if !clean_files.contains(&unit.source_file) || unit.callable_throws_fragment.is_empty()
-            {
+        for entry in &manifest.files {
+            if !clean_files.contains(&entry.rel_path) || entry.callable_throws_fragment.is_empty() {
                 continue;
             }
-            let full = root.join(&unit.source_file);
+            let full = root.join(&entry.rel_path);
             let Some(sf) = db.get_file(&full) else {
                 continue; // file removed — never seeded
             };
@@ -2031,18 +2117,18 @@ impl CacheContext {
             let honest_bytes = borsh::to_vec(honest).map_err(|e| {
                 anyhow::anyhow!(
                     "honest interface fragment for `{}` failed to serialize: {e}",
-                    unit.source_file
+                    entry.rel_path
                 )
             })?;
-            if honest_bytes != unit.callable_throws_fragment {
+            if honest_bytes != entry.callable_throws_fragment {
                 anyhow::bail!(
                     "BAML_CACHE_VERIFY: cached interface fragment for `{}` differs from a fresh \
                      derivation ({} cached vs {} fresh bytes). A clean file's stored fragment is \
                      a stale substitute — the throws-taint closure failed to dirty a file whose \
                      `callable_throws` changed, so the seeded value would be \
                      wrong. Please report this.",
-                    unit.source_file,
-                    unit.callable_throws_fragment.len(),
+                    entry.rel_path,
+                    entry.callable_throws_fragment.len(),
                     honest_bytes.len(),
                 );
             }
@@ -2164,24 +2250,26 @@ impl CacheContext {
             }
         }
 
-        // (2) Served `callable_throws` fragment vs an honest derivation. An
-        // empty fragment seeds nothing, so there is no served artifact to check.
-        if let Some(unit) = plan.prev_units.iter().find(|u| u.source_file == rel)
-            && !unit.callable_throws_fragment.is_empty()
+        // (2) Served `callable_throws` fragment vs an honest derivation. The
+        // served copy is the manifest-resident blob (what the seeds project
+        // from); an empty fragment seeds nothing, so there is no served
+        // artifact to check.
+        if let Some(fragment) = plan.clean_fragments.get(rel)
+            && !fragment.is_empty()
         {
             let honest =
                 baml_db::baml_compiler2_tir::package_interface::file_callable_throws_fragment(
                     honest_db, sf,
                 );
             let honest_bytes = borsh::to_vec(honest)?;
-            if honest_bytes != unit.callable_throws_fragment {
+            if honest_bytes != *fragment {
                 anyhow::bail!(
                     "BAML_CACHE_SAMPLED_VERIFY: the incremental cache served a STALE \
                      callable-throws seed for `{rel}` ({} served vs {} honest bytes). This is a \
                      cache-soundness bug — a warm build would infer different throws than a clean \
                      one. Re-run with BAML_CACHE_VERIFY=1 for the full compare and please report \
                      this (file `{rel}`, artifact: callable-throws fragment).",
-                    unit.callable_throws_fragment.len(),
+                    fragment.len(),
                     honest_bytes.len(),
                 );
             }
@@ -2245,12 +2333,16 @@ impl CacheContext {
             .cache
             .load_unit_shared(&CacheKey::from_bytes(entry.unit_key))
             .expect("unit present");
-        unit.callable_throws_fragment = fragment;
+        unit.callable_throws_fragment = fragment.clone();
         let (key, _) = self
             .cache
             .store_unit_shared(&unit)
             .expect("poisoned unit stored");
         entry.unit_key = *key.as_bytes();
+        // The manifest carries its own verbatim fragment copy (the one seeds
+        // project from) — poison it too so the drift is observable on the
+        // served artifact, matching what a real store-path bug would produce.
+        entry.callable_throws_fragment = fragment;
         let payload = borsh::to_vec(&manifest).expect("manifest serializes");
         self.cache
             .store_raw(&self.manifest_key, &payload)
@@ -3461,6 +3553,16 @@ mod tests {
             ("b.baml", "function b() -> int {\n  2\n}\n"),
             ("c.baml", "function c() -> int {\n  3\n}\n"),
         ];
+        // The second compile edits c.baml: unit validation (and hence missing-
+        // unit degradation) runs only when the partition has a delta — a
+        // no-delta invocation serves entirely from the manifest and never
+        // opens unit payloads (a missing unit there surfaces later as the
+        // relink fallback to a full compile).
+        let edited = [
+            ("a.baml", "function a() -> int {\n  1\n}\n"),
+            ("b.baml", "function b() -> int {\n  2\n}\n"),
+            ("c.baml", "function c() -> int {\n  3 + 0\n}\n"),
+        ];
         let root = bc_root();
         let (_db1, ctx1) = compile_and_store_v1(&root, &files);
 
@@ -3487,23 +3589,24 @@ mod tests {
             .join(format!("{hex}.bexc"));
         std::fs::remove_file(missing_path).expect("remove b unit");
 
-        let r = resolved(&root, &files);
+        let r = resolved(&root, &edited);
         let mut db2 = crate::project_load::build_db_from_sources(&r, |_| {});
         let ctx2 = CacheContext::open(&r, false).expect("cache reopens");
         let pending = ctx2.plan_reuse(&db2).expect("partial reuse survives");
         let dirty = dirty_basenames(&pending.dirty_files, &db2);
-        assert_eq!(dirty, HashSet::from(["b.baml".to_string()]));
         assert_eq!(
-            pending.clean_files,
-            HashSet::from(["a.baml".to_string(), "c.baml".to_string()])
+            dirty,
+            HashSet::from(["b.baml".to_string(), "c.baml".to_string()])
         );
+        assert_eq!(pending.clean_files, HashSet::from(["a.baml".to_string()]));
 
         let plan = prepare_reuse_plan(&mut db2, Some(pending)).expect("reuse plan");
         let _ = baml_db::baml_compiler2_emit::take_lowered_files();
         let relinked =
             compile_program(&db2, &opts(), Some(&ctx2), Some(&plan)).expect("incremental compile");
-        let lowered = baml_db::baml_compiler2_emit::take_lowered_files();
-        assert_eq!(lowered, vec!["b.baml".to_string()]);
+        let mut lowered = baml_db::baml_compiler2_emit::take_lowered_files();
+        lowered.sort();
+        assert_eq!(lowered, vec!["b.baml".to_string(), "c.baml".to_string()]);
 
         let honest_db = crate::project_load::build_db_from_sources(&r, |_| {});
         let full = compile_program(&honest_db, &opts(), Some(&ctx2), None).expect("full compile");
@@ -3901,17 +4004,17 @@ mod tests {
         let Some((root, ctx, mut plan, honest)) = sampled_setup(&files) else {
             return;
         };
-        // Corrupt a.baml's served callable-throws fragment; honest bytes differ.
-        let unit = plan
-            .prev_units
-            .iter_mut()
-            .find(|u| u.source_file == "a.baml")
-            .expect("a.baml unit present in the reuse plan");
+        // Corrupt a.baml's served callable-throws fragment (the manifest-
+        // resident copy the seeds project from); honest bytes differ.
+        let fragment = plan
+            .clean_fragments
+            .get_mut("a.baml")
+            .expect("a.baml fragment present in the reuse plan");
         assert!(
-            !unit.callable_throws_fragment.is_empty(),
+            !fragment.is_empty(),
             "a plain function must carry a non-empty fragment for this test to bite"
         );
-        unit.callable_throws_fragment = vec![0xde, 0xad, 0xbe, 0xef];
+        *fragment = vec![0xde, 0xad, 0xbe, 0xef];
         let err = ctx
             .verify_sampled_artifact(&honest, &plan, "a.baml")
             .expect_err("a stale served fragment must hard-error");

--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -5,11 +5,7 @@ use baml_db::baml_compiler_diagnostics::{Diagnostic, Severity, render};
 use baml_project::ProjectDatabase;
 use clap::Args;
 
-use crate::{
-    bytecode_cache::CacheContext,
-    project_load::{build_db_from_sources, resolve_project_sources},
-    reporter::Reporter,
-};
+use crate::reporter::Reporter;
 
 #[derive(Args, Debug)]
 pub struct CheckArgs {
@@ -21,61 +17,56 @@ pub struct CheckArgs {
 impl CheckArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
         let reporter = Reporter::new();
-        let resolved = resolve_project_sources(self.from.as_deref())?;
-        if resolved.files.is_empty() {
+        let mut session = crate::project_session::ProjectSession::open(
+            self.from.as_deref(),
+            crate::project_session::CacheUse::ReadWrite,
+        )?;
+        if session.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(
                 "no .baml files found in {}",
-                resolved.root.display()
+                session.root().display()
             ));
             return Ok(crate::ExitCode::Other);
         }
-        let file_count = resolved.files.len();
-        let mut db = build_db_from_sources(&resolved, |_| {});
-        let cache = CacheContext::open(&resolved, false);
+        let file_count = session.file_count();
 
         // The manifest can only advance alongside emitted Program/unit entries,
         // so a clean check *seeds* the cache below by running the same
         // emit-and-store path as run/test (gated to checks that actually have
         // something to advance). That turns a check-only workflow warm instead
         // of leaving it on the full-compile path forever.
-        let (reuse_plan, stdlib_interface_hit) = match &cache {
-            Some(ctx) => {
-                let prep = ctx.prepare_warm_db(&mut db);
-                (prep.reuse_plan, prep.stdlib_interface_hit)
-            }
-            None => (None, false),
-        };
+        let warmth = session.warm_prep();
+        let (reuse_plan, stdlib_interface_hit) = (warmth.reuse_plan, warmth.stdlib_interface_hit);
+        let (db, cache) = (&session.db, &session.cache);
 
         reporter.spin("Checking", format!("{file_count} file(s)"));
         // With a cache, collect through the incremental collector so the fresh
         // per-file blobs are available for seeding below; its merged set is
         // identical to the read-only collector's.
-        let (diagnostics, fresh_diagnostics) = match &cache {
+        let (diagnostics, fresh_diagnostics) = match cache {
             Some(ctx) => {
-                let incremental = ctx.collect_diagnostics_incremental(&db, reuse_plan.as_ref());
+                let incremental = ctx.collect_diagnostics_incremental(db, reuse_plan.as_ref());
                 (incremental.merged, Some(incremental.fresh_by_file))
             }
-            None => (baml_project::collect_diagnostics(&db), None),
+            None => (baml_project::collect_diagnostics(db), None),
         };
-        if let Some(cache) = &cache {
-            cache.verify_diagnostics(&db)?;
-            cache.verify_stdlib_diagnostics(&db)?;
+        if let Some(cache) = cache {
+            cache.verify_diagnostics(db)?;
+            cache.verify_stdlib_diagnostics(db)?;
             // Sampled field verification (rustc-style 1-in-32): `baml check`
             // serves clean files' cached diagnostics and seeds their throws, so
             // it is a warm serving path like run/test. After the served result
             // exists, ~1 run in 32 re-derives one served clean file on a fresh,
             // un-seeded database and hard-errors on any drift.
-            cache.maybe_sampled_verify(reuse_plan.as_ref(), || {
-                build_db_from_sources(&resolved, |_| {})
-            })?;
+            cache.maybe_sampled_verify(reuse_plan.as_ref(), || session.honest_db())?;
             // Materialize the per-toolchain builtin-diagnostics blob on a miss.
             // Unlike the manifest, this blob is a build constant (keyed only by
             // the compiler fingerprint), so a read-only `check` may safely write
             // it — letting a check-only workflow drop the builtin re-inference
             // tail on its second run. Self-gates on blob presence, and the honest
             // re-derivation is Salsa-memoized against the check just performed.
-            cache.store_stdlib_diagnostics(&db);
+            cache.store_stdlib_diagnostics(db);
         }
         // Warm-incremental evidence (mirrors run/test): with the diagnostics
         // cache serving clean user files and the stdlib blob serving builtins,
@@ -85,7 +76,7 @@ impl CheckArgs {
             baml_db::baml_compiler2_tir::inference::scope_inferences()
         ));
         if !diagnostics.is_empty() {
-            let rendered = render_project_diagnostics(&db, &diagnostics);
+            let rendered = render_project_diagnostics(db, &diagnostics);
             reporter.suspend(|| {
                 #[allow(clippy::print_stderr)]
                 {
@@ -110,13 +101,13 @@ impl CheckArgs {
         // nothing to store, and skipping keeps the no-op check emit-free.
         // Seeding is an optimization: a failed emit on a diagnostics-clean
         // project is logged, never surfaced as a check failure.
-        if let Some(ctx) = &cache {
+        if let Some(ctx) = cache {
             let should_seed = reuse_plan
                 .as_ref()
                 .is_none_or(|plan| !plan.dirty_files.is_empty());
             if should_seed {
                 match crate::bytecode_cache::compile_program_artifacts(
-                    &db,
+                    db,
                     &baml_db::baml_compiler2_emit::CompileOptions {
                         emit_test_cases: false,
                     },
@@ -128,12 +119,12 @@ impl CheckArgs {
                             .as_ref()
                             .expect("a cache is present, so fresh diagnostics were computed");
                         ctx.verify_and_store(
-                            &db,
+                            db,
                             &compiled,
                             fresh,
                             reuse_plan.as_ref(),
                             stdlib_interface_hit,
-                            || build_db_from_sources(&resolved, |_| {}),
+                            || session.honest_db(),
                         )?;
                     }
                     Err(err) => {

--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -34,21 +34,30 @@ impl CheckArgs {
         let mut db = build_db_from_sources(&resolved, |_| {});
         let cache = CacheContext::open(&resolved, false);
 
-        // Check is a read-only cache consumer. It can use the immutable stdlib
-        // interface and the last successful compile's reuse seeds, but cannot
-        // advance the manifest without emitting matching Program/unit entries.
-        // The stdlib-interface-hit flag is only useful to run/test (which write),
-        // so a read-only check discards it.
-        let reuse_plan = match &cache {
-            Some(ctx) => ctx.prepare_warm_db(&mut db).reuse_plan,
-            None => None,
+        // The manifest can only advance alongside emitted Program/unit entries,
+        // so a clean check *seeds* the cache below by running the same
+        // emit-and-store path as run/test (gated to checks that actually have
+        // something to advance). That turns a check-only workflow warm instead
+        // of leaving it on the full-compile path forever.
+        let (reuse_plan, stdlib_interface_hit) = match &cache {
+            Some(ctx) => {
+                let prep = ctx.prepare_warm_db(&mut db);
+                (prep.reuse_plan, prep.stdlib_interface_hit)
+            }
+            None => (None, false),
         };
 
         reporter.spin("Checking", format!("{file_count} file(s)"));
-        let diagnostics = cache.as_ref().map_or_else(
-            || baml_project::collect_diagnostics(&db),
-            |cache| cache.collect_diagnostics_for_check(&db, reuse_plan.as_ref()),
-        );
+        // With a cache, collect through the incremental collector so the fresh
+        // per-file blobs are available for seeding below; its merged set is
+        // identical to the read-only collector's.
+        let (diagnostics, fresh_diagnostics) = match &cache {
+            Some(ctx) => {
+                let incremental = ctx.collect_diagnostics_incremental(&db, reuse_plan.as_ref());
+                (incremental.merged, Some(incremental.fresh_by_file))
+            }
+            None => (baml_project::collect_diagnostics(&db), None),
+        };
         if let Some(cache) = &cache {
             cache.verify_diagnostics(&db)?;
             cache.verify_stdlib_diagnostics(&db)?;
@@ -92,6 +101,48 @@ impl CheckArgs {
         if error_count > 0 {
             reporter.abandon();
             return Ok(crate::ExitCode::Other);
+        }
+
+        // Seed the bytecode cache from this clean check — the same
+        // emit-and-store path run/test use — but only when it advances the
+        // manifest: no reuse plan (missing/stale manifest) or a plan with
+        // dirty files. A fully-current manifest (zero dirty files) has
+        // nothing to store, and skipping keeps the no-op check emit-free.
+        // Seeding is an optimization: a failed emit on a diagnostics-clean
+        // project is logged, never surfaced as a check failure.
+        if let Some(ctx) = &cache {
+            let should_seed = reuse_plan
+                .as_ref()
+                .is_none_or(|plan| !plan.dirty_files.is_empty());
+            if should_seed {
+                match crate::bytecode_cache::compile_program_artifacts(
+                    &db,
+                    &baml_db::baml_compiler2_emit::CompileOptions {
+                        emit_test_cases: false,
+                    },
+                    cache.as_ref(),
+                    reuse_plan.as_ref(),
+                ) {
+                    Ok(compiled) => {
+                        let fresh = fresh_diagnostics
+                            .as_ref()
+                            .expect("a cache is present, so fresh diagnostics were computed");
+                        ctx.verify_and_store(
+                            &db,
+                            &compiled,
+                            fresh,
+                            reuse_plan.as_ref(),
+                            stdlib_interface_hit,
+                            || build_db_from_sources(&resolved, |_| {}),
+                        )?;
+                    }
+                    Err(err) => {
+                        crate::bytecode_cache::cache_debug(format_args!(
+                            "check: cache seeding skipped (emit failed): {err:?}"
+                        ));
+                    }
+                }
+            }
         }
 
         reporter.finish("Finished", format!("checked {file_count} file(s)"));

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -8,10 +8,7 @@ use baml_lsp2_actions::{ResolvedTarget, SymbolDescription, describe};
 use baml_project::ProjectDatabase;
 use clap::Args;
 
-use crate::{
-    project_load::load_project_or_default,
-    util::{line_number_at_offset, relative_path},
-};
+use crate::util::{line_number_at_offset, relative_path};
 
 /// Parsed documentation entry for a BAML keyword topic.
 #[derive(serde::Deserialize)]
@@ -289,7 +286,15 @@ impl DescribeArgs {
         // baml.String` works anywhere. An empty user-file set is therefore
         // expected, not an error — unresolved names still surface through
         // the per-target "No symbol found" + did-you-mean paths below.
-        let (db, from, _baml_files) = load_project_or_default(self.from.as_deref())?;
+        let mut session = crate::project_session::ProjectSession::open_lenient(
+            self.from.as_deref(),
+            crate::project_session::CacheUse::ReadOnly,
+        )?;
+        // Warm seeds (no-delta only) + parallel index prime: describe queries
+        // the whole-package aggregates, which otherwise derive serially.
+        let _ = session.warm_prep_seeds_only();
+        session.prime();
+        let (db, from) = (session.db, session.resolved.root);
 
         // ── --symbols deprecation ───────────────────────────────────────────
         if self.symbols {

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -16,7 +16,7 @@ use sdkgen_python_pydantic2::{NamingConvention, OutputType};
 use text_size::{TextRange, TextSize};
 use toml::Spanned;
 
-use crate::{commands::release_version, project_load::load_project_for_build, reporter::Reporter};
+use crate::{commands::release_version, reporter::Reporter};
 
 #[derive(Args, Clone, Debug)]
 pub struct GenerateArgs {
@@ -51,16 +51,24 @@ impl GenerateArgs {
             "Generating",
             format!("clients with CLI version: {}", release_version()),
         );
-        let (db, from, baml_files) =
-            load_project_for_build(self.from.as_deref(), &reporter, false)?;
-        if baml_files.is_empty() {
+        // Codegen reads types across the whole project, so take the shared
+        // read-only session: warm seeds where they are provably faithful and
+        // the parallel index prime, same as describe/grep.
+        let mut session = crate::project_session::ProjectSession::open(
+            self.from.as_deref(),
+            crate::project_session::CacheUse::ReadOnly,
+        )?;
+        if session.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(
                 "no .baml files found in {}",
-                from.display()
+                session.root().display()
             ));
             return Ok(crate::ExitCode::Other);
         }
+        let _ = session.warm_prep_seeds_only();
+        session.prime();
+        let (db, from) = (session.db, session.resolved.root);
         // Compile-time diagnostics — same shape as run/pack: render the
         // ariadne block after abandoning the spinner so the colored
         // source-snippet output doesn't fight with the lamb. No "Checking"

--- a/baml_language/crates/baml_cli/src/grep_command.rs
+++ b/baml_language/crates/baml_cli/src/grep_command.rs
@@ -10,10 +10,7 @@ use baml_lsp2_actions::{
 use baml_project::ProjectDatabase;
 use clap::Args;
 
-use crate::{
-    project_load::load_project_or_default,
-    util::{line_number_at_offset, relative_path},
-};
+use crate::util::{line_number_at_offset, relative_path};
 
 #[derive(Args, Clone, Debug)]
 pub struct GrepArgs {
@@ -73,7 +70,13 @@ impl GrepArgs {
         // get a stdlib-only default state and an empty user-file set;
         // each grep mode already surfaces "no matches" / "no symbol found"
         // gracefully below, so there's no need to bail up front.
-        let (db, from, _baml_files) = load_project_or_default(self.from.as_deref())?;
+        let mut session = crate::project_session::ProjectSession::open_lenient(
+            self.from.as_deref(),
+            crate::project_session::CacheUse::ReadOnly,
+        )?;
+        let _ = session.warm_prep_seeds_only();
+        session.prime();
+        let (db, from) = (session.db, session.resolved.root);
 
         let source_files = db.get_source_files();
         let kind_filter = parse_kind_filter(&self.kind)?;

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -35,6 +35,7 @@ pub(crate) mod pack_elf;
 pub(crate) mod paint;
 pub(crate) mod playground_command;
 pub(crate) mod project_load;
+pub(crate) mod project_session;
 pub mod reporter;
 pub(crate) mod run_command;
 pub(crate) mod skill_check;

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -267,42 +267,30 @@ impl PackArgs {
         &self,
         reporter: &Reporter,
     ) -> Result<(ProjectDatabase, Program, bool)> {
-        let resolved = crate::project_load::resolve_project_sources(self.from.as_deref())?;
-        if resolved.files.is_empty() {
-            anyhow::bail!("No .baml files found in {}", resolved.root.display());
+        let mut session = crate::project_session::ProjectSession::open(
+            self.from.as_deref(),
+            crate::project_session::CacheUse::ReadWrite,
+        )?;
+        if session.is_empty() {
+            anyhow::bail!("No .baml files found in {}", session.root().display());
         }
         // Mirror `baml run`'s per-file format check: probe each source through
         // the formatter and emit a single advisory if any file would change.
-        let needs_format_hint = resolved
-            .files
-            .iter()
-            .any(|(_, source)| crate::run_command::source_needs_format_hint(source));
+        let needs_format_hint = session.needs_format_hint();
 
-        // Building the database only sets salsa inputs — the expensive work
-        // (typecheck, emit) happens lazily below, which a cache hit skips.
-        let mut db = crate::project_load::build_db_from_sources(&resolved, |_| {});
-
-        let cache =
-            crate::bytecode_cache::CacheContext::open(&resolved, /* emit_test_cases */ false);
-        if !crate::bytecode_cache::CacheContext::verify_enabled()
-            && let Some(ctx) = &cache
-            && let Some(program) = ctx.load()
-        {
+        if let Some(program) = session.try_cached_program() {
             crate::bytecode_cache::cache_debug(format_args!(
                 "pack: bytecode cache hit — skipping compile"
             ));
-            return Ok((db, program, needs_format_hint));
+            return Ok((session.db, program, needs_format_hint));
         }
 
         // Seed the stdlib typed interface and prepare the per-file reuse plan —
         // the same warm-database setup run/check/test use.
-        let (reuse_plan, stdlib_interface_hit) = match &cache {
-            Some(ctx) => {
-                let prep = ctx.prepare_warm_db(&mut db);
-                (prep.reuse_plan, prep.stdlib_interface_hit)
-            }
-            None => (None, false),
-        };
+        let warmth = session.warm_prep();
+        let (reuse_plan, stdlib_interface_hit) = (warmth.reuse_plan, warmth.stdlib_interface_hit);
+        let db = &session.db;
+        let cache = &session.cache;
 
         // Keep `baml pack` quiet during compilation. Its visible progress is
         // packaging/downloading/output-oriented; compile/count status belongs
@@ -312,22 +300,22 @@ impl PackArgs {
         // checks only the reuse plan's dirty files and serves clean files from
         // their cached blobs, returning the fresh per-file blobs to persist.
         // Without a cache, run the honest full check (no blobs to store).
-        let fresh_diagnostics = if let Some(ctx) = &cache {
-            let incremental = ctx.collect_diagnostics_incremental(&db, reuse_plan.as_ref());
+        let fresh_diagnostics = if let Some(ctx) = cache {
+            let incremental = ctx.collect_diagnostics_incremental(db, reuse_plan.as_ref());
             bail_on_error_diagnostics(
-                &db,
+                db,
                 &incremental.merged,
                 "Cannot pack: compilation errors found",
                 reporter,
             )?;
             Some(incremental.fresh_by_file)
         } else {
-            check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
+            check_diagnostics(db, "Cannot pack: compilation errors found", reporter)?;
             None
         };
 
         let compiled = crate::bytecode_cache::compile_program_artifacts(
-            &db,
+            db,
             &baml_compiler2_emit::CompileOptions {
                 emit_test_cases: false,
             },
@@ -335,20 +323,20 @@ impl PackArgs {
             reuse_plan.as_ref(),
         )
         .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
-        if let Some(ctx) = &cache {
+        if let Some(ctx) = cache {
             let fresh = fresh_diagnostics
                 .as_ref()
                 .expect("a cache is present, so fresh diagnostics were computed");
             ctx.verify_and_store(
-                &db,
+                db,
                 &compiled,
                 fresh,
                 reuse_plan.as_ref(),
                 stdlib_interface_hit,
-                || crate::project_load::build_db_from_sources(&resolved, |_| {}),
+                || session.honest_db(),
             )?;
         }
-        Ok((db, compiled.program, needs_format_hint))
+        Ok((session.db, compiled.program, needs_format_hint))
     }
 
     fn load_standalone(&self, file_path: &Path) -> Result<(ProjectDatabase, bool)> {

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -40,7 +40,7 @@ use sys_native::SysOpsExt;
 
 use crate::{
     commands::release_version,
-    project_load::{load_project_for_build, resolve_standalone_file, validate_file_from_flags},
+    project_load::{resolve_standalone_file, validate_file_from_flags},
     reporter::Reporter,
 };
 
@@ -237,44 +237,118 @@ impl PackArgs {
     }
 
     fn load_and_compile(&self, reporter: &Reporter) -> Result<(ProjectDatabase, Program, bool)> {
-        let (db, needs_format_hint) = if let Some(file) = self.file.as_deref() {
-            self.load_standalone(file)?
-        } else {
-            self.load_project(reporter)?
+        if let Some(file) = self.file.as_deref() {
+            // Standalone `--file` mode has no project root, so there is no
+            // cache seam — always a cold compile, same as `baml run --file`.
+            let (db, needs_format_hint) = self.load_standalone(file)?;
+            check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
+            let program = baml_compiler2_emit::generate_project_bytecode(
+                &db,
+                &baml_compiler2_emit::CompileOptions {
+                    emit_test_cases: false,
+                },
+            )
+            .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
+            return Ok((db, program, needs_format_hint));
+        }
+        self.load_and_compile_project(reporter)
+    }
+
+    /// Project-mode load + compile through the bytecode cache — the same warm
+    /// flow as `baml run` (`run_command::load_and_compile`): whole-program hit
+    /// when nothing changed, per-file unit reuse on a dirty edit, full compile
+    /// otherwise. Pack compiles with `emit_test_cases: false`, so it shares
+    /// run/check's exact cache key space — a pack right after a run (or a
+    /// re-pack) serves the identical `Program`. The packaged bytecode is
+    /// target-independent (the `--target` triple only selects the host binary
+    /// bytes), and emit determinism guarantees a reused image is byte-identical
+    /// to a fresh compile, so serving from cache never changes the artifact.
+    fn load_and_compile_project(
+        &self,
+        reporter: &Reporter,
+    ) -> Result<(ProjectDatabase, Program, bool)> {
+        let resolved = crate::project_load::resolve_project_sources(self.from.as_deref())?;
+        if resolved.files.is_empty() {
+            anyhow::bail!("No .baml files found in {}", resolved.root.display());
+        }
+        // Mirror `baml run`'s per-file format check: probe each source through
+        // the formatter and emit a single advisory if any file would change.
+        let needs_format_hint = resolved
+            .files
+            .iter()
+            .any(|(_, source)| crate::run_command::source_needs_format_hint(source));
+
+        // Building the database only sets salsa inputs — the expensive work
+        // (typecheck, emit) happens lazily below, which a cache hit skips.
+        let mut db = crate::project_load::build_db_from_sources(&resolved, |_| {});
+
+        let cache =
+            crate::bytecode_cache::CacheContext::open(&resolved, /* emit_test_cases */ false);
+        if !crate::bytecode_cache::CacheContext::verify_enabled()
+            && let Some(ctx) = &cache
+            && let Some(program) = ctx.load()
+        {
+            crate::bytecode_cache::cache_debug(format_args!(
+                "pack: bytecode cache hit — skipping compile"
+            ));
+            return Ok((db, program, needs_format_hint));
+        }
+
+        // Seed the stdlib typed interface and prepare the per-file reuse plan —
+        // the same warm-database setup run/check/test use.
+        let (reuse_plan, stdlib_interface_hit) = match &cache {
+            Some(ctx) => {
+                let prep = ctx.prepare_warm_db(&mut db);
+                (prep.reuse_plan, prep.stdlib_interface_hit)
+            }
+            None => (None, false),
         };
 
         // Keep `baml pack` quiet during compilation. Its visible progress is
         // packaging/downloading/output-oriented; compile/count status belongs
         // to `check` and `generate`.
-        check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
+        //
+        // With a cache, gate diagnostics through the incremental collector: it
+        // checks only the reuse plan's dirty files and serves clean files from
+        // their cached blobs, returning the fresh per-file blobs to persist.
+        // Without a cache, run the honest full check (no blobs to store).
+        let fresh_diagnostics = if let Some(ctx) = &cache {
+            let incremental = ctx.collect_diagnostics_incremental(&db, reuse_plan.as_ref());
+            bail_on_error_diagnostics(
+                &db,
+                &incremental.merged,
+                "Cannot pack: compilation errors found",
+                reporter,
+            )?;
+            Some(incremental.fresh_by_file)
+        } else {
+            check_diagnostics(&db, "Cannot pack: compilation errors found", reporter)?;
+            None
+        };
 
-        let program = baml_compiler2_emit::generate_project_bytecode(
+        let compiled = crate::bytecode_cache::compile_program_artifacts(
             &db,
             &baml_compiler2_emit::CompileOptions {
                 emit_test_cases: false,
             },
+            cache.as_ref(),
+            reuse_plan.as_ref(),
         )
         .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
-
-        Ok((db, program, needs_format_hint))
-    }
-
-    fn load_project(&self, reporter: &Reporter) -> Result<(ProjectDatabase, bool)> {
-        let (db, from, baml_files) = load_project_for_build(self.from.as_deref(), reporter, false)?;
-        if baml_files.is_empty() {
-            anyhow::bail!("No .baml files found in {}", from.display());
+        if let Some(ctx) = &cache {
+            let fresh = fresh_diagnostics
+                .as_ref()
+                .expect("a cache is present, so fresh diagnostics were computed");
+            ctx.verify_and_store(
+                &db,
+                &compiled,
+                fresh,
+                reuse_plan.as_ref(),
+                stdlib_interface_hit,
+                || crate::project_load::build_db_from_sources(&resolved, |_| {}),
+            )?;
         }
-        // Mirror `baml run`'s per-file format check: probe each source
-        // through the formatter and emit a single advisory if any file
-        // would change. Cheap enough at compile time (we already read
-        // each file from disk during discovery) and matches the
-        // warning surfaces `baml run` already provides.
-        let needs_format_hint = baml_files.iter().any(|path| {
-            std::fs::read_to_string(path)
-                .map(|source| crate::run_command::source_needs_format_hint(&source))
-                .unwrap_or(false)
-        });
-        Ok((db, needs_format_hint))
+        Ok((db, compiled.program, needs_format_hint))
     }
 
     fn load_standalone(&self, file_path: &Path) -> Result<(ProjectDatabase, bool)> {
@@ -405,15 +479,25 @@ fn label_for(targets: &[ResolvedPackTarget]) -> String {
 }
 
 /// Collect diagnostics; render errors to stderr and bail with `ctx`.
+fn check_diagnostics(db: &ProjectDatabase, ctx: &str, reporter: &Reporter) -> Result<()> {
+    let diagnostics = baml_project::collect_diagnostics(db);
+    bail_on_error_diagnostics(db, &diagnostics, ctx, reporter)
+}
+
+/// Render any `Error`-severity entries in an already-collected diagnostics
+/// list and bail with `ctx`; no-op when the list is error-free.
 ///
 /// When `reporter` has an active spinner, abandon it before printing so
 /// the multi-line ariadne block lands cleanly instead of getting
 /// interleaved with the tick character.
-fn check_diagnostics(db: &ProjectDatabase, ctx: &str, reporter: &Reporter) -> Result<()> {
+fn bail_on_error_diagnostics(
+    db: &ProjectDatabase,
+    diagnostics: &[baml_db::baml_compiler_diagnostics::Diagnostic],
+    ctx: &str,
+    reporter: &Reporter,
+) -> Result<()> {
     use baml_db::baml_compiler_diagnostics::render;
 
-    let source_files = db.get_source_files();
-    let diagnostics = baml_project::collect_diagnostics(db);
     let errors: Vec<_> = diagnostics
         .iter()
         .filter(|d| d.severity == Severity::Error)
@@ -421,6 +505,7 @@ fn check_diagnostics(db: &ProjectDatabase, ctx: &str, reporter: &Reporter) -> Re
     if errors.is_empty() {
         return Ok(());
     }
+    let source_files = db.get_source_files();
     let mut sources = HashMap::new();
     let mut file_paths = HashMap::new();
     for sf in &source_files {
@@ -1146,9 +1231,9 @@ mod tests {
         assert_eq!(name, "DoesNotExist");
     }
 
-    // ── load_project / load_standalone error paths ────────────────────
+    // ── project / load_standalone error paths ─────────────────────────
 
-    /// An empty directory has no `.baml` files → `load_project` errors
+    /// An empty directory has no `.baml` files → project loading errors
     /// before ever reaching compilation.
     #[test]
     fn test_load_project_empty_dir_errors() {
@@ -1165,7 +1250,7 @@ mod tests {
         let mut args = pack_args();
         args.from = Some(tmp.path().to_path_buf());
         let reporter = Reporter::new();
-        let err = args.load_project(&reporter).unwrap_err();
+        let err = args.load_and_compile_project(&reporter).unwrap_err();
         assert!(
             format!("{err}").contains("No .baml files"),
             "expected no-files error; got: {err}",

--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -144,6 +144,48 @@ pub(crate) fn load_project_for_build(
     }
 }
 
+/// Lenient counterpart to [`resolve_project_sources`] for introspection
+/// sessions: `Ok(None)` when no project root is found (instead of an error),
+/// and a present `baml.toml` is read **raw, unvalidated** — its bytes still
+/// key the bytecode cache identically to the strict path, but a broken
+/// manifest must not lock an agent out of `describe`/`grep`.
+pub(crate) fn resolve_project_sources_lenient(
+    from: Option<&Path>,
+) -> Result<Option<ResolvedProject>> {
+    let canonical = resolve_search_start(from)?;
+    let Some(canonical) = find_baml_project_root(&canonical) else {
+        return Ok(None);
+    };
+    let toml_path = canonical.join("baml.toml");
+    let manifest = if toml_path.exists() {
+        std::fs::read_to_string(&toml_path).ok()
+    } else {
+        None
+    };
+    let walk_root = project_source_root(&canonical);
+    use rayon::prelude::*;
+    let files = discover_baml_files(&walk_root)
+        .into_par_iter()
+        .map(|path| {
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read {}", path.display()))?;
+            Ok((path, content))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Some(ResolvedProject {
+        root: canonical,
+        manifest,
+        files,
+    }))
+}
+
+/// The directory a projectless introspection session roots at (the same
+/// fallback [`load_project_or_default`] uses when no project is found).
+pub(crate) fn projectless_search_dir(from: Option<&Path>) -> Result<PathBuf> {
+    let canonical = resolve_search_start(from)?;
+    Ok(project_search_dir(&canonical))
+}
+
 /// Read-only/introspection loader: like [`load_project_from`] but **never
 /// fails on a missing `baml.toml`**. This is for the commands an agent
 /// reaches for first (`describe`, `grep`) — the most expensive thing they

--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -280,8 +280,12 @@ pub(crate) fn resolve_project_sources(from: Option<&Path>) -> Result<ResolvedPro
     };
 
     let walk_root = project_source_root(&canonical);
+    // Read sources across worker threads; `collect` on an indexed parallel
+    // iterator preserves discovery order, so `FileId` assignment (and with it
+    // diagnostic ordering) is identical to a serial read.
+    use rayon::prelude::*;
     let files = discover_baml_files(&walk_root)
-        .into_iter()
+        .into_par_iter()
         .map(|path| {
             let content = std::fs::read_to_string(&path)
                 .with_context(|| format!("Failed to read {}", path.display()))?;
@@ -303,10 +307,17 @@ pub(crate) fn build_db_from_sources(
 ) -> ProjectDatabase {
     let mut db = ProjectDatabase::new();
     db.set_project_root(&resolved.root);
-    for (path, content) in &resolved.files {
+    for (path, _) in &resolved.files {
         on_file(path);
-        db.add_or_update_file(path, content);
     }
+    // Bulk registration: one project-file-list write instead of one per file
+    // (the per-file path is O(files²) Vec copies + one salsa revision each).
+    db.add_or_update_files(
+        resolved
+            .files
+            .iter()
+            .map(|(path, content)| (path.as_path(), content.as_str())),
+    );
     db
 }
 

--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -110,10 +110,9 @@ pub(crate) fn load_project_from(
 /// Variant of [`load_project_from`] that announces each discovered
 /// file through the [`Reporter`] as it's loaded — cargo's
 /// `   Compiling foo v0.1.0` shape but for source files. The per-file
-/// `Loading <path>` flood is verbose-only detail; prefer
-/// [`load_project_for_build`] in command code, which gates this behind the
-/// command's verbosity. `grep`/`describe` stay on the lenient
-/// [`load_project_or_default`].
+/// `Loading <path>` flood is verbose-only detail, reachable through
+/// [`resolve_source_location`] with a reporter; command code goes through
+/// `ProjectSession` instead.
 pub(crate) fn load_project_from_reporting(
     from: Option<&Path>,
     reporter: &Reporter,
@@ -121,27 +120,6 @@ pub(crate) fn load_project_from_reporting(
     load_project_from_inner(from, |path| {
         reporter.spin("Loading", path.display().to_string());
     })
-}
-
-/// Single front-end every build-style command (`run`/`test`/`generate`/
-/// `check`/`pack`) uses to load its project.
-///
-/// Centralizes the one decision they all share: the per-file `Loading <path>`
-/// flood is *verbose-only* detail. By default the load is silent and the
-/// caller's single aggregate `Compiling N file(s)` line is the only progress
-/// shown for the whole load → check → compile span; a redundant `Checking`
-/// line and ~one `Loading` line per source file are exactly the noise this
-/// removes. Pass the command's own `--verbose` (or `false` when it has none).
-pub(crate) fn load_project_for_build(
-    from: Option<&Path>,
-    reporter: &Reporter,
-    verbose: bool,
-) -> Result<(ProjectDatabase, PathBuf, Vec<PathBuf>)> {
-    if verbose {
-        load_project_from_reporting(from, reporter)
-    } else {
-        load_project_from(from)
-    }
 }
 
 /// Lenient counterpart to [`resolve_project_sources`] for introspection

--- a/baml_language/crates/baml_cli/src/project_session.rs
+++ b/baml_language/crates/baml_cli/src/project_session.rs
@@ -1,0 +1,214 @@
+//! One shared setup path for every command that loads a BAML project.
+//!
+//! `check`, `run`, `test`, `pack`, `describe`, `grep`, and `generate` all
+//! need the same preamble — resolve the project, build the database, open
+//! the bytecode cache, install the warm seeds — but historically each
+//! command hand-rolled its own subset, and the subsets drifted: `pack`
+//! shipped without any cache participation, `describe`/`grep` never got the
+//! warm seeds or the parallel index prime. [`ProjectSession`] is the single
+//! implementation; a command states *how* it uses the cache and gets the
+//! rest of the ritual identically.
+//!
+//! The phases stay separate on purpose:
+//!
+//! 1. [`ProjectSession::open`] / [`ProjectSession::open_lenient`] — resolve +
+//!    read sources + build the salsa database + open the cache. No expensive
+//!    compiler work.
+//! 2. [`ProjectSession::try_cached_program`] — the whole-program hit for
+//!    executing commands (`run`/`test`/`pack`); called *before* warm prep so
+//!    a hit skips it entirely.
+//! 3. [`ProjectSession::warm_prep`] — stdlib-interface seed + per-file reuse
+//!    plan (throw facts, callable-throws fragments, diagnostics blobs).
+//! 4. [`ProjectSession::prime`] — parallel per-file semantic-index prime for
+//!    commands that query whole-package aggregates without running the check
+//!    collectors (which prime internally): `describe`, `grep`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use baml_project::ProjectDatabase;
+
+use crate::{
+    bytecode_cache::{CacheContext, ReusePlan},
+    project_load::{ResolvedProject, build_db_from_sources, resolve_project_sources},
+};
+
+/// How a command participates in the bytecode cache.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CacheUse {
+    /// Read the warm seeds and store artifacts after a successful compile —
+    /// the `run`/`check`/`pack` keyspace (`emit_test_cases: false`).
+    ReadWrite,
+    /// Same, in the `baml test` keyspace (`emit_test_cases: true`).
+    ReadWriteTests,
+    /// Consume warm seeds, never store: introspection commands
+    /// (`describe`, `grep`, `generate`). Shares the run/check keyspace.
+    ReadOnly,
+    /// No cache at all (projectless fallback, tests).
+    Off,
+}
+
+impl CacheUse {
+    fn emit_test_cases(self) -> bool {
+        matches!(self, CacheUse::ReadWriteTests)
+    }
+}
+
+/// The state of the warm-database preamble after [`ProjectSession::warm_prep`].
+pub(crate) struct SessionWarmth {
+    pub(crate) reuse_plan: Option<ReusePlan>,
+    /// Whether the stdlib typed interface was served from the cache —
+    /// storing commands skip re-writing it in that case.
+    pub(crate) stdlib_interface_hit: bool,
+}
+
+/// A loaded project plus its cache handle: the shared preamble every
+/// project-consuming command starts from.
+pub(crate) struct ProjectSession {
+    pub(crate) resolved: ResolvedProject,
+    pub(crate) db: ProjectDatabase,
+    pub(crate) cache: Option<CacheContext>,
+}
+
+impl ProjectSession {
+    /// Strict open: manifest is validated (a build-shaped command must fail
+    /// fast on a broken `baml.toml`). The session may still have zero files —
+    /// commands own their empty-project error text.
+    pub(crate) fn open(from: Option<&Path>, cache_use: CacheUse) -> Result<Self> {
+        let resolved = resolve_project_sources(from)?;
+        Ok(Self::from_resolved(resolved, cache_use))
+    }
+
+    /// Lenient open for introspection commands (`describe`, `grep`): never
+    /// fails on a missing or invalid `baml.toml`. Inside a project the
+    /// manifest is read raw (its bytes still key the cache, unvalidated);
+    /// outside any project the session is an empty database rooted at the
+    /// search directory, with the cache off — introspection always has
+    /// *something* to work with.
+    pub(crate) fn open_lenient(from: Option<&Path>, cache_use: CacheUse) -> Result<Self> {
+        match crate::project_load::resolve_project_sources_lenient(from)? {
+            Some(resolved) => Ok(Self::from_resolved(resolved, cache_use)),
+            None => {
+                let root = crate::project_load::projectless_search_dir(from)?;
+                let mut db = ProjectDatabase::new();
+                db.set_project_root(&root);
+                Ok(Self {
+                    resolved: ResolvedProject {
+                        root,
+                        manifest: None,
+                        files: Vec::new(),
+                    },
+                    db,
+                    cache: None,
+                })
+            }
+        }
+    }
+
+    fn from_resolved(resolved: ResolvedProject, cache_use: CacheUse) -> Self {
+        let db = build_db_from_sources(&resolved, |_| {});
+        let cache = match cache_use {
+            CacheUse::Off => None,
+            _ => CacheContext::open(&resolved, cache_use.emit_test_cases()),
+        };
+        Self {
+            resolved,
+            db,
+            cache,
+        }
+    }
+
+    /// The whole-program cache hit, for commands that execute or package the
+    /// compiled program. Call before [`Self::warm_prep`]: a hit makes the
+    /// warm preamble unnecessary. Gated off under `BAML_CACHE_VERIFY` so the
+    /// verify tripwire always exercises the full compile path.
+    pub(crate) fn try_cached_program(&self) -> Option<bex_vm_types::Program> {
+        if CacheContext::verify_enabled() {
+            return None;
+        }
+        self.cache.as_ref().and_then(CacheContext::load)
+    }
+
+    /// Seed the stdlib typed interface and prepare the per-file reuse plan —
+    /// the identical warm-database setup for every cache-participating
+    /// command. A no-op (all-`None`) session without a cache.
+    pub(crate) fn warm_prep(&mut self) -> SessionWarmth {
+        let Some(ctx) = &self.cache else {
+            return SessionWarmth {
+                reuse_plan: None,
+                stdlib_interface_hit: false,
+            };
+        };
+        let prep = ctx.prepare_warm_db(&mut self.db);
+        SessionWarmth {
+            reuse_plan: prep.reuse_plan,
+            stdlib_interface_hit: prep.stdlib_interface_hit,
+        }
+    }
+
+    /// Variant of [`Self::warm_prep`] for read-only introspection
+    /// (`describe`, `grep`): installs the stdlib-interface seed always, and
+    /// the per-file throws seeds only on a **no-delta** plan — where they are
+    /// byte-for-byte the stored values and the serve-time gate is a proven
+    /// tautology. On a project with edits, introspection simply derives
+    /// honestly (no seeds, no gate, no staleness surface); the parallel
+    /// index prime keeps that fast.
+    pub(crate) fn warm_prep_seeds_only(&mut self) -> SessionWarmth {
+        let Some(ctx) = &self.cache else {
+            return SessionWarmth {
+                reuse_plan: None,
+                stdlib_interface_hit: false,
+            };
+        };
+        let stdlib_interface_hit = ctx.seed_stdlib_interface(&mut self.db);
+        let reuse_plan = ctx.plan_reuse(&self.db).and_then(|mut plan| {
+            if !plan.no_delta {
+                return None;
+            }
+            self.db
+                .set_seeded_throw_facts(std::mem::take(&mut plan.seeded_throw_facts));
+            self.db
+                .set_seeded_callable_throws(std::mem::take(&mut plan.seeded_callable_throws));
+            Some(plan)
+        });
+        SessionWarmth {
+            reuse_plan,
+            stdlib_interface_hit,
+        }
+    }
+
+    /// Parallel per-file semantic-index prime. Commands that query
+    /// whole-package aggregates *outside* the check collectors (`describe`,
+    /// `grep`) call this so the aggregate fold is parallel-fed instead of a
+    /// serial parse of the project. Harmless to call twice.
+    pub(crate) fn prime(&self) {
+        baml_project::prime_file_indexes_parallel(&self.db);
+    }
+
+    /// A fresh, un-seeded database over the same sources — the honest
+    /// baseline the sampled verify oracle compares served artifacts against.
+    pub(crate) fn honest_db(&self) -> ProjectDatabase {
+        build_db_from_sources(&self.resolved, |_| {})
+    }
+
+    pub(crate) fn file_count(&self) -> usize {
+        self.resolved.files.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.resolved.files.is_empty()
+    }
+
+    pub(crate) fn root(&self) -> &PathBuf {
+        &self.resolved.root
+    }
+
+    /// Whether any source would change under `baml fmt` — the shared input
+    /// for `run`/`pack`'s format advisory.
+    pub(crate) fn needs_format_hint(&self) -> bool {
+        self.resolved
+            .files
+            .iter()
+            .any(|(_, source)| crate::run_command::source_needs_format_hint(source))
+    }
+}

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -683,38 +683,28 @@ impl RunArgs {
             return self.load_and_compile_standalone(file, argv, reporter);
         }
 
-        let resolved = crate::project_load::resolve_project_sources(self.from.as_deref())?;
+        let mut session = crate::project_session::ProjectSession::open(
+            self.from.as_deref(),
+            crate::project_session::CacheUse::ReadWrite,
+        )?;
         self.vlog(format_args!(
             "Loading project from {}",
-            resolved.root.display()
+            session.root().display()
         ));
-        if resolved.files.is_empty() {
-            anyhow::bail!("No .baml files found in {}", resolved.root.display());
+        if session.is_empty() {
+            anyhow::bail!("No .baml files found in {}", session.root().display());
         }
-        self.vlog(format_args!("Found {} .baml file(s)", resolved.files.len()));
-        let needs_format_hint = resolved
-            .files
-            .iter()
-            .any(|(_, source)| source_needs_format_hint(source));
+        self.vlog(format_args!("Found {} .baml file(s)", session.file_count()));
+        let needs_format_hint = session.needs_format_hint();
 
-        // Building the database only sets salsa inputs — the expensive work
-        // (typecheck, emit) happens lazily in the queries below, which a
-        // bytecode-cache hit skips entirely.
-        let mut db = crate::project_load::build_db_from_sources(&resolved, |_| {});
-
-        let cache =
-            crate::bytecode_cache::CacheContext::open(&resolved, /* emit_test_cases */ false);
-        if !crate::bytecode_cache::CacheContext::verify_enabled()
-            && let Some(ctx) = &cache
-            && let Some(program) = ctx.load()
-        {
+        if let Some(program) = session.try_cached_program() {
             self.vlog(format_args!("Bytecode cache hit — skipping compile"));
             match BexEngine::new(
                 program,
                 Arc::new(sys_native::SysOps::native()),
                 argv.clone(),
             ) {
-                Ok(engine) => return Ok((db, engine, needs_format_hint)),
+                Ok(engine) => return Ok((session.db, engine, needs_format_hint)),
                 Err(error) => crate::bytecode_cache::cache_debug(format_args!(
                     "cached program rejected by VM; recompiling: {error:?}"
                 )),
@@ -725,20 +715,17 @@ impl RunArgs {
         // build constant, so it applies to every compile independent of the reuse
         // plan and is gated off under verify) and prepare the per-file reuse plan
         // — the same warm-database setup `check` and `test` run.
-        let (reuse_plan, stdlib_interface_hit) = match &cache {
-            Some(ctx) => {
-                let prep = ctx.prepare_warm_db(&mut db);
-                if let Some(plan) = &prep.reuse_plan {
-                    self.vlog(format_args!(
-                        "Per-file reuse: {} clean, {} dirty",
-                        plan.clean_files.len(),
-                        plan.dirty_files.len()
-                    ));
-                }
-                (prep.reuse_plan, prep.stdlib_interface_hit)
-            }
-            None => (None, false),
-        };
+        let warmth = session.warm_prep();
+        let (reuse_plan, stdlib_interface_hit) = (warmth.reuse_plan, warmth.stdlib_interface_hit);
+        if let Some(plan) = &reuse_plan {
+            self.vlog(format_args!(
+                "Per-file reuse: {} clean, {} dirty",
+                plan.clean_files.len(),
+                plan.dirty_files.len()
+            ));
+        }
+        let db = &session.db;
+        let cache = &session.cache;
 
         // `baml run` keeps the compile phase silent; the program's output is
         // the point. Compile/count progress belongs to `check` and `generate`.
@@ -747,22 +734,22 @@ impl RunArgs {
         // checks only the reuse plan's dirty files and serves clean files from
         // their cached blobs, returning the fresh per-file blobs to persist.
         // Without a cache, run the honest full check (no blobs to store).
-        let fresh_diagnostics = if let Some(ctx) = &cache {
-            let incremental = ctx.collect_diagnostics_incremental(&db, reuse_plan.as_ref());
+        let fresh_diagnostics = if let Some(ctx) = cache {
+            let incremental = ctx.collect_diagnostics_incremental(db, reuse_plan.as_ref());
             self.render_and_bail_on_errors(
                 &incremental.merged,
-                &db,
+                db,
                 "Cannot run: compilation errors found",
                 reporter,
             )?;
             Some(incremental.fresh_by_file)
         } else {
-            self.check_project_diagnostics(&db, "Cannot run: compilation errors found", reporter)?;
+            self.check_project_diagnostics(db, "Cannot run: compilation errors found", reporter)?;
             None
         };
         self.vlog(format_args!("Compiling..."));
         let compiled = crate::bytecode_cache::compile_program_artifacts(
-            &db,
+            db,
             &baml_compiler2_emit::CompileOptions {
                 emit_test_cases: false,
             },
@@ -770,17 +757,17 @@ impl RunArgs {
             reuse_plan.as_ref(),
         )
         .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
-        if let Some(ctx) = &cache {
+        if let Some(ctx) = cache {
             let fresh = fresh_diagnostics
                 .as_ref()
                 .expect("a cache is present, so fresh diagnostics were computed");
             ctx.verify_and_store(
-                &db,
+                db,
                 &compiled,
                 fresh,
                 reuse_plan.as_ref(),
                 stdlib_interface_hit,
-                || crate::project_load::build_db_from_sources(&resolved, |_| {}),
+                || session.honest_db(),
             )?;
         }
         // Warm-incremental evidence: with the diagnostics cache serving clean
@@ -803,7 +790,7 @@ impl RunArgs {
             "Compiled {} user function(s)",
             engine.user_functions().len()
         ));
-        Ok((db, engine, needs_format_hint))
+        Ok((session.db, engine, needs_format_hint))
     }
 
     /// Load a single .baml file in hermetic standalone mode.

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -14,12 +14,7 @@ use bex_engine::{
 use clap::{Args, ValueEnum};
 use sys_native::{CallId, SysOpsExt};
 
-use crate::{
-    bytecode_cache::CacheContext,
-    project_load::{build_db_from_sources, resolve_project_sources},
-    reporter::Reporter,
-    test_filter::TestFilter,
-};
+use crate::{bytecode_cache::CacheContext, reporter::Reporter, test_filter::TestFilter};
 
 #[derive(Args, Clone, Debug)]
 pub struct TestArgs {
@@ -199,17 +194,18 @@ impl TestArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
         let reporter = Reporter::new();
         // ── 1. Load project ────────────────────────────────────────────────
-        let resolved = resolve_project_sources(self.from.as_deref())?;
-        if resolved.files.is_empty() {
+        let mut session = crate::project_session::ProjectSession::open(
+            self.from.as_deref(),
+            crate::project_session::CacheUse::ReadWriteTests,
+        )?;
+        if session.is_empty() {
             reporter.abandon();
             crate::reporter::print_error(format_args!(
                 "no .baml files found in {}",
-                resolved.root.display()
+                session.root().display()
             ));
             return Ok(crate::ExitCode::NoTestsRun);
         }
-
-        let cache = CacheContext::open(&resolved, /* emit_test_cases */ true);
 
         // Warm `--list` fast path. The flattened test list (legacy tests +
         // fully-expanded testset leaf names) is a pure function of the compiled
@@ -220,16 +216,12 @@ impl TestArgs {
         // BAML_NO_DISCOVERY_CACHE; any miss/corruption falls through to the
         // honest path below.
         if self.list {
-            if let Some(exit) = self.try_cached_list(&reporter, cache.as_ref()) {
+            if let Some(exit) = self.try_cached_list(&reporter, session.cache.as_ref()) {
                 return Ok(exit);
             }
         }
 
-        let cached_program = if CacheContext::verify_enabled() {
-            None
-        } else {
-            cache.as_ref().and_then(CacheContext::load)
-        };
+        let cached_program = session.try_cached_program();
 
         let cached_engine = cached_program.and_then(|program| {
             // Bytecode-cache hit: the Program carries everything the test run
@@ -251,22 +243,14 @@ impl TestArgs {
         let (engine, legacy) = if let Some(hit) = cached_engine {
             hit
         } else {
-            let mut db = build_db_from_sources(&resolved, |_| {});
+            let warmth = session.warm_prep();
+            let (reuse_plan, stdlib_interface_hit) =
+                (warmth.reuse_plan, warmth.stdlib_interface_hit);
+            let db = &session.db;
+            let cache = &session.cache;
             let project = db
                 .get_project()
                 .ok_or_else(|| anyhow!("No project context"))?;
-
-            // Seed the stdlib typed interface before the first typecheck query
-            // (gated off under verify so the oracle exercises the honest path) and
-            // prepare the per-file reuse plan — the same warm-database setup `run`
-            // and `check` run.
-            let (reuse_plan, stdlib_interface_hit) = match &cache {
-                Some(ctx) => {
-                    let prep = ctx.prepare_warm_db(&mut db);
-                    (prep.reuse_plan, prep.stdlib_interface_hit)
-                }
-                None => (None, false),
-            };
 
             // ── 2. Diagnostics ─────────────────────────────────────────────
             // Keep `baml test` quiet during the compile phase. `baml check`
@@ -275,11 +259,11 @@ impl TestArgs {
             // plan's dirty files, serve clean files from their cached blobs, and
             // carry the fresh per-file blobs into the manifest); without one,
             // run the honest full check. The merged set is byte-identical.
-            let (diagnostics, fresh_diagnostics) = if let Some(ctx) = &cache {
-                let incremental = ctx.collect_diagnostics_incremental(&db, reuse_plan.as_ref());
+            let (diagnostics, fresh_diagnostics) = if let Some(ctx) = cache {
+                let incremental = ctx.collect_diagnostics_incremental(db, reuse_plan.as_ref());
                 (incremental.merged, Some(incremental.fresh_by_file))
             } else {
-                (baml_project::collect_diagnostics(&db), None)
+                (baml_project::collect_diagnostics(db), None)
             };
             let errors: Vec<_> = diagnostics
                 .iter()
@@ -291,37 +275,37 @@ impl TestArgs {
                 // run/pack errors instead of a bullet list of messages. Sources
                 // and paths cover every user file plus builtins — an error in one
                 // file may carry related spans elsewhere.
-                let rendered = crate::check_command::render_project_diagnostics(&db, &errors);
+                let rendered = crate::check_command::render_project_diagnostics(db, &errors);
                 reporter.abandon();
                 eprintln!("{rendered}");
                 return Ok(crate::ExitCode::Other);
             }
 
             // ── 3. Discover legacy tests from HIR ──────────────────────────
-            let legacy = discover_legacy_tests(&db, project);
+            let legacy = discover_legacy_tests(db, project);
 
             // ── 4. Compile + engine + runtime ──────────────────────────────
             let compile_options = baml_compiler2_emit::CompileOptions {
                 emit_test_cases: true,
             };
             let compiled = crate::bytecode_cache::compile_program_artifacts(
-                &db,
+                db,
                 &compile_options,
                 cache.as_ref(),
                 reuse_plan.as_ref(),
             )
             .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
-            if let Some(ctx) = &cache {
+            if let Some(ctx) = cache {
                 let fresh = fresh_diagnostics
                     .as_ref()
                     .expect("a cache is present, so fresh diagnostics were computed");
                 ctx.verify_and_store(
-                    &db,
+                    db,
                     &compiled,
                     fresh,
                     reuse_plan.as_ref(),
                     stdlib_interface_hit,
-                    || build_db_from_sources(&resolved, |_| {}),
+                    || session.honest_db(),
                 )?;
             }
             // Warm-run evidence: with the stdlib interface seeded this is 0 (the
@@ -413,7 +397,7 @@ impl TestArgs {
             // with no filters the display list above already IS the unfiltered
             // list, so no extra VM call. Written only from an error-free
             // discovery (never-save-on-error).
-            if let Some(ctx) = &cache {
+            if let Some(ctx) = &session.cache {
                 let all_leaf_names = if self.include.is_empty() && self.exclude.is_empty() {
                     testset_names.clone()
                 } else {

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -192,6 +192,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
         file_id,
         file,
         pkg_items,
+        &pkg_info.package,
         &pkg_info.namespace_path,
         source_text,
     ));
@@ -1242,10 +1243,35 @@ fn check_jinja_templates(
     file_id: FileId,
     file: SourceFile,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
+    package: &Name,
     namespace_path: &[Name],
     source_text: &str,
 ) -> Vec<Diagnostic> {
-    let base_types = build_jinja_types(db, pkg_items, namespace_path);
+    // Files with no LLM prompts and no template_string bodies have nothing to
+    // validate. Return before touching the package-wide Jinja environment so
+    // such files never pay for (or depend on) it at all.
+    let has_prompts = baml_compiler2_ppir::item_data::file_functions(db, file)
+        .iter()
+        .any(|&func_loc| {
+            baml_compiler2_ppir::item_data::function_llm_prompt(db, func_loc).is_some()
+        });
+    let has_templates = baml_compiler2_ppir::item_data::file_template_strings(db, file)
+        .iter()
+        .any(|&template_loc| {
+            baml_compiler2_ppir::item_data::template_string_data(db, template_loc)
+                .body
+                .is_some()
+        });
+    if !has_prompts && !has_templates {
+        return Vec::new();
+    }
+
+    let ns_id = baml_compiler2_hir::namespace::NamespaceId::new(
+        db,
+        package.clone(),
+        namespace_path.to_vec(),
+    );
+    let base_types = jinja_base_types(db, ns_id);
     let mut diagnostics = Vec::new();
 
     for &func_loc in baml_compiler2_ppir::item_data::file_functions(db, file) {
@@ -1255,7 +1281,7 @@ fn check_jinja_templates(
             func_loc,
             pkg_items,
             namespace_path,
-            &base_types,
+            base_types,
             source_text,
         ));
     }
@@ -1325,6 +1351,31 @@ fn check_llm_prompt_template(
         &prompt.text,
         sys_jinja_types::validate_template(func_data.name.as_str(), &prompt.text, &mut types),
     )
+}
+
+/// Package-wide Jinja type environment (classes, enums, aliases, and
+/// `template_strings` visible from a namespace), memoized per
+/// (package, namespace path).
+///
+/// `build_jinja_types` walks every type in the package, so before this was a
+/// Salsa query it re-ran O(package items) work once per checked file — the
+/// dominant quadratic term in whole-project checks (and it ran a second time
+/// per file inside `get_bytecode`'s error gate). As a tracked function the
+/// walk runs once per (package, namespace, revision) and every later
+/// `check_file` in the same revision gets a memo hit; `PredefinedTypes`'s
+/// `PartialEq` gives Salsa backdating, so edits that leave the environment
+/// unchanged don't invalidate downstream prompt checks.
+#[salsa::tracked(returns(ref))]
+fn jinja_base_types<'db>(
+    db: &'db dyn Db,
+    ns_id: baml_compiler2_hir::namespace::NamespaceId<'db>,
+) -> sys_jinja_types::PredefinedTypes {
+    let pkg_id = baml_compiler2_hir::package::PackageId::new(db, ns_id.package(db));
+    // Match the call-site environment exactly: `check_file` resolves items via
+    // `package_resolution_context(...).own_items`, which is ppir's
+    // `package_items` — use the same query here so the env is identical.
+    let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
+    build_jinja_types(db, pkg_items, &ns_id.path(db))
 }
 
 fn build_jinja_types(

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -163,9 +163,26 @@ pub fn collect_compiler2_diagnostics_narrowed(
     precomputed: Vec<Diagnostic>,
 ) -> NarrowedDiagnostics {
     let source_files = baml_compiler2_hir::compiler2_all_files(db);
+    // Filter up front (outside any parallel region): `should_check` is a plain
+    // `&dyn Fn`, so it never has to be thread-safe.
+    let checked: Vec<SourceFile> = source_files
+        .iter()
+        .copied()
+        .filter(|file| should_check(*file))
+        .collect();
     let mut fresh: Vec<Diagnostic> = Vec::new();
-    for file in &source_files {
-        if should_check(*file) {
+    // Same parallel-by-default policy as [`collect_compiler2_diagnostics`]. On
+    // a cold check `should_check` is all-true and `checked` is the whole
+    // project, so a serial loop here would leave every core but one idle; on a
+    // warm incremental check the dirty set is small and stays on the serial
+    // arm. Cross-file collection order is not part of the contract: `merged`
+    // gets the total-order sort below, and `fresh` consumers group by owner
+    // file (per-file order is preserved — each file's diagnostics come from
+    // one `lsp2_check_file` call, appended contiguously).
+    if checked.len() > 8 {
+        collect_file_diagnostics_parallel(db, &checked, &mut fresh);
+    } else {
+        for file in &checked {
             fresh.extend(lsp2_check_file(db, *file));
         }
     }
@@ -174,6 +191,15 @@ pub fn collect_compiler2_diagnostics_narrowed(
     merged.extend(package_level_diagnostics(db, &source_files));
     sort_diagnostics(&mut merged);
     NarrowedDiagnostics { merged, fresh }
+}
+
+/// Public wrapper over [`package_level_diagnostics`] for callers that assemble
+/// per-file diagnostics themselves (the LSP's candidate builder): these
+/// cross-file diagnostics come from `package_items`, not `check_file`, so a
+/// per-file sweep alone silently misses them.
+pub fn collect_package_level_diagnostics(db: &ProjectDatabase) -> Vec<Diagnostic> {
+    let source_files = baml_compiler2_hir::compiler2_all_files(db);
+    package_level_diagnostics(db, &source_files)
 }
 
 /// Package-level diagnostics (cross-file name conflicts and namespace shadows),

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -102,7 +102,12 @@ fn collect_file_diagnostics_parallel(
 /// thread count. Priming the per-file indexes first keeps all workers busy
 /// on file-local work; the aggregate fold itself is then cheap for whichever
 /// worker claims it.
-fn prime_file_indexes_parallel(db: &ProjectDatabase) {
+///
+/// Public because warm cache paths (the serve-time throws gate, package-level
+/// diagnostics on a no-op check) demand the same aggregates outside any
+/// per-file check fan-out. Priming twice is harmless — the second wave is all
+/// memo hits.
+pub fn prime_file_indexes_parallel(db: &ProjectDatabase) {
     const CHUNK: usize = 4;
     let all_files = baml_compiler2_hir::compiler2_all_files(db);
     let chunks: Vec<&[SourceFile]> = all_files.chunks(CHUNK).collect();
@@ -194,6 +199,12 @@ pub fn collect_compiler2_diagnostics_narrowed(
     precomputed: Vec<Diagnostic>,
 ) -> NarrowedDiagnostics {
     let source_files = baml_compiler2_hir::compiler2_all_files(db);
+    // Even a fully-served (zero-checked-files) collection ends in
+    // `package_level_diagnostics`, which derives the whole-package aggregates
+    // — prime the per-file indexes across workers so that derivation is a
+    // parallel-fed fold, not a serial parse of the project. When the caller
+    // already primed (cache gate, cold fan-out) this is all memo hits.
+    prime_file_indexes_parallel(db);
     // Filter up front (outside any parallel region): `should_check` is a plain
     // `&dyn Fn`, so it never has to be thread-safe.
     let checked: Vec<SourceFile> = source_files

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -193,7 +193,7 @@ pub fn collect_compiler2_diagnostics_narrowed(
     NarrowedDiagnostics { merged, fresh }
 }
 
-/// Public wrapper over [`package_level_diagnostics`] for callers that assemble
+/// Public wrapper over the private `package_level_diagnostics` for callers that assemble
 /// per-file diagnostics themselves (the LSP's candidate builder): these
 /// cross-file diagnostics come from `package_items`, not `check_file`, so a
 /// per-file sweep alone silently misses them.

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -79,59 +79,90 @@ pub fn collect_compiler2_diagnostics(db: &ProjectDatabase) -> Vec<Diagnostic> {
 
 /// Run `check_file` for every file across worker threads.
 ///
-/// Every query `check_file` reaches is read-only, and `ProjectDatabase`'s
-/// `Clone` produces a shared-storage salsa handle (the rust-analyzer
-/// concurrency model): workers share one memo table, so a scope inferred by
-/// one thread is a cache hit for every other. Output order does not matter —
-/// the caller sorts diagnostics by (file, span, message) — so workers just
-/// pull the next file off a shared atomic counter (files vary a lot in size;
-/// work-stealing beats fixed chunks).
-///
-/// The first file is checked serially before fanning out: it warms the
-/// package-level queries (package items / resolution context / alias maps)
-/// that every file reads, so cold workers don't all block on the same shared
-/// memo slots.
+/// Output order does not matter — the caller sorts diagnostics by
+/// (file, span, message).
 fn collect_file_diagnostics_parallel(
     db: &ProjectDatabase,
     source_files: &[SourceFile],
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    // `ProjectDatabase` is `Send` but deliberately not `Sync` (each salsa
-    // handle carries thread-confined query-stack state), so tasks cannot share
-    // `&db` — every task MOVES its own cloned shared-storage handle instead
-    // (an Arc bump; all clones share one memo table). Small chunks keep
-    // work-stealing effective on rayon's global pool — files vary a lot in
-    // check cost — while amortizing the per-task clone.
+    for file_diagnostics in check_files_parallel(db, source_files) {
+        diagnostics.extend(file_diagnostics);
+    }
+}
+
+/// Prime every compiler2 file's PPIR semantic index across worker threads.
+///
+/// Whole-package aggregate queries (`package_items` / `namespace_items`)
+/// fold over **every** file's semantic index, and every file's check demands
+/// them. On a cold database, the first worker to claim such an aggregate
+/// memo computes parse + lowering + indexing for the entire project inline
+/// on its own thread while every other worker parks on that memo's sync
+/// slot — the whole compile degenerates to ~1 effective core regardless of
+/// thread count. Priming the per-file indexes first keeps all workers busy
+/// on file-local work; the aggregate fold itself is then cheap for whichever
+/// worker claims it.
+fn prime_file_indexes_parallel(db: &ProjectDatabase) {
+    const CHUNK: usize = 4;
+    let all_files = baml_compiler2_hir::compiler2_all_files(db);
+    let chunks: Vec<&[SourceFile]> = all_files.chunks(CHUNK).collect();
+    let handles: Vec<ProjectDatabase> = chunks.iter().map(|_| db.clone()).collect();
+    rayon::scope(move |s| {
+        for (chunk, db) in chunks.into_iter().zip(handles) {
+            s.spawn(move |_| {
+                for file in chunk {
+                    let _ = baml_compiler2_ppir::file_semantic_index(&db, *file);
+                }
+            });
+        }
+    });
+}
+
+/// Check `files` across worker threads, returning each file's diagnostics in
+/// input order (so callers that group per file — the LSP's diagnostics
+/// candidate — can zip results back to their inputs).
+///
+/// Every query `check_file` reaches is read-only, and `ProjectDatabase`'s
+/// `Clone` produces a shared-storage salsa handle (the rust-analyzer
+/// concurrency model): workers share one memo table, so a scope inferred by
+/// one thread is a cache hit for every other. `ProjectDatabase` is `Send`
+/// but deliberately not `Sync` (each salsa handle carries thread-confined
+/// query-stack state), so tasks cannot share `&db` — every task MOVES its
+/// own cloned handle instead (an Arc bump; all clones share one memo table).
+/// Small chunks keep work-stealing effective on rayon's global pool — files
+/// vary a lot in check cost — while amortizing the per-task clone.
+pub fn check_files_parallel(db: &ProjectDatabase, files: &[SourceFile]) -> Vec<Vec<Diagnostic>> {
     const CHUNK: usize = 4;
 
-    let Some((first, rest)) = source_files.split_first() else {
-        return;
-    };
-    diagnostics.extend(lsp2_check_file(db, *first));
+    prime_file_indexes_parallel(db);
 
-    let chunks: Vec<&[SourceFile]> = rest.chunks(CHUNK).collect();
+    let chunks: Vec<(usize, &[SourceFile])> = files.chunks(CHUNK).enumerate().collect();
     // Handles are cloned OUTSIDE the rayon scope: a `!Sync` database can't be
     // borrowed by the (Send) scope closure, so each chunk's handle is created
     // up front and MOVED into its task.
     let handles: Vec<ProjectDatabase> = chunks.iter().map(|_| db.clone()).collect();
-    let (tx, rx) = std::sync::mpsc::channel::<Vec<Diagnostic>>();
+    let (tx, rx) = std::sync::mpsc::channel::<(usize, Vec<Vec<Diagnostic>>)>();
     rayon::scope(move |s| {
-        for (chunk, db) in chunks.into_iter().zip(handles) {
+        for ((chunk_index, chunk), db) in chunks.into_iter().zip(handles) {
             let tx = tx.clone();
             s.spawn(move |_| {
-                let mut out = Vec::new();
-                for file in chunk {
-                    out.extend(lsp2_check_file(&db, *file));
-                }
+                let out: Vec<Vec<Diagnostic>> = chunk
+                    .iter()
+                    .map(|file| lsp2_check_file(&db, *file))
+                    .collect();
                 // Receiver outlives the scope; a send only fails if it
                 // dropped early, which would mean a panic elsewhere.
-                let _ = tx.send(out);
+                let _ = tx.send((chunk_index, out));
             });
         }
     });
-    for out in rx {
-        diagnostics.extend(out);
+    let mut slots: Vec<Option<Vec<Diagnostic>>> = (0..files.len()).map(|_| None).collect();
+    for (chunk_index, out) in rx {
+        for (offset, file_diagnostics) in out.into_iter().enumerate() {
+            slots[chunk_index * CHUNK + offset] = Some(file_diagnostics);
+        }
     }
+    slots.into_iter().map(Option::unwrap_or_default).collect()
 }
 
 /// The per-checked-file split alongside the merged, honest-ordered set produced

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -450,6 +450,44 @@ impl ProjectDatabase {
         }
     }
 
+    /// Bulk [`Self::add_or_update_file`]: identical per-file semantics
+    /// (canonicalization, tombstone revival, map registration), but the
+    /// project file list is written once at the end instead of once per new
+    /// file. The per-file path clones and re-sets the whole `files` Vec and
+    /// bumps the salsa revision each time — O(files²) copies plus one
+    /// revision per file during initial project load.
+    pub fn add_or_update_files<'a, I>(&mut self, files: I)
+    where
+        I: IntoIterator<Item = (&'a std::path::Path, &'a str)>,
+    {
+        let mut new_files = Vec::new();
+        for (path, content) in files {
+            let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+
+            if let Some(&existing_file) = self.file_map.get(&canonical_path) {
+                existing_file.set_text(self).to(content.to_string());
+                continue;
+            }
+            let file = if let Some(file) = self.removed_file_tombstones.remove(&canonical_path) {
+                file.set_text(self).to(content.to_string());
+                file
+            } else {
+                self.add_file_internal(&canonical_path, content)
+            };
+            let file_id = file.file_id(self);
+            Arc::make_mut(&mut self.file_map).insert(canonical_path.clone(), file);
+            Arc::make_mut(&mut self.file_id_to_path).insert(file_id, canonical_path);
+            new_files.push(file);
+        }
+        if !new_files.is_empty()
+            && let Some(project) = self.project
+        {
+            let mut project_files: Vec<SourceFile> = project.files(self).clone();
+            project_files.extend(new_files);
+            project.set_files(self).to(project_files);
+        }
+    }
+
     /// Remove a file from the database.
     ///
     /// Note: Salsa doesn't support true removal. The input is emptied (so its

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -160,11 +160,18 @@ pub struct ProjectDatabase {
     /// long-lived `ProjectDatabase`).
     seeded_callable_throws: Option<baml_workspace::SeededCallableThrows>,
     /// Maps file paths to their `SourceFile` handles (user files only).
-    file_map: HashMap<std::path::PathBuf, SourceFile>,
+    ///
+    /// `Arc`-wrapped (with `Arc::make_mut` at the mutation sites) so cloning a
+    /// database handle stays O(1): the parallel check and emit drivers mint a
+    /// shared-storage handle per work chunk, and a deep per-clone copy of an
+    /// N-entry `PathBuf` map made every clone O(files) — quadratic CPU and
+    /// peak RSS across a whole compile.
+    file_map: Arc<HashMap<std::path::PathBuf, SourceFile>>,
     /// Maps file paths to compiler2-only `SourceFile` handles.
     compiler2_file_map: HashMap<std::path::PathBuf, SourceFile>,
-    /// Maps `FileId` to file path for reverse lookup (all files including v2 stubs).
-    file_id_to_path: HashMap<FileId, std::path::PathBuf>,
+    /// Maps `FileId` to file path for reverse lookup (all files including v2
+    /// stubs). `Arc`-wrapped for the same reason as `file_map`.
+    file_id_to_path: Arc<HashMap<FileId, std::path::PathBuf>>,
     /// `SourceFile` inputs of removed paths. Salsa never frees inputs, so a
     /// delete/recreate cycle (branch switch, codegen rewriting `.baml`
     /// files) would mint a new immortal input per cycle; instead the input
@@ -292,9 +299,9 @@ impl ProjectDatabase {
             seeded_throw_facts: None,
             seeded_stdlib_interface: None,
             seeded_callable_throws: None,
-            file_map: HashMap::new(),
+            file_map: Arc::new(HashMap::new()),
             compiler2_file_map: HashMap::new(),
-            file_id_to_path: HashMap::new(),
+            file_id_to_path: Arc::new(HashMap::new()),
             removed_file_tombstones: HashMap::new(),
         };
         db.seeded_throw_facts = Some(baml_workspace::SeededThrowFacts::new(
@@ -429,8 +436,8 @@ impl ProjectDatabase {
             };
             let file_id = file.file_id(self);
 
-            self.file_map.insert(canonical_path.clone(), file);
-            self.file_id_to_path.insert(file_id, canonical_path);
+            Arc::make_mut(&mut self.file_map).insert(canonical_path.clone(), file);
+            Arc::make_mut(&mut self.file_id_to_path).insert(file_id, canonical_path);
 
             // Update project files list if project is set
             if let Some(project) = self.project {
@@ -452,9 +459,9 @@ impl ProjectDatabase {
     pub fn remove_file(&mut self, path: &std::path::Path) {
         let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
-        if let Some(file) = self.file_map.remove(&canonical_path) {
+        if let Some(file) = Arc::make_mut(&mut self.file_map).remove(&canonical_path) {
             let file_id = file.file_id(self);
-            self.file_id_to_path.remove(&file_id);
+            Arc::make_mut(&mut self.file_id_to_path).remove(&file_id);
 
             // Remove from project files list
             if let Some(project) = self.project {
@@ -520,7 +527,7 @@ impl ProjectDatabase {
             let file = self.add_file_internal(&path, builtin.contents);
             let file_id = file.file_id(self);
 
-            self.file_id_to_path.insert(file_id, path.clone());
+            Arc::make_mut(&mut self.file_id_to_path).insert(file_id, path.clone());
             self.compiler2_file_map.insert(path, file);
 
             v2_builtin_files.push(file);
@@ -586,6 +593,20 @@ impl ProjectDatabase {
         if error_count > 0 {
             return Err(baml_compiler2_emit::LoweringError::ProjectHasErrors { error_count });
         }
+        self.get_bytecode_unchecked()
+    }
+
+    /// [`Self::get_bytecode`] without the error gate: goes straight to codegen.
+    ///
+    /// Only for callers that have already run a full-project check (per-file
+    /// `check_file` sweep **plus** package-level diagnostics) at the current
+    /// revision and found no user-file errors — the gate in `get_bytecode`
+    /// would re-derive exactly that result. Calling this on an error-bearing
+    /// project can panic in the runtime-conversion boundary (see the gate
+    /// comment above).
+    pub fn get_bytecode_unchecked(
+        &self,
+    ) -> Result<bex_vm_types::Program, baml_compiler2_emit::LoweringError> {
         let opts = baml_compiler2_emit::CompileOptions {
             emit_test_cases: false,
         };
@@ -1215,7 +1236,7 @@ impl ProjectDatabase {
             return Some(sf);
         }
         // Fallback: match by file name suffix (handles Monaco's relative paths)
-        for (stored_path, sf) in &self.file_map {
+        for (stored_path, sf) in self.file_map.iter() {
             if stored_path.ends_with(file_path)
                 || file_path.ends_with(stored_path.to_string_lossy().as_ref())
             {

--- a/baml_language/crates/baml_project/src/lib.rs
+++ b/baml_language/crates/baml_project/src/lib.rs
@@ -32,7 +32,7 @@ pub mod symbols;
 pub mod testing;
 
 pub use check::{
-    CheckResult, NarrowedDiagnostics, collect_compiler2_diagnostics,
+    CheckResult, NarrowedDiagnostics, check_files_parallel, collect_compiler2_diagnostics,
     collect_compiler2_diagnostics_narrowed, collect_diagnostics, collect_package_level_diagnostics,
 };
 pub use client_codegen::build_symbol_pool;

--- a/baml_language/crates/baml_project/src/lib.rs
+++ b/baml_language/crates/baml_project/src/lib.rs
@@ -34,6 +34,7 @@ pub mod testing;
 pub use check::{
     CheckResult, NarrowedDiagnostics, check_files_parallel, collect_compiler2_diagnostics,
     collect_compiler2_diagnostics_narrowed, collect_diagnostics, collect_package_level_diagnostics,
+    prime_file_indexes_parallel,
 };
 pub use client_codegen::build_symbol_pool;
 pub use db::{CursorContext, EventCallback, ProjectDatabase};

--- a/baml_language/crates/baml_project/src/lib.rs
+++ b/baml_language/crates/baml_project/src/lib.rs
@@ -33,7 +33,7 @@ pub mod testing;
 
 pub use check::{
     CheckResult, NarrowedDiagnostics, collect_compiler2_diagnostics,
-    collect_compiler2_diagnostics_narrowed, collect_diagnostics,
+    collect_compiler2_diagnostics_narrowed, collect_diagnostics, collect_package_level_diagnostics,
 };
 pub use client_codegen::build_symbol_pool;
 pub use db::{CursorContext, EventCallback, ProjectDatabase};

--- a/baml_language/crates/bex_cache/Cargo.toml
+++ b/baml_language/crates/bex_cache/Cargo.toml
@@ -30,6 +30,16 @@ bex_vm_types = { workspace = true }
 borsh = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking" ] }
 rustls = { workspace = true, optional = true }
+
+# The warm bytecode-cache path hashes every cached unit payload per run
+# (~230MB at a 295k LOC project), so enable sha2's hardware backend (`asm`:
+# SHA-NI / ARMv8 crypto extensions, runtime-detected) wherever it builds.
+# MSVC is the exception: sha2-asm ships GAS `.S` sources that cl.exe cannot
+# assemble, so MSVC targets keep the portable implementation.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+sha2 = { workspace = true, features = [ "asm" ] }
+
+[target.'cfg(target_env = "msvc")'.dependencies]
 sha2 = { workspace = true }
 
 [dev-dependencies]

--- a/baml_language/crates/bex_cache/src/lib.rs
+++ b/baml_language/crates/bex_cache/src/lib.rs
@@ -219,6 +219,13 @@ pub struct ManifestFile {
     /// interface blob. Because the manifest is written only after a passing
     /// error gate, a clean file's blob holds warnings / info only.
     pub diagnostics: Vec<u8>,
+    /// Opaque borsh blob of this file's `CallableThrowsFragment` — a verbatim
+    /// copy of the same bytes stored in the file's [`CompilationUnit`]. Kept
+    /// in the manifest so the warm path can seed per-function
+    /// `callable_throws` without reading any unit payloads (the units are
+    /// only needed when bytecode is actually relinked). Empty when the file
+    /// contributes no fragment.
+    pub callable_throws_fragment: Vec<u8>,
     /// Content-addressed cache key of this file's serialized [`CompilationUnit`];
     /// the manifest is the sole mutable pointer table for the immutable per-file
     /// unit entries.
@@ -256,8 +263,14 @@ pub fn manifest_key(
 /// The manifest owns reuse policy and points to the exact value produced by the
 /// last successful compile.
 pub fn unit_key(payload: &[u8]) -> CacheKey {
+    unit_key_from_digest(&Sha256::digest(payload).into())
+}
+
+/// [`unit_key`] from an already-computed payload digest (the same digest
+/// entry validation produces), skipping the payload hash.
+fn unit_key_from_digest(digest: &[u8; 32]) -> CacheKey {
     let mut h = keyed_hasher(b"unit");
-    h.update(Sha256::digest(payload));
+    h.update(digest);
     CacheKey(h.finalize().into())
 }
 
@@ -473,12 +486,36 @@ impl BytecodeCache {
         Some(payload.to_vec())
     }
 
+    /// Local/remote read-through for a raw content-addressed entry, also
+    /// returning the payload's integrity digest (already computed by entry
+    /// validation) so content-key checks derived from that digest need not
+    /// re-hash the payload.
+    fn load_raw_shared_with_digest(&self, key: &CacheKey) -> Option<(Vec<u8>, [u8; 32])> {
+        let path = self.entry_path(key);
+        if let Ok(data) = fs::read(&path)
+            && let Some((payload, digest)) = check_entry_with_digest(&data, key)
+        {
+            freshen_entry(&path);
+            return Some((payload.to_vec(), digest));
+        }
+        let remote = self.remote.as_ref()?;
+        let entry = remote.get(key)?;
+        let (payload, digest) = check_entry_with_digest(&entry, key)?;
+        let payload = payload.to_vec();
+        self.persist_from_remote(key, &entry);
+        Some((payload, digest))
+    }
+
     /// Load one content-addressed unit through the local/remote read-through
     /// path. Both the entry framing and the unit key's payload hash must agree;
     /// any mismatch is a cache miss.
     pub fn load_unit_shared(&self, key: &CacheKey) -> Option<CompilationUnit> {
-        let payload = self.load_raw_shared(key)?;
-        if unit_key(&payload) != *key {
+        // `check_entry` already verified the header's key echo and the payload
+        // integrity digest, and `unit_key` is derived from that same digest —
+        // so the content-key check here reuses the digest instead of hashing
+        // the (potentially large) payload a second time.
+        let (payload, digest) = self.load_raw_shared_with_digest(key)?;
+        if unit_key_from_digest(&digest) != *key {
             let _ = fs::remove_file(self.entry_path(key));
             return None;
         }
@@ -499,11 +536,9 @@ impl BytecodeCache {
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
         let key = unit_key(&payload);
         // load_raw already returns only a checksum-valid entry whose key echo
-        // matches, so a content-key match is a sufficient "already stored" signal.
-        if self
-            .load_raw(&key)
-            .is_some_and(|stored| unit_key(&stored) == key)
-        {
+        // matches, so byte equality with the new payload is a sufficient
+        // "already stored" signal — no need to hash the stored bytes again.
+        if self.load_raw(&key).is_some_and(|stored| stored == payload) {
             return Ok((key, false));
         }
         self.store_raw_shared(&key, &payload)?;
@@ -595,6 +630,13 @@ impl BytecodeCache {
 
 /// Validate an entry's header against `key`; return the payload slice.
 fn check_entry<'a>(data: &'a [u8], key: &CacheKey) -> Option<&'a [u8]> {
+    check_entry_with_digest(data, key).map(|(payload, _)| payload)
+}
+
+/// [`check_entry`] that also hands back the payload digest it computed, so
+/// callers whose content keys derive from that digest (see [`unit_key`]) can
+/// avoid a second full pass over the payload.
+fn check_entry_with_digest<'a>(data: &'a [u8], key: &CacheKey) -> Option<(&'a [u8], [u8; 32])> {
     if data.len() < HEADER_LEN || data[..4] != MAGIC {
         return None;
     }
@@ -611,7 +653,7 @@ fn check_entry<'a>(data: &'a [u8], key: &CacheKey) -> Option<&'a [u8]> {
     if digest != data[48..80] {
         return None;
     }
-    Some(payload)
+    Some((payload, digest))
 }
 
 /// Write via temp file + atomic rename: readers never observe a torn entry,
@@ -1164,19 +1206,6 @@ impl BytecodeCache {
         let program = borsh::from_slice::<Program>(payload).ok()?;
         self.persist_from_remote(key, &entry);
         Some(program)
-    }
-
-    /// Raw-payload counterpart to [`Self::load_shared`] for immutable
-    /// non-`Program` entries such as content-addressed compilation units.
-    pub fn load_raw_shared(&self, key: &CacheKey) -> Option<Vec<u8>> {
-        if let Some(payload) = self.load_raw(key) {
-            return Some(payload);
-        }
-        let remote = self.remote.as_ref()?;
-        let entry = remote.get(key)?;
-        let payload = check_entry(&entry, key)?.to_vec();
-        self.persist_from_remote(key, &entry);
-        Some(payload)
     }
 
     /// Like [`Self::store`], but also publishes the entry to the remote

--- a/baml_language/crates/bex_project/src/project.rs
+++ b/baml_language/crates/bex_project/src/project.rs
@@ -224,7 +224,12 @@ pub(crate) fn collect_diagnostic_candidate(guard: &SourceGuard<'_>) -> Diagnosti
     let mut documents = Vec::new();
     let mut has_errors = false;
 
-    for file in &source_files {
+    // Check across worker threads (input order preserved, so per-file zip is
+    // sound). This runs under the held source guard, so no mutation can race
+    // the cloned worker handles; the guard is the same exclusion the serial
+    // loop relied on.
+    let per_file = baml_project::check_files_parallel(db, &source_files);
+    for (file, diagnostics) in source_files.iter().zip(per_file) {
         let file_id = file.file_id(db);
         let Some(path) = db.file_id_to_path(file_id).cloned() else {
             continue;
@@ -232,7 +237,6 @@ pub(crate) fn collect_diagnostic_candidate(guard: &SourceGuard<'_>) -> Diagnosti
         let text = file.text(db).clone();
         file_texts.insert(file_id, (path.clone(), text));
 
-        let diagnostics = baml_lsp2_actions::check_file(db, *file);
         has_errors |= diagnostics
             .iter()
             .any(|d| d.severity == baml_compiler_diagnostics::Severity::Error);

--- a/baml_language/crates/bex_project/src/project.rs
+++ b/baml_language/crates/bex_project/src/project.rs
@@ -243,6 +243,34 @@ pub(crate) fn collect_diagnostic_candidate(guard: &SourceGuard<'_>) -> Diagnosti
         });
     }
 
+    // Package-level diagnostics (cross-file name conflicts and namespace
+    // shadows) come from `package_items`, not `check_file`, so the per-file
+    // sweep above misses them: without this the candidate under-reports
+    // errors relative to `get_bytecode`'s gate, and cross-file conflicts
+    // never reach the editor at all. Bucket each onto its primary-span
+    // file's document; only user-file spans count toward `has_errors`
+    // (matching the gate's filter).
+    let package_diags = baml_project::collect_package_level_diagnostics(db);
+    if !package_diags.is_empty() {
+        let doc_index: HashMap<std::path::PathBuf, usize> = documents
+            .iter()
+            .enumerate()
+            .map(|(idx, doc)| (doc.path.clone(), idx))
+            .collect();
+        for diag in package_diags {
+            let Some(span) = diag.primary_span() else {
+                continue;
+            };
+            let Some((path, _)) = file_texts.get(&span.file_id) else {
+                continue;
+            };
+            has_errors |= diag.severity == baml_compiler_diagnostics::Severity::Error;
+            if let Some(&idx) = doc_index.get(path) {
+                documents[idx].diagnostics.push(diag);
+            }
+        }
+    }
+
     DiagnosticCandidate {
         source_revision: guard.revision(),
         file_texts,
@@ -806,7 +834,10 @@ impl BexProject {
         if diagnostics.has_errors {
             return CompilationOutcome::BlockedByDiagnostics(diagnostics);
         }
-        match guard.db().get_bytecode() {
+        // The candidate above is a full-project check (per-file sweep plus
+        // package-level diagnostics), so `get_bytecode`'s error gate would
+        // re-derive exactly what `has_errors` just proved — skip it.
+        match guard.db().get_bytecode_unchecked() {
             Ok(program) => CompilationOutcome::Ready(
                 Box::new(CompiledCandidate {
                     source_revision: guard.revision(),

--- a/baml_language/crates/bex_project/src/seed.rs
+++ b/baml_language/crates/bex_project/src/seed.rs
@@ -751,6 +751,9 @@ mod tests {
                 sig_referenced_names: Vec::new(),
                 throw_facts: Vec::new(), // poison: honest is non-empty
                 diagnostics: Vec::new(),
+                // Non-empty sentinel bytes: the manifest's verbatim fragment
+                // carry must survive the disk round-trip untouched.
+                callable_throws_fragment: vec![0xca, 0xfe, 0xf0, 0x0d],
                 unit_key: [0u8; 32], // no unit → callable_throws seed empty
             }],
         };
@@ -766,6 +769,22 @@ mod tests {
                 &borsh::to_vec(&manifest).unwrap(),
             )
             .unwrap();
+        let manifest_bytes = cache
+            .load_raw(&bex_cache::manifest_key(
+                &fingerprint,
+                super::LSP_OPT_LEVEL,
+                super::LSP_EMIT_TEST_CASES,
+                &root,
+                None,
+            ))
+            .expect("manifest reloads from disk");
+        let reloaded: bex_cache::ProjectManifest =
+            borsh::from_slice(&manifest_bytes).expect("manifest decodes");
+        assert_eq!(
+            reloaded.files[0].callable_throws_fragment,
+            vec![0xca, 0xfe, 0xf0, 0x0d],
+            "the fragment blob round-trips through disk serialization verbatim"
+        );
 
         // Load from disk: both the stdlib and per-file seeds must decode.
         let loaded = LspSeedCache::load_for_root(&root).expect("blobs must load from disk");

--- a/baml_language/crates/sys_jinja_types/src/evaluate_type/mod.rs
+++ b/baml_language/crates/sys_jinja_types/src/evaluate_type/mod.rs
@@ -15,7 +15,7 @@ use minijinja::machinery::{Span, ast::Expr};
 pub(crate) use self::stmt::get_variable_types;
 pub use self::types::{EnumDefinition, EnumValueDefinition, JinjaContext, PredefinedTypes, Type};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TypeError {
     message: String,
     span: Span,

--- a/baml_language/crates/sys_jinja_types/src/evaluate_type/types.rs
+++ b/baml_language/crates/sys_jinja_types/src/evaluate_type/types.rs
@@ -14,13 +14,13 @@ use minijinja::machinery::{
 
 use super::TypeError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EnumDefinition {
     pub name: String,
     pub values: Vec<EnumValueDefinition>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EnumValueDefinition {
     pub name: String,
     pub alias: Option<String>,
@@ -300,7 +300,7 @@ impl BitOr for Type {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 enum Scope {
     CodeBlock(IndexMap<String, Type>),
     Branch(IndexMap<String, Type>, IndexMap<String, Type>, bool),
@@ -311,7 +311,7 @@ enum Scope {
     Narrowing(IndexMap<String, Type>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PredefinedTypes {
     functions: IndexMap<String, (Type, Vec<(String, Type)>)>,
     classes: HashMap<String, IndexMap<String, Type>>,

--- a/baml_language/scripts/hawk
+++ b/baml_language/scripts/hawk
@@ -5,6 +5,38 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 workspace_root="$(dirname "$script_dir")"
 
+# Self-heal the three ways a local (pre-commit / prek) invocation differs from
+# CI, so the hook works out of the box instead of tempting a SKIP:
+#
+# 1. PATH: `cargo-hawk` is provisioned by mise, whose shims aren't on the PATH
+#    git hook subshells inherit. Resolve the exact pinned revision through
+#    mise itself (honoring MISE_DATA_DIR and the mise.toml pin) rather than
+#    trusting whatever `cargo-hawk` happens to be on PATH.
+if command -v mise >/dev/null 2>&1; then
+  hawk_bin="$(cd "$workspace_root/.." && mise which cargo-hawk 2>/dev/null || true)"
+  if [ -n "$hawk_bin" ] && [ -x "$hawk_bin" ]; then
+    PATH="$(dirname "$hawk_bin"):$PATH"
+  fi
+fi
+if ! command -v cargo-hawk >/dev/null 2>&1; then
+  echo "scripts/hawk: cargo-hawk not found — run \`mise install\` from the repo root" >&2
+  exit 1
+fi
+
+# 2. RUSTC_WRAPPER: hawk drives an instrumented check through its own rustc
+#    driver, which the baml-sccache wrapper cannot probe (and caching an
+#    instrumented build is useless anyway).
+export RUSTC_WRAPPER=""
+
+# 3. macOS: the prebuilt cargo-hawk-driver carries no rpath, so it can't find
+#    the pinned toolchain's librustc_driver on its own.
+if [ "$(uname -s)" = "Darwin" ]; then
+  sysroot="$(rustc +1.97.1 --print sysroot 2>/dev/null || true)"
+  if [ -n "$sysroot" ]; then
+    export DYLD_FALLBACK_LIBRARY_PATH="$sysroot/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+  fi
+fi
+
 # Hawk performs closed-world analysis. These crates expose supported APIs at
 # bridge, WebAssembly, cloud-fork, or signing boundaries outside the native
 # production binaries configured in hawk.toml.


### PR DESCRIPTION
Consolidated stack (supersedes #4098, #4100, #4101 — their commits are all contained here, rebased onto current canary). Seven commits, reviewable independently, in dependency order.

## What this does

A ground-up performance pass on the compiler driven by head-to-head benchmarking against tsgo (native TypeScript) and `go build` on semantically identical generated corpora (1.5k–295k LOC), followed by root-cause profiling of every gap found.

### 1. `perf(compiler2)`: kill the two cold-compile quadratics; parallelize the cache-path check
- The package-wide Jinja type environment was rebuilt inside every `check_file` call (O(N²)) — and twice per compile via `get_bytecode`'s error gate. Now a memoized salsa query (`jinja_base_types`) + skipped entirely for files with no prompts.
- `ProjectDatabase` handle clones deep-copied two N-entry PathBuf maps; the parallel drivers clone ~1.55N handles per compile (quadratic CPU + peak RSS). Now Arc-wrapped, O(1).
- `baml check`/`run` routed through a serial diagnostics collector while the parallel one sat unreachable next to it. Now shared.
- The LSP proves the project error-free once (`get_bytecode_unchecked`), and its diagnostics candidate now includes package-level diagnostics — cross-file name conflicts previously **never reached the editor at all**.

### 2. `feat(cli)`: `baml pack` uses the bytecode cache; `baml check` seeds it
Pack was fully cold on every invocation (no cache participation at all); check reused but never wrote, so check-only workflows never warmed. Now one warm cache serves check → run → test → pack.

### 3–4. `build` + `fix(ci)`: hardware SHA-2 (`sha2/asm`, gated off MSVC), doc-link fix
The warm path hashes ~hundreds of MB of unit payloads per run; it was on the software SHA fallback.

### 5. `perf(compiler2)`: prime wave, bulk project load, parallel LSP sweep
Cold parallel check scaled 1.18× on 12 cores: every file's check demands whole-package aggregates, and the first worker to claim that memo computed parse+index for the entire project inline while all other workers parked on the sync slot (diagnosed against ty/ruff's salsa usage; interventionally verified). Per-file indexes are now primed across workers before fan-out. Project load stops re-writing the file list per file (O(files²)) and reads sources in parallel (FileId order preserved). The LSP candidate uses the shared order-preserving parallel checker.

### 6. `perf(cache)`: warm no-op checks stop re-proving the cache
A warm no-op check cost the same as a full recompute: the throws-gate safety compare re-parsed every file, and seeding read+hashed 78MB of unit payloads for metadata. Now: the gate is skipped when the dirty partition is provably empty (a value compared against itself), throws fragments live verbatim in the manifest so a no-op check opens **zero** unit payloads, and units load in parallel (manifest order preserved) only when a delta means relink will need them. Both verify oracles (`BAML_CACHE_VERIFY` full compare + always-on 1-in-32 sampled re-derive) now check the manifest copy — exactly what is served. Design was adversarially reviewed; the unsound variant (fact-space throws compare) was rejected and every real edit still takes the full runtime-space gate.

### 7. `refactor(cli)`: one shared `ProjectSession` for every project-loading command
check/run/test/pack/describe/grep/generate each hand-rolled a drifting subset of the same preamble — the root cause of "pack forgot the cache" and "describe never primes." One implementation; commands declare `CacheUse::{ReadWrite, ReadWriteTests, ReadOnly, Off}`. Introspection installs seeds only on a no-delta plan (provable tautology) and derives honestly otherwise.

## Measured impact (Apple Silicon, 12 cores, hyperfine)

| | before | after |
|---|--:|--:|
| cold check, 295k LOC | 21–46 s (126 s CPU, 5.3 GB RSS) | **6.6 s** (~13 s CPU, 2.7 GB) |
| cold check, 59k LOC | 3.3 s | **1.24 s** |
| warm no-op check, 295k / 59k | 7.2 s / 3.2 s | **2.0–2.6 s / 0.4–0.6 s** |
| `run` after check (59k / 295k) | full compile | **0.12 s / 0.65 s** (cache hit) |
| `pack` after check (59k / 295k) | 1.7 s / 40.5 s (always cold) | **0.19 s / 0.87 s** (cache hit) |
| LSP edit→diagnostics (250/500/1000 files) | 0.46 / 1.7 / 5.5 s | **179 / 192 / 216 ms** (flat) |
| `describe`, 295k / 59k LOC | 6.3 s / 716 ms | **2.6 s / 402 ms** |

Cold compile scaling is now ~linear in project size (was quadratic: 5× code cost 33× CPU), verified to 8000 modules.

## Verification

- Diagnostics byte-identical to the pre-change binary (error-heavy corpus, cold + warm) at each stage.
- Cache soundness: `BAML_CACHE_VERIFY=1` honest-recompile compare (no-op + after-edit) and forced `BAML_CACHE_SAMPLED_VERIFY=1` across edit sequences — all pass; 43 bytecode-cache oracle tests updated and green.
- LSP load-tested: 50-edit multi-file burst storms + sustained ~17 edits/s churn at 250/1000 files — zero crashes, stable RSS, convergence after every storm.
- Full stack green in CI (doc, Windows incl. MSVC sha2 gating, size gate, all SDK matrices).

## Deliberate trade-offs

- Cold `check` at mid-size projects (~15–30k LOC) is ~10% slower than before: it now emits + stores once to warm the cache; every later check/run/pack is served warm.
- A warm *edit* check re-emits and stores (that is what buys the instant run/pack); at 295k LOC the edit path remains ~6–9 s — the known remaining floor, tracked separately.
- A unit file deleted out from under a warm cache is not detected on a no-op run; the next compile that needs it falls back to a byte-identical full compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4oee6wrCHzXH6mM2h8eJo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands now share a consistent, cache-aware project session workflow, including lenient read-only sessions for inspection when configuration is missing.
* **Performance**
  * Faster project loading and diagnostics checking via parallel per-file processing.
  * Improved bytecode-cache reuse by avoiding unnecessary payload hashing/loading, including a fast “no-delta” warm path.
* **Bug Fixes**
  * Fixed callable-throws fragment seeding and verification for warm “no-delta” runs.
  * Improved package-level diagnostics handling during compilation and error-gating behavior.
* **Chores**
  * Improved build robustness for cryptography acceleration on MSVC targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->