### PR TITLE
Fix release pipeline contract and integrate Swift fan-in

### DIFF
--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -194,6 +194,9 @@ jobs:
           if [[ "$TARGET" == "x86_64-pc-windows-msvc" ]]; then
             export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=/STACK:67108864"
           fi
+          if [[ "$TARGET" == "wasm32-unknown-unknown" ]]; then
+            export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }--cfg=getrandom_backend=\"wasm_js\""
+          fi
           # musl targets default to `+crt-static`, and rustc cannot emit a
           # cdylib under a static CRT — it silently drops the crate type and
           # produces only the `.rlib`. Disable `crt-static` so the build yields

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -38,10 +38,10 @@ name: BAML Release - Build bridge_cffi
 #   - linux musl x86_64/aarch64: `cross`, aws-lc-sys builds fine. musl defaults
 #     to `+crt-static`, which cannot emit a cdylib, so the build disables
 #     `crt-static` (RUSTFLAGS in the build step + `Cross.toml` passthrough) to
-#     produce a musl `.so` dynamically linked against musl libc. Experimental
-#     until an Alpine (or other real musl) dlopen smoke proves a consumer loads
-#     it.
-#   - windows aarch64: experimental until a native arm64 smoke runner exists.
+#     produce a musl `.so` dynamically linked against musl libc. The C++ and C#
+#     release consumers execute it in real musl userspace.
+#   - windows aarch64: required after native C++ and C# consumer execution on
+#     the windows-11-arm runner.
 #   - windows x86_64: `AWS_LC_SYS_PREBUILT_NASM=1` (below) lets aws-lc-sys use
 #     its prebuilt NASM objects if the runner has no NASM.
 
@@ -75,9 +75,9 @@ defaults:
 jobs:
   # The cffi build matrix is generated from the repository's platform contract
   # (`release/platforms.json`) so the target set + per-target build config live
-  # in one machine-readable place, not a hand-copied YAML list. The experimental
-  # musl + arm64-Windows targets carry `experimental: true` in the contract,
-  # which drives `continue-on-error` on the build job below.
+  # in one machine-readable place, not a hand-copied YAML list. Any future
+  # experimental target carries that tier in the contract, which drives
+  # `continue-on-error` on the build job below.
   matrix:
     name: Compute target matrix
     runs-on: ubuntu-latest
@@ -172,19 +172,42 @@ jobs:
           TARGET: ${{ matrix._.target }}
         run: |
           set -euo pipefail
+          # Rust panic locations otherwise retain runner/workspace/toolchain
+          # absolute paths in the stripped cdylib. Map both native-runner and
+          # cross-container roots to stable relative identities before build.
+          source_root="${GITHUB_WORKSPACE:-$(pwd -P)}"
+          rust_sysroot="$(rustc --print sysroot)"
+          cargo_bin="$(command -v cargo)"
+          cargo_root="$(cd "$(dirname "$cargo_bin")/.." && pwd -P)"
+          export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }\
+          --remap-path-prefix=$source_root=baml-source \
+          --remap-path-prefix=$rust_sysroot=rust-toolchain \
+          --remap-path-prefix=$cargo_root=cargo-home \
+          --remap-path-prefix=/project=baml-source \
+          --remap-path-prefix=/cargo=cargo-home \
+          --remap-path-prefix=/rust=rust-toolchain"
           # `bridge_cffi` is `crate-type = ["cdylib", "lib"]`; the cdylib is the
           # release artifact. `release-bridge-cffi` = release + panic = "unwind".
           #
+          # Setting RUSTFLAGS overrides target rustflags from Cargo config.
+          # Preserve the x64 Windows stack reservation explicitly.
+          if [[ "$TARGET" == "x86_64-pc-windows-msvc" ]]; then
+            export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=/STACK:67108864"
+          fi
           # musl targets default to `+crt-static`, and rustc cannot emit a
           # cdylib under a static CRT — it silently drops the crate type and
           # produces only the `.rlib`. Disable `crt-static` so the build yields
           # a real musl `.so`, dynamically linked against musl libc and
-          # dlopen-loadable on a musl consumer (e.g. Alpine). Scoped to musl so
-          # the other targets keep their `.cargo/config.toml` rustflags (the
-          # Windows `/STACK` link-arg), which a blanket RUSTFLAGS would clobber.
-          # `cross` forwards RUSTFLAGS into the build container via `Cross.toml`.
+          # dlopen-loadable on a musl consumer (e.g. Alpine).
           if [[ "$TARGET" == *-musl ]]; then
             export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C target-feature=-crt-static"
+          fi
+          # The shared macOS artifact is installed into host-language packages
+          # under an ecosystem-specific filename. Give the dylib a portable ID
+          # at production time so every consumer receives the exact producer
+          # bytes; package assembly must never rewrite a checksummed native.
+          if [[ "$TARGET" == *-apple-darwin ]]; then
+            export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-Wl,-install_name,@rpath/libbridge_cffi.dylib"
           fi
           ${CARGO} build -p bridge_cffi --profile release-bridge-cffi --target "$TARGET"
 

--- a/.github/workflows/build2-java-sdk.reusable.yaml
+++ b/.github/workflows/build2-java-sdk.reusable.yaml
@@ -6,8 +6,9 @@ name: BAML SDK Release - Build Java
 #
 #   - inputs are the frozen release plan (`release_plan_json`) + the exact
 #     commit (`source_sha`); the bare `version` input is gone. The Maven version
-#     is the plan's `canonical_version` (Maven-legal as-is: canary → `0.15.0`,
-#     nightly → `0.15.0-nightly.YYYYMMDD.a`), injected via `-PbamlVersion`.
+#     is the plan's `registry_versions.maven` (currently an identity encoding:
+#     canary → `0.15.0`, nightly → `0.15.0-nightly.YYYYMMDD.a`), injected via
+#     `-PbamlVersion`.
 #   - the 8-target build matrix is generated from the repository platform
 #     contract (`release/platforms.json`) `java` artifact key, not a hand-copied
 #     list. Experimental targets (musl, windows-arm64) carry `experimental: true`
@@ -191,7 +192,7 @@ jobs:
           # at the repo root, the target dir 3 levels up. Relative paths keep the
           # step portable to the Windows (Git Bash) runners, where a
           # $GITHUB_WORKSPACE absolute path (D:\a\...) confuses bash path tests.
-          version="$(jq -r .canonical_version ../../../../release-plan.json)"
+          version="$(jq -r .registry_versions.maven ../../../../release-plan.json)"
           case "$BAML_TARGET" in
             *windows*) libfile="bridge_java.dll" ;;
             *apple*)   libfile="libbridge_java.dylib" ;;
@@ -251,7 +252,7 @@ jobs:
           set -euo pipefail
           # Release plan is 4 levels up at the repo root (relative path — this job
           # is linux-only, but keep it consistent with the natives step).
-          version="$(jq -r .canonical_version ../../../../release-plan.json)"
+          version="$(jq -r .registry_versions.maven ../../../../release-plan.json)"
           # `build` runs the pure-Java tests (the native smoke self-skips via
           # JUnit assumeTrue when no cdylib is present); sourcesJar/javadocJar are
           # named explicitly so the release always carries the two Central-

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -699,6 +699,62 @@ jobs:
         with:
           dotnet-version: 10.0.301
 
+      - name: "Test C# NuGet payload comparison"
+        if: matrix.sdk-label == 'csharp'
+        run: |
+          dotnet run --project \
+            baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/Baml.NuGetNormalizer.csproj \
+            -- --self-test
+
+      - name: "Test nightly C# package version"
+        if: matrix.sdk-label == 'csharp' && matrix.os-label == 'linux'
+        env:
+          BAML_LANGUAGE_RELEASED_AT: "2026-07-23T12:34:56Z"
+          BAML_LANGUAGE_VERSION_DATE: "20260723"
+          BAML_LANGUAGE_VERSION_NIGHTLY_LETTER: "h"
+        run: |
+          set -euo pipefail
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          scripts/baml-language-version plan \
+            --channel nightly \
+            --out "$work/release-plan.json"
+          canonical="$(jq -r .canonical_version "$work/release-plan.json")"
+          nuget="$(jq -r .registry_versions.nuget "$work/release-plan.json")"
+          test "$nuget" = "$canonical"
+
+          scripts/baml-csharp-release-contract matrix \
+            | jq -r '.include[]
+              | "runtimes/\(.rid)/native/\(.canonical)"' \
+            | while IFS= read -r runtime_path; do
+                mkdir -p "$work/native/$(dirname "$runtime_path")"
+                printf 'version-only fixture\n' \
+                  > "$work/native/$runtime_path"
+              done
+          printf '<Project />\n' > "$work/baml-bridge.targets"
+          expected_count="$(scripts/baml-csharp-release-contract matrix \
+            | jq '.include | length')"
+          project=baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj
+          dotnet build "$project" --configuration Release --nologo \
+            -p:NuGetAudit=false \
+            -p:Version="$canonical" \
+            -p:InformationalVersion="$canonical" \
+            -p:PackageVersion="$nuget"
+          dotnet pack "$project" --configuration Release --nologo \
+            --no-build --no-restore \
+            --output "$work/package" \
+            -p:NuGetAudit=false \
+            -p:Version="$canonical" \
+            -p:InformationalVersion="$canonical" \
+            -p:PackageVersion="$nuget" \
+            -p:BamlExpectedNativeAssetCount="$expected_count" \
+            -p:BamlNativeAssetRoot="$work/native" \
+            -p:BamlGeneratedTargetsPath="$work/baml-bridge.targets"
+          package="$work/package/baml-bridge.$nuget.nupkg"
+          test -f "$package"
+          test "$(unzip -p "$package" baml-bridge.nuspec \
+            | sed -n 's#.*<version>\([^<]*\)</version>.*#\1#p')" = "$nuget"
+
       - name: "Verify sccache"
         run: sccache --version
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -428,6 +428,9 @@ jobs:
       - name: "Validate baml_language release metadata"
         run: scripts/baml-language-version check
 
+      - name: "Test release contracts and workflow graph"
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v
+
       - name: "Validate canary/nightly version computation"
         env:
           BAML_LANGUAGE_VERSION_DATE: "20260522"
@@ -458,10 +461,37 @@ jobs:
 
           scripts/baml-language-version plan --channel nightly --out nightly-release-plan.json
           scripts/baml-language-version stamp --plan nightly-release-plan.json
+          nuget="$(jq -r .registry_versions.nuget nightly-release-plan.json)"
+          maven="$(jq -r .registry_versions.maven nightly-release-plan.json)"
+          gradle_plugin="$(jq -r \
+            .registry_versions.gradle_plugin nightly-release-plan.json)"
+          swiftpm="$(jq -r .registry_versions.swiftpm nightly-release-plan.json)"
           node_npm="$(jq -r .version baml_language/sdks/typescript/bridge_typescript/package.json)"
           web_npm="$(jq -r .version baml_language/sdks/typescript/bridge_typescript_web/package.json)"
+          csharp_nuget="$(sed -n \
+            's#^    <Version>\([^<]*\)</Version>$#\1#p' \
+            baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj)"
+          rust_crate="$(sed -n 's/^version = "\(.*\)"$/\1/p' \
+            baml_language/sdks/rust/bridge_rust/Cargo.toml)"
+          go_runtime="$(sed -n \
+            's/^const DefaultRuntimeVersion = "\(.*\)"$/\1/p' \
+            baml_language/sdks/go/baml_go/version.go)"
+          vsix="$(jq -r .version typescript2/app-vscode-ext/package.json)"
           test "$node_npm" = "$nightly"
           test "$web_npm" = "$node_npm"
+          test "$nuget" = "$nightly"
+          test "$csharp_nuget" = "$nuget"
+          test "$maven" = "$nightly"
+          test "$gradle_plugin" = "$nightly"
+          test "$swiftpm" = "$nightly"
+          test "$rust_crate" = "$nightly"
+          test "$go_runtime" = "$nightly"
+          test "$vsix" = "$nightly"
+          for shipping_version in \
+            "$node_npm" "$web_npm" "$csharp_nuget" "$maven" \
+            "$gradle_plugin" "$swiftpm" "$rust_crate" "$go_runtime" "$vsix"; do
+            test "$shipping_version" != "$canary"
+          done
 
   # Call reusable workflows
   cargo-tests:

--- a/.github/workflows/prepare-csharp-sdk.reusable.yaml
+++ b/.github/workflows/prepare-csharp-sdk.reusable.yaml
@@ -1,0 +1,125 @@
+name: BAML C# - Prepare platform-neutral product inputs
+
+on:
+  workflow_call:
+    inputs:
+      release_plan_json:
+        description: "Frozen BAML language release-plan.json content"
+        type: string
+        required: true
+      source_sha:
+        description: "Exact repository commit whose product is under test"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    name: Prepare generated C# and ABI inputs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source_sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.301
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          enable-cache: false
+          enable-cross: false
+          skip-protoc: true
+
+      - name: Stamp and validate the frozen release contract
+        env:
+          RELEASE_PLAN_JSON: ${{ inputs.release_plan_json }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          printf '%s\n' "$RELEASE_PLAN_JSON" > release-plan.json
+          scripts/baml-language-version stamp --plan release-plan.json
+          scripts/baml-csharp-release-contract validate
+          project_version="$(sed -n \
+            's#^    <Version>\([^<]*\)</Version>$#\1#p' \
+            baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj)"
+          test "$project_version" = \
+            "$(jq -r .registry_versions.nuget release-plan.json)"
+
+      - name: Verify Rust-produced callback vectors in the C# schema consumer
+        working-directory: baml_language
+        env:
+          BAML_CSHARP_OPTIONAL_HOST_CALL_VECTORS: ${{ runner.temp }}/optional-host-call-vectors.tsv
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          cargo run -p sdk_test_csharp --bin emit_optional_host_call_vectors
+          test "$(wc -l < "$BAML_CSHARP_OPTIONAL_HOST_CALL_VECTORS")" -eq 5
+          dotnet run --project \
+            sdks/csharp/bridge_csharp/tests/Baml.Bridge.ProtocolProbe/Baml.Bridge.ProtocolProbe.csproj \
+            -- "$BAML_CSHARP_OPTIONAL_HOST_CALL_VECTORS"
+
+      - name: Prepare ABI bytecode and generated consumer sources
+        env:
+          BAML_CSHARP_ABI_PROBE_BYTECODE: ${{ runner.temp }}/csharp-neutral/function-calls.bytecode
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/csharp-neutral"
+          generated_output="$output/baml_client"
+          mkdir -p "$generated_output"
+          (
+            cd baml_language
+            cargo test -p sdk_test_harness_setup \
+              csharp_abi_probe_tests::emit_function_calls_bytecode \
+              --lib -- --ignored --exact --nocapture
+            cargo run --quiet -p baml_cli -- \
+              generate --from sdk_tests/crates/csharp/primitive_slice
+          )
+          test -s "$BAML_CSHARP_ABI_PROBE_BYTECODE"
+          fixture=baml_language/sdk_tests/crates/csharp/primitive_slice
+          while IFS= read -r source; do
+            relative="${source#"$fixture/baml_client/"}"
+            destination="$generated_output/$relative"
+            mkdir -p "$(dirname "$destination")"
+            cp "$source" "$destination"
+          done < <(find "$fixture/baml_client" \
+            -type f -name '*.g.cs' | LC_ALL=C sort)
+          LC_ALL=C find "$generated_output" -type f -name '*.g.cs' \
+            -printf '%P\n' | LC_ALL=C sort | diff -u <(printf '%s\n' \
+              'Baml/Csv/CsvError.g.cs' \
+              'Baml/Csv/CsvErrorKind.g.cs' \
+              'Baml/Csv/CsvPosition.g.cs' \
+              'Baml/Csv/ReaderOptions.g.cs' \
+              'Baml/Csv/WriterOptions.g.cs' \
+              'Baml/Fs/DirEntry.g.cs' \
+              'Baml/Fs/MkdirOptions.g.cs' \
+              'Baml/Generated/BamlProgram.g.cs' \
+              'Baml/Glob/ScanOptions.g.cs' \
+              'Baml/Net/Datagram.g.cs' \
+              'CsharpSlice/Functions.g.cs') -
+          cp release-plan.json "$output/"
+
+      - name: Exercise NuGet payload comparison policy
+        run: |
+          set -euo pipefail
+          dotnet run --project \
+            baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/Baml.NuGetNormalizer.csproj \
+            -- --self-test
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: csharp-neutral-preparation
+          path: ${{ runner.temp }}/csharp-neutral
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/publish2-csharp-sdk.yaml
+++ b/.github/workflows/publish2-csharp-sdk.yaml
@@ -59,10 +59,14 @@ jobs:
             <(jq -S . expected-release-plan.json) \
             <(jq -S . product-package/release-plan.json)
 
-          version="$(jq -er \
+          canonical_version="$(jq -er \
             '.canonical_version | select(type == "string" and length > 0)' \
             expected-release-plan.json)"
-          package="product-package/baml-bridge.$version.nupkg"
+          nuget_version="$(jq -er \
+            '.registry_versions.nuget
+             | select(type == "string" and length > 0)' \
+            expected-release-plan.json)"
+          package="product-package/baml-bridge.$nuget_version.nupkg"
           test -f "$package"
           test "$(find product-package -maxdepth 1 \
             -type f -name 'baml-bridge.*.nupkg' | wc -l)" -eq 1
@@ -72,26 +76,35 @@ jobs:
             sha256sum -c product-package.sha256
           )
           test "$(unzip -p "$package" baml-bridge.nuspec \
-            | sed -n 's#.*<version>\([^<]*\)</version>.*#\1#p')" = "$version"
-          test "$(wc -l < product-package/native-provenance.tsv)" -eq 8
-          awk -F '\t' -v sha="$SOURCE_SHA" -v version="$version" '
-            NF != 8 || $2 != sha || $3 != version { exit 1 }
-          ' product-package/native-provenance.tsv
+            | sed -n 's#.*<version>\([^<]*\)</version>.*#\1#p')" = \
+            "$nuget_version"
+          scripts/baml-csharp-release-contract verify-product \
+            --release-plan expected-release-plan.json \
+            --source-sha "$SOURCE_SHA" \
+            --provenance product-package/native-provenance.json \
+            --manifest product-package/native-manifest.sha256 \
+            --package "$package"
 
           digest="$(sha256sum "$package" | cut -d ' ' -f 1)"
           grep -Fxq "$digest  $(basename "$package")" \
             product-package/product-package.sha256
           {
             echo "path=$package"
-            echo "version=$version"
+            echo "version=$nuget_version"
+            echo "canonical_version=$canonical_version"
             echo "digest=$digest"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Fail closed if the immutable version already exists
+      - name: Compare any existing immutable version by product payload
+        id: existing
         env:
           VERSION: ${{ steps.package.outputs.version }}
+          PACKAGE: ${{ steps.package.outputs.path }}
         run: |
           set -euo pipefail
+          normalizer=baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/Baml.NuGetNormalizer.csproj
+          dotnet build "$normalizer" --configuration Release --nologo \
+            -p:NuGetAudit=false
           normalized="${VERSION,,}"
           url="https://api.nuget.org/v3-flatcontainer/baml-bridge/$normalized/baml-bridge.$normalized.nupkg"
           status="$(curl --retry 3 --retry-all-errors --silent \
@@ -99,11 +112,15 @@ jobs:
             --write-out '%{http_code}' "$url")"
           case "$status" in
             404)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
               echo "baml-bridge $VERSION is not present on nuget.org"
               ;;
             200)
-              echo "::error::baml-bridge $VERSION already exists on nuget.org; the original unsigned artifact identity cannot be reconstructed from a repository-signed package"
-              exit 1
+              dotnet run --project "$normalizer" \
+                --configuration Release --no-build --no-restore -- \
+                compare "$PACKAGE" "$RUNNER_TEMP/existing.nupkg"
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "baml-bridge $VERSION already exists with identical product-owned content; skipping upload"
               ;;
             *)
               echo "::error::nuget.org version probe returned HTTP $status"
@@ -112,12 +129,14 @@ jobs:
           esac
 
       - name: Exchange GitHub OIDC for a short-lived NuGet key
+        if: ${{ steps.existing.outputs.publish == 'true' }}
         id: login
         uses: NuGet/login@v1.2.0
         with:
           user: ${{ secrets.NUGET_USER }}
 
       - name: Publish the already-verified package
+        if: ${{ steps.existing.outputs.publish == 'true' }}
         env:
           NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
           PACKAGE: ${{ steps.package.outputs.path }}

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -67,6 +67,11 @@ jobs:
       version: ${{ steps.plan.outputs.version }}
       pypi_version: ${{ steps.plan.outputs.pypi_version }}
       crates_io_version: ${{ steps.plan.outputs.crates_io_version }}
+      nuget_version: ${{ steps.plan.outputs.nuget_version }}
+      maven_version: ${{ steps.plan.outputs.maven_version }}
+      gradle_plugin_version: ${{ steps.plan.outputs.gradle_plugin_version }}
+      swiftpm_version: ${{ steps.plan.outputs.swiftpm_version }}
+      released_at: ${{ steps.plan.outputs.released_at }}
       git_tag: ${{ steps.plan.outputs.git_tag }}
       release_plan_json: ${{ steps.plan.outputs.release_plan_json }}
       source_sha: ${{ steps.plan.outputs.source_sha }}
@@ -111,12 +116,23 @@ jobs:
           version="$(jq -r .canonical_version release-plan.json)"
           pypi_version="$(jq -r .registry_versions.pypi release-plan.json)"
           crates_io_version="$(jq -r .registry_versions.crates_io release-plan.json)"
+          nuget_version="$(jq -r .registry_versions.nuget release-plan.json)"
+          maven_version="$(jq -r .registry_versions.maven release-plan.json)"
+          gradle_plugin_version="$(jq -r \
+            .registry_versions.gradle_plugin release-plan.json)"
+          swiftpm_version="$(jq -r .registry_versions.swiftpm release-plan.json)"
+          released_at="$(jq -r .released_at release-plan.json)"
           git_tag="$(jq -r .git_tag release-plan.json)"
           {
             echo "channel=$channel"
             echo "version=$version"
             echo "pypi_version=$pypi_version"
             echo "crates_io_version=$crates_io_version"
+            echo "nuget_version=$nuget_version"
+            echo "maven_version=$maven_version"
+            echo "gradle_plugin_version=$gradle_plugin_version"
+            echo "swiftpm_version=$swiftpm_version"
+            echo "released_at=$released_at"
             echo "git_tag=$git_tag"
             echo "release_plan_json<<EOF"
             cat release-plan.json
@@ -161,6 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       toolchain: ${{ steps.gen.outputs.toolchain }}
+      csharp: ${{ steps.gen.outputs.csharp }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -177,6 +194,9 @@ jobs:
             | {target: .triple, os: .artifacts.toolchain.runner, libc: .libc}]' release/platforms.json)"
           echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
           jq . <<<"$toolchain"
+          csharp="$(scripts/baml-csharp-release-contract matrix)"
+          echo "csharp=$csharp" >> "$GITHUB_OUTPUT"
+          jq . <<<"$csharp"
 
   build-toolchain:
     name: Build toolchain (${{ matrix.target }})
@@ -404,6 +424,18 @@ jobs:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}
 
+  # Platform-neutral C# work (schema vectors, generator output, ABI bytecode,
+  # package-comparison policy) runs alongside the shared native matrix.
+  prepare-csharp-sdk:
+    name: Prepare C# SDK product inputs
+    needs: [plan, build-matrix]
+    uses: ./.github/workflows/prepare-csharp-sdk.reusable.yaml
+    permissions:
+      contents: read
+    with:
+      release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
+      source_sha: ${{ needs.plan.outputs.source_sha }}
+
   # Language-neutral engine cdylib, shared by every dylib-loader SDK.
   build-bridge-cffi:
     name: Build bridge_cffi cdylib
@@ -476,7 +508,7 @@ jobs:
       - name: Zip + checksum (SwiftPM checksum == sha256 of the zip)
         id: pack
         env:
-          VERSION: ${{ needs.plan.outputs.version }}
+          VERSION: ${{ needs.plan.outputs.swiftpm_version }}
         run: |
           set -euo pipefail
           ZIP="BamlBridgeFFI-${VERSION}.xcframework.zip"
@@ -488,7 +520,7 @@ jobs:
       - name: Assemble baml-swift mirror
         env:
           TAG: ${{ needs.plan.outputs.git_tag }}
-          VERSION: ${{ needs.plan.outputs.version }}
+          VERSION: ${{ needs.plan.outputs.swiftpm_version }}
           SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
           CHECKSUM: ${{ steps.pack.outputs.checksum }}
           ZIP: ${{ steps.pack.outputs.zip }}
@@ -528,6 +560,8 @@ jobs:
           name: swift-sdk-mirror
           path: ${{ runner.temp }}/mirror
       - name: Assemble a clean consumer and link the release binary
+        env:
+          EXPECTED_VERSION: ${{ needs.plan.outputs.version }}
         run: |
           set -euo pipefail
           work="$RUNNER_TEMP/verify"
@@ -555,14 +589,20 @@ jobs:
           EOF
           cat > "$work/Sources/Verify/main.swift" <<'EOF'
           import BamlBridge
-          print("linked release BamlBridge OK")
+          import Foundation
+          let expected = ProcessInfo.processInfo.environment["BAML_EXPECTED_VERSION"]!
+          let actual = BamlRuntime.nativeVersion()
+          guard actual == expected else {
+              fatalError("native BAML version \(actual) != planned \(expected)")
+          }
+          print("executed release BamlBridge \(actual)")
           EOF
           cd "$work"
           swift build -c release
           bin=.build/release/Verify
           # Runner AMFI can SIGKILL a freshly linked binary's ad-hoc signature.
           codesign --force --sign - "$bin"
-          "$bin"
+          BAML_EXPECTED_VERSION="$EXPECTED_VERSION" "$bin"
 
   # Verify-only: the C++ SDK ships no artifact (headers are vendored at
   # generate time); it consumes the shared bridge_cffi artifacts.
@@ -578,13 +618,14 @@ jobs:
 
   verify-csharp-sdk:
     name: Verify C# SDK product package
-    needs: [plan, build-bridge-cffi]
+    needs: [plan, build-matrix, prepare-csharp-sdk, build-bridge-cffi]
     uses: ./.github/workflows/verify-csharp-product-slice.reusable.yaml
     permissions:
       contents: read
     with:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}
+      platform_matrix_json: ${{ needs.build-matrix.outputs.csharp }}
 
   build-rust-sdk:
     name: Build Rust SDK
@@ -625,6 +666,7 @@ jobs:
       - build-swift-sdk
       - verify-swift-sdk
       - verify-cpp-sdk
+      - prepare-csharp-sdk
       - verify-csharp-sdk
       # The Rust SDK is production-ready (crates.io publisher live), so its
       # build + consumer verification gate the release: a failure here blocks
@@ -751,9 +793,9 @@ jobs:
         id: ver
         run: |
           set -euo pipefail
-          # Maven version = the plan's canonical string, Maven-legal as-is
-          # (canary → 0.15.0, nightly → 0.15.0-nightly.YYYYMMDD.a).
-          version="$(jq -r .canonical_version release-plan.json)"
+          # Maven's registry encoding is the canonical SemVer identity today,
+          # but the frozen plan remains the authority for that relationship.
+          version="$(jq -r .registry_versions.maven release-plan.json)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Decide what to publish (per-coordinate Central idempotency)
         id: exists
@@ -964,7 +1006,7 @@ jobs:
       - name: Skip if this version is already on the Gradle Plugin Portal
         id: exists
         env:
-          VERSION: ${{ needs.plan.outputs.version }}
+          VERSION: ${{ needs.plan.outputs.gradle_plugin_version }}
         run: |
           set -euo pipefail
           # IDEMPOTENCY: the Portal rejects republishing an existing version. Its
@@ -988,7 +1030,7 @@ jobs:
         if: ${{ steps.exists.outputs.publish == 'true' }}
         working-directory: baml_language/sdks/java/gradle-plugin
         env:
-          VERSION: ${{ needs.plan.outputs.version }}
+          VERSION: ${{ needs.plan.outputs.gradle_plugin_version }}
           # com.gradle.plugin-publish reads these env vars natively (verified: it
           # falls back to GRADLE_PUBLISH_KEY/SECRET when the gradle.publish.*
           # properties are unset). The Portal does not require GPG signatures, so
@@ -1305,7 +1347,7 @@ jobs:
       - name: Publish immutable package tag
         env:
           SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
-          VERSION: ${{ needs.plan.outputs.version }}
+          VERSION: ${{ needs.plan.outputs.swiftpm_version }}
         run: |
           set -euo pipefail
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/baml_swift_mirror_key -o IdentitiesOnly=yes"
@@ -1431,13 +1473,99 @@ jobs:
           # verifier already smoked it). No cargo-release, no git tags.
           cargo publish -p baml_bridge --no-verify --allow-dirty
 
+  release-prerequisites-complete:
+    name: All pre-manifest publishers complete
+    needs:
+      - plan
+      - all-builds
+      - publish-pypi
+      - publish-nodejs-sdk
+      - publish-web-sdk
+      - publish-csharp-sdk
+      - publish-maven
+      - publish-gradle-plugin
+      - publish-toolchain-release
+      - publish-wrapper-release
+      - publish-bridge-cffi-release
+      - publish-swift-sdk
+      - publish-crates-io
+      - publish-homebrew
+      - publish-aur
+    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every enabled immutable publisher
+        env:
+          ALL_BUILDS: ${{ needs.all-builds.result }}
+          PYPI: ${{ needs.publish-pypi.result }}
+          NPM_NODE: ${{ needs.publish-nodejs-sdk.result }}
+          NPM_WEB: ${{ needs.publish-web-sdk.result }}
+          NUGET: ${{ needs.publish-csharp-sdk.result }}
+          MAVEN: ${{ needs.publish-maven.result }}
+          GRADLE_PLUGIN: ${{ needs.publish-gradle-plugin.result }}
+          TOOLCHAIN: ${{ needs.publish-toolchain-release.result }}
+          WRAPPER: ${{ needs.publish-wrapper-release.result }}
+          CFFI: ${{ needs.publish-bridge-cffi-release.result }}
+          SWIFTPM: ${{ needs.publish-swift-sdk.result }}
+          CRATES_IO: ${{ needs.publish-crates-io.result }}
+          HOMEBREW: ${{ needs.publish-homebrew.result }}
+          AUR: ${{ needs.publish-aur.result }}
+          CHANNEL: ${{ needs.plan.outputs.channel }}
+          WRAPPER_CHANGED: ${{ needs.plan.outputs.wrapper_changed }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            local name="$1"
+            local result="$2"
+            if [[ "$result" != "success" ]]; then
+              echo "::error::$name publisher result is $result, expected success"
+              exit 1
+            fi
+          }
+          require_skipped() {
+            local name="$1"
+            local result="$2"
+            if [[ "$result" != "skipped" ]]; then
+              echo "::error::$name publisher result is $result, expected skipped"
+              exit 1
+            fi
+          }
+
+          require_success all-builds "$ALL_BUILDS"
+          require_success PyPI "$PYPI"
+          require_success node-npm "$NPM_NODE"
+          require_success web-npm "$NPM_WEB"
+          require_success NuGet "$NUGET"
+          require_success Maven-Central "$MAVEN"
+          require_success toolchain-assets "$TOOLCHAIN"
+          require_success bridge-cffi-assets "$CFFI"
+          require_success SwiftPM "$SWIFTPM"
+          require_success crates.io "$CRATES_IO"
+
+          if [[ "$CHANNEL" == "nightly" ]]; then
+            require_skipped Gradle-Plugin-Portal "$GRADLE_PLUGIN"
+          else
+            require_success Gradle-Plugin-Portal "$GRADLE_PLUGIN"
+          fi
+
+          if [[ "$WRAPPER_CHANGED" == "true" ]]; then
+            require_success wrapper-assets "$WRAPPER"
+            require_success Homebrew "$HOMEBREW"
+            require_success AUR "$AUR"
+          else
+            require_skipped wrapper-assets "$WRAPPER"
+            require_skipped Homebrew "$HOMEBREW"
+            require_skipped AUR "$AUR"
+          fi
+
   publish-pkg-boundaryml-com:
     name: Publish pkg.boundaryml.com manifests
-    # This precedes publish-go-sdk intentionally. The Go module dynamically
-    # resolves bridge_cffi through the immutable exact-version manifest, so the
-    # manifest is part of the module's publish preconditions, not a follow-up.
-    needs: [plan, all-builds, publish-pypi, publish-nodejs-sdk, publish-web-sdk, publish-toolchain-release, publish-bridge-cffi-release, publish-crates-io, publish-wrapper-release, publish-homebrew, publish-aur]
-    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' && needs.publish-pypi.result == 'success' && needs.publish-nodejs-sdk.result == 'success' && needs.publish-web-sdk.result == 'success' && needs.publish-toolchain-release.result == 'success' && needs.publish-bridge-cffi-release.result == 'success' && (needs.publish-crates-io.result == 'success' || needs.publish-crates-io.result == 'skipped') && (needs.plan.outputs.wrapper_changed != 'true' || (needs.publish-wrapper-release.result == 'success' && needs.publish-homebrew.result == 'success' && needs.publish-aur.result == 'success')) }}
+    # The exact-version manifest is a Go publishing precondition: the public
+    # module resolves bridge_cffi through it. Every other enabled publisher is
+    # complete before the manifest is made immutable; Go closes the final gate
+    # afterward without creating a dependency cycle.
+    needs: [plan, release-prerequisites-complete]
+    if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1466,6 +1594,14 @@ jobs:
         with:
           name: baml-vscode-vsix
           path: dist/vsix
+      - uses: actions/download-artifact@v4
+        with:
+          name: csharp-product-package
+          path: dist/csharp
+      - uses: actions/download-artifact@v4
+        with:
+          name: swift-xcframework
+          path: dist/swift
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
@@ -1478,11 +1614,28 @@ jobs:
           if [[ "${{ needs.plan.outputs.wrapper_changed }}" == "true" ]]; then
             args+=(--wrapper-changed)
           fi
-          # Record sdks.rust only when the crate actually published this run, so
-          # the manifest never promises a baml_bridge version absent from crates.io.
-          if [[ "${{ needs.publish-crates-io.result }}" == "success" ]]; then
-            args+=(--crates-io-version "${{ needs.plan.outputs.crates_io_version }}")
+          (
+            cd dist/csharp
+            sha256sum -c product-package.sha256
+          )
+          csharp_digest="$(cut -d ' ' -f 1 \
+            dist/csharp/product-package.sha256)"
+          mapfile -t swift_packages < <(
+            find dist/swift -maxdepth 1 -type f \
+              -name 'BamlBridgeFFI-*.xcframework.zip' -print
+          )
+          if [[ "${#swift_packages[@]}" -ne 1 ]]; then
+            echo "::error::expected exactly one verified Swift XCFramework zip"
+            exit 1
           fi
+          swift_digest="$(sha256sum "${swift_packages[0]}" | cut -d ' ' -f 1)"
+          args+=(
+            --crates-io-version "${{ needs.plan.outputs.crates_io_version }}"
+            --nuget-version "${{ needs.plan.outputs.nuget_version }}"
+            --nuget-package-sha256 "$csharp_digest"
+            --swiftpm-version "${{ needs.plan.outputs.swiftpm_version }}"
+            --swift-package-sha256 "$swift_digest"
+          )
           scripts/baml-release-manifests \
             --toolchain-dir dist/toolchain \
             --cffi-dir dist/cffi \
@@ -1491,6 +1644,7 @@ jobs:
             --out manifests \
             --channel "${{ needs.plan.outputs.channel }}" \
             --version "${{ needs.plan.outputs.version }}" \
+            --released-at "${{ needs.plan.outputs.released_at }}" \
             --pypi-version "${{ needs.plan.outputs.pypi_version }}" \
             --wrapper-version "${{ needs.plan.outputs.wrapper_version }}" \
             "${args[@]}"
@@ -1585,7 +1739,8 @@ jobs:
     steps:
       - name: Resolve, link, and run the published package
         env:
-          VERSION: ${{ needs.plan.outputs.version }}
+          VERSION: ${{ needs.plan.outputs.swiftpm_version }}
+          EXPECTED_VERSION: ${{ needs.plan.outputs.version }}
         run: |
           set -euo pipefail
           work="$RUNNER_TEMP/baml-swift-release-smoke"
@@ -1603,20 +1758,47 @@ jobs:
           EOF
           cat > "$work/Sources/Smoke/main.swift" <<'EOF'
           import BamlBridge
-          print("resolved + linked published BamlBridge OK")
+          import Foundation
+          let expected = ProcessInfo.processInfo.environment["BAML_EXPECTED_VERSION"]!
+          let actual = BamlRuntime.nativeVersion()
+          guard actual == expected else {
+              fatalError("native BAML version \(actual) != planned \(expected)")
+          }
+          print("executed published BamlBridge \(actual)")
           EOF
           cd "$work"
           swift build -c release
           bin=.build/release/Smoke
           codesign --force --sign - "$bin"
-          "$bin"
+          BAML_EXPECTED_VERSION="$EXPECTED_VERSION" "$bin"
+
+  release-complete:
+    name: All enabled publishers complete
+    needs: [plan, release-prerequisites-complete, publish-go-sdk]
+    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require pre-manifest publishers and Go
+        env:
+          PREREQUISITES: ${{ needs.release-prerequisites-complete.result }}
+          GO: ${{ needs.publish-go-sdk.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$PREREQUISITES" != "success" ]]; then
+            echo "::error::pre-manifest publisher gate result is $PREREQUISITES, expected success"
+            exit 1
+          fi
+          if [[ "$GO" != "success" ]]; then
+            echo "::error::Go publisher result is $GO, expected success"
+            exit 1
+          fi
 
   publish-pkg-channel:
     name: Promote verified release channel manifest
     # Keep the mutable canary/nightly pointer on the preceding known-good
-    # release until the public Go module resolves, loads its native runtime,
-    # and executes successfully on every supported desktop OS.
-    needs: [plan, publish-pkg-boundaryml-com, publish-go-sdk, smoke-go-release]
+    # release until every publisher completes and the public Go and Swift
+    # packages execute their native runtimes successfully.
+    needs: [plan, publish-pkg-boundaryml-com, release-complete, smoke-go-release, smoke-swift-release]
     if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     steps:
@@ -1783,6 +1965,14 @@ jobs:
         with:
           name: baml-vscode-vsix
           path: dist/vsix
+      - uses: actions/download-artifact@v4
+        with:
+          name: csharp-product-package
+          path: dist/csharp
+      - uses: actions/download-artifact@v4
+        with:
+          name: swift-xcframework
+          path: dist/swift
       - name: Generate dry-run files
         run: |
           set -euo pipefail
@@ -1790,9 +1980,30 @@ jobs:
           if [[ "${{ needs.plan.outputs.wrapper_changed }}" == "true" ]]; then
             args+=(--wrapper-changed)
           fi
-          # Dry-run rehearses the real manifest shape: a real run publishes the
-          # Rust SDK and records sdks.rust, so include it here too.
-          args+=(--crates-io-version "${{ needs.plan.outputs.crates_io_version }}")
+          # Dry-run rehearses the real manifest shape and binds it to the exact
+          # verified native packages even though no registry mutation occurs.
+          (
+            cd dist/csharp
+            sha256sum -c product-package.sha256
+          )
+          csharp_digest="$(cut -d ' ' -f 1 \
+            dist/csharp/product-package.sha256)"
+          mapfile -t swift_packages < <(
+            find dist/swift -maxdepth 1 -type f \
+              -name 'BamlBridgeFFI-*.xcframework.zip' -print
+          )
+          if [[ "${#swift_packages[@]}" -ne 1 ]]; then
+            echo "::error::expected exactly one verified Swift XCFramework zip"
+            exit 1
+          fi
+          swift_digest="$(sha256sum "${swift_packages[0]}" | cut -d ' ' -f 1)"
+          args+=(
+            --crates-io-version "${{ needs.plan.outputs.crates_io_version }}"
+            --nuget-version "${{ needs.plan.outputs.nuget_version }}"
+            --nuget-package-sha256 "$csharp_digest"
+            --swiftpm-version "${{ needs.plan.outputs.swiftpm_version }}"
+            --swift-package-sha256 "$swift_digest"
+          )
           scripts/baml-release-manifests \
             --toolchain-dir dist/toolchain \
             --cffi-dir dist/cffi \
@@ -1801,6 +2012,7 @@ jobs:
             --out dry-run/manifest/v1 \
             --channel "${{ needs.plan.outputs.channel }}" \
             --version "${{ needs.plan.outputs.version }}" \
+            --released-at "${{ needs.plan.outputs.released_at }}" \
             --pypi-version "${{ needs.plan.outputs.pypi_version }}" \
             --wrapper-version "${{ needs.plan.outputs.wrapper_version }}" \
             "${args[@]}"

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1608,10 +1608,20 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: baml-language-release-${{ github.run_id }}
       - name: Generate release manifests
+        env:
+          WRAPPER_CHANGED: ${{ needs.plan.outputs.wrapper_changed }}
+          CRATES_IO_VERSION: ${{ needs.plan.outputs.crates_io_version }}
+          NUGET_VERSION: ${{ needs.plan.outputs.nuget_version }}
+          SWIFTPM_VERSION: ${{ needs.plan.outputs.swiftpm_version }}
+          CHANNEL: ${{ needs.plan.outputs.channel }}
+          VERSION: ${{ needs.plan.outputs.version }}
+          RELEASED_AT: ${{ needs.plan.outputs.released_at }}
+          PYPI_VERSION: ${{ needs.plan.outputs.pypi_version }}
+          WRAPPER_VERSION: ${{ needs.plan.outputs.wrapper_version }}
         run: |
           set -euo pipefail
           args=()
-          if [[ "${{ needs.plan.outputs.wrapper_changed }}" == "true" ]]; then
+          if [[ "$WRAPPER_CHANGED" == "true" ]]; then
             args+=(--wrapper-changed)
           fi
           (
@@ -1630,10 +1640,10 @@ jobs:
           fi
           swift_digest="$(sha256sum "${swift_packages[0]}" | cut -d ' ' -f 1)"
           args+=(
-            --crates-io-version "${{ needs.plan.outputs.crates_io_version }}"
-            --nuget-version "${{ needs.plan.outputs.nuget_version }}"
+            --crates-io-version "$CRATES_IO_VERSION"
+            --nuget-version "$NUGET_VERSION"
             --nuget-package-sha256 "$csharp_digest"
-            --swiftpm-version "${{ needs.plan.outputs.swiftpm_version }}"
+            --swiftpm-version "$SWIFTPM_VERSION"
             --swift-package-sha256 "$swift_digest"
           )
           scripts/baml-release-manifests \
@@ -1642,11 +1652,11 @@ jobs:
             --wrapper-dir dist/wrapper \
             --vsix-dir dist/vsix \
             --out manifests \
-            --channel "${{ needs.plan.outputs.channel }}" \
-            --version "${{ needs.plan.outputs.version }}" \
-            --released-at "${{ needs.plan.outputs.released_at }}" \
-            --pypi-version "${{ needs.plan.outputs.pypi_version }}" \
-            --wrapper-version "${{ needs.plan.outputs.wrapper_version }}" \
+            --channel "$CHANNEL" \
+            --version "$VERSION" \
+            --released-at "$RELEASED_AT" \
+            --pypi-version "$PYPI_VERSION" \
+            --wrapper-version "$WRAPPER_VERSION" \
             "${args[@]}"
       - uses: actions/upload-artifact@v4
         with:
@@ -1974,10 +1984,20 @@ jobs:
           name: swift-xcframework
           path: dist/swift
       - name: Generate dry-run files
+        env:
+          WRAPPER_CHANGED: ${{ needs.plan.outputs.wrapper_changed }}
+          CRATES_IO_VERSION: ${{ needs.plan.outputs.crates_io_version }}
+          NUGET_VERSION: ${{ needs.plan.outputs.nuget_version }}
+          SWIFTPM_VERSION: ${{ needs.plan.outputs.swiftpm_version }}
+          CHANNEL: ${{ needs.plan.outputs.channel }}
+          VERSION: ${{ needs.plan.outputs.version }}
+          RELEASED_AT: ${{ needs.plan.outputs.released_at }}
+          PYPI_VERSION: ${{ needs.plan.outputs.pypi_version }}
+          WRAPPER_VERSION: ${{ needs.plan.outputs.wrapper_version }}
         run: |
           set -euo pipefail
           args=()
-          if [[ "${{ needs.plan.outputs.wrapper_changed }}" == "true" ]]; then
+          if [[ "$WRAPPER_CHANGED" == "true" ]]; then
             args+=(--wrapper-changed)
           fi
           # Dry-run rehearses the real manifest shape and binds it to the exact
@@ -1998,10 +2018,10 @@ jobs:
           fi
           swift_digest="$(sha256sum "${swift_packages[0]}" | cut -d ' ' -f 1)"
           args+=(
-            --crates-io-version "${{ needs.plan.outputs.crates_io_version }}"
-            --nuget-version "${{ needs.plan.outputs.nuget_version }}"
+            --crates-io-version "$CRATES_IO_VERSION"
+            --nuget-version "$NUGET_VERSION"
             --nuget-package-sha256 "$csharp_digest"
-            --swiftpm-version "${{ needs.plan.outputs.swiftpm_version }}"
+            --swiftpm-version "$SWIFTPM_VERSION"
             --swift-package-sha256 "$swift_digest"
           )
           scripts/baml-release-manifests \
@@ -2010,15 +2030,15 @@ jobs:
             --wrapper-dir dist/wrapper \
             --vsix-dir dist/vsix \
             --out dry-run/manifest/v1 \
-            --channel "${{ needs.plan.outputs.channel }}" \
-            --version "${{ needs.plan.outputs.version }}" \
-            --released-at "${{ needs.plan.outputs.released_at }}" \
-            --pypi-version "${{ needs.plan.outputs.pypi_version }}" \
-            --wrapper-version "${{ needs.plan.outputs.wrapper_version }}" \
+            --channel "$CHANNEL" \
+            --version "$VERSION" \
+            --released-at "$RELEASED_AT" \
+            --pypi-version "$PYPI_VERSION" \
+            --wrapper-version "$WRAPPER_VERSION" \
             "${args[@]}"
           scripts/baml-package-manager-artifacts \
             --wrapper-dir dist/wrapper \
-            --version "${{ needs.plan.outputs.wrapper_version }}" \
+            --version "$WRAPPER_VERSION" \
             --out dry-run/package-manager
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/verify-csharp-product-slice.reusable.yaml
+++ b/.github/workflows/verify-csharp-product-slice.reusable.yaml
@@ -11,6 +11,10 @@ on:
         description: "Exact repository commit whose product is under test"
         type: string
         required: true
+      platform_matrix_json:
+        description: "Validated C# product matrix from the early release preflight"
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -20,48 +24,8 @@ defaults:
     shell: bash
 
 jobs:
-  platform-matrix:
-    name: Compute product consumer matrix
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    outputs:
-      matrix: ${{ steps.derive.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.source_sha }}
-          persist-credentials: false
-          sparse-checkout: release
-
-      - id: derive
-        name: Derive exact RID runners from the platform contract
-        env:
-          SOURCE_SHA: ${{ inputs.source_sha }}
-        run: |
-          set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
-          matrix="$(jq -c '{include: [.targets[]
-            | select(.artifacts.csharp != null and .artifacts.cffi != null)
-            | {target: .triple,
-               arch: .arch,
-               libc: .libc,
-               rid: .artifacts.csharp.rid,
-               canonical: .artifacts.csharp.native_asset,
-               runner: .artifacts.csharp.consumer_runner}]}' \
-            release/platforms.json)"
-          jq -e '
-            (.include | length) == 8
-            and ([.include[].target] | unique | length) == 8
-            and ([.include[].rid] | unique | length) == 8
-            and ([.include[].canonical] | unique | length) == 3
-            and ([.include[].runner | select(type == "string")]
-              | length) == 8
-          ' <<<"$matrix"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
   package:
     name: Assemble one provenance-bound package
-    needs: platform-matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
@@ -74,17 +38,16 @@ jobs:
         with:
           dotnet-version: 10.0.301
 
-      - uses: ./.github/actions/setup-rust
-        with:
-          enable-cache: false
-          enable-cross: false
-          skip-protoc: true
-
       - uses: actions/download-artifact@v4
         with:
           pattern: bridge-cffi-*
           path: native-downloads
           merge-multiple: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: csharp-neutral-preparation
+          path: neutral-preparation
 
       - name: Stamp the frozen release plan
         env:
@@ -92,125 +55,41 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s\n' "$RELEASE_PLAN_JSON" > release-plan.json
+          diff -u \
+            <(jq -S . release-plan.json) \
+            <(jq -S . neutral-preparation/release-plan.json)
           scripts/baml-language-version stamp --plan release-plan.json
-          test "$(scripts/baml-language-version show)" = \
-            "$(jq -r .canonical_version release-plan.json)"
+          canonical_version="$(jq -r .canonical_version release-plan.json)"
+          nuget_version="$(jq -r .registry_versions.nuget release-plan.json)"
+          test "$(sed -n \
+            's#^pub const CANONICAL_VERSION: &str = "\([^"]*\)";$#\1#p' \
+            baml_language/crates/baml_version/src/lib.rs)" = \
+            "$canonical_version"
+          test "$(sed -n \
+            's#^    <Version>\([^<]*\)</Version>$#\1#p' \
+            baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj)" = \
+            "$nuget_version"
 
-      - name: Verify Rust-produced callback vectors in the C# schema consumer
-        working-directory: baml_language
+      - name: Stage and bind the required shared producers
         env:
-          BAML_CSHARP_OPTIONAL_HOST_CALL_VECTORS: ${{ runner.temp }}/optional-host-call-vectors.tsv
-          RUSTC_WRAPPER: ""
-        run: |
-          set -euo pipefail
-          cargo run -p sdk_test_csharp --bin emit_optional_host_call_vectors
-          test "$(wc -l < "$BAML_CSHARP_OPTIONAL_HOST_CALL_VECTORS")" -eq 5
-          dotnet run --project \
-            sdks/csharp/bridge_csharp/tests/Baml.Bridge.ProtocolProbe/Baml.Bridge.ProtocolProbe.csproj \
-            -- "$BAML_CSHARP_OPTIONAL_HOST_CALL_VECTORS"
-
-      - name: Stage and bind all eight producer identities
-        env:
-          PLATFORM_MATRIX: ${{ needs.platform-matrix.outputs.matrix }}
           SOURCE_SHA: ${{ inputs.source_sha }}
           RELEASE_VERSION: ${{ fromJSON(inputs.release_plan_json).canonical_version }}
         run: |
           set -euo pipefail
-          mkdir -p staging/runtimes
-          jq -r '.include[].target | "bridge-cffi-\(.)"' \
-            <<<"$PLATFORM_MATRIX" | LC_ALL=C sort \
-            > expected-native-artifacts.txt
-          find native-downloads -mindepth 1 -maxdepth 1 -type d \
-            -printf '%f\n' | LC_ALL=C sort \
-            > actual-native-artifacts.txt
-          diff -u expected-native-artifacts.txt actual-native-artifacts.txt
-          test "$(wc -l < actual-native-artifacts.txt)" -eq 8
-          : > native-provenance.unsorted.tsv
-          jq -r '
-            .targets[]
-            | select(.artifacts.csharp != null and .artifacts.cffi != null)
-            | [.triple,
-               .artifacts.cffi.asset,
-               .artifacts.csharp.rid,
-               .artifacts.csharp.native_asset]
-            | @tsv' release/platforms.json |
-          while IFS=$'\t' read -r target asset rid canonical; do
-            artifact_root="native-downloads/bridge-cffi-$target"
-            mapfile -d '' artifact_files < <(
-              find "$artifact_root" -type f -print0
-            )
-            mapfile -d '' sources < <(
-              find "$artifact_root" -type f -name "$asset" -print0
-            )
-            mapfile -d '' sidecars < <(
-              find "$artifact_root" -type f -name "$asset.sha256" -print0
-            )
-            mapfile -d '' identities < <(
-              find "$artifact_root" -type f -name artifact-identity.txt -print0
-            )
-            test "${#artifact_files[@]}" -eq 3
-            test "${#sources[@]}" -eq 1
-            test "${#sidecars[@]}" -eq 1
-            test "${#identities[@]}" -eq 1
-            source="${sources[0]}"
-            sidecar="${sidecars[0]}"
-            identity="${identities[0]}"
-            test "$(dirname "$source")" = "$(dirname "$sidecar")"
-            test "$(dirname "$source")" = "$(dirname "$identity")"
-            test "$(wc -l < "$sidecar")" -eq 1
-            test "$(cut -d ' ' -f 2- "$sidecar")" = " $asset"
-            grep -Fxq "source_sha=$SOURCE_SHA" "$identity"
-            grep -Fxq "workflow_run_id=${{ github.run_id }}" "$identity"
-            grep -Fxq \
-              "workflow_run_attempt=${{ github.run_attempt }}" "$identity"
-            grep -Fxq "release_version=$RELEASE_VERSION" "$identity"
-            grep -Fxq "target=$target" "$identity"
-            grep -Fxq "asset=$asset" "$identity"
-            test "$(wc -l < "$identity")" -eq 6
-            (
-              cd "$(dirname "$sidecar")"
-              sha256sum -c "$(basename "$sidecar")"
-            )
-            producer_digest="$(cut -d ' ' -f 1 "$sidecar")"
-            [[ "$producer_digest" =~ ^[0-9a-f]{64}$ ]]
-            runtime_path="runtimes/$rid/native/$canonical"
-            install -Dm755 "$source" "staging/$runtime_path"
-            test "$(sha256sum "staging/$runtime_path" | cut -d ' ' -f 1)" = \
-              "$producer_digest"
-            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-              "$producer_digest" \
-              "$SOURCE_SHA" \
-              "$RELEASE_VERSION" \
-              "${{ github.run_id }}" \
-              "${{ github.run_attempt }}" \
-              "$target" \
-              "$asset" \
-              "$runtime_path" \
-              >> native-provenance.unsorted.tsv
-          done
-          LC_ALL=C sort -t $'\t' -k8,8 \
-            native-provenance.unsorted.tsv > native-provenance.tsv
-          test "$(wc -l < native-provenance.tsv)" -eq 8
-          (
-            cd staging
-            find runtimes -type f -print0 | LC_ALL=C sort -z |
-              xargs -0 sha256sum
-          ) > native-manifest.sha256
-          awk -F '\t' 'BEGIN { OFS = "  " } { print $1, $8 }' \
-            native-provenance.tsv | diff -u - native-manifest.sha256
+          scripts/baml-csharp-release-contract stage-native \
+            --downloads native-downloads \
+            --staging staging \
+            --source-sha "$SOURCE_SHA" \
+            --release-version "$RELEASE_VERSION" \
+            --workflow-run-id "${{ github.run_id }}" \
+            --provenance native-provenance.json \
+            --manifest native-manifest.sha256
 
       - name: Verify the C# ABI prefix and ownership lifetimes
         env:
-          BAML_CSHARP_ABI_PROBE_BYTECODE: ${{ runner.temp }}/function-calls.bytecode
-          RUSTC_WRAPPER: ""
+          BAML_CSHARP_ABI_PROBE_BYTECODE: ${{ github.workspace }}/neutral-preparation/function-calls.bytecode
         run: |
           set -euo pipefail
-          (
-            cd baml_language
-            cargo test -p sdk_test_harness_setup \
-              csharp_abi_probe_tests::emit_function_calls_bytecode \
-              --lib -- --ignored --exact --nocapture
-          )
           test -s "$BAML_CSHARP_ABI_PROBE_BYTECODE"
           native="$(jq -er '
             .targets[]
@@ -231,31 +110,18 @@ jobs:
           set -euo pipefail
           product_root="$RUNNER_TEMP/csharp-product"
           package_output="$product_root/packages"
-          generated_output="$product_root/baml_client"
-          mkdir -p "$package_output" "$generated_output"
+          generated_output="$PWD/neutral-preparation/baml_client"
+          mkdir -p "$package_output"
           baml_language/sdks/csharp/bridge_csharp/tools/pack-product.sh \
             staging \
             native-manifest.sha256 \
-            native-provenance.tsv \
+            native-provenance.json \
             release-plan.json \
             "$package_output"
           package="$(find "$package_output" -maxdepth 1 \
             -type f -name 'baml-bridge.*.nupkg' -print)"
           test -n "$package"
           test "$(printf '%s\n' "$package" | wc -l)" -eq 1
-          fixture=baml_language/sdk_tests/crates/csharp/primitive_slice
-          (
-            cd baml_language
-            cargo run --quiet -p baml_cli -- \
-              generate --from sdk_tests/crates/csharp/primitive_slice
-          )
-          while IFS= read -r source; do
-            relative="${source#"$fixture/baml_client/"}"
-            destination="$generated_output/$relative"
-            mkdir -p "$(dirname "$destination")"
-            cp "$source" "$destination"
-          done < <(find "$fixture/baml_client" \
-            -type f -name '*.g.cs' | LC_ALL=C sort)
           LC_ALL=C find "$generated_output" -type f -name '*.g.cs' \
             -printf '%P\n' | LC_ALL=C sort | diff -u <(printf '%s\n' \
               'Baml/Csv/CsvError.g.cs' \
@@ -292,7 +158,7 @@ jobs:
           cp "$package" product-output/
           cmp "$package" "product-output/$(basename "$package")"
           cp native-manifest.sha256 product-output/
-          cp native-provenance.tsv product-output/
+          cp native-provenance.json product-output/
           cp release-plan.json product-output/
           cp -R "$generated_output" product-output/
           mkdir -p product-output/documentation
@@ -314,10 +180,10 @@ jobs:
 
   native-consumer:
     name: Product consumer ${{ matrix.rid }}
-    needs: [platform-matrix, package]
+    needs: [package]
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.platform-matrix.outputs.matrix) }}
+      matrix: ${{ fromJSON(inputs.platform_matrix_json) }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     steps:

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -1,15 +1,20 @@
 # `cross` configuration for the `bridge_cffi` cdylib build.
 #
 # `.github/workflows/build2-bridge-cffi.reusable.yaml` runs `cross` for the
-# linux targets. The musl legs export `RUSTFLAGS=-C target-feature=-crt-static`
-# so rustc can emit a cdylib — a static CRT (musl's default) cannot produce a
-# shared object, so without this rustc silently drops the `cdylib` crate type
-# and only the `.rlib` is built.
+# linux targets. Every leg receives deterministic `--remap-path-prefix` flags.
+# The musl legs additionally disable `crt-static` so rustc can emit a cdylib —
+# a static CRT (musl's default) cannot produce a shared object, so without this
+# rustc silently drops the `cdylib` crate type and only the `.rlib` is built.
 #
 # `cross` runs the build inside a container and forwards only a curated set of
 # environment variables, so RUSTFLAGS must be listed here explicitly or it
-# never reaches the compiler. Scoped to the musl targets so a stray RUSTFLAGS
-# in the runner environment is never forwarded into the gnu builds.
+# never reaches the compiler.
+[target.x86_64-unknown-linux-gnu.env]
+passthrough = ["RUSTFLAGS"]
+
+[target.aarch64-unknown-linux-gnu.env]
+passthrough = ["RUSTFLAGS"]
+
 [target.x86_64-unknown-linux-musl.env]
 passthrough = ["RUSTFLAGS"]
 

--- a/baml_language/crates/baml_release/src/manifest.rs
+++ b/baml_language/crates/baml_release/src/manifest.rs
@@ -37,6 +37,11 @@ pub struct SdkPackage {
     /// Registry-encoded version (the identity of the canonical version for
     /// crates.io; pypi/npm have their own encodings).
     pub version: String,
+    /// Digest of the exact pre-publication package exercised by release
+    /// consumers. Optional for older SDK entries whose manifest contract has
+    /// not migrated yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verified_package_sha256: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -155,6 +160,26 @@ fn validate_sdk(language: &str, package: &SdkPackage) -> anyhow::Result<()> {
     if package.registry.is_empty() || package.package.is_empty() || package.version.is_empty() {
         anyhow::bail!("sdk {language} has an empty registry, package, or version");
     }
+    if let Some(digest) = &package.verified_package_sha256 {
+        validate_sha256(digest)
+            .map_err(|error| anyhow::anyhow!("sdk {language} package digest: {error}"))?;
+    }
+    if language == "csharp" {
+        if package.registry != "nuget" || package.package != "baml-bridge" {
+            anyhow::bail!("sdk csharp must identify nuget/baml-bridge");
+        }
+        if package.verified_package_sha256.is_none() {
+            anyhow::bail!("sdk csharp must record the verified NuGet package digest");
+        }
+    }
+    if language == "swift" {
+        if package.registry != "swiftpm" || package.package != "BoundaryML/baml-swift" {
+            anyhow::bail!("sdk swift must identify swiftpm/BoundaryML/baml-swift");
+        }
+        if package.verified_package_sha256.is_none() {
+            anyhow::bail!("sdk swift must record the verified XCFramework package digest");
+        }
+    }
     Ok(())
 }
 
@@ -251,6 +276,7 @@ mod tests {
                 registry: "crates_io".to_string(),
                 package: "baml_bridge".to_string(),
                 version: "0.15.0".to_string(),
+                verified_package_sha256: None,
             },
         )]));
         manifest.validate().unwrap();
@@ -277,9 +303,60 @@ mod tests {
                 registry: String::new(),
                 package: "baml_bridge".to_string(),
                 version: "0.15.0".to_string(),
+                verified_package_sha256: None,
             },
         )]));
         let err = manifest.validate().unwrap_err();
         assert!(format!("{err}").contains("rust"), "{err}");
+    }
+
+    #[test]
+    fn csharp_sdk_requires_a_valid_verified_package_digest() {
+        let mut manifest = manifest_with(None);
+        manifest.sdks = Some(BTreeMap::from([(
+            "csharp".to_string(),
+            SdkPackage {
+                registry: "nuget".to_string(),
+                package: "baml-bridge".to_string(),
+                version: "0.15.0".to_string(),
+                verified_package_sha256: Some("a".repeat(64)),
+            },
+        )]));
+        manifest.validate().unwrap();
+
+        manifest
+            .sdks
+            .as_mut()
+            .unwrap()
+            .get_mut("csharp")
+            .unwrap()
+            .verified_package_sha256 = Some("not-a-digest".to_string());
+        let err = manifest.validate().unwrap_err();
+        assert!(format!("{err}").contains("csharp"), "{err}");
+    }
+
+    #[test]
+    fn swift_sdk_requires_the_mirror_identity_and_verified_digest() {
+        let mut manifest = manifest_with(None);
+        manifest.sdks = Some(BTreeMap::from([(
+            "swift".to_string(),
+            SdkPackage {
+                registry: "swiftpm".to_string(),
+                package: "BoundaryML/baml-swift".to_string(),
+                version: "0.15.0".to_string(),
+                verified_package_sha256: Some("a".repeat(64)),
+            },
+        )]));
+        manifest.validate().unwrap();
+
+        manifest
+            .sdks
+            .as_mut()
+            .unwrap()
+            .get_mut("swift")
+            .unwrap()
+            .package = "wrong/mirror".to_string();
+        let err = manifest.validate().unwrap_err();
+        assert!(format!("{err}").contains("swift"), "{err}");
     }
 }

--- a/baml_language/crates/baml_release/src/platforms.rs
+++ b/baml_language/crates/baml_release/src/platforms.rs
@@ -2,10 +2,10 @@
 //! single machine-readable source for the release target set, each target's
 //! per-artifact support, and the `bridge_cffi` cdylib build config.
 //!
-//! The cffi, toolchain, and python build matrices are generated from this file
-//! (each in its own workflow); the Rust target list is kept in sync with
-//! [`crate::SUPPORTED_RELEASE_TARGETS`] by the tests below. The nodejs matrix
-//! keeps its bespoke per-target build recipes in its own workflow.
+//! The cffi, toolchain, python, Java, and C# build matrices are generated from
+//! this file (each in its own workflow); the Rust target list is kept in sync
+//! with [`crate::SUPPORTED_RELEASE_TARGETS`] by the tests below. The nodejs
+//! matrix keeps its bespoke per-target build recipes in its own workflow.
 //!
 //! Support is encoded structurally: an artifact that is `None` in [`Artifacts`]
 //! is not built for the target (unsupported), so "unsupported but configured"
@@ -51,6 +51,8 @@ pub struct Artifacts {
     pub java: Option<JavaArtifact>,
     #[serde(default)]
     pub cffi: Option<CffiArtifact>,
+    #[serde(default)]
+    pub csharp: Option<CSharpArtifact>,
 }
 
 /// The CLI toolchain artifact (baml-cli + pack host, archived per target).
@@ -128,10 +130,50 @@ pub struct CffiArtifact {
     pub experimental: bool,
 }
 
+/// The C# projection of a shared `bridge_cffi` producer artifact.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CSharpArtifact {
+    /// Portable .NET Runtime Identifier used below `runtimes/{rid}/native/`.
+    pub rid: String,
+    /// Canonical native filename installed in the RID directory.
+    pub native_asset: String,
+    /// Native GitHub Actions runner for executing the assembled package.
+    pub consumer_runner: String,
+    /// Packaging contract used by this target.
+    pub package_policy: String,
+    /// Built best-effort: a build failure must not block the release.
+    #[serde(default)]
+    pub experimental: bool,
+}
+
 /// Parse the embedded platform contract. Panics if the committed file is
 /// malformed — that is a build-blocking repository error the tests guard.
 pub fn platforms() -> Platforms {
-    serde_json::from_str(PLATFORMS_JSON).expect("release/platforms.json is valid")
+    let platforms: Platforms =
+        serde_json::from_str(PLATFORMS_JSON).expect("release/platforms.json is valid JSON");
+    validate_platforms(&platforms).expect("release/platforms.json has valid artifact dependencies");
+    platforms
+}
+
+fn validate_platforms(platforms: &Platforms) -> Result<(), String> {
+    for target in &platforms.targets {
+        let Some(csharp) = &target.artifacts.csharp else {
+            continue;
+        };
+        let Some(cffi) = &target.artifacts.cffi else {
+            return Err(format!(
+                "{}: C# requires a CFFI source artifact",
+                target.triple
+            ));
+        };
+        if !csharp.experimental && cffi.experimental {
+            return Err(format!(
+                "{}: required C# cannot consume experimental CFFI",
+                target.triple
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -291,6 +333,70 @@ mod tests {
         }
     }
 
+    #[test]
+    fn csharp_runtime_assets_follow_the_platform_contract() {
+        let expected_rids = BTreeSet::from([
+            "linux-arm64".to_string(),
+            "linux-musl-arm64".to_string(),
+            "linux-musl-x64".to_string(),
+            "linux-x64".to_string(),
+            "osx-arm64".to_string(),
+            "osx-x64".to_string(),
+            "win-arm64".to_string(),
+            "win-x64".to_string(),
+        ]);
+        let mut actual_rids = BTreeSet::new();
+
+        for t in platforms().targets {
+            let Some(csharp) = &t.artifacts.csharp else {
+                continue;
+            };
+            assert!(t.artifacts.cffi.is_some(), "{}: C# requires CFFI", t.triple);
+            assert!(
+                !csharp.experimental,
+                "{}: the eight-RID C# package is all-required",
+                t.triple
+            );
+            let arch = match t.arch.as_str() {
+                "aarch64" => "arm64",
+                "x86_64" => "x64",
+                other => panic!("{}: unsupported .NET architecture {other}", t.triple),
+            };
+            let rid = match (t.os.as_str(), t.libc.as_deref()) {
+                ("macos", _) => format!("osx-{arch}"),
+                ("linux", Some("musl")) => format!("linux-musl-{arch}"),
+                ("linux", _) => format!("linux-{arch}"),
+                ("windows", _) => format!("win-{arch}"),
+                (other, _) => panic!("{}: unsupported .NET OS {other}", t.triple),
+            };
+            let native_asset = match t.os.as_str() {
+                "macos" => "libbridge_cffi.dylib",
+                "windows" => "bridge_cffi.dll",
+                _ => "libbridge_cffi.so",
+            };
+            assert_eq!(csharp.rid, rid, "{}: unexpected .NET RID", t.triple);
+            assert!(
+                actual_rids.insert(csharp.rid.clone()),
+                "{}: duplicate .NET RID {}",
+                t.triple,
+                csharp.rid
+            );
+            assert_eq!(
+                csharp.native_asset, native_asset,
+                "{}: unexpected .NET native filename",
+                t.triple
+            );
+            assert!(
+                !csharp.consumer_runner.is_empty(),
+                "{}: empty .NET consumer runner",
+                t.triple
+            );
+            assert_eq!(csharp.package_policy, "rid-native");
+        }
+
+        assert_eq!(actual_rids, expected_rids);
+    }
+
     /// The linchpin of the schema: a missing artifact key deserializes to
     /// `None`, i.e. "not built for this target" — the only way to express
     /// unsupported, so it can never carry a contradictory build config.
@@ -307,5 +413,70 @@ mod tests {
         assert!(p.artifacts.python.is_none());
         assert!(p.artifacts.nodejs.is_none());
         assert!(p.artifacts.java.is_none());
+        assert!(p.artifacts.csharp.is_none());
+    }
+
+    #[test]
+    fn cffi_support_does_not_imply_csharp_support() {
+        let json = r#"{
+            "schema": 1,
+            "targets": [{
+                "triple": "x86_64-unknown-linux-gnu", "os": "linux", "arch": "x86_64",
+                "libc": "gnu", "archive_suffix": ".tar.gz",
+                "artifacts": { "cffi": {
+                    "asset": "libbaml_cffi-x86_64-unknown-linux-gnu.so",
+                    "runner": "ubuntu-22.04"
+                } }
+            }]
+        }"#;
+        let p: Platforms = serde_json::from_str(json).unwrap();
+        assert!(validate_platforms(&p).is_ok());
+        assert!(p.targets[0].artifacts.cffi.is_some());
+        assert!(p.targets[0].artifacts.csharp.is_none());
+    }
+
+    #[test]
+    fn csharp_without_cffi_is_rejected() {
+        let json = r#"{
+            "schema": 1,
+            "targets": [{
+                "triple": "x86_64-unknown-linux-gnu", "os": "linux", "arch": "x86_64",
+                "libc": "gnu", "archive_suffix": ".tar.gz",
+                "artifacts": { "csharp": {
+                    "rid": "linux-x64",
+                    "native_asset": "libbridge_cffi.so",
+                    "consumer_runner": "ubuntu-24.04",
+                    "package_policy": "rid-native"
+                } }
+            }]
+        }"#;
+        let p: Platforms = serde_json::from_str(json).unwrap();
+        assert!(validate_platforms(&p).is_err());
+    }
+
+    #[test]
+    fn required_csharp_cannot_consume_experimental_cffi() {
+        let json = r#"{
+            "schema": 1,
+            "targets": [{
+                "triple": "x86_64-unknown-linux-gnu", "os": "linux", "arch": "x86_64",
+                "libc": "gnu", "archive_suffix": ".tar.gz",
+                "artifacts": {
+                    "cffi": {
+                        "asset": "libbaml_cffi-x86_64-unknown-linux-gnu.so",
+                        "runner": "ubuntu-22.04",
+                        "experimental": true
+                    },
+                    "csharp": {
+                        "rid": "linux-x64",
+                        "native_asset": "libbridge_cffi.so",
+                        "consumer_runner": "ubuntu-24.04",
+                        "package_policy": "rid-native"
+                    }
+                }
+            }]
+        }"#;
+        let p: Platforms = serde_json::from_str(json).unwrap();
+        assert!(validate_platforms(&p).is_err());
     }
 }

--- a/baml_language/crates/baml_version/src/lib.rs
+++ b/baml_language/crates/baml_version/src/lib.rs
@@ -1,6 +1,8 @@
 //! Stamped BAML language product version.
 
 pub const CANONICAL_VERSION: &str = "0.15.0";
-pub const PYPI_VERSION: &str = "0.15.0";
+#[allow(dead_code)]
+const PYPI_VERSION: &str = "0.15.0";
 pub const CHANNEL: &str = "canary";
-pub const STABLE_VERSION: &str = "0.15.0";
+#[allow(dead_code)]
+const STABLE_VERSION: &str = "0.15.0";

--- a/baml_language/crates/baml_version/src/lib.rs
+++ b/baml_language/crates/baml_version/src/lib.rs
@@ -1,5 +1,6 @@
 //! Stamped BAML language product version.
 
 pub const CANONICAL_VERSION: &str = "0.15.0";
-
+pub const PYPI_VERSION: &str = "0.15.0";
 pub const CHANNEL: &str = "canary";
+pub const STABLE_VERSION: &str = "0.15.0";

--- a/baml_language/sdks/csharp/DEVELOPMENT.md
+++ b/baml_language/sdks/csharp/DEVELOPMENT.md
@@ -43,6 +43,21 @@ Release platform metadata declares `artifacts.cffi` and `artifacts.csharp` as
 sibling records. C# entries name the RID-local native asset and require the
 generic CFFI artifact for the same target; a generic CFFI target does not imply
 a C# package. `build2-bridge-cffi.reusable.yaml` produces only generic native
-artifacts. `verify-csharp-product-slice.reusable.yaml` assembles and exercises
-the eight-RID NuGet package, and `publish2-csharp-sdk.yaml` publishes that
-verified package.
+artifacts containing the library and its checksum. Actions artifacts are
+workflow-run scoped; C# records source SHA, canonical version, workflow run ID,
+target, producer filename, runtime path, and digest when it assembles the
+package. Provenance deliberately excludes `github.run_attempt`, so rerunning
+failed jobs can reuse successful producers from an earlier attempt of the same
+run. Unrelated future CFFI-only artifacts are ignored.
+
+`prepare-csharp-sdk.reusable.yaml` prepares platform-neutral generated and ABI
+inputs in parallel with the CFFI matrix.
+`verify-csharp-product-slice.reusable.yaml` assembles and exercises the required
+RID set from the validated platform contract, and `publish2-csharp-sdk.yaml`
+publishes that exact verified package. On a repair rerun, the publisher removes
+only NuGet's repository signature from the comparison model and skips an
+identical existing package; a product-owned content mismatch remains fatal.
+`release/csharp-package-size-policy.json` records the reviewed compressed
+package and per-native baselines from the first eight-target release evidence;
+package assembly enforces their regression budgets independently from the
+NuGet registry-safety ceiling.

--- a/baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj
+++ b/baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj
@@ -84,8 +84,11 @@
       Condition="'$(BamlNativeAssetRoot)' == ''"
       Text="BamlNativeAssetRoot must identify the staged eight-RID runtime tree." />
     <Error
-      Condition="'@(_BamlNativePackageAsset->Count())' != '8'"
-      Text="The staged runtime tree must contain exactly eight native assets; found @(_BamlNativePackageAsset->Count())." />
+      Condition="'$(BamlExpectedNativeAssetCount)' == ''"
+      Text="BamlExpectedNativeAssetCount must come from the validated platform contract." />
+    <Error
+      Condition="'$(BamlExpectedNativeAssetCount)' != '' and '@(_BamlNativePackageAsset->Count())' != '$(BamlExpectedNativeAssetCount)'"
+      Text="The staged runtime tree must match the validated platform contract: expected $(BamlExpectedNativeAssetCount) native assets; found @(_BamlNativePackageAsset->Count())." />
     <Error
       Condition="'$(BamlGeneratedTargetsPath)' == ''"
       Text="BamlGeneratedTargetsPath must identify the platform-contract-derived buildTransitive target." />

--- a/baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/Program.cs
+++ b/baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/Program.cs
@@ -612,24 +612,21 @@ internal static class Program
         using FileStream right = File.OpenRead(rightPath);
         byte[] leftBuffer = new byte[1 << 20];
         byte[] rightBuffer = new byte[leftBuffer.Length];
-        while (true)
+        long remaining = leftInfo.Length;
+        while (remaining > 0)
         {
-            int leftRead = left.Read(leftBuffer);
-            int rightRead = right.Read(rightBuffer);
-            if (leftRead != rightRead)
+            int chunkLength = (int)Math.Min(leftBuffer.Length, remaining);
+            Span<byte> leftChunk = leftBuffer.AsSpan(0, chunkLength);
+            Span<byte> rightChunk = rightBuffer.AsSpan(0, chunkLength);
+            left.ReadExactly(leftChunk);
+            right.ReadExactly(rightChunk);
+            if (!leftChunk.SequenceEqual(rightChunk))
             {
                 return false;
             }
-            if (leftRead == 0)
-            {
-                return true;
-            }
-            if (!leftBuffer.AsSpan(0, leftRead).SequenceEqual(
-                    rightBuffer.AsSpan(0, rightRead)))
-            {
-                return false;
-            }
+            remaining -= chunkLength;
         }
+        return true;
     }
 
     private static void RunSelfTests()

--- a/baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/Program.cs
+++ b/baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/Program.cs
@@ -20,10 +20,44 @@ internal static class Program
 
     public static int Main(string[] args)
     {
+        if (args is ["--self-test"])
+        {
+            try
+            {
+                RunSelfTests();
+                Console.WriteLine("nuget_payload_comparison_tests=ok");
+                return 0;
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"BAML NuGet self-test failed: {exception.Message}");
+                return 1;
+            }
+        }
+
+        if (args is ["compare", string expectedPath, string actualPath])
+        {
+            try
+            {
+                CompareProductPayload(expectedPath, actualPath);
+                Console.WriteLine("nuget_product_payload=identical");
+                return 0;
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"BAML NuGet payload comparison failed: {exception.Message}");
+                return 1;
+            }
+        }
+
         if (args.Length != 2)
         {
             Console.Error.WriteLine(
-                "Usage: Baml.NuGetNormalizer <unsigned-input.nupkg> <normalized-output.nupkg>");
+                "Usage: Baml.NuGetNormalizer <unsigned-input.nupkg> <normalized-output.nupkg>\n"
+                + "       Baml.NuGetNormalizer compare <verified-unsigned.nupkg> <registry-signed.nupkg>\n"
+                + "       Baml.NuGetNormalizer --self-test");
             return 2;
         }
 
@@ -31,7 +65,7 @@ internal static class Program
         {
             string inputPath = Path.GetFullPath(args[0]);
             string outputPath = Path.GetFullPath(args[1]);
-            Normalize(inputPath, outputPath);
+            Normalize(inputPath, outputPath, allowRepositorySignature: false);
 
             using FileStream output = File.OpenRead(outputPath);
             string digest = Convert.ToHexStringLower(SHA256.HashData(output));
@@ -47,7 +81,10 @@ internal static class Program
         }
     }
 
-    private static void Normalize(string inputPath, string outputPath)
+    private static void Normalize(
+        string inputPath,
+        string outputPath,
+        bool allowRepositorySignature)
     {
         if (StringComparer.Ordinal.Equals(inputPath, outputPath))
         {
@@ -96,7 +133,9 @@ internal static class Program
                        entryNameEncoding: Encoding.UTF8))
             {
                 IReadOnlyList<InputEntry> entries =
-                    ReadAndValidateEntries(inputArchive);
+                    ReadAndValidateEntries(
+                        inputArchive,
+                        allowRepositorySignature);
                 NormalizedMetadata metadata = NormalizeMetadata(entries);
 
                 using FileStream temporaryStream = new(
@@ -133,7 +172,8 @@ internal static class Program
     }
 
     private static IReadOnlyList<InputEntry> ReadAndValidateEntries(
-        ZipArchive archive)
+        ZipArchive archive,
+        bool allowRepositorySignature)
     {
         List<InputEntry> entries = new(archive.Entries.Count);
         HashSet<string> names = new(StringComparer.OrdinalIgnoreCase);
@@ -151,6 +191,11 @@ internal static class Program
                     entry.FullName,
                     SignatureEntryName))
             {
+                if (allowRepositorySignature)
+                {
+                    continue;
+                }
+
                 throw new InvalidDataException(
                     "The package is already signed. Normalize unsigned bytes before signing.");
             }
@@ -520,6 +565,213 @@ internal static class Program
                 sourceStream.CopyTo(destinationStream);
             }
         }
+    }
+
+    private static void CompareProductPayload(
+        string expectedPath,
+        string actualPath)
+    {
+        string work = Path.Combine(
+            Path.GetTempPath(),
+            $"baml-nuget-compare-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(work);
+        string expectedNormalized = Path.Combine(work, "expected.nupkg");
+        string actualNormalized = Path.Combine(work, "actual.nupkg");
+        try
+        {
+            Normalize(
+                Path.GetFullPath(expectedPath),
+                expectedNormalized,
+                allowRepositorySignature: true);
+            Normalize(
+                Path.GetFullPath(actualPath),
+                actualNormalized,
+                allowRepositorySignature: true);
+            if (!FilesEqual(expectedNormalized, actualNormalized))
+            {
+                throw new InvalidDataException(
+                    "the existing immutable version has different product-owned content");
+            }
+        }
+        finally
+        {
+            Directory.Delete(work, recursive: true);
+        }
+    }
+
+    private static bool FilesEqual(string leftPath, string rightPath)
+    {
+        FileInfo leftInfo = new(leftPath);
+        FileInfo rightInfo = new(rightPath);
+        if (leftInfo.Length != rightInfo.Length)
+        {
+            return false;
+        }
+
+        using FileStream left = File.OpenRead(leftPath);
+        using FileStream right = File.OpenRead(rightPath);
+        byte[] leftBuffer = new byte[1 << 20];
+        byte[] rightBuffer = new byte[leftBuffer.Length];
+        while (true)
+        {
+            int leftRead = left.Read(leftBuffer);
+            int rightRead = right.Read(rightBuffer);
+            if (leftRead != rightRead)
+            {
+                return false;
+            }
+            if (leftRead == 0)
+            {
+                return true;
+            }
+            if (!leftBuffer.AsSpan(0, leftRead).SequenceEqual(
+                    rightBuffer.AsSpan(0, rightRead)))
+            {
+                return false;
+            }
+        }
+    }
+
+    private static void RunSelfTests()
+    {
+        string work = Path.Combine(
+            Path.GetTempPath(),
+            $"baml-nuget-self-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(work);
+        try
+        {
+            string expected = Path.Combine(work, "expected.nupkg");
+            string signed = Path.Combine(work, "signed.nupkg");
+            WriteTestPackage(expected, signature: false, mutation: null);
+            WriteTestPackage(signed, signature: true, mutation: null);
+            CompareProductPayload(expected, signed);
+
+            foreach (string mutation in new[]
+                     {
+                         "managed-assembly",
+                         "native-asset",
+                         "nuspec-version",
+                         "nuspec-dependency",
+                     })
+            {
+                string changed = Path.Combine(work, $"{mutation}.nupkg");
+                WriteTestPackage(
+                    changed,
+                    signature: true,
+                    mutation: mutation);
+                bool rejected = false;
+                try
+                {
+                    CompareProductPayload(expected, changed);
+                }
+                catch (InvalidDataException)
+                {
+                    rejected = true;
+                }
+                if (!rejected)
+                {
+                    throw new InvalidOperationException(
+                        $"payload mutation was not rejected: {mutation}");
+                }
+            }
+        }
+        finally
+        {
+            Directory.Delete(work, recursive: true);
+        }
+    }
+
+    private static void WriteTestPackage(
+        string path,
+        bool signature,
+        string? mutation)
+    {
+        const string contentTypes =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+              <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+              <Default Extension="psmdcp" ContentType="application/vnd.openxmlformats-package.core-properties+xml" />
+              <Default Extension="nuspec" ContentType="application/octet" />
+              <Default Extension="dll" ContentType="application/octet" />
+              <Default Extension="so" ContentType="application/octet" />
+            </Types>
+            """;
+        const string relationships =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+              <Relationship Type="http://schemas.microsoft.com/packaging/2010/07/manifest" Target="/baml-bridge.nuspec" Id="manifest" />
+              <Relationship Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="/package/services/metadata/core-properties/random.psmdcp" Id="properties" />
+            </Relationships>
+            """;
+        string version = mutation == "nuspec-version" ? "1.2.4" : "1.2.3";
+        string dependency = mutation == "nuspec-dependency"
+            ? "[3.36.0,4.0.0)"
+            : "[3.35.1,4.0.0)";
+        string nuspec =
+            $"""
+             <?xml version="1.0" encoding="utf-8"?>
+             <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+               <metadata>
+                 <id>baml-bridge</id>
+                 <version>{version}</version>
+                 <authors>BoundaryML</authors>
+                 <description>comparison fixture</description>
+                 <dependencies>
+                   <group targetFramework="net10.0">
+                     <dependency id="Google.Protobuf" version="{dependency}" />
+                   </group>
+                 </dependencies>
+               </metadata>
+             </package>
+             """;
+
+        using FileStream stream = new(
+            path,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.None);
+        using ZipArchive archive = new(
+            stream,
+            ZipArchiveMode.Create,
+            leaveOpen: false,
+            entryNameEncoding: Encoding.UTF8);
+        AddTestEntry(archive, ContentTypesEntryName, contentTypes);
+        AddTestEntry(archive, RootRelationshipsEntryName, relationships);
+        AddTestEntry(
+            archive,
+            "package/services/metadata/core-properties/random.psmdcp",
+            "<core>product-owned</core>");
+        AddTestEntry(archive, "baml-bridge.nuspec", nuspec);
+        AddTestEntry(
+            archive,
+            "lib/net10.0/Baml.Bridge.dll",
+            mutation == "managed-assembly" ? "changed-managed" : "managed");
+        AddTestEntry(
+            archive,
+            "runtimes/linux-x64/native/libbridge_cffi.so",
+            mutation == "native-asset" ? "changed-native" : "native");
+        if (signature)
+        {
+            AddTestEntry(archive, SignatureEntryName, "repository-signature");
+        }
+    }
+
+    private static void AddTestEntry(
+        ZipArchive archive,
+        string name,
+        string content)
+    {
+        ZipArchiveEntry entry = archive.CreateEntry(
+            name,
+            CompressionLevel.SmallestSize);
+        entry.LastWriteTime = CanonicalTimestamp;
+        entry.ExternalAttributes = CanonicalFileExternalAttributes;
+        using StreamWriter writer = new(
+            entry.Open(),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(content);
     }
 
     private sealed record InputEntry(

--- a/baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/README.md
+++ b/baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/README.md
@@ -13,3 +13,13 @@ It rejects signed inputs, duplicate/case-colliding or unsafe paths, malformed
 OPC metadata, an occupied canonical core-properties path, existing output
 files, and in-place rewrites. Signing, if enabled by the release, occurs only
 after normalization and exact-package consumer verification.
+
+The `compare` mode implements NuGet rerun safety. It normalizes the verified
+unsigned package and the package downloaded from nuget.org, excludes only
+NuGet's repository-added `.signature.p7s`, and compares every product-owned
+entry. Managed assemblies, native assets, the nuspec version/dependencies, and
+all other payloads remain comparison inputs. An identical existing version is
+safe to reuse; any product-content mismatch fails closed.
+
+Run `--self-test` to exercise unsigned-versus-repository-signed equivalence and
+the managed, native, version, and dependency mismatch cases.

--- a/baml_language/sdks/csharp/bridge_csharp/tools/pack-product.sh
+++ b/baml_language/sdks/csharp/bridge_csharp/tools/pack-product.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ "$#" -ne 5 ]]; then
-  echo "usage: pack-product.sh <staged-native-root> <native-sha256-manifest> <native-provenance.tsv> <release-plan.json> <output-directory>" >&2
+  echo "usage: pack-product.sh <staged-native-root> <native-sha256-manifest> <native-provenance.json> <release-plan.json> <output-directory>" >&2
   exit 2
 fi
 
@@ -12,6 +12,8 @@ project="$tool_dir/../src/Baml.Bridge.csproj"
 target_template="$tool_dir/../src/baml-bridge.targets.in"
 normalizer="$tool_dir/Baml.NuGetNormalizer/Baml.NuGetNormalizer.csproj"
 platforms="$repository_root/release/platforms.json"
+release_contract="$repository_root/scripts/baml-csharp-release-contract"
+size_policy="$repository_root/release/csharp-package-size-policy.json"
 expected_exports="$tool_dir/../tests/expected-bridge-cffi-exports.txt"
 native_root="$(cd "$1" && pwd -P)"
 native_manifest="$(cd "$(dirname "$2")" && pwd -P)/$(basename "$2")"
@@ -26,9 +28,12 @@ for command in jq llvm-nm llvm-objdump llvm-readobj sha256sum strings unzip; do
   fi
 done
 
-version="$(jq -er '.canonical_version | select(type == "string" and length > 0)' \
+canonical_version="$(jq -er \
+  '.canonical_version | select(type == "string" and length > 0)' \
   "$release_plan")"
-test "$version" = "$("$repository_root/scripts/baml-language-version" show)"
+nuget_version="$(jq -er \
+  '.registry_versions.nuget | select(type == "string" and length > 0)' \
+  "$release_plan")"
 expected_native_source_sha="$(git -C "$repository_root" rev-parse HEAD)"
 [[ "$expected_native_source_sha" =~ ^[0-9a-f]{40}$ ]]
 
@@ -37,7 +42,7 @@ if [[ "$output_directory" != /* ]]; then
 fi
 mkdir -p "$output_directory"
 output_directory="$(cd "$output_directory" && pwd -P)"
-output_package="$output_directory/baml-bridge.$version.nupkg"
+output_package="$output_directory/baml-bridge.$nuget_version.nupkg"
 if [[ -e "$output_package" ]]; then
   echo "package output already exists: $output_package" >&2
   exit 1
@@ -56,49 +61,45 @@ jq -r '
 find "$native_root/runtimes" -type f -printf 'runtimes/%P\n' \
   | LC_ALL=C sort > "$actual_runtime_entries"
 diff -u "$expected_runtime_entries" "$actual_runtime_entries"
-test "$(wc -l < "$actual_runtime_entries")" -eq 8
+expected_native_count="$(wc -l < "$expected_runtime_entries")"
+test "$expected_native_count" -gt 0
+test "$(wc -l < "$actual_runtime_entries")" -eq "$expected_native_count"
 awk '{print $2}' "$native_manifest" | LC_ALL=C sort \
   > "$work/manifest-runtime-entries.txt"
 diff -u "$expected_runtime_entries" "$work/manifest-runtime-entries.txt"
 (cd "$native_root" && sha256sum -c "$native_manifest")
 
-if ! awk -F '\t' '
-  NF != 8 { exit 1 }
-  $1 !~ /^[0-9a-f]{64}$/ { exit 1 }
-  $2 !~ /^[0-9a-f]{40}$/ { exit 1 }
-  $4 !~ /^[1-9][0-9]*$/ { exit 1 }
-  $5 !~ /^[1-9][0-9]*$/ { exit 1 }
-' "$native_provenance"; then
-  echo "native provenance must contain eight valid tab-separated identity rows" >&2
-  exit 1
-fi
-test "$(wc -l < "$native_provenance")" -eq 8
-awk -F '\t' 'BEGIN { OFS = "\t" } { print $4, $5 }' \
-  "$native_provenance" | LC_ALL=C sort -u \
-  > "$work/provenance-run-attempts.tsv"
-if [[ "$(wc -l < "$work/provenance-run-attempts.tsv")" -ne 1 ]]; then
-  echo "all native inputs must come from one workflow run and attempt" >&2
-  exit 1
-fi
+"$release_contract" verify-product \
+  --platforms "$platforms" \
+  --release-plan "$release_plan" \
+  --source-sha "$expected_native_source_sha" \
+  --provenance "$native_provenance" \
+  --manifest "$native_manifest" \
+  --native-root "$native_root"
+
+native_size_regression_percent="$(jq -er \
+  '.native_assets.max_regression_percent
+   | select(type == "number" and . >= 0)' "$size_policy")"
 jq -r '
   .targets[]
-  | select(.artifacts.csharp != null and .artifacts.cffi != null)
+  | select(.artifacts.csharp != null)
   | [.triple,
-     .artifacts.cffi.asset,
      "runtimes/\(.artifacts.csharp.rid)/native/\(.artifacts.csharp.native_asset)"]
-  | @tsv' "$platforms" | LC_ALL=C sort \
-  > "$work/expected-provenance-shape.tsv"
-awk -F '\t' 'BEGIN { OFS = "\t" } { print $6, $7, $8 }' \
-  "$native_provenance" | LC_ALL=C sort \
-  > "$work/actual-provenance-shape.tsv"
-diff -u "$work/expected-provenance-shape.tsv" \
-  "$work/actual-provenance-shape.tsv"
-while IFS=$'\t' read -r digest source_sha release_version \
-  workflow_run_id workflow_run_attempt target producer_asset runtime_path; do
-  test "$source_sha" = "$expected_native_source_sha"
-  test "$release_version" = "$version"
-  grep -Fxq "$digest  $runtime_path" "$native_manifest"
-done < "$native_provenance"
+  | @tsv' "$platforms" |
+while IFS=$'\t' read -r target runtime_path; do
+  baseline="$(jq -er --arg target "$target" \
+    '.native_assets.baseline_bytes_by_target[$target]
+     | select(type == "number" and . > 0)' "$size_policy")"
+  actual="$(stat -c %s "$native_root/$runtime_path")"
+  limit="$((baseline * (100 + native_size_regression_percent) / 100))"
+  if ((actual > limit)); then
+    echo "native size regression exceeds policy: $target actual=$actual limit=$limit baseline=$baseline" >&2
+    exit 1
+  fi
+done
+policy_target_count="$(jq \
+  '.native_assets.baseline_bytes_by_target | length' "$size_policy")"
+test "$policy_target_count" -eq "$expected_native_count"
 
 inspection_root="$work/native-inspection"
 mkdir -p "$inspection_root"
@@ -264,15 +265,18 @@ dotnet build "$normalizer" --configuration Release --nologo \
   -p:NuGetAudit=false
 dotnet build "$project" --configuration Release --nologo \
   -p:NuGetAudit=false \
-  -p:Version="$version" \
-  -p:PackageVersion="$version"
+  -p:Version="$canonical_version" \
+  -p:InformationalVersion="$canonical_version" \
+  -p:PackageVersion="$nuget_version"
 for raw in raw-a raw-b; do
   dotnet pack "$project" --configuration Release --nologo \
     --no-build --no-restore \
     --output "$work/$raw" \
     -p:NuGetAudit=false \
-    -p:Version="$version" \
-    -p:PackageVersion="$version" \
+    -p:Version="$canonical_version" \
+    -p:InformationalVersion="$canonical_version" \
+    -p:PackageVersion="$nuget_version" \
+    -p:BamlExpectedNativeAssetCount="$expected_native_count" \
     -p:BamlNativeAssetRoot="$native_root" \
     -p:BamlGeneratedTargetsPath="$generated_targets"
 done
@@ -280,7 +284,7 @@ done
 for suffix in a b; do
   dotnet run --project "$normalizer" \
     --configuration Release --no-build --no-restore -- \
-    "$work/raw-$suffix/baml-bridge.$version.nupkg" \
+    "$work/raw-$suffix/baml-bridge.$nuget_version.nupkg" \
     "$work/normalized/package-$suffix.nupkg"
 done
 cmp "$work/normalized/package-a.nupkg" \
@@ -315,8 +319,28 @@ unzip -Z1 "$work/normalized/package-a.nupkg" \
 } | LC_ALL=C sort > "$work/expected-package-entries.txt"
 diff -u "$work/expected-package-entries.txt" \
   "$work/actual-package-entries.txt"
-test "$(wc -l < "$work/actual-package-entries.txt")" -eq 15
-test "$(stat -c %s "$work/normalized/package-a.nupkg")" -lt 200000000
+expected_package_entry_count="$((expected_native_count + 7))"
+test "$(wc -l < "$work/actual-package-entries.txt")" \
+  -eq "$expected_package_entry_count"
+package_size="$(stat -c %s "$work/normalized/package-a.nupkg")"
+package_baseline="$(jq -er \
+  '.compressed_package.baseline_bytes
+   | select(type == "number" and . > 0)' "$size_policy")"
+package_regression_percent="$(jq -er \
+  '.compressed_package.max_regression_percent
+   | select(type == "number" and . >= 0)' "$size_policy")"
+package_regression_limit="$((package_baseline * (100 + package_regression_percent) / 100))"
+package_safety_ceiling="$(jq -er \
+  '.compressed_package.registry_safety_ceiling_bytes
+   | select(type == "number" and . > 0)' "$size_policy")"
+if ((package_size > package_regression_limit)); then
+  echo "compressed package size regression exceeds policy: actual=$package_size limit=$package_regression_limit baseline=$package_baseline" >&2
+  exit 1
+fi
+if ((package_size >= package_safety_ceiling)); then
+  echo "compressed package exceeds registry safety ceiling: actual=$package_size ceiling=$package_safety_ceiling" >&2
+  exit 1
+fi
 unzip -p "$work/normalized/package-a.nupkg" baml-bridge.nuspec \
   > "$work/baml-bridge.nuspec"
 grep -Fq '<dependency id="Google.Protobuf"' "$work/baml-bridge.nuspec"
@@ -324,6 +348,15 @@ if grep -Fq 'Grpc.Tools' "$work/baml-bridge.nuspec"; then
   echo "Grpc.Tools leaked into the product package dependency graph" >&2
   exit 1
 fi
+
+"$release_contract" verify-product \
+  --platforms "$platforms" \
+  --release-plan "$release_plan" \
+  --source-sha "$expected_native_source_sha" \
+  --provenance "$native_provenance" \
+  --manifest "$native_manifest" \
+  --native-root "$native_root" \
+  --package "$work/normalized/package-a.nupkg"
 
 cp "$work/normalized/package-a.nupkg" "$output_package"
 cmp "$work/normalized/package-a.nupkg" "$output_package"

--- a/release/csharp-package-size-policy.json
+++ b/release/csharp-package-size-policy.json
@@ -1,0 +1,28 @@
+{
+  "schema": 1,
+  "description": "Reviewed C# NuGet size baseline. The package threshold is a regression budget, while the 200 MB limit remains a separate registry-safety ceiling.",
+  "evidence": {
+    "workflow_run_id": "29989654236",
+    "source_sha": "ceae8ea6cf9a8af561b4f1aa81ae428ce504d6d4",
+    "measured_at": "2026-07-23",
+    "compressed_native_payload_bytes": 69559373
+  },
+  "compressed_package": {
+    "baseline_bytes": 70000000,
+    "max_regression_percent": 15,
+    "registry_safety_ceiling_bytes": 200000000
+  },
+  "native_assets": {
+    "max_regression_percent": 10,
+    "baseline_bytes_by_target": {
+      "aarch64-apple-darwin": 21359712,
+      "aarch64-pc-windows-msvc": 22662656,
+      "aarch64-unknown-linux-gnu": 21692688,
+      "aarch64-unknown-linux-musl": 21606408,
+      "x86_64-apple-darwin": 21773828,
+      "x86_64-pc-windows-msvc": 24630272,
+      "x86_64-unknown-linux-gnu": 24584488,
+      "x86_64-unknown-linux-musl": 24432880
+    }
+  }
+}

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -1,5 +1,5 @@
 {
-  "description": "Repository-owned platform contract: the single machine-readable source for the BAML language release target set, per-target per-artifact support, and each artifact's build config. The cffi, toolchain, python, and java build matrices are generated from this file (see .github/workflows/build2-bridge-cffi.reusable.yaml, release-baml-language.yml, build2-python-sdk.reusable.yaml, build2-java-sdk.reusable.yaml); the Rust side is validated against it by baml_release::platforms tests. The nodejs matrix keeps its bespoke per-target build recipes in its own workflow. Per target, `artifacts` maps each supported SDK/build artifact to its config: a MISSING key means that artifact is not built for the target (unsupported); `experimental: true` means built best-effort (a failure must not block the release); absent/false means required (must succeed). `runner` is the GitHub Actions runner label, distinct from the target's `os` family.",
+  "description": "Repository-owned platform contract: the single machine-readable source for the BAML language release target set, per-target per-artifact support, and each artifact's build config. The cffi, toolchain, python, java, and C# matrices are generated from this file. CFFI entries own language-neutral native production; sibling C# entries own .NET RID projection, package-native filenames, native consumer runners, support tier, and package policy. C# requires CFFI, while CFFI support does not imply C# support. A missing artifact key means unsupported; `experimental: true` means best-effort; absent/false means required.",
   "schema": 1,
   "targets": [
     {
@@ -13,7 +13,8 @@
         "python": { "runner": "macos-latest" },
         "nodejs": {},
         "java": { "platform": "macos-aarch64", "runner": "macos-14" },
-        "cffi": { "asset": "libbaml_cffi-aarch64-apple-darwin.dylib", "runner": "macos-14", "smoke": true }
+        "cffi": { "asset": "libbaml_cffi-aarch64-apple-darwin.dylib", "runner": "macos-14", "smoke": true },
+        "csharp": { "rid": "osx-arm64", "native_asset": "libbridge_cffi.dylib", "consumer_runner": "macos-14", "package_policy": "rid-native" }
       }
     },
     {
@@ -27,7 +28,8 @@
         "python": { "runner": "macos-latest" },
         "nodejs": {},
         "java": { "platform": "macos-x86_64", "runner": "macos-15-intel" },
-        "cffi": { "asset": "libbaml_cffi-x86_64-apple-darwin.dylib", "runner": "macos-14" }
+        "cffi": { "asset": "libbaml_cffi-x86_64-apple-darwin.dylib", "runner": "macos-14" },
+        "csharp": { "rid": "osx-x64", "native_asset": "libbridge_cffi.dylib", "consumer_runner": "macos-15-intel", "package_policy": "rid-native" }
       }
     },
     {
@@ -41,7 +43,8 @@
         "python": { "runner": "ubuntu-latest", "manylinux": "2_24" },
         "nodejs": {},
         "java": { "platform": "linux-aarch64", "runner": "ubuntu-24.04-arm" },
-        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true }
+        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true },
+        "csharp": { "rid": "linux-arm64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04-arm", "package_policy": "rid-native" }
       }
     },
     {
@@ -55,7 +58,8 @@
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
         "java": { "platform": "linux-aarch64-musl", "runner": "ubuntu-latest", "experimental": true },
-        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true, "experimental": true }
+        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true },
+        "csharp": { "rid": "linux-musl-arm64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04-arm", "package_policy": "rid-native" }
       }
     },
     {
@@ -69,7 +73,8 @@
         "python": { "runner": "ubuntu-latest", "manylinux": "2_17" },
         "nodejs": {},
         "java": { "platform": "linux-x86_64", "runner": "ubuntu-latest" },
-        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true, "smoke": true }
+        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true, "smoke": true },
+        "csharp": { "rid": "linux-x64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04", "package_policy": "rid-native" }
       }
     },
     {
@@ -83,7 +88,8 @@
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
         "java": { "platform": "linux-x86_64-musl", "runner": "ubuntu-latest", "experimental": true },
-        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true, "experimental": true }
+        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true },
+        "csharp": { "rid": "linux-musl-x64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04", "package_policy": "rid-native" }
       }
     },
     {
@@ -97,7 +103,8 @@
         "python": { "runner": "windows-latest" },
         "nodejs": {},
         "java": { "platform": "windows-x86_64", "runner": "windows-latest" },
-        "cffi": { "asset": "baml_cffi-x86_64-pc-windows-msvc.dll", "runner": "windows-2022", "smoke": true }
+        "cffi": { "asset": "baml_cffi-x86_64-pc-windows-msvc.dll", "runner": "windows-2022", "smoke": true },
+        "csharp": { "rid": "win-x64", "native_asset": "bridge_cffi.dll", "consumer_runner": "windows-2022", "package_policy": "rid-native" }
       }
     },
     {
@@ -111,7 +118,8 @@
         "python": { "runner": "windows-11-arm", "architecture": "arm64" },
         "nodejs": {},
         "java": { "platform": "windows-aarch64", "runner": "windows-11-arm", "experimental": true },
-        "cffi": { "asset": "baml_cffi-aarch64-pc-windows-msvc.dll", "runner": "windows-11-arm", "smoke": true, "experimental": true }
+        "cffi": { "asset": "baml_cffi-aarch64-pc-windows-msvc.dll", "runner": "windows-11-arm", "smoke": true },
+        "csharp": { "rid": "win-arm64", "native_asset": "bridge_cffi.dll", "consumer_runner": "windows-11-arm", "package_policy": "rid-native" }
       }
     }
   ]

--- a/scripts/assemble-swift-sdk-mirror
+++ b/scripts/assemble-swift-sdk-mirror
@@ -33,18 +33,10 @@ def main() -> None:
     destination = args.out.resolve()
     if destination == repository or repository in destination.parents:
         raise SystemExit("--out must be outside the source repository")
-    # Never rmtree an arbitrary path (home, /, a populated dir): refuse
-    # roots outright, and only clear a pre-existing destination when it
-    # is empty or a prior run of *this* script (marked by SOURCE_SHA).
-    if destination.parent == destination or destination == Path.home():
-        raise SystemExit(f"refusing dangerous --out path: {destination}")
+    # A caller can choose a fresh staging directory cheaply. Refusing every
+    # existing path avoids turning a forgeable marker into deletion authority.
     if destination.exists():
-        contents = list(destination.iterdir())
-        if contents and not (destination / "SOURCE_SHA").exists():
-            raise SystemExit(
-                f"--out exists and is not a prior mirror (no SOURCE_SHA marker): {destination}"
-            )
-        shutil.rmtree(destination)
+        raise SystemExit(f"--out must not already exist: {destination}")
     # The dist/ tree is the source of truth for the mirror's non-generated
     # files: Package.swift template, README, .gitignore.
     shutil.copytree(

--- a/scripts/baml-csharp-release-contract
+++ b/scripts/baml-csharp-release-contract
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Validate and assemble the C# projection of shared bridge_cffi artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import stat
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PLATFORMS = ROOT / "release" / "platforms.json"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+SOURCE_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z](?:[0-9A-Za-z.-]*[0-9A-Za-z])?)?$"
+)
+
+
+class ContractError(ValueError):
+    """A fail-closed release contract violation."""
+
+
+def fail(message: str) -> None:
+    raise ContractError(message)
+
+
+def load_json(path: Path, description: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"{description} does not exist: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"{description} is not valid JSON: {path}: {exc}")
+
+
+def require_string(value: Any, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(f"{description} must be a nonempty string")
+    return value
+
+
+def expected_rid(target: dict[str, Any]) -> str:
+    arch = target.get("arch")
+    arch_token = {"aarch64": "arm64", "x86_64": "x64"}.get(arch)
+    if arch_token is None:
+        fail(f"{target.get('triple', '<unknown>')}: unsupported C# architecture {arch!r}")
+
+    os_name = target.get("os")
+    if os_name == "macos":
+        return f"osx-{arch_token}"
+    if os_name == "linux":
+        libc = target.get("libc")
+        return (
+            f"linux-musl-{arch_token}"
+            if libc == "musl"
+            else f"linux-{arch_token}"
+        )
+    if os_name == "windows":
+        return f"win-{arch_token}"
+    fail(f"{target.get('triple', '<unknown>')}: unsupported C# OS {os_name!r}")
+
+
+def expected_native_asset(target: dict[str, Any]) -> str:
+    return {
+        "macos": "libbridge_cffi.dylib",
+        "linux": "libbridge_cffi.so",
+        "windows": "bridge_cffi.dll",
+    }.get(target.get("os")) or fail(
+        f"{target.get('triple', '<unknown>')}: unsupported C# OS"
+    )
+
+
+def validate_consumer_runner(
+    target: dict[str, Any], runner: str
+) -> None:
+    os_name = target["os"]
+    marker = {
+        "macos": "macos",
+        "linux": "ubuntu",
+        "windows": "windows",
+    }[os_name]
+    if marker not in runner.lower():
+        fail(
+            f"{target['triple']}: C# consumer runner {runner!r} "
+            f"does not match {os_name}"
+        )
+    if target["arch"] == "aarch64" and os_name in {"linux", "windows"}:
+        if not any(token in runner.lower() for token in ("arm", "aarch64")):
+            fail(
+                f"{target['triple']}: C# arm64 consumer runner {runner!r} "
+                "is not an arm64 runner"
+            )
+
+
+def csharp_targets(platforms_path: Path) -> list[dict[str, Any]]:
+    contract = load_json(platforms_path, "platform contract")
+    if not isinstance(contract, dict) or contract.get("schema") != 1:
+        fail("platform contract must be a schema-1 JSON object")
+    targets = contract.get("targets")
+    if not isinstance(targets, list):
+        fail("platform contract targets must be a JSON array")
+
+    seen_targets: set[str] = set()
+    seen_rids: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for index, target in enumerate(targets):
+        if not isinstance(target, dict):
+            fail(f"platform target {index} must be a JSON object")
+        triple = require_string(target.get("triple"), f"platform target {index}.triple")
+        if triple in seen_targets:
+            fail(f"duplicate platform target: {triple}")
+        seen_targets.add(triple)
+
+        artifacts = target.get("artifacts")
+        if not isinstance(artifacts, dict):
+            fail(f"{triple}: artifacts must be a JSON object")
+        csharp = artifacts.get("csharp")
+        if csharp is None:
+            continue
+        if not isinstance(csharp, dict):
+            fail(f"{triple}: C# artifact must be a JSON object")
+        cffi = artifacts.get("cffi")
+        if not isinstance(cffi, dict):
+            fail(f"{triple}: C# requires a CFFI source artifact")
+
+        rid = require_string(csharp.get("rid"), f"{triple}: C# rid")
+        native_asset = require_string(
+            csharp.get("native_asset"), f"{triple}: C# native_asset"
+        )
+        consumer_runner = require_string(
+            csharp.get("consumer_runner"), f"{triple}: C# consumer_runner"
+        )
+        package_policy = require_string(
+            csharp.get("package_policy"), f"{triple}: C# package_policy"
+        )
+        producer_asset = require_string(cffi.get("asset"), f"{triple}: CFFI asset")
+
+        if rid != expected_rid(target):
+            fail(f"{triple}: C# RID {rid!r} does not match target fields")
+        if rid in seen_rids:
+            fail(f"duplicate C# RID: {rid}")
+        seen_rids.add(rid)
+        if native_asset != expected_native_asset(target):
+            fail(
+                f"{triple}: C# native asset {native_asset!r} "
+                "does not match the target OS"
+            )
+        if package_policy != "rid-native":
+            fail(f"{triple}: unsupported C# package policy {package_policy!r}")
+        if csharp.get("experimental", False):
+            fail(f"{triple}: the eight-RID C# product cannot be experimental")
+        if cffi.get("experimental", False):
+            fail(f"{triple}: required C# cannot consume experimental CFFI")
+        validate_consumer_runner(target, consumer_runner)
+
+        result.append(
+            {
+                "target": triple,
+                "arch": require_string(target.get("arch"), f"{triple}: arch"),
+                "libc": target.get("libc"),
+                "rid": rid,
+                "canonical": native_asset,
+                "runner": consumer_runner,
+                "producer_asset": producer_asset,
+            }
+        )
+
+    if not result:
+        fail("platform contract has no C# targets")
+    return sorted(result, key=lambda entry: entry["target"])
+
+
+def matrix(platforms_path: Path) -> dict[str, Any]:
+    return {
+        "include": [
+            {
+                key: entry[key]
+                for key in ("target", "arch", "libc", "rid", "canonical", "runner")
+            }
+            for entry in csharp_targets(platforms_path)
+        ]
+    }
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def artifact_files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        fail(f"expected producer artifact directory is missing: {root}")
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            fail(f"producer artifact contains a symlink: {path}")
+        if path.is_file():
+            files.append(path)
+    return files
+
+
+def parse_sidecar(path: Path, expected_name: str) -> str:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        fail(f"checksum sidecar is not UTF-8: {path}")
+    # GNU sha256sum writes two spaces for text mode; shasum on Windows writes
+    # a space plus `*` for binary mode. Both are standard checksum sidecars.
+    match = re.fullmatch(r"([0-9a-f]{64}) ([ *])([^\r\n]+)\n?", text)
+    if match is None or match.group(3) != expected_name:
+        fail(
+            f"checksum sidecar must contain '<sha256>  {expected_name}': {path}"
+        )
+    return match.group(1)
+
+
+def write_new(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            stream.write(content)
+    except FileExistsError:
+        fail(f"release contract output already exists: {path}")
+
+
+def stage_native(args: argparse.Namespace) -> None:
+    if SOURCE_SHA_RE.fullmatch(args.source_sha) is None:
+        fail("--source-sha must be a lowercase 40-character Git SHA")
+    if VERSION_RE.fullmatch(args.release_version) is None:
+        fail("--release-version must be a canonical BAML version")
+    if not args.workflow_run_id.isdigit() or int(args.workflow_run_id) < 1:
+        fail("--workflow-run-id must be a positive decimal run ID")
+
+    downloads = args.downloads.resolve()
+    staging = args.staging.resolve()
+    if staging.exists() and any(staging.iterdir()):
+        fail(f"staging directory must be empty: {staging}")
+    staging.mkdir(parents=True, exist_ok=True)
+
+    provenance_entries: list[dict[str, str]] = []
+    for entry in csharp_targets(args.platforms):
+        artifact_name = f"bridge-cffi-{entry['target']}"
+        root = downloads / artifact_name
+        files = artifact_files(root)
+        sources = [path for path in files if path.name == entry["producer_asset"]]
+        sidecars = [
+            path for path in files if path.name == f"{entry['producer_asset']}.sha256"
+        ]
+        if len(files) != 2 or len(sources) != 1 or len(sidecars) != 1:
+            fail(
+                f"{artifact_name} must contain exactly the native library and "
+                f"checksum sidecar; found {[path.name for path in files]}"
+            )
+        source = sources[0]
+        sidecar = sidecars[0]
+        if source.parent != sidecar.parent:
+            fail(f"{artifact_name}: native library and checksum are not siblings")
+        digest = parse_sidecar(sidecar, entry["producer_asset"])
+        if sha256(source) != digest:
+            fail(f"{artifact_name}: native checksum does not match")
+
+        runtime_path = (
+            Path("runtimes") / entry["rid"] / "native" / entry["canonical"]
+        )
+        destination = staging / runtime_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            fail(f"duplicate C# runtime destination: {runtime_path.as_posix()}")
+        shutil.copyfile(source, destination)
+        destination.chmod(
+            destination.stat().st_mode
+            | stat.S_IXUSR
+            | stat.S_IXGRP
+            | stat.S_IXOTH
+        )
+        if sha256(destination) != digest:
+            fail(f"{artifact_name}: staged native checksum does not match")
+        provenance_entries.append(
+            {
+                "target": entry["target"],
+                "producer_filename": entry["producer_asset"],
+                "runtime_path": runtime_path.as_posix(),
+                "sha256": digest,
+            }
+        )
+
+    provenance_entries.sort(key=lambda item: item["runtime_path"])
+    provenance = {
+        "schema": 1,
+        "source_sha": args.source_sha,
+        "release_version": args.release_version,
+        "workflow_run_id": args.workflow_run_id,
+        "artifacts": provenance_entries,
+    }
+    write_new(
+        args.provenance,
+        json.dumps(provenance, indent=2, sort_keys=True) + "\n",
+    )
+    write_new(
+        args.manifest,
+        "".join(
+            f"{entry['sha256']}  {entry['runtime_path']}\n"
+            for entry in provenance_entries
+        ),
+    )
+
+
+def load_plan(path: Path) -> tuple[str, str]:
+    plan = load_json(path, "release plan")
+    if not isinstance(plan, dict) or plan.get("schema") != 2:
+        fail("release plan must be a schema-2 JSON object")
+    canonical = require_string(plan.get("canonical_version"), "canonical_version")
+    registry_versions = plan.get("registry_versions")
+    if not isinstance(registry_versions, dict):
+        fail("release plan registry_versions must be a JSON object")
+    nuget = require_string(registry_versions.get("nuget"), "registry_versions.nuget")
+    return canonical, nuget
+
+
+def parse_manifest(path: Path) -> dict[str, str]:
+    rows: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        fail(f"native manifest does not exist: {path}")
+    for line in lines:
+        match = re.fullmatch(r"([0-9a-f]{64})  (runtimes/[^/\s]+/native/[^/\s]+)", line)
+        if match is None:
+            fail(f"invalid native manifest row: {line!r}")
+        runtime_path = match.group(2)
+        if runtime_path in rows:
+            fail(f"duplicate native manifest path: {runtime_path}")
+        rows[runtime_path] = match.group(1)
+    return rows
+
+
+def package_version(package: zipfile.ZipFile) -> str:
+    nuspec_names = [name for name in package.namelist() if name.endswith(".nuspec")]
+    if len(nuspec_names) != 1:
+        fail(f"NuGet package must contain exactly one nuspec; found {nuspec_names}")
+    try:
+        root = ElementTree.fromstring(package.read(nuspec_names[0]))
+    except ElementTree.ParseError as exc:
+        fail(f"NuGet nuspec is invalid XML: {exc}")
+    versions = [
+        element.text
+        for element in root.iter()
+        if element.tag.rsplit("}", 1)[-1] == "version"
+    ]
+    if len(versions) != 1 or not versions[0]:
+        fail("NuGet nuspec must contain exactly one nonempty version")
+    return versions[0]
+
+
+def verify_product(args: argparse.Namespace) -> None:
+    if SOURCE_SHA_RE.fullmatch(args.source_sha) is None:
+        fail("--source-sha must be a lowercase 40-character Git SHA")
+    canonical, nuget = load_plan(args.release_plan)
+    expected = csharp_targets(args.platforms)
+
+    provenance = load_json(args.provenance, "native provenance")
+    if not isinstance(provenance, dict):
+        fail("native provenance must be a JSON object")
+    if set(provenance) != {
+        "schema",
+        "source_sha",
+        "release_version",
+        "workflow_run_id",
+        "artifacts",
+    }:
+        fail("native provenance has an unexpected schema")
+    if provenance["schema"] != 1:
+        fail("native provenance schema must be 1")
+    if provenance["source_sha"] != args.source_sha:
+        fail("native provenance source SHA does not match")
+    if provenance["release_version"] != canonical:
+        fail("native provenance release version does not match")
+    if not isinstance(provenance["workflow_run_id"], str) or not provenance[
+        "workflow_run_id"
+    ].isdigit():
+        fail("native provenance workflow_run_id must be a decimal string")
+    artifacts = provenance["artifacts"]
+    if not isinstance(artifacts, list):
+        fail("native provenance artifacts must be an array")
+
+    expected_by_target = {entry["target"]: entry for entry in expected}
+    actual_by_target: dict[str, dict[str, str]] = {}
+    for artifact in artifacts:
+        if not isinstance(artifact, dict) or set(artifact) != {
+            "target",
+            "producer_filename",
+            "runtime_path",
+            "sha256",
+        }:
+            fail("native provenance artifact has an unexpected schema")
+        target = require_string(artifact.get("target"), "provenance target")
+        if target in actual_by_target:
+            fail(f"duplicate native provenance target: {target}")
+        if SHA256_RE.fullmatch(str(artifact.get("sha256"))) is None:
+            fail(f"{target}: invalid native provenance SHA-256")
+        actual_by_target[target] = artifact
+
+    if set(actual_by_target) != set(expected_by_target):
+        fail(
+            "native provenance target mismatch "
+            f"missing={sorted(set(expected_by_target) - set(actual_by_target))} "
+            f"extra={sorted(set(actual_by_target) - set(expected_by_target))}"
+        )
+
+    manifest = parse_manifest(args.manifest)
+    expected_paths: set[str] = set()
+    for target, entry in expected_by_target.items():
+        artifact = actual_by_target[target]
+        runtime_path = f"runtimes/{entry['rid']}/native/{entry['canonical']}"
+        expected_paths.add(runtime_path)
+        if artifact["producer_filename"] != entry["producer_asset"]:
+            fail(f"{target}: provenance producer filename does not match")
+        if artifact["runtime_path"] != runtime_path:
+            fail(f"{target}: provenance runtime path does not match")
+        if manifest.get(runtime_path) != artifact["sha256"]:
+            fail(f"{target}: native manifest digest does not match provenance")
+        if args.native_root is not None:
+            native = args.native_root / runtime_path
+            if not native.is_file() or sha256(native) != artifact["sha256"]:
+                fail(f"{target}: staged native does not match provenance")
+
+    if set(manifest) != expected_paths:
+        fail("native manifest paths do not match the C# platform contract")
+
+    if args.package is not None:
+        try:
+            with zipfile.ZipFile(args.package) as package:
+                names = package.namelist()
+                if len(names) != len(set(names)):
+                    fail("NuGet package contains duplicate entries")
+                if package_version(package) != nuget:
+                    fail("NuGet package version does not match the release plan")
+                for runtime_path in expected_paths:
+                    try:
+                        payload = package.read(runtime_path)
+                    except KeyError:
+                        fail(f"NuGet package is missing {runtime_path}")
+                    if hashlib.sha256(payload).hexdigest() != manifest[runtime_path]:
+                        fail(f"NuGet package native digest mismatch: {runtime_path}")
+        except FileNotFoundError:
+            fail(f"NuGet package does not exist: {args.package}")
+        except zipfile.BadZipFile as exc:
+            fail(f"NuGet package is not a valid zip archive: {exc}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
+
+    matrix_parser = subparsers.add_parser("matrix")
+    matrix_parser.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
+
+    stage = subparsers.add_parser("stage-native")
+    stage.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
+    stage.add_argument("--downloads", type=Path, required=True)
+    stage.add_argument("--staging", type=Path, required=True)
+    stage.add_argument("--source-sha", required=True)
+    stage.add_argument("--release-version", required=True)
+    stage.add_argument("--workflow-run-id", required=True)
+    stage.add_argument("--provenance", type=Path, required=True)
+    stage.add_argument("--manifest", type=Path, required=True)
+
+    verify = subparsers.add_parser("verify-product")
+    verify.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
+    verify.add_argument("--release-plan", type=Path, required=True)
+    verify.add_argument("--source-sha", required=True)
+    verify.add_argument("--provenance", type=Path, required=True)
+    verify.add_argument("--manifest", type=Path, required=True)
+    verify.add_argument("--native-root", type=Path)
+    verify.add_argument("--package", type=Path)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    try:
+        if args.command == "validate":
+            targets = csharp_targets(args.platforms)
+            print(f"ok: {len(targets)} required C# targets")
+        elif args.command == "matrix":
+            print(json.dumps(matrix(args.platforms), separators=(",", ":")))
+        elif args.command == "stage-native":
+            stage_native(args)
+        elif args.command == "verify-product":
+            verify_product(args)
+            print("ok: C# release product identity")
+    except ContractError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/baml-language-version
+++ b/scripts/baml-language-version
@@ -14,7 +14,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(
+    os.environ.get(
+        "BAML_LANGUAGE_VERSION_ROOT",
+        Path(__file__).resolve().parents[1],
+    )
+).resolve()
 RELEASE_TOML = ROOT / "baml_language" / "release.toml"
 BAML_VERSION_RS = ROOT / "baml_language" / "crates" / "baml_version" / "src" / "lib.rs"
 PYPROJECT = ROOT / "baml_language" / "sdks" / "python" / "pyproject.toml"
@@ -28,6 +33,32 @@ GO_RUNTIME_VERSION = ROOT / "baml_language" / "sdks" / "go" / "baml_go" / "versi
 RUST_BRIDGE_VERSION_RS = ROOT / "baml_language" / "sdks" / "rust" / "bridge_rust" / "src" / "version.rs"
 RUST_BRIDGE_CARGO_TOML = ROOT / "baml_language" / "sdks" / "rust" / "bridge_rust" / "Cargo.toml"
 WRAPPER_CARGO_TOML = ROOT / "baml_language" / "crates" / "baml" / "Cargo.toml"
+CSHARP_PROJECT = (
+    ROOT
+    / "baml_language"
+    / "sdks"
+    / "csharp"
+    / "bridge_csharp"
+    / "src"
+    / "Baml.Bridge.csproj"
+)
+JAVA_BRIDGE_BUILD = ROOT / "baml_language" / "sdks" / "java" / "baml_bridge" / "build.gradle.kts"
+JAVA_KOTLIN_BUILD = (
+    ROOT
+    / "baml_language"
+    / "sdks"
+    / "java"
+    / "baml-bridge-kotlin"
+    / "build.gradle.kts"
+)
+GRADLE_PLUGIN_BUILD = (
+    ROOT
+    / "baml_language"
+    / "sdks"
+    / "java"
+    / "gradle-plugin"
+    / "build.gradle.kts"
+)
 
 SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 CANONICAL_RE = re.compile(
@@ -39,14 +70,21 @@ SHA_RE = re.compile(r"^[a-z]$")
 # `registry_versions` map instead of a flat `pypi_version` field, so a new
 # registry adds a map entry rather than a top-level field. The loader fails
 # closed on any other schema.
-PLAN_SCHEMA = 2
+PLAN_SCHEMA = 3
 
-# Registries whose package version this plan carries. crates.io and npm both
-# accept the canonical SemVer verbatim (identity translation); PyPI needs the
-# `.devN` encoding (see `to_pypi_version`). No .NET/NuGet registry ships yet,
-# so it is intentionally absent — a plan must never claim a registry it does
-# not produce.
-PLAN_REGISTRIES = ("pypi", "npm", "crates_io")
+# Registries whose package version this plan carries. npm, crates.io, NuGet,
+# Maven Central, the Gradle Plugin Portal, and SwiftPM git tags accept the
+# canonical SemVer verbatim (identity translation); PyPI needs the `.devN`
+# encoding (see `to_pypi_version`).
+PLAN_REGISTRIES = (
+    "pypi",
+    "npm",
+    "crates_io",
+    "nuget",
+    "maven",
+    "gradle_plugin",
+    "swiftpm",
+)
 
 
 @dataclass(frozen=True, order=True)
@@ -86,6 +124,7 @@ class ReleasePlan:
     canonical_version: str
     registry_versions: dict[str, str]
     git_tag: str
+    released_at: str
 
     def to_json(self) -> str:
         return json.dumps(self.__dict__, indent=2, sort_keys=True) + "\n"
@@ -103,6 +142,22 @@ class ReleasePlan:
     @property
     def crates_io_version(self) -> str:
         return self.registry_versions["crates_io"]
+
+    @property
+    def nuget_version(self) -> str:
+        return self.registry_versions["nuget"]
+
+    @property
+    def maven_version(self) -> str:
+        return self.registry_versions["maven"]
+
+    @property
+    def gradle_plugin_version(self) -> str:
+        return self.registry_versions["gradle_plugin"]
+
+    @property
+    def swiftpm_version(self) -> str:
+        return self.registry_versions["swiftpm"]
 
 
 def fail(message: str, code: int = 1) -> None:
@@ -273,6 +328,11 @@ def release_tags() -> list[str]:
 
 
 def next_nightly_letter(base: Version, date: str, tags: list[str] | None = None) -> str:
+    override = os.environ.get("BAML_LANGUAGE_VERSION_NIGHTLY_LETTER")
+    if override:
+        if SHA_RE.fullmatch(override) is None:
+            fail("BAML_LANGUAGE_VERSION_NIGHTLY_LETTER must be one lowercase letter")
+        return override
     prefix = f"baml-language-{base}-nightly.{date}."
     used = sorted(
         tag.removeprefix(prefix)
@@ -319,10 +379,35 @@ def registry_versions_for(canonical: str) -> dict[str, str]:
         "pypi": to_pypi_version(canonical),
         "npm": canonical,
         "crates_io": canonical,
+        "nuget": canonical,
+        "maven": canonical,
+        "gradle_plugin": canonical,
+        "swiftpm": canonical,
     }
     # Keep the map and the declared registry set in lockstep.
     assert set(translations) == set(PLAN_REGISTRIES)
     return translations
+
+
+def released_at_for_plan() -> str:
+    value = os.environ.get("BAML_LANGUAGE_RELEASED_AT")
+    if not value:
+        value = git_output("show", "-s", "--format=%cI", "HEAD")
+    try:
+        timestamp = dt.datetime.fromisoformat(value) if value else None
+    except ValueError:
+        timestamp = None
+    if timestamp is None or timestamp.tzinfo is None:
+        fail(
+            "BAML_LANGUAGE_RELEASED_AT or the source commit timestamp "
+            "must be an ISO-8601 timestamp with a timezone"
+        )
+    return (
+        timestamp.astimezone(dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def make_plan(channel: str) -> ReleasePlan:
@@ -334,6 +419,9 @@ def make_plan(channel: str) -> ReleasePlan:
         canonical_version=canonical,
         registry_versions=registry_versions_for(canonical),
         git_tag=f"baml-language-{canonical}",
+        # The source commit timestamp is deterministic for repair workflows,
+        # unlike generating a fresh manifest timestamp in a rerun attempt.
+        released_at=released_at_for_plan(),
     )
 
 
@@ -359,21 +447,63 @@ def load_plan(path: Path) -> ReleasePlan:
     if not isinstance(raw_registry_versions, dict):
         fail(f"{path} registry_versions must be a JSON object")
     registry_versions = {str(key): str(value) for key, value in raw_registry_versions.items()}
-    missing = [name for name in PLAN_REGISTRIES if name not in registry_versions]
-    if missing:
-        fail(f"{path} registry_versions is missing {', '.join(missing)}")
+    missing = sorted(set(PLAN_REGISTRIES) - set(registry_versions))
+    extra = sorted(set(registry_versions) - set(PLAN_REGISTRIES))
+    if missing or extra:
+        fail(
+            f"{path} registry_versions keys do not match the supported set: "
+            f"missing={missing} extra={extra}"
+        )
 
     try:
-        return ReleasePlan(
+        plan = ReleasePlan(
             schema=PLAN_SCHEMA,
             channel=str(data["channel"]),
             canary_version=str(data["canary_version"]),
             canonical_version=str(data["canonical_version"]),
             registry_versions=registry_versions,
             git_tag=str(data["git_tag"]),
+            released_at=str(data["released_at"]),
         )
     except KeyError as exc:
         fail(f"{path} is missing {exc.args[0]!r}")
+
+    try:
+        canary = Version.parse(plan.canary_version)
+    except ValueError as exc:
+        fail(f"{path} has an invalid canary_version: {exc}")
+    match = CANONICAL_RE.fullmatch(plan.canonical_version)
+    if match is None:
+        fail(f"{path} has an invalid canonical_version {plan.canonical_version!r}")
+    if plan.channel == "canary":
+        if plan.canonical_version != str(canary):
+            fail(f"{path} canary canonical_version must equal canary_version")
+    elif plan.channel == "nightly":
+        base = f"{match.group(1)}.{match.group(2)}.{match.group(3)}"
+        if base != str(canary.next_patch()) or match.group(4) is None:
+            fail(
+                f"{path} nightly canonical_version must be the next canary patch "
+                "with a nightly suffix"
+            )
+    else:
+        fail(f"{path} has unsupported channel {plan.channel!r}")
+    expected_registry_versions = registry_versions_for(plan.canonical_version)
+    if plan.registry_versions != expected_registry_versions:
+        fail(
+            f"{path} registry_versions do not encode canonical_version: "
+            f"expected {expected_registry_versions!r}"
+        )
+    if plan.git_tag != f"baml-language-{plan.canonical_version}":
+        fail(f"{path} git_tag does not match canonical_version")
+    try:
+        released_at = dt.datetime.fromisoformat(
+            plan.released_at.replace("Z", "+00:00")
+        )
+    except ValueError:
+        fail(f"{path} released_at is not an ISO-8601 timestamp")
+    if released_at.tzinfo is None or not plan.released_at.endswith("Z"):
+        fail(f"{path} released_at must be a UTC timestamp ending in Z")
+    return plan
 
 
 def replace_regex(path: Path, pattern: str, replacement: str) -> None:
@@ -426,6 +556,11 @@ def stamp(plan: ReleasePlan) -> None:
         r'^const DefaultRuntimeVersion = ".*"$',
         f'const DefaultRuntimeVersion = "{plan.canonical_version}"',
     )
+    replace_regex(
+        CSHARP_PROJECT,
+        r"^    <Version>.*</Version>$",
+        f"    <Version>{plan.nuget_version}</Version>",
+    )
 
     text = PY_INIT.read_text(encoding="utf-8")
     version_line = f'__version__ = "{plan.canonical_version}"\n'
@@ -474,6 +609,24 @@ def sync_canary() -> None:
     regenerate_node_bridge()
 
 
+def exact_regex_field(path: Path, pattern: str, expected: str) -> bool:
+    values = re.findall(
+        pattern,
+        path.read_text(encoding="utf-8"),
+        flags=re.MULTILINE,
+    )
+    return values == [expected]
+
+
+def json_version(path: Path) -> str | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    value = data.get("version") if isinstance(data, dict) else None
+    return value if isinstance(value, str) else None
+
+
 def check_release() -> None:
     current = load_release()
     previous = previous_release_toml()
@@ -488,29 +641,92 @@ def check_release() -> None:
     expected = make_plan("canary")
     mismatches: list[str] = []
     checks = {
-        "baml_version::CANONICAL_VERSION": expected.canonical_version in BAML_VERSION_RS.read_text(encoding="utf-8"),
-        "baml_version::PYPI_VERSION": expected.pypi_version in BAML_VERSION_RS.read_text(encoding="utf-8"),
-        "python pyproject version": f'version = "{expected.pypi_version}"' in PYPROJECT.read_text(encoding="utf-8"),
-        "python __version__": f'__version__ = "{expected.canonical_version}"' in PY_INIT.read_text(encoding="utf-8"),
+        "baml_version::CANONICAL_VERSION": exact_regex_field(
+            BAML_VERSION_RS,
+            r'^pub const CANONICAL_VERSION: &str = "([^"]+)";$',
+            expected.canonical_version,
+        ),
+        "baml_version::PYPI_VERSION": exact_regex_field(
+            BAML_VERSION_RS,
+            r'^pub const PYPI_VERSION: &str = "([^"]+)";$',
+            expected.pypi_version,
+        ),
+        "baml_version::CHANNEL": exact_regex_field(
+            BAML_VERSION_RS,
+            r'^pub const CHANNEL: &str = "([^"]+)";$',
+            expected.channel,
+        ),
+        "baml_version::STABLE_VERSION": exact_regex_field(
+            BAML_VERSION_RS,
+            r'^pub const STABLE_VERSION: &str = "([^"]+)";$',
+            expected.canary_version,
+        ),
+        "python pyproject version": exact_regex_field(
+            PYPROJECT,
+            r'^version = "([^"]+)"$',
+            expected.pypi_version,
+        ),
+        "python __version__": exact_regex_field(
+            PY_INIT,
+            r'^__version__ = "([^"]+)"$',
+            expected.canonical_version,
+        ),
         # Load-bearing beyond drift hygiene: the Rust bridge's loader
         # handshakes the loaded engine's version() against this constant,
         # in development builds too.
-        "rust bridge CANONICAL_VERSION": (
-            f'pub(crate) const CANONICAL_VERSION: &str = "{expected.canonical_version}";'
-            in RUST_BRIDGE_VERSION_RS.read_text(encoding="utf-8")
+        "rust bridge CANONICAL_VERSION": exact_regex_field(
+            RUST_BRIDGE_VERSION_RS,
+            r'^pub\(crate\) const CANONICAL_VERSION: &str = "([^"]+)";$',
+            expected.canonical_version,
         ),
-        "rust bridge Cargo.toml version": (
+        "rust bridge Cargo.toml version": exact_regex_field(
             # stamp() writes this from crates_io_version; check the same
             # property (identity of canonical today, but the encodings may
             # diverge as PyPI's already does).
-            f'version = "{expected.crates_io_version}"'
-            in RUST_BRIDGE_CARGO_TOML.read_text(encoding="utf-8")
+            RUST_BRIDGE_CARGO_TOML,
+            r'^version = "([^"]+)"$',
+            expected.crates_io_version,
         ),
-        "vsix package version": f'"version": "{expected.canonical_version}"' in VSIX_PACKAGE.read_text(encoding="utf-8"),
-        "go runtime version": f'DefaultRuntimeVersion = "{expected.canonical_version}"' in GO_RUNTIME_VERSION.read_text(encoding="utf-8"),
+        "vsix package version": (
+            json_version(VSIX_PACKAGE) == expected.canonical_version
+        ),
+        "go runtime version": exact_regex_field(
+            GO_RUNTIME_VERSION,
+            r'^const DefaultRuntimeVersion = "([^"]+)"$',
+            expected.canonical_version,
+        ),
+        "C# NuGet project version": exact_regex_field(
+            CSHARP_PROJECT,
+            r"^    <Version>([^<]+)</Version>$",
+            expected.nuget_version,
+        ),
+        # Java/Kotlin packages intentionally receive their identity-valued
+        # Maven version from the frozen plan through -PbamlVersion.
+        "Java bridge Maven version input": exact_regex_field(
+            JAVA_BRIDGE_BUILD,
+            r"^version = (bamlVersion)$",
+            "bamlVersion",
+        ),
+        "Kotlin bridge Maven version input": exact_regex_field(
+            JAVA_KOTLIN_BUILD,
+            r"^version = (bamlVersion)$",
+            "bamlVersion",
+        ),
+        "Kotlin bridge exact Java dependency version": exact_regex_field(
+            JAVA_KOTLIN_BUILD,
+            r'^\s*api\("com\.boundaryml:baml-bridge:(\$bamlVersion)"\)$',
+            "$bamlVersion",
+        ),
+        "Gradle Plugin Portal version input": exact_regex_field(
+            GRADLE_PLUGIN_BUILD,
+            r"^version = (bamlVersion)$",
+            "bamlVersion",
+        ),
     }
     if NODE_PACKAGE.exists():
-        checks["node package version"] = f'"version": "{expected.canonical_version}"' in NODE_PACKAGE.read_text(encoding="utf-8")
+        checks["node package version"] = (
+            json_version(NODE_PACKAGE) == expected.npm_version
+        )
         if not NODE_NATIVE_JS.exists():
             mismatches.append(
                 "node native loader version guards: "
@@ -535,7 +751,9 @@ def check_release() -> None:
                     "`scripts/baml-language-version sync` and commit the generated output."
                 )
     if WEB_PACKAGE.exists():
-        checks["web package version"] = f'"version": "{expected.canonical_version}"' in WEB_PACKAGE.read_text(encoding="utf-8")
+        checks["web package version"] = (
+            json_version(WEB_PACKAGE) == expected.npm_version
+        )
 
     for name, ok in checks.items():
         if not ok:
@@ -592,7 +810,9 @@ def main() -> None:
 
     compute_parser = subparsers.add_parser("compute")
     compute_parser.add_argument("--channel", choices=["canary", "nightly"], required=True)
-    compute_parser.add_argument("--pypi", action="store_true")
+    compute_output = compute_parser.add_mutually_exclusive_group()
+    compute_output.add_argument("--pypi", action="store_true")
+    compute_output.add_argument("--registry", choices=PLAN_REGISTRIES)
 
     plan_parser = subparsers.add_parser("plan")
     plan_parser.add_argument("--channel", choices=["canary", "nightly"], required=True)
@@ -627,7 +847,12 @@ def main() -> None:
         sync_canary()
     elif args.command == "compute":
         canonical = compute_version(args.channel)
-        print(to_pypi_version(canonical) if args.pypi else canonical)
+        if args.pypi:
+            print(to_pypi_version(canonical))
+        elif args.registry:
+            print(registry_versions_for(canonical)[args.registry])
+        else:
+            print(canonical)
     elif args.command == "plan":
         args.out.write_text(make_plan(args.channel).to_json(), encoding="utf-8")
     elif args.command == "stamp":

--- a/scripts/baml-language-version
+++ b/scripts/baml-language-version
@@ -522,9 +522,11 @@ def stamp(plan: ReleasePlan) -> None:
                 "//! Stamped BAML language product version.",
                 "",
                 f'pub const CANONICAL_VERSION: &str = "{plan.canonical_version}";',
-                f'pub const PYPI_VERSION: &str = "{plan.pypi_version}";',
+                "#[allow(dead_code)]",
+                f'const PYPI_VERSION: &str = "{plan.pypi_version}";',
                 f'pub const CHANNEL: &str = "{plan.channel}";',
-                f'pub const STABLE_VERSION: &str = "{plan.canary_version}";',
+                "#[allow(dead_code)]",
+                f'const STABLE_VERSION: &str = "{plan.canary_version}";',
                 "",
             ]
         ),
@@ -648,7 +650,7 @@ def check_release() -> None:
         ),
         "baml_version::PYPI_VERSION": exact_regex_field(
             BAML_VERSION_RS,
-            r'^pub const PYPI_VERSION: &str = "([^"]+)";$',
+            r'^const PYPI_VERSION: &str = "([^"]+)";$',
             expected.pypi_version,
         ),
         "baml_version::CHANNEL": exact_regex_field(
@@ -658,7 +660,7 @@ def check_release() -> None:
         ),
         "baml_version::STABLE_VERSION": exact_regex_field(
             BAML_VERSION_RS,
-            r'^pub const STABLE_VERSION: &str = "([^"]+)";$',
+            r'^const STABLE_VERSION: &str = "([^"]+)";$',
             expected.canary_version,
         ),
         "python pyproject version": exact_regex_field(

--- a/scripts/baml-release-manifests
+++ b/scripts/baml-release-manifests
@@ -107,23 +107,55 @@ def main() -> None:
     parser.add_argument("--out", required=True, type=Path)
     parser.add_argument("--channel", required=True, choices=["canary", "nightly"])
     parser.add_argument("--version", required=True)
+    parser.add_argument("--released-at", required=True)
     parser.add_argument("--pypi-version", required=True)
-    # Optional until the crates.io publisher lands; when set, the toolchain
-    # manifest records `sdks.rust`. crates.io's version encoding is the identity
-    # of the canonical version (SemVer prereleases are valid).
+    # Registry coordinates are optional to keep this utility useful for partial
+    # fixture generation; the release workflow supplies every enabled SDK only
+    # after its publisher succeeds.
     parser.add_argument("--crates-io-version", default=None)
+    parser.add_argument("--nuget-version", default=None)
+    parser.add_argument("--nuget-package-sha256", default=None)
+    parser.add_argument("--swiftpm-version", default=None)
+    parser.add_argument("--swift-package-sha256", default=None)
     parser.add_argument("--wrapper-version", required=True)
     parser.add_argument("--wrapper-changed", action="store_true")
     args = parser.parse_args()
 
+    for version, digest, version_flag, digest_flag in (
+        (
+            args.nuget_version,
+            args.nuget_package_sha256,
+            "--nuget-version",
+            "--nuget-package-sha256",
+        ),
+        (
+            args.swiftpm_version,
+            args.swift_package_sha256,
+            "--swiftpm-version",
+            "--swift-package-sha256",
+        ),
+    ):
+        if (version is None) != (digest is None):
+            raise SystemExit(
+                f"{version_flag} and {digest_flag} must be supplied together"
+            )
+        if digest is not None and (
+            len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+        ):
+            raise SystemExit(f"{digest_flag} must be a lowercase SHA-256 digest")
+    try:
+        released_at = dt.datetime.fromisoformat(
+            args.released_at.replace("Z", "+00:00")
+        )
+    except ValueError as exc:
+        raise SystemExit("--released-at must be an ISO-8601 timestamp") from exc
+    if released_at.tzinfo is None or not args.released_at.endswith("Z"):
+        raise SystemExit("--released-at must be a UTC timestamp ending in Z")
+
     args.out.mkdir(parents=True, exist_ok=True)
     (args.out / "version").mkdir(parents=True, exist_ok=True)
-    released_at = (
-        dt.datetime.now(dt.timezone.utc)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    released_at = args.released_at
 
     vsix = next(args.vsix_dir.glob("*.vsix"), None)
     if vsix is None:
@@ -147,17 +179,32 @@ def main() -> None:
         },
         "cffi": collect_cffi_artifacts(args.cffi_dir, args.version),
     }
-    # Generated-SDK registry coordinates, recorded once a language's publisher
-    # lands. Rust is gated on --crates-io-version so a manifest never claims a
-    # baml_bridge crate that has not been published to crates.io yet.
+    # Generated-SDK registry coordinates are supplied only after the matching
+    # publisher succeeds. Native packages also bind the manifest to the digest
+    # of the exact pre-publication package exercised by their consumer gates.
+    sdks = {}
     if args.crates_io_version:
-        toolchain["sdks"] = {
-            "rust": {
-                "registry": "crates_io",
-                "package": "baml_bridge",
-                "version": args.crates_io_version,
-            },
+        sdks["rust"] = {
+            "registry": "crates_io",
+            "package": "baml_bridge",
+            "version": args.crates_io_version,
         }
+    if args.nuget_version:
+        sdks["csharp"] = {
+            "registry": "nuget",
+            "package": "baml-bridge",
+            "version": args.nuget_version,
+            "verified_package_sha256": args.nuget_package_sha256,
+        }
+    if args.swiftpm_version:
+        sdks["swift"] = {
+            "registry": "swiftpm",
+            "package": "BoundaryML/baml-swift",
+            "version": args.swiftpm_version,
+            "verified_package_sha256": args.swift_package_sha256,
+        }
+    if sdks:
+        toolchain["sdks"] = sdks
     text = json.dumps(toolchain, indent=2, sort_keys=True) + "\n"
     (args.out / "version" / f"{args.version}.json").write_text(text)
     (args.out / f"{args.channel}.json").write_text(text)

--- a/scripts/tests/test_baml_language_version.py
+++ b/scripts/tests/test_baml_language_version.py
@@ -48,9 +48,11 @@ class VersionToolTests(unittest.TestCase):
             "\n".join(
                 [
                     f'pub const CANONICAL_VERSION: &str = "{version}";',
-                    f'pub const PYPI_VERSION: &str = "{version}";',
+                    "#[allow(dead_code)]",
+                    f'const PYPI_VERSION: &str = "{version}";',
                     'pub const CHANNEL: &str = "canary";',
-                    f'pub const STABLE_VERSION: &str = "{version}";',
+                    "#[allow(dead_code)]",
+                    f'const STABLE_VERSION: &str = "{version}";',
                     "",
                 ]
             ),

--- a/scripts/tests/test_baml_language_version.py
+++ b/scripts/tests/test_baml_language_version.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VERSION_TOOL = ROOT / "scripts" / "baml-language-version"
+
+
+class VersionToolTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.make_fixture("1.2.3")
+        self.env = {
+            **os.environ,
+            "BAML_LANGUAGE_VERSION_ROOT": str(self.root),
+            "BAML_LANGUAGE_RELEASED_AT": "2026-07-23T12:34:56Z",
+            "BAML_LANGUAGE_VERSION_DATE": "20260723",
+            "BAML_LANGUAGE_VERSION_NIGHTLY_LETTER": "h",
+            "PATH": f"{self.bin}:{os.environ['PATH']}",
+        }
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write(self, relative: str, content: str) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def make_fixture(self, version: str) -> None:
+        self.write(
+            "baml_language/release.toml",
+            f'[release]\ncanary_version = "{version}"\n',
+        )
+        self.write(
+            "baml_language/crates/baml_version/src/lib.rs",
+            "\n".join(
+                [
+                    f'pub const CANONICAL_VERSION: &str = "{version}";',
+                    f'pub const PYPI_VERSION: &str = "{version}";',
+                    'pub const CHANNEL: &str = "canary";',
+                    f'pub const STABLE_VERSION: &str = "{version}";',
+                    "",
+                ]
+            ),
+        )
+        self.write(
+            "baml_language/sdks/python/pyproject.toml",
+            f'[project]\nversion = "{version}"\n',
+        )
+        self.write(
+            "baml_language/sdks/python/src/baml_bridge/__init__.py",
+            f'__version__ = "{version}"\n',
+        )
+        for package in (
+            "baml_language/sdks/typescript/bridge_typescript/package.json",
+            "baml_language/sdks/typescript/bridge_typescript_web/package.json",
+            "typescript2/app-vscode-ext/package.json",
+        ):
+            self.write(
+                package,
+                json.dumps({"version": version, "name": "fixture"}, indent=2)
+                + "\n",
+            )
+        self.write(
+            "baml_language/sdks/typescript/bridge_typescript/dist/native.js",
+            f"if (bindingPackageVersion !== '{version}') {{ throw new Error(); }}\n",
+        )
+        self.write(
+            "baml_language/sdks/go/baml_go/version.go",
+            f'const DefaultRuntimeVersion = "{version}"\n',
+        )
+        self.write(
+            "baml_language/sdks/rust/bridge_rust/src/version.rs",
+            f'pub(crate) const CANONICAL_VERSION: &str = "{version}";\n',
+        )
+        self.write(
+            "baml_language/sdks/rust/bridge_rust/Cargo.toml",
+            f'[package]\nversion = "{version}"\n',
+        )
+        self.write(
+            "baml_language/crates/baml/Cargo.toml",
+            '[package]\nversion = "1.0.0"\n',
+        )
+        self.write(
+            "baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj",
+            f"<Project>\n  <PropertyGroup>\n    <Version>{version}</Version>\n"
+            "  </PropertyGroup>\n</Project>\n",
+        )
+        self.write(
+            "baml_language/sdks/java/baml_bridge/build.gradle.kts",
+            "val bamlVersion = \"fixture\"\nversion = bamlVersion\n",
+        )
+        self.write(
+            "baml_language/sdks/java/baml-bridge-kotlin/build.gradle.kts",
+            "val bamlVersion = \"fixture\"\nversion = bamlVersion\n"
+            'dependencies {\n    api("com.boundaryml:baml-bridge:$bamlVersion")\n}\n',
+        )
+        self.write(
+            "baml_language/sdks/java/gradle-plugin/build.gradle.kts",
+            "val bamlVersion = \"fixture\"\nversion = bamlVersion\n",
+        )
+        fake_pnpm = self.write(
+            "bin/pnpm",
+            """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+if "build:debug" in sys.argv:
+    root = pathlib.Path.cwd()
+    version = json.loads((root / "package.json").read_text())["version"]
+    output = root / "dist" / "native.js"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        f"if (bindingPackageVersion !== '{version}') {{ throw new Error(); }}\\n"
+    )
+""",
+        )
+        fake_pnpm.chmod(0o755)
+
+    def run_tool(
+        self,
+        *args: str,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(VERSION_TOOL), *args],
+            cwd=self.root,
+            env=self.env,
+            check=check,
+            text=True,
+            capture_output=True,
+        )
+
+    def plan(self, channel: str) -> dict:
+        path = self.root / f"{channel}-plan.json"
+        self.run_tool("plan", "--channel", channel, "--out", str(path))
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def surface_versions(self) -> dict[str, str]:
+        def json_version(relative: str) -> str:
+            return json.loads((self.root / relative).read_text())["version"]
+
+        def match(relative: str, pattern: str) -> str:
+            text = (self.root / relative).read_text(encoding="utf-8")
+            result = re.search(pattern, text, flags=re.MULTILINE)
+            self.assertIsNotNone(result, relative)
+            return result.group(1)
+
+        return {
+            "python": match(
+                "baml_language/sdks/python/pyproject.toml",
+                r'^version = "([^"]+)"$',
+            ),
+            "node": json_version(
+                "baml_language/sdks/typescript/bridge_typescript/package.json"
+            ),
+            "web": json_version(
+                "baml_language/sdks/typescript/bridge_typescript_web/package.json"
+            ),
+            "rust": match(
+                "baml_language/sdks/rust/bridge_rust/Cargo.toml",
+                r'^version = "([^"]+)"$',
+            ),
+            "go": match(
+                "baml_language/sdks/go/baml_go/version.go",
+                r'^const DefaultRuntimeVersion = "([^"]+)"$',
+            ),
+            "csharp": match(
+                "baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj",
+                r"^    <Version>([^<]+)</Version>$",
+            ),
+            "vsix": json_version("typescript2/app-vscode-ext/package.json"),
+        }
+
+    def test_set_bump_sync_check_and_registry_plan(self) -> None:
+        self.run_tool("sync")
+        self.run_tool("check")
+        self.run_tool("set", "2.3.4")
+        self.assertEqual(set(self.surface_versions().values()), {"2.3.4"})
+        self.run_tool("check")
+        self.run_tool("bump", "--patch")
+        self.assertEqual(set(self.surface_versions().values()), {"2.3.5"})
+        self.run_tool("check")
+
+        plan = self.plan("canary")
+        self.assertEqual(plan["schema"], 3)
+        self.assertEqual(
+            plan["registry_versions"],
+            {
+                "pypi": "2.3.5",
+                "npm": "2.3.5",
+                "crates_io": "2.3.5",
+                "nuget": "2.3.5",
+                "maven": "2.3.5",
+                "gradle_plugin": "2.3.5",
+                "swiftpm": "2.3.5",
+            },
+        )
+        self.assertEqual(plan["released_at"], "2026-07-23T12:34:56Z")
+
+    def test_prerelease_plan_and_stamp_cover_every_shipping_sdk(self) -> None:
+        plan_path = self.root / "nightly-plan.json"
+        self.run_tool("plan", "--channel", "nightly", "--out", str(plan_path))
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        canonical = "1.2.4-nightly.20260723.h"
+        self.assertEqual(plan["canonical_version"], canonical)
+        self.assertEqual(plan["registry_versions"]["pypi"], "1.2.4.dev2026072307")
+        for registry in (
+            "npm",
+            "crates_io",
+            "nuget",
+            "maven",
+            "gradle_plugin",
+            "swiftpm",
+        ):
+            self.assertEqual(plan["registry_versions"][registry], canonical)
+
+        self.run_tool("stamp", "--plan", str(plan_path))
+        versions = self.surface_versions()
+        self.assertEqual(versions["python"], "1.2.4.dev2026072307")
+        for sdk in ("node", "web", "rust", "go", "csharp", "vsix"):
+            self.assertEqual(versions[sdk], canonical)
+        # Restoring committed Canary metadata exercises sync after a
+        # prerelease stamp and proves nightly values do not remain behind.
+        self.run_tool("sync")
+        self.run_tool("check")
+        self.assertEqual(set(self.surface_versions().values()), {"1.2.3"})
+
+    def test_exact_named_field_checks_reject_loose_version_text(self) -> None:
+        rust_version = (
+            self.root
+            / "baml_language/sdks/rust/bridge_rust/src/version.rs"
+        )
+        rust_version.write_text(
+            'pub(crate) const CANONICAL_VERSION: &str = "9.9.9";\n'
+            'pub(crate) const DECOY: &str = "1.2.3";\n',
+            encoding="utf-8",
+        )
+        result = self.run_tool("check", check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("rust bridge CANONICAL_VERSION", result.stderr)
+
+        self.run_tool("sync")
+        csharp = (
+            self.root
+            / "baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj"
+        )
+        csharp.write_text(
+            "<Project>\n  <PropertyGroup>\n    <Version>9.9.9</Version>\n"
+            "    <DecoyVersion>1.2.3</DecoyVersion>\n"
+            "  </PropertyGroup>\n</Project>\n",
+            encoding="utf-8",
+        )
+        result = self.run_tool("check", check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("C# NuGet project version", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_baml_release_manifests.py
+++ b/scripts/tests/test_baml_release_manifests.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_TOOL = ROOT / "scripts" / "baml-release-manifests"
+PLATFORMS = ROOT / "release" / "platforms.json"
+
+
+class ReleaseManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.toolchain = self.root / "toolchain"
+        self.cffi = self.root / "cffi"
+        self.wrapper = self.root / "wrapper"
+        self.vsix = self.root / "vsix"
+        for directory in (self.toolchain, self.cffi, self.wrapper, self.vsix):
+            directory.mkdir()
+
+        contract = json.loads(PLATFORMS.read_text(encoding="utf-8"))
+        for target in contract["targets"]:
+            triple = target["triple"]
+            suffix = ".zip" if target["os"] == "windows" else ".tar.gz"
+            (self.toolchain / f"baml-language-1.2.3-{triple}{suffix}").write_bytes(
+                triple.encode()
+            )
+            (self.wrapper / f"baml-wrapper-9.8.7-{triple}{suffix}").write_bytes(
+                triple.encode()
+            )
+            cffi = target["artifacts"].get("cffi")
+            if cffi is not None:
+                (self.cffi / cffi["asset"]).write_bytes(triple.encode())
+        (self.vsix / "baml-language-1.2.3.vsix").write_bytes(b"vsix")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_tool(
+        self,
+        output: Path,
+        *extra: str,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                str(MANIFEST_TOOL),
+                "--toolchain-dir",
+                str(self.toolchain),
+                "--cffi-dir",
+                str(self.cffi),
+                "--wrapper-dir",
+                str(self.wrapper),
+                "--vsix-dir",
+                str(self.vsix),
+                "--out",
+                str(output),
+                "--channel",
+                "canary",
+                "--version",
+                "1.2.3",
+                "--released-at",
+                "2026-07-23T12:34:56Z",
+                "--pypi-version",
+                "1.2.3",
+                "--wrapper-version",
+                "9.8.7",
+                *extra,
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=check,
+        )
+
+    def test_csharp_digest_and_registry_identity_are_in_dry_run_shape(self) -> None:
+        digest = "a" * 64
+        first = self.root / "first"
+        second = self.root / "second"
+        extra = (
+            "--crates-io-version",
+            "1.2.3",
+            "--nuget-version",
+            "1.2.3",
+            "--nuget-package-sha256",
+            digest,
+            "--swiftpm-version",
+            "1.2.3",
+            "--swift-package-sha256",
+            digest,
+        )
+        self.run_tool(first, *extra)
+        self.run_tool(second, *extra)
+        first_manifest = first / "version" / "1.2.3.json"
+        second_manifest = second / "version" / "1.2.3.json"
+        self.assertEqual(first_manifest.read_bytes(), second_manifest.read_bytes())
+        manifest = json.loads(first_manifest.read_text(encoding="utf-8"))
+        self.assertEqual(manifest["released_at"], "2026-07-23T12:34:56Z")
+        self.assertEqual(
+            manifest["sdks"]["csharp"],
+            {
+                "registry": "nuget",
+                "package": "baml-bridge",
+                "version": "1.2.3",
+                "verified_package_sha256": digest,
+            },
+        )
+        self.assertEqual(manifest["sdks"]["rust"]["registry"], "crates_io")
+        self.assertEqual(
+            manifest["sdks"]["swift"],
+            {
+                "registry": "swiftpm",
+                "package": "BoundaryML/baml-swift",
+                "version": "1.2.3",
+                "verified_package_sha256": digest,
+            },
+        )
+
+    def test_partial_or_invalid_native_sdk_identity_fails(self) -> None:
+        cases = (
+            ("--nuget-version", "1.2.3"),
+            ("--nuget-package-sha256", "a" * 64),
+            (
+                "--nuget-version",
+                "1.2.3",
+                "--nuget-package-sha256",
+                "not-a-digest",
+            ),
+            ("--swiftpm-version", "1.2.3"),
+            ("--swift-package-sha256", "a" * 64),
+            (
+                "--swiftpm-version",
+                "1.2.3",
+                "--swift-package-sha256",
+                "not-a-digest",
+            ),
+        )
+        for index, extra in enumerate(cases):
+            result = self.run_tool(
+                self.root / f"invalid-{index}",
+                *extra,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 import tempfile
 import unittest
+from collections.abc import Callable
 from pathlib import Path
 
 
@@ -22,6 +23,9 @@ CSHARP_VERIFIER = (
     / "verify-csharp-product-slice.reusable.yaml"
 )
 CARGO_TESTS = ROOT / ".github" / "workflows" / "cargo-tests.reusable.yaml"
+CFFI_BUILDER = (
+    ROOT / ".github" / "workflows" / "build2-bridge-cffi.reusable.yaml"
+)
 PACK_PRODUCT = (
     ROOT
     / "baml_language"
@@ -30,6 +34,16 @@ PACK_PRODUCT = (
     / "bridge_csharp"
     / "tools"
     / "pack-product.sh"
+)
+NUGET_NORMALIZER = (
+    ROOT
+    / "baml_language"
+    / "sdks"
+    / "csharp"
+    / "bridge_csharp"
+    / "tools"
+    / "Baml.NuGetNormalizer"
+    / "Program.cs"
 )
 
 
@@ -131,7 +145,7 @@ class CSharpReleaseContractTests(unittest.TestCase):
         )
 
     def test_invalid_or_missing_csharp_metadata_fails_early(self) -> None:
-        cases: list[tuple[str, callable]] = [
+        cases: list[tuple[str, Callable[[dict], object]]] = [
             (
                 "empty",
                 lambda contract: [
@@ -408,6 +422,22 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("--nuget-package-sha256", dry_run)
         self.assertIn("name: swift-xcframework", dry_run)
         self.assertIn("--swift-package-sha256", dry_run)
+        for block in (manifest, dry_run):
+            for output, variable in (
+                ("wrapper_changed", "WRAPPER_CHANGED"),
+                ("crates_io_version", "CRATES_IO_VERSION"),
+                ("nuget_version", "NUGET_VERSION"),
+                ("swiftpm_version", "SWIFTPM_VERSION"),
+                ("channel", "CHANNEL"),
+                ("version", "VERSION"),
+                ("released_at", "RELEASED_AT"),
+                ("pypi_version", "PYPI_VERSION"),
+                ("wrapper_version", "WRAPPER_VERSION"),
+            ):
+                self.assertIn(
+                    f"{variable}: ${{{{ needs.plan.outputs.{output} }}}}",
+                    block,
+                )
 
         swift_verify = job_block(workflow, "verify-swift-sdk")
         swift_smoke = job_block(workflow, "smoke-swift-release")
@@ -415,12 +445,17 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("BamlRuntime.nativeVersion()", swift_verify)
         self.assertIn("BamlRuntime.nativeVersion()", swift_smoke)
         self.assertIn("publish-pkg-channel", dispatch)
+        self.assertIn(
+            '--cfg=getrandom_backend=\\"wasm_js\\"',
+            CFFI_BUILDER.read_text(encoding="utf-8"),
+        )
 
     def test_nuget_repair_and_nightly_pack_contracts_are_fail_closed(self) -> None:
         publisher = NUGET_PUBLISHER.read_text(encoding="utf-8")
         verifier = CSHARP_VERIFIER.read_text(encoding="utf-8")
         cargo_tests = CARGO_TESTS.read_text(encoding="utf-8")
         pack = PACK_PRODUCT.read_text(encoding="utf-8")
+        normalizer = NUGET_NORMALIZER.read_text(encoding="utf-8")
         self.assertIn('404)', publisher)
         self.assertIn('echo "publish=true"', publisher)
         self.assertIn('200)', publisher)
@@ -444,6 +479,9 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn('name: "Test nightly C# package version"', cargo_tests)
         self.assertIn('-p:PackageVersion="$nuget"', cargo_tests)
         self.assertIn("baml-bridge.$nuget.nupkg", cargo_tests)
+        self.assertIn("left.ReadExactly(leftChunk)", normalizer)
+        self.assertIn("right.ReadExactly(rightChunk)", normalizer)
+        self.assertNotIn("left.Read(leftBuffer)", normalizer)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_TOOL = ROOT / "scripts" / "baml-csharp-release-contract"
+PLATFORMS = ROOT / "release" / "platforms.json"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
+SIZE_POLICY = ROOT / "release" / "csharp-package-size-policy.json"
+NUGET_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-csharp-sdk.yaml"
+CSHARP_VERIFIER = (
+    ROOT
+    / ".github"
+    / "workflows"
+    / "verify-csharp-product-slice.reusable.yaml"
+)
+CARGO_TESTS = ROOT / ".github" / "workflows" / "cargo-tests.reusable.yaml"
+PACK_PRODUCT = (
+    ROOT
+    / "baml_language"
+    / "sdks"
+    / "csharp"
+    / "bridge_csharp"
+    / "tools"
+    / "pack-product.sh"
+)
+
+
+class CSharpReleaseContractTests(unittest.TestCase):
+    maxDiff = None
+
+    def run_tool(
+        self,
+        *args: str,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(CONTRACT_TOOL), *args],
+            cwd=ROOT,
+            check=check,
+            text=True,
+            capture_output=True,
+        )
+
+    def write_contract(self, root: Path, contract: dict) -> Path:
+        path = root / "platforms.json"
+        path.write_text(json.dumps(contract), encoding="utf-8")
+        return path
+
+    def current_contract(self) -> dict:
+        return json.loads(PLATFORMS.read_text(encoding="utf-8"))
+
+    def test_exact_required_matrix(self) -> None:
+        output = self.run_tool("matrix").stdout
+        matrix = json.loads(output)["include"]
+        actual = {
+            (
+                entry["target"],
+                entry["rid"],
+                entry["canonical"],
+                entry["runner"],
+            )
+            for entry in matrix
+        }
+        expected = {
+            (
+                "aarch64-apple-darwin",
+                "osx-arm64",
+                "libbridge_cffi.dylib",
+                "macos-14",
+            ),
+            (
+                "x86_64-apple-darwin",
+                "osx-x64",
+                "libbridge_cffi.dylib",
+                "macos-15-intel",
+            ),
+            (
+                "aarch64-unknown-linux-gnu",
+                "linux-arm64",
+                "libbridge_cffi.so",
+                "ubuntu-24.04-arm",
+            ),
+            (
+                "x86_64-unknown-linux-gnu",
+                "linux-x64",
+                "libbridge_cffi.so",
+                "ubuntu-24.04",
+            ),
+            (
+                "aarch64-unknown-linux-musl",
+                "linux-musl-arm64",
+                "libbridge_cffi.so",
+                "ubuntu-24.04-arm",
+            ),
+            (
+                "x86_64-unknown-linux-musl",
+                "linux-musl-x64",
+                "libbridge_cffi.so",
+                "ubuntu-24.04",
+            ),
+            (
+                "aarch64-pc-windows-msvc",
+                "win-arm64",
+                "bridge_cffi.dll",
+                "windows-11-arm",
+            ),
+            (
+                "x86_64-pc-windows-msvc",
+                "win-x64",
+                "bridge_cffi.dll",
+                "windows-2022",
+            ),
+        }
+        self.assertEqual(actual, expected)
+        size_policy = json.loads(SIZE_POLICY.read_text(encoding="utf-8"))
+        self.assertEqual(
+            set(size_policy["native_assets"]["baseline_bytes_by_target"]),
+            {entry[0] for entry in expected},
+        )
+        self.assertLess(
+            size_policy["compressed_package"]["baseline_bytes"],
+            size_policy["compressed_package"]["registry_safety_ceiling_bytes"],
+        )
+
+    def test_invalid_or_missing_csharp_metadata_fails_early(self) -> None:
+        cases: list[tuple[str, callable]] = [
+            (
+                "empty",
+                lambda contract: [
+                    target["artifacts"].pop("csharp", None)
+                    for target in contract["targets"]
+                ],
+            ),
+            (
+                "duplicate-target",
+                lambda contract: contract["targets"].append(
+                    copy.deepcopy(contract["targets"][0])
+                ),
+            ),
+            (
+                "duplicate-rid",
+                lambda contract: contract["targets"][1]["artifacts"]["csharp"].update(
+                    {"rid": contract["targets"][0]["artifacts"]["csharp"]["rid"]}
+                ),
+            ),
+            (
+                "missing-runner",
+                lambda contract: contract["targets"][0]["artifacts"]["csharp"].update(
+                    {"consumer_runner": ""}
+                ),
+            ),
+            (
+                "missing-native-name",
+                lambda contract: contract["targets"][0]["artifacts"]["csharp"].update(
+                    {"native_asset": ""}
+                ),
+            ),
+            (
+                "optional-producer",
+                lambda contract: contract["targets"][0]["artifacts"]["cffi"].update(
+                    {"experimental": True}
+                ),
+            ),
+        ]
+        for name, mutate in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                contract = self.current_contract()
+                mutate(contract)
+                path = self.write_contract(Path(temporary), contract)
+                result = self.run_tool(
+                    "validate",
+                    "--platforms",
+                    str(path),
+                    check=False,
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def make_downloads(
+        self,
+        root: Path,
+        *,
+        missing_checksum_target: str | None = None,
+        wrong_checksum_target: str | None = None,
+        duplicate_target: str | None = None,
+        include_unrelated: bool = True,
+    ) -> Path:
+        downloads = root / "downloads"
+        contract = self.current_contract()
+        for target in contract["targets"]:
+            csharp = target["artifacts"].get("csharp")
+            if csharp is None:
+                continue
+            triple = target["triple"]
+            asset = target["artifacts"]["cffi"]["asset"]
+            artifact = downloads / f"bridge-cffi-{triple}" / "nested"
+            artifact.mkdir(parents=True)
+            payload = f"native:{triple}".encode()
+            (artifact / asset).write_bytes(payload)
+            if triple != missing_checksum_target:
+                digest = hashlib.sha256(payload).hexdigest()
+                if triple == wrong_checksum_target:
+                    digest = "0" * 64
+                marker = " *" if "windows" in triple else "  "
+                (artifact / f"{asset}.sha256").write_text(
+                    f"{digest}{marker}{asset}\n",
+                    encoding="utf-8",
+                )
+            if triple == duplicate_target:
+                (artifact / "unexpected.txt").write_text("duplicate", encoding="utf-8")
+        if include_unrelated:
+            unrelated = downloads / "bridge-cffi-future-cffi-only"
+            unrelated.mkdir(parents=True)
+            (unrelated / "future.so").write_text("ignored", encoding="utf-8")
+        return downloads
+
+    def stage(
+        self,
+        root: Path,
+        downloads: Path,
+        *,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return self.run_tool(
+            "stage-native",
+            "--downloads",
+            str(downloads),
+            "--staging",
+            str(root / "staging"),
+            "--source-sha",
+            "1" * 40,
+            "--release-version",
+            "1.2.3-nightly.20260723.a",
+            "--workflow-run-id",
+            "29989654236",
+            "--provenance",
+            str(root / "native-provenance.json"),
+            "--manifest",
+            str(root / "native-manifest.sha256"),
+            check=check,
+        )
+
+    def write_plan(self, root: Path) -> Path:
+        path = root / "release-plan.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema": 2,
+                    "canonical_version": "1.2.3-nightly.20260723.a",
+                    "registry_versions": {
+                        "nuget": "1.2.3-nightly.20260723.a",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def verify(self, root: Path, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return self.run_tool(
+            "verify-product",
+            "--release-plan",
+            str(self.write_plan(root)),
+            "--source-sha",
+            "1" * 40,
+            "--provenance",
+            str(root / "native-provenance.json"),
+            "--manifest",
+            str(root / "native-manifest.sha256"),
+            "--native-root",
+            str(root / "staging"),
+            check=check,
+        )
+
+    def test_library_and_checksum_are_accepted_and_cffi_only_extra_is_ignored(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.stage(root, self.make_downloads(root))
+            self.verify(root)
+            provenance = json.loads(
+                (root / "native-provenance.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(provenance["workflow_run_id"], "29989654236")
+            self.assertNotIn("workflow_run_attempt", provenance)
+            self.assertEqual(len(provenance["artifacts"]), 8)
+
+    def test_missing_wrong_and_duplicate_producer_inputs_are_rejected(self) -> None:
+        target = "x86_64-unknown-linux-gnu"
+        options = (
+            {"missing_checksum_target": target},
+            {"wrong_checksum_target": target},
+            {"duplicate_target": target},
+        )
+        for option in options:
+            with self.subTest(option=option), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                result = self.stage(
+                    root,
+                    self.make_downloads(root, **option),
+                    check=False,
+                )
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_wrong_source_version_target_and_attempt_binding_are_rejected(self) -> None:
+        mutations = (
+            lambda data: data.update({"source_sha": "2" * 40}),
+            lambda data: data.update({"release_version": "9.9.9"}),
+            lambda data: data["artifacts"][0].update({"target": "wrong-target"}),
+            lambda data: data.update({"workflow_run_attempt": "2"}),
+        )
+        for mutate in mutations:
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                self.stage(root, self.make_downloads(root))
+                path = root / "native-provenance.json"
+                provenance = json.loads(path.read_text(encoding="utf-8"))
+                mutate(provenance)
+                path.write_text(json.dumps(provenance), encoding="utf-8")
+                result = self.verify(root, check=False)
+                self.assertNotEqual(result.returncode, 0)
+
+
+def job_block(text: str, job: str) -> str:
+    marker = f"  {job}:\n"
+    start = text.index(marker)
+    remainder = text[start + len(marker) :]
+    next_job = next(
+        (
+            index
+            for index, line in enumerate(remainder.splitlines(keepends=True))
+            if line.startswith("  ")
+            and not line.startswith("    ")
+            and line.rstrip().endswith(":")
+        ),
+        None,
+    )
+    if next_job is None:
+        return remainder
+    lines = remainder.splitlines(keepends=True)
+    return "".join(lines[:next_job])
+
+
+class WorkflowGraphTests(unittest.TestCase):
+    def test_release_graph_has_early_preflight_parallel_producers_and_complete_fanin(
+        self,
+    ) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        build_matrix = job_block(workflow, "build-matrix")
+        prepare = job_block(workflow, "prepare-csharp-sdk")
+        cffi = job_block(workflow, "build-bridge-cffi")
+        verify = job_block(workflow, "verify-csharp-sdk")
+        all_builds = job_block(workflow, "all-builds")
+        nuget = job_block(workflow, "publish-csharp-sdk")
+        prerequisites = job_block(workflow, "release-prerequisites-complete")
+        complete = job_block(workflow, "release-complete")
+        manifest = job_block(workflow, "publish-pkg-boundaryml-com")
+        go_publisher = job_block(workflow, "publish-go-sdk")
+        channel = job_block(workflow, "publish-pkg-channel")
+        dry_run = job_block(workflow, "dry-run-artifacts")
+
+        self.assertIn("baml-csharp-release-contract matrix", build_matrix)
+        self.assertIn("needs: [plan, build-matrix]", prepare)
+        self.assertNotIn("build-bridge-cffi", prepare)
+        self.assertIn("needs: [plan]", cffi)
+        self.assertIn("prepare-csharp-sdk", verify)
+        self.assertIn("build-bridge-cffi", verify)
+        self.assertIn("- verify-csharp-sdk", all_builds)
+        self.assertIn("all-builds", nuget)
+        for publisher in (
+            "publish-pypi",
+            "publish-nodejs-sdk",
+            "publish-web-sdk",
+            "publish-csharp-sdk",
+            "publish-maven",
+            "publish-gradle-plugin",
+            "publish-toolchain-release",
+            "publish-wrapper-release",
+            "publish-bridge-cffi-release",
+            "publish-swift-sdk",
+            "publish-crates-io",
+            "publish-homebrew",
+            "publish-aur",
+        ):
+            self.assertIn(f"- {publisher}", prerequisites)
+        self.assertIn(
+            "needs: [plan, release-prerequisites-complete]",
+            manifest,
+        )
+        self.assertIn("publish-pkg-boundaryml-com", go_publisher)
+        self.assertIn("release-prerequisites-complete", complete)
+        self.assertIn("publish-go-sdk", complete)
+        self.assertIn("release-complete", channel)
+        self.assertIn("smoke-go-release", channel)
+        self.assertIn("smoke-swift-release", channel)
+        self.assertIn("--nuget-package-sha256", manifest)
+        self.assertIn("name: swift-xcframework", manifest)
+        self.assertIn("--swift-package-sha256", manifest)
+        self.assertIn("name: csharp-product-package", dry_run)
+        self.assertIn("--nuget-package-sha256", dry_run)
+        self.assertIn("name: swift-xcframework", dry_run)
+        self.assertIn("--swift-package-sha256", dry_run)
+
+        swift_verify = job_block(workflow, "verify-swift-sdk")
+        swift_smoke = job_block(workflow, "smoke-swift-release")
+        dispatch = job_block(workflow, "dispatch-nightly-after-canary")
+        self.assertIn("BamlRuntime.nativeVersion()", swift_verify)
+        self.assertIn("BamlRuntime.nativeVersion()", swift_smoke)
+        self.assertIn("publish-pkg-channel", dispatch)
+
+    def test_nuget_repair_and_nightly_pack_contracts_are_fail_closed(self) -> None:
+        publisher = NUGET_PUBLISHER.read_text(encoding="utf-8")
+        verifier = CSHARP_VERIFIER.read_text(encoding="utf-8")
+        cargo_tests = CARGO_TESTS.read_text(encoding="utf-8")
+        pack = PACK_PRODUCT.read_text(encoding="utf-8")
+        self.assertIn('404)', publisher)
+        self.assertIn('echo "publish=true"', publisher)
+        self.assertIn('200)', publisher)
+        self.assertIn('compare "$PACKAGE"', publisher)
+        self.assertIn(
+            "if: ${{ steps.existing.outputs.publish == 'true' }}",
+            publisher,
+        )
+        smoke = publisher.index(
+            "- name: Restore and execute the exact public version from a clean cache"
+        )
+        self.assertNotIn("\n        if:", publisher[smoke : smoke + 300])
+
+        self.assertIn(".registry_versions.nuget", pack)
+        self.assertIn('-p:PackageVersion="$nuget_version"', pack)
+        self.assertIn('-p:InformationalVersion="$canonical_version"', pack)
+        self.assertNotIn("baml-language-version\" show", pack)
+        self.assertNotIn("workflow_run_attempt", pack)
+        self.assertNotIn("baml-language-version show", verifier)
+        self.assertIn(".registry_versions.nuget", verifier)
+        self.assertIn('name: "Test nightly C# package version"', cargo_tests)
+        self.assertIn('-p:PackageVersion="$nuget"', cargo_tests)
+        self.assertIn("baml-bridge.$nuget.nupkg", cargo_tests)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_swift_release_contract.py
+++ b/scripts/tests/test_swift_release_contract.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ASSEMBLER = ROOT / "scripts" / "assemble-swift-sdk-mirror"
+
+
+class SwiftReleaseContractTests(unittest.TestCase):
+    def run_assembler(
+        self,
+        output: Path,
+        *,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                str(ASSEMBLER),
+                "--out",
+                str(output),
+                "--version",
+                "1.2.3",
+                "--source-sha",
+                "1" * 40,
+                "--zip-url",
+                "https://example.com/BamlBridgeFFI-1.2.3.xcframework.zip",
+                "--checksum",
+                "a" * 64,
+            ],
+            cwd=ROOT,
+            check=check,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_assembles_fresh_mirror_and_refuses_existing_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "mirror"
+            self.run_assembler(output)
+
+            manifest = (output / "Package.swift").read_text(encoding="utf-8")
+            self.assertIn("1.2.3", manifest)
+            self.assertIn("a" * 64, manifest)
+            self.assertIn("https://example.com/", manifest)
+            self.assertNotIn("__VERSION__", manifest)
+            self.assertEqual(
+                (output / "SOURCE_SHA").read_text(encoding="utf-8"),
+                "1" * 40 + "\n",
+            )
+            self.assertTrue((output / "Sources" / "BamlBridge").is_dir())
+
+            sentinel = output / "do-not-delete"
+            sentinel.write_text("preserve me\n", encoding="utf-8")
+            result = self.run_assembler(output, check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must not already exist", result.stderr)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve me\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make the eight-RID C# product an explicit release contract backed by the shared CFFI artifacts, with platform-neutral preparation running in parallel and per-RID verification fanning out afterward
- freeze registry identities, timestamps, and native provenance in the release plan; stamp NuGet/Maven/Gradle consistently; make NuGet retries content-aware; and bind manifests to the exact verified package
- gate channel advancement on all enabled publishers, rehearse the production manifest in dry runs, and replace the registry ceiling with a measured C# package-size policy
- preserve Dhilan's Swift build-once/passive-mirror/immutable-publish design while adding SwiftPM to the frozen plan, release completion, production and dry-run manifests, and the post-publish nightly gate
- make both Swift consumer gates invoke `BamlRuntime.nativeVersion()` so the native binary cannot be dead-stripped, and make the mirror assembler refuse every pre-existing output path instead of treating a forgeable `SOURCE_SHA` marker as recursive-delete authority

## Swift review

Dhilan's merged PR #4149 chose the right overall direction: one XCFramework build, verification before publication, an immutable GitHub release asset, and a passive `baml-swift` mirror consumed from a clean project. I kept that architecture.

It did not yet fully adhere to the shared release plan: the Swift publisher was outside the final publisher fan-in, Swift was absent from the frozen registry plan and manifests, nightly dispatch did not wait for the Swift smoke, and both Swift checks only imported/printed without calling native code. Its normal CI passed, but the release-dispatch job was skipped, so those edges were not exercised end to end. This PR closes those correctness gaps. Explicit Swift package-size history and broader generated/simulator coverage should remain measured follow-ups rather than an invented policy in this change.

## Validation

- 13 focused Python release-contract tests pass
- 45 `baml_release` Rust tests pass
- C# managed tests and the CFFI/C# ABI/lifetime probe pass
- a nightly C# package was produced locally with the planned NuGet version
- a representative remapped Linux release cdylib compiled and passed the shipping-path scan
- NuGet normalizer self-tests pass
- changed release workflows pass `actionlint` and YAML parsing
- commit hooks pass except `cargo-hawk`, which was skipped after its environment failed because `gofmt` is unavailable; cargo fmt, clippy, and YAML hooks pass independently

## Release readiness

No production release was triggered. NuGet package ownership/trusted-publisher configuration still needs an administrative confirmation before declaring the production publisher ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contract-driven C# SDK preparation and platform-aware native staging, with per-target native asset sizing and package digest validation.
  * Enriched release planning with registry-specific versions and `released_at`, plus verified package digests in generated manifests.
* **Bug Fixes**
  * Improved NuGet publishing safety by compare-then-allow republishing based on normalized payload equality.
  * Strengthened fail-closed platform and SDK contract validation (including C#↔native dependency rules).
* **Tests**
  * Expanded CI with additional unit tests and stricter version/gating assertions; added new release-contract and manifest/version test suites.
* **Documentation**
  * Updated C# SDK release pipeline docs and NuGet normalizer usage (including new comparison mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->