### PR TITLE
Assert projection call bases are evaluated once

### DIFF
--- a/baml_language/crates/bex_vm/tests/projection_dest_calls.rs
+++ b/baml_language/crates/bex_vm/tests/projection_dest_calls.rs
@@ -112,15 +112,20 @@ fn method_call_result_can_be_the_base_of_nested_field_assignment() {
         class Record { info: Info }
         class Store {
             record: Record
-            function require(self) -> Record { self.record }
+            calls: int
+            function require(self) -> Record {
+                self.calls += 1;
+                self.record
+            }
         }
 
         function main() -> bool {
             let store = Store {
                 record: Record { info: Info { title: null } },
+                calls: 0,
             };
             store.require().info.title = "triage";
-            store.record.info.title == "triage"
+            store.record.info.title == "triage" && store.calls == 1
         }
     "#;
 


### PR DESCRIPTION
## Summary
- make the nested projection assignment regression track calls to `Store.require()`
- assert the assignment still mutates the expected nested field
- assert the projection base is evaluated exactly once

## Why
This is a test-only follow-up to the unresolved review on #4140. The original regression used a pure `require()` method, so it could not detect duplicate evaluation of the projection base.

## Impact
No production behavior changes. The strengthened regression now guards both correct nested assignment and exactly-once evaluation.

## Validation
- `cargo nextest run -p bex_vm --test projection_dest_calls method_call_result_can_be_the_base_of_nested_field_assignment`
- `cargo nextest run -p bex_vm --test projection_dest_calls`
- `cargo fmt --all --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates an integration test; no compiler, MIR, or runtime behavior changes.
> 
> **Overview**
> **Test-only** change to `method_call_result_can_be_the_base_of_nested_field_assignment` in `projection_dest_calls.rs`.
> 
> The nested assignment `store.require().info.title = "triage"` still must mutate the right field; the test now also proves the projection base is evaluated **exactly once**. `Store` gains a `calls` counter incremented inside `require()`, and `main` asserts `store.calls == 1` in addition to the title check. A pure `require()` that only returned `self.record` could pass even if MIR evaluated the call twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f027146972b1e5005e678d8334ddb2429d2e55c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->