### PR TITLE
Generate validated AST fields from ast_node!

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -964,6 +964,7 @@ version = "0.0.0-beta"
 dependencies = [
  "baml_base",
  "rowan 0.16.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/baml_language/crates/baml_compiler_syntax/Cargo.toml
+++ b/baml_language/crates/baml_compiler_syntax/Cargo.toml
@@ -19,4 +19,4 @@ workspace = true
 [dependencies]
 baml_base = { workspace = true }
 rowan = { workspace = true }
-
+thiserror = { workspace = true }

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -2,7 +2,7 @@
 
 use rowan::ast::AstNode;
 
-use crate::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken};
+use crate::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TextRange};
 
 /// Extract a dotted name from a token sequence (e.g., `baml.http.Request` → `"baml.http.Request"`).
 ///
@@ -89,8 +89,29 @@ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     }
 }
 
-/// Macro to define AST node types.
-macro_rules! ast_node {
+/// A parsed syntax node did not match the structural shape declared for its AST node.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AstShapeError {
+    #[error("expected {expected}, but the element was missing from {parent:?}")]
+    Missing {
+        expected: &'static str,
+        parent: TextRange,
+    },
+    #[error("expected {expected}, but found {found:?} at {at:?}")]
+    Unexpected {
+        expected: &'static str,
+        found: SyntaxKind,
+        at: TextRange,
+    },
+    #[error("unexpected extra {found:?} at {at:?} in {parent:?}")]
+    Extra {
+        found: SyntaxKind,
+        at: TextRange,
+        parent: TextRange,
+    },
+}
+
+macro_rules! define_ast_node {
     ($name:ident, $kind:ident) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
         pub struct $name {
@@ -116,6 +137,175 @@ macro_rules! ast_node {
 
             fn syntax(&self) -> &SyntaxNode {
                 &self.syntax
+            }
+        }
+    };
+}
+
+macro_rules! validated_field_type {
+    (required token $expected:tt) => {
+        SyntaxToken
+    };
+    (optional token $expected:tt) => {
+        Option<SyntaxToken>
+    };
+    (required node $expected:ty) => {
+        $expected
+    };
+    (optional node $expected:ty) => {
+        Option<$expected>
+    };
+}
+
+macro_rules! parse_validated_field {
+    ($elements:ident, $parent:ident, required token $expected:ident) => {{
+        let element = $elements.next().ok_or(AstShapeError::Missing {
+            expected: stringify!($expected),
+            parent: $parent,
+        })?;
+        match element {
+            rowan::NodeOrToken::Token(token) if token.kind() == SyntaxKind::$expected => token,
+            other => {
+                return Err(AstShapeError::Unexpected {
+                    expected: stringify!($expected),
+                    found: other.kind(),
+                    at: other.text_range(),
+                });
+            }
+        }
+    }};
+    ($elements:ident, $parent:ident, optional token $expected:ident) => {{
+        let present = $elements
+            .peek()
+            .is_some_and(|element| element.kind() == SyntaxKind::$expected);
+        if present {
+            match $elements.next().expect("peeked element must exist") {
+                rowan::NodeOrToken::Token(token) => Some(token),
+                rowan::NodeOrToken::Node(_) => unreachable!("token kind cannot belong to a node"),
+            }
+        } else {
+            None
+        }
+    }};
+    ($elements:ident, $parent:ident, required node $expected:ty) => {{
+        let element = $elements.next().ok_or(AstShapeError::Missing {
+            expected: stringify!($expected),
+            parent: $parent,
+        })?;
+        match element {
+            rowan::NodeOrToken::Node(node) => {
+                let found = node.kind();
+                let at = node.text_range();
+                <$expected as AstNode>::cast(node).ok_or(AstShapeError::Unexpected {
+                    expected: stringify!($expected),
+                    found,
+                    at,
+                })?
+            }
+            rowan::NodeOrToken::Token(token) => {
+                return Err(AstShapeError::Unexpected {
+                    expected: stringify!($expected),
+                    found: token.kind(),
+                    at: token.text_range(),
+                });
+            }
+        }
+    }};
+    ($elements:ident, $parent:ident, optional node $expected:ty) => {{
+        let present = $elements.peek().is_some_and(|element| {
+            element
+                .as_node()
+                .is_some_and(|node| <$expected as AstNode>::can_cast(node.kind()))
+        });
+        if present {
+            match $elements.next().expect("peeked element must exist") {
+                rowan::NodeOrToken::Node(node) => {
+                    Some(<$expected as AstNode>::cast(node).expect("node kind was checked"))
+                }
+                rowan::NodeOrToken::Token(_) => unreachable!("node kind cannot belong to a token"),
+            }
+        } else {
+            None
+        }
+    }};
+}
+
+/// Macro to define AST node types.
+macro_rules! ast_node {
+    ($name:ident, $kind:ident) => {
+        define_ast_node!($name, $kind);
+    };
+    (
+        $name:ident, $kind:ident,
+        validated $validated:ident {
+            $(
+                $cardinality:ident $element_kind:ident $field:ident: $expected:tt;
+            )*
+        }
+    ) => {
+        define_ast_node!($name, $kind);
+
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub struct $validated {
+            syntax: $name,
+            $(
+                pub $field: validated_field_type!($cardinality $element_kind $expected),
+            )*
+        }
+
+        impl $name {
+            pub fn validate(self) -> Result<$validated, AstShapeError> {
+                let parent = self.syntax.text_range();
+                let mut elements = self
+                    .syntax
+                    .children_with_tokens()
+                    .filter(|element| !element.kind().is_trivia())
+                    .peekable();
+                $(
+                    let $field = parse_validated_field!(
+                        elements,
+                        parent,
+                        $cardinality $element_kind $expected
+                    );
+                )*
+                if let Some(extra) = elements.next() {
+                    return Err(AstShapeError::Extra {
+                        found: extra.kind(),
+                        at: extra.text_range(),
+                        parent,
+                    });
+                }
+                Ok($validated {
+                    syntax: self,
+                    $($field,)*
+                })
+            }
+        }
+
+        impl $validated {
+            #[must_use]
+            pub fn syntax(&self) -> &SyntaxNode {
+                self.syntax.syntax()
+            }
+        }
+
+        impl TryFrom<SyntaxElement> for $validated {
+            type Error = AstShapeError;
+
+            fn try_from(element: SyntaxElement) -> Result<Self, Self::Error> {
+                let found = element.kind();
+                let at = element.text_range();
+                let node = element.into_node().ok_or(AstShapeError::Unexpected {
+                    expected: stringify!($kind),
+                    found,
+                    at,
+                })?;
+                let syntax = <$name as AstNode>::cast(node).ok_or(AstShapeError::Unexpected {
+                    expected: stringify!($kind),
+                    found,
+                    at,
+                })?;
+                syntax.validate()
             }
         }
     };
@@ -876,8 +1066,22 @@ ast_node!(WhileLetStmt, WHILE_LET_STMT);
 ast_node!(BlockExpr, BLOCK_EXPR);
 ast_node!(ReturnStmt, RETURN_STMT);
 ast_node!(ThrowStmt, THROW_STMT);
-ast_node!(BreakStmt, BREAK_STMT);
-ast_node!(ContinueStmt, CONTINUE_STMT);
+ast_node!(
+    BreakStmt,
+    BREAK_STMT,
+    validated ValidatedBreakStmt {
+        required token keyword: KW_BREAK;
+        optional token semicolon: SEMICOLON;
+    }
+);
+ast_node!(
+    ContinueStmt,
+    CONTINUE_STMT,
+    validated ValidatedContinueStmt {
+        required token keyword: KW_CONTINUE;
+        optional token semicolon: SEMICOLON;
+    }
+);
 ast_node!(DeferStmt, DEFER_STMT);
 ast_node!(PathExpr, PATH_EXPR);
 ast_node!(FieldAccessExpr, FIELD_ACCESS_EXPR);
@@ -893,7 +1097,14 @@ ast_node!(CatchArm, CATCH_ARM);
 ast_node!(CatchPattern, CATCH_PATTERN);
 ast_node!(ThrowExpr, THROW_EXPR);
 ast_node!(ReturnExpr, RETURN_EXPR);
-ast_node!(ThrowsClause, THROWS_CLAUSE);
+ast_node!(
+    ThrowsClause,
+    THROWS_CLAUSE,
+    validated ValidatedThrowsClause {
+        required token keyword: KW_THROWS;
+        required node ty: TypeExpr;
+    }
+);
 
 // Implement accessor methods
 impl SourceFile {

--- a/baml_language/crates/baml_compiler_syntax/src/tests.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/tests.rs
@@ -2,7 +2,7 @@
 mod builder_tests {
     use rowan::ast::AstNode;
 
-    use crate::{SyntaxKind, SyntaxNode, ast, builder::SyntaxTreeBuilder};
+    use crate::{AstShapeError, SyntaxKind, SyntaxNode, ast, builder::SyntaxTreeBuilder};
 
     #[test]
     fn test_build_function() {
@@ -115,5 +115,80 @@ mod builder_tests {
         let root = SyntaxNode::new_root(green);
 
         assert_eq!(root.text(), "function test()");
+    }
+
+    #[test]
+    fn validated_node_extracts_required_and_optional_tokens() {
+        let mut builder = SyntaxTreeBuilder::new();
+        builder.start_node(SyntaxKind::BREAK_STMT);
+        builder.token(SyntaxKind::KW_BREAK, "break");
+        builder.token(SyntaxKind::WHITESPACE, " ");
+        builder.token(SyntaxKind::SEMICOLON, ";");
+        builder.finish_node();
+
+        let syntax = ast::BreakStmt::cast(SyntaxNode::new_root(builder.finish())).unwrap();
+        let validated = syntax.validate().unwrap();
+
+        assert_eq!(validated.keyword.text(), "break");
+        assert_eq!(validated.semicolon.unwrap().text(), ";");
+    }
+
+    #[test]
+    fn validated_node_rejects_wrong_required_token() {
+        let mut builder = SyntaxTreeBuilder::new();
+        builder.start_node(SyntaxKind::BREAK_STMT);
+        builder.token(SyntaxKind::SEMICOLON, ";");
+        builder.finish_node();
+
+        let syntax = ast::BreakStmt::cast(SyntaxNode::new_root(builder.finish())).unwrap();
+        let error = syntax.validate().unwrap_err();
+
+        assert!(matches!(
+            error,
+            AstShapeError::Unexpected {
+                expected: "KW_BREAK",
+                found: SyntaxKind::SEMICOLON,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn validated_node_rejects_extra_elements() {
+        let mut builder = SyntaxTreeBuilder::new();
+        builder.start_node(SyntaxKind::CONTINUE_STMT);
+        builder.token(SyntaxKind::KW_CONTINUE, "continue");
+        builder.token(SyntaxKind::SEMICOLON, ";");
+        builder.token(SyntaxKind::WORD, "extra");
+        builder.finish_node();
+
+        let syntax = ast::ContinueStmt::cast(SyntaxNode::new_root(builder.finish())).unwrap();
+        let error = syntax.validate().unwrap_err();
+
+        assert!(matches!(
+            error,
+            AstShapeError::Extra {
+                found: SyntaxKind::WORD,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn validated_node_extracts_required_child_node() {
+        let mut builder = SyntaxTreeBuilder::new();
+        builder.start_node(SyntaxKind::THROWS_CLAUSE);
+        builder.token(SyntaxKind::KW_THROWS, "throws");
+        builder.token(SyntaxKind::WHITESPACE, " ");
+        builder.start_node(SyntaxKind::TYPE_EXPR);
+        builder.token(SyntaxKind::WORD, "Error");
+        builder.finish_node();
+        builder.finish_node();
+
+        let syntax = ast::ThrowsClause::cast(SyntaxNode::new_root(builder.finish())).unwrap();
+        let validated = syntax.validate().unwrap();
+
+        assert_eq!(validated.keyword.text(), "throws");
+        assert_eq!(validated.ty.syntax().text(), "Error");
     }
 }

--- a/baml_language/crates/baml_fmt/src/ast/mod.rs
+++ b/baml_language/crates/baml_fmt/src/ast/mod.rs
@@ -9,7 +9,9 @@ mod types;
 use std::{borrow::Cow, path::Path};
 
 pub use attributes::*;
-use baml_db::baml_compiler_syntax::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken};
+use baml_db::baml_compiler_syntax::{
+    AstShapeError, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken,
+};
 pub use declarations::*;
 pub use expressions::*;
 pub use pattern::*;
@@ -38,6 +40,8 @@ pub trait KnownKind {
 /// Errors that can occur when parsing from a [`SyntaxNode`] with [`FromCST`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum StrongAstError {
+    #[error("{0}")]
+    AstShape(#[from] AstShapeError),
     /// When an element is expected (of a specific [`SyntaxKind`]) but was found to be of a different kind.
     #[error("Expected token/node of kind {expected:?}, but found {found:?} at {at:?}")]
     UnexpectedKind {
@@ -151,6 +155,7 @@ impl StrongAstError {
             Some((line, column))
         }
         match self {
+            StrongAstError::AstShape(error) => error.to_string(),
             StrongAstError::UnexpectedKind {
                 expected,
                 found,

--- a/baml_language/crates/baml_fmt/src/ast/statements.rs
+++ b/baml_language/crates/baml_fmt/src/ast/statements.rs
@@ -1,4 +1,7 @@
-use baml_db::baml_compiler_syntax::{SyntaxElement, SyntaxKind};
+use baml_db::baml_compiler_syntax::{
+    SyntaxElement, SyntaxKind, ValidatedBreakStmt as BreakStmt,
+    ValidatedContinueStmt as ContinueStmt,
+};
 use rowan::TextRange;
 
 use super::tokens as t;
@@ -50,8 +53,12 @@ impl FromCST for Statement {
             SyntaxKind::WHILE_STMT => WhileStmt::from_cst(elem).map(Statement::While),
             SyntaxKind::WHILE_LET_STMT => WhileLetStmt::from_cst(elem).map(Statement::WhileLet),
             SyntaxKind::FOR_EXPR => ForStmt::from_cst(elem).map(Statement::For),
-            SyntaxKind::BREAK_STMT => BreakStmt::from_cst(elem).map(Statement::Break),
-            SyntaxKind::CONTINUE_STMT => ContinueStmt::from_cst(elem).map(Statement::Continue),
+            SyntaxKind::BREAK_STMT => BreakStmt::try_from(elem)
+                .map(Statement::Break)
+                .map_err(StrongAstError::from),
+            SyntaxKind::CONTINUE_STMT => ContinueStmt::try_from(elem)
+                .map(Statement::Continue)
+                .map_err(StrongAstError::from),
             SyntaxKind::SEMICOLON => t::Semicolon::from_cst(elem).map(Statement::EmptySemicolon),
             SyntaxKind::HEADER_COMMENT => {
                 t::HeaderComment::from_cst(elem).map(Statement::HeaderComment)
@@ -1060,30 +1067,6 @@ impl Printable for ReturnStmt {
     }
 }
 
-/// Corresponds to a [`SyntaxKind::BREAK_STMT`] node.
-#[derive(Debug)]
-pub struct BreakStmt {
-    pub keyword: t::Break,
-    pub semicolon: Option<t::Semicolon>,
-}
-
-impl FromCST for BreakStmt {
-    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
-        let node = StrongAstError::assert_is_node(elem)?;
-        StrongAstError::assert_kind_node(&node, SyntaxKind::BREAK_STMT)?;
-
-        let mut it = SyntaxNodeIter::new(&node);
-
-        let keyword = it.expect_parse()?;
-
-        let semicolon = it.next().map(t::Semicolon::from_cst).transpose()?;
-
-        it.expect_end()?;
-
-        Ok(BreakStmt { keyword, semicolon })
-    }
-}
-
 impl KnownKind for BreakStmt {
     fn kind() -> SyntaxKind {
         SyntaxKind::BREAK_STMT
@@ -1109,30 +1092,6 @@ impl Printable for BreakStmt {
         self.semicolon
             .as_ref()
             .map_or(self.keyword.span(), Token::span)
-    }
-}
-
-/// Corresponds to a [`SyntaxKind::CONTINUE_STMT`] node.
-#[derive(Debug)]
-pub struct ContinueStmt {
-    pub keyword: t::Continue,
-    pub semicolon: Option<t::Semicolon>,
-}
-
-impl FromCST for ContinueStmt {
-    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
-        let node = StrongAstError::assert_is_node(elem)?;
-        StrongAstError::assert_kind_node(&node, SyntaxKind::CONTINUE_STMT)?;
-
-        let mut it = SyntaxNodeIter::new(&node);
-
-        let keyword = it.expect_parse()?;
-
-        let semicolon = it.next().map(t::Semicolon::from_cst).transpose()?;
-
-        it.expect_end()?;
-
-        Ok(ContinueStmt { keyword, semicolon })
     }
 }
 

--- a/baml_language/crates/baml_fmt/src/ast/tokens.rs
+++ b/baml_language/crates/baml_fmt/src/ast/tokens.rs
@@ -1,4 +1,4 @@
-use baml_db::baml_compiler_syntax::{SyntaxElement, SyntaxKind, SyntaxNodeExt};
+use baml_db::baml_compiler_syntax::{SyntaxElement, SyntaxKind, SyntaxNodeExt, SyntaxToken};
 use rowan::{TextRange, TextSize};
 
 use crate::{
@@ -8,6 +8,12 @@ use crate::{
 
 pub trait Token {
     fn span(&self) -> TextRange;
+}
+
+impl Token for SyntaxToken {
+    fn span(&self) -> TextRange {
+        self.text_range()
+    }
 }
 
 macro_rules! define_keyword_tokens {


### PR DESCRIPTION
## Changes

- extend `ast_node!` to generate field-bearing validated syntax facades
- validate required, optional, token, and child-node fields with structural errors
- migrate formatter `break` and `continue` nodes without changing print logic
- add validation coverage, including nested AST fields

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p baml_compiler_syntax -p baml_compiler_parser -p baml_fmt -p baml_compiler2_ast`
- `cargo clippy -p baml_compiler_syntax -p baml_fmt --all-targets -- -D warnings`

No snapshot files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated syntax handling for break, continue, and throws statements.
  * Improved detection and reporting of malformed or unexpected syntax elements.

* **Bug Fixes**
  * Formatter errors now provide clearer messages when statement structure is invalid.
  * Break and continue statement parsing now consistently validates required and optional tokens.

* **Tests**
  * Added coverage for valid statements, missing or unexpected elements, extra tokens, and nested type expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->