### PR TITLE
fix(release): satisfy the C# product-slice verify contract (#4120 follow-up)

### DIFF
--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -191,6 +191,8 @@ jobs:
       - name: Rename and checksum artifact
         id: artifact
         working-directory: baml_language
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha != '' && inputs.source_sha || github.sha }}
         run: |
           set -euo pipefail
           target="${{ matrix._.target }}"
@@ -218,6 +220,18 @@ jobs:
               shasum -a 256 "${asset}"
             fi
           ) > "${outdir}/${asset}.sha256"
+
+          # Provenance identity consumed by the C# product-slice verifier: it
+          # re-derives every field and refuses to package a cdylib whose
+          # identity doesn't match the run that built it.
+          {
+            echo "source_sha=${SOURCE_SHA}"
+            echo "workflow_run_id=${{ github.run_id }}"
+            echo "workflow_run_attempt=${{ github.run_attempt }}"
+            echo "release_version=$(jq -r .canonical_version ../release-plan.json)"
+            echo "target=${target}"
+            echo "asset=${asset}"
+          } > "${outdir}/artifact-identity.txt"
 
           echo "dir=${outdir}" >> "$GITHUB_OUTPUT"
           echo "asset=${asset}" >> "$GITHUB_OUTPUT"
@@ -267,4 +281,5 @@ jobs:
           path: |
             baml_language/${{ steps.artifact.outputs.dir }}/${{ steps.artifact.outputs.asset }}
             baml_language/${{ steps.artifact.outputs.dir }}/${{ steps.artifact.outputs.asset }}.sha256
+            baml_language/${{ steps.artifact.outputs.dir }}/artifact-identity.txt
           if-no-files-found: error

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -13,7 +13,8 @@
         "python": { "runner": "macos-latest" },
         "nodejs": {},
         "java": { "platform": "macos-aarch64", "runner": "macos-14" },
-        "cffi": { "asset": "libbaml_cffi-aarch64-apple-darwin.dylib", "runner": "macos-14", "smoke": true }
+        "cffi": { "asset": "libbaml_cffi-aarch64-apple-darwin.dylib", "runner": "macos-14", "smoke": true },
+        "csharp": { "rid": "osx-arm64", "native_asset": "libbridge_cffi.dylib", "consumer_runner": "macos-14" }
       }
     },
     {
@@ -27,7 +28,8 @@
         "python": { "runner": "macos-latest" },
         "nodejs": {},
         "java": { "platform": "macos-x86_64", "runner": "macos-15-intel" },
-        "cffi": { "asset": "libbaml_cffi-x86_64-apple-darwin.dylib", "runner": "macos-14" }
+        "cffi": { "asset": "libbaml_cffi-x86_64-apple-darwin.dylib", "runner": "macos-14" },
+        "csharp": { "rid": "osx-x64", "native_asset": "libbridge_cffi.dylib", "consumer_runner": "macos-15-intel" }
       }
     },
     {
@@ -41,7 +43,8 @@
         "python": { "runner": "ubuntu-latest", "manylinux": "2_24" },
         "nodejs": {},
         "java": { "platform": "linux-aarch64", "runner": "ubuntu-24.04-arm" },
-        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true }
+        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true },
+        "csharp": { "rid": "linux-arm64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04-arm" }
       }
     },
     {
@@ -55,7 +58,8 @@
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
         "java": { "platform": "linux-aarch64-musl", "runner": "ubuntu-latest", "experimental": true },
-        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true, "experimental": true }
+        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true, "experimental": true },
+        "csharp": { "rid": "linux-musl-arm64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04-arm" }
       }
     },
     {
@@ -69,7 +73,8 @@
         "python": { "runner": "ubuntu-latest", "manylinux": "2_17" },
         "nodejs": {},
         "java": { "platform": "linux-x86_64", "runner": "ubuntu-latest" },
-        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true, "smoke": true }
+        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true, "smoke": true },
+        "csharp": { "rid": "linux-x64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-latest" }
       }
     },
     {
@@ -83,7 +88,8 @@
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
         "java": { "platform": "linux-x86_64-musl", "runner": "ubuntu-latest", "experimental": true },
-        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true, "experimental": true }
+        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true, "experimental": true },
+        "csharp": { "rid": "linux-musl-x64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-latest" }
       }
     },
     {
@@ -97,7 +103,8 @@
         "python": { "runner": "windows-latest" },
         "nodejs": {},
         "java": { "platform": "windows-x86_64", "runner": "windows-latest" },
-        "cffi": { "asset": "baml_cffi-x86_64-pc-windows-msvc.dll", "runner": "windows-2022", "smoke": true }
+        "cffi": { "asset": "baml_cffi-x86_64-pc-windows-msvc.dll", "runner": "windows-2022", "smoke": true },
+        "csharp": { "rid": "win-x64", "native_asset": "bridge_cffi.dll", "consumer_runner": "windows-latest" }
       }
     },
     {
@@ -111,7 +118,8 @@
         "python": { "runner": "windows-11-arm", "architecture": "arm64" },
         "nodejs": {},
         "java": { "platform": "windows-aarch64", "runner": "windows-11-arm", "experimental": true },
-        "cffi": { "asset": "baml_cffi-aarch64-pc-windows-msvc.dll", "runner": "windows-11-arm", "smoke": true, "experimental": true }
+        "cffi": { "asset": "baml_cffi-aarch64-pc-windows-msvc.dll", "runner": "windows-11-arm", "smoke": true, "experimental": true },
+        "csharp": { "rid": "win-arm64", "native_asset": "bridge_cffi.dll", "consumer_runner": "windows-11-arm" }
       }
     }
   ]


### PR DESCRIPTION
## Problem

Since #4120 merged, **every BAML Language Release run fails** at `Verify C# SDK product package / Compute product consumer matrix`, and because the manifest-publish job is downstream of that gate, **the pkg.boundaryml.com channel manifests have been frozen at `0.15.1-nightly.20260716.b`** — `baml toolchain install nightly` resolves a week-stale toolchain everywhere (and no per-version manifest exists for anything newer, so pinning doesn't work either).

Two gaps between #4120's verifier and what the repo/pipeline actually provide:

1. `release/platforms.json` has **no `artifacts.csharp` blocks**, but the matrix derivation asserts 8 targets with `csharp` + `cffi`, 8 unique RIDs, 3 canonical native assets, and 8 string runners → `jq -e` prints `false` and the job exits 1.
2. The `bridge-cffi-*` producer uploads only the cdylib + `.sha256`, but the packager requires **exactly 3 files** per artifact including a 6-line `artifact-identity.txt` (source_sha / workflow_run_id / workflow_run_attempt / release_version / target / asset) it verifies line-by-line.

## Fix

- **`release/platforms.json`**: add `csharp: { rid, native_asset, consumer_runner }` to all 8 targets. RIDs are the standard .NET RIDs (8 unique); canonical assets are `libbridge_cffi.dylib` / `libbridge_cffi.so` / `bridge_cffi.dll` (3 unique, matching the pre-rename base names in the cffi build and the hard-coded `libbridge_cffi.so` in the verify scripts); consumer runners mirror each target's existing toolchain runner.
- **`build2-bridge-cffi.reusable.yaml`**: emit `artifact-identity.txt` next to the cdylib in the rename/checksum step and add it to the uploaded artifact.

@rossirpaulo — please sanity-check the RID/runner choices against what `publish2-csharp-sdk` expects; happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added C# artifact configurations across supported macOS, Linux, and Windows targets.
  * Published native C# assets with platform-specific .NET runtime identifiers.

* **Improvements**
  * Build artifacts now include provenance details such as source revision, workflow run, release version, target, and asset.
  * Artifact uploads include an identity record alongside the library and checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->