### PR TITLE
chore: notify slack when nightly release fails

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2243,3 +2243,44 @@ jobs:
             echo "BAML_HOME=\"\$(mktemp -d)\" BAML_MANIFEST_BASE_URL=\"$base\" baml toolchain use ${{ needs.plan.outputs.channel }}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  notify-slack:
+    name: Notify Slack
+    needs: [plan, publish-pkg-boundaryml-com]
+    if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    runs-on: ubuntu-latest
+    environment: boundary-tools-dev
+    steps:
+      - name: Send Slack notification
+        env:
+          SLACK_CHANNEL_ID: C03KV1PJ6EM
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
+          VERSION: ${{ needs.plan.outputs.version }}
+          CHANNEL: ${{ needs.plan.outputs.channel }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SLACK_BOT_TOKEN:-}" ]]; then
+            echo "::error::SLACK_BOUNDARY_BOT_TOKEN secret is not set"
+            exit 1
+          fi
+          
+          message="🚀 BAML Language $VERSION ($CHANNEL) has been released!"
+          
+          curl -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d @- <<EOF
+          {
+            "channel": "$SLACK_CHANNEL_ID",
+            "text": "$message",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "$message\n\n*Version:* $VERSION\n*Channel:* $CHANNEL\n*Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                }
+              }
+            ]
+          }
+          EOF

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2284,6 +2284,9 @@ jobs:
     if: ${{ always() && inputs.dry_run == false && github.ref_name == 'canary' }}
     runs-on: ubuntu-latest
     environment: boundary-tools-dev
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2246,41 +2246,62 @@ jobs:
 
   notify-slack:
     name: Notify Slack on failure
-    needs: [plan, publish-pkg-boundaryml-com]
-    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' && needs.publish-pkg-boundaryml-com.result == 'failure' }}
+    needs:
+      - plan
+      - build-matrix
+      - build-toolchain
+      - build-vsix
+      - build-wrapper
+      - build-python-sdk
+      - build-nodejs-sdk
+      - build-java-sdk
+      - build-web-sdk
+      - build-bridge-cffi
+      - build-go-sdk
+      - verify-cpp-sdk
+      - build-rust-sdk
+      - verify-rust-sdk
+      - all-builds
+      - publish-pypi
+      - publish-nodejs-sdk
+      - publish-web-sdk
+      - publish-maven
+      - publish-gradle-plugin
+      - publish-toolchain-release
+      - publish-wrapper-release
+      - publish-bridge-cffi-release
+      - publish-go-sdk
+      - publish-crates-io
+      - publish-pkg-boundaryml-com
+      - smoke-go-release
+      - dispatch-nightly-after-canary
+      - publish-homebrew
+      - publish-aur
+      - dry-run-artifacts
+      - dry-run-summary
+    # Use the dispatch input so a failure in plan itself is still reportable.
+    # This job must run after failed dependencies; the script posts only when the run contains failures.
+    if: ${{ always() && inputs.dry_run == false && github.ref_name == 'canary' }}
     runs-on: ubuntu-latest
     environment: boundary-tools-dev
     steps:
-      - name: Send Slack failure notification
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.plan.outputs.source_sha || github.sha }}
+          sparse-checkout: |
+            .github/actions/setup-mise
+            mise.toml
+            tools/notify-release-failure.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: uv
+      - name: Find failures and notify Slack
         env:
+          GH_TOKEN: ${{ github.token }}
           SLACK_CHANNEL: "#general"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
           VERSION: ${{ needs.plan.outputs.version }}
           CHANNEL: ${{ needs.plan.outputs.channel }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${SLACK_BOT_TOKEN:-}" ]]; then
-            echo "::error::SLACK_BOUNDARY_BOT_TOKEN secret is not set"
-            exit 1
-          fi
-          
-          message="❌ BAML Language $VERSION ($CHANNEL) release failed!"
-          
-          curl -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -H "Content-Type: application/json; charset=utf-8" \
-            -d @- <<EOF
-          {
-            "channel": "$SLACK_CHANNEL",
-            "text": "$message",
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "$message\n\n*Version:* $VERSION\n*Channel:* $CHANNEL\n*Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
-                }
-              }
-            ]
-          }
-          EOF
+        run: uv run --script tools/notify-release-failure.py

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2279,9 +2279,18 @@ jobs:
       - publish-aur
       - dry-run-artifacts
       - dry-run-summary
+      - build-swift-sdk
+      - verify-swift-sdk
+      - prepare-csharp-sdk
+      - verify-csharp-sdk
+      - publish-csharp-sdk
+      - release-prerequisites-complete
+      - release-complete
+      - publish-pkg-channel
+      - smoke-swift-release
     # Use the dispatch input so a failure in plan itself is still reportable.
     # This job must run after failed dependencies; the script posts only when the run contains failures.
-    if: ${{ always() && inputs.dry_run == false && github.ref_name == 'canary' }}
+    if: ${{ always() && inputs.dry_run == false && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     environment: boundary-tools-dev
     permissions:

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2245,15 +2245,15 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify-slack:
-    name: Notify Slack
+    name: Notify Slack on failure
     needs: [plan, publish-pkg-boundaryml-com]
-    if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' && needs.publish-pkg-boundaryml-com.result == 'failure' }}
     runs-on: ubuntu-latest
     environment: boundary-tools-dev
     steps:
-      - name: Send Slack notification
+      - name: Send Slack failure notification
         env:
-          SLACK_CHANNEL_ID: C03KV1PJ6EM
+          SLACK_CHANNEL: "#general"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
           VERSION: ${{ needs.plan.outputs.version }}
           CHANNEL: ${{ needs.plan.outputs.channel }}
@@ -2264,14 +2264,14 @@ jobs:
             exit 1
           fi
           
-          message="🚀 BAML Language $VERSION ($CHANNEL) has been released!"
+          message="❌ BAML Language $VERSION ($CHANNEL) release failed!"
           
           curl -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
             -d @- <<EOF
           {
-            "channel": "$SLACK_CHANNEL_ID",
+            "channel": "$SLACK_CHANNEL",
             "text": "$message",
             "blocks": [
               {

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -20,6 +20,8 @@ from zoneinfo import ZoneInfo
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError, SlackClientError
 
+GITHUB_API_TIMEOUT_SECONDS = 30
+
 
 @dataclass(frozen=True)
 class Failure:
@@ -56,7 +58,9 @@ def get_json(url: str, token: str) -> tuple[dict[str, Any], str | None]:
         },
     )
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with urllib.request.urlopen(
+            request, timeout=GITHUB_API_TIMEOUT_SECONDS
+        ) as response:
             return json.load(response), response.headers.get("Link")
     except urllib.error.HTTPError as error:
         body = error.read().decode(errors="replace")

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "slack-sdk==3.41.0",
+# ]
+# ///
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError, SlackClientError
+
+
+@dataclass(frozen=True)
+class Failure:
+    job_name: str
+    job_url: str
+    step_names: list[str]
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value:
+        raise RuntimeError(f"{name} is not set")
+    return value
+
+
+def next_page(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+    for link in link_header.split(","):
+        url, *parameters = link.strip().split(";")
+        if any(parameter.strip() == 'rel="next"' for parameter in parameters):
+            return url.strip("<>")
+    return None
+
+
+def get_json(url: str, token: str) -> tuple[dict[str, Any], str | None]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "baml-release-failure-notifier",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response), response.headers.get("Link")
+    except urllib.error.HTTPError as error:
+        body = error.read().decode(errors="replace")
+        raise RuntimeError(
+            f"GitHub API request failed with HTTP {error.code}: {body}"
+        ) from error
+
+
+def find_failures(
+    repository: str, run_id: str, run_attempt: str, token: str
+) -> list[Failure]:
+    url: str | None = (
+        f"https://api.github.com/repos/{repository}/actions/runs/{run_id}"
+        f"/attempts/{run_attempt}/jobs?per_page=100"
+    )
+    failures: list[Failure] = []
+    while url:
+        payload, link_header = get_json(url, token)
+        for job in payload["jobs"]:
+            failed_steps = [
+                step["name"]
+                for step in job.get("steps", [])
+                if step.get("conclusion") == "failure"
+            ]
+            if job.get("conclusion") == "failure" or failed_steps:
+                failures.append(
+                    Failure(
+                        job_name=job["name"],
+                        job_url=job["html_url"],
+                        step_names=failed_steps,
+                    )
+                )
+        url = next_page(link_header)
+    return failures
+
+
+def get_run_started_at(
+    repository: str, run_id: str, run_attempt: str, token: str
+) -> datetime:
+    url = (
+        f"https://api.github.com/repos/{repository}/actions/runs/{run_id}"
+        f"/attempts/{run_attempt}"
+    )
+    payload, _ = get_json(url, token)
+    return datetime.fromisoformat(payload["run_started_at"].replace("Z", "+00:00"))
+
+
+def format_pacific_time(timestamp: datetime) -> str:
+    pacific = timestamp.astimezone(ZoneInfo("America/Los_Angeles"))
+    hour = pacific.strftime("%I").lstrip("0")
+    am_pm = pacific.strftime("%p").lower()
+    return f"{pacific.strftime('%b')} {pacific.day} {hour}:{pacific.strftime('%M')}{am_pm} PT"
+
+
+def format_failure(failure: Failure) -> str:
+    job = f"<{failure.job_url}|{failure.job_name}>"
+    if not failure.step_names:
+        return f"• {job} — job failed before a failed step was reported"
+    suffix = "" if len(failure.step_names) == 1 else "s"
+    return f"• {job} — failed step{suffix}: {', '.join(failure.step_names)}"
+
+
+def main() -> int:
+    try:
+        repository = required_env("GITHUB_REPOSITORY")
+        run_id = required_env("GITHUB_RUN_ID")
+        run_attempt = required_env("GITHUB_RUN_ATTEMPT")
+        github_token = required_env("GH_TOKEN")
+        slack_channel = required_env("SLACK_CHANNEL")
+        slack_token = required_env("SLACK_BOT_TOKEN")
+
+        started_at = get_run_started_at(repository, run_id, run_attempt, github_token)
+        failures = find_failures(repository, run_id, run_attempt, github_token)
+        if not failures:
+            print("No failed jobs or steps found; skipping Slack notification.")
+            return 0
+
+        version = os.environ.get("VERSION") or "unknown version"
+        channel = os.environ.get("CHANNEL") or "unknown channel"
+        run_url = (
+            f"https://github.com/{repository}/actions/runs/{run_id}"
+            f"/attempts/{run_attempt}"
+        )
+        failure_text = "\n".join(format_failure(failure) for failure in failures)
+        message = (
+            f"BAML {channel} release failed: {version}, "
+            f"started at {format_pacific_time(started_at)}\n\n"
+            f"*Failures:*\n{failure_text}\n\n"
+            f"*Run:* <{run_url}|View workflow run>"
+        )
+
+        WebClient(token=slack_token).chat_postMessage(
+            channel=slack_channel,
+            text=message,
+            unfurl_links=False,
+        )
+        return 0
+    except SlackApiError as error:
+        print(
+            f"Slack API rejected the notification: {error.response.get('error', 'unknown_error')}",
+            file=sys.stderr,
+        )
+    except SlackClientError as error:
+        print(f"Slack request failed: {error}", file=sys.stderr)
+    except (KeyError, RuntimeError, urllib.error.URLError) as error:
+        print(f"Release failure notification failed: {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue Reference
N/A - Direct request from Slack

## Changes
Added a Slack notification job to the `release-baml-language.yml` workflow that:
- Runs **only when a non-dry-run release fails** (checks `publish-pkg-boundaryml-com` job failure)
- Uses the `boundary-tools-dev` GitHub environment
- Posts a failure notification to Slack channel `#general`
- Uses `SLACK_BOUNDARY_BOT_TOKEN` from the environment secrets
- Includes version, channel, and workflow run link in the failure notification

The notification job is configured to run only when:
- `dry_run == false`
- `source_branch == 'canary'`
- `publish-pkg-boundaryml-com.result == 'failure'`

## Testing
- [ ] Manual testing performed
- [ ] Tested in boundary-tools-dev environment

The workflow change can be tested by:
1. Triggering a release workflow run that fails
2. Verifying the Slack failure notification is posted to `#general`

## PR Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
The Slack notification will only be sent for failed non-dry-run releases from the canary branch. The job requires the following environment variables to be configured in the `boundary-tools-dev` environment:
- `SLACK_BOUNDARY_BOT_TOKEN` (required for authentication)

The notification uses `#general` as the channel name, which the Slack API will resolve to the appropriate channel ID.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1784682731692559?thread_ts=1784682731.692559&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-0173fe2c-367d-50f1-ba8d-6d6c6d6d1a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0173fe2c-367d-50f1-ba8d-6d6c6d6d1a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated Slack notifications for failed canary release workflow runs, sent only for real (non–dry-run) attempts.
  - Alerts include the release version/channel, a link to the workflow attempt, and a “Failures” section listing failed jobs and related step details.

- **Chores**
  - Improved release monitoring by aggregating workflow run attempt failure signals and reporting them to Slack when a release process fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->