### PR TITLE
Preserve structural VM values in diagnostics and JSON

### DIFF
--- a/baml_language/crates/baml_tests/tests/errorcontext.rs
+++ b/baml_language/crates/baml_tests/tests/errorcontext.rs
@@ -573,4 +573,14 @@ function main() -> string {
         wide.contains('…'),
         "wide array error exceeded its budget without truncation:\n{wide}"
     );
+    assert_eq!(
+        wide.matches('…').count(),
+        1,
+        "wide array should use one truncation marker:\n{wide}"
+    );
+    assert!(
+        wide.len() < 2_000,
+        "wide array diagnostic should remain bounded, got {} bytes",
+        wide.len()
+    );
 }

--- a/baml_language/crates/baml_tests/tests/errorcontext.rs
+++ b/baml_language/crates/baml_tests/tests/errorcontext.rs
@@ -411,3 +411,75 @@ function main() -> string {
         "expected two chain separators (origin->wrap->cleanup):\n{rendered}"
     );
 }
+
+/// ErrorContext rendering runs inside a native call, so it cannot yield to
+/// user `ToString` implementations. It must still preserve the qualified
+/// thrown class name and recursively render its fields.
+#[tokio::test]
+async fn class_error_renders_qualified_name_and_structural_fields() {
+    let output = baml_test!(
+        r#"
+class Detail {
+  label string
+
+  implements baml.ToString {
+    function to_string(self) -> string throws never { "DETAIL OVERRIDE" }
+  }
+}
+
+class AppError {
+  message string
+  detail Detail
+
+  implements baml.ToString {
+    function to_string(self) -> string throws never { "ERROR OVERRIDE" }
+  }
+}
+
+function main() -> string {
+  (
+    throw AppError {
+      message: "boom",
+      detail: Detail { label: "visible" },
+    }
+  ) catch (e, ctx) {
+    _ => ctx.to_string()
+  }
+}
+"#
+    );
+    let rendered = expect_string(output.result.unwrap());
+    assert!(
+        rendered
+            .contains(r#"user.AppError {message: "boom", detail: Detail { label: "visible" }}"#),
+        "class error lost its identity or fields:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("OVERRIDE"),
+        "ErrorContext unexpectedly dispatched a user ToString override:\n{rendered}"
+    );
+}
+
+/// Arbitrary thrown values are legal. Their context should retain the value's
+/// structural representation rather than replacing it with `<error>`.
+#[tokio::test]
+async fn non_class_error_renders_structurally() {
+    let output = baml_test!(
+        r#"
+function main() -> string {
+  (throw {"first": "alpha", "second": "beta"}) catch (e, ctx) {
+    _ => ctx.to_string()
+  }
+}
+"#
+    );
+    let rendered = expect_string(output.result.unwrap());
+    assert!(
+        rendered.contains(r#"{"first": "alpha", "second": "beta"}"#),
+        "non-class error was not rendered structurally:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("<error>"),
+        "non-class error fell back to the old placeholder:\n{rendered}"
+    );
+}

--- a/baml_language/crates/baml_tests/tests/errorcontext.rs
+++ b/baml_language/crates/baml_tests/tests/errorcontext.rs
@@ -450,8 +450,9 @@ function main() -> string {
     );
     let rendered = expect_string(output.result.unwrap());
     assert!(
-        rendered
-            .contains(r#"user.AppError {message: "boom", detail: Detail { label: "visible" }}"#),
+        rendered.contains(
+            r#"user.AppError { message: "boom", detail: user.Detail { label: "visible" } }"#
+        ),
         "class error lost its identity or fields:\n{rendered}"
     );
     assert!(
@@ -481,5 +482,95 @@ function main() -> string {
     assert!(
         !rendered.contains("<error>"),
         "non-class error fell back to the old placeholder:\n{rendered}"
+    );
+}
+
+#[tokio::test]
+async fn structural_error_rendering_truncates_object_cycles() {
+    let output = baml_test!(
+        r#"
+class RecursiveError {
+  next RecursiveError?
+}
+
+function fail() -> string {
+  let error = RecursiveError { next: null }
+  error.next = error
+  throw error
+}
+
+function main() -> string {
+  fail() catch (e, ctx) {
+    _ => ctx.to_string()
+  }
+}
+"#
+    );
+    let rendered = expect_string(output.result.unwrap());
+    assert!(
+        rendered.contains("user.RecursiveError { next: … }"),
+        "cyclic class error was not safely truncated:\n{rendered}"
+    );
+}
+
+#[tokio::test]
+async fn structural_error_rendering_enforces_depth_and_node_budgets() {
+    let output = baml_test!(
+        r#"
+class Link {
+  next Link?
+}
+
+function fail_deep() -> string {
+  let root = Link { next: null }
+  let current = root
+  let i = 0
+  while (i < 40) {
+    let next = Link { next: null }
+    current.next = next
+    current = next
+    i += 1
+  }
+  throw root
+}
+
+function fail_wide() -> string {
+  let values: int[] = []
+  let i = 0
+  while (i < 300) {
+    values.push(i)
+    i += 1
+  }
+  throw values
+}
+
+function render_deep() -> string {
+  fail_deep() catch (e, ctx) {
+    _ => ctx.to_string()
+  }
+}
+
+function render_wide() -> string {
+  fail_wide() catch (e, ctx) {
+    _ => ctx.to_string()
+  }
+}
+
+function main() -> string {
+  render_deep() + "|" + render_wide()
+}
+"#
+    );
+    let rendered = expect_string(output.result.unwrap());
+    let (deep, wide) = rendered
+        .split_once('|')
+        .expect("expected both bounded renderings");
+    assert!(
+        deep.contains('…'),
+        "deep class error exceeded its budget without truncation:\n{deep}"
+    );
+    assert!(
+        wide.contains('…'),
+        "wide array error exceeded its budget without truncation:\n{wide}"
     );
 }

--- a/baml_language/crates/baml_tests/tests/exceptions.rs
+++ b/baml_language/crates/baml_tests/tests/exceptions.rs
@@ -240,7 +240,7 @@ function main() -> int | string {
     Traceback (most recent call last):
       File "test.baml", line 7, in user.main
       File "test.baml", line 3, in user.divider
-    baml.panics.DivisionByZero
+    baml.panics.DivisionByZero {dividend: 42}
     "#);
 }
 

--- a/baml_language/crates/baml_tests/tests/exceptions.rs
+++ b/baml_language/crates/baml_tests/tests/exceptions.rs
@@ -240,7 +240,7 @@ function main() -> int | string {
     Traceback (most recent call last):
       File "test.baml", line 7, in user.main
       File "test.baml", line 3, in user.divider
-    baml.panics.DivisionByZero {dividend: 42}
+    baml.panics.DivisionByZero { dividend: 42 }
     "#);
 }
 

--- a/baml_language/crates/baml_tests/tests/json_typed_union.rs
+++ b/baml_language/crates/baml_tests/tests/json_typed_union.rs
@@ -41,3 +41,64 @@ function main() -> string {
         )
     );
 }
+
+#[tokio::test]
+async fn typed_class_and_union_serialization_are_equivalent() {
+    let output = baml_test!(
+        r#"
+class Detail {
+  label string
+}
+
+class Record {
+  name string
+  detail Detail
+}
+
+type Payload = Record | string
+
+function main() -> string {
+  let record = Record {
+    name: "Ada",
+    detail: Detail { label: "nested" },
+  }
+  baml.json.to_string<Record>(record)
+    + "|" + baml.json.to_string<Payload>(record)
+}
+"#
+    );
+
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String(
+            concat!(
+                r#"{"name":"Ada","detail":{"label":"nested"}}"#,
+                r#"|{"name":"Ada","detail":{"label":"nested"}}"#,
+            )
+            .into()
+        )
+    );
+}
+
+#[tokio::test]
+async fn typed_union_preserves_uint8array_serialization_error() {
+    let output = baml_test!(
+        r#"
+type Payload = uint8array | string
+
+function main() -> string {
+  {
+    let _ = baml.json.to_string<Payload>(baml.Uint8Array.from_hex("00ff"))
+    "unexpected success"
+  } catch (e) {
+    baml.json.JsonSerializationError => "serialization error"
+  }
+}
+"#
+    );
+
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("serialization error".into())
+    );
+}

--- a/baml_language/crates/baml_tests/tests/json_typed_union.rs
+++ b/baml_language/crates/baml_tests/tests/json_typed_union.rs
@@ -1,0 +1,43 @@
+//! Runtime regressions for typed JSON serialization of structural union values.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+#[tokio::test]
+async fn typed_union_preserves_class_enum_and_media_values() {
+    let output = baml_test!(
+        r#"
+class Record {
+  name string
+}
+
+enum Phase {
+  Ready
+}
+
+type Payload = Record | Phase | image
+
+function serialize(value: Payload) -> string {
+  baml.json.to_string<Payload>(value)
+}
+
+function main() -> string {
+  serialize(Record { name: "Ada" })
+    + "|" + serialize(Phase.Ready)
+    + "|" + serialize(image.from_url("https://example.com/a.png", "image/png"))
+}
+"#
+    );
+
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String(
+            concat!(
+                r#"{"name":"Ada"}"#,
+                r#"|"Ready""#,
+                r#"|{"kind":"image","source":"url","value":"https://example.com/a.png","mime":"image/png"}"#,
+            )
+            .into()
+        )
+    );
+}

--- a/baml_language/crates/bex_vm/src/package_baml/error_context.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/error_context.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Write;
 
-use bex_vm_types::types::{Object, Value};
+use bex_vm_types::types::Value;
 
 use super::{BamlClassErrorsErrorContext, BamlClassErrorsStackTrace, PackageBamlImpl, view};
 use crate::BexVm;
@@ -18,27 +18,6 @@ use crate::BexVm;
 fn render_error_value(vm: &BexVm, value: Value) -> String {
     if let Ok(message) = vm.as_string(&value) {
         return message.to_string();
-    }
-    if let Some(ptr) = value.as_object_ptr()
-        && let Object::Instance(instance) = vm.get_object(ptr)
-        && let Object::Class(class) = vm.get_object(instance.class)
-    {
-        let fields = class
-            .fields
-            .iter()
-            .zip(instance.fields.iter())
-            .map(|(field, value)| {
-                format!(
-                    "{}: {}",
-                    field.name,
-                    super::root::render_value_structural(vm, value.load(), true)
-                )
-            })
-            .collect::<Vec<_>>();
-        if fields.is_empty() {
-            return class.name.to_string();
-        }
-        return format!("{} {{{}}}", class.name, fields.join(", "));
     }
     super::root::render_value_structural(vm, value, false)
 }

--- a/baml_language/crates/bex_vm/src/package_baml/error_context.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/error_context.rs
@@ -12,9 +12,9 @@ use bex_vm_types::types::{Object, Value};
 use super::{BamlClassErrorsErrorContext, BamlClassErrorsStackTrace, PackageBamlImpl, view};
 use crate::BexVm;
 
-/// Render a thrown error value for the chain trace: a string is its own
-/// message; an error instance shows its class name (Python's `Type`); anything
-/// else falls back to a placeholder.
+/// Render a thrown error value for the chain trace. Error instances retain
+/// their qualified class name and fields so a caught-and-reported test failure
+/// is as actionable as an error escaping directly from `baml run`.
 fn render_error_value(vm: &BexVm, value: Value) -> String {
     if let Ok(message) = vm.as_string(&value) {
         return message.to_string();
@@ -23,9 +23,24 @@ fn render_error_value(vm: &BexVm, value: Value) -> String {
         && let Object::Instance(instance) = vm.get_object(ptr)
         && let Object::Class(class) = vm.get_object(instance.class)
     {
-        return class.name.to_string();
+        let fields = class
+            .fields
+            .iter()
+            .zip(instance.fields.iter())
+            .map(|(field, value)| {
+                format!(
+                    "{}: {}",
+                    field.name,
+                    super::root::render_value_structural(vm, value.load(), true)
+                )
+            })
+            .collect::<Vec<_>>();
+        if fields.is_empty() {
+            return class.name.to_string();
+        }
+        return format!("{} {{{}}}", class.name, fields.join(", "));
     }
-    "<error>".to_string()
+    super::root::render_value_structural(vm, value, false)
 }
 
 const CHAIN_SEPARATOR: &str = "\n\nDuring handling of the above error, another error occurred:\n\n";

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use baml_type::{MediaKind, RealizedTy, TypeName};
+use baml_type::{MediaKind, RealizedTy, TyTemplate, TypeName};
 
 /// FQN of the recursive `json` type alias declared in `baml.json`.
 /// Mirrors `baml_base::qualified_name::BAML_JSON_JSON`; inlined here to
@@ -859,16 +859,29 @@ fn ty_value_to_serde(
             "uint8array",
         )),
 
-        RealizedTy::Union(_, _) => {
-            // Tagged structurally — dispatch on the runtime Value shape rather
-            // than trying each member. `value_to_serde` is intentionally only
-            // an untyped-json converter; although it already handles enum
-            // variants, class and media instances become null. Use the complete
-            // structural walker so every representable runtime shape survives.
-            // Empty override tables preserve typed `to_string`'s canonical
-            // behavior: custom `ToJson` implementations are not invoked.
-            let mut counter = 0;
-            render_to_serde(vm, value, &[], &[], &mut counter, path)
+        RealizedTy::Union(members, _) => {
+            // Select the first declared member that contains the runtime value,
+            // using the same ordered, decidable membership relation as `is` and
+            // typed match arms. Serialization then remains fully type-directed:
+            // a class/media/uint8array member behaves exactly as it would outside
+            // the union, and values outside every member fail the type contract.
+            let member = members.iter().find(|member| {
+                crate::type_match::value_matches_template(
+                    vm,
+                    value,
+                    &TyTemplate::from((*member).clone()),
+                    &[],
+                )
+            });
+            match member {
+                Some(member) => ty_value_to_serde(vm, value, member, path),
+                None => Err(raise_serialize(
+                    vm,
+                    "value is not a member of the union",
+                    path,
+                    "union",
+                )),
+            }
         }
 
         RealizedTy::Resource { .. } | RealizedTy::PromptAst { .. } => Err(raise_serialize(

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -861,8 +861,14 @@ fn ty_value_to_serde(
 
         RealizedTy::Union(_, _) => {
             // Tagged structurally — dispatch on the runtime Value shape rather
-            // than trying each member. Matches json-alias union semantics.
-            Ok(value_to_serde(vm, value))
+            // than trying each member. `value_to_serde` is intentionally only
+            // an untyped-json converter; although it already handles enum
+            // variants, class and media instances become null. Use the complete
+            // structural walker so every representable runtime shape survives.
+            // Empty override tables preserve typed `to_string`'s canonical
+            // behavior: custom `ToJson` implementations are not invoked.
+            let mut counter = 0;
+            render_to_serde(vm, value, &[], &[], &mut counter, path)
         }
 
         RealizedTy::Resource { .. } | RealizedTy::PromptAst { .. } => Err(raise_serialize(

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use bex_heap::TlabHolder;
 use bex_vm_types::{
@@ -357,8 +360,8 @@ fn render_done(
     pending: &[HeapPtr],
     results: &[String],
 ) -> NativeCallResult {
-    let mut counter = 0;
-    let rendered = render_to_string(vm, root, false, pending, results, &mut counter);
+    let mut state = StringRenderState::with_overrides(pending, results);
+    let rendered = render_to_string(vm, root, false, 0, &mut state);
     NativeCallResult::Done(Value::object(vm.alloc_string(rendered)))
 }
 
@@ -436,23 +439,87 @@ enum DisplaySnap {
     Instance(String, Vec<(String, Value)>),
 }
 
+const DIAGNOSTIC_RENDER_MAX_DEPTH: usize = 32;
+const DIAGNOSTIC_RENDER_MAX_NODES: usize = 256;
+const TRUNCATED_RENDER: &str = "…";
+
+/// Mutable traversal state for structural string rendering.
+///
+/// User-facing `ToString` rendering is unbounded to preserve its existing
+/// behavior and carries the precomputed override tables. Native diagnostic
+/// rendering has empty override tables and strict depth/node/cycle guards:
+/// an error-reporting path must degrade to an ellipsis rather than dispatch,
+/// throw, or recurse forever.
+struct StringRenderState<'a> {
+    pending: &'a [HeapPtr],
+    results: &'a [String],
+    counter: usize,
+    qualified_class_names: bool,
+    remaining_nodes: Option<usize>,
+    max_depth: Option<usize>,
+    active_objects: Option<HashSet<HeapPtr>>,
+}
+
+impl<'a> StringRenderState<'a> {
+    fn with_overrides(pending: &'a [HeapPtr], results: &'a [String]) -> Self {
+        Self {
+            pending,
+            results,
+            counter: 0,
+            qualified_class_names: false,
+            remaining_nodes: None,
+            max_depth: None,
+            active_objects: None,
+        }
+    }
+
+    fn diagnostic() -> Self {
+        Self {
+            pending: &[],
+            results: &[],
+            counter: 0,
+            qualified_class_names: true,
+            remaining_nodes: Some(DIAGNOSTIC_RENDER_MAX_NODES),
+            max_depth: Some(DIAGNOSTIC_RENDER_MAX_DEPTH),
+            active_objects: Some(HashSet::new()),
+        }
+    }
+
+    fn consume_node(&mut self, depth: usize) -> bool {
+        if self.max_depth.is_some_and(|max_depth| depth > max_depth) {
+            return false;
+        }
+        match &mut self.remaining_nodes {
+            Some(remaining) if *remaining == 0 => false,
+            Some(remaining) => {
+                *remaining -= 1;
+                true
+            }
+            None => true,
+        }
+    }
+}
+
 /// Human-readable rendering used by `string.from` / the `baml.ToString` default.
-/// Structural and total: every value type renders to *something* and nothing
-/// throws. A node whose runtime class overrides `baml.ToString` (recorded
+/// Structural: every value type renders to *something* and nothing throws. A
+/// node whose runtime class overrides `baml.ToString` (recorded
 /// pre-order in `pending` by [`collect_to_string_overrides`]) is rendered via its
-/// precomputed result (`results[*counter]`, produced by pass 2), spliced in bare
+/// precomputed result (`results[state.counter]`, produced by pass 2), spliced in bare
 /// regardless of nesting. Because collect and render share the same pre-order,
-/// `pending[*counter]` is exactly the next override node — so the check is a
+/// `pending[state.counter]` is exactly the next override node — so the check is a
 /// pointer compare, not a per-node global lookup. With an empty `pending` this is
 /// a pure structural walk.
 fn render_to_string(
     vm: &BexVm,
     value: Value,
     nested: bool,
-    pending: &[HeapPtr],
-    results: &[String],
-    counter: &mut usize,
+    depth: usize,
+    state: &mut StringRenderState<'_>,
 ) -> String {
+    if !state.consume_node(depth) {
+        return TRUNCATED_RENDER.to_string();
+    }
+
     let ptr = match value.kind() {
         ValueKind::Null => return "null".to_string(),
         ValueKind::Int(i) => return i.to_string(),
@@ -462,10 +529,22 @@ fn render_to_string(
     };
 
     // Override node: splice its precomputed `to_string` result in bare.
-    if pending.get(*counter) == Some(&ptr) {
-        let rendered = results.get(*counter).cloned().unwrap_or_default();
-        *counter += 1;
+    if state.pending.get(state.counter) == Some(&ptr) {
+        let rendered = state
+            .results
+            .get(state.counter)
+            .cloned()
+            .unwrap_or_default();
+        state.counter += 1;
         return rendered;
+    }
+
+    // Only an object currently on the recursion stack is a cycle. Shared DAG
+    // children render normally after the first branch removes them on unwind.
+    if let Some(active_objects) = &mut state.active_objects
+        && !active_objects.insert(ptr)
+    {
+        return TRUNCATED_RENDER.to_string();
     }
 
     // Capture an owned snapshot, dropping the heap borrow / container lock
@@ -494,7 +573,11 @@ fn render_to_string(
             let field_values: Vec<Value> = inst.fields.iter().map(AtomicValueSlot::load).collect();
             let (class_name, field_names) = match vm.get_object(inst.class) {
                 Object::Class(class) => (
-                    class.name.name().to_string(),
+                    if state.qualified_class_names {
+                        class.name.to_string()
+                    } else {
+                        class.name.name().to_string()
+                    },
                     class
                         .fields
                         .iter()
@@ -527,7 +610,7 @@ fn render_to_string(
         other => DisplaySnap::Leaf(other.to_string()),
     };
 
-    match snap {
+    let rendered = match snap {
         DisplaySnap::Leaf(s) => s,
         DisplaySnap::Str(s) => {
             if nested {
@@ -539,7 +622,7 @@ fn render_to_string(
         DisplaySnap::Seq(values) => {
             let mut parts: Vec<String> = Vec::with_capacity(values.len());
             for v in &values {
-                parts.push(render_to_string(vm, *v, true, pending, results, counter));
+                parts.push(render_to_string(vm, *v, true, depth + 1, state));
             }
             format!("[{}]", parts.join(", "))
         }
@@ -548,7 +631,7 @@ fn render_to_string(
             for (k, v) in &entries {
                 parts.push(format!(
                     "{k:?}: {}",
-                    render_to_string(vm, *v, true, pending, results, counter)
+                    render_to_string(vm, *v, true, depth + 1, state)
                 ));
             }
             format!("{{{}}}", parts.join(", "))
@@ -561,21 +644,26 @@ fn render_to_string(
                 for (name, v) in &paired {
                     parts.push(format!(
                         "{name}: {}",
-                        render_to_string(vm, *v, true, pending, results, counter)
+                        render_to_string(vm, *v, true, depth + 1, state)
                     ));
                 }
                 format!("{class_name} {{ {} }}", parts.join(", "))
             }
         }
+    };
+    if let Some(active_objects) = &mut state.active_objects {
+        active_objects.remove(&ptr);
     }
+    rendered
 }
 
 /// VM-heap-allocation-free structural rendering for diagnostics that already
 /// execute inside a native call and therefore cannot yield to user `ToString`
-/// overrides. `ErrorContext` uses this for fields of the thrown value so test
-/// failures retain useful data instead of printing only the error class name.
+/// overrides. The bounded traversal uses qualified class names consistently and
+/// truncates on excessive depth, node count, or an object cycle.
 pub(super) fn render_value_structural(vm: &BexVm, value: Value, nested: bool) -> String {
-    render_to_string(vm, value, nested, &[], &[], &mut 0)
+    let mut state = StringRenderState::diagnostic();
+    render_to_string(vm, value, nested, 0, &mut state)
 }
 
 fn deep_copy_value_recursive(

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -430,13 +430,14 @@ enum DisplaySnap {
     Leaf(String),
     /// A string's contents — quoted when nested, bare at top level.
     Str(String),
-    /// An array (or `uint8array`) — elements rendered as `[a, b, c]`.
-    Seq(Vec<Value>),
+    /// An array — elements rendered as `[a, b, c]`, with at most one trailing
+    /// ellipsis when diagnostic limits omit further siblings.
+    Seq(Vec<Value>, bool),
     /// A map — entries rendered as `{"k": v, ...}` (keys are always strings, and
     /// are quoted so keys containing `:`/`,` stay unambiguous).
-    Entries(Vec<(String, Value)>),
+    Entries(Vec<(String, Value)>, bool),
     /// A class instance — `ClassName { field: value, ... }`.
-    Instance(String, Vec<(String, Value)>),
+    Instance(String, Vec<(String, Value)>, bool),
 }
 
 const DIAGNOSTIC_RENDER_MAX_DEPTH: usize = 32;
@@ -486,16 +487,30 @@ impl<'a> StringRenderState<'a> {
     }
 
     fn consume_node(&mut self, depth: usize) -> bool {
-        if self.max_depth.is_some_and(|max_depth| depth > max_depth) {
-            return false;
-        }
-        match &mut self.remaining_nodes {
+        let has_budget = match &mut self.remaining_nodes {
             Some(remaining) if *remaining == 0 => false,
             Some(remaining) => {
                 *remaining -= 1;
                 true
             }
             None => true,
+        };
+        has_budget && self.max_depth.is_none_or(|max_depth| depth <= max_depth)
+    }
+
+    fn can_render_node(&self, depth: usize) -> bool {
+        self.remaining_nodes.is_none_or(|remaining| remaining != 0)
+            && self.max_depth.is_none_or(|max_depth| depth <= max_depth)
+    }
+
+    fn snapshot_child_limit(&self, child_count: usize) -> usize {
+        self.remaining_nodes
+            .map_or(child_count, |remaining| remaining.min(child_count))
+    }
+
+    fn consume_leaf_children(&mut self, count: usize) {
+        if let Some(remaining) = &mut self.remaining_nodes {
+            *remaining = remaining.saturating_sub(count);
         }
     }
 }
@@ -553,48 +568,73 @@ fn render_to_string(
         Object::String(s) => DisplaySnap::Str(s.as_str().to_string()),
         Object::Float(f) => DisplaySnap::Leaf(bex_vm_types::format_float(*f)),
         Object::Bigint(b) => DisplaySnap::Leaf(b.to_string()),
-        Object::Array(values) => DisplaySnap::Seq(values.to_vec()),
+        Object::Array(values) => {
+            let values = values.lock();
+            let limit = state.snapshot_child_limit(values.len());
+            DisplaySnap::Seq(
+                values.iter().take(limit).copied().collect(),
+                values.len() > limit,
+            )
+        }
         Object::Uint8Array(bytes) => {
-            let rendered = bytes
-                .to_vec()
+            let bytes = bytes.lock();
+            let limit = state.snapshot_child_limit(bytes.len());
+            let truncated = bytes.len() > limit;
+            let mut rendered = bytes
                 .iter()
+                .take(limit)
                 .map(u8::to_string)
                 .collect::<Vec<_>>()
                 .join(", ");
+            state.consume_leaf_children(limit);
+            if truncated {
+                if !rendered.is_empty() {
+                    rendered.push_str(", ");
+                }
+                rendered.push_str(TRUNCATED_RENDER);
+            }
             DisplaySnap::Leaf(format!("[{rendered}]"))
         }
-        Object::Map(map) => DisplaySnap::Entries(
-            map.to_index_map()
-                .into_iter()
-                .map(|(k, v)| (k.as_str().to_string(), v))
-                .collect(),
-        ),
+        Object::Map(map) => {
+            let map = map.lock();
+            let limit = state.snapshot_child_limit(map.len());
+            DisplaySnap::Entries(
+                map.iter()
+                    .take(limit)
+                    .map(|(k, v)| (k.as_str().to_string(), *v))
+                    .collect(),
+                map.len() > limit,
+            )
+        }
         Object::Instance(inst) => {
-            let field_values: Vec<Value> = inst.fields.iter().map(AtomicValueSlot::load).collect();
-            let (class_name, field_names) = match vm.get_object(inst.class) {
-                Object::Class(class) => (
-                    if state.qualified_class_names {
+            let limit = state.snapshot_child_limit(inst.fields.len());
+            let (class_name, paired) = match vm.get_object(inst.class) {
+                Object::Class(class) => {
+                    let name = if state.qualified_class_names {
                         class.name.to_string()
                     } else {
                         class.name.name().to_string()
-                    },
-                    class
+                    };
+                    let fields = inst
                         .fields
                         .iter()
-                        .map(|f| f.name.clone())
-                        .collect::<Vec<_>>(),
-                ),
+                        .take(limit)
+                        .map(AtomicValueSlot::load)
+                        .enumerate()
+                        .map(|(i, v)| {
+                            let field_name = class
+                                .fields
+                                .get(i)
+                                .map(|field| field.name.clone())
+                                .unwrap_or_else(|| i.to_string());
+                            (field_name, v)
+                        })
+                        .collect();
+                    (name, fields)
+                }
                 _ => (String::new(), Vec::new()),
             };
-            let paired = field_values
-                .into_iter()
-                .enumerate()
-                .map(|(i, v)| {
-                    let name = field_names.get(i).cloned().unwrap_or_else(|| i.to_string());
-                    (name, v)
-                })
-                .collect();
-            DisplaySnap::Instance(class_name, paired)
+            DisplaySnap::Instance(class_name, paired, inst.fields.len() > limit)
         }
         Object::Variant(var) => {
             let name = match vm.get_object(var.enm) {
@@ -619,33 +659,58 @@ fn render_to_string(
                 s
             }
         }
-        DisplaySnap::Seq(values) => {
+        DisplaySnap::Seq(values, mut truncated) => {
             let mut parts: Vec<String> = Vec::with_capacity(values.len());
             for v in &values {
+                if !state.can_render_node(depth + 1) {
+                    truncated = true;
+                    break;
+                }
                 parts.push(render_to_string(vm, *v, true, depth + 1, state));
+            }
+            if truncated {
+                parts.push(TRUNCATED_RENDER.to_string());
             }
             format!("[{}]", parts.join(", "))
         }
-        DisplaySnap::Entries(entries) => {
+        DisplaySnap::Entries(entries, mut truncated) => {
             let mut parts: Vec<String> = Vec::with_capacity(entries.len());
             for (k, v) in &entries {
+                if !state.can_render_node(depth + 1) {
+                    truncated = true;
+                    break;
+                }
                 parts.push(format!(
                     "{k:?}: {}",
                     render_to_string(vm, *v, true, depth + 1, state)
                 ));
             }
+            if truncated {
+                parts.push(TRUNCATED_RENDER.to_string());
+            }
             format!("{{{}}}", parts.join(", "))
         }
-        DisplaySnap::Instance(class_name, paired) => {
+        DisplaySnap::Instance(class_name, paired, mut truncated) => {
             if paired.is_empty() {
-                class_name
+                if truncated {
+                    format!("{class_name} {{ {TRUNCATED_RENDER} }}")
+                } else {
+                    class_name
+                }
             } else {
                 let mut parts: Vec<String> = Vec::with_capacity(paired.len());
                 for (name, v) in &paired {
+                    if !state.can_render_node(depth + 1) {
+                        truncated = true;
+                        break;
+                    }
                     parts.push(format!(
                         "{name}: {}",
                         render_to_string(vm, *v, true, depth + 1, state)
                     ));
+                }
+                if truncated {
+                    parts.push(TRUNCATED_RENDER.to_string());
                 }
                 format!("{class_name} {{ {} }}", parts.join(", "))
             }

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -570,6 +570,14 @@ fn render_to_string(
     }
 }
 
+/// VM-heap-allocation-free structural rendering for diagnostics that already
+/// execute inside a native call and therefore cannot yield to user `ToString`
+/// overrides. `ErrorContext` uses this for fields of the thrown value so test
+/// failures retain useful data instead of printing only the error class name.
+pub(super) fn render_value_structural(vm: &BexVm, value: Value, nested: bool) -> String {
+    render_to_string(vm, value, nested, &[], &[], &mut 0)
+}
+
 fn deep_copy_value_recursive(
     vm: &mut BexVm,
     value: Value,


### PR DESCRIPTION
## Root cause

Two VM rendering paths used incomplete fallbacks for values whose runtime shape carried more information than the fallback understood:

- `ErrorContext.to_string()` executes inside a native call and cannot yield to user `ToString` implementations. It therefore rendered class errors as only their class name and replaced other non-string values with `<error>`, losing the values needed to diagnose caught failures.
- typed-union JSON serialization delegated to a runtime-shape walker instead of selecting a union member. That lost the member’s declared-type behavior, so class/media values could be dropped and non-JSON members such as `uint8array` could behave differently inside versus outside a union.

## Scope

- add a VM-heap-allocation-free structural value renderer for native diagnostic paths with depth, node, and active-cycle guards
- render ErrorContext class errors with consistent qualified names, brace spacing, and recursively rendered fields
- structurally render non-class thrown values instead of `<error>`
- keep ErrorContext rendering non-dispatching, so user `ToString` overrides are not invoked from the native call
- select the first union member containing the runtime value with the VM’s canonical ordered membership check, then serialize through that member’s typed path
- raise `JsonSerializationError` when a value matches no member, or when the selected member itself is not JSON-serializable (including `uint8array` without explicit encoding)
- add focused regressions for ErrorContext class/non-class values and unions containing class, enum, and media values

## User impact

Caught errors retain actionable structural detail without risking unbounded diagnostic recursion. `baml.json.to_string<T>()` now preserves typed-member behavior inside unions; consequently, union serialization can fail when the runtime value matches no member or the selected member is not JSON-serializable.

## Validation

- `cargo nextest run -p baml_tests --test errorcontext --test json_typed_union` (19 passed)
- `cargo nextest run -p bex_vm` (61 passed)
- `cargo clippy -p bex_vm --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VM error rendering and typed JSON serialization paths used in diagnostics and `baml.json.to_string<T>()`, with behavior changes for union members and non-class thrown values.
> 
> **Overview**
> Improves how thrown values appear in **ErrorContext** cause chains and stack traces, and fixes **typed union** JSON serialization so it follows declared member types instead of a loose runtime-shape walk.
> 
> **ErrorContext / diagnostics:** Non-string errors no longer collapse to a class name or `<error>`. Native rendering uses a new bounded structural printer (`render_value_structural`) with qualified class names, recursive fields, depth/node limits, and cycle truncation—without calling user `ToString` overrides (native paths cannot yield). Panic snapshots now include payload fields (e.g. `DivisionByZero { dividend: 42 }`).
> 
> **JSON:** `baml.json.to_string<T>()` for unions picks the **first declared member** that contains the value via `value_matches_template` (same as `is` / match), then serializes through that member’s typed path. Class, enum, and media values are preserved; values outside the union or non-JSON members (e.g. `uint8array`) raise `JsonSerializationError` consistently inside and outside unions.
> 
> Regression tests cover ErrorContext rendering, truncation budgets, and typed union JSON (including equivalence with direct class serialization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94b78bd84527140f196057ca580d980ecc304c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thrown-error rendering so class-identity and structural fields are preserved in error cause chains, including safe handling for non-string throws and suppression of user `ToString` overrides for class-thrown values.
  * Structural string rendering now safely truncates cyclic and deeply nested structures with clear ellipsis/limit markers.
  * Panic output now includes the panic payload, not just the variant name.
  * Typed JSON union serialization now selects the first compatible union member; invalid values fail with a `JsonSerializationError`.
* **Tests**
  * Added regression coverage for error context rendering, truncation behavior (including cyclic/deep and large arrays), and typed union JSON serialization (success and failure). Updated the panic snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->