### PR TITLE
Make compiler codegen deterministic and keyword-safe

### DIFF
--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -13,7 +13,10 @@
 
 use std::{collections::BTreeMap, fmt::Write};
 
-use crate::types::{BamlType, NativeBuiltin, NativeClassDef, Receiver, VmUsage};
+use crate::{
+    rust_ident::{rust_field_ident, rust_field_value_ident},
+    types::{BamlType, NativeBuiltin, NativeClassDef, Receiver, VmUsage},
+};
 
 // ============================================================================
 // Fallibility
@@ -235,7 +238,7 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
 
     for field in &def.fields {
         let raw_name = &field.name;
-        let field_name = escape_rust_ident(raw_name);
+        let field_name = rust_field_ident(raw_name);
         match &field.field_type {
             BamlType::RustType => {
                 // Generic downcast accessor: fn _data<T: 'static>(&self, vm: &BexVm) -> &T
@@ -533,7 +536,7 @@ fn emit_copy_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
         writeln!(
             out,
             "{inner}pub {}: {rust_type},",
-            escape_rust_ident(&field.name)
+            rust_field_ident(&field.name)
         )
         .unwrap();
     }
@@ -551,8 +554,12 @@ fn emit_copy_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
 
     // Convert each field to a Value
     for field in &def.fields {
-        let conversion = copy_field_to_value(&escape_rust_ident(&field.name), &field.field_type);
-        writeln!(out, "{inner2}let f_{} = {conversion};", field.name).unwrap();
+        let value_ident = rust_field_value_ident(&field.name);
+        let conversion = copy_field_to_value(
+            &rust_field_ident(&field.name).to_string(),
+            &field.field_type,
+        );
+        writeln!(out, "{inner2}let {value_ident} = {conversion};").unwrap();
     }
 
     // Build the fields vec
@@ -565,7 +572,7 @@ fn emit_copy_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
         if i > 0 {
             out.push_str(", ");
         }
-        write!(out, "f_{}", field.name).unwrap();
+        write!(out, "{}", rust_field_value_ident(&field.name)).unwrap();
     }
     out.push_str("]))\n");
     writeln!(out, "{inner}}}").unwrap();
@@ -674,25 +681,6 @@ fn class_dispatch_name(namespace_prefix: &str, class_name: &str) -> String {
         format!("__dispatch_{class_lower}")
     } else {
         format!("__dispatch_{namespace_prefix}_{class_lower}")
-    }
-}
-
-/// A BAML field name as a Rust identifier: `type` is a Rust keyword, so it is
-/// emitted as the raw identifier `r#type`. Field names come from `.baml`
-/// source, where BAML's keywords and Rust's do not coincide, so any of them
-/// can collide with Rust's.
-fn escape_rust_ident(name: &str) -> String {
-    const RUST_KEYWORDS: &[&str] = &[
-        "as", "async", "await", "become", "box", "break", "const", "continue", "crate", "do",
-        "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in", "let",
-        "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub", "ref", "return",
-        "static", "struct", "super", "trait", "true", "try", "type", "typeof", "unsafe", "unsized",
-        "use", "virtual", "where", "while", "yield",
-    ];
-    if RUST_KEYWORDS.contains(&name) {
-        format!("r#{name}")
-    } else {
-        name.to_string()
     }
 }
 

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
@@ -431,6 +431,21 @@ fn external_to_typed_expr(
     }
 }
 
+/// Turn a BAML field name into a Rust identifier for generated structs and accessors.
+///
+/// Rust keywords such as `type`, `match`, and `move` are valid BAML field names, so
+/// emit them as raw identifiers. Rust does not permit raw forms of `self`, `Self`,
+/// `super`, `crate`, or `_`; those names use a trailing underscore instead. This
+/// only changes the generated Rust spelling: VM and external-value lookups continue
+/// to use the original BAML field name.
+fn field_ident(name: &str) -> proc_macro2::Ident {
+    match name {
+        "self" | "Self" | "super" | "crate" | "_" => format_ident!("{}_", name),
+        _ if syn::parse_str::<syn::Ident>(name).is_err() => format_ident!("r#{}", name),
+        _ => format_ident!("{}", name),
+    }
+}
+
 /// Generate the `into_owned` conversion expression for a view field.
 fn into_owned_expr(
     field_name: &str,
@@ -438,7 +453,7 @@ fn into_owned_expr(
     class_ns_map: &BTreeMap<String, String>,
     paths: &CodegenPaths,
 ) -> TokenStream {
-    let field_ident = format_ident!("{}", field_name);
+    let field_ident = field_ident(field_name);
     match ty {
         BamlType::Int | BamlType::Bool => {
             quote! { self.#field_ident()? }
@@ -991,7 +1006,7 @@ fn emit_view_struct(
             let mut needs_heap = false;
             let ret_type = view_return_type(&field.field_type, &mut needs_heap);
             let body = view_accessor_body(&field.name, &field.field_type);
-            let field_ident = format_ident!("{}", field.name);
+            let field_ident = field_ident(&field.name);
 
             if needs_heap {
                 quote! {
@@ -1022,7 +1037,7 @@ fn emit_view_struct(
         .fields
         .iter()
         .map(|field| {
-            let field_ident = format_ident!("{}", field.name);
+            let field_ident = field_ident(&field.name);
             let expr = into_owned_expr(&field.name, &field.field_type, class_ns_map, paths);
             quote! { #field_ident: #expr }
         })
@@ -1198,7 +1213,7 @@ fn emit_owned_struct(
         .fields
         .iter()
         .map(|field| {
-            let field_ident = format_ident!("{}", field.name);
+            let field_ident = field_ident(&field.name);
             let rust_ty = owned_rust_type(&field.field_type, class_ns_map, paths);
             quote! { pub #field_ident: #rust_ty }
         })
@@ -1210,7 +1225,7 @@ fn emit_owned_struct(
         .iter()
         .map(|field| {
             let field_name_str = &field.name;
-            let field_ident = format_ident!("{}", field.name);
+            let field_ident = field_ident(&field.name);
             let conv = owned_to_external_expr(
                 &quote! { self.#field_ident },
                 &field.field_type,
@@ -1225,7 +1240,7 @@ fn emit_owned_struct(
         .fields
         .iter()
         .map(|field| {
-            let field_ident = format_ident!("{}", field.name);
+            let field_ident = field_ident(&field.name);
             let field_name_str = &field.name;
             let field_val = quote! {
                 fields.swap_remove(#field_name_str).unwrap_or(BexExternalValue::Null)
@@ -2199,7 +2214,7 @@ fn emit_runtime_io_handles(
                     if field.field_type == BamlType::RustType {
                         continue;
                     }
-                    let field_ident = format_ident!("{}", field.name);
+                    let field_ident = field_ident(&field.name);
                     let field_ty = owned_rust_type(&field.field_type, class_ns_map, paths);
                     pub_fields.push(quote! { pub #field_ident: #field_ty });
 
@@ -2696,6 +2711,97 @@ fn emit_build_runtime_io(io_builtins: &[NativeBuiltin]) -> TokenStream {
                 ctx: ctx.clone(),
                 #(#field_inits,)*
             })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashSet};
+
+    use super::{CodegenPaths, emit_owned_struct, emit_view_struct, field_ident};
+    use crate::types::{BamlType, NativeClassDef, NativeClassField};
+
+    #[test]
+    fn field_ident_escapes_keywords_and_uses_legal_fallbacks() {
+        for keyword in ["type", "match", "move"] {
+            assert_eq!(field_ident(keyword).to_string(), format!("r#{keyword}"));
+        }
+
+        for (name, expected) in [
+            ("self", "self_"),
+            ("Self", "Self_"),
+            ("super", "super_"),
+            ("crate", "crate_"),
+            ("_", "__"),
+        ] {
+            assert_eq!(field_ident(name).to_string(), expected);
+        }
+
+        assert_eq!(field_ident("ordinary").to_string(), "ordinary");
+    }
+
+    #[test]
+    fn generated_keyword_fields_keep_original_vm_keys() {
+        let class = NativeClassDef {
+            name: "KeywordFields".to_string(),
+            namespace_prefix: "baml.test".to_string(),
+            generic_params: Vec::new(),
+            fields: [
+                "type", "match", "move", "self", "Self", "super", "crate", "_",
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(index, name)| NativeClassField {
+                name: name.to_string(),
+                field_type: BamlType::Bool,
+                index,
+            })
+            .collect(),
+            source_file: "<test>/keywords.baml".to_string(),
+        };
+        let class_ns_map = BTreeMap::new();
+        let paths = CodegenPaths::inline();
+
+        let owned = crate::format_tokens(&emit_owned_struct(
+            &class,
+            &class_ns_map,
+            "test",
+            &paths,
+            &HashSet::new(),
+        ));
+        let view = crate::format_tokens(&emit_view_struct(&class, &class_ns_map, "test", &paths));
+        let compact_owned: String = owned.chars().filter(|c| !c.is_whitespace()).collect();
+        let compact_view: String = view.chars().filter(|c| !c.is_whitespace()).collect();
+
+        for rust_name in [
+            "r#type", "r#match", "r#move", "self_", "Self_", "super_", "crate_", "__",
+        ] {
+            assert!(
+                compact_owned.contains(&format!("pub{rust_name}:bool")),
+                "missing escaped owned field `{rust_name}`:\n{owned}"
+            );
+            assert!(
+                compact_view.contains(&format!("pubfn{rust_name}(&self)")),
+                "missing escaped view accessor `{rust_name}`:\n{view}"
+            );
+        }
+
+        for baml_name in [
+            "type", "match", "move", "self", "Self", "super", "crate", "_",
+        ] {
+            assert!(
+                compact_owned.contains(&format!("\"{baml_name}\".to_string()")),
+                "external conversion changed the BAML key `{baml_name}`:\n{owned}"
+            );
+            assert!(
+                compact_owned.contains(&format!("fields.swap_remove(\"{baml_name}\")")),
+                "external lookup changed the BAML key `{baml_name}`:\n{owned}"
+            );
+            assert!(
+                compact_view.contains(&format!("self.cls.field(\"{baml_name}\")")),
+                "VM lookup changed the BAML key `{baml_name}`:\n{view}"
+            );
         }
     }
 }

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
@@ -15,7 +15,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::types::{BamlType, NativeBuiltin, NativeClassDef, Receiver};
+use crate::{
+    rust_ident::rust_field_ident,
+    types::{BamlType, NativeBuiltin, NativeClassDef, Receiver},
+};
 
 // ============================================================================
 // Path configuration for generated code
@@ -431,21 +434,6 @@ fn external_to_typed_expr(
     }
 }
 
-/// Turn a BAML field name into a Rust identifier for generated structs and accessors.
-///
-/// Rust keywords such as `type`, `match`, and `move` are valid BAML field names, so
-/// emit them as raw identifiers. Rust does not permit raw forms of `self`, `Self`,
-/// `super`, `crate`, or `_`; those names use a trailing underscore instead. This
-/// only changes the generated Rust spelling: VM and external-value lookups continue
-/// to use the original BAML field name.
-fn field_ident(name: &str) -> proc_macro2::Ident {
-    match name {
-        "self" | "Self" | "super" | "crate" | "_" => format_ident!("{}_", name),
-        _ if syn::parse_str::<syn::Ident>(name).is_err() => format_ident!("r#{}", name),
-        _ => format_ident!("{}", name),
-    }
-}
-
 /// Generate the `into_owned` conversion expression for a view field.
 fn into_owned_expr(
     field_name: &str,
@@ -453,7 +441,7 @@ fn into_owned_expr(
     class_ns_map: &BTreeMap<String, String>,
     paths: &CodegenPaths,
 ) -> TokenStream {
-    let field_ident = field_ident(field_name);
+    let field_ident = rust_field_ident(field_name);
     match ty {
         BamlType::Int | BamlType::Bool => {
             quote! { self.#field_ident()? }
@@ -1006,7 +994,7 @@ fn emit_view_struct(
             let mut needs_heap = false;
             let ret_type = view_return_type(&field.field_type, &mut needs_heap);
             let body = view_accessor_body(&field.name, &field.field_type);
-            let field_ident = field_ident(&field.name);
+            let field_ident = rust_field_ident(&field.name);
 
             if needs_heap {
                 quote! {
@@ -1037,7 +1025,7 @@ fn emit_view_struct(
         .fields
         .iter()
         .map(|field| {
-            let field_ident = field_ident(&field.name);
+            let field_ident = rust_field_ident(&field.name);
             let expr = into_owned_expr(&field.name, &field.field_type, class_ns_map, paths);
             quote! { #field_ident: #expr }
         })
@@ -1213,7 +1201,7 @@ fn emit_owned_struct(
         .fields
         .iter()
         .map(|field| {
-            let field_ident = field_ident(&field.name);
+            let field_ident = rust_field_ident(&field.name);
             let rust_ty = owned_rust_type(&field.field_type, class_ns_map, paths);
             quote! { pub #field_ident: #rust_ty }
         })
@@ -1225,7 +1213,7 @@ fn emit_owned_struct(
         .iter()
         .map(|field| {
             let field_name_str = &field.name;
-            let field_ident = field_ident(&field.name);
+            let field_ident = rust_field_ident(&field.name);
             let conv = owned_to_external_expr(
                 &quote! { self.#field_ident },
                 &field.field_type,
@@ -1240,7 +1228,7 @@ fn emit_owned_struct(
         .fields
         .iter()
         .map(|field| {
-            let field_ident = field_ident(&field.name);
+            let field_ident = rust_field_ident(&field.name);
             let field_name_str = &field.name;
             let field_val = quote! {
                 fields.swap_remove(#field_name_str).unwrap_or(BexExternalValue::Null)
@@ -2214,7 +2202,7 @@ fn emit_runtime_io_handles(
                     if field.field_type == BamlType::RustType {
                         continue;
                     }
-                    let field_ident = field_ident(&field.name);
+                    let field_ident = rust_field_ident(&field.name);
                     let field_ty = owned_rust_type(&field.field_type, class_ns_map, paths);
                     pub_fields.push(quote! { pub #field_ident: #field_ty });
 
@@ -2719,45 +2707,40 @@ fn emit_build_runtime_io(io_builtins: &[NativeBuiltin]) -> TokenStream {
 mod tests {
     use std::collections::{BTreeMap, HashSet};
 
-    use super::{CodegenPaths, emit_owned_struct, emit_view_struct, field_ident};
+    use super::{CodegenPaths, emit_owned_struct, emit_view_struct};
+    use crate::rust_ident::rust_field_ident;
     use crate::types::{BamlType, NativeClassDef, NativeClassField};
 
     #[test]
-    fn field_ident_escapes_keywords_and_uses_legal_fallbacks() {
-        for keyword in ["type", "match", "move"] {
-            assert_eq!(field_ident(keyword).to_string(), format!("r#{keyword}"));
-        }
-
-        for (name, expected) in [
-            ("self", "self_"),
-            ("Self", "Self_"),
-            ("super", "super_"),
-            ("crate", "crate_"),
-            ("_", "__"),
-        ] {
-            assert_eq!(field_ident(name).to_string(), expected);
-        }
-
-        assert_eq!(field_ident("ordinary").to_string(), "ordinary");
-    }
-
-    #[test]
     fn generated_keyword_fields_keep_original_vm_keys() {
+        const BAML_FIELD_NAMES: &[&str] = &[
+            "type",
+            "match",
+            "move",
+            "self",
+            "self_",
+            "Self",
+            "super",
+            "crate",
+            "_",
+            "dash-name",
+            "$data",
+            "__baml_field_73656c66",
+        ];
         let class = NativeClassDef {
             name: "KeywordFields".to_string(),
             namespace_prefix: "baml.test".to_string(),
             generic_params: Vec::new(),
-            fields: [
-                "type", "match", "move", "self", "Self", "super", "crate", "_",
-            ]
-            .into_iter()
-            .enumerate()
-            .map(|(index, name)| NativeClassField {
-                name: name.to_string(),
-                field_type: BamlType::Bool,
-                index,
-            })
-            .collect(),
+            fields: BAML_FIELD_NAMES
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(index, name)| NativeClassField {
+                    name: name.to_string(),
+                    field_type: BamlType::Bool,
+                    index,
+                })
+                .collect(),
             source_file: "<test>/keywords.baml".to_string(),
         };
         let class_ns_map = BTreeMap::new();
@@ -2774,22 +2757,19 @@ mod tests {
         let compact_owned: String = owned.chars().filter(|c| !c.is_whitespace()).collect();
         let compact_view: String = view.chars().filter(|c| !c.is_whitespace()).collect();
 
-        for rust_name in [
-            "r#type", "r#match", "r#move", "self_", "Self_", "super_", "crate_", "__",
-        ] {
+        for baml_name in BAML_FIELD_NAMES {
+            let rust_name = rust_field_ident(baml_name);
             assert!(
                 compact_owned.contains(&format!("pub{rust_name}:bool")),
                 "missing escaped owned field `{rust_name}`:\n{owned}"
             );
             assert!(
-                compact_view.contains(&format!("pubfn{rust_name}(&self)")),
+                compact_view.contains(&format!("pubfn{rust_name}(")),
                 "missing escaped view accessor `{rust_name}`:\n{view}"
             );
         }
 
-        for baml_name in [
-            "type", "match", "move", "self", "Self", "super", "crate", "_",
-        ] {
+        for baml_name in BAML_FIELD_NAMES {
             assert!(
                 compact_owned.contains(&format!("\"{baml_name}\".to_string()")),
                 "external conversion changed the BAML key `{baml_name}`:\n{owned}"

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen_io.rs
@@ -2708,8 +2708,10 @@ mod tests {
     use std::collections::{BTreeMap, HashSet};
 
     use super::{CodegenPaths, emit_owned_struct, emit_view_struct};
-    use crate::rust_ident::rust_field_ident;
-    use crate::types::{BamlType, NativeClassDef, NativeClassField};
+    use crate::{
+        rust_ident::rust_field_ident,
+        types::{BamlType, NativeClassDef, NativeClassField},
+    };
 
     #[test]
     fn generated_keyword_fields_keep_original_vm_keys() {

--- a/baml_language/crates/baml_builtins2_codegen/src/lib.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/lib.rs
@@ -3,6 +3,7 @@ mod codegen_errors;
 mod codegen_io;
 mod codegen_panics;
 mod extract;
+mod rust_ident;
 mod types;
 
 pub use codegen::{generate_native_trait, generate_native_trait_for};

--- a/baml_language/crates/baml_builtins2_codegen/src/rust_ident.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/rust_ident.rs
@@ -1,0 +1,102 @@
+use std::fmt::Write as _;
+
+use proc_macro2::{Ident, Span};
+
+/// Prefix reserved for BAML field names that cannot be represented by a Rust
+/// identifier, even as a raw identifier.
+///
+/// Names that already start with this prefix are encoded too, which keeps the
+/// mapping injective: a user field can never collide with an escaped field.
+const ESCAPED_FIELD_PREFIX: &str = "__baml_field_";
+
+/// Map a BAML field name to a legal, collision-free Rust identifier.
+///
+/// Ordinary names are preserved for readable generated APIs. Rust keywords
+/// that support raw identifiers use `r#name`. The few names Rust forbids even
+/// in raw form (`self`, `Self`, `super`, `crate`, and `_`), plus BAML names
+/// containing Rust-illegal punctuation, use a reversible hex encoding.
+pub(crate) fn rust_field_ident(name: &str) -> Ident {
+    if !name.starts_with(ESCAPED_FIELD_PREFIX) {
+        if let Ok(ident) = syn::parse_str::<Ident>(name) {
+            return ident;
+        }
+        if let Ok(ident) = syn::parse_str::<Ident>(&format!("r#{name}")) {
+            return ident;
+        }
+    }
+
+    let encoded = encoded_ident(ESCAPED_FIELD_PREFIX, name);
+    Ident::new(&encoded, Span::call_site())
+}
+
+/// Internal local used while converting a generated field back to a VM value.
+/// Always encode these bindings: they are implementation details, so readability
+/// is less important than avoiding another identifier-concatenation edge case.
+pub(crate) fn rust_field_value_ident(name: &str) -> Ident {
+    Ident::new(
+        &encoded_ident("__baml_field_value_", name),
+        Span::call_site(),
+    )
+}
+
+fn encoded_ident(prefix: &str, name: &str) -> String {
+    let mut encoded = String::with_capacity(prefix.len() + name.len() * 2);
+    encoded.push_str(prefix);
+    for byte in name.as_bytes() {
+        write!(encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use proc_macro2::Ident;
+
+    use super::{rust_field_ident, rust_field_value_ident};
+
+    #[test]
+    fn preserves_plain_names_and_uses_raw_rust_keywords() {
+        assert_eq!(rust_field_ident("ordinary").to_string(), "ordinary");
+        for keyword in ["type", "match", "move"] {
+            assert_eq!(
+                rust_field_ident(keyword).to_string(),
+                format!("r#{keyword}")
+            );
+        }
+    }
+
+    #[test]
+    fn escaping_is_legal_and_collision_free() {
+        let names = [
+            "self",
+            "Self",
+            "super",
+            "crate",
+            "_",
+            "dash-name",
+            "$data",
+            "__baml_field_73656c66",
+            "self_",
+        ];
+        let idents = names
+            .iter()
+            .map(|name| rust_field_ident(name).to_string())
+            .collect::<std::collections::HashSet<_>>();
+
+        assert_eq!(idents.len(), names.len());
+        assert!(
+            idents
+                .iter()
+                .all(|ident| syn::parse_str::<Ident>(ident).is_ok())
+        );
+        assert_eq!(rust_field_ident("self_").to_string(), "self_");
+        assert_ne!(
+            rust_field_ident("self").to_string(),
+            rust_field_ident("__baml_field_73656c66").to_string()
+        );
+        assert_ne!(
+            rust_field_value_ident("dash-name"),
+            rust_field_value_ident("dash_name")
+        );
+    }
+}

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -929,13 +929,17 @@ pub fn namespace_items<'db>(
 pub fn package_items<'db>(db: &'db dyn Db, package_id: PackageId<'db>) -> PackageItems<'db> {
     let package_name = package_id.name(db);
 
-    let mut ns_paths: std::collections::HashSet<Vec<Name>> = std::collections::HashSet::new();
+    // Consumers observe the insertion order of `namespaces`, so namespace
+    // discovery must not inherit `HashSet`'s per-process randomized order.
+    let mut ns_paths: Vec<Vec<Name>> = Vec::new();
     for file in baml_compiler2_hir::compiler2_all_files(db) {
         let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
         if pkg_info.package == *package_name {
-            ns_paths.insert(pkg_info.namespace_path.clone());
+            ns_paths.push(pkg_info.namespace_path.clone());
         }
     }
+    ns_paths.sort();
+    ns_paths.dedup();
 
     let mut namespaces: FxHashMap<Vec<Name>, NamespaceItems<'db>> = FxHashMap::default();
     let mut all_conflicts: Vec<NameConflict<'db>> = Vec::new();

--- a/baml_language/crates/baml_tests/src/compiler2_ppir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_ppir.rs
@@ -1,0 +1,51 @@
+//! Focused regressions for PPIR package aggregation.
+
+#[cfg(test)]
+mod tests {
+    use baml_base::Name;
+    use baml_compiler2_hir::package::PackageId;
+    use baml_project::ProjectDatabase;
+
+    fn namespace_iteration_order(files: &[&str]) -> Vec<Vec<String>> {
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("."));
+
+        for (index, namespace) in files.iter().enumerate() {
+            db.add_file(
+                format!("ns_{namespace}/marker_{index}.baml"),
+                &format!("class Marker{index} {{}}"),
+            );
+        }
+
+        let package =
+            baml_compiler2_ppir::package_items(&db, PackageId::new(&db, Name::new("user")));
+        package
+            .namespaces
+            .keys()
+            .map(|path| path.iter().map(ToString::to_string).collect())
+            .collect()
+    }
+
+    #[test]
+    fn package_namespace_iteration_is_independent_of_file_discovery_order() {
+        let namespaces = [
+            "zulu", "alpha", "quebec", "bravo", "papa", "charlie", "oscar", "delta", "november",
+            "echo", "mike", "foxtrot", "lima", "golf", "kilo", "hotel", "juliet", "india", "alpha",
+            "zulu", "golf",
+        ];
+        let expected = namespace_iteration_order(&namespaces);
+        assert_eq!(
+            expected.len(),
+            18,
+            "duplicate namespace paths must be removed"
+        );
+
+        let mut reversed = namespaces;
+        reversed.reverse();
+        assert_eq!(namespace_iteration_order(&reversed), expected);
+
+        let mut rotated = namespaces;
+        rotated.rotate_left(7);
+        assert_eq!(namespace_iteration_order(&rotated), expected);
+    }
+}

--- a/baml_language/crates/baml_tests/src/lib.rs
+++ b/baml_language/crates/baml_tests/src/lib.rs
@@ -219,6 +219,9 @@ macro_rules! assert_compiler2_snapshot {
 pub mod compiler2_hir;
 
 #[cfg(test)]
+pub mod compiler2_ppir;
+
+#[cfg(test)]
 pub mod compiler2_tir;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- use one shared BAML-field-to-Rust-identifier policy across the native and IO Rust generators
- preserve ordinary field names, use raw Rust identifiers for compatible keywords, and reversibly encode names Rust cannot represent directly
- reserve and self-escape the encoding prefix so generated identifiers cannot collide
- preserve the exact original BAML field name for every VM and external-value lookup
- sort and deduplicate PPIR namespace paths so output is independent of file discovery order

## Why
BAML field names are not constrained by Rust: valid names include Rust keywords and punctuation such as `type`, `self`, `dash-name`, and `$data`. Internal build-time Rust generation must map those names legally without changing runtime keys or collapsing two BAML fields to one Rust identifier. Separately, PPIR namespace discovery previously inherited randomized `HashSet` iteration order.

## Validation
- `cargo nextest run -p baml_builtins2_codegen` (26 passed)
- focused PPIR namespace-order regression (1 passed)
- `cargo clippy -p baml_builtins2_codegen --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all generated builtin/IO Rust glue; incorrect mapping could break field access at runtime, though tests lock VM keys and encoding behavior.
> 
> **Overview**
> **Centralizes how BAML field names become Rust identifiers** in native and IO build-time generators, replacing the old keyword-only `escape_rust_ident` helper.
> 
> The new `rust_ident` policy keeps normal names readable, uses `r#…` for compatible Rust keywords, and **reversibly hex-encodes** names Rust cannot represent (`self`, punctuation, etc.) with a **self-escaping prefix** so two BAML fields cannot map to one Rust id. Generated **owned/view/copy** code uses these ids for struct members and accessors while **VM `field("…")`, external `swap_remove`, and map keys still use the original BAML strings**.
> 
> **PPIR `package_items`** no longer discovers namespace paths via `HashSet` (random iteration order); paths are collected, **sorted, and deduped** so package namespace ordering is stable regardless of file discovery order. Regressions cover keyword field codegen and namespace iteration order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39560de4bec71982da1850b4bec63f2b0b493b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->