### PR TITLE
ci: stop size gate report on cancellation

### DIFF
--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -415,7 +415,7 @@ jobs:
   size-gate-report:
     name: "enforce-baml-size"
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: always()
+    if: ${{ always() && !cancelled() }}
     needs: [size-gate-linux, size-gate-macos, size-gate-windows, size-gate-wasm]
     permissions:
       contents: read


### PR DESCRIPTION
The size-gate report job uses always(), which causes GitHub Actions to launch it after a workflow is canceled. A recent canceled run spent another 12 minutes installing tools and restoring caches in that report job. Keep aggregating reports after platform failures, but skip the report job when the workflow itself is canceled.\n\nValidated with actionlint 1.7.12 and repository commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workflow reporting so cancelled runs are no longer processed as completed size-gate reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->