### PR TITLE
Fix Rust and C++ bridge release verification

### DIFF
--- a/.github/workflows/verify-rust-sdk.reusable.yaml
+++ b/.github/workflows/verify-rust-sdk.reusable.yaml
@@ -128,6 +128,7 @@ jobs:
           echo "dylib=$(abspath "$dylib")" >> "$GITHUB_OUTPUT"
 
       - name: Assert version triple (crate == dylib version() == plan canonical)
+        working-directory: baml_language
         run: |
           set -euo pipefail
           crate_version="$(basename "${{ steps.art.outputs.crate }}" .crate)"
@@ -135,7 +136,9 @@ jobs:
           [[ "$crate_version" == "$CANONICAL" ]] || {
             echo "::error::crate version ${crate_version} != plan canonical ${CANONICAL}"; exit 1; }
           # dylib version() must equal the plan canonical too.
-          python3 scripts/smoke-bridge-cffi.py "${{ steps.art.outputs.dylib }}" "$CANONICAL"
+          python3 crates/bridge_cffi/tests/run_abi_smoke.py \
+            "${{ steps.art.outputs.dylib }}" \
+            "$CANONICAL"
 
       - name: Extract baml-cli from the same-plan toolchain artifact
         id: cli

--- a/baml_language/sdk_tests/crates/cpp/setup.sh
+++ b/baml_language/sdk_tests/crates/cpp/setup.sh
@@ -5,11 +5,12 @@
 # in `baml_language/.config/nextest.toml` whenever the run selects any
 # sdk_test_cpp test. For plain `cargo test` (no nextest) run this manually.
 #
-# One responsibility: build the dev-profile bridge_cffi cdylib that every
-# fixture's test.sh dlopens at run time (target/debug/libbridge_cffi.*). The dev
-# profile has panic=unwind by default, matching the release-bridge-cffi
-# shipping profile's unwind requirement. Features mirror the workspace test
-# convention (ring-crypto instead of the default aws-crypto).
+# Builds the dev-profile bridge_cffi cdylib that every fixture's test.sh
+# dlopens at run time (target/debug/libbridge_cffi.*), then runs the bridge_cpp
+# core consumer smoke against that same library. The dev profile has
+# panic=unwind by default, matching the release-bridge-cffi shipping profile's
+# unwind requirement. Features mirror the workspace test convention
+# (ring-crypto instead of the default aws-crypto).
 #
 # This placement (out of build.rs) mirrors the python/typescript targets so
 # `cargo check`/`cargo doc` succeed without a C++ toolchain and the heavy
@@ -46,6 +47,15 @@ clone_pinned() {
 }
 clone_pinned https://github.com/protocolbuffers/protobuf.git v31.1 "$PROTOBUF_SRC"
 clone_pinned https://github.com/abseil/abseil-cpp.git 20250127.0 "$ABSL_SRC"
+
+case "$(uname -s)" in
+    Darwin) RUNTIME_LIB="libbridge_cffi.dylib" ;;
+    MSYS* | MINGW* | CYGWIN*) RUNTIME_LIB="bridge_cffi.dll" ;;
+    *) RUNTIME_LIB="libbridge_cffi.so" ;;
+esac
+echo "==> run bridge_cpp core consumer smoke"
+BAML_RUNTIME_PATH="$WORKSPACE_ROOT/target/debug/$RUNTIME_LIB" \
+    "$WORKSPACE_ROOT/sdks/cpp/bridge_cpp/tests/run.sh"
 
 # Per-run breadcrumb for the in-test guard; see setup_guard in
 # harness_runner and SETUP_ENV_VAR in harness_setup/src/cpp.rs.

--- a/baml_language/sdks/cpp/bridge_cpp/tests/run.sh
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/run.sh
@@ -1,21 +1,32 @@
 #!/usr/bin/env bash
-# Configure, build, and run the bridge_cpp core smoke against the locally
-# built cdylib. Builds bridge_cffi first if the library is missing. CMake
-# drives the build; the pinned protobuf/abseil sources are cloned once
-# into target/cpp-protobuf-src and target/cpp-absl-src (shared with the
-# sdk-test harness) and passed via FETCHCONTENT_SOURCE_DIR_* overrides.
+# Configure, build, and run the bridge_cpp core smoke against a locally built
+# cdylib. Uses BAML_RUNTIME_PATH when provided; otherwise builds bridge_cffi if
+# the release-profile library is missing. CMake drives the build; the pinned
+# protobuf/abseil sources are cloned once into target/cpp-protobuf-src and
+# target/cpp-absl-src (shared with the sdk-test harness) and passed via
+# FETCHCONTENT_SOURCE_DIR_* overrides.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 bridge_cpp_dir="$PWD"
 cd ../../..
 
-target="${BAML_CPP_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
-libdir="target/$target/release-bridge-cffi"
-if ! ls "$libdir"/libbridge_cffi.* "$libdir"/bridge_cffi.dll > /dev/null 2>&1; then
-    cargo build --profile release-bridge-cffi -p bridge_cffi --target "$target" \
-        ${BAML_CPP_FEATURES:+--no-default-features --features "$BAML_CPP_FEATURES"}
+runtime_path="${BAML_RUNTIME_PATH:-}"
+if [[ -z "$runtime_path" ]]; then
+    target="${BAML_CPP_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
+    libdir="target/$target/release-bridge-cffi"
+    if ! ls "$libdir"/libbridge_cffi.* "$libdir"/bridge_cffi.dll > /dev/null 2>&1; then
+        cargo build --profile release-bridge-cffi -p bridge_cffi --target "$target" \
+            ${BAML_CPP_FEATURES:+--no-default-features --features "$BAML_CPP_FEATURES"}
+    fi
+    case "$target" in
+        *apple*) runtime_lib="libbridge_cffi.dylib" ;;
+        *windows*) runtime_lib="bridge_cffi.dll" ;;
+        *) runtime_lib="libbridge_cffi.so" ;;
+    esac
+    runtime_path="$PWD/$libdir/$runtime_lib"
 fi
+[[ -f "$runtime_path" ]] || { echo "bridge_cffi library not found: $runtime_path" >&2; exit 1; }
 
 # Pre-cloned pinned sources (shared with the sdk-test harness; cloned here
 # when missing so this script stays self-sufficient). Atomic temp+rename so
@@ -37,9 +48,4 @@ cmake -B "$build_dir" -S "$bridge_cpp_dir/tests" \
     -DFETCHCONTENT_SOURCE_DIR_ABSL="$PWD/target/cpp-absl-src" > /dev/null
 cmake --build "$build_dir" -j "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" > /dev/null
 
-case "$target" in
-    *apple*) runtime_lib="libbridge_cffi.dylib" ;;
-    *windows*) runtime_lib="bridge_cffi.dll" ;;
-    *) runtime_lib="libbridge_cffi.so" ;;
-esac
-BAML_RUNTIME_PATH="$PWD/$libdir/$runtime_lib" "$build_dir/runtime_smoke"
+BAML_RUNTIME_PATH="$runtime_path" "$build_dir/runtime_smoke"

--- a/baml_language/sdks/cpp/bridge_cpp/tests/run.sh
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/run.sh
@@ -15,15 +15,15 @@ runtime_path="${BAML_RUNTIME_PATH:-}"
 if [[ -z "$runtime_path" ]]; then
     target="${BAML_CPP_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
     libdir="target/$target/release-bridge-cffi"
-    if ! ls "$libdir"/libbridge_cffi.* "$libdir"/bridge_cffi.dll > /dev/null 2>&1; then
-        cargo build --profile release-bridge-cffi -p bridge_cffi --target "$target" \
-            ${BAML_CPP_FEATURES:+--no-default-features --features "$BAML_CPP_FEATURES"}
-    fi
     case "$target" in
         *apple*) runtime_lib="libbridge_cffi.dylib" ;;
         *windows*) runtime_lib="bridge_cffi.dll" ;;
         *) runtime_lib="libbridge_cffi.so" ;;
     esac
+    if [[ ! -f "$libdir/$runtime_lib" ]]; then
+        cargo build --profile release-bridge-cffi -p bridge_cffi --target "$target" \
+            ${BAML_CPP_FEATURES:+--no-default-features --features "$BAML_CPP_FEATURES"}
+    fi
     runtime_path="$PWD/$libdir/$runtime_lib"
 fi
 [[ -f "$runtime_path" ]] || { echo "bridge_cffi library not found: $runtime_path" >&2; exit 1; }

--- a/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
@@ -39,9 +39,10 @@ static void TestCallRegistryRoundTrip() {
   const std::vector<int8_t> payload = {1, 2, 3, 4};
   baml_cpp_result_trampoline(started.correlation_id, payload.data(),
                              payload.size());
-  auto status = started.envelope.wait_for(std::chrono::seconds(1));
-  assert(status == std::future_status::ready);
-  const std::vector<uint8_t> got = started.envelope.get();
+  const bool ready = started.state->wait_until(
+      std::chrono::steady_clock::now() + std::chrono::seconds(1));
+  assert(ready);
+  const std::vector<uint8_t>& got = started.state->wait();
   assert(got.size() == 4 && got[0] == 1 && got[3] == 4);
   std::printf("call registry round trip ok\n");
 }

--- a/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
@@ -39,9 +39,10 @@ static void TestCallRegistryRoundTrip() {
   const std::vector<int8_t> payload = {1, 2, 3, 4};
   baml_cpp_result_trampoline(started.correlation_id, payload.data(),
                              payload.size());
-  const bool ready = started.state->wait_until(
-      std::chrono::steady_clock::now() + std::chrono::seconds(1));
-  assert(ready);
+  if (!started.state->wait_until(std::chrono::steady_clock::now() +
+                                 std::chrono::seconds(1))) {
+    throw std::runtime_error("call registry round trip timed out");
+  }
   const std::vector<uint8_t>& got = started.state->wait();
   assert(got.size() == 4 && got[0] == 1 && got[3] == 4);
   std::printf("call registry round trip ok\n");


### PR DESCRIPTION
## Summary

- update the C++ bridge core smoke for the shared call_state introduced by async calls
- run the core consumer smoke in normal C++ SDK presubmit setup, reusing the already-built dev bridge
- switch Rust release version verification to the canonical public C/C++ ABI smoke that replaced the deleted legacy script

Production bridge code is unchanged, so this has no runtime performance impact.

## Testing

- full sdk_test_cpp nextest suite: 12 passed
- bridge_cpp core consumer smoke passed
- public C and C++ ABI smoke passed
- actionlint, bash syntax, clang-format, and diff checks passed

Fixes the bridge failures in https://github.com/BoundaryML/baml/actions/runs/29874397753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C++ SDK runtime discovery and loading across macOS, Windows, and Linux.
  * Added stronger validation and clear failure behavior when the required runtime library can’t be found.
  * Enhanced reliability of C++ smoke tests by waiting for call completion before assertions.
* **Tests**
  * Strengthened Rust SDK verification to validate the downloaded ABI/dylib using the appropriate test harness and working directory.
  * Strengthened C++ SDK smoke testing with optional externally provided runtime path support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->