### PR TITLE
Format spawn expressions and trailing block arguments

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -46,6 +46,8 @@ pub enum Expression {
     BacktickString(t::BacktickString),
     ByteString(t::ByteString),
     Lambda(Box<LambdaExpr>),
+    /// A `spawn name? (with opts)? { … }` task-spawn expression (BEP-034).
+    Spawn(Box<SpawnExpr>),
     /// A braceless `return …` in expression position (a `RETURN_EXPR`, e.g. a
     /// `catch`/`match` arm value like `_ => return 0`). Printed verbatim, like
     /// [`Expression::Unknown`] and backed by the same [`VerbatimSpan`], but kept
@@ -67,7 +69,7 @@ pub enum Expression {
 }
 
 /// A node the strong AST does not model and prints verbatim: an unmodeled
-/// expression (e.g. `defer { … }`, `throw e`, `await f`, `spawn { … }`,
+/// expression (e.g. `defer { … }`, `throw e`, `await f`,
 /// `x.as<T>`) held as [`Expression::Unknown`], or a braceless jump held as
 /// [`Expression::Return`], [`Expression::Break`], or [`Expression::Continue`].
 ///
@@ -134,6 +136,7 @@ impl Expression {
                 | Expression::IfLet(_)
                 | Expression::Match(_)
                 | Expression::Lambda(_)
+                | Expression::Spawn(_)
                 | Expression::Unknown(_)
         )
     }
@@ -215,6 +218,7 @@ impl FromCST for Expression {
                 t::ByteString::from_cst(elem).map(Expression::ByteString)?
             }
             SyntaxKind::LAMBDA_EXPR => Expression::Lambda(Box::new(LambdaExpr::from_cst(elem)?)),
+            SyntaxKind::SPAWN_EXPR => Expression::Spawn(Box::new(SpawnExpr::from_cst(elem)?)),
             SyntaxKind::RETURN_EXPR => Expression::Return(VerbatimSpan::from_element(&elem)),
             SyntaxKind::BREAK_EXPR => Expression::Break(VerbatimSpan::from_element(&elem)),
             SyntaxKind::CONTINUE_EXPR => Expression::Continue(VerbatimSpan::from_element(&elem)),
@@ -267,9 +271,10 @@ impl Expression {
             }
             Expression::ByteString(bs) => Some(usize::from(bs.span().len())),
             Expression::Lambda(_) => None,
+            Expression::Spawn(spawn) => spawn.single_line_width(input),
             Expression::Return(_) | Expression::Break(_) | Expression::Continue(_) => None,
             Expression::Unknown(unknown) => {
-                // Unmodeled nodes (e.g. `await f`, `x.as<T>`, `spawn { … }`,
+                // Unmodeled nodes (e.g. `await f`, `x.as<T>`,
                 // `throw e`) print their source verbatim (see `print`). When that
                 // text is a single line it occupies a known width and can sit
                 // inline like any other fitting expression. Reporting `None` here
@@ -319,6 +324,7 @@ impl Printable for Expression {
             Expression::BacktickString(bt) => bt.print(shape, printer),
             Expression::ByteString(bs) => bs.print(shape, printer),
             Expression::Lambda(lambda) => lambda.print(shape, printer),
+            Expression::Spawn(spawn) => spawn.print(shape, printer),
             // Print the raw `return …` / `break` / `continue` text. The arm
             // printers add the `;` when they wrap this into a block (see
             // `CatchArm`/`MatchArm`). A braceless jump only appears as a whole
@@ -370,6 +376,7 @@ impl Printable for Expression {
             Expression::BacktickString(bt) => bt.leftmost_token(),
             Expression::ByteString(bs) => bs.leftmost_token(),
             Expression::Lambda(lambda) => lambda.leftmost_token(),
+            Expression::Spawn(spawn) => spawn.leftmost_token(),
             Expression::Return(span)
             | Expression::Break(span)
             | Expression::Continue(span)
@@ -404,6 +411,7 @@ impl Printable for Expression {
             Expression::BacktickString(bt) => bt.rightmost_token(),
             Expression::ByteString(bs) => bs.rightmost_token(),
             Expression::Lambda(lambda) => lambda.rightmost_token(),
+            Expression::Spawn(spawn) => spawn.rightmost_token(),
             Expression::Return(span)
             | Expression::Break(span)
             | Expression::Continue(span)
@@ -2422,8 +2430,16 @@ impl Printable for CallExpr {
     /// The main way to call this should be through [`PrintChain`]
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         let mut multi_lined = false;
+        let line_len_before = printer.current_line_len();
         multi_lined |= printer.print(&*self.callee, shape.clone()).multi_lined;
-        multi_lined |= printer.print(&self.args, shape).multi_lined;
+        // Account for the callee on the call line so the args' hug layout
+        // (see `CallArgs::try_print_hug`) budgets its first line correctly.
+        let args_shape = Shape {
+            first_line_offset: shape.first_line_offset
+                + printer.current_line_len().saturating_sub(line_len_before),
+            ..shape
+        };
+        multi_lined |= printer.print(&self.args, args_shape).multi_lined;
         PrintInfo { multi_lined }
     }
     fn leftmost_token(&self) -> TextRange {
@@ -2526,6 +2542,14 @@ impl FromCST for CallArg {
 }
 
 impl CallArg {
+    /// A block-terminal argument (a lambda or a `spawn { … }`) that may hug
+    /// the call parens instead of forcing the whole call to break: the
+    /// argument's block opens on the call line and its `}` is immediately
+    /// followed by `)`.
+    const fn is_huggable(&self) -> bool {
+        matches!(self.expr, Expression::Lambda(_) | Expression::Spawn(_))
+    }
+
     pub(crate) fn single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
         let mut len = 0;
         if let Some((name, equals)) = &self.label {
@@ -2720,12 +2744,96 @@ impl CallArgs {
             Some(PrintInfo::default_single_line())
         }
     }
+
+    /// Whether the hug layout (see [`Self::try_print_hug`]) applies: the last
+    /// argument is block-terminal (a lambda or `spawn { … }`).
+    fn can_hug(&self) -> bool {
+        self.args
+            .split_last()
+            .is_some_and(|((arg, _), _)| arg.is_huggable())
+    }
+
+    /// Hug layout for a trailing block-terminal argument: everything up to
+    /// the last argument prints on one line, the last argument's block opens
+    /// on that same line and closes at the outer indent, immediately followed
+    /// by the closing paren (no trailing comma).
+    ///
+    /// ```baml
+    /// futures.push(spawn {
+    ///     work(c)
+    /// })
+    /// ```
+    ///
+    /// Should be passed a sub-printer to avoid printing trivia in the outer
+    /// printer in the event that the hug layout does not apply.
+    fn try_print_hug(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
+        let ((last_arg, last_comma), init) = self.args.split_last()?;
+        if !last_arg.is_huggable() {
+            return None;
+        }
+
+        printer.print_raw_token(&self.open_paren);
+        let (_, open_trailing) = printer.trivia.get_for_range_split(self.open_paren.span());
+        printer.try_print_trivia_single_line_squished(open_trailing)?;
+
+        for (arg, comma) in init {
+            let (arg_leading, arg_trailing) = printer.trivia.get_for_element(arg);
+            printer.try_print_trivia_single_line_squished(arg_leading)?;
+            if printer
+                .print(arg, Shape::unlimited_single_line())
+                .multi_lined
+            {
+                return None;
+            }
+            printer.try_print_trivia_single_line_squished(arg_trailing)?;
+            if let Some(comma) = comma {
+                let (comma_leading, comma_trailing) =
+                    printer.trivia.get_for_range_split(comma.span());
+                printer.try_print_trivia_single_line_squished(comma_leading)?;
+                printer.print_raw_token(comma);
+                printer.try_print_trivia_single_line_squished(comma_trailing)?;
+            } else {
+                printer.print_str(",");
+            }
+            printer.print_str(" ");
+        }
+
+        let (last_leading, last_trailing) = printer.trivia.get_for_element(last_arg);
+        printer.try_print_trivia_single_line_squished(last_leading)?;
+        // The hugged argument's first line continues the call line, so its
+        // single-line budget is what remains after the indent, the call's own
+        // offset, and everything printed since the open paren.
+        let first_line_offset = shape.first_line_offset + printer.current_line_len();
+        let arg_shape = Shape {
+            width: printer
+                .config
+                .line_width
+                .saturating_sub(shape.indent + first_line_offset),
+            indent: shape.indent,
+            first_line_offset,
+        };
+        printer.print(last_arg, arg_shape);
+        // The trailing comma is dropped in the hug layout, but keep any
+        // comments attached around it.
+        printer.try_print_trivia_single_line_squished(last_trailing)?;
+        if let Some(comma) = last_comma {
+            let (comma_leading, comma_trailing) = printer.trivia.get_for_range_split(comma.span());
+            printer.try_print_trivia_single_line_squished(comma_leading)?;
+            printer.try_print_trivia_single_line_squished(comma_trailing)?;
+        }
+        let (close_leading, _) = printer.trivia.get_for_range_split(self.close_paren.span());
+        printer.try_print_trivia_single_line_squished(close_leading)?;
+        printer.print_raw_token(&self.close_paren);
+
+        Some(PrintInfo::default_multi_lined())
+    }
 }
 
 impl Printable for CallArgs {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         printer
             .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .or_else(|| printer.try_sub_printer(|p| self.try_print_hug(&shape, p)))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {
@@ -3312,6 +3420,20 @@ impl KnownKind for BlockExpr {
 
 impl Printable for BlockExpr {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        // An empty block with no comment trapped inside collapses to `{}`
+        // (e.g. an empty match arm `null => {},` or an empty `if` body).
+        if self.stmts.is_empty() && self.expr.is_none() {
+            let (_, open_trailing) = printer.trivia.get_for_range_split(self.open_brace.span());
+            let (close_leading, _) = printer.trivia.get_for_range_split(self.close_brace.span());
+            if !open_trailing.iter().any(EmittableTrivia::is_comment)
+                && !close_leading.iter().any(EmittableTrivia::is_comment)
+            {
+                printer.print_raw_token(&self.open_brace);
+                printer.print_raw_token(&self.close_brace);
+                return PrintInfo::default_single_line();
+            }
+        }
+
         printer.print_raw_token(&self.open_brace);
         printer.print_trivia_all_trailing_for(self.open_brace.span());
         printer.print_newline();
@@ -4664,6 +4786,279 @@ impl Printable for LambdaExpr {
     }
 }
 
+/// The `with` options clause of a [`SpawnExpr`]: the keyword and its
+/// comma-separated expressions (in v1 a single `baml.spawn.options(...)`
+/// call).
+pub type SpawnWithClause = (t::With, Vec<(Expression, Option<t::Comma>)>);
+
+/// Corresponds to a [`SyntaxKind::SPAWN_EXPR`] node.
+///
+/// `spawn name_expr? (with expr (, expr)*)? { body }` (BEP-034). The name
+/// expression and the `with` options clause are both optional; the body is
+/// always a brace-delimited block.
+#[derive(Debug)]
+pub struct SpawnExpr {
+    pub keyword: t::Spawn,
+    /// Optional task-name expression between `spawn` and `with`/the body.
+    pub name: Option<Expression>,
+    pub with_clause: Option<SpawnWithClause>,
+    pub block: BlockExpr,
+}
+
+impl FromCST for SpawnExpr {
+    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
+        let node = StrongAstError::assert_is_node(elem)?;
+        StrongAstError::assert_kind_node(&node, SyntaxKind::SPAWN_EXPR)?;
+
+        let mut it = SyntaxNodeIter::new(&node);
+        let keyword: t::Spawn = it.expect_parse()?;
+
+        let mut name = None;
+        let mut with_clause = None;
+        let block = loop {
+            let elem = it.expect_next("spawn body block")?;
+            match elem.kind() {
+                SyntaxKind::BLOCK_EXPR => break BlockExpr::from_cst(elem)?,
+                SyntaxKind::KW_WITH => {
+                    let with_kw = t::With::from_cst(elem)?;
+                    let mut options = Vec::new();
+                    while let Some(next) = it.peek() {
+                        if next.kind() == SyntaxKind::BLOCK_EXPR {
+                            break;
+                        }
+                        let expr = Expression::from_cst(it.next().expect("peeked"))?;
+                        let comma = it
+                            .next_if_kind(SyntaxKind::COMMA)
+                            .map(t::Comma::from_cst)
+                            .transpose()?;
+                        options.push((expr, comma));
+                    }
+                    with_clause = Some((with_kw, options));
+                }
+                _ if name.is_none() && with_clause.is_none() => {
+                    name = Some(Expression::from_cst(elem)?);
+                }
+                _ => {
+                    return Err(StrongAstError::UnexpectedAdditionalElement {
+                        parent: it.parent,
+                        at: elem.text_range(),
+                    });
+                }
+            }
+        };
+        it.expect_end()?;
+
+        Ok(SpawnExpr {
+            keyword,
+            name,
+            with_clause,
+            block,
+        })
+    }
+}
+
+impl KnownKind for SpawnExpr {
+    fn kind() -> SyntaxKind {
+        SyntaxKind::SPAWN_EXPR
+    }
+}
+
+impl SpawnExpr {
+    /// Source range for the spawn header, excluding the body block's opening
+    /// brace. Keeping a commented header verbatim avoids dropping trivia that
+    /// sits between the keyword, optional name, `with` options, and commas.
+    fn header_range(&self) -> TextRange {
+        TextRange::new(
+            self.keyword.span().start(),
+            self.block.open_brace.span().start(),
+        )
+    }
+
+    /// Header comments are deliberately kept verbatim. The structured header
+    /// layout canonicalizes whitespace and commas, but does not otherwise have
+    /// enough information to place a line comment without changing its line.
+    /// The trivia classifier catches both line and block comments here.
+    fn header_requires_verbatim(&self, input: &Printer<'_>) -> bool {
+        let header_start = self.keyword.span().start();
+        let block_start = self.block.open_brace.span().start();
+        input.trivia.all_trivia().iter().any(|trivia| {
+            let attached_at = trivia.attached_to().start();
+            trivia.is_comment() && attached_at >= header_start && attached_at <= block_start
+        })
+    }
+
+    /// Width of the header (`spawn`, optional name, optional `with` clause)
+    /// without the body block. `None` if any part can never be single-lined.
+    fn header_single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
+        if self.header_requires_verbatim(input) {
+            return None;
+        }
+        let mut len = usize::from(self.keyword.span().len());
+        if let Some(name) = &self.name {
+            len += const { " ".len() } + name.single_line_width(input)?;
+        }
+        if let Some((with_kw, options)) = &self.with_clause {
+            len += const { " ".len() } + usize::from(with_kw.span().len());
+            for (i, (expr, _)) in options.iter().enumerate() {
+                len += if i == 0 {
+                    const { " ".len() }
+                } else {
+                    const { ", ".len() }
+                };
+                len += expr.single_line_width(input)?;
+            }
+        }
+        Some(len)
+    }
+
+    /// Returns the width of the expression if it fits on a single line —
+    /// a simple body (`{}` or `{ tail }`) and a single-lineable header.
+    /// Returns `None` if it can never be single-lined.
+    pub(crate) fn single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
+        if !self.block.stmts.is_empty() {
+            return None;
+        }
+        let header = self.header_single_line_width(input)?;
+        let (_, open_trailing) = input
+            .trivia
+            .get_for_range_split(self.block.open_brace.span());
+        let (close_leading, _) = input
+            .trivia
+            .get_for_range_split(self.block.close_brace.span());
+        let body = match self.block.expr.as_deref() {
+            Some(tail) => {
+                let (tail_leading, tail_trailing) = input.trivia.get_for_element(tail);
+                (const { " {  }".len() })
+                    + open_trailing.try_squished_len(input.input)?
+                    + tail_leading.try_squished_len(input.input)?
+                    + tail.single_line_width(input)?
+                    + tail_trailing.try_squished_len(input.input)?
+                    + close_leading.try_squished_len(input.input)?
+            }
+            None => {
+                if open_trailing.iter().any(EmittableTrivia::is_comment)
+                    || close_leading.iter().any(EmittableTrivia::is_comment)
+                {
+                    return None;
+                }
+                const { " {}".len() }
+            }
+        };
+        Some(header + body)
+    }
+
+    /// Prints the header: `spawn`, then the optional name and `with` clause.
+    /// Returns whether any part spilled onto multiple lines.
+    fn print_header(&self, shape: &Shape, printer: &mut Printer) -> bool {
+        let mut multi_lined = false;
+        printer.print_raw_token(&self.keyword);
+        if let Some(name) = &self.name {
+            printer.print_str(" ");
+            multi_lined |= printer.print(name, shape.clone()).multi_lined;
+        }
+        if let Some((with_kw, options)) = &self.with_clause {
+            printer.print_str(" ");
+            printer.print_raw_token(with_kw);
+            for (i, (expr, _)) in options.iter().enumerate() {
+                printer.print_str(if i == 0 { " " } else { ", " });
+                multi_lined |= printer.print(expr, shape.clone()).multi_lined;
+            }
+        }
+        multi_lined
+    }
+
+    /// Single-line layout: `spawn name? (with opts)? {}` or `… { tail }`.
+    /// Only possible when the body has no statements.
+    ///
+    /// Should be passed a sub-printer to avoid printing trivia in the outer
+    /// printer in the event that the expression cannot fit on a single line.
+    fn try_print_single_line(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
+        if !self.block.stmts.is_empty() || self.header_requires_verbatim(printer) {
+            return None;
+        }
+        if self.print_header(&Shape::unlimited_single_line(), printer) {
+            return None;
+        }
+        printer.print_str(" ");
+
+        let (_, open_trailing) = printer
+            .trivia
+            .get_for_range_split(self.block.open_brace.span());
+        let (close_leading, _) = printer
+            .trivia
+            .get_for_range_split(self.block.close_brace.span());
+        match self.block.expr.as_deref() {
+            Some(tail) => {
+                printer.print_raw_token(&self.block.open_brace);
+                printer.print_str(" ");
+                printer.try_print_trivia_single_line_squished(open_trailing)?;
+                let (tail_leading, tail_trailing) = printer.trivia.get_for_element(tail);
+                printer.try_print_trivia_single_line_squished(tail_leading)?;
+                if printer
+                    .print(tail, Shape::unlimited_single_line())
+                    .multi_lined
+                {
+                    return None;
+                }
+                printer.try_print_trivia_single_line_squished(tail_trailing)?;
+                printer.try_print_trivia_single_line_squished(close_leading)?;
+                printer.print_str(" ");
+                printer.print_raw_token(&self.block.close_brace);
+            }
+            None => {
+                if open_trailing.iter().any(EmittableTrivia::is_comment)
+                    || close_leading.iter().any(EmittableTrivia::is_comment)
+                {
+                    return None;
+                }
+                printer.print_raw_token(&self.block.open_brace);
+                printer.print_raw_token(&self.block.close_brace);
+            }
+        }
+
+        if printer.output.len() > shape.width {
+            None
+        } else {
+            Some(PrintInfo::default_single_line())
+        }
+    }
+}
+
+impl PrintMultiLine for SpawnExpr {
+    /// Multi-line layout: the header stays on the current line and the block
+    /// opens right after it, closing at the outer indent.
+    ///
+    /// ```baml
+    /// spawn with baml.spawn.options(group = g) {
+    ///     compute()
+    /// }
+    /// ```
+    fn print_multi_line(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        if self.header_requires_verbatim(printer) {
+            printer.print_input_range(self.header_range());
+        } else {
+            self.print_header(&shape, printer);
+            printer.print_str(" ");
+        }
+        printer.print(&self.block, shape);
+        PrintInfo::default_multi_lined()
+    }
+}
+
+impl Printable for SpawnExpr {
+    fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        printer
+            .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .unwrap_or_else(|| self.print_multi_line(shape, printer))
+    }
+    fn leftmost_token(&self) -> TextRange {
+        self.keyword.span()
+    }
+    fn rightmost_token(&self) -> TextRange {
+        self.block.rightmost_token()
+    }
+}
+
 // ─── PrintChain ───────────────────────────────────────────────────────────────
 
 /// Only used for printing chained expressions.
@@ -4951,7 +5346,15 @@ impl PrintChain<'_> {
         }
     }
 
-    fn try_print_single_line(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
+    /// Prints `first` followed by `members` in single-line form. Returns
+    /// `None` if any element refuses to single-line. The final total-width
+    /// check is left to the caller.
+    fn try_print_members_single_line(
+        &self,
+        members: &[PrintChainItem<'_>],
+        shape: &Shape,
+        printer: &mut Printer,
+    ) -> Option<()> {
         match self.first {
             Expression::Path(path_expr) => {
                 printer.print_raw_token(&path_expr.first);
@@ -4990,7 +5393,7 @@ impl PrintChain<'_> {
                 }
             }
         }
-        for item in &self.chain_members {
+        for item in members {
             if printer.output.len() > shape.width {
                 return None;
             }
@@ -5022,11 +5425,56 @@ impl PrintChain<'_> {
                 }
             }
         }
+        Some(())
+    }
+
+    fn try_print_single_line(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
+        self.try_print_members_single_line(&self.chain_members, shape, printer)?;
         if printer.output.len() > shape.width {
             None
         } else {
             Some(PrintInfo::default_single_line())
         }
+    }
+
+    /// Hug layout: the whole chain prints on one line except the final call,
+    /// whose trailing block-terminal argument hugs the parens (see
+    /// [`CallArgs::try_print_hug`]).
+    ///
+    /// ```baml
+    /// futures.push(spawn {
+    ///     work(c)
+    /// });
+    /// ```
+    ///
+    /// Should be passed a sub-printer to avoid printing partial output in the
+    /// event that the hug layout does not apply.
+    fn try_print_hug(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
+        let (last, prefix) = self.chain_members.split_last()?;
+        let (question_dot, call_args) = match last {
+            PrintChainItem::Call(args) => (None, *args),
+            PrintChainItem::OptionalCall(qd, args) => (Some(*qd), *args),
+            _ => return None,
+        };
+        if !call_args.can_hug() {
+            return None;
+        }
+        self.try_print_members_single_line(prefix, shape, printer)?;
+        if printer.output.len() > shape.width {
+            return None;
+        }
+        if let Some(qd) = question_dot {
+            printer.print_raw_token(qd);
+        }
+        let hug_shape = Shape {
+            width: shape.width,
+            indent: shape.indent,
+            // `try_print_hug` runs in this same sub-printer, so its
+            // `current_line_len()` already includes the printed chain prefix.
+            // Keep only the offset that existed before this chain began.
+            first_line_offset: shape.first_line_offset,
+        };
+        call_args.try_print_hug(&hug_shape, printer)
     }
 }
 
@@ -5034,6 +5482,7 @@ impl Printable for PrintChain<'_> {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         printer
             .try_sub_printer(|p| self.try_print_single_line(&shape, p))
+            .or_else(|| printer.try_sub_printer(|p| self.try_print_hug(&shape, p)))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {

--- a/baml_language/crates/baml_fmt/src/ast/tokens.rs
+++ b/baml_language/crates/baml_fmt/src/ast/tokens.rs
@@ -86,6 +86,7 @@ define_keyword_tokens! {
     "instanceof" => SyntaxKind::KW_INSTANCEOF => Instanceof;
     "is" => SyntaxKind::KW_IS => Is;
     "dynamic" => SyntaxKind::KW_DYNAMIC => Dynamic;
+    "spawn" => SyntaxKind::KW_SPAWN => Spawn;
     "with" => SyntaxKind::KW_WITH => With;
     "throws" => SyntaxKind::KW_THROWS => Throws;
     "type" => SyntaxKind::KW_TYPE => TypeKw;

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -403,6 +403,135 @@ mod linear_formatter_regression_tests {
 }
 
 #[cfg(test)]
+mod spawn_and_hug_format_tests {
+    use super::*;
+
+    fn assert_formats_to(source: &str, expected: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert_eq!(formatted, expected);
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// A relocated `spawn { … }` body reindents like any block instead of
+    /// printing verbatim at its original columns, and a call whose sole
+    /// argument is a spawn hugs the parens (`push(spawn {` … `});`).
+    #[test]
+    fn test_spawn_call_arg_hugs_parens() {
+        let source = "function f(calls: int[]) -> int[] {\n    let futures: baml.future.Future<int, null>[] = [];\n    for (let c in calls) {\n        futures\n            .push(\n                spawn {\n            compute_something_with(c, \"a long string to push this past the line width limit!\")\n        },\n            );\n    }\n    await baml.future.all(futures)\n}\n";
+        let expected = "function f(calls: int[]) -> int[] {\n    let futures: baml.future.Future<int, null>[] = [];\n    for (let c in calls) {\n        futures.push(spawn {\n            compute_something_with(c, \"a long string to push this past the line width limit!\")\n        });\n    }\n    await baml.future.all(futures)\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// A lambda argument hugs the call parens the same way, including with
+    /// leading non-block arguments on the call line.
+    #[test]
+    fn test_trailing_lambda_arg_hugs_parens() {
+        let source = "function f(rows: int[]) -> int {\n    rows.reduce(0, (acc: int, x: int) -> {\n        acc + x + 1000000 + 2000000 + 3000000 + 4000000 + 5000000 + 6000000\n    })\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    /// Width used by a hugged trailing argument includes the chain prefix
+    /// exactly once. Double-counting `receiver.method` would wrap parameters
+    /// even though this lambda header fits the configured line width.
+    #[test]
+    fn test_hug_width_accounts_for_chain_prefix_once() {
+        let source = "function f() -> int {\n    receiver.method((a: int, b: int) -> {\n        a + b\n    })\n}\n";
+        let options = FormatOptions {
+            line_width: 45,
+            ..FormatOptions::default()
+        };
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert_eq!(formatted, source);
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// The hug layout may remove the trailing comma, but comments attached to
+    /// the final argument and comma must remain in the formatted output.
+    #[test]
+    fn test_hug_preserves_trailing_argument_comments() {
+        let source = "function f() -> int {\n    consume(0, /* before spawn */ spawn {\n        let x = 1;\n        x\n    } /* after spawn */, /* after comma */)\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        for marker in [
+            "/* before spawn */",
+            "/* after spawn */",
+            "/* after comma */",
+        ] {
+            assert!(
+                formatted.contains(marker),
+                "hug comment {marker} must survive, got:\n{formatted}"
+            );
+        }
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// A simple spawn body (`{ tail }`) stays on one line when it fits.
+    #[test]
+    fn test_simple_spawn_stays_single_line() {
+        let source = "function f() -> int {\n    let nm = \"n\";\n    let a = spawn nm { 7 };\n    let b = spawn with baml.spawn.options(name = nm) { 8 };\n    (await a) + (await b)\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    /// A spawn body with statements expands into a normal indented block.
+    #[test]
+    fn test_multi_statement_spawn_body_expands() {
+        let source =
+            "function f() -> int {\n    let a = spawn { let x = 1; x + 1 };\n    await a\n}\n";
+        let expected = "function f() -> int {\n    let a = spawn {\n        let x = 1;\n        x + 1\n    };\n    await a\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// An empty block with no interior comment collapses to `{}` — most
+    /// visibly in match arms (`null => {},`) and empty `if` bodies.
+    #[test]
+    fn test_empty_blocks_collapse() {
+        let source = "function f(p: string?) -> int {\n    match (p) {\n        null => {\n        },\n        let t: string => {\n            log(t);\n        },\n    }\n    if (p == null) {\n    }\n    0\n}\n";
+        let expected = "function f(p: string?) -> int {\n    match (p) {\n        null => {},\n        let t: string => {\n            log(t);\n        },\n    }\n    if (p == null) {}\n    0\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// An empty block that holds a comment must NOT collapse — the comment
+    /// would be lost.
+    #[test]
+    fn test_empty_block_with_comment_stays_multi_line() {
+        let source = "function f(p: string?) -> int {\n    if (p == null) {\n        // nothing to do\n    }\n    0\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert!(
+            formatted.contains("// nothing to do"),
+            "interior comment must survive, got:\n{formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    #[test]
+    fn test_spawn_header_comments_are_preserved() {
+        let source = "function f(name: string) -> int {\n    let future = spawn // after spawn\n        name /* before with */ with /* before first */ first(), /* after comma */ second() /* before body */ { 1 };\n    await future\n}\n";
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        for marker in [
+            "// after spawn",
+            "/* before with */",
+            "/* before first */",
+            "/* after comma */",
+            "/* before body */",
+        ] {
+            assert!(
+                formatted.contains(marker),
+                "spawn header comment {marker} must survive, got:\n{formatted}"
+            );
+        }
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+}
+
+#[cfg(test)]
 mod pattern_format_tests {
     use super::*;
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__10_formatter__demo.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__10_formatter__demo.snap
@@ -5,12 +5,9 @@ function sum_array(arr: int[]) -> int {
     let sum = 0;
     let total = [];
     for (let i in arr) {
-        total
-            .push(
-                () -> {
-                    sum += i;
-                },
-            )
+        total.push(() -> {
+            sum += i;
+        })
     }
     for (let cb in total) {
         cb();

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__10_formatter__lambda_advanced.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__10_formatter__lambda_advanced.snap
@@ -4,29 +4,20 @@ source: crates/baml_tests/src/generated_tests.rs
 // ── Chained map: two-step transform ───────────────────────────────
 function test_chained_map() -> int[] {
     let items: int[] = [1, 2, 3];
-    let step1: int[] = items
-        .map(
-            (x) -> {
-                x * 10
-            },
-        );
-    step1
-        .map(
-            (x) -> {
-                x + 1
-            },
-        )
+    let step1: int[] = items.map((x) -> {
+        x * 10
+    });
+    step1.map((x) -> {
+        x + 1
+    })
 }
 
 // ── Map over strings to ints ──────────────────────────────────────
 function test_map_string_to_int() -> int[] {
     let words: string[] = ["hello", "world"];
-    words
-        .map(
-            (w: string) -> int {
-                w.length()
-            },
-        )
+    words.map((w: string) -> int {
+        w.length()
+    })
 }
 
 // ── Lambda returning a lambda (higher-order return) ───────────────
@@ -94,41 +85,30 @@ function test_lambda_with_if() -> string {
 function test_map_with_capture() -> int[] {
     let items: int[] = [1, 2, 3];
     let factor = 10;
-    items
-        .map(
-            (x) -> {
-                x * factor
-            },
-        )
+    items.map((x) -> {
+        x * factor
+    })
 }
 
 // ── Nested map: map inside a map callback ────────────────────────
 function test_nested_map() -> int[][] {
     let matrix: int[][] = [[1, 2], [3, 4]];
     // Flatten-map: for each row, map and collect
-    matrix
-        .map(
-            (row: int[]) -> {
-                row.map(
-                    (x) -> {
-                        x * x
-                    },
-                )
-            },
-        )
+    matrix.map((row: int[]) -> {
+        row.map((x) -> {
+            x * x
+        })
+    })
 }
 
 // ── Map with multi-statement lambda body ─────────────────────────
 function test_map_multi_statement() -> int[] {
     let items: int[] = [1, 2, 3];
-    items
-        .map(
-            (x) -> {
-                let doubled = x * 2;
-                let offset = 100;
-                doubled + offset
-            },
-        )
+    items.map((x) -> {
+        let doubled = x * 2;
+        let offset = 100;
+        doubled + offset
+    })
 }
 
 // ── Lambda assigned then passed ──────────────────────────────────
@@ -144,12 +124,9 @@ function test_lambda_variable_then_pass() -> int[] {
 function test_shadowing() -> string {
     let x = "999";
     let items: int[] = [1, 2, 3];
-    let mapped: int[] = items
-        .map(
-            (x) -> {
-                x + 1
-            },
-        );
+    let mapped: int[] = items.map((x) -> {
+        x + 1
+    });
     for (let y in mapped) {
         let i = 0;
         while (i < y) {
@@ -189,12 +166,9 @@ function test_optional_return() -> int? {
 // ── map with no annotations at all: param AND return inferred ────
 function test_fully_inferred_map() -> int[] {
     let items: int[] = [1, 2, 3];
-    items
-        .map(
-            (x) -> {
-                x * 2
-            },
-        )
+    items.map((x) -> {
+        x * 2
+    })
     // x: int inferred from T in Array<int>.map
     // return: int inferred from body x * 2
     // U binds to int, result is int[]
@@ -203,15 +177,13 @@ function test_fully_inferred_map() -> int[] {
 // ── map where return type changes: infer U != T ──────────────────
 function test_map_type_change_inferred() -> string[] {
     let nums: int[] = [1, 2, 3];
-    nums.map(
-        (n) -> {
-            match (n) {
-                1 => "one",
-                2 => "two",
-                _ => "other",
-            }
-        },
-    )
+    nums.map((n) -> {
+        match (n) {
+            1 => "one",
+            2 => "two",
+            _ => "other",
+        }
+    })
     // n: int inferred, return: string inferred from match body
     // U binds to "one"|"two"|"other", result is string[]?
 }
@@ -219,12 +191,9 @@ function test_map_type_change_inferred() -> string[] {
 // ── Lambda returning literal 0 — does U bind to 0 or int? ───────
 function test_literal_return_inference() -> int[] {
     let items: int[] = [1, 2, 3];
-    items
-        .map(
-            (x) -> {
-                0
-            },
-        )
+    items.map((x) -> {
+        0
+    })
     // body returns literal 0, U binds to 0 (literal type)
     // result is 0[], function returns int[] — needs 0 <: int
 }
@@ -232,18 +201,12 @@ function test_literal_return_inference() -> int[] {
 // ── Compose: fully inferred lambdas ──────────────────────────────
 function test_compose_inferred() -> int[] {
     let items: int[] = [1, 2, 3];
-    let step1: int[] = items
-        .map(
-            (x) -> {
-                x * 2
-            },
-        );
-    step1
-        .map(
-            (x) -> {
-                x + 1
-            },
-        )
+    let step1: int[] = items.map((x) -> {
+        x * 2
+    });
+    step1.map((x) -> {
+        x + 1
+    })
     // Both lambdas: x inferred as int, return inferred as int
 }
 
@@ -326,12 +289,9 @@ function test_lambda_in_match_inferred() -> int {
 function test_capture_in_map_inferred() -> int[] {
     let items: int[] = [1, 2, 3];
     let factor = 10;
-    items
-        .map(
-            (x) -> {
-                x * factor
-            },
-        )
+    items.map((x) -> {
+        x * factor
+    })
     // x inferred as int, factor captured as int, return int
 }
 
@@ -374,15 +334,12 @@ function test_capture_lambda_inferred() -> int {
 // ── Map over optional array: param type int? inferred ────────────
 function test_map_optional_inferred() -> int[] {
     let items: int?[] = [1, null, 3];
-    items
-        .map(
-            (x) -> {
-                match (x) {
-                    null => 0,
-                    _ => 1,
-                }
-            },
-        )
+    items.map((x) -> {
+        match (x) {
+            null => 0,
+            _ => 1,
+        }
+    })
     // x: int? inferred from T in Array<int?>.map
     // return: 0|1 inferred from match
 }
@@ -391,12 +348,9 @@ function test_map_optional_inferred() -> int[] {
 function test_shadowing_inferred() -> int[] {
     let x = "not a number";
     let items: int[] = [1, 2, 3];
-    items
-        .map(
-            (x) -> {
-                x + 1
-            },
-        )
+    items.map((x) -> {
+        x + 1
+    })
     // lambda x: int (from map context), shadows outer x: string
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__10_formatter__lambda_basic.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__10_formatter__lambda_basic.snap
@@ -28,12 +28,9 @@ function test_zero_param() -> int {
 // Lambda passed to higher-order function with inferred param types
 function test_map_inferred() -> int[] {
     let items: int[] = [1, 2, 3];
-    items
-        .map(
-            (x) -> {
-                x * 2
-            },
-        )
+    items.map((x) -> {
+        x * 2
+    })
 }
 
 // Lambda with throws clause

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__10_formatter__patterns_new.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__10_formatter__patterns_new.snap
@@ -112,18 +112,14 @@ function call_with_callback(
 ) -> int {
     match (runner) {
         let r: ((int) -> int throws never) -> int throws never => {
-            r(
-                (x: int) -> int {
-                    x + 1
-                },
-            )
+            r((x: int) -> int {
+                x + 1
+            })
         },
         let r: ((string) -> int throws never) -> int throws never => {
-            r(
-                (s: string) -> int {
-                    0
-                },
-            )
+            r((s: string) -> int {
+                0
+            })
         },
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/captured_field_chain/baml_tests__diagnostic_errors__captured_field_chain__10_formatter__captured_field_chain.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/captured_field_chain/baml_tests__diagnostic_errors__captured_field_chain__10_formatter__captured_field_chain.snap
@@ -17,24 +17,18 @@ class Outer {
 // `outer.inner.value` inside the lambda should resolve via Place::Capture,
 // not fall back to Null because `outer` isn't in self.locals.
 function test_captured_chain(outer: Outer) -> int {
-    let result = [1]
-        .map(
-            (x) -> {
-                outer.inner.value
-            },
-        );
+    let result = [1].map((x) -> {
+        outer.inner.value
+    });
     result[0]
 }
 
 // Issue #1 variant: captured root used as method receiver inside lambda.
 // `outer.inner` should resolve through capture, not produce a dummy temp.
 function test_captured_method(outer: Outer) -> string {
-    let result = [1]
-        .map(
-            (x) -> {
-                outer.name
-            },
-        );
+    let result = [1].map((x) -> {
+        outer.name
+    });
     result[0]
 }
 

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/function_type_missing_throws/baml_tests__diagnostic_errors__function_type_missing_throws__10_formatter__negative.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/function_type_missing_throws/baml_tests__diagnostic_errors__function_type_missing_throws__10_formatter__negative.snap
@@ -16,11 +16,9 @@ function let_annotation() -> int {
 }
 
 function nested_param(cb: ((value: int) -> int) -> int) -> int {
-    cb(
-        (value: int) -> int {
-            value
-        },
-    )
+    cb((value: int) -> int {
+        value
+    })
 }
 
 function optional_param(cb: ((value: int) -> int)?) -> int {

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/function_type_missing_throws/baml_tests__diagnostic_errors__function_type_missing_throws__10_formatter__positive.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/function_type_missing_throws/baml_tests__diagnostic_errors__function_type_missing_throws__10_formatter__positive.snap
@@ -27,11 +27,9 @@ function lambda_explicit_callback() -> int {
 }
 
 function explicit_nested(cb: ((value: int) -> int throws never) -> int) -> int {
-    cb(
-        (value: int) -> int {
-            value
-        },
-    )
+    cb((value: int) -> int {
+        value
+    })
 }
 
 function explicit_let() -> int {

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/lambda_errors/baml_tests__diagnostic_errors__lambda_errors__10_formatter__lambda_errors.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/lambda_errors/baml_tests__diagnostic_errors__lambda_errors__10_formatter__lambda_errors.snap
@@ -20,23 +20,17 @@ function test_no_annotation_no_context() -> int {
 // Arity mismatch: lambda has wrong number of params for expected type
 function test_arity_mismatch() -> int[] {
     let items: int[] = [1, 2, 3];
-    items
-        .map(
-            (x, y) -> {
-                x
-            },
-        )
+    items.map((x, y) -> {
+        x
+    })
 }
 
 // Wrong param type annotation vs expected
 function test_param_type_mismatch() -> int[] {
     let items: int[] = [1, 2, 3];
-    items
-        .map(
-            (x: string) -> {
-                x
-            },
-        )
+    items.map((x: string) -> {
+        x
+    })
 }
 
 // Unknown type name in lambda param annotation (should report UnresolvedType)

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__10_formatter__void_lambda.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__10_formatter__void_lambda.snap
@@ -3,16 +3,14 @@ source: crates/baml_tests/src/generated_tests.rs
 ---
 // Void lambda with explicit annotation
 function test_void_lambda() -> int {
-    let f = () -> void {
-    };
+    let f = () -> void {};
     f();
     1
 }
 
 // ERROR: assigning void lambda result
 function test_void_lambda_assign() -> int {
-    let f = () -> void {
-    };
+    let f = () -> void {};
     let x = f();
     1
 }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__10_formatter__void_return_type.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__10_formatter__void_return_type.snap
@@ -2,8 +2,7 @@
 source: crates/baml_tests/src/generated_tests.rs
 ---
 // Basic void function — empty body
-function do_nothing() -> void {
-}
+function do_nothing() -> void {}
 
 // Void function with bare return
 function do_return() -> void {


### PR DESCRIPTION
## Root cause

The formatter had no structured representation or dedicated layout for `spawn` expressions, and generic call formatting could over-expand calls whose final argument was a block-like lambda or `spawn`. That produced unstable indentation, detached closing parentheses, inaccurate width budgeting for chained calls, and risked losing trivia around trailing arguments.

## Scope

- add structured formatter support for `spawn name? (with ...)? { ... }`
- keep simple spawn bodies inline and expand multi-statement bodies with normal block indentation
- hug trailing lambda and spawn arguments to call parentheses when the layout fits
- account for chained-call prefixes in width calculations
- collapse truly empty blocks while preserving blocks containing comments
- preserve spawn-header and trailing-argument comments
- add focused formatter regression coverage for each layout and trivia case

All formatter fixes are contained in this single PR and only touch `crates/baml_fmt`.

## User impact

`baml fmt` now produces compact, stable formatting for spawn expressions and trailing block arguments without dropping comments or miscounting line width.

## Validation

- `cargo nextest run -p baml_fmt` (91 passed)
- `cargo fmt --all --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the formatter’s AST and print logic; no runtime, compiler, or auth behavior is affected, though output diffs may surprise users until they re-fmt.
> 
> **Overview**
> **`baml fmt`** now treats **`spawn`** (BEP-034) as a first-class expression instead of verbatim `Unknown` text: optional name, optional **`with`** options, and body get dedicated CST lowering, width, and print paths (inline simple bodies, expanded blocks, verbatim header when header comments would be lost).
> 
> **Call and chain layout** gains a **hug** style when the last argument is a **lambda** or **spawn** block—e.g. `futures.push(spawn { … })`—including for method chains, with trailing-comma trivia preserved and **`first_line_offset`** fixed so callee/chain prefix isn’t double-counted in line-width budgets.
> 
> **Empty blocks** without interior comments collapse to **`{}`** (match arms, void lambdas, empty `if` bodies). Regression tests and formatter snapshots reflect the new output (notably compact **`.map((x) -> { … })`** forms).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15d0b8f6db50fcc58d2410d320825d2b2b2b4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added formatter support for `spawn` expressions, including optional names and `with` clauses.
  - Supports concise single-line formatting for simple spawn bodies and structured multi-line formatting for larger blocks.

- **Improvements**
  - Improved call formatting for block-style arguments, including lambdas and spawn expressions.
  - Empty blocks now format as `{}` when appropriate.
  - Preserved comments and header spacing during formatting.
  - Improved line-width calculations and indentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->