### PR TITLE
Add BAML property shorthand

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -608,6 +608,11 @@ pub struct AstSourceMap {
     /// For labeled call arguments, the span of the label name keyed by
     /// `(call_expr_id, argument_expr_id)`.
     pub call_arg_label_spans: HashMap<(ExprId, ExprId), TextRange>,
+    /// Value expressions synthesized from property shorthand. For example,
+    /// `{ options }` lowers to the same key/value shape as
+    /// `{ options: options }`, while this set preserves that the user wrote the
+    /// shorthand so diagnostics can explain its exact-name requirement.
+    pub property_shorthand_exprs: HashSet<ExprId>,
 
     /// Ids of compiler-synthesized nodes — desugarings that have no
     /// user-written source of their own (e.g. the `string.from(${…})` wrapper
@@ -635,6 +640,7 @@ impl AstSourceMap {
             member_access_member_spans: HashMap::new(),
             path_segment_spans: HashMap::new(),
             call_arg_label_spans: HashMap::new(),
+            property_shorthand_exprs: HashSet::new(),
             synthetic_exprs: HashSet::new(),
             synthetic_stmts: HashSet::new(),
             synthetic_patterns: HashSet::new(),
@@ -649,6 +655,12 @@ impl AstSourceMap {
     /// Whether `id` names a compiler-synthesized statement (see `synthetic_stmts`).
     pub fn is_synthetic_stmt(&self, id: StmtId) -> bool {
         self.synthetic_stmts.contains(&id)
+    }
+
+    /// Whether `id` is the value expression synthesized for a shorthand
+    /// property such as the `options` value in `{ options }`.
+    pub fn is_property_shorthand_expr(&self, id: ExprId) -> bool {
+        self.property_shorthand_exprs.contains(&id)
     }
 
     /// Look up the source span of a statement by its `StmtId`.

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -608,6 +608,9 @@ pub struct AstSourceMap {
     /// For labeled call arguments, the span of the label name keyed by
     /// `(call_expr_id, argument_expr_id)`.
     pub call_arg_label_spans: HashMap<(ExprId, ExprId), TextRange>,
+    /// For object-constructor fields, the span of the field name keyed by
+    /// `(object_expr_id, value_expr_id)`.
+    pub object_field_name_spans: HashMap<(ExprId, ExprId), TextRange>,
     /// Value expressions synthesized from property shorthand. For example,
     /// `{ options }` lowers to the same key/value shape as
     /// `{ options: options }`, while this set preserves that the user wrote the
@@ -640,6 +643,7 @@ impl AstSourceMap {
             member_access_member_spans: HashMap::new(),
             path_segment_spans: HashMap::new(),
             call_arg_label_spans: HashMap::new(),
+            object_field_name_spans: HashMap::new(),
             property_shorthand_exprs: HashSet::new(),
             synthetic_exprs: HashSet::new(),
             synthetic_stmts: HashSet::new(),
@@ -703,6 +707,15 @@ impl AstSourceMap {
             .get(&id)
             .and_then(|spans| spans.get(segment_idx).copied())
             .unwrap_or_else(|| self.expr_span(id))
+    }
+
+    /// Look up the field-name span for an object-constructor field.
+    /// Returns the value-expression span as fallback.
+    pub fn object_field_name_span(&self, object_id: ExprId, value_id: ExprId) -> TextRange {
+        self.object_field_name_spans
+            .get(&(object_id, value_id))
+            .copied()
+            .unwrap_or_else(|| self.expr_span(value_id))
     }
 
     /// Look up the source span of a pattern by its `PatId`.

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -1958,9 +1958,13 @@ retry_policy MyRetry {
         assert_eq!(let_def.name.as_str(), "MyRetry");
         assert_eq!(let_def.origin, LetOrigin::RetryPolicy);
 
-        let (body, _source_map) = let_def.initializer.as_ref().expect("expected initializer");
+        let (body, source_map) = let_def.initializer.as_ref().expect("expected initializer");
 
         let root_id = body.root_expr.expect("expected root expr");
+        assert!(
+            source_map.is_synthetic_expr(root_id),
+            "retry_policy's class-shaped initializer is compiler-synthesized"
+        );
         let root_expr = &body.exprs[root_id];
 
         let (type_name, fields, _) = match root_expr {

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -2484,10 +2484,15 @@ fn synthesize_retry_policy_let(
         type_annotations: la_arena::Arena::new(),
         root_expr: Some(root),
     };
-    let source_map = AstSourceMap {
+    let mut source_map = AstSourceMap {
         expr_spans,
         ..Default::default()
     };
+    // The object constructor is an implementation detail of `retry_policy`
+    // config lowering, not a user-written class literal. TIR uses this marker
+    // to avoid applying ordinary object-literal field diagnostics to config
+    // keys such as the legacy `strategy` block.
+    source_map.synthetic_exprs.insert(root);
 
     Some(Item::Let(LetDef {
         name: Name::new(name_token.text()),

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -4106,6 +4106,7 @@ impl LoweringContext {
         }
 
         let mut fields = Vec::new();
+        let mut field_name_spans = Vec::new();
         let mut spreads = Vec::new();
         let mut position = 0;
         let mut type_args: Vec<TypeExpr> = vec![];
@@ -4149,7 +4150,7 @@ impl LoweringContext {
                 SyntaxKind::OBJECT_FIELD => {
                     // OBJECT_FIELD: WORD (DOT WORD)* COLON expr, or shorthand WORD.
                     let mut key_segments = Vec::new();
-                    let mut shorthand_span = None;
+                    let mut key_span: Option<TextRange> = None;
                     let mut val = None;
                     let mut seen_colon = false;
                     for elem in child.children_with_tokens() {
@@ -4160,9 +4161,12 @@ impl LoweringContext {
                             rowan::NodeOrToken::Token(t)
                                 if is_ident_token(t.kind()) && !seen_colon =>
                             {
-                                if shorthand_span.is_none() {
-                                    shorthand_span = Some(t.text_range());
-                                }
+                                key_span = Some(match key_span {
+                                    Some(span) => {
+                                        TextRange::new(span.start(), t.text_range().end())
+                                    }
+                                    None => t.text_range(),
+                                });
                                 key_segments.push(t.text().to_string());
                             }
                             rowan::NodeOrToken::Node(n) if seen_colon && val.is_none() => {
@@ -4177,7 +4181,7 @@ impl LoweringContext {
                     }
                     if !seen_colon
                         && key_segments.len() == 1
-                        && let Some(span) = shorthand_span
+                        && let Some(span) = key_span
                     {
                         let val_id =
                             self.alloc_expr(Expr::Path(vec![Name::new(&key_segments[0])]), span);
@@ -4190,6 +4194,9 @@ impl LoweringContext {
                         Some(Name::new(key_segments.join(".")))
                     };
                     if let (Some(k), Some(val_id)) = (key, val) {
+                        if let Some(span) = key_span {
+                            field_name_spans.push((val_id, span));
+                        }
                         fields.push((k, val_id));
                     }
                     position += 1;
@@ -4214,7 +4221,7 @@ impl LoweringContext {
             }
         }
 
-        self.alloc_expr(
+        let object_id = self.alloc_expr(
             Expr::Object {
                 type_name,
                 type_args,
@@ -4222,7 +4229,13 @@ impl LoweringContext {
                 spreads,
             },
             node.span_range(),
-        )
+        );
+        for (value_id, field_name_span) in field_name_spans {
+            self.source_map
+                .object_field_name_spans
+                .insert((object_id, value_id), field_name_span);
+        }
+        object_id
     }
 
     fn lower_map_literal(&mut self, node: &SyntaxNode) -> ExprId {

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -4142,13 +4142,14 @@ impl LoweringContext {
         // brace, so the segments are always present.
         let type_name = TypePath::new(type_path_segments);
 
-        // Object fields are child nodes after L_BRACE
-        // They come as key-value pairs: WORD COLON expr or SPREAD expr
+        // Object fields are child nodes after L_BRACE. They come as key-value
+        // pairs (`WORD COLON expr`), shorthand (`WORD`), or spreads.
         for child in node.children() {
             match child.kind() {
                 SyntaxKind::OBJECT_FIELD => {
-                    // OBJECT_FIELD: WORD (DOT WORD)* COLON expr
+                    // OBJECT_FIELD: WORD (DOT WORD)* COLON expr, or shorthand WORD.
                     let mut key_segments = Vec::new();
+                    let mut shorthand_span = None;
                     let mut val = None;
                     let mut seen_colon = false;
                     for elem in child.children_with_tokens() {
@@ -4159,6 +4160,9 @@ impl LoweringContext {
                             rowan::NodeOrToken::Token(t)
                                 if is_ident_token(t.kind()) && !seen_colon =>
                             {
+                                if shorthand_span.is_none() {
+                                    shorthand_span = Some(t.text_range());
+                                }
                                 key_segments.push(t.text().to_string());
                             }
                             rowan::NodeOrToken::Node(n) if seen_colon && val.is_none() => {
@@ -4170,6 +4174,15 @@ impl LoweringContext {
                             rowan::NodeOrToken::Token(_) => {}
                             rowan::NodeOrToken::Node(_) => {}
                         }
+                    }
+                    if !seen_colon
+                        && key_segments.len() == 1
+                        && let Some(span) = shorthand_span
+                    {
+                        let val_id =
+                            self.alloc_expr(Expr::Path(vec![Name::new(&key_segments[0])]), span);
+                        self.source_map.property_shorthand_exprs.insert(val_id);
+                        val = Some(val_id);
                     }
                     let key = if key_segments.is_empty() {
                         None
@@ -4214,7 +4227,7 @@ impl LoweringContext {
 
     fn lower_map_literal(&mut self, node: &SyntaxNode) -> ExprId {
         // MAP_LITERAL uses OBJECT_FIELD children (same as OBJECT_LITERAL).
-        // Each OBJECT_FIELD: key (WORD or expr), COLON, value expr.
+        // Each OBJECT_FIELD is `key: value` or shorthand `key`.
         // For maps the key can also be a string literal or expression.
         let entries = node
             .children()
@@ -4224,6 +4237,7 @@ impl LoweringContext {
                 let mut key_expr = None;
                 let mut val_expr = None;
                 let mut seen_colon = false;
+                let mut shorthand_name = None;
 
                 for elem in field_node.children_with_tokens() {
                     match elem {
@@ -4233,6 +4247,7 @@ impl LoweringContext {
                             } else if !seen_colon && key_expr.is_none() && is_ident_token(t.kind())
                             {
                                 let span = t.text_range();
+                                shorthand_name = Some((Name::new(t.text()), span));
                                 key_expr = Some(self.alloc_expr(
                                     Expr::Literal(Literal::String(t.text().to_string())),
                                     span,
@@ -4259,6 +4274,12 @@ impl LoweringContext {
                             }
                         }
                     }
+                }
+
+                if !seen_colon && let Some((name, span)) = shorthand_name {
+                    let value = self.alloc_expr(Expr::Path(vec![name]), span);
+                    self.source_map.property_shorthand_exprs.insert(value);
+                    val_expr = Some(value);
                 }
 
                 match (key_expr, val_expr) {

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -5840,7 +5840,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         };
 
-        self.context.report_simple(error, field_expr);
+        if let Some(source_map) = &self.body_source_map {
+            self.context.report_at_span(
+                error,
+                source_map.object_field_name_span(object_expr, field_expr),
+            );
+        } else {
+            self.context.report_simple(error, field_expr);
+        }
     }
 
     #[inline(never)]

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -5803,29 +5803,44 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    fn report_unknown_class_property_shorthand(
+    fn report_unknown_class_property(
         &mut self,
+        object_expr: ExprId,
         class_name: &crate::ty::QualifiedTypeName,
         field_name: &Name,
         field_expr: ExprId,
         declared_fields: &FxHashMap<Name, Ty>,
     ) {
-        let is_shorthand = self
+        let (is_shorthand, is_synthetic_object) = self
             .body_source_map
             .as_ref()
-            .is_some_and(|source_map| source_map.is_property_shorthand_expr(field_expr));
-        if !is_shorthand {
+            .map(|source_map| {
+                (
+                    source_map.is_property_shorthand_expr(field_expr),
+                    source_map.is_synthetic_expr(object_expr),
+                )
+            })
+            .unwrap_or_default();
+        if !is_shorthand && is_synthetic_object {
             return;
         }
 
-        self.context.report_simple(
+        let suggestions = Self::similar_name_suggestions(field_name, declared_fields.keys());
+        let error = if is_shorthand {
             TirTypeError::UnknownClassPropertyShorthand {
                 class_name: class_name.clone(),
                 name: field_name.clone(),
-                suggestions: Self::similar_name_suggestions(field_name, declared_fields.keys()),
-            },
-            field_expr,
-        );
+                suggestions,
+            }
+        } else {
+            TirTypeError::UnknownClassField {
+                class_name: class_name.clone(),
+                field_name: field_name.clone(),
+                suggestions,
+            }
+        };
+
+        self.context.report_simple(error, field_expr);
     }
 
     #[inline(never)]
@@ -6020,7 +6035,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                     );
                     self.check_expr(*field_expr, body, &declared_ty);
                 } else {
-                    self.report_unknown_class_property_shorthand(
+                    self.report_unknown_class_property(
+                        expr_id,
                         class_name,
                         field_name,
                         *field_expr,
@@ -6152,7 +6168,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                     );
                     self.check_expr(*field_expr, body, &declared_ty);
                 } else {
-                    self.report_unknown_class_property_shorthand(
+                    self.report_unknown_class_property(
+                        expr_id,
                         class_name,
                         field_name,
                         *field_expr,

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -5803,6 +5803,31 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    fn report_unknown_class_property_shorthand(
+        &mut self,
+        class_name: &crate::ty::QualifiedTypeName,
+        field_name: &Name,
+        field_expr: ExprId,
+        declared_fields: &FxHashMap<Name, Ty>,
+    ) {
+        let is_shorthand = self
+            .body_source_map
+            .as_ref()
+            .is_some_and(|source_map| source_map.is_property_shorthand_expr(field_expr));
+        if !is_shorthand {
+            return;
+        }
+
+        self.context.report_simple(
+            TirTypeError::UnknownClassPropertyShorthand {
+                class_name: class_name.clone(),
+                name: field_name.clone(),
+                suggestions: Self::similar_name_suggestions(field_name, declared_fields.keys()),
+            },
+            field_expr,
+        );
+    }
+
     #[inline(never)]
     fn infer_object_expr(
         &mut self,
@@ -5995,6 +6020,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                     );
                     self.check_expr(*field_expr, body, &declared_ty);
                 } else {
+                    self.report_unknown_class_property_shorthand(
+                        class_name,
+                        field_name,
+                        *field_expr,
+                        &field_types,
+                    );
                     self.infer_expr(*field_expr, body);
                 }
             }
@@ -6121,6 +6152,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                     );
                     self.check_expr(*field_expr, body, &declared_ty);
                 } else {
+                    self.report_unknown_class_property_shorthand(
+                        class_name,
+                        field_name,
+                        *field_expr,
+                        &field_types,
+                    );
                     self.infer_expr(*field_expr, body);
                 }
             }
@@ -9745,8 +9782,19 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .is_none()
                 && !is_dep_package
             {
-                self.context
-                    .report_simple(TirTypeError::UnresolvedName { name: name.clone() }, expr_id);
+                let error = if self
+                    .body_source_map
+                    .as_ref()
+                    .is_some_and(|source_map| source_map.is_property_shorthand_expr(expr_id))
+                {
+                    TirTypeError::UnresolvedPropertyShorthand {
+                        name: name.clone(),
+                        suggestions: Self::similar_name_suggestions(name, self.locals.keys()),
+                    }
+                } else {
+                    TirTypeError::UnresolvedName { name: name.clone() }
+                };
+                self.context.report_simple(error, expr_id);
             }
             ty
         } else if segments.len() >= 2 {
@@ -16439,12 +16487,22 @@ impl TypeInferenceBuilder<'_> {
         unknown_field: &Name,
         declared_fields: &[Name],
     ) -> Vec<Name> {
-        let needle = unknown_field.as_str().to_ascii_lowercase();
+        Self::similar_name_suggestions(unknown_field, declared_fields.iter())
+    }
+
+    /// Rank close names for diagnostics. Prefix and substring relationships get
+    /// a small boost so singular/plural and missing-suffix mistakes remain
+    /// helpful without suggesting unrelated short identifiers.
+    fn similar_name_suggestions<'a>(
+        unknown_name: &Name,
+        candidates: impl IntoIterator<Item = &'a Name>,
+    ) -> Vec<Name> {
+        let needle = unknown_name.as_str().to_ascii_lowercase();
         if needle.is_empty() {
             return Vec::new();
         }
-        let mut scored: Vec<(f64, Name)> = declared_fields
-            .iter()
+        let mut scored: Vec<(f64, Name)> = candidates
+            .into_iter()
             .map(|candidate| {
                 let candidate_lower = candidate.as_str().to_ascii_lowercase();
                 let mut score = strsim::jaro_winkler(&needle, &candidate_lower);

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -121,6 +121,12 @@ pub enum TirTypeError {
         name: Name,
         suggestions: Vec<Name>,
     },
+    /// A class constructor explicitly names a field the class does not declare.
+    UnknownClassField {
+        class_name: crate::ty::QualifiedTypeName,
+        field_name: Name,
+        suggestions: Vec<Name>,
+    },
     /// Unreachable code after a diverging statement (return/break/continue).
     DeadCode {
         after: StmtId,
@@ -890,7 +896,12 @@ impl fmt::Display for TirTypeError {
             TirTypeError::NotIndexable { ty } => {
                 write!(f, "type `{}` is not indexable", ty.render_user_facing())
             }
-            TirTypeError::UnknownClassPatternField {
+            TirTypeError::UnknownClassField {
+                class_name,
+                field_name,
+                suggestions,
+            }
+            | TirTypeError::UnknownClassPatternField {
                 class_name,
                 field_name,
                 suggestions,

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -110,6 +110,17 @@ pub enum TirTypeError {
     UnionMemberNoCommonInterface { union: Ty, member: Name },
     /// Name could not be resolved at all.
     UnresolvedName { name: Name },
+    /// A shorthand property (`{ name }`) could not resolve its implicit value.
+    /// Suggestions are in-scope values with similar names; the diagnostic
+    /// renders them as explicit `name: suggestion` mappings.
+    UnresolvedPropertyShorthand { name: Name, suggestions: Vec<Name> },
+    /// A class constructor shorthand property resolves as a value but its name
+    /// is not an exact class-field match.
+    UnknownClassPropertyShorthand {
+        class_name: crate::ty::QualifiedTypeName,
+        name: Name,
+        suggestions: Vec<Name>,
+    },
     /// Unreachable code after a diverging statement (return/break/continue).
     DeadCode {
         after: StmtId,
@@ -777,6 +788,66 @@ impl fmt::Display for TirTypeError {
             }
             TirTypeError::UnresolvedName { name } => {
                 write!(f, "unresolved name: {name}")
+            }
+            TirTypeError::UnresolvedPropertyShorthand { name, suggestions } => {
+                if suggestions.is_empty() {
+                    write!(
+                        f,
+                        "property shorthand `{name}` requires an in-scope value named `{name}`"
+                    )
+                } else if suggestions.len() == 1 {
+                    write!(
+                        f,
+                        "property shorthand `{name}` requires an in-scope value named `{name}`. \
+                         Did you mean `{name}: {}`?",
+                        suggestions[0]
+                    )
+                } else {
+                    let joined = suggestions
+                        .iter()
+                        .map(|suggestion| format!("{name}: {suggestion}"))
+                        .collect::<Vec<_>>()
+                        .join("`, `");
+                    write!(
+                        f,
+                        "property shorthand `{name}` requires an in-scope value named `{name}`. \
+                         Did you mean one of these: `{joined}`?"
+                    )
+                }
+            }
+            TirTypeError::UnknownClassPropertyShorthand {
+                class_name,
+                name,
+                suggestions,
+            } => {
+                if suggestions.is_empty() {
+                    write!(
+                        f,
+                        "property shorthand `{name}` requires class `{}` to have a field named \
+                         `{name}`",
+                        class_name.render_user_facing()
+                    )
+                } else if suggestions.len() == 1 {
+                    write!(
+                        f,
+                        "class `{}` has no field `{name}` for property shorthand. Did you mean \
+                         `{}: {name}`?",
+                        class_name.render_user_facing(),
+                        suggestions[0]
+                    )
+                } else {
+                    let joined = suggestions
+                        .iter()
+                        .map(|field| format!("{field}: {name}"))
+                        .collect::<Vec<_>>()
+                        .join("`, `");
+                    write!(
+                        f,
+                        "class `{}` has no field `{name}` for property shorthand. Did you mean \
+                         one of these: `{joined}`?",
+                        class_name.render_user_facing()
+                    )
+                }
             }
             TirTypeError::DeadCode {
                 unreachable_count, ..

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -2913,6 +2913,11 @@ pub fn infer_scope_types<'db>(
                     let body = baml_compiler2_hir::body::let_body(db, let_loc);
 
                     if let LetBody::Expr(expr_body) = body.as_ref() {
+                        if let Some(source_map) =
+                            baml_compiler2_hir::body::let_body_source_map(db, let_loc)
+                        {
+                            builder.set_body_source_map(source_map);
+                        }
                         // Infer the root expression type bottom-up.
                         if let Some(root_expr) = expr_body.root_expr {
                             builder.infer_expr(root_expr, expr_body);

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -2714,7 +2714,9 @@ impl<'a> Parser<'a> {
             // Non-parenthesized iterator form.
             self.parse_for_in_pattern();
             self.expect(TokenKind::In);
+            self.suppress_object_literal_depth += 1;
             self.parse_expr();
+            self.suppress_object_literal_depth -= 1;
         }
     }
 
@@ -4703,7 +4705,9 @@ impl<'a> Parser<'a> {
             // destructure here must wrap it in parens — parens reset the
             // suppression in `parse_pattern_atom`.
             p.suppress_destructure_pattern_depth += 1;
+            p.suppress_object_literal_depth += 1;
             p.parse_expr();
+            p.suppress_object_literal_depth -= 1;
             p.suppress_destructure_pattern_depth -= 1;
 
             // Then block
@@ -4759,7 +4763,9 @@ impl<'a> Parser<'a> {
             // and apply condition-position destructure suppression so a
             // trailing `is Class { ... }` doesn't eat the then-block.
             p.suppress_destructure_pattern_depth += 1;
+            p.suppress_object_literal_depth += 1;
             p.parse_expr_bp(3);
+            p.suppress_object_literal_depth -= 1;
             p.suppress_destructure_pattern_depth -= 1;
 
             // Then block
@@ -5603,7 +5609,9 @@ impl<'a> Parser<'a> {
             // Condition: same destructure suppression as `if` — see
             // `parse_if_expr` for rationale.
             p.suppress_destructure_pattern_depth += 1;
+            p.suppress_object_literal_depth += 1;
             p.parse_expr();
+            p.suppress_object_literal_depth -= 1;
             p.suppress_destructure_pattern_depth -= 1;
 
             // Body
@@ -5644,7 +5652,9 @@ impl<'a> Parser<'a> {
             // if-let), and apply condition-position destructure suppression so
             // a trailing `is Class { ... }` doesn't eat the loop body block.
             p.suppress_destructure_pattern_depth += 1;
+            p.suppress_object_literal_depth += 1;
             p.parse_expr_bp(3);
+            p.suppress_object_literal_depth -= 1;
             p.suppress_destructure_pattern_depth -= 1;
 
             // Body
@@ -5709,7 +5719,9 @@ impl<'a> Parser<'a> {
                 // The `let` is required — bindings always require it.
                 p.parse_for_in_pattern();
                 p.expect(TokenKind::In);
+                p.suppress_object_literal_depth += 1;
                 p.parse_expr();
+                p.suppress_object_literal_depth -= 1;
             }
 
             // Body
@@ -6180,7 +6192,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Peek past the current `{` token to check if the brace content starts with
-    /// `<word> :` or `...` (spread), which indicates an object literal / constructor.
+    /// `<word> :`, a shorthand field (`<word> ,` / `<word> }`), or `...`
+    /// (spread), which indicates an object literal / constructor.
     /// If it starts with something else (e.g. a statement, keyword, or expression),
     /// the `{` is more likely a block body.
     fn brace_content_looks_like_fields(&self) -> bool {
@@ -6198,9 +6211,10 @@ impl<'a> Parser<'a> {
                 {
                     i += 2;
                 }
-                self.peek(i)
-                    .map(|t| t.kind == TokenKind::Colon)
-                    .unwrap_or(false)
+                self.peek(i).is_some_and(|t| {
+                    t.kind == TokenKind::Colon
+                        || (i == 2 && matches!(t.kind, TokenKind::Comma | TokenKind::RBrace))
+                })
             }
             _ => false,
         }
@@ -6367,15 +6381,17 @@ impl<'a> Parser<'a> {
             // Lambda expression: (params) -> [RetType] { body }
             self.parse_lambda_expr();
         } else if self.at(TokenKind::LParen) {
-            // Parenthesized expression. Parens reset the destructure
-            // suppression: `if (x is Foo { f })` lets the user opt back
-            // into a destructure that condition-position would otherwise
-            // forbid.
+            // Parenthesized expression. Parens reset the destructure and
+            // object-literal suppression: `if (x is Foo { f })` and
+            // `if (Config { enabled })` let the user opt back into syntax that
+            // condition position would otherwise confuse with the body block.
             self.with_node(SyntaxKind::PAREN_EXPR, |p| {
                 p.bump(); // (
-                let saved = std::mem::take(&mut p.suppress_destructure_pattern_depth);
+                let saved_destructure = std::mem::take(&mut p.suppress_destructure_pattern_depth);
+                let saved_object = std::mem::take(&mut p.suppress_object_literal_depth);
                 p.parse_expr();
-                p.suppress_destructure_pattern_depth = saved;
+                p.suppress_destructure_pattern_depth = saved_destructure;
+                p.suppress_object_literal_depth = saved_object;
                 p.expect(TokenKind::RParen);
             });
         } else if self.at(TokenKind::LBracket) {
@@ -6800,7 +6816,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Check if the current position looks like a map literal rather than a block
-    /// Maps start with { "string": or { identifier:
+    /// Maps start with { "string":, { identifier:, or a shorthand property
+    /// such as { identifier } / { identifier, ... }.
     /// Blocks typically start with { keyword or { expression (but not field:value pattern)
     fn looks_like_map(&self) -> bool {
         // Must start with {
@@ -6848,6 +6865,14 @@ impl<'a> Parser<'a> {
                 }
                 if self.peek(i).map(|t| t.kind) == Some(TokenKind::Colon) {
                     return true; // word: pattern indicates a map
+                }
+                if i == 2
+                    && matches!(
+                        self.peek(i).map(|t| t.kind),
+                        Some(TokenKind::Comma | TokenKind::RBrace)
+                    )
+                {
+                    return true; // bare word followed by ',' / '}' is shorthand
                 }
             }
         }
@@ -7072,14 +7097,17 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse a single map entry in expression context: key: value
-    /// Requires colon between key and value (JSON-style)
+    /// Parse a single map entry in expression context: `key: value` or the
+    /// shorthand `key`, which desugars to `key: key` during AST lowering.
     fn parse_map_entry(&mut self) {
         self.with_node(SyntaxKind::OBJECT_FIELD, |p| {
             // Key - can be identifier, qualified identifier, or string literal.
+            let mut shorthand_candidate = false;
             if p.at(TokenKind::Word) {
+                shorthand_candidate = true;
                 p.bump(); // identifier key
                 while p.at(TokenKind::Dot) {
+                    shorthand_candidate = false;
                     p.bump();
                     if !p.expect(TokenKind::Word) {
                         return;
@@ -7087,6 +7115,10 @@ impl<'a> Parser<'a> {
                 }
             } else if !p.parse_any_string() {
                 p.error_unexpected_token("map key".to_string());
+                return;
+            }
+
+            if shorthand_candidate && (p.at(TokenKind::Comma) || p.at(TokenKind::RBrace)) {
                 return;
             }
 
@@ -7188,15 +7220,18 @@ impl<'a> Parser<'a> {
         });
     }
 
-    /// Parse a single object field: name: value
+    /// Parse a single object field: `name: value` or shorthand `name`.
     fn parse_object_field(&mut self) {
         self.with_node(SyntaxKind::OBJECT_FIELD, |p| {
             // Field name - can be identifier, qualified identifier, or string literal.
             // `client` is a keyword but a valid field name (BEP-049 §10
             // `Context { client: ... }`).
+            let mut shorthand_candidate = false;
             if p.at(TokenKind::Word) || p.at(TokenKind::Client) {
+                shorthand_candidate = true;
                 p.bump(); // identifier field name
                 while p.at(TokenKind::Dot) {
+                    shorthand_candidate = false;
                     p.bump();
                     if !p.expect(TokenKind::Word) {
                         return;
@@ -7204,6 +7239,10 @@ impl<'a> Parser<'a> {
                 }
             } else if !p.parse_any_string() {
                 p.error_unexpected_token("field name".to_string());
+                return;
+            }
+
+            if shorthand_candidate && (p.at(TokenKind::Comma) || p.at(TokenKind::RBrace)) {
                 return;
             }
 
@@ -12023,6 +12062,99 @@ function f() -> int {
         assert_eq!(
             call_exprs, 2,
             "a non-block callee followed by `(` on the next line must still chain as a call"
+        );
+    }
+
+    #[test]
+    fn parses_map_property_shorthand() {
+        let source = r#"
+function build(options: string, retries: int) -> map<string, string | int> {
+    { options, retries, explicit: "value" }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let map = root
+            .descendants()
+            .find(|node| node.kind() == SyntaxKind::MAP_LITERAL)
+            .expect("expected shorthand braces to parse as a map literal");
+        let fields = map
+            .children()
+            .filter(|node| node.kind() == SyntaxKind::OBJECT_FIELD)
+            .collect::<Vec<_>>();
+        assert_eq!(fields.len(), 3);
+        assert!(
+            fields[0]
+                .children_with_tokens()
+                .all(|elem| elem.kind() != SyntaxKind::COLON),
+            "the shorthand field must remain distinguishable in the CST"
+        );
+        assert!(
+            fields[2]
+                .children_with_tokens()
+                .any(|elem| elem.kind() == SyntaxKind::COLON),
+            "explicit fields must retain their colon"
+        );
+    }
+
+    #[test]
+    fn parses_object_property_shorthand() {
+        let source = r#"
+class Request { options string retries int }
+function build(options: string, retries: int) -> Request {
+    Request { options, retries }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let object = root
+            .descendants()
+            .find(|node| node.kind() == SyntaxKind::OBJECT_LITERAL)
+            .expect("expected shorthand braces after Request to parse as an object literal");
+        let fields = object
+            .children()
+            .filter(|node| node.kind() == SyntaxKind::OBJECT_FIELD)
+            .collect::<Vec<_>>();
+        assert_eq!(fields.len(), 2);
+        assert!(fields.iter().all(|field| {
+            field
+                .children_with_tokens()
+                .all(|elem| elem.kind() != SyntaxKind::COLON)
+        }));
+    }
+
+    #[test]
+    fn shorthand_lookahead_does_not_consume_control_flow_bodies() {
+        let source = r#"
+class Flag { enabled bool }
+
+function from_optional(value: int?) -> int {
+    if let v: int = value { v } else { 0 }
+}
+
+function from_if(flag: bool, value: int) -> int {
+    if flag { value } else { 0 }
+}
+
+function from_for(values: int[]) -> int {
+    for let value in values { value }
+    0
+}
+
+function parenthesized_object(enabled: bool) -> bool {
+    if (Flag { enabled }).enabled { true } else { false }
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        assert_eq!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::OBJECT_LITERAL)
+                .count(),
+            1,
+            "only the explicitly parenthesized constructor should parse as an object literal"
         );
     }
 }

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -2693,7 +2693,14 @@ impl<'a> Parser<'a> {
                 if self.looks_like_for_in_loop() {
                     self.parse_for_in_pattern();
                     self.expect(TokenKind::In);
+                    let suppress_object_literal = !self.has_for_header_closing_paren_ahead();
+                    if suppress_object_literal {
+                        self.suppress_object_literal_depth += 1;
+                    }
                     self.parse_expr();
+                    if suppress_object_literal {
+                        self.suppress_object_literal_depth -= 1;
+                    }
                 } else {
                     self.parse_let_stmt();
                     if !self.at(TokenKind::Semicolon) && !self.at(TokenKind::RParen) {
@@ -5683,7 +5690,14 @@ impl<'a> Parser<'a> {
                         // Iterator-style: for (let var in expr) / for (const var in expr)
                         p.parse_for_in_pattern();
                         p.expect(TokenKind::In);
+                        let suppress_object_literal = !p.has_for_header_closing_paren_ahead();
+                        if suppress_object_literal {
+                            p.suppress_object_literal_depth += 1;
+                        }
                         p.parse_expr(); // iterator expression
+                        if suppress_object_literal {
+                            p.suppress_object_literal_depth -= 1;
+                        }
                     } else {
                         // C-style: for (let i = 0; cond; update)
                         p.parse_let_stmt();
@@ -5731,6 +5745,58 @@ impl<'a> Parser<'a> {
                 p.error_unexpected_token("block after for expression".to_string());
             }
         });
+    }
+
+    /// Whether the current parenthesized for-in header has a closing `)` ahead.
+    ///
+    /// If it does not, a following `{ ... }` must remain available as the loop
+    /// body instead of being consumed as an object literal. Balanced nested
+    /// delimiters are skipped so valid iterables such as `Items { values }`,
+    /// arrays containing objects, and calls continue to work.
+    fn has_for_header_closing_paren_ahead(&self) -> bool {
+        let mut stack: Vec<TokenKind> = Vec::new();
+        let mut saw_top_level_brace = false;
+        let mut i = 0;
+
+        loop {
+            let Some(tok) = self.peek(i) else {
+                return false;
+            };
+            match tok.kind {
+                TokenKind::LParen => stack.push(TokenKind::RParen),
+                TokenKind::LBracket => stack.push(TokenKind::RBracket),
+                TokenKind::LBrace => {
+                    if stack.is_empty() {
+                        saw_top_level_brace = true;
+                    }
+                    stack.push(TokenKind::RBrace);
+                }
+                TokenKind::RParen if stack.is_empty() => return true,
+                close @ (TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace) => {
+                    let Some(expected) = stack.pop() else {
+                        return false;
+                    };
+                    if expected != close {
+                        return false;
+                    }
+                }
+                TokenKind::Semicolon if stack.is_empty() => return false,
+                TokenKind::For
+                | TokenKind::If
+                | TokenKind::While
+                | TokenKind::Let
+                | TokenKind::Return
+                | TokenKind::Break
+                | TokenKind::Continue
+                | TokenKind::Match
+                    if stack.is_empty() && saw_top_level_brace =>
+                {
+                    return false;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
     }
 
     /// Check if this looks like a for-in loop. We're at a binding introducer.
@@ -12155,6 +12221,84 @@ function parenthesized_object(enabled: bool) -> bool {
                 .count(),
             1,
             "only the explicitly parenthesized constructor should parse as an object literal"
+        );
+    }
+
+    #[test]
+    fn parenthesized_for_iterable_does_not_consume_body_brace() {
+        let source = r#"
+function iterate(values: int[]) -> int {
+    for (let value in values { value }
+    0
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                ParseError::UnexpectedToken {
+                    expected,
+                    found,
+                    ..
+                } if expected == "')'" && found == "'{'"
+            )),
+            "expected the missing ')' diagnostic, got: {errors:#?}"
+        );
+        assert_eq!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::OBJECT_LITERAL)
+                .count(),
+            0,
+            "the loop body must not be consumed as an object literal"
+        );
+        assert!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::FOR_EXPR)
+                .flat_map(|node| node.children())
+                .any(|node| node.kind() == SyntaxKind::BLOCK_EXPR),
+            "the brace after the iterable must remain the loop body"
+        );
+    }
+
+    #[test]
+    fn nested_parens_allow_object_literal_in_for_iterable() {
+        let source = r#"
+class Values { items int[] }
+
+function iterate(items: int[]) -> int {
+    for (let item in (Values { items }).items) { item }
+    0
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        assert_eq!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::OBJECT_LITERAL)
+                .count(),
+            1,
+            "nested parentheses must opt back into an explicit object literal"
+        );
+    }
+
+    #[test]
+    fn object_literal_is_allowed_in_parenthesized_for_iterable() {
+        let source = r#"
+class Values { items int[] }
+
+function iterate(items: int[]) -> int {
+    for (let item in Values { items }.items) { item }
+    0
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        assert_eq!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::OBJECT_LITERAL)
+                .count(),
+            1,
+            "a real header-closing ')' keeps direct object literals unambiguous"
         );
     }
 }

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -218,6 +218,13 @@ pub(crate) struct Parser<'a> {
     /// available to `parse_spawn_expr`. Counter so nested spawns nest
     /// correctly.
     suppress_object_literal_depth: u32,
+    /// While parsing an unparenthesized for-in iterable, permit an object
+    /// literal only when its closing brace is immediately followed by syntax
+    /// that continues the iterable (or by the loop body's opening brace).
+    ///
+    /// This keeps `for let x in xs { body }` unambiguous while allowing
+    /// iterables such as `Values { items }.items`.
+    allow_object_literal_before_for_body_depth: u32,
     /// Suppresses destructure patterns (`Class { fields }`) in pattern
     /// position, mirroring Rust's `Restrictions::NO_STRUCT_LITERAL` for
     /// struct literals in `if` / `while` condition expressions. Bumped
@@ -240,6 +247,7 @@ impl<'a> Parser<'a> {
             suppress_catch_depth: 0,
             testset_body_depth: 0,
             suppress_object_literal_depth: 0,
+            allow_object_literal_before_for_body_depth: 0,
             suppress_destructure_pattern_depth: 0,
         }
     }
@@ -5734,7 +5742,9 @@ impl<'a> Parser<'a> {
                 p.parse_for_in_pattern();
                 p.expect(TokenKind::In);
                 p.suppress_object_literal_depth += 1;
+                p.allow_object_literal_before_for_body_depth += 1;
                 p.parse_expr();
+                p.allow_object_literal_before_for_body_depth -= 1;
                 p.suppress_object_literal_depth -= 1;
             }
 
@@ -6085,7 +6095,10 @@ impl<'a> Parser<'a> {
                 // while parsing the optional name expression — without it,
                 // `spawn nm { y: 1 }` would consume the body's `{ y: 1 }` as
                 // a struct literal and then fail to find a body brace.
-                if self.suppress_object_literal_depth == 0
+                let object_literal_allowed = self.suppress_object_literal_depth == 0
+                    || (self.allow_object_literal_before_for_body_depth > 0
+                        && self.object_literal_can_precede_for_body());
+                if object_literal_allowed
                     && self.events.len() > expr_start
                     && self.looks_like_object_constructor()
                 {
@@ -6283,6 +6296,52 @@ impl<'a> Parser<'a> {
                 })
             }
             _ => false,
+        }
+    }
+
+    /// Whether the current `{ ... }` can be an object literal inside an
+    /// unparenthesized for-in iterable without stealing the loop body.
+    ///
+    /// A matching brace followed by postfix continuation (`.field`, indexing,
+    /// a call, etc.) is still part of the iterable. A second `{` is the
+    /// unambiguous `Constructor { fields } { body }` shape.
+    fn object_literal_can_precede_for_body(&self) -> bool {
+        debug_assert!(self.at(TokenKind::LBrace));
+
+        let mut stack = vec![TokenKind::RBrace];
+        let mut i = 1;
+        loop {
+            let Some(token) = self.peek(i) else {
+                return false;
+            };
+            match token.kind {
+                TokenKind::LParen => stack.push(TokenKind::RParen),
+                TokenKind::LBracket => stack.push(TokenKind::RBracket),
+                TokenKind::LBrace => stack.push(TokenKind::RBrace),
+                close @ (TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace) => {
+                    let Some(expected) = stack.pop() else {
+                        return false;
+                    };
+                    if close != expected {
+                        return false;
+                    }
+                    if stack.is_empty() {
+                        return self.peek(i + 1).is_some_and(|next| {
+                            matches!(
+                                next.kind,
+                                TokenKind::LBrace
+                                    | TokenKind::Dot
+                                    | TokenKind::Dollar
+                                    | TokenKind::QuestionDot
+                                    | TokenKind::LBracket
+                                    | TokenKind::LParen
+                            )
+                        });
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
         }
     }
 
@@ -12299,6 +12358,34 @@ function iterate(items: int[]) -> int {
                 .count(),
             1,
             "a real header-closing ')' keeps direct object literals unambiguous"
+        );
+    }
+
+    #[test]
+    fn object_literal_is_allowed_in_unparenthesized_for_iterable() {
+        let source = r#"
+class Values { items int[] }
+
+function iterate(items: int[]) -> int {
+    for let item in Values { items }.items { item }
+    0
+}
+"#;
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        assert_eq!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::OBJECT_LITERAL)
+                .count(),
+            1,
+            "an object literal followed by postfix continuation must remain part of the iterable"
+        );
+        assert!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::FOR_EXPR)
+                .flat_map(|node| node.children())
+                .any(|node| node.kind() == SyntaxKind::BLOCK_EXPR),
+            "the final brace must remain the loop body"
         );
     }
 }

--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -4169,8 +4169,10 @@ impl Printable for MapLiteral {
 #[derive(Debug)]
 pub struct ObjectField {
     pub name: ObjectFieldKey,
-    pub colon: t::Colon,
-    pub value: Expression,
+    /// Absent for property shorthand (`{ options }`). The parser only permits
+    /// shorthand for a bare identifier, never for a quoted or qualified key.
+    pub colon: Option<t::Colon>,
+    pub value: Option<Expression>,
 }
 
 impl FromCST for ObjectField {
@@ -4183,10 +4185,17 @@ impl FromCST for ObjectField {
         let name = it.expect_next("WORD or STRING_LITERAL")?;
         let name = ObjectFieldKey::from_cst(name)?;
 
-        let colon = it.expect_parse()?;
+        let colon = it
+            .next_if_kind(SyntaxKind::COLON)
+            .map(t::Colon::from_cst)
+            .transpose()?;
 
-        let value = it.expect_next("value")?;
-        let value = Expression::from_cst(value)?;
+        let value = if colon.is_some() {
+            let value = it.expect_next("value")?;
+            Some(Expression::from_cst(value)?)
+        } else {
+            None
+        };
 
         it.expect_end()?;
 
@@ -4205,18 +4214,21 @@ impl ObjectField {
     /// Returns `None` if it can never be single-lined.
     pub(crate) fn single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
         let name = self.name.single_line_width(input)?;
-        let value = self.value.single_line_width(input)?;
+        let (Some(colon), Some(value)) = (&self.colon, &self.value) else {
+            return Some(name);
+        };
+        let value_width = value.single_line_width(input)?;
         // Must match trivia handled by print: colon_trailing + value_leading
         let mut trivia_len = 0usize;
-        let (_, colon_trailing) = input.trivia.get_for_range_split(self.colon.span());
+        let (_, colon_trailing) = input.trivia.get_for_range_split(colon.span());
         for t in colon_trailing {
             trivia_len += t.single_line_len(input.input)?;
         }
-        let value_leading = input.trivia.get_leading_for_element(&self.value);
+        let value_leading = input.trivia.get_leading_for_element(value);
         for t in value_leading {
             trivia_len += t.single_line_len(input.input)?;
         }
-        Some(name + const { ": ".len() } + value + trivia_len)
+        Some(name + const { ": ".len() } + value_width + trivia_len)
     }
 }
 
@@ -4224,20 +4236,26 @@ impl Printable for ObjectField {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         let mut multi_lined = false;
         multi_lined |= printer.print(&self.name, shape.clone()).multi_lined;
-        printer.print_raw_token(&self.colon);
-        let (_, colon_trailing) = printer.trivia.get_for_range_split(self.colon.span());
+        let (Some(colon), Some(value)) = (&self.colon, &self.value) else {
+            return PrintInfo { multi_lined };
+        };
+        printer.print_raw_token(colon);
+        let (_, colon_trailing) = printer.trivia.get_for_range_split(colon.span());
         printer.print_str(" ");
         printer.print_trivia_squished(colon_trailing);
-        let value_leading = printer.trivia.get_leading_for_element(&self.value);
+        let value_leading = printer.trivia.get_leading_for_element(value);
         printer.print_trivia_squished(value_leading);
-        multi_lined |= printer.print(&self.value, shape).multi_lined;
+        multi_lined |= printer.print(value, shape).multi_lined;
         PrintInfo { multi_lined }
     }
     fn leftmost_token(&self) -> TextRange {
         self.name.leftmost_token()
     }
     fn rightmost_token(&self) -> TextRange {
-        self.value.rightmost_token()
+        self.value
+            .as_ref()
+            .map(Printable::rightmost_token)
+            .unwrap_or_else(|| self.name.rightmost_token())
     }
 }
 

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -1084,6 +1084,18 @@ mod map_literal_format_tests {
     }
 
     #[test]
+    fn test_property_shorthand_is_preserved() {
+        let source = "function f(options: string) -> map<string, string> {\n    { options, explicit: options }\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
+    fn test_object_property_shorthand_is_preserved() {
+        let source = "class Config {\n    options: string,\n}\n\nfunction f(options: string) -> Config {\n    Config { options }\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    #[test]
     fn test_empty_map_with_block_comment_keeps_padding() {
         // An interior comment is real content, so the padding stays.
         let source = "function f() -> int {\n    { /* keep */ };\n    0\n}\n";

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -1923,7 +1923,9 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::TypeMismatch { .. } => DiagnosticId::TypeMismatch,
         TirTypeError::UnresolvedMember { .. } => DiagnosticId::NoSuchField,
         TirTypeError::UnionMemberNoCommonInterface { .. } => DiagnosticId::NoSuchField,
-        TirTypeError::UnknownClassPatternField { .. } => DiagnosticId::NoSuchField,
+        TirTypeError::UnknownClassField { .. } | TirTypeError::UnknownClassPatternField { .. } => {
+            DiagnosticId::NoSuchField
+        }
         TirTypeError::UnknownClassPropertyShorthand { .. } => DiagnosticId::NoSuchField,
         TirTypeError::UnresolvedName { .. } | TirTypeError::UnresolvedPropertyShorthand { .. } => {
             DiagnosticId::UnknownVariable

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -1924,7 +1924,10 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::UnresolvedMember { .. } => DiagnosticId::NoSuchField,
         TirTypeError::UnionMemberNoCommonInterface { .. } => DiagnosticId::NoSuchField,
         TirTypeError::UnknownClassPatternField { .. } => DiagnosticId::NoSuchField,
-        TirTypeError::UnresolvedName { .. } => DiagnosticId::UnknownVariable,
+        TirTypeError::UnknownClassPropertyShorthand { .. } => DiagnosticId::NoSuchField,
+        TirTypeError::UnresolvedName { .. } | TirTypeError::UnresolvedPropertyShorthand { .. } => {
+            DiagnosticId::UnknownVariable
+        }
         TirTypeError::DeadCode { .. } => DiagnosticId::UnreachableCode,
         TirTypeError::VoidUsedAsValue => DiagnosticId::TypeMismatch,
         TirTypeError::VoidFunctionResultUsed => DiagnosticId::TypeMismatch,

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/class.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/class.baml
@@ -54,83 +54,83 @@ function fo() -> int {
 //----
 //- diagnostics
 // error: class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
-//     ╭─[ class.baml:39:17 ]
+//     ╭─[ class.baml:39:13 ]
 //     │
 //  39 │     Color { re: 255, gree: 0, blu: 0 },
-//     │                 ─┬─
-//     │                  ╰─── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     │             ─┬
+//     │              ╰── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯
 // error: class `Color` has no field `gree`. Did you mean `green`?
-//     ╭─[ class.baml:39:28 ]
+//     ╭─[ class.baml:39:22 ]
 //     │
 //  39 │     Color { re: 255, gree: 0, blu: 0 },
-//     │                            ┬
-//     │                            ╰── class `Color` has no field `gree`. Did you mean `green`?
+//     │                      ──┬─
+//     │                        ╰─── class `Color` has no field `gree`. Did you mean `green`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯
 // error: class `Color` has no field `blu`. Did you mean `blue`?
-//     ╭─[ class.baml:39:36 ]
+//     ╭─[ class.baml:39:31 ]
 //     │
 //  39 │     Color { re: 255, gree: 0, blu: 0 },
-//     │                                    ┬
-//     │                                    ╰── class `Color` has no field `blu`. Did you mean `blue`?
+//     │                               ─┬─
+//     │                                ╰─── class `Color` has no field `blu`. Did you mean `blue`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯
 // error: class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
-//     ╭─[ class.baml:40:17 ]
+//     ╭─[ class.baml:40:13 ]
 //     │
 //  40 │     Color { re: 0, gree: 255, blu: 0 },
-//     │                 ┬
-//     │                 ╰── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     │             ─┬
+//     │              ╰── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯
 // error: class `Color` has no field `gree`. Did you mean `green`?
-//     ╭─[ class.baml:40:26 ]
+//     ╭─[ class.baml:40:20 ]
 //     │
 //  40 │     Color { re: 0, gree: 255, blu: 0 },
-//     │                          ─┬─
-//     │                           ╰─── class `Color` has no field `gree`. Did you mean `green`?
+//     │                    ──┬─
+//     │                      ╰─── class `Color` has no field `gree`. Did you mean `green`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯
 // error: class `Color` has no field `blu`. Did you mean `blue`?
-//     ╭─[ class.baml:40:36 ]
+//     ╭─[ class.baml:40:31 ]
 //     │
 //  40 │     Color { re: 0, gree: 255, blu: 0 },
-//     │                                    ┬
-//     │                                    ╰── class `Color` has no field `blu`. Did you mean `blue`?
+//     │                               ─┬─
+//     │                                ╰─── class `Color` has no field `blu`. Did you mean `blue`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯
 // error: class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
-//     ╭─[ class.baml:41:17 ]
+//     ╭─[ class.baml:41:13 ]
 //     │
 //  41 │     Color { re: 0, gree: 0, blu: 255 },
-//     │                 ┬
-//     │                 ╰── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     │             ─┬
+//     │              ╰── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯
 // error: class `Color` has no field `gree`. Did you mean `green`?
-//     ╭─[ class.baml:41:26 ]
+//     ╭─[ class.baml:41:20 ]
 //     │
 //  41 │     Color { re: 0, gree: 0, blu: 255 },
-//     │                          ┬
-//     │                          ╰── class `Color` has no field `gree`. Did you mean `green`?
+//     │                    ──┬─
+//     │                      ╰─── class `Color` has no field `gree`. Did you mean `green`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯
 // error: class `Color` has no field `blu`. Did you mean `blue`?
-//     ╭─[ class.baml:41:34 ]
+//     ╭─[ class.baml:41:29 ]
 //     │
 //  41 │     Color { re: 0, gree: 0, blu: 255 },
-//     │                                  ─┬─
-//     │                                   ╰─── class `Color` has no field `blu`. Did you mean `blue`?
+//     │                             ─┬─
+//     │                              ╰─── class `Color` has no field `blu`. Did you mean `blue`?
 //     │
 //     │ Note: Error code: E0007
 // ────╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/class.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/class.baml
@@ -53,6 +53,87 @@ function fo() -> int {
 
 //----
 //- diagnostics
+// error: class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     ╭─[ class.baml:39:17 ]
+//     │
+//  39 │     Color { re: 255, gree: 0, blu: 0 },
+//     │                 ─┬─
+//     │                  ╰─── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
+// error: class `Color` has no field `gree`. Did you mean `green`?
+//     ╭─[ class.baml:39:28 ]
+//     │
+//  39 │     Color { re: 255, gree: 0, blu: 0 },
+//     │                            ┬
+//     │                            ╰── class `Color` has no field `gree`. Did you mean `green`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
+// error: class `Color` has no field `blu`. Did you mean `blue`?
+//     ╭─[ class.baml:39:36 ]
+//     │
+//  39 │     Color { re: 255, gree: 0, blu: 0 },
+//     │                                    ┬
+//     │                                    ╰── class `Color` has no field `blu`. Did you mean `blue`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
+// error: class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     ╭─[ class.baml:40:17 ]
+//     │
+//  40 │     Color { re: 0, gree: 255, blu: 0 },
+//     │                 ┬
+//     │                 ╰── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
+// error: class `Color` has no field `gree`. Did you mean `green`?
+//     ╭─[ class.baml:40:26 ]
+//     │
+//  40 │     Color { re: 0, gree: 255, blu: 0 },
+//     │                          ─┬─
+//     │                           ╰─── class `Color` has no field `gree`. Did you mean `green`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
+// error: class `Color` has no field `blu`. Did you mean `blue`?
+//     ╭─[ class.baml:40:36 ]
+//     │
+//  40 │     Color { re: 0, gree: 255, blu: 0 },
+//     │                                    ┬
+//     │                                    ╰── class `Color` has no field `blu`. Did you mean `blue`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
+// error: class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     ╭─[ class.baml:41:17 ]
+//     │
+//  41 │     Color { re: 0, gree: 0, blu: 255 },
+//     │                 ┬
+//     │                 ╰── class `Color` has no field `re`. Did you mean one of these: `red`, `green`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
+// error: class `Color` has no field `gree`. Did you mean `green`?
+//     ╭─[ class.baml:41:26 ]
+//     │
+//  41 │     Color { re: 0, gree: 0, blu: 255 },
+//     │                          ┬
+//     │                          ╰── class `Color` has no field `gree`. Did you mean `green`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
+// error: class `Color` has no field `blu`. Did you mean `blue`?
+//     ╭─[ class.baml:41:34 ]
+//     │
+//  41 │     Color { re: 0, gree: 0, blu: 255 },
+//     │                                  ─┬─
+//     │                                   ╰─── class `Color` has no field `blu`. Did you mean `blue`?
+//     │
+//     │ Note: Error code: E0007
+// ────╯
 // error: type `Color` has no member `get_re`
 //     ╭─[ class.baml:44:29 ]
 //     │

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/constructors_invalid.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/constructors_invalid.baml
@@ -81,11 +81,11 @@ function Foo() -> Bar {
 //    │ Note: Error code: E0001
 // ───╯
 // error: class `Bar` has no field `c`
-//    ╭─[ expr_constructors_invalid.baml:7:32 ]
+//    ╭─[ expr_constructors_invalid.baml:7:29 ]
 //    │
 //  7 │   let x = Bar { a: "hello", c: 12 };
-//    │                                ─┬
-//    │                                 ╰── class `Bar` has no field `c`
+//    │                             ┬
+//    │                             ╰── class `Bar` has no field `c`
 //    │
 //    │ Note: Error code: E0007
 // ───╯

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/constructors_invalid.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/constructors_invalid.baml
@@ -80,6 +80,15 @@ function Foo() -> Bar {
 //    │
 //    │ Note: Error code: E0001
 // ───╯
+// error: class `Bar` has no field `c`
+//    ╭─[ expr_constructors_invalid.baml:7:32 ]
+//    │
+//  7 │   let x = Bar { a: "hello", c: 12 };
+//    │                                ─┬
+//    │                                 ╰── class `Bar` has no field `c`
+//    │
+//    │ Note: Error code: E0007
+// ───╯
 // error: unresolved type: baml.HttpRequest
 //     ╭─[ expr_constructors_invalid.baml:8:17 ]
 //     │

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/parens.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/parens.baml
@@ -569,30 +569,12 @@ function foo() -> int {
 //     │
 //     │ Note: Error code: E0010
 // ────╯
-// error: Expected block after for expression, found for
-//     ╭─[ parens.baml:57:4 ]
+// error: Expected ')', found '{'
+//     ╭─[ parens.baml:57:21 ]
 //     │
 //  57 │    for (let a in as {}
-//     │    ─┬─
-//     │     ╰─── Expected block after for expression, found for
-//     │
-//     │ Note: Error code: E0010
-// ────╯
-// error: Expected ')', found for
-//     ╭─[ parens.baml:59:4 ]
-//     │
-//  59 │    for let a in as) {}
-//     │    ─┬─
-//     │     ╰─── Expected ')', found for
-//     │
-//     │ Note: Error code: E0010
-// ────╯
-// error: Expected block after for expression, found for
-//     ╭─[ parens.baml:59:4 ]
-//     │
-//  59 │    for let a in as) {}
-//     │    ─┬─
-//     │     ╰─── Expected block after for expression, found for
+//     │                     ┬
+//     │                     ╰── Expected ')', found '{'
 //     │
 //     │ Note: Error code: E0010
 // ────╯

--- a/baml_language/crates/baml_tests/baml_src/ns_property_shorthand/property_shorthand.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_property_shorthand/property_shorthand.baml
@@ -13,6 +13,18 @@ class PropertyShorthandEnvelope {
     request PropertyShorthandRequest
 }
 
+class PropertyShorthandLeaf {
+    value string
+}
+
+class PropertyShorthandMiddle {
+    leaf PropertyShorthandLeaf
+}
+
+class PropertyShorthandOuter {
+    middle PropertyShorthandMiddle
+}
+
 function property_shorthand_class(
     mode: string,
     retries: int,
@@ -65,6 +77,25 @@ test "shorthand mixes with explicit properties and nests" {
                 options: { "mode": "fast" },
                 retries: 5,
                 label: "nested",
+            },
+        },
+    ))
+}
+
+function property_shorthand_multi_nested(value: string) -> PropertyShorthandOuter {
+    let leaf = PropertyShorthandLeaf { value };
+    let middle = PropertyShorthandMiddle { leaf };
+    PropertyShorthandOuter { middle }
+}
+
+test "shorthand works across multiple nested classes" {
+    assert.is_true(baml.deep_equals(
+        property_shorthand_multi_nested("deep"),
+        PropertyShorthandOuter {
+            middle: PropertyShorthandMiddle {
+                leaf: PropertyShorthandLeaf {
+                    value: "deep",
+                },
             },
         },
     ))

--- a/baml_language/crates/baml_tests/baml_src/ns_property_shorthand/property_shorthand.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_property_shorthand/property_shorthand.baml
@@ -1,0 +1,71 @@
+// Native runtime coverage for object/map property shorthand.
+//
+// A bare property name is equivalent to `name: name`; explicit properties can
+// be mixed with shorthand in any position.
+
+class PropertyShorthandRequest {
+    options map<string, string>
+    retries int
+    label string
+}
+
+class PropertyShorthandEnvelope {
+    request PropertyShorthandRequest
+}
+
+function property_shorthand_class(
+    mode: string,
+    retries: int,
+    label: string,
+) -> PropertyShorthandRequest {
+    let options = { "mode": mode };
+    PropertyShorthandRequest { options, retries, label }
+}
+
+test "class properties use shorthand" {
+    assert.is_true(baml.deep_equals(
+        property_shorthand_class("safe", 2, "primary"),
+        PropertyShorthandRequest {
+            options: { "mode": "safe" },
+            retries: 2,
+            label: "primary",
+        },
+    ))
+}
+
+function property_shorthand_map(count: int, retries: int) -> map<string, int> {
+    { count, retries }
+}
+
+test "map entries use shorthand" {
+    let result = property_shorthand_map(7, 3);
+    assert.equal(result.get("count"), 7);
+    assert.equal(result.get("retries"), 3)
+}
+
+function property_shorthand_mixed(
+    mode: string,
+    retries: int,
+    label: string,
+) -> PropertyShorthandEnvelope {
+    let options = { "mode": mode };
+    let request = PropertyShorthandRequest {
+        options,
+        retries: retries + 1,
+        label,
+    };
+    PropertyShorthandEnvelope { request }
+}
+
+test "shorthand mixes with explicit properties and nests" {
+    assert.is_true(baml.deep_equals(
+        property_shorthand_mixed("fast", 4, "nested"),
+        PropertyShorthandEnvelope {
+            request: PropertyShorthandRequest {
+                options: { "mode": "fast" },
+                retries: 5,
+                label: "nested",
+            },
+        },
+    ))
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -321,6 +321,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/property_shorthand.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/property_shorthand.snap
@@ -20,6 +20,12 @@ function property_shorthand.$init_test_ns_property_shorthand_property_shorthand(
     load_const null
     call testing.TestCollector.register_test
     pop 1
+    load_var registry
+    load_const "shorthand works across multiple nested classes"
+    make_closure .<lambda($init_test_ns_property_shorthand_property_shorthand, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
     load_const null
     return
 }
@@ -57,5 +63,13 @@ function property_shorthand.property_shorthand_mixed(mode: string, retries: int,
     load_var label
     init_instance user.property_shorthand.PropertyShorthandRequest .options, .retries, .label
     init_instance user.property_shorthand.PropertyShorthandEnvelope .request
+    return
+}
+
+function property_shorthand.property_shorthand_multi_nested(value: string) -> property_shorthand.PropertyShorthandOuter {
+    load_var value
+    init_instance user.property_shorthand.PropertyShorthandLeaf .value
+    init_instance user.property_shorthand.PropertyShorthandMiddle .leaf
+    init_instance user.property_shorthand.PropertyShorthandOuter .middle
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/property_shorthand.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/property_shorthand.snap
@@ -1,0 +1,61 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function property_shorthand.$init_test_ns_property_shorthand_property_shorthand(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "class properties use shorthand"
+    make_closure .<lambda($init_test_ns_property_shorthand_property_shorthand, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "map entries use shorthand"
+    make_closure .<lambda($init_test_ns_property_shorthand_property_shorthand, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_var registry
+    load_const "shorthand mixes with explicit properties and nests"
+    make_closure .<lambda($init_test_ns_property_shorthand_property_shorthand, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test
+    pop 1
+    load_const null
+    return
+}
+
+function property_shorthand.property_shorthand_class(mode: string, retries: int, label: string) -> property_shorthand.PropertyShorthandRequest {
+    load_var mode
+    load_const "mode"
+    load_type string
+    load_type string
+    alloc_map 1
+    load_var2 2 3
+    init_instance user.property_shorthand.PropertyShorthandRequest .options, .retries, .label
+    return
+}
+
+function property_shorthand.property_shorthand_map(count: int, retries: int) -> map<string, int> {
+    load_var2 1 2
+    load_const "count"
+    load_const "retries"
+    load_type string
+    load_type int
+    alloc_map 2
+    return
+}
+
+function property_shorthand.property_shorthand_mixed(mode: string, retries: int, label: string) -> property_shorthand.PropertyShorthandEnvelope {
+    load_var mode
+    load_const "mode"
+    load_type string
+    load_type string
+    alloc_map 1
+    load_var retries
+    load_const 1
+    add_int
+    load_var label
+    init_instance user.property_shorthand.PropertyShorthandRequest .options, .retries, .label
+    init_instance user.property_shorthand.PropertyShorthandEnvelope .request
+    return
+}

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
@@ -475,6 +475,53 @@ function build(option: string) -> Config {
 }
 
 #[test]
+fn explicit_unknown_class_field_is_rejected() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Config { goodField int }
+function build() -> Config {
+  Config { badField: 5 }
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains("class `Config` has no field `badField`"),
+        "expected an unknown-field diagnostic for an explicit property, got:\n{tir}"
+    );
+    assert!(
+        !tir.contains("property shorthand"),
+        "explicit properties should use the general unknown-field diagnostic:\n{tir}"
+    );
+}
+
+#[test]
+fn inferred_object_rejects_explicit_unknown_class_field() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Config { goodField int }
+function build() -> Config {
+  let config = Config { badField: 5 };
+  config
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains("class `Config` has no field `badField`"),
+        "expected inference to diagnose an explicit unknown field, got:\n{tir}"
+    );
+    assert!(
+        !tir.contains("property shorthand"),
+        "explicit properties should use the general unknown-field diagnostic:\n{tir}"
+    );
+}
+
+#[test]
 fn unresolved_function_call_reports_callee_span() {
     let mut db = make_db();
     let file = db.add_file(

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
@@ -424,6 +424,57 @@ fn unresolved_variable_in_let() {
 }
 
 #[test]
+fn property_shorthand_suggests_explicit_mapping_for_nearby_variable() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+function build(option: string) -> map<string, string> {
+  { options }
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains(
+            "property shorthand `options` requires an in-scope value named `options`. Did you \
+             mean `options: option`?"
+        ),
+        "expected a shorthand-specific near-match diagnostic, got:\n{tir}"
+    );
+    assert!(
+        !tir.contains("unresolved name: options"),
+        "shorthand should not fall back to the generic unresolved-name diagnostic:\n{tir}"
+    );
+}
+
+#[test]
+fn class_property_shorthand_suggests_field_to_variable_mapping() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Config { options string }
+function build(option: string) -> Config {
+  Config { option }
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains(
+            "class `Config` has no field `option` for property shorthand. Did you mean \
+             `options: option`?"
+        ),
+        "expected an exact-field-name shorthand diagnostic, got:\n{tir}"
+    );
+    assert!(
+        !tir.contains("unresolved name: option"),
+        "the shorthand value resolves; only the class-field mismatch should be diagnosed:\n{tir}"
+    );
+}
+
+#[test]
 fn unresolved_function_call_reports_callee_span() {
     let mut db = make_db();
     let file = db.add_file(


### PR DESCRIPTION
## Summary

- Allow map and class properties such as `{ options: options }` to be shortened to `{ options }`.
- Preserve shorthand through parsing and formatting while lowering it to the existing key/value representation.
- Add targeted diagnostics when the implicit value is unresolved or a class field only nearly matches, including explicit fixes such as `options: option`.
- Keep control-flow body braces unambiguous and retain parenthesized object literals in condition position.
- Add native BAML runtime tests and bytecode snapshots for map, class, mixed, and nested shorthand.

## Why

Property values commonly repeat their field names. Shorthand removes that duplication without changing runtime representation or explicit-property behavior.

Linear: [B-947](https://linear.app/boundaryml2/issue/B-947/support-shorthand-object-properties-in-baml)

## Validation

- `cargo nextest run -p baml_compiler_parser -p baml_compiler2_ast -p baml_compiler2_tir -p baml_fmt -p baml_lsp2_actions` — 703 passed, 2 skipped.
- `cargo nextest run -p baml_tests property_shorthand` — 2 diagnostic tests passed.
- `INSTA_UPDATE=always cargo nextest run -p baml_tests --test baml_src bytecode` — passed; snapshots reviewed.
- `cargo nextest run -p baml_tests --test baml_src baml_test` — the corpus compiled and 2,445 tests passed; 25 existing HTTP/SSE/server tests failed because sandbox networking is unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parser disambiguation for `{` in loops and conditions plus new TIR paths for class/map construction; behavior is heavily tested but edge cases in ambiguous brace parsing could still surface.
> 
> **Overview**
> Adds **property shorthand** (`{ options }` instead of `{ options: options }`) for map literals and class constructors, end-to-end from parsing through runtime.
> 
> **Parser** accepts bare identifier fields in object/map literals and tightens `{ … }` disambiguation so loop and control-flow bodies are not stolen as constructors—especially in `for … in` headers, with exceptions when postfix continuation (e.g. `Values { items }.items`) or parentheses make an object literal unambiguous.
> 
> **AST lowering** desugars shorthand to the existing key/value shape while recording `property_shorthand_exprs` and `object_field_name_spans` on `AstSourceMap`; retry-policy config objects are marked **synthetic** so normal class-field diagnostics do not apply to legacy keys.
> 
> **TIR** uses those markers for shorthand-specific errors (`UnresolvedPropertyShorthand`, `UnknownClassPropertyShorthand`) and explicit unknown-field errors (`UnknownClassField`), with “did you mean `field: value`?” suggestions via shared `similar_name_suggestions`. Let-body inference now installs the let’s source map for accurate spans.
> 
> **Formatter** preserves shorthand (optional colon/value on `ObjectField`). LSP action mapping and tests cover parsing, diagnostics, formatting, native runtime, and bytecode snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d3b9b35e80cf4eb57fc6cee66ccc706d152b939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native property shorthand support for object/map literals, including nested and mixed constructions.
  * Enhanced shorthand-specific diagnostics with “Did you mean …?” suggestions for unresolved shorthand and class constructor field mismatches.
* **Bug Fixes**
  * Improved parsing lookahead to prevent `{ ... }` from being consumed in control-flow and `for` headers, and refined errors for malformed parenthesized `for` cases.
* **Formatting**
  * Updated formatting to preserve shorthand field syntax exactly and keep it stable across formatting passes.
* **Tests**
  * Added and updated parser, formatter, LSP/diagnostic, and runtime fixtures to cover shorthand behavior and new error mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->