### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -44,13 +44,13 @@ policy.max_delta_pct = 3.0
 # output).
 # macOS arm64: baseline 19.55 MB file (19_545_088), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 20_165_687
+max_file_bytes = 20_404_152
 # Linux x86_64: baseline 25.27 MB file (25_272_400), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 26_043_822
+max_file_bytes = 26_327_081
 # Windows x86_64: baseline 21.08 MB file (21_075_968), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 21_739_362
+max_file_bytes = 21_977_201
 
 [artifacts.packed-program]
 kind = "pack"
@@ -58,13 +58,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 13.21 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 13_620_179
+max_file_bytes = 13_824_382
 # Linux x86_64: baseline 17.03 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 17_542_483
+max_file_bytes = 17_700_163
 # Windows x86_64: baseline 14.14 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 14_578_079
+max_file_bytes = 14_733_118
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -88,4 +88,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.40 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_534_455
+max_gzip_bytes = 4_554_230

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-21T10:07:22Z"
-git_sha = "070b3a3b60721597b31bb1eb9ebf0dc663def3dc"
+recorded_at = "2026-07-22T10:07:42Z"
+git_sha = "6951c866434f7ab480162b38483a2d54a76c6529"
 
 [artifacts.baml-cli]
-file_bytes = 19578336
-stripped_bytes = 19578384
-gzip_bytes = 9326991
+file_bytes = 19809856
+stripped_bytes = 19809904
+gzip_bytes = 9435123
 
 [artifacts.packed-program]
-file_bytes = 13223474
-gzip_bytes = 6153330
+file_bytes = 13421730
+gzip_bytes = 6210333

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-07-21T10:07:22Z"
-git_sha = "070b3a3b60721597b31bb1eb9ebf0dc663def3dc"
+recorded_at = "2026-07-22T10:07:42Z"
+git_sha = "6951c866434f7ab480162b38483a2d54a76c6529"
 
 [artifacts.bridge_wasm]
-file_bytes = 16174902
-gzip_bytes = 4402383
+file_bytes = 16254751
+gzip_bytes = 4421582

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-21T10:07:22Z"
-git_sha = "070b3a3b60721597b31bb1eb9ebf0dc663def3dc"
+recorded_at = "2026-07-22T10:07:42Z"
+git_sha = "6951c866434f7ab480162b38483a2d54a76c6529"
 
 [artifacts.baml-cli]
-file_bytes = 21106176
-stripped_bytes = 21106176
-gzip_bytes = 9544410
+file_bytes = 21337088
+stripped_bytes = 21337088
+gzip_bytes = 9654543
 
 [artifacts.packed-program]
-file_bytes = 14153474
-gzip_bytes = 6248717
+file_bytes = 14303998
+gzip_bytes = 6308028

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-21T10:07:22Z"
-git_sha = "070b3a3b60721597b31bb1eb9ebf0dc663def3dc"
+recorded_at = "2026-07-22T10:07:42Z"
+git_sha = "6951c866434f7ab480162b38483a2d54a76c6529"
 
 [artifacts.baml-cli]
-file_bytes = 25285264
-stripped_bytes = 25285256
-gzip_bytes = 10715101
+file_bytes = 25560272
+stripped_bytes = 25560264
+gzip_bytes = 10837273
 
 [artifacts.packed-program]
-file_bytes = 17031536
-gzip_bytes = 7027724
+file_bytes = 17184624
+gzip_bytes = 7089725


### PR DESCRIPTION
Adopted from CI run [`6951c866434f7ab480162b38483a2d54a76c6529`](https://github.com/BoundaryML/baml/actions/runs/29884298446).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 25.6 MB | 10.8 MB | **file** | 25.3 MB | +275.0 KB (+1.1%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 17.2 MB | 7.1 MB | **file** | 17.0 MB | +153.1 KB (+0.9%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 19.8 MB | 9.4 MB | **file** | 19.6 MB | +231.5 KB (+1.2%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 13.4 MB | 6.2 MB | **file** | 13.2 MB | +198.3 KB (+1.5%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 16.3 MB | 🔒 4.4 MB | **gzip** | 4.4 MB | +19.2 KB (+0.4%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 21.3 MB | 9.7 MB | **file** | 21.1 MB | +230.9 KB (+1.1%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 14.3 MB | 6.3 MB | **file** | 14.2 MB | +150.5 KB (+1.1%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build artifact size thresholds across macOS, Linux, Windows, and WebAssembly targets.
  * Refreshed recorded artifact size metrics and build metadata for supported platforms.
  * Helps ensure size checks reflect current release artifact sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->