### PR TITLE
feat(runtime): add explicit garbage collection

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
@@ -37,6 +37,13 @@ function sleep(delay: root.time.Duration) -> null throws root.errors.Io {
   $rust_io_function
 }
 
+/// Forces a full garbage collection and runs queued `cleanup()` finalizers before returning.
+/// Intended for deterministic tests and runtime diagnostics; production code should normally
+/// let the runtime schedule collections automatically.
+function collect_garbage() -> null throws never {
+  $rust_io_function
+}
+
 /// Panics with `message`, throwing a `baml.panics.UserPanic`. Never returns.
 //baml:fallible
 function panic(message: string) -> never throws never {

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -275,10 +275,11 @@ class            baml.sys.ShellOutput             <builtin>/baml/ns_sys/sys.baml
 function         baml.sys.exec                    <builtin>/baml/ns_sys/sys.baml:26
 function         baml.sys.shell                   <builtin>/baml/ns_sys/sys.baml:31
 function         baml.sys.sleep                   <builtin>/baml/ns_sys/sys.baml:36
-function         baml.sys.panic                   <builtin>/baml/ns_sys/sys.baml:42
-function         baml.sys.exit                    <builtin>/baml/ns_sys/sys.baml:48
-function         baml.sys.now_ms                  <builtin>/baml/ns_sys/sys.baml:53
-function         baml.sys.argv                    <builtin>/baml/ns_sys/sys.baml:59
+function         baml.sys.collect_garbage         <builtin>/baml/ns_sys/sys.baml:43
+function         baml.sys.panic                   <builtin>/baml/ns_sys/sys.baml:49
+function         baml.sys.exit                    <builtin>/baml/ns_sys/sys.baml:55
+function         baml.sys.now_ms                  <builtin>/baml/ns_sys/sys.baml:60
+function         baml.sys.argv                    <builtin>/baml/ns_sys/sys.baml:66
 class            baml.time.Duration               <builtin>/baml/ns_time/duration.baml:4
 class            baml.time.Instant                <builtin>/baml/ns_time/instant.baml:2
 class            baml.time.PlainDate              <builtin>/baml/ns_time/plaindate.baml:5

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 4640
 ---
 === PPIR ===
 
@@ -1974,6 +1973,7 @@ class baml.sys.ShellOutput$stream {
   exit_code: int | null
 }
 function baml.sys.argv() -> string[]  [builtin]
+function baml.sys.collect_garbage() -> null  [builtin]
 function baml.sys.exec(program: string, args: string[]?, options: baml.sys.ProcessOptions?) -> baml.sys.ShellOutput  [builtin]
 function baml.sys.exit(code: int) -> never  [builtin]
 function baml.sys.now_ms() -> int  [builtin]

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -8460,6 +8460,8 @@ fn baml.sys.shell = builtin(io)
 
 fn baml.sys.sleep = builtin(io)
 
+fn baml.sys.collect_garbage = builtin(io)
+
 fn baml.sys.panic = builtin(vm)
 
 fn baml.sys.exit = builtin(vm)

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -5822,6 +5822,9 @@ function baml.sys.ShellOutput.ok(self: baml.sys.ShellOutput) -> bool {
 function baml.sys.argv() -> string[] {
 }
 
+function baml.sys.collect_garbage() -> null {
+}
+
 function baml.sys.exec(program: string, args: string[] | null, options: baml.sys.ProcessOptions | null) -> baml.sys.ShellOutput {
 }
 

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -296,6 +296,7 @@ namespace baml.sys:
   class ProcessOptions { methods: [] }
   class ShellOutput { methods: [ok] }
   function argv
+  function collect_garbage
   function exec
   function exit
   function now_ms

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 771 ntypeargs=0   (assert.format_operand)
+       26   call 772 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 771 ntypeargs=0   (assert.format_operand)
+       29   call 772 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 771 ntypeargs=0   (assert.format_operand)
+       32   call 772 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 771 ntypeargs=0   (assert.format_operand)
+       35   call 772 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -63,11 +63,11 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        49   bin_op +               
        50   load_var 8             (_22)
        51   bin_op +               
-       52   call 246 ntypeargs=0   (baml.sys.panic)
+       52   call 247 ntypeargs=0   (baml.sys.panic)
        53   jump +3                (to 56)
 
   78   54   load_const 6           ("assertion failed: epsilon must be a non-negative number")
-       55   call 246 ntypeargs=0   (baml.sys.panic)
+       55   call 247 ntypeargs=0   (baml.sys.panic)
        56   return                 
 }
 
@@ -83,13 +83,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   100   6   jump +3                (to 9)
 
   101   7   load_const 1           ("assertion failed: string does not contain expected substring")
-        8   call 246 ntypeargs=0   (baml.sys.panic)
+        8   call 247 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 638 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 639 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 771 ntypeargs=0   (assert.format_operand)
+       8    call 772 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 771 ntypeargs=0   (assert.format_operand)
+       11   call 772 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -113,7 +113,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 246 ntypeargs=0   (baml.sys.panic)
+       20   call 247 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
@@ -134,14 +134,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 246 ntypeargs=0   (baml.sys.panic)
+      7   call 247 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 638 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 639 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -150,7 +150,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 246 ntypeargs=0   (baml.sys.panic)
+       8   call 247 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -176,7 +176,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1413 0   
+  101   0   make_closure 1414 0   
         1   return                
 }
 
@@ -197,11 +197,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 246 ntypeargs=0   (baml.sys.panic)
+       14   call 247 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1408 1    
+       17   make_closure 1409 1    
        18   return                 
 }
 
@@ -231,16 +231,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 246 ntypeargs=0   (baml.sys.panic)
+       22   call 247 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 246 ntypeargs=0   (baml.sys.panic)
+       26   call 247 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1392 2    
+       29   make_closure 1393 2    
        30   return                 
 }
 
@@ -255,16 +255,16 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 246 ntypeargs=0   (baml.sys.panic)
+       8    call 247 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1402 1    
+       11   make_closure 1403 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1411 0   
+  95   0   make_closure 1412 0   
        1   return                
 }
 
@@ -562,11 +562,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   198   22   load_var2 1 5                      
-        23   call 737 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 738 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   199   25   load_var 1                         (self)
-        26   call 729 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 730 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   203   28   load_type 5                        
@@ -603,7 +603,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   206   58   load_var2 9 2                      
-        59   call 736 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 737 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   209   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -626,7 +626,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +36               (to 47)
 
-  216   12   call 248 ntypeargs=0   (baml.sys.now_ms)
+  216   12   call 249 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 4            (start)
 
   217   14   load_var 2             (ts)
@@ -643,7 +643,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         24   call_indirect          
         25   pop 1                  
 
-  219   26   call 248 ntypeargs=0   (baml.sys.now_ms)
+  219   26   call 249 ntypeargs=0   (baml.sys.now_ms)
         27   store_var 6            (_19)
 
   221   28   load_var 5             (sub_collector)
@@ -677,7 +677,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 756 ntypeargs=0   (testing.select_names)
+        2   call 757 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -694,9 +694,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 738 ntypeargs=0   (testing.testset_children)
+        1   call 739 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 748 ntypeargs=0   (testing.run_testset)
+        3   call 749 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -720,24 +720,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   16   load_var2 1 2          
         17   load_var 3             (exclude)
-        18   call 756 ntypeargs=0   (testing.select_names)
+        18   call 757 ntypeargs=0   (testing.select_names)
         19   store_var 6            (_9)
         20   load_var2 1 6          
-        21   call 733 ntypeargs=0   (testing.TestRegistry.run_selected)
+        21   call 734 ntypeargs=0   (testing.TestRegistry.run_selected)
         22   jump +3                (to 25)
 
   180   23   load_var 1             (self)
-        24   call 732 ntypeargs=0   (testing.TestRegistry.run_all)
+        24   call 733 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   25   call 760 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   25   call 761 ntypeargs=0   (testing.flatten_with_tolerated)
         26   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 739 ntypeargs=0   (testing.testset_children_selected)
+        1   call 740 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 748 ntypeargs=0   (testing.run_testset)
+        3   call 749 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -770,7 +770,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 747 ntypeargs=0               (testing.run_test)
+        26   call 748 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   140   28   load_type 5                        
@@ -807,7 +807,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   144   58   load_var2 9 2                      
-        59   call 730 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 731 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   147   61   load_const 12                      ("Test not found: ")
@@ -842,11 +842,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   153   22   load_var2 1 5                      
-        23   call 737 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 738 ntypeargs=0               (testing.testset_children)
+        23   call 738 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 739 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 748 ntypeargs=0               (testing.run_testset)
+        27   call 749 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   156   29   load_type 5                        
@@ -883,7 +883,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   159   59   load_var2 9 2                      
-        60   call 731 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 732 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   162   62   load_const 12                      ("TestSet not found: ")
@@ -974,7 +974,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         69   store_var 10                       (_27)
 
   119   70   load_var 9                         (sub)
-        71   call 729 ntypeargs=0               (testing.TestRegistry.serialize)
+        71   call 730 ntypeargs=0               (testing.TestRegistry.serialize)
         72   store_var 11                       (_28)
 
   117   73   load_var2 2 10                     
@@ -1030,7 +1030,7 @@ function testing._int_to_float(value: int) -> float {
         6   throw_if_panic         
 
   126   7   load_const 1           ("failed to convert int to float")
-        8   call 246 ntypeargs=0   (baml.sys.panic)
+        8   call 247 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
@@ -1119,7 +1119,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   334   47    load_var 11                        (outcome)
         48    load_const 10                      ("pass")
-        49    call 638 ntypeargs=0               (baml.ops.equals_equals)
+        49    call 639 ntypeargs=0               (baml.ops.equals_equals)
         50    pop_jump_if_false +2               (to 52)
         51    jump +57                           (to 108)
 
@@ -1185,7 +1185,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   349   101   load_var 11                        (outcome)
         102   load_const 16                      ("error")
-        103   call 638 ntypeargs=0               (baml.ops.equals_equals)
+        103   call 639 ntypeargs=0               (baml.ops.equals_equals)
         104   pop_jump_if_false -87              (to 17)
 
   350   105   load_const 17                      (true)
@@ -1255,13 +1255,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   16   load_field 0                       (func_pat)
         17   load_var 2                         (function_name)
-        18   call 753 ntypeargs=0               (testing.filter_match)
+        18   call 754 ntypeargs=0               (testing.filter_match)
         19   jump_if_false +6                   (to 25)
         20   pop 1                              
         21   load_var 6                         (p)
         22   load_field 1                       (test_pat)
         23   load_var 3                         (test_name)
-        24   call 753 ntypeargs=0               (testing.filter_match)
+        24   call 754 ntypeargs=0               (testing.filter_match)
         25   pop_jump_if_false -20              (to 5)
 
   527   26   load_const 5                       (true)
@@ -1298,7 +1298,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         22   load_var 5                         (r)
         23   load_field 5                       (results)
         24   load_var 2                         (out)
-        25   call 761 ntypeargs=0               (testing.collect_leaf_messages)
+        25   call 762 ntypeargs=0               (testing.collect_leaf_messages)
         26   pop 1                              
         27   jump -22                           (to 5)
         28   load_var 6                         (_8)
@@ -1322,7 +1322,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   665   45   load_field 0                       (outcome)
         46   load_const 10                      ("pass")
-        47   call 638 ntypeargs=0               (baml.ops.equals_equals)
+        47   call 639 ntypeargs=0               (baml.ops.equals_equals)
         48   unary_op !                         
         49   pop_jump_if_false -15              (to 34)
 
@@ -1391,7 +1391,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   567   40   load_var2 1 6                      
 
-  566   41   call 758 ntypeargs=0               (testing.collect_subtree_names)
+  566   41   call 759 ntypeargs=0               (testing.collect_subtree_names)
 
   567   42   load_type 10                       
         43   load_const 11                      ("iter")
@@ -1419,8 +1419,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 737 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 757 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 738 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 758 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +20               (to 23)
         4    load_var 3             (e)
         5    type_tag               
@@ -1494,7 +1494,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 12                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 638 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 639 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 13                       (ft)
 
   615   42    load_var 12                        (tsr)
@@ -1538,14 +1538,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   74    load_var 12                        (tsr)
         75    load_field 5                       (results)
         76    load_var 13                        (ft)
-        77    call 759 ntypeargs=0               (testing.count_leaves)
+        77    call 760 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +30                           (to 109)
 
   603   80    load_var 11                        (_13)
         81    load_field 0                       (outcome)
         82    load_const 8                       ("pass")
-        83    call 638 ntypeargs=0               (baml.ops.equals_equals)
+        83    call 639 ntypeargs=0               (baml.ops.equals_equals)
 
   605   84    pop_jump_if_false +2               (to 86)
         85    jump +18                           (to 103)
@@ -1633,7 +1633,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 752 ntypeargs=0   (testing.glob_match)
+        6   call 753 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -1644,7 +1644,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   637   0    load_var 1             (report)
         1    load_field 0           (outcome)
         2    load_const 0           ("pass")
-        3    call 638 ntypeargs=0   (baml.ops.equals_equals)
+        3    call 639 ntypeargs=0   (baml.ops.equals_equals)
         4    store_var 2            (top_tolerated)
 
   638   5    load_var 1             (report)
@@ -1688,7 +1688,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   37   load_var 1             (report)
         38   load_field 5           (results)
         39   load_var 2             (top_tolerated)
-        40   call 759 ntypeargs=0   (testing.count_leaves)
+        40   call 760 ntypeargs=0   (testing.count_leaves)
         41   store_var 3            (counts)
 
   645   42   load_type 2            
@@ -1698,7 +1698,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   45   load_var 1             (report)
         46   load_field 5           (results)
         47   load_var 5             (messages)
-        48   call 761 ntypeargs=0   (testing.collect_leaf_messages)
+        48   call 762 ntypeargs=0   (testing.collect_leaf_messages)
         49   pop 1                  
 
   648   50   load_var 1             (report)
@@ -1852,14 +1852,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 750 ntypeargs=0   (testing.split_top)
+        1    call 751 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 754 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 755 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +17               (to 26)
 
@@ -1876,7 +1876,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         19   load_field 0           (head)
         20   load_var 4             (split)
         21   load_field 1           (tail)
-        22   call 754 ntypeargs=0   (testing.any_pattern_matches)
+        22   call 755 ntypeargs=0   (testing.any_pattern_matches)
         23   jump +4                (to 27)
 
   541   24   load_const 1           (true)
@@ -1989,7 +1989,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   370   25   load_var 5                         (child)
-        26   make_closure 1326 1                
+        26   make_closure 1327 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   spawn                              
@@ -2002,16 +2002,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   374   35   load_type 7                        
         36   load_type 8                        
         37   load_var 2                         (futures)
-        38   call 508 ntypeargs=2               (baml.future.all_complete)
+        38   call 509 ntypeargs=2               (baml.future.all_complete)
         39   await                              
         40   jump +5                            (to 45)
         41   load_var 7                         (e)
         42   throw_if_panic                     
 
   375   43   load_const 9                       ("unexpected test child failure")
-        44   call 246 ntypeargs=0               (baml.sys.panic)
+        44   call 247 ntypeargs=0               (baml.sys.panic)
 
-  377   45   call 745 ntypeargs=0               (testing.aggregate_reports)
+  377   45   call 746 ntypeargs=0               (testing.aggregate_reports)
         46   return                             
 }
 
@@ -2067,16 +2067,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         43   pop 1                              
         44   load_var 8                         (outcome)
         45   load_const 7                       ("pass")
-        46   call 638 ntypeargs=0               (baml.ops.equals_equals)
+        46   call 639 ntypeargs=0               (baml.ops.equals_equals)
         47   unary_op !                         
         48   pop_jump_if_false -40              (to 8)
 
   116   49   load_var 3                         (named_results)
-        50   call 745 ntypeargs=0               (testing.aggregate_reports)
+        50   call 746 ntypeargs=0               (testing.aggregate_reports)
         51   jump +3                            (to 54)
 
   121   52   load_var 3                         (named_results)
-        53   call 745 ntypeargs=0               (testing.aggregate_reports)
+        53   call 746 ntypeargs=0               (testing.aggregate_reports)
         54   return                             
 }
 
@@ -2086,7 +2086,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1336 1    
+        4    make_closure 1337 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -2118,17 +2118,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   418   8    load_var 1             (children)
-        9    call 746 ntypeargs=0   (testing.run_children_parallel)
+        9    call 747 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0    load_var 2                         (include)
-        1    call 751 ntypeargs=0               (testing.parse_filter_patterns)
+        1    call 752 ntypeargs=0               (testing.parse_filter_patterns)
         2    store_var 4                        (inc)
 
   550   3    load_var 3                         (exclude)
-        4    call 751 ntypeargs=0               (testing.parse_filter_patterns)
+        4    call 752 ntypeargs=0               (testing.parse_filter_patterns)
         5    store_var 5                        (exc)
 
   551   6    load_type 0                        
@@ -2136,7 +2136,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8    store_var 6                        (out)
 
   552   9    load_var 1                         (registry)
-        10   call 757 ntypeargs=0               (testing.collect_leaf_names)
+        10   call 758 ntypeargs=0               (testing.collect_leaf_names)
         11   load_type 1                        
         12   load_const 2                       ("iter")
         13   virtual_call nargs=1 ntypeargs=0   
@@ -2154,7 +2154,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         25   store_var_load_var 9               (name)
 
   553   26   load_var2 4 5                      
-        27   call 755 ntypeargs=0               (testing.leaf_selected)
+        27   call 756 ntypeargs=0               (testing.leaf_selected)
         28   pop_jump_if_false -13              (to 15)
 
   554   29   load_var2 6 9                      
@@ -2211,7 +2211,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1303 2   
+        8    make_closure 1304 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -2228,7 +2228,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1305 2   
+        9    make_closure 1306 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -2249,7 +2249,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1307 3   
+        13   make_closure 1308 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -2283,7 +2283,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 740 ntypeargs=0               (testing.test_child)
+        26   call 741 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_var2 2 6                      
         29   call 4 ntypeargs=0                 (baml.Array.push)
@@ -2309,7 +2309,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   238   48   load_var2 1 8                      
 
-  237   49   call 741 ntypeargs=0               (testing.testset_child)
+  237   49   call 742 ntypeargs=0               (testing.testset_child)
         50   store_var 9                        (_21)
 
   238   51   load_var2 2 9                      
@@ -2347,7 +2347,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 743 ntypeargs=0               (testing._name_selected)
+        23   call 744 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   247   25   load_var 6                         (t)
@@ -2356,7 +2356,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 740 ntypeargs=0               (testing.test_child)
+        31   call 741 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_var2 3 7                      
         34   call 4 ntypeargs=0                 (baml.Array.push)
@@ -2384,12 +2384,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 744 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 745 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   259   59   load_var2 1 10                     
         60   load_var 2                         (names)
-        61   call 742 ntypeargs=0               (testing.testset_child_selected)
+        61   call 743 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 11                       (_26)
         63   load_var2 3 11                     
         64   call 4 ntypeargs=0                 (baml.Array.push)
@@ -2409,7 +2409,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 776 ntypeargs=0   (user.score)
+       7    call 777 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -33,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 771 ntypeargs=0   (assert.format_operand)
+       26   call 772 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 771 ntypeargs=0   (assert.format_operand)
+       29   call 772 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 771 ntypeargs=0   (assert.format_operand)
+       32   call 772 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 771 ntypeargs=0   (assert.format_operand)
+       35   call 772 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -63,11 +63,11 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        49   bin_op +               
        50   load_var 8             (_22)
        51   bin_op +               
-       52   call 246 ntypeargs=0   (baml.sys.panic)
+       52   call 247 ntypeargs=0   (baml.sys.panic)
        53   jump +3                (to 56)
 
   78   54   load_const 6           ("assertion failed: epsilon must be a non-negative number")
-       55   call 246 ntypeargs=0   (baml.sys.panic)
+       55   call 247 ntypeargs=0   (baml.sys.panic)
        56   return                 
 }
 
@@ -83,13 +83,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   100   6   jump +3                (to 9)
 
   101   7   load_const 1           ("assertion failed: string does not contain expected substring")
-        8   call 246 ntypeargs=0   (baml.sys.panic)
+        8   call 247 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 638 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 639 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -99,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 771 ntypeargs=0   (assert.format_operand)
+       8    call 772 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 771 ntypeargs=0   (assert.format_operand)
+       11   call 772 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -113,7 +113,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 246 ntypeargs=0   (baml.sys.panic)
+       20   call 247 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
@@ -134,14 +134,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 246 ntypeargs=0   (baml.sys.panic)
+      7   call 247 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 638 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 639 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -150,7 +150,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 246 ntypeargs=0   (baml.sys.panic)
+       8   call 247 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -176,7 +176,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  101   0   make_closure 1413 0   
+  101   0   make_closure 1414 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -199,11 +199,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 246 ntypeargs=0   (baml.sys.panic)
+       14   call 247 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1408 1    
+       17   make_closure 1409 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -235,16 +235,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 246 ntypeargs=0   (baml.sys.panic)
+       22   call 247 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 246 ntypeargs=0   (baml.sys.panic)
+       26   call 247 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1392 2    
+       29   make_closure 1393 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -261,18 +261,18 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 246 ntypeargs=0   (baml.sys.panic)
+       8    call 247 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1402 1    
+       11   make_closure 1403 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  95   0   make_closure 1411 0   
+  95   0   make_closure 1412 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -582,11 +582,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   198   22   load_var2 1 5                      
-        23   call 737 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 738 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   199   25   load_var 1                         (self)
-        26   call 729 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 730 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   203   28   load_type 5                        
@@ -623,7 +623,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   206   58   load_var2 9 2                      
-        59   call 736 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 737 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   209   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -646,7 +646,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +37               (to 48)
 
-  216   12   call 248 ntypeargs=0   (baml.sys.now_ms)
+  216   12   call 249 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 5            (start)
 
   217   14   load_var 2             (ts)
@@ -663,7 +663,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         24   call_indirect          
         25   pop 1                  
 
-  219   26   call 248 ntypeargs=0   (baml.sys.now_ms)
+  219   26   call 249 ntypeargs=0   (baml.sys.now_ms)
         27   load_var 5             (start)
         28   sub_int                
         29   store_var 7            (elapsed)
@@ -701,7 +701,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
 function testing.TestRegistry.list_filtered(self: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   189   0   load_var2 1 2          
         1   load_var 3             (exclude)
-        2   call 756 ntypeargs=0   (testing.select_names)
+        2   call 757 ntypeargs=0   (testing.select_names)
         3   return                 
 }
 
@@ -720,9 +720,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   166   0   load_var 1             (self)
-        1   call 738 ntypeargs=0   (testing.testset_children)
+        1   call 739 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 748 ntypeargs=0   (testing.run_testset)
+        3   call 749 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -746,24 +746,24 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, include: 
 
   182   16   load_var2 1 2          
         17   load_var 3             (exclude)
-        18   call 756 ntypeargs=0   (testing.select_names)
+        18   call 757 ntypeargs=0   (testing.select_names)
         19   store_var 6            (_9)
         20   load_var2 1 6          
-        21   call 733 ntypeargs=0   (testing.TestRegistry.run_selected)
+        21   call 734 ntypeargs=0   (testing.TestRegistry.run_selected)
         22   jump +3                (to 25)
 
   180   23   load_var 1             (self)
-        24   call 732 ntypeargs=0   (testing.TestRegistry.run_all)
+        24   call 733 ntypeargs=0   (testing.TestRegistry.run_all)
 
-  184   25   call 760 ntypeargs=0   (testing.flatten_with_tolerated)
+  184   25   call 761 ntypeargs=0   (testing.flatten_with_tolerated)
         26   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   170   0   load_var2 1 2          
-        1   call 739 ntypeargs=0   (testing.testset_children_selected)
+        1   call 740 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 748 ntypeargs=0   (testing.run_testset)
+        3   call 749 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -796,7 +796,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 747 ntypeargs=0               (testing.run_test)
+        26   call 748 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   140   28   load_type 5                        
@@ -833,7 +833,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   144   58   load_var2 9 2                      
-        59   call 730 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 731 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   147   61   load_const 12                      ("Test not found: ")
@@ -868,11 +868,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   153   22   load_var2 1 5                      
-        23   call 737 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 738 ntypeargs=0               (testing.testset_children)
+        23   call 738 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 739 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 748 ntypeargs=0               (testing.run_testset)
+        27   call 749 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   156   29   load_type 5                        
@@ -909,7 +909,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   159   59   load_var2 9 2                      
-        60   call 731 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 732 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   162   62   load_const 12                      ("TestSet not found: ")
@@ -1001,7 +1001,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 12                       (_27)
 
   119   72   load_var 11                        (sub)
-        73   call 729 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 730 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 13                       (_28)
 
   117   75   load_var2 3 12                     
@@ -1063,7 +1063,7 @@ function testing._int_to_float(value: int) -> float {
         6   throw_if_panic         
 
   126   7   load_const 1           ("failed to convert int to float")
-        8   call 246 ntypeargs=0   (baml.sys.panic)
+        8   call 247 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
@@ -1162,7 +1162,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   334   51    load_var 12                        (outcome)
         52    load_const 10                      ("pass")
-        53    call 638 ntypeargs=0               (baml.ops.equals_equals)
+        53    call 639 ntypeargs=0               (baml.ops.equals_equals)
         54    pop_jump_if_false +2               (to 56)
         55    jump +59                           (to 114)
 
@@ -1229,7 +1229,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   349   107   load_var 12                        (outcome)
         108   load_const 16                      ("error")
-        109   call 638 ntypeargs=0               (baml.ops.equals_equals)
+        109   call 639 ntypeargs=0               (baml.ops.equals_equals)
         110   pop_jump_if_false -93              (to 17)
 
   350   111   load_const 17                      (true)
@@ -1301,13 +1301,13 @@ function testing.any_pattern_matches(pats: testing.FilterPat[], function_name: s
 
   526   16   load_field 0                       (func_pat)
         17   load_var 2                         (function_name)
-        18   call 753 ntypeargs=0               (testing.filter_match)
+        18   call 754 ntypeargs=0               (testing.filter_match)
         19   jump_if_false +6                   (to 25)
         20   pop 1                              
         21   load_var 6                         (p)
         22   load_field 1                       (test_pat)
         23   load_var 3                         (test_name)
-        24   call 753 ntypeargs=0               (testing.filter_match)
+        24   call 754 ntypeargs=0               (testing.filter_match)
         25   pop_jump_if_false -20              (to 5)
 
   527   26   load_const 5                       (true)
@@ -1346,7 +1346,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   673   24   load_field 5                       (results)
         25   load_var 2                         (out)
-        26   call 761 ntypeargs=0               (testing.collect_leaf_messages)
+        26   call 762 ntypeargs=0               (testing.collect_leaf_messages)
         27   pop 1                              
         28   jump -23                           (to 5)
 
@@ -1372,7 +1372,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   665   47   load_field 0                       (outcome)
         48   load_const 10                      ("pass")
-        49   call 638 ntypeargs=0               (baml.ops.equals_equals)
+        49   call 639 ntypeargs=0               (baml.ops.equals_equals)
         50   unary_op !                         
         51   pop_jump_if_false -15              (to 36)
 
@@ -1446,7 +1446,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         43   store_var 9                        (ts)
 
   567   44   load_var2 1 9                      
-        45   call 758 ntypeargs=0               (testing.collect_subtree_names)
+        45   call 759 ntypeargs=0               (testing.collect_subtree_names)
         46   load_type 10                       
         47   load_const 11                      ("iter")
         48   virtual_call nargs=1 ntypeargs=0   
@@ -1476,8 +1476,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   580   0    load_var2 1 2          
-        1    call 737 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 757 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 738 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 758 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +20               (to 23)
         4    load_var 3             (e)
         5    type_tag               
@@ -1551,7 +1551,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 13                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 638 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 639 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 14                       (ft)
 
   615   42    load_var 13                        (tsr)
@@ -1595,7 +1595,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   616   74    load_var 13                        (tsr)
         75    load_field 5                       (results)
         76    load_var 14                        (ft)
-        77    call 759 ntypeargs=0               (testing.count_leaves)
+        77    call 760 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +31                           (to 110)
 
@@ -1604,7 +1604,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   605   82    load_field 0                       (outcome)
         83    load_const 8                       ("pass")
-        84    call 638 ntypeargs=0               (baml.ops.equals_equals)
+        84    call 639 ntypeargs=0               (baml.ops.equals_equals)
         85    pop_jump_if_false +2               (to 87)
         86    jump +18                           (to 104)
 
@@ -1693,7 +1693,7 @@ function testing.filter_match(expr: string, subject: string) -> bool {
         4   jump +4                (to 8)
 
   520   5   load_var2 2 1          
-        6   call 752 ntypeargs=0   (testing.glob_match)
+        6   call 753 ntypeargs=0   (testing.glob_match)
         7   jump +2                (to 9)
 
   518   8   load_const 1           (true)
@@ -1704,7 +1704,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   637   0    load_var 1             (report)
         1    load_field 0           (outcome)
         2    load_const 0           ("pass")
-        3    call 638 ntypeargs=0   (baml.ops.equals_equals)
+        3    call 639 ntypeargs=0   (baml.ops.equals_equals)
         4    store_var 2            (top_tolerated)
 
   638   5    load_var 1             (report)
@@ -1748,7 +1748,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   639   37   load_var 1             (report)
         38   load_field 5           (results)
         39   load_var 2             (top_tolerated)
-        40   call 759 ntypeargs=0   (testing.count_leaves)
+        40   call 760 ntypeargs=0   (testing.count_leaves)
         41   store_var 3            (counts)
 
   645   42   load_type 2            
@@ -1758,7 +1758,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport) -> testin
   646   45   load_var 1             (report)
         46   load_field 5           (results)
         47   load_var 5             (messages)
-        48   call 761 ntypeargs=0   (testing.collect_leaf_messages)
+        48   call 762 ntypeargs=0   (testing.collect_leaf_messages)
         49   pop 1                  
 
   648   50   load_var 1             (report)
@@ -1913,14 +1913,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: testing.FilterPat[], exclude: testing.FilterPat[]) -> bool {
   536   0    load_var 1             (name)
-        1    call 750 ntypeargs=0   (testing.split_top)
+        1    call 751 ntypeargs=0   (testing.split_top)
         2    store_var 4            (split)
 
   537   3    load_var2 3 4          
         4    load_field 0           (head)
         5    load_var 4             (split)
         6    load_field 1           (tail)
-        7    call 754 ntypeargs=0   (testing.any_pattern_matches)
+        7    call 755 ntypeargs=0   (testing.any_pattern_matches)
         8    pop_jump_if_false +2   (to 10)
         9    jump +17               (to 26)
 
@@ -1937,7 +1937,7 @@ function testing.leaf_selected(name: string, include: testing.FilterPat[], exclu
         19   load_field 0           (head)
         20   load_var 4             (split)
         21   load_field 1           (tail)
-        22   call 754 ntypeargs=0   (testing.any_pattern_matches)
+        22   call 755 ntypeargs=0   (testing.any_pattern_matches)
         23   jump +4                (to 27)
 
   541   24   load_const 1           (true)
@@ -2052,7 +2052,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   370   25   load_var 5                         (child)
-        26   make_closure 1326 1                
+        26   make_closure 1327 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   spawn                              
@@ -2065,16 +2065,16 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   374   35   load_type 7                        
         36   load_type 8                        
         37   load_var 2                         (futures)
-        38   call 508 ntypeargs=2               (baml.future.all_complete)
+        38   call 509 ntypeargs=2               (baml.future.all_complete)
         39   await                              
         40   jump +5                            (to 45)
         41   load_var 7                         (e)
         42   throw_if_panic                     
 
   375   43   load_const 9                       ("unexpected test child failure")
-        44   call 246 ntypeargs=0               (baml.sys.panic)
+        44   call 247 ntypeargs=0               (baml.sys.panic)
 
-  377   45   call 745 ntypeargs=0               (testing.aggregate_reports)
+  377   45   call 746 ntypeargs=0               (testing.aggregate_reports)
         46   return                             
 }
 
@@ -2137,16 +2137,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         47   pop 1                              
         48   load_var 8                         (outcome)
         49   load_const 7                       ("pass")
-        50   call 638 ntypeargs=0               (baml.ops.equals_equals)
+        50   call 639 ntypeargs=0               (baml.ops.equals_equals)
         51   unary_op !                         
         52   pop_jump_if_false -44              (to 8)
 
   116   53   load_var 3                         (named_results)
-        54   call 745 ntypeargs=0               (testing.aggregate_reports)
+        54   call 746 ntypeargs=0               (testing.aggregate_reports)
         55   jump +3                            (to 58)
 
   121   56   load_var 3                         (named_results)
-        57   call 745 ntypeargs=0               (testing.aggregate_reports)
+        57   call 746 ntypeargs=0               (testing.aggregate_reports)
         58   return                             
 }
 
@@ -2156,7 +2156,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   382   3    load_var 1             (body)
-        4    make_closure 1336 1    
+        4    make_closure 1337 1    
         5    store_var 3            (base_run)
 
   406   6    load_var 2             (runner)
@@ -2192,17 +2192,17 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   418   10   load_var 1             (children)
-        11   call 746 ntypeargs=0   (testing.run_children_parallel)
+        11   call 747 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
 function testing.select_names(registry: testing.TestRegistry, include: string[], exclude: string[]) -> string[] {
   549   0    load_var 2                         (include)
-        1    call 751 ntypeargs=0               (testing.parse_filter_patterns)
+        1    call 752 ntypeargs=0               (testing.parse_filter_patterns)
         2    store_var 5                        (inc)
 
   550   3    load_var 3                         (exclude)
-        4    call 751 ntypeargs=0               (testing.parse_filter_patterns)
+        4    call 752 ntypeargs=0               (testing.parse_filter_patterns)
         5    store_var 6                        (exc)
 
   551   6    load_type 0                        
@@ -2210,7 +2210,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         8    store_var 7                        (out)
 
   552   9    load_var 1                         (registry)
-        10   call 757 ntypeargs=0               (testing.collect_leaf_names)
+        10   call 758 ntypeargs=0               (testing.collect_leaf_names)
         11   load_type 1                        
         12   load_const 2                       ("iter")
         13   virtual_call nargs=1 ntypeargs=0   
@@ -2228,7 +2228,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         25   store_var_load_var 10              (name)
 
   553   26   load_var2 5 6                      
-        27   call 755 ntypeargs=0               (testing.leaf_selected)
+        27   call 756 ntypeargs=0               (testing.leaf_selected)
         28   pop_jump_if_false -13              (to 15)
 
   554   29   load_var2 7 10                     
@@ -2287,7 +2287,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   268   6    load_var2 1 2         
 
   270   7    load_var 3            (runner)
-        8    make_closure 1303 2   
+        8    make_closure 1304 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -2306,7 +2306,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   277   8    load_var2 1 2         
-        9    make_closure 1305 2   
+        9    make_closure 1306 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -2329,7 +2329,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   289   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1307 3   
+        13   make_closure 1308 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -2365,7 +2365,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 740 ntypeargs=0               (testing.test_child)
+        26   call 741 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_var2 3 7                      
         29   call 4 ntypeargs=0                 (baml.Array.push)
@@ -2392,7 +2392,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         49   store_var 10                       (ts)
 
   238   50   load_var2 1 10                     
-        51   call 741 ntypeargs=0               (testing.testset_child)
+        51   call 742 ntypeargs=0               (testing.testset_child)
         52   store_var 11                       (_21)
         53   load_var2 3 11                     
         54   call 4 ntypeargs=0                 (baml.Array.push)
@@ -2431,7 +2431,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   246   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 743 ntypeargs=0               (testing._name_selected)
+        23   call 744 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   247   25   load_var 7                         (t)
@@ -2440,7 +2440,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 740 ntypeargs=0               (testing.test_child)
+        31   call 741 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_var2 4 8                      
         34   call 4 ntypeargs=0                 (baml.Array.push)
@@ -2468,12 +2468,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   258   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 744 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 745 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   259   59   load_var2 1 11                     
         60   load_var 2                         (names)
-        61   call 742 ntypeargs=0               (testing.testset_child_selected)
+        61   call 743 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 12                       (_26)
         63   load_var2 4 12                     
         64   call 4 ntypeargs=0                 (baml.Array.push)
@@ -2495,7 +2495,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 776 ntypeargs=0   (user.score)
+       7    call 777 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/crates/baml_tests/tests/cleanup.rs
+++ b/baml_language/crates/baml_tests/tests/cleanup.rs
@@ -7,6 +7,52 @@
 //! `should_panic`, which is not expressible in BAML test blocks.
 
 use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+#[track_caller]
+fn expect_strings(v: BexExternalValue) -> Vec<String> {
+    match v {
+        BexExternalValue::Array { items, .. } => items
+            .into_iter()
+            .map(|it| match it {
+                BexExternalValue::String(s) => s.to_string(),
+                other => panic!("expected String element, got {other:?}"),
+            })
+            .collect(),
+        other => panic!("expected Array, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn baml_collect_garbage_runs_unreachable_cleanup_before_returning() {
+    // BAML tests sometimes need to observe a finalizer deterministically. The
+    // builtin performs a major collection and drains the finalizer queue before
+    // returning, so the shared log is already updated at the next statement.
+    let output = baml_test!(
+        r#"
+class Resource {
+  log string[]
+  function cleanup(self) -> void throws never {
+    self.log.push("cleaned")
+  }
+}
+function abandon(log: string[]) -> void throws never {
+  let resource = Resource { log: log }
+  resource.log.push("created")
+}
+function main() -> string[] {
+  let log: string[] = []
+  abandon(log)
+  baml.sys.collect_garbage()
+  log
+}
+"#
+    );
+    assert_eq!(
+        expect_strings(output.result.unwrap()),
+        vec!["created", "cleaned"]
+    );
+}
 
 // ── Reserved-name shape enforcement (E0144) ───────────────────────────────
 

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -5214,6 +5214,21 @@ impl BexEngine {
         cancel: &CancellationToken,
         permit: bex_heap::PermitProof<'_>,
     ) -> SysOpResult {
+        if op == SysOp::BamlSysCollectGarbage {
+            // A collection cannot run while this VM holds its active heap
+            // permit. Returning an async operation makes the event loop release
+            // that permit before polling us; the engine can then park every VM,
+            // collect, drain `cleanup()` finalizers, and only afterward resume
+            // the caller.
+            let engine = self.clone();
+            return SysOpResult::Async(Box::pin(async move {
+                engine
+                    .collect_garbage(bex_heap::CollectionLevel::Major)
+                    .await;
+                Ok(BexExternalValue::Null)
+            }));
+        }
+
         fn check(op: SysOp, err: &OpError) {
             if let sys_types::OpErrorPayload::Vm(kind) = &err.payload {
                 if let Err(violation) = sys_types::validate_sys_op_error(op, kind) {

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -5214,6 +5214,14 @@ impl BexEngine {
         cancel: &CancellationToken,
         permit: bex_heap::PermitProof<'_>,
     ) -> SysOpResult {
+        fn check(op: SysOp, err: &OpError) {
+            if let sys_types::OpErrorPayload::Vm(kind) = &err.payload {
+                if let Err(violation) = sys_types::validate_sys_op_error(op, kind) {
+                    tracing::warn!("{violation}");
+                }
+            }
+        }
+
         if op == SysOp::BamlSysCollectGarbage {
             // A collection cannot run while this VM holds its active heap
             // permit. Returning an async operation makes the event loop release
@@ -5227,14 +5235,6 @@ impl BexEngine {
                     .await;
                 Ok(BexExternalValue::Null)
             }));
-        }
-
-        fn check(op: SysOp, err: &OpError) {
-            if let sys_types::OpErrorPayload::Vm(kind) = &err.payload {
-                if let Err(violation) = sys_types::validate_sys_op_error(op, kind) {
-                    tracing::warn!("{violation}");
-                }
-            }
         }
         let args = args.iter().map(std::convert::Into::into).collect();
         let fn_ptr = self.sys_ops.get(op);

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -118,6 +118,31 @@ use sys_types::{OpError, SysOpResult};
 use thiserror::Error;
 pub use tokio_util::sync::CancellationToken;
 
+/// Sets the VM park request flag for the lifetime of a pending GC park request.
+///
+/// In particular, dropping the future returned by [`BexEngine::collect_garbage`]
+/// while it is waiting for active heap permits must not leave every VM believing
+/// that a park is still requested.
+#[cfg(not(target_arch = "wasm32"))]
+struct ParkRequestGuard {
+    park_requested: Arc<AtomicBool>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl ParkRequestGuard {
+    fn new(park_requested: Arc<AtomicBool>) -> Self {
+        park_requested.store(true, Ordering::Relaxed);
+        Self { park_requested }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for ParkRequestGuard {
+    fn drop(&mut self) {
+        self.park_requested.store(false, Ordering::Relaxed);
+    }
+}
+
 use crate::value_capture::{CaptureKind, TraceCaptureProducer, TraceLogMetadata};
 pub use crate::{
     future::{FutureManager, FutureManagerGuard, FutureManagerInner},
@@ -1937,10 +1962,10 @@ impl BexEngine {
         level: bex_heap::CollectionLevel,
     ) -> bex_heap::GcStats {
         #[cfg(not(target_arch = "wasm32"))]
-        self.park_requested.store(true, Ordering::Relaxed);
+        let park_request_guard = ParkRequestGuard::new(Arc::clone(&self.park_requested));
         let mut heap_guard = self.heap_permit_manager.request_park().await;
         #[cfg(not(target_arch = "wasm32"))]
-        self.park_requested.store(false, Ordering::Relaxed);
+        drop(park_request_guard);
 
         // Collect roots from handles (objects returned to external code)
         let mut all_roots = self.heap.collect_handle_roots();
@@ -5324,6 +5349,59 @@ impl sys_types::VmSpawner for BexEngine {
 
 #[cfg(test)]
 mod concurrent_tests {
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn cancelling_pending_gc_park_request_clears_vm_flag() {
+        use std::{
+            sync::{
+                Arc,
+                atomic::{AtomicBool, Ordering},
+            },
+            time::Duration,
+        };
+
+        use super::ParkRequestGuard;
+        use crate::HeapPermitManager;
+
+        let permit_manager = Arc::new(HeapPermitManager::new());
+        let active_permit = permit_manager.new_permit(()).await.acquire().await;
+        let park_requested = Arc::new(AtomicBool::new(false));
+
+        let request = {
+            let permit_manager = Arc::clone(&permit_manager);
+            let park_requested = Arc::clone(&park_requested);
+            tokio::spawn(async move {
+                let park_request_guard = ParkRequestGuard::new(park_requested);
+                let _heap_guard = permit_manager.request_park().await;
+                drop(park_request_guard);
+            })
+        };
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !park_requested.load(Ordering::Relaxed) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("GC request should set the VM park flag");
+        assert!(
+            !request.is_finished(),
+            "the active heap permit should keep the GC request pending"
+        );
+
+        request.abort();
+        let join_error = request
+            .await
+            .expect_err("aborted GC request should not complete normally");
+        assert!(join_error.is_cancelled());
+        assert!(
+            !park_requested.load(Ordering::Relaxed),
+            "cancelling the GC request must clear the VM park flag"
+        );
+
+        drop(active_permit);
+    }
+
     /// Test that demonstrates concurrent `call_function` is safe.
     /// This test verifies that:
     /// 1. Multiple concurrent calls complete successfully

--- a/baml_language/crates/bridge_wasm/src/wasm_sys.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_sys.rs
@@ -97,6 +97,19 @@ fn options_to_js(options: Option<&io::owned::sys::ProcessOptions>) -> JsValue {
 }
 
 impl IoNamespaceSys for WasmSys {
+    fn collect_garbage(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        // BexEngine intercepts this operation before ordinary sys-op dispatch
+        // so it can release the calling VM's heap permit and coordinate a
+        // stop-the-world collection. This fallback keeps the generated IO
+        // contract complete for alternate dispatchers.
+        SysOpOutput::ok(())
+    }
+
     fn exec(
         &self,
         _heap: &Arc<BexHeap>,

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -1190,6 +1190,19 @@ async fn run_process(
 }
 
 impl io::IoNamespaceSys for NativeSysOps {
+    fn collect_garbage(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        // BexEngine intercepts this operation before ordinary sys-op dispatch
+        // so it can release the calling VM's heap permit and coordinate a
+        // stop-the-world collection. This fallback keeps the generated IO
+        // contract complete for alternate dispatchers.
+        SysOpOutput::ok(())
+    }
+
     fn exec(
         &self,
         _heap: &Arc<BexHeap>,

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -1594,6 +1594,17 @@ impl io::IoNamespaceIo for DefaultIoOps {
 }
 
 impl io::IoNamespaceSys for DefaultIoOps {
+    fn collect_garbage(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        // The engine handles this intrinsic before consulting the platform IO
+        // table. Returning success is the safe fallback for other runtimes.
+        SysOpOutput::ok(())
+    }
+
     fn exec(
         &self,
         _h: &Arc<BexHeap>,


### PR DESCRIPTION
## Root cause

BAML cleanup finalizers run when the runtime garbage collector reclaims unreachable instances, but tests and runtime diagnostics had no supported way to trigger a collection and wait for queued `cleanup()` finalizers. That made deterministic observation of unreachable-object cleanup impossible.

## Scope

- add `baml.sys.collect_garbage()` as an explicit diagnostic/testing builtin
- intercept the sys-op in `BexEngine`, release the caller's heap permit, run a major collection, drain cleanup finalizers, and resume only after completion
- keep native/default sys-op tables contract-complete with safe fallback implementations
- add an integration test proving unreachable cleanup runs before the builtin returns

This intentionally does **not** make an inherent `cleanup()` method satisfy an interface or change virtual/interface dispatch. Interface dispatch support is out of scope and tracked separately.

## User impact

Tests and runtime diagnostics can now force deterministic reclamation with `baml.sys.collect_garbage()`. Production programs should continue relying on normal runtime collection scheduling.

## Validation

- `cargo nextest run -p baml_tests --test cleanup` (5 passed)
- `cargo nextest run -p baml_tests --test interfaces in_body_inherent_method_does_not_implicitly_satisfy_interface` (1 passed; confirms nominal interface conformance remains unchanged)
- `cargo fmt --all --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stop-the-world GC, VM parking, and heap permits; misuse in hot paths could cause pauses, though the API is aimed at tests/diagnostics.
> 
> **Overview**
> Adds **`baml.sys.collect_garbage()`**, a diagnostic builtin that forces a major GC and runs queued **`cleanup()`** finalizers before returning, documented for tests and diagnostics rather than normal production use.
> 
> **`BexEngine`** intercepts the sys-op and handles it as an **async** operation: the caller’s heap permit is released so VMs can park, then **`collect_garbage(Major)`** runs stop-the-world. Platform IO tables (native, WASM, default) get stub **`collect_garbage`** implementations for contract completeness when dispatch does not go through the engine.
> 
> **`ParkRequestGuard`** scopes the VM park-request flag so aborting or dropping a pending GC wait cannot leave **`park_requested`** stuck true; **`collect_garbage`** uses this guard instead of manual flag toggling.
> 
> An integration test asserts that after abandoning a resource with a **`cleanup`** hook, calling **`baml.sys.collect_garbage()`** leaves **`["created", "cleaned"]`** in the log on the next line. Compiler and bytecode snapshots reflect the new builtin and shifted call indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ca992172c454d7b06c55e43fb34c3311a4d48a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `collect_garbage()` system builtin that forces full garbage collection and runs pending cleanup finalizers before returning.
  * The operation returns `null` and completes without throwing errors.

* **Tests**
  * Added coverage confirming unreachable resources are cleaned up deterministically before `collect_garbage()` returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->