### PR TITLE
Preserve SAP parsing type and value fidelity

### DIFF
--- a/baml_language/crates/baml_tests/baml_src/ns_generic_union_returns/generic_union_returns.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_generic_union_returns/generic_union_returns.baml
@@ -1,0 +1,76 @@
+class FinalValue {
+  value string
+}
+
+class PendingCalls {
+  calls string[]
+}
+
+class ModelStep<T> {
+  outcome T | PendingCalls
+}
+
+class ParsedChild {
+  name string
+}
+
+enum ParsedStatus {
+  Ready
+}
+
+class ParsedNullableContainers {
+  empty_json json[]?
+  metadata map<string, json>?
+  children ParsedChild[]?
+  statuses ParsedStatus[]?
+}
+
+function parse_model_step<T>(raw string) -> ModelStep<T> throws unknown {
+  ModelStep<T> {
+    outcome: baml.llm.parse<T | PendingCalls, T | PendingCalls>(raw),
+  }
+}
+
+function model_step_flattens_union_type_arg() -> bool throws unknown {
+  let step = parse_model_step<FinalValue | string>(`"done"`);
+  match (step.outcome) {
+    let value: string => value == "done",
+    let value: FinalValue => value.value == "never",
+    let calls: PendingCalls => calls.calls.length() == 99,
+  }
+}
+
+function sap_parses_optional_json_null() -> bool throws unknown {
+  let parsed = baml.llm.parse<json?, json?>(`null`);
+  match (parsed) {
+    null => true,
+    let value: json => baml.json.stringify(value) == "never",
+  }
+}
+
+function sap_parses_optional_json_value() -> bool throws unknown {
+  let parsed = baml.llm.parse<json?, json?>(`true`);
+  baml.json.stringify(parsed) == "true"
+}
+
+function sap_nullable_container_types_are_preserved() -> bool throws unknown {
+  let parsed = baml.llm.parse<ParsedNullableContainers, ParsedNullableContainers>(
+    `{
+      "empty_json": [],
+      "metadata": {"attempt": 1},
+      "children": [{"name": "first"}],
+      "statuses": ["Ready"]
+    }`
+  );
+  // These annotations are the static regression: SAP must preserve each
+  // declared container type through the nullable wrapper.
+  let empty_json: json[]? = parsed.empty_json;
+  let metadata: map<string, json>? = parsed.metadata;
+  let children: ParsedChild[]? = parsed.children;
+  let statuses: ParsedStatus[]? = parsed.statuses;
+  let empty_ok = (empty_json?.length() ?? -1) == 0;
+  let map_ok = (metadata?.length() ?? 0) == 1;
+  let children_ok = children?.at(0)?.name == "first";
+  let statuses_ok = statuses?.at(0) == ParsedStatus.Ready;
+  empty_ok && map_ok && children_ok && statuses_ok
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/generic_union_returns.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/generic_union_returns.snap
@@ -1,0 +1,260 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function generic_union_returns.model_step_flattens_union_type_arg() -> bool {
+    load_type generic_union_returns.FinalValue | string
+    load_const "\"done\""
+    call user.generic_union_returns.parse_model_step
+    load_field .outcome
+    store_var _3
+    load_var _3
+    store_var _4
+    load_var _4
+    narrow_bind string, slot=2
+    pop_jump_if_false L0
+    jump L3
+
+  L0:
+    load_var _3
+    store_var _7
+    load_var _7
+    narrow_bind generic_union_returns.FinalValue, slot=3
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_var _3
+    load_field .calls
+    container_len
+    store_var _11
+    load_var _11
+    load_const 99
+    cmp_int_op ==
+    jump L4
+
+  L2:
+    load_var _7
+    load_field .value
+    load_const "never"
+    cmp_op ==
+    jump L4
+
+  L3:
+    load_var _4
+    load_const "done"
+    cmp_op ==
+
+  L4:
+    return
+}
+
+function generic_union_returns.parse_model_step(raw: string) -> generic_union_returns.ModelStep<T> {
+    load_type #0 | generic_union_returns.PendingCalls
+    load_type #0 | generic_union_returns.PendingCalls
+    load_var raw
+    call baml.llm.parse
+    load_type #0
+    init_instance<1> user.generic_union_returns.ModelStep .outcome
+    return
+}
+
+function generic_union_returns.sap_nullable_container_types_are_preserved() -> bool {
+    load_type generic_union_returns.ParsedNullableContainers
+    load_type generic_union_returns.ParsedNullableContainers
+    load_const "{\n      \"empty_json\": [],\n      \"metadata\": {\"attempt\": 1},\n      \"children\": [{\"name\": \"first\"}],\n      \"statuses\": [\"Ready\"]\n    }"
+    call baml.llm.parse
+    store_var parsed
+    load_var parsed
+    load_field .empty_json
+    store_var empty_json
+    load_var parsed
+    load_field .metadata
+    store_var metadata
+    load_var parsed
+    load_field .children
+    store_var children
+    load_var parsed
+    load_field .statuses
+    store_var statuses
+    load_var empty_json
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var empty_json
+    make_bound_method baml.Array.length
+    call_indirect
+    store_var _10
+    jump L2
+
+  L1:
+    load_const null
+    store_var _10
+
+  L2:
+    load_var _10
+    store_var _9
+    load_var _10
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L3
+    load_const 1
+    unary_op -
+    store_var _9
+
+  L3:
+    load_var _9
+    load_const 0
+    cmp_int_op ==
+    store_var empty_ok
+    load_var metadata
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L4
+    jump L5
+
+  L4:
+    load_var metadata
+    make_bound_method baml.Map.length
+    call_indirect
+    store_var _18
+    jump L6
+
+  L5:
+    load_const null
+    store_var _18
+
+  L6:
+    load_var _18
+    store_var _17
+    load_var _18
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L7
+    load_const 0
+    store_var _17
+
+  L7:
+    load_var _17
+    load_const 1
+    cmp_int_op ==
+    store_var map_ok
+    load_var children
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L8
+    jump L11
+
+  L8:
+    load_const 0
+    load_var children
+    make_bound_method baml.Array.at
+    call_indirect
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L9
+    jump L11
+
+  L9:
+    load_var children
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L10
+    jump L11
+
+  L10:
+    load_const 0
+    load_var children
+    make_bound_method baml.Array.at
+    call_indirect
+    load_field .0
+    jump L12
+
+  L11:
+    load_const null
+
+  L12:
+    load_const "first"
+    call baml.ops.equals_equals
+    store_var children_ok
+    load_var statuses
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L13
+    jump L14
+
+  L13:
+    load_const 0
+    load_var statuses
+    make_bound_method baml.Array.at
+    call_indirect
+    store_var _38
+    jump L15
+
+  L14:
+    load_const null
+    store_var _38
+
+  L15:
+    load_var _38
+    load_const user.generic_union_returns.ParsedStatus.Ready
+    alloc_variant user.generic_union_returns.ParsedStatus
+    call baml.ops.equals_equals
+    store_var statuses_ok
+    load_var empty_ok
+    jump_if_false L16
+    pop 1
+    load_var map_ok
+
+  L16:
+    jump_if_false L17
+    pop 1
+    load_var children_ok
+
+  L17:
+    jump_if_false L18
+    pop 1
+    load_var statuses_ok
+
+  L18:
+    return
+}
+
+function generic_union_returns.sap_parses_optional_json_null() -> bool {
+    load_type baml.json.json | null
+    load_type baml.json.json | null
+    load_const "null"
+    call baml.llm.parse
+    store_var parsed
+    load_var parsed
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var parsed
+    call baml.json.stringify
+    load_const "never"
+    cmp_op ==
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function generic_union_returns.sap_parses_optional_json_value() -> bool {
+    load_type baml.json.json | null
+    load_type baml.json.json | null
+    load_const "true"
+    call baml.llm.parse
+    call baml.json.stringify
+    load_const "true"
+    cmp_op ==
+    return
+}

--- a/baml_language/crates/baml_tests/tests/generic_union_returns.rs
+++ b/baml_language/crates/baml_tests/tests/generic_union_returns.rs
@@ -1,0 +1,35 @@
+use baml_tests::baml_test;
+use bex_external_types::BexExternalValue;
+
+const SOURCE: &str =
+    include_str!("../baml_src/ns_generic_union_returns/generic_union_returns.baml");
+
+#[tokio::test]
+async fn model_step_flattens_union_type_arg_before_sap_conversion() {
+    let output = baml_test!(
+        baml: SOURCE,
+        entry: "model_step_flattens_union_type_arg"
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn sap_parses_null_as_optional_json() {
+    let output = baml_test!(baml: SOURCE, entry: "sap_parses_optional_json_null");
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn sap_parses_non_null_optional_json_value() {
+    let output = baml_test!(baml: SOURCE, entry: "sap_parses_optional_json_value");
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn sap_preserves_declared_types_for_nullable_containers() {
+    let output = baml_test!(
+        baml: SOURCE,
+        entry: "sap_nullable_container_types_are_preserved"
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}

--- a/baml_language/crates/baml_tests/tests/parse_companions.rs
+++ b/baml_language/crates/baml_tests/tests/parse_companions.rs
@@ -86,3 +86,60 @@ async fn parse_companion_allows_missing_nullable_alias_field() {
         })
     );
 }
+
+#[tokio::test]
+async fn sap_parse_decodes_a_complete_top_level_json_string() {
+    let output = baml_test!(
+        r##"
+        client<llm> TestClient {
+            provider openai
+            options {
+                model "gpt-4o-mini"
+                api_key "test-key"
+                base_url "http://localhost:1234"
+            }
+        }
+
+        function ParseString() -> string {
+            client TestClient
+            prompt #"{{ ctx.output_format }}"#
+        }
+
+        function main() -> string {
+            ParseString$parse(`"Fred"`)
+        }
+        "##
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::String("Fred".into())));
+}
+
+#[tokio::test]
+async fn sap_parse_preserves_plain_llm_text() {
+    let output = baml_test!(
+        r##"
+        client<llm> TestClient {
+            provider openai
+            options {
+                model "gpt-4o-mini"
+                api_key "test-key"
+                base_url "http://localhost:1234"
+            }
+        }
+
+        function ParseString() -> string {
+            client TestClient
+            prompt #"{{ ctx.output_format }}"#
+        }
+
+        function main() -> string {
+            ParseString$parse("Fred says hello")
+        }
+        "##
+    );
+
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("Fred says hello".into()))
+    );
+}

--- a/baml_language/crates/baml_type/src/simplify_sap.rs
+++ b/baml_language/crates/baml_type/src/simplify_sap.rs
@@ -310,13 +310,27 @@ pub fn simplify(
     aliases: &HashMap<TypeName, RuntimeTy>,
     recursive_aliases: &HashSet<TypeName>,
 ) -> RuntimeTy {
-    simplify_impl(ty, aliases, recursive_aliases)
+    simplify_impl(ty, aliases, recursive_aliases, false)
+}
+
+/// Simplify a runtime-materialized SAP parse target.
+///
+/// In addition to [`simplify`], this expands a recursive union alias when it
+/// appears directly as another union's member. This turns `json | null` into a
+/// flat union while retaining recursive `json` references below lists/maps.
+pub fn simplify_parse_target(
+    ty: RuntimeTy,
+    aliases: &HashMap<TypeName, RuntimeTy>,
+    recursive_aliases: &HashSet<TypeName>,
+) -> RuntimeTy {
+    simplify_impl(ty, aliases, recursive_aliases, true)
 }
 
 fn simplify_impl(
     ty: RuntimeTy,
     aliases: &HashMap<TypeName, RuntimeTy>,
     recursive: &HashSet<TypeName>,
+    expand_recursive_alias_unions: bool,
 ) -> RuntimeTy {
     match ty {
         RuntimeTy::TypeAlias(ref name, ref outer_attr) => {
@@ -327,22 +341,44 @@ fn simplify_impl(
                 // Non-recursive: expand, merge attrs (nesting), simplify result.
                 let merged = merge_attr_nested(target.attr(), outer_attr);
                 let expanded = target.clone().with_attr(merged);
-                simplify_impl(expanded, aliases, recursive)
+                simplify_impl(expanded, aliases, recursive, expand_recursive_alias_unions)
             } else {
                 // Unknown alias — leave as-is.
                 ty
             }
         }
 
-        RuntimeTy::Union(variants, attr) => simplify_union(variants, attr, aliases, recursive),
+        RuntimeTy::Union(variants, attr) => simplify_union(
+            variants,
+            attr,
+            aliases,
+            recursive,
+            expand_recursive_alias_unions,
+        ),
 
         // Recurse into compound types.
-        RuntimeTy::List(inner, attr) => {
-            RuntimeTy::List(Box::new(simplify_impl(*inner, aliases, recursive)), attr)
-        }
+        RuntimeTy::List(inner, attr) => RuntimeTy::List(
+            Box::new(simplify_impl(
+                *inner,
+                aliases,
+                recursive,
+                expand_recursive_alias_unions,
+            )),
+            attr,
+        ),
         RuntimeTy::Map { key, value, attr } => RuntimeTy::Map {
-            key: Box::new(simplify_impl(*key, aliases, recursive)),
-            value: Box::new(simplify_impl(*value, aliases, recursive)),
+            key: Box::new(simplify_impl(
+                *key,
+                aliases,
+                recursive,
+                expand_recursive_alias_unions,
+            )),
+            value: Box::new(simplify_impl(
+                *value,
+                aliases,
+                recursive,
+                expand_recursive_alias_unions,
+            )),
             attr,
         },
 
@@ -360,27 +396,38 @@ fn simplify_union(
     attr: TyAttr,
     aliases: &HashMap<TypeName, RuntimeTy>,
     recursive: &HashSet<TypeName>,
+    expand_recursive_alias_unions: bool,
 ) -> RuntimeTy {
     // 1. Simplify each variant recursively.
     let variants: Vec<RuntimeTy> = variants
         .into_iter()
-        .map(|v| simplify_impl(v, aliases, recursive))
+        .map(|v| simplify_impl(v, aliases, recursive, expand_recursive_alias_unions))
         .collect();
 
-    // 2. Distribute outer attrs into variants.
+    // 2. A recursive alias may itself be a union. It must stay named under an
+    // indirection such as `json[]`, but when used directly as another union's
+    // member (`json | null`) its immediate variants must be spliced into this
+    // union so SAP never receives an alias-hidden nested union.
+    let variants = if expand_recursive_alias_unions {
+        expand_recursive_union_aliases(variants, aliases, recursive)
+    } else {
+        variants
+    };
+
+    // 3. Distribute outer attrs into variants.
     //    SAP flags: or'd in, kept at union level.
     let (variants, attr) = distribute_attrs(variants, attr);
 
-    // 3. Flatten nested unions.
+    // 4. Flatten nested unions.
     let variants = flatten_union(variants);
 
-    // 4. Deduplicate (attr-aware subtyping).
+    // 5. Deduplicate (attr-aware subtyping).
     let variants = dedup_variants(variants);
 
-    // 5. Push null to end.
+    // 6. Push null to end.
     let variants = null_to_end(variants);
 
-    // 6. Unwrap singleton.
+    // 7. Unwrap singleton.
     if variants.len() == 1 {
         let v = variants.into_iter().next().unwrap();
         // Merge remaining union-level SAP flags onto the single variant.
@@ -389,6 +436,54 @@ fn simplify_union(
     } else {
         RuntimeTy::Union(variants, attr)
     }
+}
+
+fn expand_recursive_union_aliases(
+    variants: Vec<RuntimeTy>,
+    aliases: &HashMap<TypeName, RuntimeTy>,
+    recursive: &HashSet<TypeName>,
+) -> Vec<RuntimeTy> {
+    let mut out = Vec::new();
+    let mut expanding = HashSet::new();
+    for variant in variants {
+        expand_recursive_union_alias_variant(variant, aliases, recursive, &mut expanding, &mut out);
+    }
+    out
+}
+
+fn expand_recursive_union_alias_variant(
+    variant: RuntimeTy,
+    aliases: &HashMap<TypeName, RuntimeTy>,
+    recursive: &HashSet<TypeName>,
+    expanding: &mut HashSet<TypeName>,
+    out: &mut Vec<RuntimeTy>,
+) {
+    let RuntimeTy::TypeAlias(name, reference_attr) = variant else {
+        out.push(variant);
+        return;
+    };
+
+    let Some(RuntimeTy::Union(alias_variants, alias_attr)) = aliases.get(&name) else {
+        out.push(RuntimeTy::TypeAlias(name, reference_attr));
+        return;
+    };
+    if !recursive.contains(&name) || !expanding.insert(name.clone()) {
+        out.push(RuntimeTy::TypeAlias(name, reference_attr));
+        return;
+    }
+
+    let inherited_attr = merge_attr_nested(alias_attr, &reference_attr);
+    for member in alias_variants {
+        let member_attr = merge_attr_nested(member.attr(), &inherited_attr);
+        let member = simplify_impl(
+            member.clone().with_attr(member_attr),
+            aliases,
+            recursive,
+            true,
+        );
+        expand_recursive_union_alias_variant(member, aliases, recursive, expanding, out);
+    }
+    expanding.remove(&name);
 }
 
 // ---------------------------------------------------------------------------

--- a/baml_language/crates/baml_type/tests/simplify_sap_tests.rs
+++ b/baml_language/crates/baml_type/tests/simplify_sap_tests.rs
@@ -8,7 +8,8 @@
 use std::collections::{HashMap, HashSet};
 
 use baml_type::{
-    Freshness, Literal, RuntimeTy, TyAttr, TyAttrValue, TypeName, simplify_sap::simplify,
+    Freshness, Literal, RuntimeTy, TyAttr, TyAttrValue, TypeName,
+    simplify_sap::{simplify, simplify_parse_target},
 };
 
 // =========================================================================
@@ -469,4 +470,19 @@ fn simplify_sap_tests() {
             failures.join("\n\n"),
         );
     }
+}
+
+#[test]
+fn parse_target_expands_recursive_union_alias_member_once() {
+    let json_name = TypeName::local("Json".into());
+    let aliases = HashMap::from([(
+        json_name,
+        parse_ty("null | bool | $Json[] | map<string, $Json>"),
+    )]);
+    let recursive = find_recursive_aliases(&aliases);
+
+    let actual = simplify_parse_target(parse_ty("$Json | null"), &aliases, &recursive);
+    let expected = parse_ty("bool | $Json[] | map<string, $Json> | null");
+
+    assert_eq!(actual, expected);
 }

--- a/baml_language/crates/bex_sap/src/deserializer/coercer/coerce_ty.rs
+++ b/baml_language/crates/bex_sap/src/deserializer/coercer/coerce_ty.rs
@@ -141,12 +141,19 @@ where
 
         let result = match value {
             jsonish::Value::AnyOf(candidates, primitive) => match target.ty {
-                TyResolvedRef::String(_) => BamlValueWithFlags::new(
-                    BamlValue::String(BamlString {
-                        value: primitive.clone(),
-                    }),
-                    DeserializerMeta::new(target.clone()),
-                ),
+                TyResolvedRef::String(_) => {
+                    // If the complete response is a JSON string literal, honor
+                    // that structure and return the decoded value. Plain text,
+                    // partial strings, and prose containing JSON stay verbatim.
+                    let value = serde_json::from_str::<String>(primitive.as_ref())
+                        .map(Cow::Owned)
+                        .unwrap_or_else(|_| primitive.clone());
+
+                    BamlValueWithFlags::new(
+                        BamlValue::String(BamlString { value }),
+                        DeserializerMeta::new(target.clone()),
+                    )
+                }
                 TyResolvedRef::Enum(enum_ty) => {
                     let primitive =
                         jsonish::Value::String(primitive.clone(), CompletionState::Complete);

--- a/baml_language/crates/bex_sap/src/lib.rs
+++ b/baml_language/crates/bex_sap/src/lib.rs
@@ -30,6 +30,11 @@ impl CompiledSapModel {
         target: baml_type::RuntimeTy,
         stream_target: baml_type::RuntimeTy,
     ) -> Result<Self, sap_model::ConvertError> {
+        // A generic `T` can materialize as a union after the context's declared
+        // types were simplified. Normalize both runtime targets at the SAP
+        // boundary so the converter always receives its required flat form.
+        let target = type_ctx.normalize_parse_target(target);
+        let stream_target = type_ctx.normalize_parse_target(stream_target);
         let inner = CompiledSapModelInner::try_new(
             type_ctx,
             target,

--- a/baml_language/crates/bex_sap/src/sap_model/convert.rs
+++ b/baml_language/crates/bex_sap/src/sap_model/convert.rs
@@ -100,7 +100,7 @@ impl TypeCtx {
             .map(|(k, v)| {
                 let fields = v.fields.iter().map(|field| {
                     let mut field = field.clone();
-                    field.field_type = ::baml_type::simplify_sap::simplify(
+                    field.field_type = ::baml_type::simplify_sap::simplify_parse_target(
                         field.field_type,
                         &type_alias_definitions,
                         &recursive_aliases,
@@ -163,6 +163,19 @@ impl TypeCtx {
             &ctx.class_definitions,
             ctx.enum_definitions.clone(),
             &type_alias_definitions,
+        )
+    }
+
+    /// Normalize a runtime-materialized parse target before converting it to
+    /// the SAP model. Generic substitution happens after [`TypeCtx::new`] has
+    /// simplified the declared class and alias definitions, so it can create a
+    /// fresh nested union such as `(string | int) | ToolCalls` at runtime.
+    pub(crate) fn normalize_parse_target(&self, ty: baml_type::RuntimeTy) -> baml_type::RuntimeTy {
+        let recursive_aliases = self.type_alias_definitions.keys().cloned().collect();
+        ::baml_type::simplify_sap::simplify_parse_target(
+            ty,
+            &self.type_alias_definitions,
+            &recursive_aliases,
         )
     }
 

--- a/baml_language/crates/bex_sap/src/sap_model/mod.rs
+++ b/baml_language/crates/bex_sap/src/sap_model/mod.rs
@@ -84,6 +84,12 @@ impl<'t, N: TypeIdent> TypeRefDb<'t, N> {
         }
     }
 
+    /// Resolve a named SAP type without first constructing a borrowed
+    /// [`Ty::Unresolved`] wrapper.
+    pub fn resolve_name(&'t self, ident: &N) -> Option<TyResolvedRef<'t, N>> {
+        self.types.get(ident).map(TyResolved::as_ref)
+    }
+
     /// Like [`TypeRefDb::resolve`], but maps the result to keep the type annotations.
     #[allow(clippy::needless_pass_by_value)]
     pub fn resolve_with_meta(

--- a/baml_language/crates/bex_sap/src/tests/mod.rs
+++ b/baml_language/crates/bex_sap/src/tests/mod.rs
@@ -31,11 +31,11 @@ test_deserializer!(
 );
 
 test_deserializer!(
-    test_string_from_string_with_quotes,
+    test_string_from_complete_json_string,
     r#""hello""#,
     baml_tyannotated!(string),
     baml_db! {},
-    "\"hello\""
+    "hello"
 );
 
 test_deserializer!(

--- a/baml_language/crates/bex_sap/src/tests/test_basics.rs
+++ b/baml_language/crates/bex_sap/src/tests/test_basics.rs
@@ -184,11 +184,11 @@ test_deserializer!(
 // --- String tests ---
 
 test_deserializer!(
-    test_string,
+    test_complete_json_string,
     r#""hello""#,
     baml_tyannotated!(string),
     baml_db! {},
-    "\"hello\""
+    "hello"
 );
 
 // --- Bool tests ---

--- a/baml_language/crates/bex_sap/src/to_external.rs
+++ b/baml_language/crates/bex_sap/src/to_external.rs
@@ -12,7 +12,7 @@ use crate::{
     deserializer::types::BamlValueWithFlags,
     sap_model::{
         ArrayTy, ClassTy, EnumTy, EnumVariantTy, MapTy, MediaTy, StreamStateTy, Ty, TyResolvedRef,
-        TyWithMeta, TypeAnnotations, UnionTy,
+        TyWithMeta, TypeAnnotations, TypeRefDb, UnionTy,
     },
 };
 
@@ -25,15 +25,16 @@ use crate::{
 /// # Known simplifications (not round-trip safe)
 ///
 /// - `Optional(T)` was converted to `Union([Null, T])` on the way in; it stays as `Union` here.
-/// - `TypeAlias` was flattened; the alias name is lost.
+/// - Aliases already resolved into the target type have no nominal name to recover; named alias
+///   references inside containers are preserved.
 /// - `EnumVariant` becomes `Enum` (variant specificity lost at the type level).
 /// - `TyAttr` annotations are not reconstructed; `TyAttr::default()` is used throughout.
 pub trait ToBamlTy {
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy;
+    fn to_baml_ty(&self, db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy;
 }
 
 impl ToBamlTy for TyResolvedRef<'_, TypeName> {
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
+    fn to_baml_ty(&self, db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
         let attr = baml_type::TyAttr::default();
         match self {
             TyResolvedRef::Int(_) => baml_type::RuntimeTy::Int { attr },
@@ -65,79 +66,84 @@ impl ToBamlTy for TyResolvedRef<'_, TypeName> {
                 baml_type::Freshness::Regular,
                 attr,
             ),
-            TyResolvedRef::Array(a) => a.to_baml_ty(),
-            TyResolvedRef::Map(m) => m.to_baml_ty(),
-            TyResolvedRef::Class(c) => c.to_baml_ty(),
-            TyResolvedRef::Enum(e) => e.to_baml_ty(),
-            TyResolvedRef::EnumVariant(ev) => ev.to_baml_ty(),
-            TyResolvedRef::Union(u) => u.to_baml_ty(),
-            TyResolvedRef::StreamState(s) => s.to_baml_ty(),
+            TyResolvedRef::Array(a) => a.to_baml_ty(db),
+            TyResolvedRef::Map(m) => m.to_baml_ty(db),
+            TyResolvedRef::Class(c) => c.to_baml_ty(db),
+            TyResolvedRef::Enum(e) => e.to_baml_ty(db),
+            TyResolvedRef::EnumVariant(ev) => ev.to_baml_ty(db),
+            TyResolvedRef::Union(u) => u.to_baml_ty(db),
+            TyResolvedRef::StreamState(s) => s.to_baml_ty(db),
         }
     }
 }
 
 impl ToBamlTy for Ty<'_, TypeName> {
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
+    fn to_baml_ty(&self, db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
         match self {
-            Ty::Resolved(resolved) => resolved.as_ref().to_baml_ty(),
-            Ty::ResolvedRef(resolved_ref) => resolved_ref.to_baml_ty(),
-            Ty::Unresolved(_name) => {
-                // Unresolved names are class/enum references; we can't distinguish
-                // without access to the TypeRefDb. Use unknown rather than guessing.
-                baml_type::RuntimeTy::unknown()
-            }
+            Ty::Resolved(resolved) => resolved.as_ref().to_baml_ty(db),
+            Ty::ResolvedRef(resolved_ref) => resolved_ref.to_baml_ty(db),
+            Ty::Unresolved(name) => match db.resolve_name(name) {
+                Some(TyResolvedRef::Class(class)) if class.name == *name => class.to_baml_ty(db),
+                Some(TyResolvedRef::Enum(enm)) if enm.name == *name => enm.to_baml_ty(db),
+                // Any other named entry is an alias. Keep it nominal here
+                // instead of recursively expanding aliases such as `json`.
+                Some(_) => {
+                    baml_type::RuntimeTy::TypeAlias(name.clone(), baml_type::TyAttr::default())
+                }
+                None => baml_type::RuntimeTy::unknown(),
+            },
         }
     }
 }
 
 impl ToBamlTy for ArrayTy<'_, TypeName> {
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
-        let inner = self.ty.ty.to_baml_ty();
+    fn to_baml_ty(&self, db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
+        let inner = self.ty.ty.to_baml_ty(db);
         baml_type::RuntimeTy::List(Box::new(inner), baml_type::TyAttr::default())
     }
 }
 
 impl ToBamlTy for MapTy<'_, TypeName> {
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
+    fn to_baml_ty(&self, db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
         baml_type::RuntimeTy::Map {
-            key: Box::new(self.key.ty.to_baml_ty()),
-            value: Box::new(self.value.ty.to_baml_ty()),
+            key: Box::new(self.key.ty.to_baml_ty(db)),
+            value: Box::new(self.value.ty.to_baml_ty(db)),
             attr: baml_type::TyAttr::default(),
         }
     }
 }
 
 impl ToBamlTy for ClassTy<'_, TypeName> {
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
+    fn to_baml_ty(&self, _db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
         baml_type::RuntimeTy::Class(self.name.clone(), Vec::new(), baml_type::TyAttr::default())
     }
 }
 
 impl ToBamlTy for EnumTy<'_, TypeName> {
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
+    fn to_baml_ty(&self, _db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
         baml_type::RuntimeTy::Enum(self.name.clone(), baml_type::TyAttr::default())
     }
 }
 
 impl ToBamlTy for EnumVariantTy<'_, TypeName> {
     /// Loses variant specificity — maps back to the parent enum type.
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
+    fn to_baml_ty(&self, _db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
         baml_type::RuntimeTy::Enum(self.name.clone(), baml_type::TyAttr::default())
     }
 }
 
 impl ToBamlTy for UnionTy<'_, TypeName> {
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
+    fn to_baml_ty(&self, db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
         let members: Vec<baml_type::RuntimeTy> =
-            self.variants.iter().map(|v| v.ty.to_baml_ty()).collect();
+            self.variants.iter().map(|v| v.ty.to_baml_ty(db)).collect();
         baml_type::RuntimeTy::Union(members, baml_type::TyAttr::default())
     }
 }
 
 impl ToBamlTy for StreamStateTy<'_, TypeName> {
     /// `StreamState` is a value-level concept; at the type level we return the inner type.
-    fn to_baml_ty(&self) -> baml_type::RuntimeTy {
-        self.value.ty.to_baml_ty()
+    fn to_baml_ty(&self, db: &TypeRefDb<'_, TypeName>) -> baml_type::RuntimeTy {
+        self.value.ty.to_baml_ty(db)
     }
 }
 
@@ -163,13 +169,15 @@ impl MediaTy {
 /// Deserializer metadata (flags, scores) is discarded.
 pub fn baml_value_to_external(
     value: &BamlValueWithFlags<'_, '_, '_, TypeName>,
+    db: &TypeRefDb<'_, TypeName>,
 ) -> BexExternalValue {
-    baml_value_inner_to_external(&value.value, &value.meta.ty)
+    baml_value_inner_to_external(&value.value, &value.meta.ty, db)
 }
 
 fn baml_value_inner_to_external(
     value: &BamlValue<'_, '_, '_, TypeName>,
     ty: &TyWithMeta<TyResolvedRef<'_, TypeName>, &TypeAnnotations<'_, TypeName>>,
+    db: &TypeRefDb<'_, TypeName>,
 ) -> BexExternalValue {
     match value {
         BamlValue::String(s) => BexExternalValue::String(bex_str::BexStr::from(s.value.as_ref())),
@@ -183,11 +191,14 @@ fn baml_value_inner_to_external(
         }
         BamlValue::Array(arr) => {
             let element_type = match ty.ty {
-                TyResolvedRef::Array(a) => a.ty.ty.to_baml_ty(),
+                TyResolvedRef::Array(a) => a.ty.ty.to_baml_ty(db),
                 _ => baml_type::RuntimeTy::unknown(),
             };
-            let items: Vec<BexExternalValue> =
-                arr.value.iter().map(baml_value_to_external).collect();
+            let items: Vec<BexExternalValue> = arr
+                .value
+                .iter()
+                .map(|item| baml_value_to_external(item, db))
+                .collect();
             BexExternalValue::Array {
                 element_type,
                 items,
@@ -195,7 +206,7 @@ fn baml_value_inner_to_external(
         }
         BamlValue::Map(map) => {
             let (key_type, value_type) = match ty.ty {
-                TyResolvedRef::Map(m) => (m.key.ty.to_baml_ty(), m.value.ty.to_baml_ty()),
+                TyResolvedRef::Map(m) => (m.key.ty.to_baml_ty(db), m.value.ty.to_baml_ty(db)),
                 _ => (
                     baml_type::RuntimeTy::string(),
                     baml_type::RuntimeTy::unknown(),
@@ -204,7 +215,7 @@ fn baml_value_inner_to_external(
             let entries: IndexMap<String, BexExternalValue> = map
                 .value
                 .iter()
-                .map(|(k, v)| (k.to_string(), baml_value_to_external(v)))
+                .map(|(k, v)| (k.to_string(), baml_value_to_external(v, db)))
                 .collect();
             BexExternalValue::Map {
                 key_type,
@@ -220,7 +231,7 @@ fn baml_value_inner_to_external(
             let fields: IndexMap<String, BexExternalValue> = c
                 .value
                 .iter()
-                .map(|(k, v)| (k.to_string(), baml_value_to_external(v)))
+                .map(|(k, v)| (k.to_string(), baml_value_to_external(v, db)))
                 .collect();
             BexExternalValue::Instance {
                 class_name: c.name.to_string(),
@@ -228,18 +239,21 @@ fn baml_value_inner_to_external(
                 fields,
             }
         }
-        BamlValue::StreamState(state) => stream_state_to_external(state),
+        BamlValue::StreamState(state) => stream_state_to_external(state, db),
     }
 }
 
-fn stream_state_to_external(state: &BamlStreamState<'_, '_, '_, TypeName>) -> BexExternalValue {
+fn stream_state_to_external(
+    state: &BamlStreamState<'_, '_, '_, TypeName>,
+    db: &TypeRefDb<'_, TypeName>,
+) -> BexExternalValue {
     let (inner, state_name) = match state {
         BamlStreamState::Pending(v) => (v, "Pending"),
         BamlStreamState::Incomplete(v) => (v, "Incomplete"),
         BamlStreamState::Complete(v) => (v, "Complete"),
     };
     let mut fields = IndexMap::new();
-    fields.insert("value".to_string(), baml_value_to_external(inner));
+    fields.insert("value".to_string(), baml_value_to_external(inner, db));
     fields.insert(
         "state".to_string(),
         BexExternalValue::String(bex_str::BexStr::from(state_name)),

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -996,7 +996,10 @@ pub fn execute_sap_parse_final(
         })?;
 
     // === Convert back to baml ===
-    Ok(::bex_sap::to_external::baml_value_to_external(&parsed))
+    Ok(::bex_sap::to_external::baml_value_to_external(
+        &parsed,
+        sap.db(),
+    ))
 }
 
 pub fn execute_sap_parse_partial(
@@ -1020,7 +1023,7 @@ pub fn execute_sap_parse_partial(
     // === Convert back to baml ===
     match parsed {
         Some(parsed) => {
-            let converted = ::bex_sap::to_external::baml_value_to_external(&parsed);
+            let converted = ::bex_sap::to_external::baml_value_to_external(&parsed, sap.db());
             Ok(Some(converted))
         }
         None => Ok(None),


### PR DESCRIPTION
## Root cause

SAP parse targets could lose type information at two boundaries. Recursive union aliases used directly inside another union remained hidden behind the alias, leaving SAP with a nested union shape instead of a flat parse target. On conversion back to runtime values, unresolved named types lacked access to the SAP type database, so aliases inside containers could degrade to `unknown` or be expanded inconsistently. Separately, a complete top-level JSON string literal was returned verbatim, including JSON quoting, while ordinary model text needed to remain untouched.

These issues affected generic union returns, nullable `json` values and containers, and string parse companions.

## Changes

- Add parse-target-specific simplification that expands a recursive union alias only when it is a direct union member, while preserving recursive alias references below list/map indirections.
- Normalize SAP parse targets before conversion and flatten union type arguments used by model steps.
- Make SAP-to-runtime type/value conversion database-aware so named classes, enums, and aliases retain their declared types through nested containers.
- Decode complete top-level JSON string literals while preserving plain or partial LLM text verbatim.
- Add regressions for generic union returns, optional JSON, nullable containers, recursive aliases, and parse companions.

## Validation

- `cargo nextest run -p baml_type --test simplify_sap_tests` (2 passed)
- `cargo nextest run -p baml_tests --test generic_union_returns` (4 passed)
- `cargo nextest run -p baml_tests --test parse_companions` (4 passed)
- `cargo nextest run -p baml_type` (107 passed)
- `cargo nextest run -p bex_sap` (594 passed)
- `cargo nextest run -p sys_llm` (447 passed)
- `cargo fmt --all --check`
- `git diff --check origin/canary..HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SAP type simplification, model conversion, and LLM parse output paths; behavior changes for string targets and generic union parse types, mitigated by broad test updates.
> 
> **Overview**
> Fixes SAP losing type shape and value fidelity at parse boundaries: generic unions, optional `json`, nullable containers, and string targets.
> 
> **Parse-target normalization** adds `simplify_parse_target`, which splices recursive union aliases (e.g. `json`) only when they are direct union members (`json | null` → flat variants) while keeping named `json` under lists/maps. Runtime targets are normalized in `CompiledSapModel` and class fields use this path so generic substitutions like `T | PendingCalls` reach the converter flattened.
> 
> **Round-trip typing** threads `TypeRefDb` through `to_baml_ty` and `baml_value_to_external` so arrays/maps keep declared element types (including aliases) instead of degrading to `unknown`.
> 
> **String coercion** decodes a **complete** top-level JSON string literal (e.g. `"Fred"` → `Fred`) via `serde_json::from_str`; plain or partial LLM text stays verbatim.
> 
> Regressions cover generic union model steps, optional/nullable `json`, nullable container fields, parse companions, and updated SAP deserializer expectations for quoted JSON strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe4443d62481954232918670a7fcabbde84c423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->