### PR TITLE
Fix Rust and C++ release verification regressions

### DIFF
--- a/.github/workflows/verify-cpp-sdk.reusable.yaml
+++ b/.github/workflows/verify-cpp-sdk.reusable.yaml
@@ -152,6 +152,7 @@ jobs:
           Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation `
             -DevCmdArguments "-arch=${{ matrix.msvc_arch }} -host_arch=${{ matrix.msvc_arch }}"
+          $env:BAML_RUNTIME_PATH = (Resolve-Path .\runtime-dist\bridge_cffi.dll).Path
           cmake -S baml_language\sdks\cpp\bridge_cpp\tests -B smoke-build
           if ($LASTEXITCODE -ne 0) { throw "cmake configure failed" }
           cmake --build smoke-build --target runtime_smoke -j --config Release

--- a/.github/workflows/verify-cpp-sdk.reusable.yaml
+++ b/.github/workflows/verify-cpp-sdk.reusable.yaml
@@ -122,7 +122,7 @@ jobs:
         run: |
           set -euo pipefail
           cmake -S baml_language/sdks/cpp/bridge_cpp/tests -B smoke-build
-          cmake --build smoke-build -j
+          cmake --build smoke-build --target runtime_smoke -j
           out="$(./smoke-build/runtime_smoke)"
           echo "$out"
           echo "$out" | grep -qx "version: $BAML_EXPECTED_VERSION"
@@ -137,7 +137,7 @@ jobs:
             ${{ matrix.smoke_container }} \
             sh -c 'apk add --no-cache bash g++ cmake make git linux-headers && \
               cmake -S baml_language/sdks/cpp/bridge_cpp/tests -B smoke-build && \
-              cmake --build smoke-build -j && \
+              cmake --build smoke-build --target runtime_smoke -j && \
               out="$(./smoke-build/runtime_smoke)" && echo "$out" && \
               echo "$out" | grep -qx "version: $BAML_EXPECTED_VERSION"'
 
@@ -154,7 +154,7 @@ jobs:
           cmake -S baml_language\sdks\cpp\bridge_cpp\tests -B smoke-build
           if ($LASTEXITCODE -ne 0) { throw "cmake configure failed" }
           # Debug config: the smoke asserts must stay compiled in (NDEBUG off).
-          cmake --build smoke-build -j --config Debug
+          cmake --build smoke-build --target runtime_smoke -j --config Debug
           if ($LASTEXITCODE -ne 0) { throw "cmake build failed" }
           $out = & .\smoke-build\Debug\runtime_smoke.exe
           if ($LASTEXITCODE -ne 0) { throw "runtime_smoke exited with $LASTEXITCODE" }

--- a/.github/workflows/verify-cpp-sdk.reusable.yaml
+++ b/.github/workflows/verify-cpp-sdk.reusable.yaml
@@ -154,10 +154,9 @@ jobs:
             -DevCmdArguments "-arch=${{ matrix.msvc_arch }} -host_arch=${{ matrix.msvc_arch }}"
           cmake -S baml_language\sdks\cpp\bridge_cpp\tests -B smoke-build
           if ($LASTEXITCODE -ne 0) { throw "cmake configure failed" }
-          # Debug config: the smoke asserts must stay compiled in (NDEBUG off).
-          cmake --build smoke-build --target runtime_smoke -j --config Debug
+          cmake --build smoke-build --target runtime_smoke -j --config Release
           if ($LASTEXITCODE -ne 0) { throw "cmake build failed" }
-          $out = & .\smoke-build\Debug\runtime_smoke.exe
+          $out = & .\smoke-build\Release\runtime_smoke.exe
           if ($LASTEXITCODE -ne 0) { throw "runtime_smoke exited with $LASTEXITCODE" }
           Write-Output $out
           if (-not ($out -contains "version: $env:BAML_EXPECTED_VERSION")) {

--- a/.github/workflows/verify-cpp-sdk.reusable.yaml
+++ b/.github/workflows/verify-cpp-sdk.reusable.yaml
@@ -69,6 +69,7 @@ jobs:
 
   verify:
     needs: platform-matrix
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.platform-matrix.outputs.matrix) }}

--- a/.github/workflows/verify-rust-sdk.reusable.yaml
+++ b/.github/workflows/verify-rust-sdk.reusable.yaml
@@ -50,29 +50,41 @@ defaults:
     shell: bash
 
 jobs:
+  platform-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.derive.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
+          persist-credentials: false
+          sparse-checkout: release
+      - id: derive
+        run: |
+          set -euo pipefail
+          matrix="$(jq -c '{include: ([.targets[]
+            | select((.os == "linux" or .os == "macos")
+                     and .libc != "musl"
+                     and .artifacts.toolchain != null
+                     and .artifacts.cffi != null)
+            | {target: .triple, os: .artifacts.toolchain.runner}]
+            + [{target: "x86_64-unknown-linux-gnu",
+                os: (.targets[]
+                     | select(.triple == "x86_64-unknown-linux-gnu")
+                     | .artifacts.toolchain.runner),
+                toolchain: "1.91.1",
+                label: " (MSRV)",
+                compile_only: true}])}' release/platforms.json)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   verify:
+    needs: platform-matrix
     name: verify rust sdk (${{ matrix.target }}${{ matrix.label }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
-          - target: x86_64-apple-darwin
-            os: macos-15-intel
-          - target: aarch64-apple-darwin
-            os: macos-14
-          # MSRV leg: prove the packaged crate + generated SDK compile on the
-          # crate's declared minimum Rust. Compile-only — it skips the runtime
-          # engine-acquisition smokes.
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
-            toolchain: "1.91.1"
-            label: " (MSRV)"
-            compile_only: true
+      matrix: ${{ fromJSON(needs.platform-matrix.outputs.matrix) }}
     env:
       TARGET: ${{ matrix.target }}
     steps:

--- a/.github/workflows/verify-rust-sdk.reusable.yaml
+++ b/.github/workflows/verify-rust-sdk.reusable.yaml
@@ -51,6 +51,8 @@ defaults:
 
 jobs:
   platform-matrix:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.derive.outputs.matrix }}

--- a/baml_language/sdks/cpp/bridge_cpp/cmake/fetch_protobuf.cmake
+++ b/baml_language/sdks/cpp/bridge_cpp/cmake/fetch_protobuf.cmake
@@ -27,6 +27,8 @@ set(protobuf_BUILD_PROTOC_BINARIES OFF)
 set(protobuf_BUILD_LIBUPB OFF)
 set(protobuf_INSTALL OFF)
 set(protobuf_FORCE_FETCH_DEPENDENCIES ON)
+# Match CMake's default dynamic MSVC runtime used by SDK consumers.
+set(protobuf_MSVC_STATIC_RUNTIME OFF)
 
 FetchContent_Declare(protobuf
   GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/loader.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/detail/loader.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -202,15 +203,6 @@ inline void* open_library(const std::string& path, std::string& error) {
 #endif
 }
 
-inline void* resolve_symbol(void* library, const char* name) {
-#if defined(_WIN32)
-  return reinterpret_cast<void*>(
-      GetProcAddress(reinterpret_cast<HMODULE>(library), name));
-#else
-  return ::dlsym(library, name);
-#endif
-}
-
 struct loaded_api {
   const BamlApiV1* table = nullptr;
 };
@@ -289,8 +281,16 @@ inline const loaded_api& load_api() {
     }
 
     using get_api_fn = const BamlApiV1* (*)();
-    auto get_api = reinterpret_cast<get_api_fn>(
-        resolve_symbol(library, "baml_get_api_v1"));
+    get_api_fn get_api = nullptr;
+#if defined(_WIN32)
+    FARPROC symbol =
+        GetProcAddress(reinterpret_cast<HMODULE>(library), "baml_get_api_v1");
+    static_assert(sizeof(symbol) == sizeof(get_api),
+                  "Windows function pointer size mismatch");
+    std::memcpy(&get_api, &symbol, sizeof(get_api));
+#else
+    get_api = reinterpret_cast<get_api_fn>(::dlsym(library, "baml_get_api_v1"));
+#endif
     if (get_api == nullptr) {
       throw runtime_error(
           "BAML_RUNTIME_ABI_MISMATCH",

--- a/baml_language/sdks/cpp/bridge_cpp/include/baml/variant.h
+++ b/baml_language/sdks/cpp/bridge_cpp/include/baml/variant.h
@@ -79,9 +79,11 @@ template <class... Ts>
 struct canon_sort {
   static constexpr canon_indices<sizeof...(Ts)> canon =
       sorted_unique_indices<Ts...>();
+  using source_types = std::tuple<Ts...>;
+  template <std::size_t I>
+  using canonical_type = std::tuple_element_t<canon.idx[I], source_types>;
   template <std::size_t... Is>
-  static std::variant<std::tuple_element_t<canon.idx[Is], std::tuple<Ts...>>...>
-      helper(std::index_sequence<Is...>);
+  static std::variant<canonical_type<Is>...> helper(std::index_sequence<Is...>);
   using type = decltype(helper(std::make_index_sequence<canon.count>{}));
 };
 

--- a/baml_language/sdks/cpp/bridge_cpp/tests/run.sh
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/run.sh
@@ -46,6 +46,7 @@ build_dir="target/bridge-cpp-smoke"
 cmake -B "$build_dir" -S "$bridge_cpp_dir/tests" \
     -DFETCHCONTENT_SOURCE_DIR_PROTOBUF="$PWD/target/cpp-protobuf-src" \
     -DFETCHCONTENT_SOURCE_DIR_ABSL="$PWD/target/cpp-absl-src" > /dev/null
-cmake --build "$build_dir" -j "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" > /dev/null
+cmake --build "$build_dir" --target runtime_smoke \
+    -j "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" > /dev/null
 
 BAML_RUNTIME_PATH="$runtime_path" "$build_dir/runtime_smoke"

--- a/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
@@ -5,7 +5,6 @@
 // real bytecode.
 #include <baml/baml.h>
 
-#include <cassert>
 #include <chrono>
 #include <cstdio>
 #include <stdexcept>
@@ -13,16 +12,15 @@
 #include <type_traits>
 #include <vector>
 
+static void Require(bool condition, const char* message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
 static void TestVersion() {
-  std::fprintf(stderr, "loading runtime API\n");
-  std::fflush(stderr);
-  (void)baml::detail::api();
-  std::fprintf(stderr, "loaded runtime API\n");
-  std::fflush(stderr);
   const std::string v = baml::version();
-  std::fprintf(stderr, "called runtime version\n");
-  std::fflush(stderr);
-  assert(!v.empty());
+  Require(!v.empty(), "runtime version is empty");
   std::printf("version: %s\n", v.c_str());
 }
 
@@ -37,7 +35,7 @@ static void TestBytecodeInitRejectsGarbage() {
   } catch (const baml::error&) {
     threw = true;
   }
-  assert(threw);
+  Require(threw, "garbage bytecode was accepted");
   std::printf("bytecode init rejects garbage ok\n");
 }
 
@@ -51,20 +49,23 @@ static void TestCallRegistryRoundTrip() {
     throw std::runtime_error("call registry round trip timed out");
   }
   const std::vector<uint8_t>& got = started.state->wait();
-  assert(got.size() == 4 && got[0] == 1 && got[3] == 4);
+  Require(got.size() == 4 && got[0] == 1 && got[3] == 4,
+          "call registry returned the wrong payload");
   std::printf("call registry round trip ok\n");
 }
 
 static void TestArgTwoState() {
   // Non-nullable optional argument (BAML `count: int = 5`).
   baml::arg<int64_t> unset_arg;
-  assert(unset_arg.is_unset() && !unset_arg.is_set());
+  Require(unset_arg.is_unset() && !unset_arg.is_set(),
+          "default argument is not unset");
 
   baml::arg<int64_t> explicit_unset = baml::unset;
-  assert(explicit_unset.is_unset());
+  Require(explicit_unset.is_unset(), "explicit unset argument is set");
 
   baml::arg<int64_t> value_arg = int64_t{42};
-  assert(value_arg.is_set() && value_arg.value() == 42);
+  Require(value_arg.is_set() && value_arg.value() == 42,
+          "value argument was not preserved");
 
   // Null is not in a non-nullable argument's type: rejected at compile time.
   static_assert(
@@ -76,17 +77,20 @@ static void TestArgTwoState() {
 
   // Nullable optional argument (BAML `lang: string? = "en"`).
   baml::arg<std::optional<std::string>> lang_value = std::string("fr");
-  assert(lang_value.is_set() && lang_value.value().has_value());
+  Require(lang_value.is_set() && lang_value.value().has_value(),
+          "nullable argument lost its value");
 
   baml::arg<std::optional<std::string>> lang_null = std::nullopt;
-  assert(lang_null.is_set() && !lang_null.value().has_value());
+  Require(lang_null.is_set() && !lang_null.value().has_value(),
+          "null argument is not explicitly set");
 
   baml::arg<std::optional<std::string>> lang_null2 = std::monostate{};
-  assert(lang_null2.is_set() && !lang_null2.value().has_value());
+  Require(lang_null2.is_set() && !lang_null2.value().has_value(),
+          "monostate argument is not explicitly null");
 
   // Bare-null-typed argument: monostate is the VALUE there.
   baml::arg<std::monostate> null_typed_arg = std::monostate{};
-  assert(null_typed_arg.is_set());
+  Require(null_typed_arg.is_set(), "bare null argument is not set");
 
   bool threw = false;
   try {
@@ -94,7 +98,7 @@ static void TestArgTwoState() {
   } catch (const std::logic_error&) {
     threw = true;
   }
-  assert(threw);
+  Require(threw, "reading an unset argument did not fail");
 
   // Setters take arg<T> by value; a string literal must convert in one hop.
   struct Opts {
@@ -104,19 +108,24 @@ static void TestArgTwoState() {
       return *this;
     }
   };
-  assert(Opts{}.set_lang("fr").lang.value().value() == "fr");
-  assert(Opts{}.set_lang(std::nullopt).lang.is_set());
-  assert(!Opts{}.set_lang(std::nullopt).lang.value().has_value());
-  assert(Opts{}.set_lang(std::monostate{}).lang.is_set());
-  assert(Opts{}.lang.is_unset());
+  Require(Opts{}.set_lang("fr").lang.value().value() == "fr",
+          "string literal argument was not preserved");
+  Require(Opts{}.set_lang(std::nullopt).lang.is_set(),
+          "nullopt argument is not set");
+  Require(!Opts{}.set_lang(std::nullopt).lang.value().has_value(),
+          "nullopt argument has a value");
+  Require(Opts{}.set_lang(std::monostate{}).lang.is_set(),
+          "monostate argument is not set");
+  Require(Opts{}.lang.is_unset(), "default options argument is set");
   std::printf("arg two-state ok\n");
 }
 
 static void TestOwnedBufferMove() {
   baml::detail::owned_buffer a{baml::detail::api().version()};
-  assert(!a.empty());
+  Require(!a.empty(), "runtime returned an empty owned buffer");
   baml::detail::owned_buffer b = std::move(a);
-  assert(a.empty() && !b.empty());
+  Require(a.empty() && !b.empty(),
+          "owned buffer move did not transfer ownership");
   std::printf("owned buffer move ok\n");
 }
 

--- a/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
@@ -14,7 +14,14 @@
 #include <vector>
 
 static void TestVersion() {
+  std::fprintf(stderr, "loading runtime API\n");
+  std::fflush(stderr);
+  (void)baml::detail::api();
+  std::fprintf(stderr, "loaded runtime API\n");
+  std::fflush(stderr);
   const std::string v = baml::version();
+  std::fprintf(stderr, "called runtime version\n");
+  std::fflush(stderr);
   assert(!v.empty());
   std::printf("version: %s\n", v.c_str());
 }

--- a/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
+++ b/baml_language/sdks/cpp/bridge_cpp/tests/runtime_smoke.cc
@@ -113,12 +113,20 @@ static void TestOwnedBufferMove() {
   std::printf("owned buffer move ok\n");
 }
 
+static void RunTest(const char* name, void (*test)()) {
+  std::fprintf(stderr, "running %s\n", name);
+  std::fflush(stderr);
+  test();
+  std::fprintf(stderr, "passed %s\n", name);
+  std::fflush(stderr);
+}
+
 int main() {
-  TestVersion();
-  TestBytecodeInitRejectsGarbage();
-  TestCallRegistryRoundTrip();
-  TestArgTwoState();
-  TestOwnedBufferMove();
+  RunTest("version", TestVersion);
+  RunTest("bytecode init", TestBytecodeInitRejectsGarbage);
+  RunTest("call registry", TestCallRegistryRoundTrip);
+  RunTest("argument states", TestArgTwoState);
+  RunTest("owned buffer move", TestOwnedBufferMove);
   std::printf("bridge core smoke: all ok\n");
   return 0;
 }

--- a/baml_language/sdks/rust/verify/consumer_main.rs
+++ b/baml_language/sdks/rust/verify/consumer_main.rs
@@ -8,12 +8,16 @@
 //! Cancellation and streaming are intentionally absent — those SDK features
 //! are not implemented yet; the verifier grows to cover them as they land.
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
+fn main() {
     let sync = baml_sdk::rt_int(7).expect("sync rt_int call");
     assert_eq!(sync, 7, "sync roundtrip");
 
-    let asyncd = baml_sdk::rt_int_async(9).await.expect("async rt_int call");
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("build Tokio runtime");
+    let asyncd = runtime
+        .block_on(baml_sdk::rt_int_async(9))
+        .expect("async rt_int call");
     assert_eq!(asyncd, 9, "async roundtrip");
 
     let greet = baml_sdk::rt_greet("kai".to_string()).expect("rt_greet call");


### PR DESCRIPTION
## Summary

- make the canonical C++ variant template compile under MSVC by isolating the nested pack expansion
- build only the `runtime_smoke` CMake target so verification does not compile unused full protobuf targets
- derive Rust verifier runners from the toolchain platform contract, matching the glibc used by shipped CLI artifacts
- run generated Rust sync calls outside the Tokio runtime while still exercising the async entry point

Fixes the Rust and C++ failures in https://github.com/BoundaryML/baml/actions/runs/29884885305.

## Testing

- `actionlint .github/workflows/verify-rust-sdk.reusable.yaml .github/workflows/verify-cpp-sdk.reusable.yaml`
- `RUSTC_WRAPPER= cargo test -p baml_release platforms --locked` (9 passed)
- canonical/deduplicated `baml::variant` C++17 compile smoke
- configured protobuf 31.1 and built the exact `runtime_smoke` CMake target
- pre-commit hooks, including Cargo fmt, Clang format, Clippy, and YAML validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved C++ SDK verification by enforcing a 10-minute timeout and explicitly building the `runtime_smoke` target for Unix/musl/Windows, running the Release binary on Windows.
  - Improved Rust SDK verification by generating the platform matrix dynamically.
  - Enhanced the C++ runtime smoke harness with stronger failure reporting and clearer progress output.
  - Stabilized the Rust consumer smoke entry point by switching to a synchronous `main`.
- **Refactor**
  - Refined internal C++ variant type canonicalization (no behavior change).
- **Chores**
  - Updated protobuf FetchContent to align MSVC runtime behavior with downstream consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->