### PR TITLE
Fix compiler edge-case regressions

### DIFF
--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -2199,6 +2199,12 @@ impl<'db> LoweringContext<'db> {
             Tir2Ty::Class(qtn, args, _) => self
                 .interface_view_for_class_tir_ty(qtn, args, target_tn)
                 .or_else(|| self.realized_interface_view_for(ty, target_tn)),
+            Tir2Ty::TypeAlias(qtn, _) if !self.resolved_aliases.recursive.contains(qtn) => self
+                .resolved_aliases
+                .aliases
+                .get(qtn)
+                .and_then(|target| self.interface_view_for_tir_ty(target, target_tn))
+                .or_else(|| self.realized_interface_view_for(ty, target_tn)),
             Tir2Ty::TypeVar(name, _) => self
                 .generic_param_bounds
                 .get(name)
@@ -12089,6 +12095,10 @@ impl LoweringContext<'_> {
             _ => {
                 let ty = self.expr_ty(expr_id);
                 let temp = self.builder.temp(ty);
+                // A projection assignment may use an arbitrary expression as
+                // its base (`store.require().info.title = ...`). Materialize
+                // that base exactly once before projecting through it.
+                self.lower_expr(expr_id, Place::Local(temp));
                 Place::Local(temp)
             }
         }

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -4170,14 +4170,33 @@ impl<'a> Parser<'a> {
                         return false;
                     }
                     if text == "client" || text == "prompt" {
-                        return true;
+                        // An LLM field is `client <value>` / `prompt <template>`.
+                        // A following `=`, `,`, or `)` means a named call arg
+                        // or plain identifier use, so this is an expression body.
+                        let j = self.skip_trivia_and_comments_from(i + 1);
+                        let next = self.tokens.get(j).map(|t| t.kind);
+                        if !matches!(
+                            next,
+                            Some(TokenKind::Equals | TokenKind::Comma | TokenKind::RParen)
+                        ) {
+                            return true;
+                        }
                     }
                 }
-                // `client` as KW_CLIENT: LLM directive is `client Model`, not `client.method(...)`.
+                // `client` as KW_CLIENT: LLM directive is `client Model`, not
+                // `client.method(...)` or the named call arg `client = ...`.
                 TokenKind::Client if brace_depth == 1 => {
                     let j = self.skip_trivia_and_comments_from(i + 1);
                     let next = self.tokens.get(j).map(|t| t.kind);
-                    if next != Some(TokenKind::Dot) {
+                    if !matches!(
+                        next,
+                        Some(
+                            TokenKind::Dot
+                                | TokenKind::Equals
+                                | TokenKind::Comma
+                                | TokenKind::RParen
+                        )
+                    ) {
                         return true;
                     }
                 }
@@ -9003,6 +9022,50 @@ function call_llm_function(client: Client, function_name: string) -> unknown {
         let source = r#"
 function f() -> int {
   client.execute()
+}
+"#;
+
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let func = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::FUNCTION_DEF)
+            .expect("expected FUNCTION_DEF");
+        assert!(
+            func.children()
+                .any(|n| n.kind() == SyntaxKind::EXPR_FUNCTION_BODY),
+            "expected expression body, not LLM body"
+        );
+    }
+
+    #[test]
+    fn expression_body_call_with_client_named_arg_is_not_llm_body() {
+        let source = r#"
+function main() -> string {
+  Ask("hi", client = override_provider())
+}
+"#;
+
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let func = root
+            .descendants()
+            .find(|n| n.kind() == SyntaxKind::FUNCTION_DEF)
+            .expect("expected FUNCTION_DEF");
+        assert!(
+            func.children()
+                .any(|n| n.kind() == SyntaxKind::EXPR_FUNCTION_BODY),
+            "expected expression body, not LLM body"
+        );
+    }
+
+    #[test]
+    fn expression_body_call_with_prompt_named_arg_is_not_llm_body() {
+        let source = r#"
+function main() -> string {
+  render(prompt = "hello", client = c)
 }
 "#;
 

--- a/baml_language/crates/baml_tests/tests/interface_type_alias_iteration.rs
+++ b/baml_language/crates/baml_tests/tests/interface_type_alias_iteration.rs
@@ -1,0 +1,44 @@
+//! Regression coverage for iterating through an interface method whose return
+//! type is a transparent alias for an array.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+#[tokio::test]
+async fn interface_method_array_alias_is_iterable() {
+    let output = baml_test!(
+        r#"
+        class Event {
+            value: int
+        }
+
+        type EventStream = Event[]
+
+        interface Live {
+            function events(self) -> EventStream throws never
+        }
+
+        class Fixture {
+            implements Live {
+                function events(self) -> EventStream throws never {
+                    [Event { value: 2 }, Event { value: 3 }]
+                }
+            }
+        }
+
+        function total(live: Live) -> int throws never {
+            let sum = 0;
+            for (let event in live.events()) {
+                sum += event.value;
+            }
+            sum
+        }
+
+        function main() -> int throws never {
+            total(Fixture {})
+        }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Int(5)));
+}

--- a/baml_language/crates/bex_vm/tests/projection_dest_calls.rs
+++ b/baml_language/crates/bex_vm/tests/projection_dest_calls.rs
@@ -102,3 +102,27 @@ fn virtual_call_result_assigned_to_field() {
     assert!(run_bool(SRC, "user.flag_into_field_true"));
     assert!(!run_bool(SRC, "user.flag_into_field_false"));
 }
+
+// The base of a projection is itself allowed to be a call expression. MIR must
+// evaluate that call into a local before appending field projections.
+#[test]
+fn method_call_result_can_be_the_base_of_nested_field_assignment() {
+    const SRC: &str = r#"
+        class Info { title: string? }
+        class Record { info: Info }
+        class Store {
+            record: Record
+            function require(self) -> Record { self.record }
+        }
+
+        function main() -> bool {
+            let store = Store {
+                record: Record { info: Info { title: null } },
+            };
+            store.require().info.title = "triage";
+            store.record.info.title == "triage"
+        }
+    "#;
+
+    assert!(run_bool(SRC, "user.main"));
+}


### PR DESCRIPTION
## Summary
- materialize arbitrary lvalue projection bases correctly in MIR
- preserve the interface view through non-recursive type aliases
- parse named `client =` and `prompt =` call arguments as ordinary arguments instead of LLM function bodies

## Why
These independent compiler edge cases surfaced while migrating the BEPv2 scenarios. Each bug now has focused regression coverage.

## Validation
- parser and MIR suites: 145 passed
- interface type-alias iteration regression: 1 passed
- projection-destination call regressions: 3 passed
- `cargo fmt --all --check`
- `git diff --check origin/canary..HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MIR lvalue lowering, type-alias interface resolution, and function-body disambiguation; behavior changes are narrow but affect core compile paths.
> 
> **Overview**
> Three independent compiler edge-case fixes, each with focused regression tests.
> 
> **MIR lowering** now evaluates the base expression of a projection assignment (e.g. `store.require().info.title = ...`) into a temp before building the lvalue, so call results can serve as nested assignment bases.
> 
> **Interface iteration** resolves **non-recursive type aliases** when looking up interface views (e.g. `for` over `live.events()` when the return type is `type EventStream = Event[]`), so iterable lowering works through transparent aliases.
> 
> **Parser** no longer treats `client` / `prompt` at the start of a function body as LLM directives when the next token is `=`, `,`, or `)`, so bodies like `Ask("hi", client = ...)` parse as expression bodies instead of LLM bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f66d4281a1d64dd080d8fce38365aeabe0c465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of type aliases when iterating over interface method results.
  * Fixed nested field assignments so method-call results are evaluated correctly before updating fields.
  * Improved detection of expression-based function bodies using `client` or `prompt` named arguments.

* **Tests**
  * Added regression coverage for interface type aliases, nested field assignments, and expression-body parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->