### PR TITLE
feat(cli): add agent-friendly diagnostic output

### DIFF
--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -40,7 +40,7 @@ sdkgen_typescript_shared = { workspace = true }
 sys_native = { workspace = true }
 anyhow = { workspace = true }
 borsh = { workspace = true }
-clap = { workspace = true, features = [ "color" ] }
+clap = { workspace = true, features = [ "color", "env" ] }
 console = { workspace = true }
 ctrlc = { workspace = true }
 flate2 = { workspace = true }

--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -123,6 +123,6 @@ pub(crate) fn render_project_diagnostics(
         diagnostics,
         &sources,
         &file_paths,
-        &crate::output::diagnostic_render_config(),
+        &crate::output::policy().diagnostic_render_config(),
     )
 }

--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -123,6 +123,6 @@ pub(crate) fn render_project_diagnostics(
         diagnostics,
         &sources,
         &file_paths,
-        &render::RenderConfig::cli_auto(),
+        &crate::output::diagnostic_render_config(),
     )
 }

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -30,17 +30,8 @@ pub(crate) struct RuntimeCli {
     #[arg(long = "features", value_name = "FEATURE", global = true)]
     pub features: Vec<String>,
 
-    /// When to use colored / hyperlinked output: auto (default), always, or never.
-    ///
-    /// `auto` enables color on an interactive terminal and disables it when the
-    /// output is piped or captured by a known AI coding agent.
-    #[arg(
-        long,
-        value_enum,
-        default_value_t = crate::paint::ColorChoice::Auto,
-        global = true
-    )]
-    pub color: crate::paint::ColorChoice,
+    #[command(flatten)]
+    pub output: crate::output::OutputArgs,
 
     /// Specifies a subcommand to run.
     #[command(subcommand)]
@@ -230,8 +221,8 @@ impl RuntimeCli {
             self.invoked_subcommand.as_deref().unwrap_or("unknown"),
         );
 
-        // Resolve color/hyperlink output once, before any subcommand writes.
-        crate::paint::init_color(self.color);
+        // Resolve every output dial once, before any subcommand writes.
+        crate::output::init(self.output);
 
         // Passive skill warning + background freshness refresh, only on the
         // core authoring commands (init, run, generate, pack) so the nag
@@ -359,6 +350,52 @@ mod tests {
         let help = help_for(&["baml-cli", "--help"]);
         assert!(help.contains("playground"), "{help}");
         assert!(help.contains("Open the BAML playground"), "{help}");
+    }
+
+    #[test]
+    fn output_dials_are_global_and_independent() {
+        let cli = RuntimeCli::parse_from_smart(vec![
+            "baml-cli".into(),
+            "check".into(),
+            "--output-preset".into(),
+            "human".into(),
+            "--color".into(),
+            "never".into(),
+            "--hyperlinks".into(),
+            "always".into(),
+            "--diagnostic-format".into(),
+            "agent".into(),
+        ]);
+
+        assert_eq!(cli.output.preset, crate::output::OutputPreset::Human);
+        assert_eq!(cli.output.color, Some(crate::output::ColorChoice::Never));
+        assert_eq!(
+            cli.output.hyperlinks,
+            Some(crate::output::HyperlinkChoice::Always)
+        );
+        assert_eq!(
+            cli.output.diagnostic_format,
+            Some(crate::output::DiagnosticFormatChoice::Agent)
+        );
+    }
+
+    #[test]
+    fn output_dials_expose_documented_environment_variables() {
+        let command = RuntimeCli::command();
+        let expected = [
+            ("preset", "BAML_OUTPUT_PRESET"),
+            ("color", "BAML_COLOR"),
+            ("hyperlinks", "BAML_HYPERLINKS"),
+            ("diagnostic_format", "BAML_DIAGNOSTIC_FORMAT"),
+        ];
+
+        for (id, env) in expected {
+            let arg = command
+                .get_arguments()
+                .find(|arg| arg.get_id() == id)
+                .unwrap_or_else(|| panic!("missing argument {id}"));
+            assert_eq!(arg.get_env(), Some(std::ffi::OsStr::new(env)));
+        }
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/diagnostics_cache.rs
+++ b/baml_language/crates/baml_cli/src/diagnostics_cache.rs
@@ -464,7 +464,7 @@ mod tests {
             sources.insert(sf.file_id(&db), sf.text(&db).to_string());
             paths.insert(sf.file_id(&db), p.clone());
         }
-        let cfg = render::RenderConfig::cli_auto();
+        let cfg = render::RenderConfig::test();
         assert_eq!(
             render::render_diagnostics(&[diag], &sources, &paths, &cfg),
             render::render_diagnostics(&restored, &sources, &paths, &cfg),

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -85,7 +85,7 @@ impl GenerateArgs {
                 &errors.iter().copied().cloned().collect::<Vec<_>>(),
                 &sources,
                 &file_paths,
-                &render::RenderConfig::cli_auto(),
+                &crate::output::diagnostic_render_config(),
             );
             reporter.abandon();
             eprintln!("{rendered}");
@@ -119,7 +119,7 @@ impl GenerateArgs {
                 &gen_diags,
                 &sources,
                 &file_paths,
-                &render::RenderConfig::cli_auto(),
+                &crate::output::diagnostic_render_config(),
             );
             reporter.abandon();
             eprintln!("{rendered}");

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -85,7 +85,7 @@ impl GenerateArgs {
                 &errors.iter().copied().cloned().collect::<Vec<_>>(),
                 &sources,
                 &file_paths,
-                &crate::output::diagnostic_render_config(),
+                &crate::output::policy().diagnostic_render_config(),
             );
             reporter.abandon();
             eprintln!("{rendered}");
@@ -119,7 +119,7 @@ impl GenerateArgs {
                 &gen_diags,
                 &sources,
                 &file_paths,
-                &crate::output::diagnostic_render_config(),
+                &crate::output::policy().diagnostic_render_config(),
             );
             reporter.abandon();
             eprintln!("{rendered}");

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -29,6 +29,7 @@ pub(crate) mod ide_command;
 pub(crate) mod init_command;
 pub(crate) mod lsp;
 pub(crate) mod manifest;
+pub(crate) mod output;
 pub(crate) mod pack_command;
 pub(crate) mod pack_elf;
 pub(crate) mod paint;

--- a/baml_language/crates/baml_cli/src/output.rs
+++ b/baml_language/crates/baml_cli/src/output.rs
@@ -1,0 +1,347 @@
+//! Unified CLI output policy.
+//!
+//! A preset supplies defaults for each independent output dial. Explicit CLI
+//! flags and their environment-variable equivalents override those defaults.
+
+use std::{
+    io::IsTerminal,
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
+};
+
+use baml_db::baml_compiler_diagnostics::render::{DiagnosticFormat, RenderConfig};
+use clap::{Args, ValueEnum};
+
+#[derive(Args, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[command(next_help_heading = "Output options")]
+pub(crate) struct OutputArgs {
+    /// Output defaults: auto, human, or agent.
+    ///
+    /// `auto` selects the agent preset when a known coding-agent environment
+    /// is detected and the human preset otherwise.
+    #[arg(
+        long = "output-preset",
+        env = "BAML_OUTPUT_PRESET",
+        value_enum,
+        default_value_t = OutputPreset::Auto,
+        global = true
+    )]
+    pub preset: OutputPreset,
+
+    /// When to emit ANSI color: auto, always, or never.
+    ///
+    /// Overrides the selected output preset.
+    #[arg(long, env = "BAML_COLOR", value_enum, global = true)]
+    pub color: Option<ColorChoice>,
+
+    /// When to emit terminal hyperlinks: auto, always, or never.
+    ///
+    /// Overrides the selected output preset.
+    #[arg(long, env = "BAML_HYPERLINKS", value_enum, global = true)]
+    pub hyperlinks: Option<HyperlinkChoice>,
+
+    /// Compiler diagnostic format: human, agent, or concise.
+    ///
+    /// Overrides the selected output preset.
+    #[arg(
+        long = "diagnostic-format",
+        env = "BAML_DIAGNOSTIC_FORMAT",
+        value_enum,
+        global = true
+    )]
+    pub diagnostic_format: Option<DiagnosticFormatChoice>,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum OutputPreset {
+    /// Detect a known coding agent; otherwise use human defaults.
+    #[default]
+    Auto,
+    /// Human-readable output with terminal decorations when supported.
+    Human,
+    /// Compact agent-readable output without terminal decorations.
+    Agent,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ColorChoice {
+    /// Enable color independently for each interactive terminal stream.
+    Auto,
+    /// Always emit ANSI color.
+    Always,
+    /// Never emit ANSI color.
+    Never,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HyperlinkChoice {
+    /// Enable hyperlinks independently for each interactive terminal stream.
+    Auto,
+    /// Always emit terminal hyperlinks.
+    Always,
+    /// Never emit terminal hyperlinks.
+    Never,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DiagnosticFormatChoice {
+    /// Source snippets and labels intended for terminal users.
+    Human,
+    /// Compact locations and messages intended for coding agents.
+    Agent,
+    /// One diagnostic per line without secondary locations.
+    Concise,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct OutputConfig {
+    stdout_color: bool,
+    stderr_color: bool,
+    stdout_hyperlinks: bool,
+    stderr_hyperlinks: bool,
+    diagnostic_format: DiagnosticFormat,
+}
+
+#[derive(Clone, Copy)]
+struct OutputSignals {
+    running_in_agent: bool,
+    color_forced: bool,
+    stdout_auto_color: bool,
+    stderr_auto_color: bool,
+    stdout_is_terminal: bool,
+    stderr_is_terminal: bool,
+}
+
+const HUMAN_FORMAT: u8 = 0;
+const AGENT_FORMAT: u8 = 1;
+const CONCISE_FORMAT: u8 = 2;
+
+static STDOUT_HYPERLINKS: AtomicBool = AtomicBool::new(false);
+static STDERR_HYPERLINKS: AtomicBool = AtomicBool::new(false);
+static DIAGNOSTIC_FORMAT: AtomicU8 = AtomicU8::new(HUMAN_FORMAT);
+
+/// Resolve and install the process-wide output policy before a command writes.
+pub(crate) fn init(args: OutputArgs) {
+    let config = resolve(args, output_signals());
+    console::set_colors_enabled(config.stdout_color);
+    console::set_colors_enabled_stderr(config.stderr_color);
+    STDOUT_HYPERLINKS.store(config.stdout_hyperlinks, Ordering::Relaxed);
+    STDERR_HYPERLINKS.store(config.stderr_hyperlinks, Ordering::Relaxed);
+    DIAGNOSTIC_FORMAT.store(format_to_u8(config.diagnostic_format), Ordering::Relaxed);
+}
+
+pub(crate) fn stdout_hyperlinks_enabled() -> bool {
+    STDOUT_HYPERLINKS.load(Ordering::Relaxed)
+}
+
+pub(crate) fn stderr_hyperlinks_enabled() -> bool {
+    STDERR_HYPERLINKS.load(Ordering::Relaxed)
+}
+
+/// Compiler diagnostic configuration derived from the same resolved output
+/// policy used by the rest of the CLI.
+pub(crate) fn diagnostic_render_config() -> RenderConfig {
+    RenderConfig {
+        format: match DIAGNOSTIC_FORMAT.load(Ordering::Relaxed) {
+            AGENT_FORMAT => DiagnosticFormat::Agent,
+            CONCISE_FORMAT => DiagnosticFormat::Concise,
+            _ => DiagnosticFormat::Ariadne,
+        },
+        color: console::colors_enabled_stderr(),
+        show_error_codes: true,
+    }
+}
+
+fn resolve(args: OutputArgs, signals: OutputSignals) -> OutputConfig {
+    let preset = match args.preset {
+        OutputPreset::Auto if signals.running_in_agent => OutputPreset::Agent,
+        OutputPreset::Auto => OutputPreset::Human,
+        explicit => explicit,
+    };
+
+    let default_color = match preset {
+        OutputPreset::Agent if !signals.color_forced => ColorChoice::Never,
+        OutputPreset::Agent => ColorChoice::Always,
+        OutputPreset::Human | OutputPreset::Auto => ColorChoice::Auto,
+    };
+    let default_hyperlinks = match preset {
+        OutputPreset::Agent => HyperlinkChoice::Never,
+        OutputPreset::Human | OutputPreset::Auto => HyperlinkChoice::Auto,
+    };
+    let default_format = match preset {
+        OutputPreset::Agent => DiagnosticFormatChoice::Agent,
+        OutputPreset::Human | OutputPreset::Auto => DiagnosticFormatChoice::Human,
+    };
+
+    let color = args.color.unwrap_or(default_color);
+    let hyperlinks = args.hyperlinks.unwrap_or(default_hyperlinks);
+    let diagnostic_format = args.diagnostic_format.unwrap_or(default_format);
+
+    OutputConfig {
+        stdout_color: resolve_color(color, signals.stdout_auto_color),
+        stderr_color: resolve_color(color, signals.stderr_auto_color),
+        stdout_hyperlinks: resolve_hyperlinks(hyperlinks, signals.stdout_is_terminal),
+        stderr_hyperlinks: resolve_hyperlinks(hyperlinks, signals.stderr_is_terminal),
+        diagnostic_format: match diagnostic_format {
+            DiagnosticFormatChoice::Human => DiagnosticFormat::Ariadne,
+            DiagnosticFormatChoice::Agent => DiagnosticFormat::Agent,
+            DiagnosticFormatChoice::Concise => DiagnosticFormat::Concise,
+        },
+    }
+}
+
+fn resolve_color(choice: ColorChoice, auto: bool) -> bool {
+    match choice {
+        ColorChoice::Auto => auto,
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+    }
+}
+
+fn resolve_hyperlinks(choice: HyperlinkChoice, is_terminal: bool) -> bool {
+    match choice {
+        HyperlinkChoice::Auto => is_terminal,
+        HyperlinkChoice::Always => true,
+        HyperlinkChoice::Never => false,
+    }
+}
+
+fn output_signals() -> OutputSignals {
+    OutputSignals {
+        running_in_agent: running_in_agent(),
+        color_forced: env_truthy("CLICOLOR_FORCE"),
+        stdout_auto_color: auto_color(&console::Term::stdout()),
+        stderr_auto_color: auto_color(&console::Term::stderr()),
+        stdout_is_terminal: std::io::stdout().is_terminal(),
+        stderr_is_terminal: std::io::stderr().is_terminal(),
+    }
+}
+
+fn auto_color(term: &console::Term) -> bool {
+    (term.features().colors_supported() && !env_equals("CLICOLOR", "0"))
+        || env_truthy("CLICOLOR_FORCE")
+}
+
+fn env_equals(var: &str, expected: &str) -> bool {
+    std::env::var(var).is_ok_and(|value| value == expected)
+}
+
+fn env_truthy(var: &str) -> bool {
+    std::env::var(var).is_ok_and(|value| !value.is_empty() && value != "0")
+}
+
+/// Environment variables that identify a known coding-agent process.
+const AGENT_ENV_VARS: &[&str] = &[
+    "CLAUDECODE",
+    "CODEX_SANDBOX",
+    "PI_CODING_AGENT",
+    "OPENCODE_CLIENT",
+    "AI_AGENT",
+    "CURSOR_TRACE_ID",
+    "REPL_ID",
+    "AGENT",
+];
+
+fn running_in_agent() -> bool {
+    AGENT_ENV_VARS.iter().any(|var| env_truthy(var))
+}
+
+const fn format_to_u8(format: DiagnosticFormat) -> u8 {
+    match format {
+        DiagnosticFormat::Ariadne => HUMAN_FORMAT,
+        DiagnosticFormat::Agent => AGENT_FORMAT,
+        DiagnosticFormat::Concise => CONCISE_FORMAT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const INTERACTIVE: OutputSignals = OutputSignals {
+        running_in_agent: false,
+        color_forced: false,
+        stdout_auto_color: true,
+        stderr_auto_color: true,
+        stdout_is_terminal: true,
+        stderr_is_terminal: true,
+    };
+
+    fn args(preset: OutputPreset) -> OutputArgs {
+        OutputArgs {
+            preset,
+            color: None,
+            hyperlinks: None,
+            diagnostic_format: None,
+        }
+    }
+
+    #[test]
+    fn auto_selects_agent_defaults_when_agent_is_detected() {
+        let config = resolve(
+            args(OutputPreset::Auto),
+            OutputSignals {
+                running_in_agent: true,
+                ..INTERACTIVE
+            },
+        );
+
+        assert!(!config.stdout_color);
+        assert!(!config.stderr_color);
+        assert!(!config.stdout_hyperlinks);
+        assert!(!config.stderr_hyperlinks);
+        assert_eq!(config.diagnostic_format, DiagnosticFormat::Agent);
+    }
+
+    #[test]
+    fn human_preset_uses_per_stream_terminal_capabilities() {
+        let config = resolve(
+            args(OutputPreset::Human),
+            OutputSignals {
+                stdout_auto_color: false,
+                stderr_auto_color: true,
+                stdout_is_terminal: false,
+                stderr_is_terminal: true,
+                ..INTERACTIVE
+            },
+        );
+
+        assert!(!config.stdout_color);
+        assert!(config.stderr_color);
+        assert!(!config.stdout_hyperlinks);
+        assert!(config.stderr_hyperlinks);
+        assert_eq!(config.diagnostic_format, DiagnosticFormat::Ariadne);
+    }
+
+    #[test]
+    fn granular_settings_override_agent_preset() {
+        let mut output_args = args(OutputPreset::Agent);
+        output_args.color = Some(ColorChoice::Always);
+        output_args.hyperlinks = Some(HyperlinkChoice::Always);
+        output_args.diagnostic_format = Some(DiagnosticFormatChoice::Human);
+
+        let config = resolve(output_args, INTERACTIVE);
+
+        assert!(config.stdout_color);
+        assert!(config.stderr_color);
+        assert!(config.stdout_hyperlinks);
+        assert!(config.stderr_hyperlinks);
+        assert_eq!(config.diagnostic_format, DiagnosticFormat::Ariadne);
+    }
+
+    #[test]
+    fn conventional_force_color_overrides_agent_preset() {
+        let config = resolve(
+            args(OutputPreset::Agent),
+            OutputSignals {
+                color_forced: true,
+                ..INTERACTIVE
+            },
+        );
+
+        assert!(config.stdout_color);
+        assert!(config.stderr_color);
+        assert!(!config.stdout_hyperlinks);
+        assert!(!config.stderr_hyperlinks);
+        assert_eq!(config.diagnostic_format, DiagnosticFormat::Agent);
+    }
+}

--- a/baml_language/crates/baml_cli/src/output.rs
+++ b/baml_language/crates/baml_cli/src/output.rs
@@ -1,12 +1,9 @@
 //! Unified CLI output policy.
 //!
-//! A preset supplies defaults for each independent output dial. Explicit CLI
-//! flags and their environment-variable equivalents override those defaults.
+//! A preset produces a concrete output policy. Explicit CLI flags and their
+//! environment-variable equivalents override individual fields afterward.
 
-use std::{
-    io::IsTerminal,
-    sync::atomic::{AtomicBool, AtomicU8, Ordering},
-};
+use std::{io::IsTerminal, sync::RwLock};
 
 use baml_db::baml_compiler_diagnostics::render::{DiagnosticFormat, RenderConfig};
 use clap::{Args, ValueEnum};
@@ -93,12 +90,22 @@ pub(crate) enum DiagnosticFormatChoice {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct OutputConfig {
-    stdout_color: bool,
-    stderr_color: bool,
-    stdout_hyperlinks: bool,
-    stderr_hyperlinks: bool,
-    diagnostic_format: DiagnosticFormat,
+pub(crate) struct OutputPolicy {
+    pub stdout: StreamPolicy,
+    pub stderr: StreamPolicy,
+    pub diagnostics: DiagnosticPolicy,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StreamPolicy {
+    pub color: bool,
+    pub hyperlinks: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DiagnosticPolicy {
+    pub format: DiagnosticFormat,
+    pub show_error_codes: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -111,81 +118,108 @@ struct OutputSignals {
     stderr_is_terminal: bool,
 }
 
-const HUMAN_FORMAT: u8 = 0;
-const AGENT_FORMAT: u8 = 1;
-const CONCISE_FORMAT: u8 = 2;
+const DEFAULT_POLICY: OutputPolicy = OutputPolicy {
+    stdout: StreamPolicy {
+        color: false,
+        hyperlinks: false,
+    },
+    stderr: StreamPolicy {
+        color: false,
+        hyperlinks: false,
+    },
+    diagnostics: DiagnosticPolicy {
+        format: DiagnosticFormat::Ariadne,
+        show_error_codes: true,
+    },
+};
 
-static STDOUT_HYPERLINKS: AtomicBool = AtomicBool::new(false);
-static STDERR_HYPERLINKS: AtomicBool = AtomicBool::new(false);
-static DIAGNOSTIC_FORMAT: AtomicU8 = AtomicU8::new(HUMAN_FORMAT);
+static OUTPUT_POLICY: RwLock<OutputPolicy> = RwLock::new(DEFAULT_POLICY);
 
 /// Resolve and install the process-wide output policy before a command writes.
 pub(crate) fn init(args: OutputArgs) {
-    let config = resolve(args, output_signals());
-    console::set_colors_enabled(config.stdout_color);
-    console::set_colors_enabled_stderr(config.stderr_color);
-    STDOUT_HYPERLINKS.store(config.stdout_hyperlinks, Ordering::Relaxed);
-    STDERR_HYPERLINKS.store(config.stderr_hyperlinks, Ordering::Relaxed);
-    DIAGNOSTIC_FORMAT.store(format_to_u8(config.diagnostic_format), Ordering::Relaxed);
+    let policy = resolve(args, output_signals());
+    console::set_colors_enabled(policy.stdout.color);
+    console::set_colors_enabled_stderr(policy.stderr.color);
+    *OUTPUT_POLICY
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = policy;
 }
 
-pub(crate) fn stdout_hyperlinks_enabled() -> bool {
-    STDOUT_HYPERLINKS.load(Ordering::Relaxed)
+pub(crate) fn policy() -> OutputPolicy {
+    *OUTPUT_POLICY
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
-pub(crate) fn stderr_hyperlinks_enabled() -> bool {
-    STDERR_HYPERLINKS.load(Ordering::Relaxed)
-}
-
-/// Compiler diagnostic configuration derived from the same resolved output
-/// policy used by the rest of the CLI.
-pub(crate) fn diagnostic_render_config() -> RenderConfig {
-    RenderConfig {
-        format: match DIAGNOSTIC_FORMAT.load(Ordering::Relaxed) {
-            AGENT_FORMAT => DiagnosticFormat::Agent,
-            CONCISE_FORMAT => DiagnosticFormat::Concise,
-            _ => DiagnosticFormat::Ariadne,
-        },
-        color: console::colors_enabled_stderr(),
-        show_error_codes: true,
+impl OutputPolicy {
+    pub(crate) fn diagnostic_render_config(self) -> RenderConfig {
+        RenderConfig {
+            format: self.diagnostics.format,
+            color: self.stderr.color,
+            show_error_codes: self.diagnostics.show_error_codes,
+        }
     }
 }
 
-fn resolve(args: OutputArgs, signals: OutputSignals) -> OutputConfig {
+fn resolve(args: OutputArgs, signals: OutputSignals) -> OutputPolicy {
     let preset = match args.preset {
         OutputPreset::Auto if signals.running_in_agent => OutputPreset::Agent,
         OutputPreset::Auto => OutputPreset::Human,
         explicit => explicit,
     };
+    let mut policy = preset.policy(signals);
 
-    let default_color = match preset {
-        OutputPreset::Agent if !signals.color_forced => ColorChoice::Never,
-        OutputPreset::Agent => ColorChoice::Always,
-        OutputPreset::Human | OutputPreset::Auto => ColorChoice::Auto,
-    };
-    let default_hyperlinks = match preset {
-        OutputPreset::Agent => HyperlinkChoice::Never,
-        OutputPreset::Human | OutputPreset::Auto => HyperlinkChoice::Auto,
-    };
-    let default_format = match preset {
-        OutputPreset::Agent => DiagnosticFormatChoice::Agent,
-        OutputPreset::Human | OutputPreset::Auto => DiagnosticFormatChoice::Human,
-    };
-
-    let color = args.color.unwrap_or(default_color);
-    let hyperlinks = args.hyperlinks.unwrap_or(default_hyperlinks);
-    let diagnostic_format = args.diagnostic_format.unwrap_or(default_format);
-
-    OutputConfig {
-        stdout_color: resolve_color(color, signals.stdout_auto_color),
-        stderr_color: resolve_color(color, signals.stderr_auto_color),
-        stdout_hyperlinks: resolve_hyperlinks(hyperlinks, signals.stdout_is_terminal),
-        stderr_hyperlinks: resolve_hyperlinks(hyperlinks, signals.stderr_is_terminal),
-        diagnostic_format: match diagnostic_format {
+    if let Some(color) = args.color {
+        policy.stdout.color = resolve_color(color, signals.stdout_auto_color);
+        policy.stderr.color = resolve_color(color, signals.stderr_auto_color);
+    }
+    if let Some(hyperlinks) = args.hyperlinks {
+        policy.stdout.hyperlinks = resolve_hyperlinks(hyperlinks, signals.stdout_is_terminal);
+        policy.stderr.hyperlinks = resolve_hyperlinks(hyperlinks, signals.stderr_is_terminal);
+    }
+    if let Some(format) = args.diagnostic_format {
+        policy.diagnostics.format = match format {
             DiagnosticFormatChoice::Human => DiagnosticFormat::Ariadne,
             DiagnosticFormatChoice::Agent => DiagnosticFormat::Agent,
             DiagnosticFormatChoice::Concise => DiagnosticFormat::Concise,
-        },
+        };
+    }
+
+    policy
+}
+
+impl OutputPreset {
+    fn policy(self, signals: OutputSignals) -> OutputPolicy {
+        match self {
+            Self::Agent => OutputPolicy {
+                stdout: StreamPolicy {
+                    color: signals.color_forced,
+                    hyperlinks: false,
+                },
+                stderr: StreamPolicy {
+                    color: signals.color_forced,
+                    hyperlinks: false,
+                },
+                diagnostics: DiagnosticPolicy {
+                    format: DiagnosticFormat::Agent,
+                    show_error_codes: true,
+                },
+            },
+            Self::Human | Self::Auto => OutputPolicy {
+                stdout: StreamPolicy {
+                    color: signals.stdout_auto_color,
+                    hyperlinks: signals.stdout_is_terminal,
+                },
+                stderr: StreamPolicy {
+                    color: signals.stderr_auto_color,
+                    hyperlinks: signals.stderr_is_terminal,
+                },
+                diagnostics: DiagnosticPolicy {
+                    format: DiagnosticFormat::Ariadne,
+                    show_error_codes: true,
+                },
+            },
+        }
     }
 }
 
@@ -245,14 +279,6 @@ fn running_in_agent() -> bool {
     AGENT_ENV_VARS.iter().any(|var| env_truthy(var))
 }
 
-const fn format_to_u8(format: DiagnosticFormat) -> u8 {
-    match format {
-        DiagnosticFormat::Ariadne => HUMAN_FORMAT,
-        DiagnosticFormat::Agent => AGENT_FORMAT,
-        DiagnosticFormat::Concise => CONCISE_FORMAT,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -277,7 +303,7 @@ mod tests {
 
     #[test]
     fn auto_selects_agent_defaults_when_agent_is_detected() {
-        let config = resolve(
+        let policy = resolve(
             args(OutputPreset::Auto),
             OutputSignals {
                 running_in_agent: true,
@@ -285,16 +311,16 @@ mod tests {
             },
         );
 
-        assert!(!config.stdout_color);
-        assert!(!config.stderr_color);
-        assert!(!config.stdout_hyperlinks);
-        assert!(!config.stderr_hyperlinks);
-        assert_eq!(config.diagnostic_format, DiagnosticFormat::Agent);
+        assert!(!policy.stdout.color);
+        assert!(!policy.stderr.color);
+        assert!(!policy.stdout.hyperlinks);
+        assert!(!policy.stderr.hyperlinks);
+        assert_eq!(policy.diagnostics.format, DiagnosticFormat::Agent);
     }
 
     #[test]
     fn human_preset_uses_per_stream_terminal_capabilities() {
-        let config = resolve(
+        let policy = resolve(
             args(OutputPreset::Human),
             OutputSignals {
                 stdout_auto_color: false,
@@ -305,11 +331,11 @@ mod tests {
             },
         );
 
-        assert!(!config.stdout_color);
-        assert!(config.stderr_color);
-        assert!(!config.stdout_hyperlinks);
-        assert!(config.stderr_hyperlinks);
-        assert_eq!(config.diagnostic_format, DiagnosticFormat::Ariadne);
+        assert!(!policy.stdout.color);
+        assert!(policy.stderr.color);
+        assert!(!policy.stdout.hyperlinks);
+        assert!(policy.stderr.hyperlinks);
+        assert_eq!(policy.diagnostics.format, DiagnosticFormat::Ariadne);
     }
 
     #[test]
@@ -319,18 +345,18 @@ mod tests {
         output_args.hyperlinks = Some(HyperlinkChoice::Always);
         output_args.diagnostic_format = Some(DiagnosticFormatChoice::Human);
 
-        let config = resolve(output_args, INTERACTIVE);
+        let policy = resolve(output_args, INTERACTIVE);
 
-        assert!(config.stdout_color);
-        assert!(config.stderr_color);
-        assert!(config.stdout_hyperlinks);
-        assert!(config.stderr_hyperlinks);
-        assert_eq!(config.diagnostic_format, DiagnosticFormat::Ariadne);
+        assert!(policy.stdout.color);
+        assert!(policy.stderr.color);
+        assert!(policy.stdout.hyperlinks);
+        assert!(policy.stderr.hyperlinks);
+        assert_eq!(policy.diagnostics.format, DiagnosticFormat::Ariadne);
     }
 
     #[test]
     fn conventional_force_color_overrides_agent_preset() {
-        let config = resolve(
+        let policy = resolve(
             args(OutputPreset::Agent),
             OutputSignals {
                 color_forced: true,
@@ -338,10 +364,10 @@ mod tests {
             },
         );
 
-        assert!(config.stdout_color);
-        assert!(config.stderr_color);
-        assert!(!config.stdout_hyperlinks);
-        assert!(!config.stderr_hyperlinks);
-        assert_eq!(config.diagnostic_format, DiagnosticFormat::Agent);
+        assert!(policy.stdout.color);
+        assert!(policy.stderr.color);
+        assert!(!policy.stdout.hyperlinks);
+        assert!(!policy.stderr.hyperlinks);
+        assert_eq!(policy.diagnostics.format, DiagnosticFormat::Agent);
     }
 }

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -432,7 +432,7 @@ fn check_diagnostics(db: &ProjectDatabase, ctx: &str, reporter: &Reporter) -> Re
         &errors.iter().copied().cloned().collect::<Vec<_>>(),
         &sources,
         &file_paths,
-        &render::RenderConfig::cli_auto(),
+        &crate::output::diagnostic_render_config(),
     );
     reporter.abandon();
     eprintln!("{rendered}");

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -432,7 +432,7 @@ fn check_diagnostics(db: &ProjectDatabase, ctx: &str, reporter: &Reporter) -> Re
         &errors.iter().copied().cloned().collect::<Vec<_>>(),
         &sources,
         &file_paths,
-        &crate::output::diagnostic_render_config(),
+        &crate::output::policy().diagnostic_render_config(),
     );
     reporter.abandon();
     eprintln!("{rendered}");

--- a/baml_language/crates/baml_cli/src/paint.rs
+++ b/baml_language/crates/baml_cli/src/paint.rs
@@ -22,69 +22,6 @@ use baml_project::ProjectDatabase;
 use console::Style;
 use text_size::{TextRange, TextSize};
 
-// ── Output mode (color / hyperlinks) ───────────────────────────────────────────
-
-/// When to emit color and hyperlinks. Mirrors the conventional `--color` flag.
-#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum ColorChoice {
-    /// Color on an interactive terminal; off when piped or inside an AI agent.
-    #[default]
-    Auto,
-    /// Always emit color/hyperlinks.
-    Always,
-    /// Never emit color/hyperlinks.
-    Never,
-}
-
-/// Environment variables that signal a non-interactive AI agent is capturing
-/// output, where ANSI color and hyperlinks are noise rather than UI. Sourced
-/// from each agent's docs and from maintained detection matrices
-/// (`@vercel/detect-agent`, Bun's agent checks).
-const AGENT_ENV_VARS: &[&str] = &[
-    "CLAUDECODE",      // Claude Code (code.claude.com/docs/en/env-vars)
-    "CODEX_SANDBOX",   // OpenAI Codex CLI (set in its sandbox)
-    "PI_CODING_AGENT", // Pi (earendil-works/pi)
-    "OPENCODE_CLIENT", // opencode
-    "AI_AGENT",        // @vercel/detect-agent universal var (+ custom agents)
-    "CURSOR_TRACE_ID", // Cursor agent terminal
-    "REPL_ID",         // Replit
-    "AGENT",           // generic (Codex `AGENT=codex`, Bun)
-];
-
-fn env_truthy(var: &str) -> bool {
-    std::env::var(var).is_ok_and(|v| !v.is_empty() && v != "0")
-}
-
-/// Whether output is being captured by a known AI coding agent.
-fn running_in_agent() -> bool {
-    AGENT_ENV_VARS.iter().any(|var| env_truthy(var))
-}
-
-/// Resolve color/hyperlink output once at startup, applying the decision to both
-/// stdout and stderr so the two streams agree (avoids leaking codes into a
-/// redirected stream or dropping color on a redirected sibling).
-pub fn init_color(choice: ColorChoice) {
-    match choice {
-        ColorChoice::Always => {
-            console::set_colors_enabled(true);
-            console::set_colors_enabled_stderr(true);
-        }
-        ColorChoice::Never => {
-            console::set_colors_enabled(false);
-            console::set_colors_enabled_stderr(false);
-        }
-        ColorChoice::Auto => {
-            // An explicit `CLICOLOR_FORCE` (honored by console's defaults) always
-            // wins; only suppress for agents when color was not force-requested.
-            if !env_truthy("CLICOLOR_FORCE") && running_in_agent() {
-                console::set_colors_enabled(false);
-                console::set_colors_enabled_stderr(false);
-            }
-            // Otherwise leave console's per-stream TTY / NO_COLOR / CLICOLOR defaults.
-        }
-    }
-}
-
 /// Style for a semantic token, honoring its modifiers.
 ///
 /// Colors are restricted to the terminal's *named* ANSI palette plus the
@@ -298,28 +235,31 @@ fn file_uri(path: &Path) -> String {
 /// helpers never have to guess which stream they're feeding (which previously
 /// risked leaking codes into a redirected sibling stream).
 pub struct Painter {
-    enabled: bool,
+    color: bool,
+    hyperlinks: bool,
 }
 
 impl Painter {
     /// Painter for stdout-bound output.
     pub fn stdout() -> Self {
         Self {
-            enabled: console::colors_enabled(),
+            color: console::colors_enabled(),
+            hyperlinks: crate::output::stdout_hyperlinks_enabled(),
         }
     }
 
     /// Painter for stderr-bound output.
     pub fn stderr() -> Self {
         Self {
-            enabled: console::colors_enabled_stderr(),
+            color: console::colors_enabled_stderr(),
+            hyperlinks: crate::output::stderr_hyperlinks_enabled(),
         }
     }
 
     /// Whether this stream renders color. Also gates the verbatim-vs-cleaned body
     /// rendering fork in `describe` (a behavior choice, not just a color toggle).
     pub fn enabled(&self) -> bool {
-        self.enabled
+        self.color
     }
 
     /// A dotted name: namespace-colored qualifiers, leaf colored by `leaf_kind`.
@@ -329,7 +269,7 @@ impl Painter {
 
     /// Like [`Painter::fqn`] but the leaf kind is optional (`None` => namespace).
     pub fn fqn_opt(&self, name: &str, leaf_kind: Option<DefinitionKind>) -> String {
-        if self.enabled {
+        if self.color {
             highlight_fqn_opt(name, leaf_kind)
         } else {
             name.to_string()
@@ -338,7 +278,7 @@ impl Painter {
 
     /// A name whose *visible* width is padded to `width` columns.
     pub fn name_padded(&self, name: &str, leaf_kind: DefinitionKind, width: usize) -> String {
-        if self.enabled {
+        if self.color {
             highlight_name_padded(name, leaf_kind, width)
         } else {
             format!("{name:<width$}")
@@ -348,7 +288,7 @@ impl Painter {
     /// A definition-kind label padded to `width` columns, colored by kind.
     pub fn kind_label(&self, kind: DefinitionKind, width: usize) -> String {
         let label = kind.as_str();
-        if self.enabled {
+        if self.color {
             kind_style(kind)
                 .apply_to(format!("{label:<width$}"))
                 .to_string()
@@ -359,7 +299,7 @@ impl Painter {
 
     /// An arbitrary BAML fragment with no source backing (signatures, examples).
     pub fn fragment(&self, text: &str) -> String {
-        if self.enabled {
+        if self.color {
             highlight_str(text)
         } else {
             text.to_string()
@@ -368,7 +308,7 @@ impl Painter {
 
     /// `text` styled as a keyword (for keyword-doc headers).
     pub fn keyword(&self, text: &str) -> String {
-        if self.enabled {
+        if self.color {
             style_for_plain(SemanticTokenType::Keyword)
                 .apply_to(text)
                 .to_string()
@@ -378,12 +318,12 @@ impl Painter {
     }
 
     /// A `display:line_label` location, rendered as a clickable `file://`
-    /// hyperlink when this stream is colored and `abs_path` is a real (absolute)
+    /// hyperlink when enabled and `abs_path` is a real (absolute)
     /// file. Plain `display:line_label` otherwise (pipes / JSON / tests / builtin
     /// `<...>` paths).
     pub fn location(&self, abs_path: &Path, display: &str, line_label: &str) -> String {
         let text = format!("{display}:{line_label}");
-        if self.enabled && abs_path.is_absolute() {
+        if self.hyperlinks && abs_path.is_absolute() {
             osc8(&file_uri(abs_path), &text)
         } else {
             text

--- a/baml_language/crates/baml_cli/src/paint.rs
+++ b/baml_language/crates/baml_cli/src/paint.rs
@@ -31,9 +31,9 @@ use text_size::{TextRange, TextSize};
 /// attributes the way editor themes do: declarations are bold, stdlib
 /// entities italic, deprecated ones struck through.
 ///
-/// Styling is **forced** so emission is decided by the caller per output stream
-/// (gating on `colors_enabled()` for stdout vs `colors_enabled_stderr()` for
-/// stderr), not by console's ambient stdout flag.
+/// Styling is **forced** so emission is decided by the caller from the resolved
+/// output policy for the destination stream, not by console's ambient stdout
+/// flag.
 fn style_for(token_type: SemanticTokenType, modifiers: ModifierSet) -> Style {
     use SemanticTokenType as T;
     // (base color, dimmed) — dim is a *base* trait of quiet token types, kept
@@ -242,17 +242,19 @@ pub struct Painter {
 impl Painter {
     /// Painter for stdout-bound output.
     pub fn stdout() -> Self {
+        let policy = crate::output::policy().stdout;
         Self {
-            color: console::colors_enabled(),
-            hyperlinks: crate::output::stdout_hyperlinks_enabled(),
+            color: policy.color,
+            hyperlinks: policy.hyperlinks,
         }
     }
 
     /// Painter for stderr-bound output.
     pub fn stderr() -> Self {
+        let policy = crate::output::policy().stderr;
         Self {
-            color: console::colors_enabled_stderr(),
-            hyperlinks: crate::output::stderr_hyperlinks_enabled(),
+            color: policy.color,
+            hyperlinks: policy.hyperlinks,
         }
     }
 

--- a/baml_language/crates/baml_compiler_diagnostics/src/render.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/render.rs
@@ -195,13 +195,17 @@ pub fn render_diagnostic(
             let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
             render_ariadne(diagnostic, sources, &mut cache, config.color)
         }
-        DiagnosticFormat::Agent => render_agent(
-            diagnostic,
-            sources,
-            file_paths,
-            config.color,
-            config.show_error_codes,
-        ),
+        DiagnosticFormat::Agent => {
+            let mut path_cache = HashMap::new();
+            render_agent(
+                diagnostic,
+                sources,
+                file_paths,
+                &mut path_cache,
+                config.color,
+                config.show_error_codes,
+            )
+        }
         DiagnosticFormat::Concise => render_concise(diagnostic, sources, file_paths),
     }
 }
@@ -227,6 +231,7 @@ pub fn render_diagnostics(
     // identical (safe under `BAML_CACHE_VERIFY`).
     let mut ariadne_cache = matches!(config.format, DiagnosticFormat::Ariadne)
         .then(|| SourceCache::new(sources.clone(), file_paths.clone()));
+    let mut path_cache = HashMap::new();
     diagnostics
         .iter()
         .map(|d| match (&config.format, &mut ariadne_cache) {
@@ -237,6 +242,7 @@ pub fn render_diagnostics(
                 d,
                 sources,
                 file_paths,
+                &mut path_cache,
                 config.color,
                 config.show_error_codes,
             ),
@@ -407,6 +413,7 @@ fn render_agent(
     diagnostic: &Diagnostic,
     sources: &HashMap<FileId, String>,
     file_paths: &HashMap<FileId, PathBuf>,
+    path_cache: &mut HashMap<FileId, String>,
     color: bool,
     show_error_codes: bool,
 ) -> String {
@@ -431,7 +438,12 @@ fn render_agent(
     let mut lines =
         Vec::with_capacity(1 + diagnostic.annotations.len() + diagnostic.related_info.len());
     if let Some(index) = primary_index {
-        let location = format_span(diagnostic.annotations[index].span, sources, file_paths);
+        let location = format_span(
+            diagnostic.annotations[index].span,
+            sources,
+            file_paths,
+            path_cache,
+        );
         lines.push(format!("{location} {label}: {}", diagnostic.message));
 
         if diagnostic.annotations[index]
@@ -460,7 +472,7 @@ fn render_agent(
         } else {
             "secondary"
         };
-        let location = format_span(annotation.span, sources, file_paths);
+        let location = format_span(annotation.span, sources, file_paths, path_cache);
         match &annotation.message {
             Some(message) => lines.push(format!("  {kind} {location}: {message}")),
             None => lines.push(format!("  {kind} {location}")),
@@ -469,7 +481,7 @@ fn render_agent(
 
     for related in &diagnostic.related_info {
         let location = related.file_path.as_ref().map_or_else(
-            || format_span(related.span, sources, file_paths),
+            || format_span(related.span, sources, file_paths, path_cache),
             |path| format_span_with_path(related.span, path, sources),
         );
         lines.push(format!("  related {location}: {}", related.message));
@@ -498,9 +510,12 @@ fn format_span(
     span: Span,
     sources: &HashMap<FileId, String>,
     file_paths: &HashMap<FileId, PathBuf>,
+    path_cache: &mut HashMap<FileId, String>,
 ) -> String {
-    let path = shortest_unique_path(span.file_id, file_paths);
-    format_span_with_path(span, &path, sources)
+    let path = path_cache
+        .entry(span.file_id)
+        .or_insert_with(|| shortest_unique_path(span.file_id, file_paths));
+    format_span_with_path(span, path, sources)
 }
 
 fn format_span_with_path(span: Span, path: &str, sources: &HashMap<FileId, String>) -> String {

--- a/baml_language/crates/baml_compiler_diagnostics/src/render.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/render.rs
@@ -21,7 +21,11 @@
 //! let concise = render_diagnostic(&diag, &sources, RenderConfig::concise());
 //! ```
 
-use std::{collections::HashMap, fmt, path::PathBuf};
+use std::{
+    collections::HashMap,
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use ariadne::{Fmt, Label, Report, ReportKind, Source};
 use baml_base::{FileId, Span};
@@ -569,10 +573,15 @@ fn shortest_unique_path(file_id: FileId, file_paths: &HashMap<FileId, PathBuf>) 
             .filter(|(other_id, _)| **other_id != file_id)
             .all(|(_, other)| !other.ends_with(&suffix));
         if unique {
-            return suffix.display().to_string();
+            return display_agent_path(&suffix);
         }
     }
-    path.display().to_string()
+    display_agent_path(path)
+}
+
+fn display_agent_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, "/")
 }
 
 /// Render a diagnostic in concise one-line format.

--- a/baml_language/crates/baml_compiler_diagnostics/src/render.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/render.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides rendering of unified `Diagnostic` types to various formats:
 //! - **Ariadne**: Beautiful CLI output with colors and source snippets
+//! - **Agent**: Compact exact locations without source diagrams
 //! - **Concise**: One-line format like `file:line:col: [E0001] message`
 //! - **LSP**: Converts to `lsp_types::Diagnostic` for editor integration
 //!
@@ -22,7 +23,7 @@
 
 use std::{collections::HashMap, fmt, path::PathBuf};
 
-use ariadne::{Label, Report, ReportKind, Source};
+use ariadne::{Fmt, Label, Report, ReportKind, Source};
 use baml_base::{FileId, Span};
 
 use crate::diagnostic::{Diagnostic, Severity};
@@ -110,6 +111,8 @@ pub enum DiagnosticFormat {
     /// Full Ariadne output with colors and source context.
     #[default]
     Ariadne,
+    /// Compact location-based output for coding agents.
+    Agent,
     /// Concise one-line format: `file:line:col: [E0001] message`
     Concise,
 }
@@ -136,12 +139,7 @@ impl Default for RenderConfig {
 }
 
 impl RenderConfig {
-    /// Configuration for CLI output, always colored (Ariadne).
-    ///
-    /// Prefer [`Self::cli_auto`] for actual CLI surfaces — that variant
-    /// strips ANSI codes when stderr isn't a TTY (e.g. when the user pipes
-    /// to a file, redirects in CI, or runs through `less`) and when the
-    /// `NO_COLOR` env var is set (<https://no-color.org>).
+    /// Configuration for human CLI output, always colored (Ariadne).
     pub fn cli() -> Self {
         Self {
             format: DiagnosticFormat::Ariadne,
@@ -150,23 +148,11 @@ impl RenderConfig {
         }
     }
 
-    /// Configuration for CLI output with auto-detected color.
-    ///
-    /// Color is enabled when *both* of:
-    ///   - the `NO_COLOR` env var is unset (per <https://no-color.org>), and
-    ///   - `stderr` is a TTY.
-    ///
-    /// Use this from any `baml` subcommand that renders diagnostics so
-    /// `baml run 2> errors.log` (or piping through `less`/CI) doesn't get
-    /// raw ANSI codes embedded.
-    pub fn cli_auto() -> Self {
-        use std::io::IsTerminal;
+    /// Configuration for compact agent output.
+    pub fn agent() -> Self {
         Self {
-            format: DiagnosticFormat::Ariadne,
-            color: Self::pure_color_decision(
-                std::env::var_os("NO_COLOR").is_some(),
-                std::io::stderr().is_terminal(),
-            ),
+            format: DiagnosticFormat::Agent,
+            color: false,
             show_error_codes: true,
         }
     }
@@ -178,13 +164,6 @@ impl RenderConfig {
             color: false,
             show_error_codes: true,
         }
-    }
-
-    /// Pure helper underlying [`Self::cli_auto`]. Extracted so the
-    /// behavior can be unit-tested without manipulating process env or
-    /// terminal state.
-    fn pure_color_decision(no_color_set: bool, stderr_is_tty: bool) -> bool {
-        !no_color_set && stderr_is_tty
     }
 
     /// Configuration for concise one-line output.
@@ -216,6 +195,13 @@ pub fn render_diagnostic(
             let mut cache = SourceCache::new(sources.clone(), file_paths.clone());
             render_ariadne(diagnostic, sources, &mut cache, config.color)
         }
+        DiagnosticFormat::Agent => render_agent(
+            diagnostic,
+            sources,
+            file_paths,
+            config.color,
+            config.show_error_codes,
+        ),
         DiagnosticFormat::Concise => render_concise(diagnostic, sources, file_paths),
     }
 }
@@ -247,6 +233,13 @@ pub fn render_diagnostics(
             (DiagnosticFormat::Ariadne, Some(cache)) => {
                 render_ariadne(d, sources, cache, config.color)
             }
+            (DiagnosticFormat::Agent, _) => render_agent(
+                d,
+                sources,
+                file_paths,
+                config.color,
+                config.show_error_codes,
+            ),
             _ => render_concise(d, sources, file_paths),
         })
         .collect::<Vec<_>>()
@@ -409,6 +402,164 @@ fn strip_ansi(s: &str) -> String {
     out
 }
 
+/// Render one diagnostic as compact, location-first text for coding agents.
+fn render_agent(
+    diagnostic: &Diagnostic,
+    sources: &HashMap<FileId, String>,
+    file_paths: &HashMap<FileId, PathBuf>,
+    color: bool,
+    show_error_codes: bool,
+) -> String {
+    let primary_index = diagnostic
+        .annotations
+        .iter()
+        .position(|annotation| annotation.is_primary)
+        .or((!diagnostic.annotations.is_empty()).then_some(0));
+
+    let level = severity_name(diagnostic.severity);
+    let label = if show_error_codes {
+        format!("{level}[{}]", diagnostic.code())
+    } else {
+        level.to_string()
+    };
+    let label = if color {
+        label.fg(severity_color(diagnostic.severity)).to_string()
+    } else {
+        label
+    };
+
+    let mut lines =
+        Vec::with_capacity(1 + diagnostic.annotations.len() + diagnostic.related_info.len());
+    if let Some(index) = primary_index {
+        let location = format_span(diagnostic.annotations[index].span, sources, file_paths);
+        lines.push(format!("{location} {label}: {}", diagnostic.message));
+
+        if diagnostic.annotations[index]
+            .message
+            .as_deref()
+            .is_some_and(|message| message != diagnostic.message)
+        {
+            lines.push(format!(
+                "  primary: {}",
+                diagnostic.annotations[index]
+                    .message
+                    .as_deref()
+                    .unwrap_or_default()
+            ));
+        }
+    } else {
+        lines.push(format!("{label}: {}", diagnostic.message));
+    }
+
+    for (index, annotation) in diagnostic.annotations.iter().enumerate() {
+        if Some(index) == primary_index {
+            continue;
+        }
+        let kind = if annotation.is_primary {
+            "primary"
+        } else {
+            "secondary"
+        };
+        let location = format_span(annotation.span, sources, file_paths);
+        match &annotation.message {
+            Some(message) => lines.push(format!("  {kind} {location}: {message}")),
+            None => lines.push(format!("  {kind} {location}")),
+        }
+    }
+
+    for related in &diagnostic.related_info {
+        let location = related.file_path.as_ref().map_or_else(
+            || format_span(related.span, sources, file_paths),
+            |path| format_span_with_path(related.span, path, sources),
+        );
+        lines.push(format!("  related {location}: {}", related.message));
+    }
+
+    lines.join("\n")
+}
+
+fn severity_name(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+        Severity::Info => "info",
+    }
+}
+
+fn severity_color(severity: Severity) -> ariadne::Color {
+    match severity {
+        Severity::Error => ariadne::Color::Red,
+        Severity::Warning => ariadne::Color::Yellow,
+        Severity::Info => ariadne::Color::Fixed(147),
+    }
+}
+
+fn format_span(
+    span: Span,
+    sources: &HashMap<FileId, String>,
+    file_paths: &HashMap<FileId, PathBuf>,
+) -> String {
+    let path = shortest_unique_path(span.file_id, file_paths);
+    format_span_with_path(span, &path, sources)
+}
+
+fn format_span_with_path(span: Span, path: &str, sources: &HashMap<FileId, String>) -> String {
+    let Some(source) = sources.get(&span.file_id) else {
+        let start: u32 = span.range.start().into();
+        let end: u32 = span.range.end().into();
+        return format!("{path}:bytes:{start}-{end}");
+    };
+
+    let start: usize = span.range.start().into();
+    let end: usize = span.range.end().into();
+    let start = line_column(source, start);
+    let end = line_column(source, end);
+    if start == end {
+        format!("{path}:{}:{}", start.0, start.1)
+    } else {
+        format!("{path}:{}:{}-{}:{}", start.0, start.1, end.0, end.1)
+    }
+}
+
+/// Return a 1-based Unicode-scalar line and column for a byte offset.
+fn line_column(source: &str, byte_offset: usize) -> (usize, usize) {
+    let mut offset = byte_offset.min(source.len());
+    while !source.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let line_start = prefix.rfind('\n').map_or(0, |position| position + 1);
+    let column = source[line_start..offset].chars().count() + 1;
+    (line, column)
+}
+
+/// Use the shortest path suffix that uniquely identifies this file in the
+/// render batch. Most projects get a filename; duplicate filenames retain just
+/// enough parent directories to disambiguate them.
+fn shortest_unique_path(file_id: FileId, file_paths: &HashMap<FileId, PathBuf>) -> String {
+    let Some(path) = file_paths.get(&file_id) else {
+        return file_id.to_string();
+    };
+
+    let mut suffix = PathBuf::new();
+    for component in path.components().rev() {
+        suffix = if suffix.as_os_str().is_empty() {
+            PathBuf::from(component.as_os_str())
+        } else {
+            PathBuf::from(component.as_os_str()).join(suffix)
+        };
+        let unique = file_paths
+            .iter()
+            .filter(|(other_id, _)| **other_id != file_id)
+            .all(|(_, other)| !other.ends_with(&suffix));
+        if unique {
+            return suffix.display().to_string();
+        }
+    }
+    path.display().to_string()
+}
+
 /// Render a diagnostic in concise one-line format.
 fn render_concise(
     diagnostic: &Diagnostic,
@@ -477,35 +628,6 @@ mod tests {
 
     use super::*;
     use crate::diagnostic::DiagnosticId;
-
-    // ── cli_auto color-decision logic ─────────────────────────────────
-
-    /// `NO_COLOR=…` always wins over TTY detection. (<https://no-color.org>)
-    #[test]
-    fn no_color_env_disables_color_even_on_tty() {
-        assert!(!RenderConfig::pure_color_decision(true, true));
-    }
-
-    /// Piped/redirected stderr disables color even with `NO_COLOR` unset.
-    /// Catches the original symptom: `baml run 2> errors.log` was getting
-    /// raw ANSI codes embedded in the log file.
-    #[test]
-    fn non_tty_stderr_disables_color() {
-        assert!(!RenderConfig::pure_color_decision(false, false));
-    }
-
-    /// The only path that produces colored output: stderr is a TTY AND
-    /// the user hasn't opted out via `NO_COLOR`.
-    #[test]
-    fn tty_without_no_color_enables_color() {
-        assert!(RenderConfig::pure_color_decision(false, true));
-    }
-
-    /// Defense in depth: both signals say "no" → definitely no color.
-    #[test]
-    fn no_color_and_non_tty_disables_color() {
-        assert!(!RenderConfig::pure_color_decision(true, false));
-    }
 
     fn make_source() -> HashMap<FileId, String> {
         let mut sources = HashMap::new();
@@ -602,5 +724,76 @@ mod tests {
             !output.contains("─[ 0:"),
             "Should not show file ID, got: {output}"
         );
+    }
+
+    #[test]
+    fn agent_render_is_compact_and_does_not_repeat_the_primary_message() {
+        let diag = Diagnostic::error(DiagnosticId::DuplicateName, "Duplicate class 'Foo'")
+            .with_primary_span(test_span());
+
+        let output = render_diagnostic(
+            &diag,
+            &make_source(),
+            &make_file_paths(),
+            &RenderConfig::agent(),
+        );
+
+        assert_eq!(
+            output,
+            "test.baml:1:7-1:10 error[E0011]: Duplicate class 'Foo'"
+        );
+    }
+
+    #[test]
+    fn agent_render_preserves_secondary_and_related_locations() {
+        let mut sources = HashMap::new();
+        sources.insert(FileId::new(0), "class Foo {}".to_string());
+        sources.insert(FileId::new(1), "class Foo {}".to_string());
+        let mut paths = HashMap::new();
+        paths.insert(FileId::new(0), PathBuf::from("/project/first/main.baml"));
+        paths.insert(FileId::new(1), PathBuf::from("/project/second/main.baml"));
+
+        let first = Span {
+            file_id: FileId::new(0),
+            range: TextRange::new(6.into(), 9.into()),
+        };
+        let second = Span {
+            file_id: FileId::new(1),
+            range: TextRange::new(6.into(), 9.into()),
+        };
+        let diag = Diagnostic::error(DiagnosticId::DuplicateName, "Duplicate class 'Foo'")
+            .with_primary_span(second)
+            .with_secondary(first, "Conflicts with this declaration")
+            .with_related(first, "First defined here");
+
+        let output = render_diagnostic(&diag, &sources, &paths, &RenderConfig::agent());
+
+        assert_eq!(
+            output,
+            "second/main.baml:1:7-1:10 error[E0011]: Duplicate class 'Foo'\n  secondary first/main.baml:1:7-1:10: Conflicts with this declaration\n  related first/main.baml:1:7-1:10: First defined here"
+        );
+    }
+
+    #[test]
+    fn agent_render_uses_character_columns_for_utf8() {
+        let name = "caf\u{e9}";
+        let source = format!("let {name} = 1");
+        let start = source.find(name).unwrap();
+        let end = start + name.len();
+        let span = Span {
+            file_id: FileId::new(0),
+            range: TextRange::new(
+                u32::try_from(start).unwrap().into(),
+                u32::try_from(end).unwrap().into(),
+            ),
+        };
+        let message = format!("Unknown variable `{name}`");
+        let diag =
+            Diagnostic::error(DiagnosticId::UnknownVariable, &message).with_primary_span(span);
+        let sources = HashMap::from([(FileId::new(0), source)]);
+
+        let output = render_diagnostic(&diag, &sources, &make_file_paths(), &RenderConfig::agent());
+
+        assert_eq!(output, format!("test.baml:1:5-1:9 error[E0003]: {message}"));
     }
 }


### PR DESCRIPTION
## Summary
- centralize output preset, color, hyperlink, and diagnostic-format resolution
- select compact diagnostics automatically in known coding-agent environments
- add an agent renderer with exact ranges and primary, secondary, and related locations
- expose granular CLI and environment overrides while preserving the existing human renderer

## Example

    type_malformed.baml:7:6-7:9 error[E0010]: Expected =, found identifier

## Configuration
- --output-preset / BAML_OUTPUT_PRESET
- --color / BAML_COLOR
- --hyperlinks / BAML_HYPERLINKS
- --diagnostic-format / BAML_DIAGNOSTIC_FORMAT

## Tests
- cargo test -p baml_compiler_diagnostics
- cargo test -p baml_cli --lib
- cargo clippy -p baml_compiler_diagnostics -p baml_cli --all-targets -- -D warnings
- cargo fmt --all -- --check

Linear: B-407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable CLI output presets with environment-variable support, including an agent-optimized diagnostic format.
  - Color and hyperlink behavior are now driven by a unified output policy with sensible automatic defaults (or explicit overrides).
  - Hyperlinks and styling adapt per output stream (stdout vs stderr) based on terminal capability.

- **Bug Fixes**
  - Standardized diagnostic rendering configuration across check, generate, pack, and cache-related validations for more consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->