### PR TITLE
fix(sdk-java): build musl natives inside cross containers

### DIFF
--- a/.github/workflows/build2-java-sdk.reusable.yaml
+++ b/.github/workflows/build2-java-sdk.reusable.yaml
@@ -15,7 +15,8 @@ name: BAML SDK Release - Build Java
 #
 # Per target the cdylib is built NATIVELY (each target's `runner` is native-arch,
 # like the toolchain matrix), so `cargo build --target <triple>` needs no cross C
-# toolchain except the musl linker (`setup-musl-cross`). `bridge_java` is the JVM
+# toolchain except musl, which builds inside `cross` containers (like
+# build2-bridge-cffi — the container carries the full musl toolchain). `bridge_java` is the JVM
 # analog of `bridge_cffi`: it loads into the user's JVM, so it is built
 # `--profile release-bridge-java` (`panic = "unwind"`) — an engine panic must
 # unwind into the bridge's `catch_unwind` -> `BamlPanic` boundary, not SIGABRT
@@ -146,11 +147,18 @@ jobs:
           enable-cross: false
           skip-protoc: true
 
-      - name: Setup musl cross toolchain
+      - name: Install cross (musl targets)
+        # musl builds run inside `cross` containers (mirroring
+        # build2-bridge-cffi): the container image carries the full musl
+        # toolchain, so the JNI cdylib links against musl libc cleanly —
+        # the native-runner musl-cross toolchain lacks libgcc_s.so.1 for
+        # the cdylib link (rehearsal run 29862339596). `Cross.toml` at the
+        # workspace root forwards RUSTFLAGS into the container.
         if: ${{ matrix._.libc == 'musl' }}
-        uses: ./.github/actions/setup-musl-cross
-        with:
-          target: ${{ matrix._.target }}
+        run: |
+          set -euo pipefail
+          cargo install cross --locked --version 0.2.5
+          echo 'CARGO=cross' >> "$GITHUB_ENV"
 
       - name: Build bridge_java cdylib
         working-directory: baml_language
@@ -169,7 +177,7 @@ jobs:
           if [[ "$TARGET" == *-musl ]]; then
             export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C target-feature=-crt-static"
           fi
-          cargo build -p bridge_java --profile release-bridge-java --target "$TARGET"
+          "${CARGO:-cargo}" build -p bridge_java --profile release-bridge-java --target "$TARGET"
 
       - name: Package natives-<platform> jar
         working-directory: baml_language/sdks/java/baml_bridge

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -54,7 +54,7 @@
         "toolchain": { "runner": "ubuntu-24.04-arm" },
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
-        "java": { "platform": "linux-aarch64-musl", "runner": "ubuntu-24.04-arm", "experimental": true },
+        "java": { "platform": "linux-aarch64-musl", "runner": "ubuntu-latest", "experimental": true },
         "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true, "experimental": true }
       }
     },


### PR DESCRIPTION
The dry-run rehearsal (run 29862339596) surfaced both experimental musl legs failing at the JNI cdylib link (`ld: cannot find libgcc_s.so.1`) — the native-runner musl-cross toolchain lacks what the cdylib link needs. `build2-bridge-cffi`'s musl legs are green because they build inside `cross` containers; this mirrors that recipe exactly (cross 0.2.5, `$CARGO` dispatch, existing workspace `Cross.toml` RUSTFLAGS passthrough covers both musl triples). Non-musl legs byte-identical. Will validate by dispatching the build workflow from this branch before enqueueing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the build and release process for Java SDK artifacts targeting Linux ARM musl environments.
  * Updated cross-compilation handling to improve consistency across supported build platforms.
  * Adjusted the ARM musl build runner configuration to support more reliable artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->