### PR TITLE
docs(sdk-java): quickstart pins the e2e-verified family nightly

### DIFF
--- a/baml_language/sdks/java/examples/quickstart/README.md
+++ b/baml_language/sdks/java/examples/quickstart/README.md
@@ -7,16 +7,17 @@ The complete setup is one plugin line — write BAML in `baml_src/`, build, done
 plugins {
     java
     application
-    id("com.boundaryml.baml") version "0.15.0-nightly.1"
+    id("com.boundaryml.baml") version "0.15.1-nightly.20260723.g"
 }
 repositories { mavenCentral() }
 ```
 
-> ⚠ The plugin, runtime artifacts, and `baml` CLI publish together at one
-> family version, and the version in the `plugins` block must match your
-> installed CLI. Until the first fully-matched family nightly ships, this
-> example shows the shape of the setup; it becomes copy-paste-runnable the
-> moment that nightly publishes.
+> The plugin, runtime artifacts, and `baml` CLI publish together at one
+> family version; the version in the `plugins` block must match your
+> installed CLI. This example pins a published, end-to-end-verified
+> version. Plugin resolution needs no repository configuration on any
+> channel: stables live on the Gradle Plugin Portal, and the Portal
+> proxies Maven Central for the rest.
 
 The plugin resolves from the Gradle Plugin Portal, runs `baml generate`
 before compilation (incrementally — it reruns only when a generation

--- a/baml_language/sdks/java/examples/quickstart/README.md
+++ b/baml_language/sdks/java/examples/quickstart/README.md
@@ -15,9 +15,11 @@ repositories { mavenCentral() }
 > The plugin, runtime artifacts, and `baml` CLI publish together at one
 > family version; the version in the `plugins` block must match your
 > installed CLI. This example pins a published, end-to-end-verified
-> version. Plugin resolution needs no repository configuration on any
-> channel: stables live on the Gradle Plugin Portal, and the Portal
-> proxies Maven Central for the rest.
+> version. Stable plugin versions resolve from the Gradle Plugin Portal
+> with zero configuration; for nightlies (published to Maven Central)
+> the example's `settings.gradle.kts` carries the standard
+> `pluginManagement` stanza so resolution rests on documented Gradle
+> behavior rather than the Portal's Central-proxying.
 
 The plugin resolves from the Gradle Plugin Portal, runs `baml generate`
 before compilation (incrementally — it reruns only when a generation

--- a/baml_language/sdks/java/examples/quickstart/build.gradle.kts
+++ b/baml_language/sdks/java/examples/quickstart/build.gradle.kts
@@ -13,10 +13,10 @@ plugins {
     java
     application
     // The plugin/runtime/CLI publish together at one family version — the
-    // version here must match the installed `baml` CLI. Until the first
-    // fully-matched family nightly ships, treat this example as the shape
-    // of the setup rather than a copy-paste-runnable snapshot.
-    id("com.boundaryml.baml") version "0.15.0-nightly.1"
+    // version here must match the installed `baml` CLI (download the
+    // matching release archive, or install a newer matched pair and bump
+    // this line to it).
+    id("com.boundaryml.baml") version "0.15.1-nightly.20260723.g"
 }
 
 repositories {

--- a/baml_language/sdks/java/examples/quickstart/settings.gradle.kts
+++ b/baml_language/sdks/java/examples/quickstart/settings.gradle.kts
@@ -1,1 +1,14 @@
+// Plugin resolution: stable versions resolve from the Gradle Plugin Portal
+// with no configuration at all. Nightly versions publish to Maven Central,
+// so this stanza makes their resolution guaranteed by documented Gradle
+// behavior. (In practice the Portal's endpoint also proxies Central, which
+// is why a bare plugins block resolves nightlies too — but an example
+// should not depend on infrastructure behavior.)
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "baml-java-quickstart"


### PR DESCRIPTION
Replaces the dead `0.15.0-nightly.1` pair with `0.15.1-nightly.20260723.g` — a matched triplet verified end-to-end from public infrastructure (downloaded CLI release + Portal-proxied plugin + Central runtime/natives + pristine Gradle home → live engine call). Docs-only; the Portal stays stable-publish-only (its repo proxies Central for reads, which is how nightlies resolve zero-config). 1.0 supersedes the pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Java quickstart to use the newer BAML Gradle plugin nightly version.
  - Clarified how to keep the Gradle plugin, runtime artifacts, and the BAML CLI version aligned.
  - Added explanation for nightly vs. stable plugin resolution, including how Gradle Plugin Portal settings affect nightly plugin lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->