### PR TITLE
fix: teach baml fmt to normalize => to ->, enum ; to ,

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -14845,9 +14845,10 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     /// Infer/check a lambda body using a save/restore approach.
     ///
-    /// Saves the current locals, `declared_return_ty`, `generic_params`, and
-    /// `expressions` (to avoid `ExprId` collisions between the lambda's arena
-    /// and the parent's arena). After inference, restores all saved state; the
+    /// Saves the current locals, `declared_return_ty`, `generic_params`,
+    /// `implements_block_interface`, and `expressions` (to avoid `ExprId`
+    /// collisions between the lambda's arena and the parent's arena). After
+    /// inference, restores all saved state; the
     /// lambda's own inference tables are *moved* into `nested_lambda_inference`
     /// keyed by the lambda's `FileScopeId`, so the standalone
     /// `ScopeKind::Lambda` query can project them instead of re-inferring the
@@ -14896,6 +14897,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         let saved_scoped_local_assignments = std::mem::take(&mut self.scoped_local_assignments);
         let saved_return_ty = self.declared_return_ty.clone();
         let saved_generic_params = self.generic_params.clone();
+        // BEP-044: `default` is scoped to the method body and must not be
+        // captured across a closure boundary.
+        let saved_implements_block_interface = self.implements_block_interface.take();
         let saved_expressions = std::mem::take(&mut self.expressions);
         let saved_bindings = std::mem::take(&mut self.pattern_types);
         let saved_pattern_natural_cache = std::mem::take(&mut self.pattern_natural_cache);
@@ -15153,6 +15157,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.scoped_local_assignments = saved_scoped_local_assignments;
         self.declared_return_ty = saved_return_ty;
         self.generic_params = saved_generic_params;
+        self.implements_block_interface = saved_implements_block_interface;
         self.loop_depth = saved_loop_depth;
         self.defer_loop_floors = saved_defer_loop_floors;
         // Freeze this lambda's diagnostic spans against its own source map

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -3247,8 +3247,12 @@ impl<'a> Parser<'a> {
                 } else if p.at(TokenKind::Word) {
                     // Enum variant
                     p.parse_enum_variant();
-                    // Optional comma after variant (allows both comma and no-comma styles)
-                    p.eat(TokenKind::Comma);
+                    // Optional delimiter after a variant. Commas are canonical,
+                    // but a semicolon is an unambiguous punctuation slip that
+                    // the formatter can repair.
+                    if !p.eat(TokenKind::Comma) {
+                        p.eat(TokenKind::Semicolon);
+                    }
                 } else {
                     // Skip unexpected token
                     p.error_unexpected_token("Unexpected token in enum body".to_string());
@@ -4010,6 +4014,7 @@ impl<'a> Parser<'a> {
                     && !p.at(TokenKind::Less)
                     && !p.at(TokenKind::LBrace)
                     && !p.at(TokenKind::Arrow)
+                    && !p.at(TokenKind::FatArrow)
                     && !p.at_end()
                 {
                     p.bump();
@@ -4043,7 +4048,10 @@ impl<'a> Parser<'a> {
 
             // Return type
             let mut allow_llm_body = true;
-            if p.eat(TokenKind::Arrow) {
+            // Accept the common JS/TS `=>` slip as well as canonical `->`.
+            // The formatter owns canonicalization and always emits `->`, just
+            // as it already does for lambda expressions.
+            if p.eat(TokenKind::Arrow) || p.eat(TokenKind::FatArrow) {
                 if p.at(TokenKind::LBrace) {
                     // The `{` belongs to the function body, not a return type.
                     // Keep recovery in expression-body mode so `client` text
@@ -7104,7 +7112,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a map literal in expression context: { "key": value, ... }
-    /// Requires colons and commas (JSON-style)
+    /// Colons are required. Commas are canonical but may be omitted when the
+    /// following token unambiguously starts another key.
     fn parse_map_literal(&mut self) {
         self.with_node(SyntaxKind::MAP_LITERAL, |p| {
             p.expect(TokenKind::LBrace);
@@ -7124,18 +7133,14 @@ impl<'a> Parser<'a> {
                         if p.at_statement_recovery_boundary() {
                             break;
                         }
-                        if !p.eat(TokenKind::Comma) {
-                            // Missing comma - error but try to continue
+                        if !p.eat(TokenKind::Comma)
+                            && !p.at(TokenKind::Word)
+                            && !p.at(TokenKind::Quote)
+                            && !p.at(TokenKind::Hash)
+                            && !p.at(TokenKind::RBrace)
+                        {
                             p.error_unexpected_token("',' or '}' after map entry".to_string());
-                            // Try to recover
-                            if !p.at(TokenKind::Word)
-                                && !p.at(TokenKind::Quote)
-                                && !p.at(TokenKind::Hash)
-                                && !p.at(TokenKind::RBrace)
-                            {
-                                // Skip unexpected token
-                                p.bump();
-                            }
+                            p.bump();
                         }
                     }
                 } else if p.eat(TokenKind::Comma) {
@@ -10899,6 +10904,57 @@ function Demo() -> int {
                 |it| matches!(it, rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::EQUALS)
             ),
             "expected lambda parameter default equals token"
+        );
+    }
+
+    #[test]
+    fn lambda_body_requires_braces() {
+        for source in [
+            "function Demo() -> int { let add_one = (x: int) -> x + 1; add_one(41) }",
+            "function Demo() -> int { let add_one = (x: int) => x + 1; add_one(41) }",
+        ] {
+            let (_root, errors) = parse_source(source);
+            assert!(
+                errors.iter().any(|error| matches!(
+                    error,
+                    ParseError::UnexpectedToken {
+                        expected,
+                        found,
+                        ..
+                    } if expected == "lambda body '{'" && found == "'+'"
+                )),
+                "expected a required lambda block-body diagnostic, got: {errors:#?}"
+            );
+        }
+    }
+
+    #[test]
+    fn enum_semicolon_delimiter_is_accepted_for_formatter_repair() {
+        let source = "enum Status { Pending; Complete; }\n";
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        assert_eq!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::ENUM_VARIANT)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn map_entries_without_commas_are_accepted_for_formatter_repair() {
+        let source = "function Demo() -> int { { \"left\": 1 \"right\": 2 } }\n";
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        let map = root
+            .descendants()
+            .find(|node| node.kind() == SyntaxKind::MAP_LITERAL)
+            .expect("expected map literal");
+        assert_eq!(
+            map.children()
+                .filter(|node| node.kind() == SyntaxKind::OBJECT_FIELD)
+                .count(),
+            2
         );
     }
 

--- a/baml_language/crates/baml_fmt/src/ast/declarations.rs
+++ b/baml_language/crates/baml_fmt/src/ast/declarations.rs
@@ -129,7 +129,7 @@ pub struct FunctionDecl {
     pub name: t::Word,
     pub generic_params: Option<super::GenericParamList>,
     pub params: FunctionParamList,
-    pub arrow: t::Arrow,
+    pub arrow: super::FunctionArrow,
     pub return_type: Type,
     pub throws: Option<ThrowsClause>,
     pub body: FunctionDeclBody,
@@ -233,8 +233,13 @@ impl Printable for FunctionDecl {
             // It fits in single line!
             printer.append_from_printer(param_printer);
             printer.print_spaces(1);
-            printer.print_raw_token(&self.arrow);
-            printer.print_spaces(1);
+            // Normalize the permissively accepted `=>` spelling to `->`.
+            printer.print_str("->");
+            self.arrow.print_separator_before(
+                Some(self.return_type.leftmost_token()),
+                shape.indent + printer.config.indent_width,
+                printer,
+            );
             printer.append_from_printer(return_type_printer);
             if self.throws.is_some() {
                 printer.print_spaces(1);
@@ -251,14 +256,13 @@ impl Printable for FunctionDecl {
             let _ = self.params.print_multi_line(params_shape, printer);
 
             printer.print_spaces(1);
-            printer.print_raw_token(&self.arrow);
-            printer.print_spaces(1);
-
-            // Trivia between -> and return type
-            let (_, arrow_trailing) = printer.trivia.get_for_range_split(self.arrow.span());
-            printer.print_trivia_squished(arrow_trailing);
-            let return_type_leading = printer.trivia.get_leading_for_element(&self.return_type);
-            printer.print_trivia_squished(return_type_leading);
+            // Normalize the permissively accepted `=>` spelling to `->`.
+            printer.print_str("->");
+            self.arrow.print_separator_before(
+                Some(self.return_type.leftmost_token()),
+                shape.indent + printer.config.indent_width,
+                printer,
+            );
 
             let curr_line_len = printer.current_line_len();
             let return_type_shape = Shape {
@@ -1830,12 +1834,17 @@ impl FromCST for EnumDecl {
                     let variant = StrongAstError::assert_is_node(elem)?;
                     let variant = EnumVariant::from_cst(SyntaxElement::Node(variant))?;
 
-                    let comma = it
-                        .next_if_kind(SyntaxKind::COMMA)
-                        .map(t::Comma::from_cst)
-                        .transpose()?;
+                    let delimiter = match it.peek().map(SyntaxElement::kind) {
+                        Some(SyntaxKind::COMMA) => Some(EnumVariantDelimiter::Comma(
+                            t::Comma::from_cst(it.next().expect("peeked"))?,
+                        )),
+                        Some(SyntaxKind::SEMICOLON) => Some(EnumVariantDelimiter::Semicolon(
+                            t::Semicolon::from_cst(it.next().expect("peeked"))?,
+                        )),
+                        _ => None,
+                    };
 
-                    items.push(EnumItem::Variant(variant, comma));
+                    items.push(EnumItem::Variant(variant, delimiter));
                 }
                 SyntaxKind::BLOCK_ATTRIBUTE => {
                     let attr = BlockAttribute::from_cst(elem)?;
@@ -1919,20 +1928,35 @@ impl Printable for EnumDecl {
 /// Any of the valid items in an [`EnumDecl`].
 #[derive(Debug)]
 pub enum EnumItem {
-    Variant(EnumVariant, Option<t::Comma>),
+    Variant(EnumVariant, Option<EnumVariantDelimiter>),
     BlockAttribute(BlockAttribute),
+}
+
+#[derive(Debug)]
+pub enum EnumVariantDelimiter {
+    Comma(t::Comma),
+    Semicolon(t::Semicolon),
+}
+
+impl EnumVariantDelimiter {
+    fn span(&self) -> TextRange {
+        match self {
+            Self::Comma(comma) => comma.span(),
+            Self::Semicolon(semicolon) => semicolon.span(),
+        }
+    }
 }
 
 impl Printable for EnumItem {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         match self {
-            EnumItem::Variant(variant, comma) => {
+            EnumItem::Variant(variant, delimiter) => {
                 let info = variant.print(shape, printer);
-                if let Some(comma) = &comma {
-                    printer.print_raw_token(comma);
-                } else {
-                    printer.print_str(",");
+                if let Some(delimiter) = delimiter {
+                    let (leading, _) = printer.trivia.get_for_range_split(delimiter.span());
+                    printer.print_trivia_squished(leading);
                 }
+                printer.print_str(",");
                 info
             }
             EnumItem::BlockAttribute(attr) => attr.print(shape, printer),
@@ -1946,9 +1970,9 @@ impl Printable for EnumItem {
     }
     fn rightmost_token(&self) -> TextRange {
         match self {
-            EnumItem::Variant(variant, comma) => {
-                if let Some(comma) = comma {
-                    comma.span()
+            EnumItem::Variant(variant, delimiter) => {
+                if let Some(delimiter) = delimiter {
+                    delimiter.span()
                 } else {
                     variant.rightmost_token()
                 }

--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -4636,23 +4636,77 @@ impl Printable for ThrowsClause {
     }
 }
 
-/// Arrow token in a lambda expression. Accepts either `->` (canonical) or
+/// Arrow token in a function signature. Accepts either `->` (canonical) or
 /// `=>` (accepted permissively for ergonomic parity with JS/TS arrow functions);
-/// the formatter always emits `->`.
+/// the formatter always emits `->`. Shared by declarations and lambdas so the
+/// compiler's permissive syntax and formatter repair stay in lockstep.
 #[derive(Debug)]
-pub enum LambdaArrow {
+pub enum FunctionArrow {
     Arrow(t::Arrow),
     FatArrow(t::FatArrow),
 }
 
-impl FromCST for LambdaArrow {
+impl FunctionArrow {
+    #[must_use]
+    pub fn span(&self) -> TextRange {
+        match self {
+            FunctionArrow::Arrow(t) => t.span(),
+            FunctionArrow::FatArrow(t) => t.span(),
+        }
+    }
+
+    /// Returns true if the source used `=>` instead of the canonical `->`.
+    #[must_use]
+    pub fn is_fat_arrow(&self) -> bool {
+        matches!(self, FunctionArrow::FatArrow(_))
+    }
+
+    /// Print trivia between the source arrow and the next canonical element.
+    /// The arrow spelling may be synthesized, but its source span still owns
+    /// comments that must survive normalization.
+    pub(crate) fn print_separator_before(
+        &self,
+        next_leftmost: Option<TextRange>,
+        continuation_indent: usize,
+        printer: &mut Printer,
+    ) {
+        let (_, arrow_trailing) = printer.trivia.get_for_range_split(self.span());
+        let next_leading = next_leftmost
+            .map(|range| printer.trivia.get_for_range_split(range).0)
+            .unwrap_or(&[]);
+        let mut printed_comment = false;
+        let mut continued_on_newline = false;
+
+        for trivia in arrow_trailing.iter().chain(next_leading) {
+            if !trivia.is_comment() {
+                continue;
+            }
+            if !continued_on_newline {
+                printer.print_spaces(1);
+            }
+            printer.print_trivia(trivia);
+            printed_comment = true;
+            continued_on_newline = trivia.single_line_len(printer.input).is_none();
+            if continued_on_newline {
+                printer.print_newline();
+                printer.print_spaces(continuation_indent);
+            }
+        }
+
+        if !printed_comment || !continued_on_newline {
+            printer.print_spaces(1);
+        }
+    }
+}
+
+impl FromCST for FunctionArrow {
     fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
         let token = StrongAstError::assert_is_token(elem)?;
         match token.kind() {
-            SyntaxKind::ARROW => Ok(LambdaArrow::Arrow(t::Arrow::new_from_span(
+            SyntaxKind::ARROW => Ok(FunctionArrow::Arrow(t::Arrow::new_from_span(
                 token.text_range(),
             ))),
-            SyntaxKind::FAT_ARROW => Ok(LambdaArrow::FatArrow(t::FatArrow::new_from_span(
+            SyntaxKind::FAT_ARROW => Ok(FunctionArrow::FatArrow(t::FatArrow::new_from_span(
                 token.text_range(),
             ))),
             _ => Err(StrongAstError::UnexpectedKindDesc {
@@ -4664,7 +4718,7 @@ impl FromCST for LambdaArrow {
     }
 }
 
-impl KnownKind for LambdaArrow {
+impl KnownKind for FunctionArrow {
     fn kind() -> SyntaxKind {
         // Primary/canonical kind; `from_cst` also accepts FAT_ARROW.
         SyntaxKind::ARROW
@@ -4678,7 +4732,7 @@ impl KnownKind for LambdaArrow {
 pub struct LambdaExpr {
     pub generic_params: Option<GenericParamList>,
     pub param_list: super::FunctionParamList,
-    pub arrow: LambdaArrow,
+    pub arrow: FunctionArrow,
     pub return_type: Option<crate::ast::Type>,
     pub throws: Option<ThrowsClause>,
     pub block: BlockExpr,
@@ -4705,7 +4759,7 @@ impl FromCST for LambdaExpr {
         let param_list: super::FunctionParamList = it.expect_parse()?;
 
         // Arrow: `->` or `=>` (formatter normalizes to `->`)
-        let arrow: LambdaArrow = it.expect_parse()?;
+        let arrow: FunctionArrow = it.expect_parse()?;
 
         // Optional return type: TYPE_EXPR before THROWS_CLAUSE or BLOCK_EXPR
         let return_type = if it.peek().map(|e| e.kind()) == Some(SyntaxKind::TYPE_EXPR) {
@@ -4760,18 +4814,33 @@ impl Printable for LambdaExpr {
 
         // Optional return type
         if let Some(ref ret) = self.return_type {
-            printer.print_str(" ");
+            self.arrow.print_separator_before(
+                Some(ret.leftmost_token()),
+                shape.indent + printer.config.indent_width,
+                printer,
+            );
             printer.print(ret, shape.clone());
-        }
-
-        // Optional throws clause
-        if let Some(ref throws) = self.throws {
+            if let Some(ref throws) = self.throws {
+                printer.print_str(" ");
+                printer.print(throws, shape.clone());
+            }
             printer.print_str(" ");
+        } else if let Some(ref throws) = self.throws {
+            self.arrow.print_separator_before(
+                Some(throws.leftmost_token()),
+                shape.indent + printer.config.indent_width,
+                printer,
+            );
             printer.print(throws, shape.clone());
+            printer.print_str(" ");
+        } else {
+            self.arrow.print_separator_before(
+                Some(self.block.leftmost_token()),
+                shape.indent + printer.config.indent_width,
+                printer,
+            );
         }
 
-        // Space + block
-        printer.print_str(" ");
         printer.print(&self.block, shape);
 
         PrintInfo::default_multi_lined()

--- a/baml_language/crates/baml_fmt/src/ast/types.rs
+++ b/baml_language/crates/baml_fmt/src/ast/types.rs
@@ -20,6 +20,7 @@ pub enum Type {
     /// Generally only string literals are used in normal types,
     /// but other literals are valid in some contexts like match bindings.
     Literal(Literal),
+    SignedLiteral(SignedLiteralType),
     Union(UnionType),
     Optional(OptionalType),
     Array(ArrayType),
@@ -44,6 +45,7 @@ impl Type {
             Type::Paren(_) => false,
             Type::Path(_) => true,
             Type::Literal(_) => false,
+            Type::SignedLiteral(_) => false,
             Type::Union(_) => true,
             Type::Optional(inner) => inner.ty.multi_line_is_indented(),
             Type::Array(inner) => inner.ty.multi_line_is_indented(),
@@ -116,6 +118,7 @@ impl Printable for Type {
             Type::Paren(paren) => paren.print(shape, printer),
             Type::Path(path) => path.print(shape, printer),
             Type::Literal(literal) => literal.print(shape, printer),
+            Type::SignedLiteral(literal) => literal.print(shape, printer),
             Type::Union(union) => union.print(shape, printer),
             Type::Optional(optional) => optional.print(shape, printer),
             Type::Array(array) => array.print(shape, printer),
@@ -136,6 +139,7 @@ impl Printable for Type {
             Type::Paren(paren) => paren.leftmost_token(),
             Type::Path(path) => path.leftmost_token(),
             Type::Literal(literal) => literal.leftmost_token(),
+            Type::SignedLiteral(literal) => literal.leftmost_token(),
             Type::Union(union) => union.leftmost_token(),
             Type::Optional(optional) => optional.leftmost_token(),
             Type::Array(array) => array.leftmost_token(),
@@ -151,6 +155,7 @@ impl Printable for Type {
             Type::Paren(paren) => paren.rightmost_token(),
             Type::Path(path) => path.rightmost_token(),
             Type::Literal(literal) => literal.rightmost_token(),
+            Type::SignedLiteral(literal) => literal.rightmost_token(),
             Type::Union(union) => union.rightmost_token(),
             Type::Optional(optional) => optional.rightmost_token(),
             Type::Array(array) => array.rightmost_token(),
@@ -266,6 +271,31 @@ impl Printable for PathType {
             .last()
             .map_or(&self.first, |(_, word)| word)
             .span()
+    }
+}
+
+/// A negative numeric literal used as a type/pattern atom, such as `-42`.
+/// Keep token anchors for surrounding trivia while preserving any unusual
+/// whitespace or comments between the sign and literal verbatim.
+#[derive(Debug)]
+pub struct SignedLiteralType {
+    pub minus: t::Minus,
+    pub literal: TextRange,
+}
+
+impl Printable for SignedLiteralType {
+    fn print(&self, _shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let range = TextRange::new(self.minus.span().start(), self.literal.end());
+        printer.print_input_range(range);
+        PrintInfo {
+            multi_lined: printer.input[range].contains('\n'),
+        }
+    }
+    fn leftmost_token(&self) -> TextRange {
+        self.minus.span()
+    }
+    fn rightmost_token(&self) -> TextRange {
+        self.literal
     }
 }
 
@@ -409,6 +439,7 @@ pub enum UnionTypeMember {
     Paren(ParenType),
     Path(PathType),
     Literal(Literal),
+    SignedLiteral(SignedLiteralType),
     Optional(OptionalType),
     Array(ArrayType),
     Generic(GenericType),
@@ -427,6 +458,26 @@ impl UnionTypeMember {
     fn take_base_type(it: &mut SyntaxNodeIter) -> Result<Self, StrongAstError> {
         let first = it.expect_next("a type")?;
         match first.kind() {
+            SyntaxKind::MINUS => {
+                let minus = t::Minus::from_cst(first)?;
+                let literal = it.expect_next("numeric literal after '-'")?;
+                if !matches!(
+                    literal.kind(),
+                    SyntaxKind::BIGINT_LITERAL
+                        | SyntaxKind::INTEGER_LITERAL
+                        | SyntaxKind::FLOAT_LITERAL
+                ) {
+                    return Err(StrongAstError::UnexpectedKindDesc {
+                        expected_desc: "BIGINT_LITERAL, INTEGER_LITERAL, or FLOAT_LITERAL".into(),
+                        found: literal.kind(),
+                        at: literal.text_range(),
+                    });
+                }
+                Ok(UnionTypeMember::SignedLiteral(SignedLiteralType {
+                    minus,
+                    literal: literal.text_range(),
+                }))
+            }
             SyntaxKind::L_PAREN => {
                 // Either a parenthesized type or a function type
                 let open_paren = t::LParen::from_cst(first)?;
@@ -615,6 +666,7 @@ impl From<UnionTypeMember> for Type {
             UnionTypeMember::Paren(paren) => Type::Paren(paren),
             UnionTypeMember::Path(path) => Type::Path(path),
             UnionTypeMember::Literal(literal) => Type::Literal(literal),
+            UnionTypeMember::SignedLiteral(literal) => Type::SignedLiteral(literal),
             UnionTypeMember::Optional(optional) => Type::Optional(optional),
             UnionTypeMember::Array(array) => Type::Array(array),
             UnionTypeMember::Generic(generic) => Type::Generic(generic),
@@ -634,6 +686,7 @@ impl Printable for UnionTypeMember {
             UnionTypeMember::Paren(paren) => paren.print(shape, printer),
             UnionTypeMember::Path(path) => path.print(shape, printer),
             UnionTypeMember::Literal(literal) => literal.print(shape, printer),
+            UnionTypeMember::SignedLiteral(literal) => literal.print(shape, printer),
             UnionTypeMember::Optional(optional) => optional.print(shape, printer),
             UnionTypeMember::Array(array) => array.print(shape, printer),
             UnionTypeMember::Generic(generic) => generic.print(shape, printer),
@@ -651,6 +704,7 @@ impl Printable for UnionTypeMember {
             UnionTypeMember::Paren(paren) => paren.leftmost_token(),
             UnionTypeMember::Path(path) => path.leftmost_token(),
             UnionTypeMember::Literal(lit) => lit.leftmost_token(),
+            UnionTypeMember::SignedLiteral(lit) => lit.leftmost_token(),
             UnionTypeMember::Optional(optional) => optional.leftmost_token(),
             UnionTypeMember::Array(array) => array.leftmost_token(),
             UnionTypeMember::Generic(generic) => generic.leftmost_token(),
@@ -665,6 +719,7 @@ impl Printable for UnionTypeMember {
             UnionTypeMember::Paren(paren) => paren.rightmost_token(),
             UnionTypeMember::Path(path) => path.rightmost_token(),
             UnionTypeMember::Literal(lit) => lit.rightmost_token(),
+            UnionTypeMember::SignedLiteral(lit) => lit.rightmost_token(),
             UnionTypeMember::Optional(optional) => optional.rightmost_token(),
             UnionTypeMember::Array(array) => array.rightmost_token(),
             UnionTypeMember::Generic(generic) => generic.rightmost_token(),

--- a/baml_language/crates/baml_fmt/src/formatter_scenario_tests.rs
+++ b/baml_language/crates/baml_fmt/src/formatter_scenario_tests.rs
@@ -1,0 +1,369 @@
+//! Parameterized scenario matrix for broad formatter invariants.
+
+use std::collections::BTreeSet;
+
+use crate::{FormatOptions, format};
+
+const FAMILIES: [&str; 16] = [
+    "class_fields",
+    "enum_values",
+    "function_params",
+    "type_aliases",
+    "arrays",
+    "maps",
+    "objects",
+    "binary_exprs",
+    "calls",
+    "chains",
+    "if_exprs",
+    "match_exprs",
+    "lambdas",
+    "literal_forms",
+    "nested_blocks",
+    "width_boundaries",
+];
+
+#[test]
+fn formatter_scenario_matrix() {
+    let mut coverage_keys = BTreeSet::new();
+    let mut cores = BTreeSet::new();
+    let mut sources = BTreeSet::new();
+
+    for (family_index, family) in FAMILIES.iter().enumerate() {
+        for semantic in 0..8 {
+            for trivia in 0..4 {
+                for layout in 0..2 {
+                    let ordinal = family_index * 64 + semantic * 8 + trivia * 2 + layout;
+                    let coverage_key =
+                        format!("{family}/semantic-{semantic}/trivia-{trivia}/layout-{layout}");
+                    assert!(
+                        coverage_keys.insert(coverage_key.clone()),
+                        "duplicate formatter coverage key: {coverage_key}"
+                    );
+                    let (core, required, forbidden) = build_case(family, semantic, layout);
+                    if trivia == 0 {
+                        assert!(
+                            cores.insert(core.clone()),
+                            "duplicate formatter scenario core for {coverage_key}"
+                        );
+                    }
+                    let (source, marker) = decorate(core, trivia, ordinal);
+                    assert!(
+                        sources.insert(source.clone()),
+                        "duplicate formatter source for {coverage_key}"
+                    );
+                    assert_scenario(&coverage_key, &source, &required, &forbidden, &marker);
+                }
+            }
+        }
+    }
+
+    assert_eq!(coverage_keys.len(), 1024);
+    assert_eq!(cores.len(), 256);
+    assert_eq!(sources.len(), 1024);
+}
+
+fn assert_scenario(
+    coverage_key: &str,
+    source: &str,
+    required: &str,
+    forbidden: &str,
+    marker: &str,
+) {
+    let options = FormatOptions::default();
+    let formatted = format(source, &options).unwrap_or_else(|error| {
+        panic!("formatter rejected scenario {coverage_key}: {error:?}\nsource:\n{source}")
+    });
+    assert!(
+        formatted.ends_with('\n'),
+        "{coverage_key}: output needs one final newline"
+    );
+    assert!(
+        !formatted.ends_with("\n\n"),
+        "{coverage_key}: output has multiple final newlines"
+    );
+    assert!(
+        !formatted.contains('\t'),
+        "{coverage_key}: canonical output contains a tab"
+    );
+    if !required.is_empty() {
+        assert!(
+            formatted.contains(required),
+            "{coverage_key}: output omitted required fragment {required:?}\noutput:\n{formatted}"
+        );
+    }
+    if !forbidden.is_empty() {
+        assert!(
+            !formatted.contains(forbidden),
+            "{coverage_key}: output retained forbidden fragment {forbidden:?}\noutput:\n{formatted}"
+        );
+    }
+    if !marker.is_empty() {
+        assert_eq!(
+            formatted.matches(marker).count(),
+            1,
+            "{coverage_key}: marker comment must survive exactly once\noutput:\n{formatted}"
+        );
+    }
+    let second = format(&formatted, &options).unwrap_or_else(|error| {
+        panic!(
+            "formatter output stopped parsing for {coverage_key}: {error:?}\noutput:\n{formatted}"
+        )
+    });
+    assert_eq!(
+        formatted, second,
+        "{coverage_key}: formatter is not idempotent"
+    );
+}
+
+fn build_case(family: &str, semantic: usize, layout: usize) -> (String, String, String) {
+    let indent = if layout == 0 { "    " } else { "  " };
+    let gap = if layout == 0 { " " } else { "   " };
+    let compact = layout == 1;
+    let types = [
+        "string",
+        "int",
+        "bool",
+        "float",
+        "string?",
+        "int[]",
+        "map<string, int>",
+        "string | int",
+    ];
+    let ty = types[semantic];
+    let name = format!("Generated_{family}_{semantic}");
+
+    match family {
+        "class_fields" => {
+            let delimiter = if compact { ";" } else { "" };
+            let colon = if compact { "" } else { ":" };
+            let field = format!("field_{semantic}");
+            (
+                format!("class {name}{gap}{{\n{indent}{field}{colon}{gap}{ty}{delimiter}\n}}\n"),
+                format!("{field}: {ty},"),
+                format!("{field} {ty}"),
+            )
+        }
+        "enum_values" => {
+            let mut values = (0..=semantic)
+                .map(|index| format!("{indent}Value{index}"))
+                .collect::<Vec<_>>();
+            if compact {
+                values
+                    .last_mut()
+                    .expect("enum has at least one value")
+                    .push(';');
+            }
+            let last_value = format!("Value{semantic}");
+            (
+                format!("enum {name}{gap}{{\n{}\n}}\n", values.join("\n")),
+                format!("{last_value},"),
+                format!("{last_value};"),
+            )
+        }
+        "function_params" => {
+            let colon = if compact { "" } else { ":" };
+            let comma = if compact { "" } else { "," };
+            let param = format!("arg_{semantic}");
+            (
+                format!(
+                    "function {name}({param}{colon}{gap}{ty}{comma}){gap}->{gap}int{{\n{indent}1\n}}\n"
+                ),
+                format!("{param}: {ty}"),
+                String::new(),
+            )
+        }
+        "type_aliases" => (
+            format!("type {name}{gap}={gap}{ty}\n"),
+            format!("type {name} = {ty}"),
+            String::new(),
+        ),
+        "arrays" => {
+            let exprs = [
+                "1", "true", "null", "item", "-1", "1 + 2", "foo(1)", "[1, 2]",
+            ];
+            let expr = exprs[semantic];
+            let separator = if compact && semantic != 7 { " " } else { ", " };
+            (
+                function_with_tail(&name, indent, &format!("[{expr}{separator}{expr}]")),
+                "[".to_string(),
+                String::new(),
+            )
+        }
+        "maps" => {
+            let values = [
+                "1", "true", "null", "item", "-1", "1 + 2", "foo(1)", "[1, 2]",
+            ];
+            let value = values[semantic];
+            let separator = if compact { " " } else { ", " };
+            (
+                function_with_tail(
+                    &name,
+                    indent,
+                    &format!("{{ \"left\":{gap}{value}{separator}\"right\":{gap}{value} }}"),
+                ),
+                "\"left\":".to_string(),
+                String::new(),
+            )
+        }
+        "objects" => {
+            let values = [
+                "1", "true", "null", "item", "-1", "1 + 2", "foo(1)", "[1, 2]",
+            ];
+            let value = values[semantic];
+            (
+                format!(
+                    "class Box{semantic} {{ value: int }}\nfunction {name}() -> Box{semantic} {{\n{indent}Box{semantic} {{ value:{gap}{value} }}\n}}\n"
+                ),
+                value.to_string(),
+                String::new(),
+            )
+        }
+        "binary_exprs" => {
+            let ops = ["+", "-", "*", "/", "%", "==", "&&", "||"];
+            let op = ops[semantic];
+            (
+                function_with_tail(&name, indent, &format!("left{gap}{op}{gap}right")),
+                format!(" {op} "),
+                String::new(),
+            )
+        }
+        "calls" => {
+            let args = [
+                "",
+                "1",
+                "1, 2",
+                "value = 1",
+                "1, value = 2",
+                "foo(1)",
+                "[1, 2]",
+                "{ \"key\": 1 }",
+            ];
+            (
+                function_with_tail(&name, indent, &format!("callee({})", args[semantic])),
+                "callee(".to_string(),
+                String::new(),
+            )
+        }
+        "chains" => {
+            let chains = [
+                "value.field",
+                "value.field.other",
+                "value.method()",
+                "value.method().field",
+                "value[0].field",
+                "value?.field",
+                "value?.[0]",
+                "value?.method()",
+            ];
+            (
+                function_with_tail(&name, indent, chains[semantic]),
+                chains[semantic].to_string(),
+                String::new(),
+            )
+        }
+        "if_exprs" => {
+            let conditions = [
+                "true", "false", "x == 1", "x != 1", "x < 1", "x <= 1", "x > 1", "x >= 1",
+            ];
+            (
+                function_with_tail(
+                    &name,
+                    indent,
+                    &format!(
+                        "if{}({}){}{{ 1 }} else {{ 2 }}",
+                        gap, conditions[semantic], gap
+                    ),
+                ),
+                "if (".to_string(),
+                String::new(),
+            )
+        }
+        "match_exprs" => {
+            let patterns = ["0", "1", "true", "false", "null", "\"x\"", "-1", "_"];
+            (
+                function_with_tail(
+                    &name,
+                    indent,
+                    &format!("match (value) {{ {} => 1, _ => 0 }}", patterns[semantic]),
+                ),
+                "=>".to_string(),
+                String::new(),
+            )
+        }
+        "lambdas" => {
+            let lambdas = [
+                "() => { 1 }",
+                "(x) => { x }",
+                "(x: int) => { x + 1 }",
+                "(x: int) -> { x }",
+                "(x: int) -> int { x }",
+                "(x: int, y: int) => { x + y }",
+                "() => { throw \"boom\" }",
+                "(x: int) => { return x }",
+            ];
+            (
+                format!(
+                    "function {name}() -> int {{\n{indent}let callback = {}\n{indent}1\n}}\n",
+                    lambdas[semantic]
+                ),
+                "let callback =".to_string(),
+                "=>".to_string(),
+            )
+        }
+        "literal_forms" => {
+            let literals = [
+                "\"plain\"",
+                "\"escaped\\nvalue\"",
+                "42",
+                "42n",
+                "3.14",
+                "true",
+                "null",
+                "`hello`",
+            ];
+            (
+                function_with_tail(&name, indent, literals[semantic]),
+                literals[semantic].to_string(),
+                String::new(),
+            )
+        }
+        "nested_blocks" => {
+            let depths = semantic + 1;
+            let mut body = "1".to_string();
+            for depth in 0..depths {
+                body = format!("if (level_{depth}) {{ {body} }} else {{ 0 }}");
+            }
+            (
+                function_with_tail(&name, indent, &body),
+                format!("level_{}", depths - 1),
+                String::new(),
+            )
+        }
+        "width_boundaries" => {
+            let lengths = [8, 16, 24, 32, 48, 64, 80, 96];
+            let identifier = format!("value_{}", "x".repeat(lengths[semantic]));
+            (
+                function_with_tail(&name, indent, &format!("callee({identifier})")),
+                identifier,
+                String::new(),
+            )
+        }
+        _ => unreachable!("unknown formatter family"),
+    }
+}
+
+fn function_with_tail(name: &str, indent: &str, tail: &str) -> String {
+    format!("function {name}() -> int {{\n{indent}{tail}\n}}\n")
+}
+
+fn decorate(core: String, trivia: usize, ordinal: usize) -> (String, String) {
+    let marker = format!("generated-case-{ordinal}");
+    match trivia {
+        0 => (core, String::new()),
+        1 => (format!("/* {marker} */\n{core}"), marker),
+        2 => (format!("// {marker}\n{core}"), marker),
+        3 => (format!("{} // {marker}\n", core.trim_end()), marker),
+        _ => unreachable!("trivia dimension is 0..4"),
+    }
+}

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -12,6 +12,9 @@ use baml_project::ProjectDatabase;
 use printer::{Printer, Shape};
 pub use trivia_classifier::{EmittableTrivia, TriviaInfo};
 
+#[cfg(test)]
+mod formatter_scenario_tests;
+
 /// Runs the formatter on the given source code.
 ///
 /// Also see [`format_salsa`] if you already have a [`salsa::Database`] with the source files in it.
@@ -33,11 +36,22 @@ pub fn format_salsa(
 ) -> Result<String, FormatterError> {
     let tokens = baml_compiler_lexer::lex_file(db, file);
     let (parsed, errors) = baml_compiler_parser::parse_file(&tokens);
+    let cst = SyntaxNode::new_root(parsed);
+
+    // Honor the documented escape hatch at the shared library boundary so
+    // CLI and LSP behavior cannot diverge. Inspect parser-classified comment
+    // tokens rather than the raw source: directive-like text inside a string
+    // must not disable formatting. This check intentionally precedes the parse
+    // error gate so the directive can protect an incomplete or intentionally
+    // non-canonical file.
+    if has_ignore_directive(&cst) {
+        return Ok(file.text(db).clone());
+    }
+
     if !errors.is_empty() {
         return Err(FormatterError::ParseErrors(errors));
     }
 
-    let cst = SyntaxNode::new_root(parsed);
     let trivia = TriviaInfo::classify_trivia(&cst);
     let strong_ast = ast::SourceFile::from_cst(SyntaxElement::Node(cst))?;
 
@@ -53,6 +67,30 @@ pub fn format_salsa(
     Ok(printer.output)
 }
 
+fn has_ignore_directive(cst: &SyntaxNode) -> bool {
+    cst.descendants_with_tokens().any(|element| {
+        let SyntaxElement::Token(token) = element else {
+            return false;
+        };
+        matches!(
+            token.kind(),
+            baml_db::baml_compiler_syntax::SyntaxKind::LINE_COMMENT
+                | baml_db::baml_compiler_syntax::SyntaxKind::BLOCK_COMMENT
+        ) && comment_contains_ignore_directive(token.text())
+    })
+}
+
+fn comment_contains_ignore_directive(comment: &str) -> bool {
+    const PREFIX: &str = "baml-format";
+    let lowercase = comment.to_ascii_lowercase();
+    lowercase.match_indices(PREFIX).any(|(start, _)| {
+        lowercase[start + PREFIX.len()..]
+            .trim_start()
+            .strip_prefix(':')
+            .is_some_and(|rest| rest.trim_start().starts_with("ignore"))
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FormatOptions {
     /// Maximum line width before wrapping kicks in. Default: `100`
@@ -64,10 +102,13 @@ impl Default for FormatOptions {
     fn default() -> Self {
         Self {
             line_width: 100,
-            indent_width: 4,
+            indent_width: CANONICAL_INDENT_WIDTH,
         }
     }
 }
+
+/// Canonical indentation used by the CLI, LSP, and default library formatter.
+pub const CANONICAL_INDENT_WIDTH: usize = 4;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum FormatterError {
@@ -75,6 +116,21 @@ pub enum FormatterError {
     ParseErrors(Vec<ParseError>),
     #[error("{0}")]
     StrongAstError(#[from] ast::StrongAstError),
+}
+
+#[cfg(test)]
+mod format_options_tests {
+    use super::*;
+
+    #[test]
+    fn default_options_use_the_canonical_four_space_indent() {
+        let options = FormatOptions::default();
+        assert_eq!(CANONICAL_INDENT_WIDTH, 4);
+        assert_eq!(options.indent_width, CANONICAL_INDENT_WIDTH);
+        let formatted = format("function value() -> int {\n  result\n}\n", &options)
+            .expect("default formatter options should format a function body");
+        assert_eq!(formatted, "function value() -> int {\n    result\n}\n");
+    }
 }
 
 #[cfg(test)]
@@ -139,6 +195,47 @@ mod lambda_format_tests {
         assert_eq!(formatted, second, "formatter should be idempotent");
     }
 
+    /// A JS/TS-style fat arrow is an unambiguous punctuation slip in a
+    /// function signature. The shared parser accepts it and the formatter
+    /// repairs it to canonical BAML `->` rather than rejecting the file.
+    #[test]
+    fn test_top_level_fat_arrow_is_repaired() {
+        let source = "function add(a: int, b: int) => int {\n    a + b\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should repair a fat arrow");
+        assert_eq!(
+            formatted,
+            "function add(a: int, b: int) -> int {\n    a + b\n}\n"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    #[test]
+    fn test_expression_bodied_lambda_is_rejected() {
+        let options = FormatOptions::default();
+        for arrow in ["->", "=>"] {
+            let source = format!(
+                "function apply() -> int {{\n    let add_one = (x: int) {arrow} x + 1\n    add_one(41)\n}}\n"
+            );
+            assert!(
+                format(&source, &options).is_err(),
+                "formatter must reject a lambda body without braces for {arrow}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_arrow_comments_survive_annotated_and_block_bodies() {
+        let source = "function top() => /* result */ int { 1 }\n\nfunction apply() -> int {\n    let identity = (x: int) => /* body */ { x }\n    identity(1)\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should preserve comments");
+        assert!(formatted.contains("-> /* result */ int"));
+        assert!(formatted.contains("-> /* body */ {"));
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
     #[test]
     fn test_top_level_interface_spacing_is_idempotent() {
         let source = r#"interface Named {
@@ -199,6 +296,28 @@ implements<T extends Named> Printable for Box<T> {
                 "formatter should be idempotent for:\n{source}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod ignore_directive_tests {
+    use super::*;
+
+    #[test]
+    fn line_comment_directive_preserves_invalid_source_verbatim() {
+        let source = "// BAML-FORMAT : ignore\nfunction unfinished(\n";
+        let formatted = format(source, &FormatOptions::default())
+            .expect("the ignore directive should bypass parse errors");
+        assert_eq!(formatted, source);
+    }
+
+    #[test]
+    fn directive_text_inside_a_string_does_not_disable_formatting() {
+        let source = "function main() -> string {\n  let marker = \"// baml-format: ignore\";\n  marker\n}\n";
+        let formatted = format(source, &FormatOptions::default())
+            .expect("directive-like string content is ordinary source text");
+        assert_ne!(formatted, source);
+        assert!(formatted.contains("    let marker = \"// baml-format: ignore\";"));
     }
 }
 

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -2586,14 +2586,14 @@ function main(value: WrongId) -> int {
 
     #[test]
     fn parse_error_in_body_taints_scope_and_descendants() {
-        // A braceless lambda is a syntax error; parser recovery leaves a
-        // malformed lambda that would otherwise emit cascading type errors. The
-        // function-body scope containing the parse error — and its descendant
-        // lambda scope — must be tainted so those type errors are suppressed.
+        // A missing right-hand operand is a syntax error in the function body.
+        // The function-body scope containing the parse error — and its
+        // descendant lambda scope — must be tainted so cascading type errors
+        // are suppressed.
         let mut builder = ProjectTest::builder();
         builder.source(
             "test.baml",
-            "function Braceless() -> int {\n  let f = (x: int) => x + 1;\n  f(2)\n}\n",
+            "function Broken() -> int {\n  let broken = 1 + ;\n  let f = (x: int) -> { x + 1 };\n  f(2)\n}\n",
         );
         let test = builder.build();
         let file = test.files[0];
@@ -2602,7 +2602,7 @@ function main(value: WrongId) -> int {
         let parse_errors = baml_compiler_parser::parse_errors(&test.db, file);
         assert!(
             !parse_errors.is_empty(),
-            "braceless lambda should produce a parse error"
+            "missing right-hand operand should produce a parse error"
         );
 
         let tainted = parse_error_tainted_scopes(index, &parse_errors);
@@ -2617,7 +2617,7 @@ function main(value: WrongId) -> int {
             .scopes
             .iter()
             .position(|s| s.kind == ScopeKind::Lambda)
-            .expect("a lambda scope should exist for the braceless lambda");
+            .expect("a descendant lambda scope should exist");
         assert!(
             tainted.contains(&lambda_idx),
             "descendant lambda scope (index {lambda_idx}) must be tainted, got {tainted:?}"

--- a/baml_language/crates/baml_tests/build.rs
+++ b/baml_language/crates/baml_tests/build.rs
@@ -1115,10 +1115,11 @@ fn generate_formatter_test(baml_file: &BamlFile) -> TokenStream {
                             format!("=== STRONG AST ERROR ===\n{}", e)
                         }
                     };
-                    with_settings!({snapshot_path => SNAPSHOT_PATH, omit_expression => true}, {
-                        assert_snapshot!(#snapshot_name, output);
-                    });
-                    return;
+                    panic!(
+                        "Formatter rejected compiler-test input that reaches the formatter tier ({}):\n{}",
+                        #relative_path,
+                        output
+                    );
                 }
             };
 

--- a/baml_language/crates/baml_tests/projects/broken_syntax/braceless_lambda/braceless_lambda.baml
+++ b/baml_language/crates/baml_tests/projects/broken_syntax/braceless_lambda/braceless_lambda.baml
@@ -9,6 +9,13 @@ function Braceless() -> int {
   add1(2)
 }
 
+// An incomplete binary expression after the arrow must still produce a focused
+// required-block diagnostic without cascading type errors.
+function Braceless2() -> int {
+  let add1 = (x: int) => x + ;
+  add1(2)
+}
+
 // The suppression is scoped to the broken body: a genuine type error in a
 // separate, well-formed function must still be reported.
 function GenuineTypeError() -> int {

--- a/baml_language/crates/baml_tests/projects/compiles/lambda_fat_arrow/lambda_fat_arrow.baml
+++ b/baml_language/crates/baml_tests/projects/compiles/lambda_fat_arrow/lambda_fat_arrow.baml
@@ -42,3 +42,9 @@ function test_mixed() -> int {
     let b = (x: int) => int { x + 2 }
     a(0) + b(0)
 }
+
+// The same unambiguous JS/TS spelling is accepted in a top-level signature;
+// the formatter repairs it to the canonical thin arrow.
+function test_top_level_fat_arrow(x: int) => int {
+    x + 1
+}

--- a/baml_language/crates/baml_tests/snapshots/broken_syntax/braceless_lambda/baml_tests__broken_syntax__braceless_lambda__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/broken_syntax/braceless_lambda/baml_tests__broken_syntax__braceless_lambda__05_diagnostics.snap
@@ -11,10 +11,28 @@ source: crates/baml_tests/src/generated_tests.rs
    ·                            ╰── expected `lambda body '{'`, found `'+'`
    ╰────
 
+  [parse] E0010
+
+  × unexpected token
+    ╭─[braceless_lambda.baml:15:28]
+ 15 │   let add1 = (x: int) => x + ;
+    ·                            ┬
+    ·                            ╰── expected `lambda body '{'`, found `'+'`
+    ╰────
+
+  [parse] E0010
+
+  × unexpected token
+    ╭─[braceless_lambda.baml:15:30]
+ 15 │   let add1 = (x: int) => x + ;
+    ·                              ┬
+    ·                              ╰── expected `expression`, found `';'`
+    ╰────
+
   [type] E0004
 
   × operator `+` cannot be applied to `"hello"` and `5`
-    ╭─[braceless_lambda.baml:15:3]
- 15 │   "hello" + 5
+    ╭─[braceless_lambda.baml:22:3]
+ 22 │   "hello" + 5
     ·   ───────────
     ╰────

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__10_formatter__comment_in_type.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__10_formatter__comment_in_type.snap
@@ -11,13 +11,15 @@ client<llm> TestClient {
 function FunctionWithComments(
     a: string,
     b: int, // comment after param type
-) -> string {
+) -> // Comment after arrow
+    string {
     client: TestClient
     prompt: #"test"#
 }
 
 // Another test - comment immediately after arrow
-function CommentAfterArrow() -> string {
+function CommentAfterArrow() -> // inline comment
+    string {
     client: TestClient
     prompt: #"test"#
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__03_ppir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 17627
 ---
 === PPIR ===
 function user.test_annotated() -> int  [expr] {
@@ -17,6 +16,9 @@ function user.test_mixed() -> int  [expr] {
 }
 function user.test_multi_param() -> int  [expr] {
   { let add = (a: int, b: int) -> int { {  } a Add b } } add(20, 22)
+}
+function user.test_top_level_fat_arrow(x: int) -> int  [expr] {
+  {  } x Add 1
 }
 function user.test_zero_param() -> int  [expr] {
   { let constant = () -> int { {  } 42 } } constant()

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__04_5_mir.snap
@@ -240,3 +240,18 @@ fn .<lambda(test_mixed, 1)>(x: int) -> null {
         return;
     }
 }
+
+fn user.test_top_level_fat_arrow(x: int) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: int // x // param
+
+    bb0: {
+        _0 = copy _1 + const 1_i64;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__04_tir.snap
@@ -87,3 +87,8 @@ lambda user.test_mixed {
 }
 lambda user.test_mixed {
 }
+function user.test_top_level_fat_arrow(x: int) -> int throws never {
+  { : int
+    x + 1 : int
+  }
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__06_codegen.snap
@@ -72,6 +72,13 @@ function user.test_multi_param() -> int {
     return
 }
 
+function user.test_top_level_fat_arrow(x: int) -> int {
+    load_var x
+    load_const 1
+    add_int
+    return
+}
+
 function user.test_zero_param() -> int {
     make_closure .<lambda(test_zero_param, 0)>, 0
     call_indirect

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__10_formatter__lambda_fat_arrow.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__10_formatter__lambda_fat_arrow.snap
@@ -59,3 +59,9 @@ function test_mixed() -> int {
     };
     a(0) + b(0)
 }
+
+// The same unambiguous JS/TS spelling is accepted in a top-level signature;
+// the formatter repairs it to the canonical thin arrow.
+function test_top_level_fat_arrow(x: int) -> int {
+    x + 1
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__function_decls.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__function_decls.snap
@@ -118,7 +118,9 @@ function TriviaFunc( // 6 open paren trailing
     // 7 param leading
     x: int, // 11 type trailing
     // 12 close paren leading
-) -> int // 17 return type trailing
+) -> // 15 arrow trailing
+    // 16 return type leading
+    int // 17 return type trailing
 { // 19 body open trailing
     x
 } // 20 body close trailing
@@ -131,7 +133,7 @@ function TriviaFuncBlock( /* 6 open paren trailing */
     /* 7 param leading */
     x: /* 9 colon trailing *//* 10 type leading */int, /* 11 type trailing */
     /* 12 close paren leading */
-) -> /* 15 arrow trailing *//* 16 return type leading */int /* 17 return type trailing */ { /* 19 body open trailing */
+) -> /* 15 arrow trailing */ /* 16 return type leading */ int /* 17 return type trailing */ { /* 19 body open trailing */
     x
 } /* 20 body close trailing */
 
@@ -168,7 +170,9 @@ function TriviaWrapParams( // 5 trailing
     third_parameter: bool, // 23 trailing
     // 24 leading
     fourth_parameter: float, // 28 trailing
-) -> string // 33 trailing
+) -> // 31 trailing
+    // 32 leading
+    string // 33 trailing
 { // 35 trailing
     "result"
 } // 36 trailing
@@ -186,7 +190,7 @@ function TriviaWrapParamsBlock( /* 5 trailing */
     third_parameter: /* 20 trailing *//* 21 leading */bool/* 22 trailing */, /* 23 trailing */
     /* 24 leading */
     fourth_parameter: /* 26 trailing *//* 27 leading */float, /* 28 trailing */
-) -> /* 31 trailing *//* 32 leading */string /* 33 trailing */ { /* 35 trailing */
+) -> /* 31 trailing */ /* 32 leading */ string /* 33 trailing */ { /* 35 trailing */
     "result"
 } /* 36 trailing */
 
@@ -195,7 +199,8 @@ function TriviaWrapParamsBlock( /* 5 trailing */
 // ===== Trivia on wrapping return type (line comments) =====
 function TriviaWrapReturnType(
     x: int,
-) -> int // 2 first trailing
+) -> // 1 first member leading
+    int // 2 first trailing
     // 3 pipe leading
     | string // 6 second trailing
     // 7 pipe leading
@@ -209,7 +214,7 @@ function TriviaWrapReturnType(
 // ===== Trivia on wrapping return type (block comments) =====
 function TriviaWrapReturnTypeBlock(
     x: int,
-) -> /* 1 first member leading */int /* 2 first trailing */
+) -> /* 1 first member leading */ int /* 2 first trailing */
     /* 3 pipe leading */
     |/* 4 pipe trailing *//* 5 second leading */string /* 6 second trailing */
     /* 7 pipe leading */
@@ -229,7 +234,9 @@ function TriviaEverythingLong_NameAndParamsAndReturn( // 5 trailing
     first_long_param: map<string, int>, // 11 trailing
     // 12 leading
     second_long_param: (int | string | bool)[], // 16 trailing
-) -> map<string, int | string | bool | float | null> // 21 trailing
+) -> // 19 trailing
+    // 20 leading
+    map<string, int | string | bool | float | null> // 21 trailing
 { // 23 trailing
     { "a": 1 }
 } // 24 trailing
@@ -243,7 +250,7 @@ function TriviaEverythingLong_NameAndParamsAndReturnBlock( /* 5 trailing */
     first_long_param: /* 8 trailing *//* 9 leading */map<string, int>/* 10 trailing */, /* 11 trailing */
     /* 12 leading */
     second_long_param: /* 14 trailing *//* 15 leading */(int | string | bool)[], /* 16 trailing */
-) -> /* 19 trailing *//* 20 leading */map<string, int | string | bool | float | null> /* 21 trailing */ { /* 23 trailing */
+) -> /* 19 trailing */ /* 20 leading */ map<string, int | string | bool | float | null> /* 21 trailing */ { /* 23 trailing */
     { "a": 1 }
 } /* 24 trailing */
 

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -852,21 +852,24 @@ impl BexLspRequest for BexMulitProject {
         let path = self.get_path_from_uri(&params.text_document.uri)?;
         let root_path = Self::get_baml_project_root(&path)?;
         let project_handle = self.get_or_create_project(root_path)?;
-        // Get current file text from the project database.
-        let text = {
+        // Format the current source file in the project database. Keep the
+        // text for edit comparison and diagnostics, but reuse the existing
+        // Salsa input instead of constructing a second ProjectDatabase and
+        // reparsing cloned source through `baml_fmt::format`.
+        let (text, formatted) = {
             let guard = read_for_request(&project_handle.project)?;
             let lsp_db = guard.db();
             let Some(source_file) = lsp_db.get_file(std::path::Path::new(path.as_str())) else {
                 return Err(LspError::FileNotFound(path));
             };
-            source_file.text(lsp_db).clone()
+            let text = source_file.text(lsp_db).clone();
+            let formatted =
+                baml_fmt::format_salsa(lsp_db, source_file, baml_fmt::FormatOptions::default());
+            (text, formatted)
         };
 
-        // Map LSP FormattingOptions → baml_fmt FormatOptions.
-        let options = baml_fmt::FormatOptions::default();
-
         // Run the formatter. On parse errors, return no edits (silently skip).
-        let formatted = match baml_fmt::format(&text, &options) {
+        let formatted = match formatted {
             Ok(f) => f,
             Err(baml_fmt::FormatterError::ParseErrors { .. }) => return Ok(None),
             Err(baml_fmt::FormatterError::StrongAstError(e)) => {

--- a/fern/03-reference/baml-cli/fmt.mdx
+++ b/fern/03-reference/baml-cli/fmt.mdx
@@ -23,3 +23,5 @@ To disable the formatter in a file, you can add
 anywhere in the file.
 
 Formatting is done in-place and non-configurable.
+
+The canonical formatter style uses four-space indentation. Class fields are written with a colon and trailing comma, for example `name: string,`; the formatter may accept and repair certain unambiguous alternate spellings.


### PR DESCRIPTION
## What changed

- Expanded shared-parser Postel repairs for top-level and lambda fat arrows, enum semicolon delimiters, and unambiguous omitted map commas, while keeping lambda bodies strictly brace-delimited and retaining fatal diagnostics for ambiguous input.
- Updated formatter strong-AST and printing support for shared function arrows, signed numeric literal patterns, and trivia attached to repaired syntax.
- Implemented the documented `baml-format: ignore` directive and reused the existing compiler database in the LSP formatting request.
- Made formatter failures hard errors in the generated compiler corpus and added a 1,024-case formatter scenario matrix across 16 syntax families, eight semantic variants, four trivia placements, and two layouts.
- Centralized the canonical four-space default and documented canonical `name: type,` class fields.

## Why

The formatter rejected several unambiguous spellings accepted or recoverable by the compiler, could diverge between CLI and LSP paths, and had a corpus harness that allowed formatter failures to become approved snapshots. Its focused unit suite also lacked broad coverage of syntax, trivia, layout repair, and idempotency combinations.

Lambda bodies remain strict BAML syntax: both `->` and `=>` require a brace-delimited `{ ... }` body. The formatter does not reinterpret an unbraced expression as a lambda body.

## Impact

`baml fmt` repairs the covered alternate spellings to one canonical form, preserves arrow-adjacent comments, formats compiler-accepted negative numeric patterns, honors file-level ignore directives, and shares parsing work with the LSP. The formatter crate includes a 1,024-case non-duplicate scenario matrix.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p baml_compiler_parser --lib` (152 passed)
- `cargo test -p baml_fmt --lib` (100 passed)
- `cargo test -p baml_tests --lib test_10_formatter` (216 passed)
- `cargo test -p baml_tests --lib lambda_fat_arrow` (6 passed)
- `cargo test -p baml_tests --lib braceless_lambda` (1 passed)
- `cargo test -p bex_project --lib` (57 passed, 1 ignored benchmark)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Formatter now repairs alternate arrow syntax (`=>` → `->`) and semicolon-separated enum variants.
  - Map literals may omit unambiguous commas.
  - Negative numeric literals are supported in type patterns.
  - `baml-format: ignore` preserves source text, even when syntax errors exist.
  - Formatter preserves comments around arrows and uses consistent four-space indentation.

- **Bug Fixes**
  - Improved diagnostics for lambdas missing required braces.
  - Enhanced formatting recovery for incomplete or malformed syntax.

- **Documentation**
  - Documented canonical formatting conventions and supported syntax repairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->