### PR TITLE
docs(sdk-java): quickstart becomes the one-liner

### DIFF
--- a/baml_language/sdks/java/examples/quickstart/README.md
+++ b/baml_language/sdks/java/examples/quickstart/README.md
@@ -1,25 +1,32 @@
 # BAML Java quickstart
 
-Minimal consumer of the `com.boundaryml:baml-bridge` Maven artifact.
+The complete setup is one plugin line — write BAML in `baml_src/`, build, done:
 
-```sh
-# 1. Generate the typed SDK from baml_src/ (writes ./baml_sdk/)
-baml generate
-
-# 2. Build & run — resolves baml-bridge from mavenLocal()/Central and
-#    loads the engine from the embedded native jar (no env vars).
-gradle run -PbamlVersion=<published version>
+```kotlin
+// build.gradle.kts
+plugins {
+    java
+    application
+    id("com.boundaryml.baml") version "0.15.0-nightly.1"
+}
+repositories { mavenCentral() }
 ```
 
-Expected output:
+The plugin resolves from the Gradle Plugin Portal, runs `baml generate`
+before compilation (incrementally — no cost when `.baml` files are
+unchanged), registers the generated sources for the compiler and IDE,
+and injects the version-locked `com.boundaryml:baml-bridge` runtime
+plus the correct `natives-<platform>` jar for your machine (Kotlin
+projects also get `baml-bridge-kotlin`). Overrides live on the `baml {}`
+extension (`nativePlatforms`, `manageDependencies`, `bamlExecutable`).
+
+Requirements: JDK 17+, the `baml` CLI on PATH at a version matching the
+plugin (install via the standard BAML install flow — the CLI, plugin,
+and runtime artifacts publish together at one version).
+
+Run it:
 
 ```
-add(2, 3) = 5
-Hello, Maven!
+gradle run
+# add(2, 3) = 5
 ```
-
-The Gradle wiring is three ideas: `mavenLocal()`/`mavenCentral()` +
-the `baml-bridge` dependency (plus its `natives-<platform>` classifier
-jar), the generated tree registered as a source root (parent of
-`baml_sdk/`, resources include the `.b64` bytecode), and
-`options.release = 17`.

--- a/baml_language/sdks/java/examples/quickstart/README.md
+++ b/baml_language/sdks/java/examples/quickstart/README.md
@@ -12,9 +12,16 @@ plugins {
 repositories { mavenCentral() }
 ```
 
+> ⚠ The plugin, runtime artifacts, and `baml` CLI publish together at one
+> family version, and the version in the `plugins` block must match your
+> installed CLI. Until the first fully-matched family nightly ships, this
+> example shows the shape of the setup; it becomes copy-paste-runnable the
+> moment that nightly publishes.
+
 The plugin resolves from the Gradle Plugin Portal, runs `baml generate`
-before compilation (incrementally — no cost when `.baml` files are
-unchanged), registers the generated sources for the compiler and IDE,
+before compilation (incrementally — it reruns only when a generation
+input changes: the `.baml` sources, `baml.toml`, or the resolved CLI
+version), registers the generated sources for the compiler and IDE,
 and injects the version-locked `com.boundaryml:baml-bridge` runtime
 plus the correct `natives-<platform>` jar for your machine (Kotlin
 projects also get `baml-bridge-kotlin`). Overrides live on the `baml {}`
@@ -26,7 +33,7 @@ and runtime artifacts publish together at one version).
 
 Run it:
 
-```
+```console
 gradle run
 # add(2, 3) = 5
 ```

--- a/baml_language/sdks/java/examples/quickstart/build.gradle.kts
+++ b/baml_language/sdks/java/examples/quickstart/build.gradle.kts
@@ -12,6 +12,10 @@
 plugins {
     java
     application
+    // The plugin/runtime/CLI publish together at one family version — the
+    // version here must match the installed `baml` CLI. Until the first
+    // fully-matched family nightly ships, treat this example as the shape
+    // of the setup rather than a copy-paste-runnable snapshot.
     id("com.boundaryml.baml") version "0.15.0-nightly.1"
 }
 

--- a/baml_language/sdks/java/examples/quickstart/build.gradle.kts
+++ b/baml_language/sdks/java/examples/quickstart/build.gradle.kts
@@ -1,36 +1,22 @@
-// BAML Java quickstart: consumes com.boundaryml:baml-bridge from a
-// Maven repository (mavenLocal for the rehearsal; Central once published)
-// and registers the `baml generate --output_type java` output as sources.
+// BAML Java quickstart — the one-liner setup.
+//
+// The `com.boundaryml.baml` plugin does everything: runs `baml generate`
+// before compilation (incrementally), registers the generated sources,
+// and injects the version-locked `com.boundaryml:baml-bridge` runtime
+// plus the right `natives-<platform>` jar for this machine. Write BAML
+// in `baml_src/`, build, done.
+//
+// The plugin resolves from the Gradle Plugin Portal (default) and the
+// runtime artifacts from Maven Central — no repository configuration
+// needed beyond `mavenCentral()` for the injected dependencies.
 plugins {
     java
     application
+    id("com.boundaryml.baml") version "0.15.0-nightly.1"
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
-}
-
-val bamlVersion = providers.gradleProperty("bamlVersion").getOrElse("0.15.0-nightly.local")
-
-dependencies {
-    implementation("com.boundaryml:baml-bridge:$bamlVersion")
-    // Native engine for this platform (classifier jar). Variant-aware
-    // auto-selection is a follow-up; today the platform is explicit.
-    runtimeOnly("com.boundaryml:baml-bridge:$bamlVersion:natives-linux-x86_64")
-}
-
-sourceSets {
-    main {
-        java {
-            srcDir(".")
-            include("baml_sdk/**", "src/main/java/**")
-        }
-        resources {
-            srcDir(".")
-            include("baml_sdk/**/*.b64")
-        }
-    }
 }
 
 tasks.withType<JavaCompile> {


### PR DESCRIPTION
The Portal approved `com.boundaryml.baml` — the marker resolves publicly — so the quickstart now demonstrates the end-state consumer experience: one `plugins` line, nothing else. Plugin resolution + dependency injection verified against a pristine Gradle home; the full compile-and-run proof lands with the first pipeline nightly (CLI/runtime/plugin at one version — currently blocked family-wide on the C++ verify fix). Example + README only; no code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Java quickstart to use a dedicated Gradle plugin for streamlined setup.
  * Automatically generates BAML sources before compilation with IDE/compiled-source integration and version-locked runtime artifacts (including native platform libraries).
  * Simplified `gradle run` instructions and clarified required Java 17+ plus a matching `baml` CLI “family” version.

* **Documentation**
  * Rewrote the quickstart guide to place BAML in `baml_src/`, show the plugin configuration, and replace old manual `baml generate`/`-PbamlVersion` steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->