### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -44,13 +44,13 @@ policy.max_delta_pct = 3.0
 # unformatted generated SDK output).
 # macOS arm64: baseline 21.02 MB file (21_018_272), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 21_648_821
+max_file_bytes = 21_648_854
 # Linux x86_64: baseline 27.07 MB file (27_071_888), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 27_884_045
+max_file_bytes = 27_894_065
 # Windows x86_64: baseline 22.67 MB file (22_665_216), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 23_345_173
+max_file_bytes = 23_350_447
 
 [artifacts.packed-program]
 kind = "pack"
@@ -58,13 +58,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 13.57 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 13_977_943
+max_file_bytes = 13_994_967
 # Linux x86_64: baseline 17.42 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 17_947_207
+max_file_bytes = 17_955_644
 # Windows x86_64: baseline 14.50 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 14_934_288
+max_file_bytes = 14_940_089
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -88,4 +88,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.48 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_613_794
+max_gzip_bytes = 4_616_127

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-24T02:25:23Z"
-git_sha = "b51a52df250ef55fa1f7255321f9a9f1b06139bf"
+recorded_at = "2026-07-24T10:01:59Z"
+git_sha = "560dc6e23af0b3910ddcbdbf3a34153ea2c709be"
 
 [artifacts.baml-cli]
-file_bytes = 21018272
-stripped_bytes = 21018320
-gzip_bytes = 10044371
+file_bytes = 21018304
+stripped_bytes = 21018336
+gzip_bytes = 10049725
 
 [artifacts.packed-program]
-file_bytes = 13570818
-gzip_bytes = 6298972
+file_bytes = 13587346
+gzip_bytes = 6304073

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-07-24T02:25:23Z"
-git_sha = "b51a52df250ef55fa1f7255321f9a9f1b06139bf"
+recorded_at = "2026-07-24T10:01:59Z"
+git_sha = "560dc6e23af0b3910ddcbdbf3a34153ea2c709be"
 
 [artifacts.bridge_wasm]
-file_bytes = 16420280
-gzip_bytes = 4479411
+file_bytes = 16428315
+gzip_bytes = 4481676

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-24T02:25:23Z"
-git_sha = "b51a52df250ef55fa1f7255321f9a9f1b06139bf"
+recorded_at = "2026-07-24T10:01:59Z"
+git_sha = "560dc6e23af0b3910ddcbdbf3a34153ea2c709be"
 
 [artifacts.baml-cli]
-file_bytes = 22665216
-stripped_bytes = 22665216
-gzip_bytes = 10260724
+file_bytes = 22670336
+stripped_bytes = 22670336
+gzip_bytes = 10264447
 
 [artifacts.packed-program]
-file_bytes = 14499308
-gzip_bytes = 6390251
+file_bytes = 14504940
+gzip_bytes = 6394252

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-24T02:25:23Z"
-git_sha = "b51a52df250ef55fa1f7255321f9a9f1b06139bf"
+recorded_at = "2026-07-24T10:01:59Z"
+git_sha = "560dc6e23af0b3910ddcbdbf3a34153ea2c709be"
 
 [artifacts.baml-cli]
-file_bytes = 27071888
-stripped_bytes = 27071880
-gzip_bytes = 11512232
+file_bytes = 27081616
+stripped_bytes = 27081608
+gzip_bytes = 11520074
 
 [artifacts.packed-program]
-file_bytes = 17424472
-gzip_bytes = 7192426
+file_bytes = 17432664
+gzip_bytes = 7197468


### PR DESCRIPTION
Adopted from CI run [`560dc6e23af0b3910ddcbdbf3a34153ea2c709be`](https://github.com/BoundaryML/baml/actions/runs/30079713253).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 27.1 MB | 11.5 MB | **file** | 27.1 MB | +9.7 KB (+0.0%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 17.4 MB | 7.2 MB | **file** | 17.4 MB | +8.2 KB (+0.0%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 21.0 MB | 10.0 MB | **file** | 21.0 MB | +32 B (+0.0%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 13.6 MB | 6.3 MB | **file** | 13.6 MB | +16.5 KB (+0.1%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 16.4 MB | 🔒 4.5 MB | **gzip** | 4.5 MB | +2.3 KB (+0.1%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 22.7 MB | 10.3 MB | **file** | 22.7 MB | +5.1 KB (+0.0%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 14.5 MB | 6.4 MB | **file** | 14.5 MB | +5.6 KB (+0.0%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release artifact size baselines across macOS, Linux, Windows, and WebAssembly builds.
  * Refreshed recorded build measurements and validation limits to keep shipped artifacts within expected size ranges.
  * No user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->