### PR TITLE
Fix class spread inference and VM stack carry

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1676,6 +1676,31 @@ fn is_call_result_immediate(local: Local, du: &LocalDefUse, body: &MirFunctionBo
         return false;
     }
 
+    // A class spread is emitted incrementally as
+    // `AllocInstance; InitField/InitSpread`. Its explicit field operands must
+    // be pushed after the destination instance exists. Carrying a call result
+    // from the preceding block leaves it below that instance and reverses the
+    // `InitField` operands. Reject this structurally here, including when the
+    // aggregate destination is virtual and its use is forwarded elsewhere.
+    let use_loc = &du.uses[0];
+    if let StatementRef::Statement(stmt_idx) = use_loc.statement_ref
+        && let Some(StatementKind::Assign {
+            value:
+                Rvalue::Aggregate {
+                    kind: baml_compiler2_mir::AggregateKind::Class { .. },
+                    fields,
+                },
+            ..
+        }) = body
+            .block(use_loc.block)
+            .statements
+            .get(stmt_idx)
+            .map(|stmt| &stmt.kind)
+        && fields.iter().any(is_class_field_copy_operand)
+    {
+        return false;
+    }
+
     // Must have a definition from a terminator (Call/Await/SysOp)
     let Some(def) = &du.def else {
         return false;
@@ -2001,6 +2026,74 @@ mod tests {
         assert!(!is_call_result_aggregate_operand(
             target, &du, &body, &def_use,
         ));
+    }
+
+    #[test]
+    fn call_result_immediate_rejects_incremental_class_spread_init() {
+        let result = Local(1);
+        let spread_base = Local(2);
+        let body = MirFunctionBody {
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![],
+                    terminator: Some(Terminator::Call {
+                        callee: Operand::Constant(Constant::Null),
+                        args: vec![],
+                        ntypeargs: 0,
+                        runtime_id: None,
+                        destination: Place::Local(result),
+                        target: BlockId(1),
+                        unwind: None,
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(Local(0)),
+                            value: Rvalue::Aggregate {
+                                kind: baml_compiler2_mir::AggregateKind::Class {
+                                    name: "GuideHooks".to_string(),
+                                    type_arg_templates: vec![],
+                                },
+                                fields: vec![
+                                    Operand::copy_local(result),
+                                    Operand::Copy(Place::Field {
+                                        base: Box::new(Place::Local(spread_base)),
+                                        field: 1,
+                                    }),
+                                ],
+                            },
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Return),
+                    span: None,
+                    terminator_span: None,
+                },
+            ],
+            entry: BlockId(0),
+            locals: vec![],
+            catch_regions: vec![],
+            viz_nodes: vec![],
+        };
+        let du = LocalDefUse {
+            def: Some(DefLocation {
+                block: BlockId(0),
+                statement_ref: StatementRef::Terminator,
+                rvalue: Rvalue::Use(Operand::Constant(Constant::Null)),
+            }),
+            uses: vec![UseLocation {
+                block: BlockId(1),
+                statement_ref: StatementRef::Statement(0),
+            }],
+            all_defs: vec![(BlockId(0), StatementRef::Terminator)],
+        };
+
+        assert!(!is_call_result_immediate(result, &du, &body));
     }
 
     /// Builds a minimal integer local declaration for MIR analysis tests.

--- a/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use baml_compiler2_mir::{
-    BinOp, Constant, Local, MirFunctionBody, Operand, Place, Rvalue, StatementKind, Terminator,
+    AggregateKind, BinOp, Constant, Local, MirFunctionBody, Operand, Place, Rvalue, StatementKind,
+    Terminator,
 };
 use baml_type::{Literal, RuntimeTy, TyTemplate};
 
@@ -813,6 +814,22 @@ fn simulate_rvalue_pull_stack(
         simulate_aggregate_operand_pull_stack(rvalue, sim, carried_local, classifications, def_use)
     {
         return result;
+    }
+
+    // Class aggregates containing field-copy operands are emitted incrementally
+    // as `AllocInstance; InitField/InitSpread`, not as the generic
+    // stack-consuming aggregate modeled by `walk_rvalue_pull`. A call result
+    // carried into that sequence would sit below the newly allocated instance,
+    // reversing the `InitField` operands and treating the call result as the
+    // destination object. Reject stack carry for this shape.
+    if matches!(
+        rvalue,
+        Rvalue::Aggregate {
+            kind: AggregateKind::Class { .. },
+            fields,
+        } if fields.iter().any(is_class_field_copy_operand)
+    ) {
+        return false;
     }
 
     // The emitter pulls binary operands left-to-right. If the right operand is
@@ -1690,6 +1707,37 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn class_spread_rejects_call_result_immediate_before_incremental_init() {
+        let carried = Local(1);
+        let spread_base = Local(2);
+        let rvalue = Rvalue::Aggregate {
+            kind: AggregateKind::Class {
+                name: "GuideHooks".to_string(),
+                type_arg_templates: vec![],
+            },
+            fields: vec![
+                Operand::copy_local(carried),
+                Operand::Copy(Place::Field {
+                    base: Box::new(Place::Local(spread_base)),
+                    field: 1,
+                }),
+            ],
+        };
+        let body = body_with_locals(vec![int_ty(), int_ty(), int_ty()]);
+        let mut sim = StackCarrySim::new();
+
+        assert!(!simulate_rvalue_pull_stack(
+            &rvalue,
+            &mut sim,
+            carried,
+            &body,
+            &HashMap::new(),
+            &HashMap::new(),
+        ));
+        assert!(!sim.used);
     }
 
     #[test]

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -4781,8 +4781,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 type_name,
                 type_args: obj_type_args,
                 fields,
+                spreads,
                 ..
-            } => self.infer_object_expr(expr_id, body, type_name, obj_type_args, fields),
+            } => self.infer_object_expr(expr_id, body, type_name, obj_type_args, fields, spreads),
             Expr::Index { base, index } => self.infer_index_expr(expr_id, body, *base, *index),
             Expr::OptionalIndex { base, index } => {
                 self.infer_optional_index_expr(expr_id, body, *base, *index)
@@ -5810,7 +5811,19 @@ impl<'db> TypeInferenceBuilder<'db> {
         type_name: &baml_base::core_types::TypePath,
         obj_type_args: &[TypeExpr],
         fields: &[(Name, ExprId)],
+        spreads: &[ast::SpreadField],
     ) -> Ty {
+        // Spread expressions are ordinary expressions: infer them even before
+        // resolving the destination class so calls nested inside a spread get
+        // their TIR call plans (including omitted-default bindings). Skipping
+        // these used to let MIR fall back to the source argument list, so a
+        // five-parameter factory called with two values emitted no OmittedArg
+        // sentinels and consumed three slots from its caller's VM frame.
+        let spread_types: Vec<(ExprId, Ty)> = spreads
+            .iter()
+            .map(|spread| (spread.expr, self.infer_expr(spread.expr, body)))
+            .collect();
+
         // Class-instance literals only: map literals (`map { .. }`) are routed
         // to `infer_map_object_expr` by the `is_map_object_literal` guard in the
         // `Expr::Object` arm before reaching here. The parser only emits an
@@ -5853,6 +5866,20 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 &field_ty,
                                 &mut bindings,
                             );
+                        }
+                        // An exact-class spread can determine otherwise omitted
+                        // class arguments (`Box { ...box_int }` => `Box<int>`).
+                        for (_, spread_ty) in &spread_types {
+                            if let Ty::Class(spread_name, spread_args, _) = spread_ty
+                                && spread_name == &class_name
+                                && spread_args.len() == class_data.generic_params.len()
+                            {
+                                for (param, arg) in
+                                    class_data.generic_params.iter().zip(spread_args)
+                                {
+                                    bindings.entry(param.clone()).or_insert_with(|| arg.clone());
+                                }
+                            }
                         }
                         // Params that appear in some field's declared type are
                         // inferable in principle, so leaving one unbound (e.g. `T`
@@ -5909,6 +5936,24 @@ impl<'db> TypeInferenceBuilder<'db> {
             ty => ty,
         };
         self.validate_type_generic_bounds(expr_id, &ty);
+        // Class spread is nominal and invariant: the source must be the same
+        // resolved class with compatible generic arguments. Besides preventing
+        // runtime field-layout violations, checking here ensures every nested
+        // expression is fully typed before MIR lowering.
+        for (spread_expr, spread_ty) in &spread_types {
+            if !matches!(spread_ty, Ty::Unknown { .. } | Ty::Error { .. })
+                && !self.is_subtype(spread_ty, &ty)
+            {
+                self.context.report(
+                    TirTypeError::TypeMismatch {
+                        expected: ty.clone(),
+                        got: spread_ty.clone(),
+                    },
+                    *spread_expr,
+                    Vec::new(),
+                );
+            }
+        }
         if let Ty::Class(class_name, type_args, _) = &ty {
             let field_types: FxHashMap<Name, Ty> = self
                 .class_actual_fields_ordered(class_name, type_args)
@@ -5974,15 +6019,13 @@ impl<'db> TypeInferenceBuilder<'db> {
         // class that differs from the expected class, it must be a subtype.
         // Keep this out of `check_expr` proper so its temporary lowering
         // state doesn't bloat every recursive checking frame in debug builds.
-        let Ty::Class(expected_qtn, _, _) = expected else {
+        let Ty::Class(..) = expected else {
             return None;
         };
         let path = type_name;
 
         let lit_ty = self.lower_object_type_name(expr_id, path, obj_type_args);
-        if let Ty::Class(lit_qtn, _, _) = &lit_ty
-            && lit_qtn != expected_qtn
-        {
+        if matches!(&lit_ty, Ty::Class(..)) && !self.is_subtype(&lit_ty, expected) {
             let inferred = self.infer_expr(expr_id, body);
             if !matches!(inferred, Ty::Unknown { .. } | Ty::Error { .. })
                 && !self.is_subtype(&inferred, expected)
@@ -6009,6 +6052,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         body: &ExprBody,
         expected: &Ty,
         fields: &[(Name, ExprId)],
+        spreads: &[ast::SpreadField],
         type_name: &baml_base::core_types::TypePath,
         obj_type_args: &[TypeExpr],
     ) -> Ty {
@@ -6027,6 +6071,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
         self.validate_type_generic_bounds(expr_id, expected);
         if let Ty::Class(class_name, type_args, _) = expected {
+            for spread in spreads {
+                self.check_expr(spread.expr, body, expected);
+            }
             let field_types: FxHashMap<Name, Ty> = self
                 .class_actual_fields_ordered(class_name, type_args)
                 .into_iter()
@@ -6823,8 +6870,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 fields,
                 type_name,
                 type_args,
+                spreads,
                 ..
-            } => self.check_object_expr(expr_id, body, expected, fields, type_name, type_args),
+            } => self.check_object_expr(
+                expr_id, body, expected, fields, spreads, type_name, type_args,
+            ),
             Expr::Map { entries } => {
                 // Look through aliases, a nullable wrapper (`map<string, int>?`),
                 // and a union with a unique map member (`json` is

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -6019,13 +6019,19 @@ impl<'db> TypeInferenceBuilder<'db> {
         // class that differs from the expected class, it must be a subtype.
         // Keep this out of `check_expr` proper so its temporary lowering
         // state doesn't bloat every recursive checking frame in debug builds.
-        let Ty::Class(..) = expected else {
+        let Ty::Class(expected_qtn, _, _) = expected else {
             return None;
         };
         let path = type_name;
 
         let lit_ty = self.lower_object_type_name(expr_id, path, obj_type_args);
-        if matches!(&lit_ty, Ty::Class(..)) && !self.is_subtype(&lit_ty, expected) {
+        let declared_mismatch = if let Ty::Class(lit_qtn, _, _) = &lit_ty {
+            lit_qtn != expected_qtn
+                || (!obj_type_args.is_empty() && !self.is_subtype(&lit_ty, expected))
+        } else {
+            false
+        };
+        if declared_mismatch {
             let inferred = self.infer_expr(expr_id, body);
             if !matches!(inferred, Ty::Unknown { .. } | Ty::Error { .. })
                 && !self.is_subtype(&inferred, expected)
@@ -6045,6 +6051,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[inline(never)]
     fn check_object_expr(
         &mut self,

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -998,10 +998,15 @@ fn class_spread_requires_the_same_nominal_class_and_generic_arguments() {
         r#"
 class Left<T> { value T }
 class Right<T> { value T }
+class Wrapper<T, E> { body () -> T throws E }
 
 function infer_from_spread(source: Left<int>) -> int {
   let copy = Left { ...source };
   copy.value
+}
+
+function expected_type_supplies_omitted_arguments() -> Wrapper<int, null> {
+  Wrapper { body: () -> 1 }
 }
 
 function wrong_class() -> Left<int> {
@@ -1015,6 +1020,10 @@ function wrong_type_argument() -> Left<int> {
     );
     let tir = render_tir(&db, file);
     assert!(!tir.contains("cannot infer type parameter `T`"), "{tir}");
+    assert!(
+        !tir.contains("expected Wrapper<int, null>, got Wrapper<int, never>"),
+        "{tir}"
+    );
     assert!(
         tir.contains("type mismatch: expected Left<int>, got Right<int>"),
         "{tir}"

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -989,3 +989,38 @@ fn narrowed_nullable_index_is_accepted() {
         "a nullable index narrowed to non-null must stay allowed"
     );
 }
+
+#[test]
+fn class_spread_requires_the_same_nominal_class_and_generic_arguments() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Left<T> { value T }
+class Right<T> { value T }
+
+function infer_from_spread(source: Left<int>) -> int {
+  let copy = Left { ...source };
+  copy.value
+}
+
+function wrong_class() -> Left<int> {
+  Left<int> { ...Right<int> { value: 1 } }
+}
+
+function wrong_type_argument() -> Left<int> {
+  Left<int> { ...Left<string> { value: "bad" } }
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(!tir.contains("cannot infer type parameter `T`"), "{tir}");
+    assert!(
+        tir.contains("type mismatch: expected Left<int>, got Right<int>"),
+        "{tir}"
+    );
+    assert!(
+        tir.contains("type mismatch: expected Left<int>, got Left<string>"),
+        "{tir}"
+    );
+}

--- a/baml_language/crates/bex_engine/tests/collect_tests.rs
+++ b/baml_language/crates/bex_engine/tests/collect_tests.rs
@@ -201,6 +201,21 @@ async fn run_named_testset(
         .await
 }
 
+/// Helper: run every registered child through the stdlib's parallel test path.
+async fn run_all_tests(
+    engine: &Arc<BexEngine>,
+    registry: BexExternalValue,
+) -> Result<BexExternalValue, bex_engine::EngineError> {
+    engine
+        .call_function(
+            "testing.TestRegistry.run_all",
+            vec![registry],
+            bex_engine::FunctionCallContextBuilder::new(CallId::next()).build(),
+            true,
+        )
+        .await
+}
+
 fn unwrap_union(value: &BexExternalValue) -> &BexExternalValue {
     match value {
         BexExternalValue::Union { value, .. } => unwrap_union(value),
@@ -1095,6 +1110,69 @@ async fn test_body_let_local_resolves_to_binding() {
         .await
         .expect("run_test should not crash on a let-bound local");
     assert_outcome(&report, "pass");
+}
+
+/// Class spreads inside concurrently spawned test bodies must retain a valid
+/// frame-local region. `TestRegistry.run_all` spawns every child, and each
+/// child races its body against a timeout future.
+#[tokio::test]
+async fn collect_tests_run_all_parallel_class_spreads_keep_local_slots_in_bounds() {
+    let source = r#"
+        class Options {
+            value: int,
+            registry: string?,
+            hook: string?,
+            observers: string[],
+            dispatch: (int[]) -> int[] throws never,
+        }
+
+        function dispatch(values: int[]) -> int[] throws never {
+            values
+        }
+
+        function defaults(
+            value: int,
+            callback: (int[]) -> int[] throws never,
+            registry: string? = null,
+            hook: string? = null,
+            observers: string[] = [],
+        ) -> Options {
+            Options {
+                value: value,
+                registry: registry,
+                hook: hook,
+                observers: observers,
+                dispatch: callback,
+            }
+        }
+
+        test "spread 1" {
+            let options = Options { ...defaults(1, dispatch), value: 11 };
+            assert.equal(options.dispatch([options.value]), [11]);
+        }
+
+        test "spread 2" {
+            let options = Options { ...defaults(2, dispatch), value: 22 };
+            assert.equal(options.dispatch([options.value]), [22]);
+        }
+
+        test "spread 3" {
+            let options = Options { ...defaults(3, dispatch), value: 33 };
+            assert.equal(options.dispatch([options.value]), [33]);
+        }
+    "#;
+
+    let engine = make_engine(source);
+    let registry = engine
+        .collect_tests("user", CallId::next(), CancellationToken::default())
+        .await
+        .expect("collect_tests should succeed");
+
+    let report = run_all_tests(&engine, registry)
+        .await
+        .expect("parallel class-spread tests should keep local slots in bounds");
+    assert_eq!(outcome(&report), "pass");
+    assert_eq!(int_field(&report, "total"), 3);
 }
 
 /// Extract the `outcome` string from a `testing.TestReport` instance.

--- a/baml_language/crates/bex_vm/tests/class_spread_runtime.rs
+++ b/baml_language/crates/bex_vm/tests/class_spread_runtime.rs
@@ -1,0 +1,109 @@
+//! Runtime regressions for exact-class spread lowering.
+
+use std::sync::{Arc, atomic::AtomicBool};
+
+use baml_project::testing::compile_source;
+use bex_vm::{BexVm, VmExecState};
+
+fn run_bool(src: &str, fn_name: &str) -> bool {
+    let program = compile_source(src);
+    let idx = program
+        .function_index(fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name:?} not found"));
+    let mut vm =
+        BexVm::from_program(program, Arc::new(AtomicBool::new(false))).expect("construct test VM");
+    let fptr = vm.heap.compile_time_ptr(idx);
+    vm.set_entry_point(fptr, &[]);
+
+    for _ in 0..256 {
+        match vm.exec().expect("execute test program") {
+            VmExecState::Complete(value) => {
+                return value.as_bool().expect("entry point returns bool");
+            }
+            VmExecState::EarlyYield => {}
+            state => panic!("unexpected VM state: {state:?}"),
+        }
+    }
+    panic!("VM did not complete within 256 exec calls");
+}
+
+#[test]
+fn generic_spread_preserves_callable_and_last_field() {
+    const SRC: &str = r#"
+        class Task<T> {
+            value: T,
+            transform: (T) -> T throws never,
+            events: string[],
+        }
+
+        function defaults<T>(value: T, transform: (T) -> T throws never) -> Task<T> {
+            Task<T> { value: value, transform: transform, events: ["created"] }
+        }
+
+        function main() -> bool {
+            let task = Task {
+                ...defaults<int>(1, (value: int) -> int { value + 1 }),
+                value: 41,
+            };
+            task.transform(task.value) == 42 && task.events == ["created"]
+        }
+    "#;
+
+    assert!(run_bool(SRC, "user.main"));
+}
+
+#[test]
+fn spread_factory_call_with_omitted_defaults_preserves_caller_frame() {
+    const SRC: &str = r#"
+        class Tool {
+            name: string,
+        }
+
+        class Options {
+            budget: int,
+            tools: Tool[],
+            registry: Tool?,
+            hook: Tool?,
+            observers: Tool[],
+            dispatch: (int[]) -> int[] throws never,
+        }
+
+        function tool() -> Tool {
+            Tool { name: "knowledge" }
+        }
+
+        function dispatch(values: int[]) -> int[] throws never {
+            values
+        }
+
+        function defaults(
+            tools: Tool[],
+            callback: (int[]) -> int[] throws never,
+            registry: Tool? = null,
+            hook: Tool? = null,
+            observers: Tool[] = [],
+        ) -> Options {
+            Options {
+                budget: 5,
+                tools: tools,
+                registry: registry,
+                hook: hook,
+                observers: observers,
+                dispatch: callback,
+            }
+        }
+
+        function main() -> bool {
+            let options = Options {
+                ...defaults([tool()], dispatch),
+                budget: 1,
+            };
+            options.budget == 1 &&
+                options.dispatch([1]).length() == 1 &&
+                options.registry == null &&
+                options.hook == null
+        }
+    "#;
+
+    assert!(run_bool(SRC, "user.main"));
+}


### PR DESCRIPTION
## Root cause

Class spread expressions were not inferred as ordinary expressions during TIR construction. Calls nested in a spread could therefore miss their call plan, including omitted-default bindings, and MIR lowering could consume caller-frame slots as arguments. Separately, emit stack-carry analysis modeled spread-containing class aggregates like ordinary stack-consuming aggregates even though they are emitted incrementally (`AllocInstance` followed by field/spread initialization), which could reverse operands around a carried call result.

## Changes

- Infer every class spread expression before resolving the destination class.
- Use same-class spread types to infer generic arguments and validate spreads nominally/invariantly.
- Reject call-result stack carry for incrementally initialized class-spread aggregates in both analysis and stack simulation.
- Add TIR, emit, VM runtime, and parallel test-collection regressions covering generic spreads, omitted defaults, caller-frame preservation, and local-slot bounds.

## Validation

- `cargo nextest run -p baml_compiler2_emit` (37 passed)
- `cargo nextest run -p baml_tests compiler2_tir::inference` (42 passed)
- `cargo nextest run -p bex_vm --test class_spread_runtime` (2 passed)
- `cargo nextest run -p bex_vm` (63 passed)
- `cargo nextest run -p bex_engine --test collect_tests` (30 passed)
- `cargo fmt --all --check`
- `git diff --check origin/canary..HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TIR inference/checking, MIR emit optimizations, and VM-visible lowering for class literals with spreads; regressions are covered by new tests but the interaction of stack-carry and incremental class init is subtle.
> 
> **Overview**
> Fixes **class spread** handling end-to-end: spreads were skipped during TIR object inference, so nested calls could miss call plans and omitted-default bindings and MIR/VM could mis-account caller frame slots.
> 
> **TIR** now treats spread expressions like any other expression—`infer_object_expr` / `check_object_expr` infer spreads before resolving the destination class, use same-class spreads to fill generic arguments, and validate spreads nominally (wrong class or type args get `type mismatch`). Declared-type mismatch checking also considers explicit type arguments against the expected type.
> 
> **Bytecode emit** rejects **call-result stack carry** when the sole use is a class aggregate with field-copy operands (the `...spread` / `InitField`/`InitSpread` path). Incremental `AllocInstance` then field init requires operands in a fixed order; carrying a call result on the stack would sit under the instance and scramble `InitField` operands. The same guard exists in MIR analysis (`is_call_result_immediate`) and stack-carry simulation.
> 
> Adds **TIR**, **emit**, **VM runtime**, and **parallel `TestRegistry.run_all`** tests for generic spreads, factory calls with omitted defaults, and frame-local slot bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93b548a35c0b83bfaf980e2422311bd58042cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type inference and validation for class spread expressions, including generic arguments and nominal type compatibility.
  * Class spreads now provide clearer mismatch diagnostics when source and destination types are incompatible.

* **Bug Fixes**
  * Fixed runtime handling of class spreads, including field overrides, optional defaults, callable fields, and frame-local behavior.
  * Prevented unsafe optimizations for incremental class spread initialization.

* **Tests**
  * Added compiler, runtime, and integration coverage for generic class spreads and concurrent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->