### PR TITLE
Rust sdk trusted publishing use `release` env

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1059,6 +1059,7 @@ jobs:
     # like PyPI/npm above. Match the builder's runner + toolchain so the
     # repackaged `.crate` is byte-reproducible.
     runs-on: ubuntu-22.04
+    environment: release
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to run under the designated release environment, improving deployment controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->