### PR TITLE
Release workflow should trigger on dispatch not run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1085,3 +1085,49 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "::error::One or more CI jobs failed!"
           exit 1
+
+  # Entry point for the release: a green push to canary hands off to
+  # release-baml-language.yml. The release deliberately has no `workflow_run`
+  # trigger -- crates.io refuses to mint a Trusted Publishing token for
+  # `workflow_run` (and `pull_request_target`) runs, so a `workflow_run` release
+  # can never publish baml_bridge.
+  #
+  # Same required-gate set as ci-failure-alert above; keep the two lists in sync.
+  dispatch-release:
+    name: "Dispatch BAML Language Release"
+    runs-on: ubuntu-latest
+    needs:
+      - prek
+      - release-metadata
+      - cargo-tests
+      - wasm-pack-tests
+      - docs
+      - webview-tests
+      - grammar-tests
+      - linguist-compile-gate
+      # - miri-tests  # TEMPORARILY DISABLED: miri tests timing out
+      - prof-concurrency
+      - proto-sync
+    # `!failure() && !cancelled()` rather than `success()`, because that is what
+    # the old `workflow_run.conclusion == 'success'` gate meant: a skipped gate
+    # is not a failure. prof-concurrency and proto-sync are change-detected with
+    # no `|| ref == canary` escape hatch, so they are skipped on most canary
+    # pushes and `success()` would keep the release from ever firing.
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref_name == 'canary' }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch release for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # --ref canary selects the workflow *definition* from canary HEAD;
+          # source_sha pins the commit that actually gets built and released.
+          gh workflow run release-baml-language.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref canary \
+            -f channel=auto \
+            -f dry_run=false \
+            -f source_sha="$GITHUB_SHA"

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -3,16 +3,21 @@ name: BAML Language Release
 # Channel-aware replacement for the legacy BAML language release workflow.
 # Release workflows run packaging smoke tests only; the full suite runs in CI.
 
+# Dispatch-only: `CI - BAML Language` calls `gh workflow run` on this file after
+# a green push to canary. That is deliberately not a `workflow_run` trigger --
+# crates.io refuses to mint a Trusted Publishing token for `workflow_run` (and
+# `pull_request_target`) runs, so a `workflow_run` release can never publish
+# baml_bridge. Dispatching from CI keeps the same "CI must be green" gate while
+# tightening the trust chain: `workflow_run` fires for *every* CI run including
+# fork pull requests, whereas a fork's CI has a read-only token and cannot
+# dispatch at all.
 on:
-  workflow_run:
-    workflows: ["CI - BAML Language"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       channel:
-        description: "Release channel to plan"
+        description: "Release channel to plan (auto: pick canary/nightly from release.toml, as CI does)"
         type: choice
-        options: [nightly, canary]
+        options: [auto, nightly, canary]
         default: nightly
         required: true
       dry_run:
@@ -20,6 +25,11 @@ on:
         type: boolean
         default: true
         required: true
+      source_sha:
+        description: "Commit to release (defaults to the dispatched ref's head)"
+        type: string
+        default: ""
+        required: false
 
 permissions:
   contents: write
@@ -46,11 +56,6 @@ env:
 jobs:
   plan:
     name: Plan release
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'canary')
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.plan.outputs.channel }}
@@ -68,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ inputs.source_sha || github.sha }}
           fetch-depth: 2
           persist-credentials: false
 
@@ -84,9 +89,8 @@ jobs:
           dry_run="${INPUT_DRY_RUN:-false}"
           source_branch="${GITHUB_REF_NAME:-}"
           dispatch_nightly_after_canary="false"
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+          if [[ "$channel" == "auto" ]]; then
             channel="nightly"
-            source_branch="${{ github.event.workflow_run.head_branch }}"
             if git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- baml_language/release.toml; then
               :
             elif git rev-parse HEAD^ >/dev/null 2>&1; then
@@ -1293,12 +1297,17 @@ jobs:
       - name: Dispatch nightly release run
         env:
           GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
         run: |
           set -euo pipefail
+          # Pin the nightly to the commit this canary released, not to whatever
+          # canary HEAD happens to be by the time this job runs.
           gh workflow run release-baml-language.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref canary \
             -f channel=nightly \
-            -f dry_run=false
+            -f dry_run=false \
+            -f source_sha="$SOURCE_SHA"
 
   publish-homebrew:
     name: Publish Homebrew wrapper formula


### PR DESCRIPTION
Due to `crates.io` trusted publishing security policy, `workflow_run` is rejected. We now explicitly dispatch from the CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canary builds now automatically trigger the language release workflow after required CI checks pass.
  * Releases can be dispatched with a specific source commit and automatic channel selection.
  * Nightly releases are queued using the exact commit published to the canary channel.

* **Bug Fixes**
  * Improved release reliability by preventing releases from starting after failed or cancelled CI runs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->