### PR TITLE
Generate boundary's native dispatch from its .baml

### DIFF
--- a/baml_language/crates/bex_vm/build.rs
+++ b/baml_language/crates/bex_vm/build.rs
@@ -6,6 +6,7 @@ fn main() {
     for (package, file) in [
         ("baml", "nativefunctions_generated.rs"),
         ("reflect", "reflectfunctions_generated.rs"),
+        ("boundary", "boundaryfunctions_generated.rs"),
     ] {
         let (vm_builtins, _io_builtins, class_defs) =
             baml_builtins2_codegen::extract_native_builtins_for(package)

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -382,9 +382,8 @@ pub(super) fn to_json_override_fn_name(vm: &BexVm, v: Value) -> Option<String> {
 // =============================================================================
 
 /// The stdlib packages whose natives this VM implements, each paired with its
-/// dispatcher. `baml` and `reflect` dispatch through their generated root
-/// traits (see `baml_builtins2_codegen`), so their entries cannot drift from
-/// the `.baml` declarations; `boundary` is still hand-wired.
+/// dispatcher. Every one dispatches through its generated root trait (see `baml_builtins2_codegen`), so no entry can drift from its
+/// `.baml` declarations.
 ///
 /// One entry per package drives both resolution and the missing-native check,
 /// so adding a package is a single line here plus its `build.rs` generation.
@@ -396,7 +395,10 @@ const VM_NATIVE_PACKAGES: &[(&str, NativeResolver)] = &[
         "reflect.",
         <crate::package_reflect::PackageReflectImpl as crate::package_reflect::BamlPackageReflect>::get_native_fn,
     ),
-    ("boundary.", crate::package_boundary::get_native_fn),
+    (
+        "boundary.",
+        <crate::package_boundary::PackageBoundaryImpl as crate::package_boundary::BamlPackageBoundary>::get_native_fn,
+    ),
 ];
 
 /// Resolves native function pointers for unresolved native functions in objects.

--- a/baml_language/crates/bex_vm/src/package_boundary/id.rs
+++ b/baml_language/crates/bex_vm/src/package_boundary/id.rs
@@ -1,13 +1,12 @@
 use std::sync::{Arc, Mutex};
 
 use bex_events::ids::{BoundaryId, RuntimeId};
-use bex_heap::TlabHolder;
-use bex_vm_types::types::{Value, ValueKind};
+use bex_vm_types::types::Value;
 
+use super::{BamlClassLocalId, BamlNamespaceId, BamlPackageBoundary, PackageBoundaryImpl};
 use crate::{
     BexVm, VmPanic,
-    errors::{VmBamlError, VmInternalError, VmRustFnError},
-    package_baml::{NativeCallResult, NativeFunctionResult},
+    errors::{VmBamlError, VmRustFnError},
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -50,22 +49,17 @@ pub(crate) struct ConsumedLocalId {
     pub capture: LocalIdCaptureOverrides,
 }
 
-pub(super) fn current(vm: &mut BexVm, _args: &[Value]) -> NativeCallResult {
-    let result: NativeFunctionResult = {
-        let id = crate::package_baml::id::current_runtime_id(vm).map_or_else(
+impl BamlNamespaceId for PackageBoundaryImpl {
+    fn current(vm: &BexVm) -> bex_str::BexStr {
+        crate::package_baml::id::current_runtime_id(vm).map_or_else(
             || bex_str::BexStr::from(""),
             |id| bex_str::BexStr::from(id.as_str()),
-        );
-        Ok(Value::object(vm.alloc_string(id)))
-    };
-    match result {
-        Ok(value) => NativeCallResult::Done(value),
-        Err(err) => NativeCallResult::Error(err),
+        )
     }
 }
 
-pub(super) fn new(vm: &mut BexVm, _args: &[Value]) -> NativeCallResult {
-    let result: NativeFunctionResult = (|| {
+impl BamlPackageBoundary for PackageBoundaryImpl {
+    fn id(vm: &mut BexVm) -> Result<Value, VmRustFnError> {
         let mut id = [0u8; 16];
         getrandom::getrandom(&mut id).map_err(|e| VmPanic::HostUnavailable {
             resource: "entropy".to_string(),
@@ -80,26 +74,18 @@ pub(super) fn new(vm: &mut BexVm, _args: &[Value]) -> NativeCallResult {
             consumed: false,
         };
         Ok(alloc_local_id(vm, state))
-    })();
-    match result {
-        Ok(value) => NativeCallResult::Done(value),
-        Err(err) => NativeCallResult::Error(err),
     }
 }
 
-pub(super) fn capture(vm: &mut BexVm, args: &[Value]) -> NativeCallResult {
-    let result: NativeFunctionResult = (|| {
-        let [this, inputs, output, error] = args else {
-            return Err(VmInternalError::InvalidArgumentCount {
-                expected: 4,
-                got: args.len(),
-            }
-            .into());
-        };
-        let state = local_id_state(vm, *this)?;
-        let inputs = optional_bool(*inputs, "inputs")?;
-        let output = optional_bool(*output, "output")?;
-        let error = optional_bool(*error, "error")?;
+impl BamlClassLocalId for PackageBoundaryImpl {
+    fn capture(
+        vm: &mut BexVm,
+        localid: &Value,
+        inputs: Option<bool>,
+        output: Option<bool>,
+        error: Option<bool>,
+    ) -> Result<Value, VmRustFnError> {
+        let state = local_id_state(vm, *localid)?;
         let mut guard = state.lock().map_err(|_| VmBamlError::InvalidArgument {
             message: "boundary.LocalId state is unavailable".to_string(),
         })?;
@@ -119,11 +105,7 @@ pub(super) fn capture(vm: &mut BexVm, args: &[Value]) -> NativeCallResult {
         if let Some(error) = error {
             guard.capture.error = Some(error);
         }
-        Ok(*this)
-    })();
-    match result {
-        Ok(value) => NativeCallResult::Done(value),
-        Err(err) => NativeCallResult::Error(err),
+        Ok(*localid)
     }
 }
 
@@ -136,9 +118,10 @@ pub(crate) fn consume_local_id(vm: &BexVm, value: Value) -> Result<ConsumedLocal
 }
 
 fn alloc_local_id(vm: &mut BexVm, state: LocalIdState) -> Value {
-    let class = vm.resolve_class("boundary.LocalId");
-    let handle = Value::object(vm.alloc_rust_data(Arc::new(Mutex::new(state))));
-    Value::object(vm.alloc_instance(class, vec![handle]))
+    super::copy::LocalId {
+        _handle: Arc::new(Mutex::new(state)),
+    }
+    .to_value(vm)
 }
 
 fn local_id_state(vm: &BexVm, value: Value) -> Result<&Mutex<LocalIdState>, VmRustFnError> {
@@ -146,15 +129,4 @@ fn local_id_state(vm: &BexVm, value: Value) -> Result<&Mutex<LocalIdState>, VmRu
     let handle = instance.load_field(0);
     vm.as_rust_data::<Mutex<LocalIdState>>(&handle)
         .map_err(VmRustFnError::from)
-}
-
-fn optional_bool(value: Value, name: &str) -> Result<Option<bool>, VmRustFnError> {
-    match value.kind() {
-        ValueKind::Bool(value) => Ok(Some(value)),
-        ValueKind::Null | ValueKind::OmittedArg => Ok(None),
-        _ => Err(VmBamlError::InvalidArgument {
-            message: format!("boundary.LocalId.capture `{name}` must be bool or null"),
-        }
-        .into()),
-    }
 }

--- a/baml_language/crates/bex_vm/src/package_boundary/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_boundary/mod.rs
@@ -1,12 +1,46 @@
+//! Native implementations for the `boundary` stdlib package.
+//!
+//! Dispatch and the class constructors are generated from `boundary`'s `.baml`
+//! sources by `baml_builtins2_codegen`, exactly as for [`crate::package_baml`]
+//! and [`crate::package_reflect`]: declaring a `$rust_function` adds a required
+//! trait method, so the declaration and its implementation cannot drift.
+
 pub(crate) mod id;
 
-use crate::package_baml::NativeFunction;
+// `Instance`/`Type`, the allocator trait, and the error types are referenced
+// by the generated module.
+use bex_heap::TlabHolder;
+use bex_vm_types::types::{Instance, Type, Value};
 
-pub fn get_native_fn(path: &str) -> Option<NativeFunction> {
-    match path.strip_prefix("boundary.")? {
-        "id" => Some(id::new),
-        "id.current" => Some(id::current),
-        "LocalId.capture" => Some(id::capture),
-        _ => None,
-    }
+use crate::{
+    BexVm,
+    errors::{VmInternalError, VmRustFnError},
+    package_baml::{NativeCallResult, NativeFunction, NativeFunctionResult},
+};
+
+// The `BamlPackageBoundary` trait hierarchy and its `get_native_fn`
+// dispatcher, generated from the package's `.baml` declarations.
+#[allow(
+    unused_variables,
+    unsafe_code,
+    non_camel_case_types,
+    clippy::wildcard_imports,
+    clippy::pub_underscore_fields,
+    clippy::used_underscore_binding,
+    clippy::elidable_lifetime_names,
+    clippy::get_first,
+    clippy::iter_not_returning_iterator,
+    clippy::needless_lifetimes,
+    clippy::redundant_closure_call,
+    clippy::new_ret_no_self,
+    clippy::too_many_arguments,
+    non_snake_case
+)]
+mod generated {
+    use super::*;
+    include!(concat!(env!("OUT_DIR"), "/boundaryfunctions_generated.rs"));
 }
+pub use generated::*;
+
+/// The VM's `boundary` native implementations.
+pub struct PackageBoundaryImpl;


### PR DESCRIPTION
Follow-up to #4099, which made `baml_builtins2_codegen` package-generic and moved `reflect` onto it. `boundary` was the last package still hand-wiring its natives.

## What it was

```rust
pub fn get_native_fn(path: &str) -> Option<NativeFunction> {
    match path.strip_prefix("boundary.")? {
        "id" => Some(id::new),
        "id.current" => Some(id::current),
        "LocalId.capture" => Some(id::capture),
        _ => None,
    }
}
```

Nothing kept that in sync with the `.baml` declarations: adding a `$rust_function` and forgetting an arm gave a runtime lookup miss, not a build error. Each native also hand-rolled the boilerplate the generated glue already writes: arity checks, argument conversion, and the `Result` -> `NativeCallResult` match.

## What it is now

`boundary` generates its `BamlPackageBoundary` / `BamlNamespaceId` / `BamlClassLocalId` hierarchy like `baml` and `reflect` (three lines in `bex_vm/build.rs`), so:

- the three natives are required trait methods, and a declared `$rust_function` without an implementation is a compile error;
- arguments arrive converted, so `LocalId.capture` takes `Option<bool>` triples instead of unpacking raw `Value`s, and the hand-written `optional_bool` helper is deleted;
- the `LocalId` constructor builds through the generated `copy::LocalId` struct instead of a positional `alloc_instance(vec![...])`;
- `VM_NATIVE_PACKAGES` now points every package at a generated dispatcher, so no entry in it can drift.

## Scope

I checked the other stdlib packages: `log` is entirely `$compiler_intrinsic` (no natives), and `assert` and `testing` declare none, so `boundary` was the only remaining offender.

Net +10 lines (the generation loop entry and trait scaffolding, minus the deleted dispatch and glue). Verified: `bex_vm` + `baml_tests` 2929 passing, `baml_cli` + `bex_engine` 976 passing, clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Boundary runtime package to use the same generated native-function dispatch as other standard-library packages.
  * Improved handling of Boundary IDs and local ID capture through typed interfaces.
  * Preserved local ID capture behavior while simplifying argument handling and state management.
  * Added generated Boundary native-function support to the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->