### PR TITLE
fix(release): harden Go mirror publication

### DIFF
--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -2,7 +2,7 @@ name: BAML Release - Build bridge_cffi
 
 # Builds the standalone `bridge_cffi` engine cdylib, one per target. This is a
 # LANGUAGE-NEUTRAL artifact: every dylib-loader SDK dlopens the same library at
-# runtime (the Rust `baml_bridge` crate today; the Go bridge when it migrates),
+# runtime (including the Rust `baml_bridge` crate and public `baml-go` module),
 # so it is built once here rather than inside any one language's SDK workflow.
 #
 # Adapts the legacy `libbaml-cffi` job shape (build -> rename to the loader's

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -429,9 +429,13 @@ jobs:
           go-version-file: baml_language/sdks/go/baml_go/go.mod
           cache-dependency-path: baml_language/sdks/go/baml_go/go.sum
       - name: Assemble and test public module
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
         run: |
           set -euo pipefail
-          scripts/assemble-go-sdk-mirror --out "$RUNNER_TEMP/go-sdk-mirror"
+          scripts/assemble-go-sdk-mirror \
+            --out "$RUNNER_TEMP/go-sdk-mirror" \
+            --version "$VERSION"
           cd "$RUNNER_TEMP/go-sdk-mirror"
           test "$(go list -m)" = "github.com/boundaryml/baml-go"
           go test ./...
@@ -1133,7 +1137,10 @@ jobs:
 
   publish-go-sdk:
     name: Publish Go SDK mirror
-    needs: [plan, build-go-sdk, all-builds]
+    # The exact-version runtime manifest must exist before the public Go tag:
+    # once a tag reaches proxy.golang.org it is immutable, while baml-go needs
+    # that manifest to resolve its native runtime on first use.
+    needs: [plan, build-go-sdk, all-builds, publish-pkg-boundaryml-com]
     if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     steps:
@@ -1164,8 +1171,55 @@ jobs:
           set -euo pipefail
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/baml_go_mirror_key -o IdentitiesOnly=yes"
           tag="v$VERSION"
-          rsync -a --delete --exclude .git /tmp/go-sdk-package/ /tmp/baml-go/
+          manifest_url="https://pkg.boundaryml.com/manifest/v1/version/$VERSION.json"
+
+          # Do not expose an immutable Go module tag until the exact-version
+          # manifest it needs is live and identifies this same module version.
+          manifest="$(mktemp)"
+          for attempt in $(seq 1 10); do
+            if curl -fsSL "$manifest_url" -o "$manifest"; then
+              break
+            fi
+            if [[ "$attempt" == 10 ]]; then
+              echo "::error::release manifest is unavailable: $manifest_url"
+              exit 1
+            fi
+            sleep "$attempt"
+          done
+          jq -e \
+            --arg version "$VERSION" \
+            --arg module "github.com/boundaryml/baml-go" \
+            '
+              .version == $version
+              and .baml_bridge_go == {
+                "module": $module,
+                "version": ("v" + $version)
+              }
+              and (.cffi | type == "object" and length > 0)
+            ' "$manifest" >/dev/null
+          rm -f "$manifest"
+
+          # Artifact extraction and git clone can give same-sized files the
+          # same second-resolution mtime. Force content comparison so rsync
+          # cannot silently retain bytes from the preceding release.
+          rsync -a --checksum --delete --exclude .git /tmp/go-sdk-package/ /tmp/baml-go/
+          drift="$(
+            rsync -rcni --delete --exclude .git \
+              /tmp/go-sdk-package/ /tmp/baml-go/
+          )"
+          if [[ -n "$drift" ]]; then
+            echo "::error::mirror tree differs from the verified build artifact"
+            printf '%s\n' "$drift"
+            exit 1
+          fi
+
           cd /tmp/baml-go
+          test "$(sed -n '1p' go.mod)" = "module github.com/boundaryml/baml-go"
+          if ! grep -qxF "const DefaultRuntimeVersion = \"$VERSION\"" version.go; then
+            echo "::error::version.go is not stamped for $VERSION"
+            grep -n "DefaultRuntimeVersion" version.go || true
+            exit 1
+          fi
           git add -A
 
           if git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1; then
@@ -1374,8 +1428,11 @@ jobs:
 
   publish-pkg-boundaryml-com:
     name: Publish pkg.boundaryml.com manifests
-    needs: [plan, all-builds, publish-pypi, publish-nodejs-sdk, publish-web-sdk, publish-toolchain-release, publish-bridge-cffi-release, publish-go-sdk, publish-crates-io, publish-wrapper-release, publish-homebrew, publish-aur]
-    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' && needs.publish-pypi.result == 'success' && needs.publish-nodejs-sdk.result == 'success' && needs.publish-web-sdk.result == 'success' && needs.publish-toolchain-release.result == 'success' && needs.publish-bridge-cffi-release.result == 'success' && needs.publish-go-sdk.result == 'success' && (needs.publish-crates-io.result == 'success' || needs.publish-crates-io.result == 'skipped') && (needs.plan.outputs.wrapper_changed != 'true' || (needs.publish-wrapper-release.result == 'success' && needs.publish-homebrew.result == 'success' && needs.publish-aur.result == 'success')) }}
+    # This precedes publish-go-sdk intentionally. The Go module dynamically
+    # resolves bridge_cffi through the immutable exact-version manifest, so the
+    # manifest is part of the module's publish preconditions, not a follow-up.
+    needs: [plan, all-builds, publish-pypi, publish-nodejs-sdk, publish-web-sdk, publish-toolchain-release, publish-bridge-cffi-release, publish-crates-io, publish-wrapper-release, publish-homebrew, publish-aur]
+    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' && needs.publish-pypi.result == 'success' && needs.publish-nodejs-sdk.result == 'success' && needs.publish-web-sdk.result == 'success' && needs.publish-toolchain-release.result == 'success' && needs.publish-bridge-cffi-release.result == 'success' && (needs.publish-crates-io.result == 'success' || needs.publish-crates-io.result == 'skipped') && (needs.plan.outputs.wrapper_changed != 'true' || (needs.publish-wrapper-release.result == 'success' && needs.publish-homebrew.result == 'success' && needs.publish-aur.result == 'success')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1432,7 +1489,12 @@ jobs:
             --pypi-version "${{ needs.plan.outputs.pypi_version }}" \
             --wrapper-version "${{ needs.plan.outputs.wrapper_version }}" \
             "${args[@]}"
-      - name: Upload install scripts, index, and manifests
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-manifests
+          path: manifests
+          if-no-files-found: error
+      - name: Upload immutable manifest, install scripts, and index
         run: |
           set -euo pipefail
           upload_immutable() {
@@ -1470,11 +1532,7 @@ jobs:
           }
 
           version="${{ needs.plan.outputs.version }}"
-          channel="${{ needs.plan.outputs.channel }}"
           upload_immutable "manifests/version/$version.json" "manifest/v1/version/$version.json"
-          aws s3 cp "manifests/$channel.json" "s3://$PKG_BUCKET/manifest/v1/$channel.json" \
-            --content-type application/json \
-            --cache-control "public, max-age=60, must-revalidate"
           if [[ -f manifests/wrapper.json ]]; then
             aws s3 cp manifests/wrapper.json "s3://$PKG_BUCKET/manifest/v1/wrapper.json" \
               --content-type application/json \
@@ -1548,9 +1606,37 @@ jobs:
           codesign --force --sign - "$bin"
           "$bin"
 
+  publish-pkg-channel:
+    name: Promote verified release channel manifest
+    # Keep the mutable canary/nightly pointer on the preceding known-good
+    # release until the public Go module resolves, loads its native runtime,
+    # and executes successfully on every supported desktop OS.
+    needs: [plan, publish-pkg-boundaryml-com, publish-go-sdk, smoke-go-release]
+    if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-manifests
+          path: manifests
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: baml-language-channel-${{ github.run_id }}
+      - name: Promote mutable channel manifest
+        env:
+          CHANNEL: ${{ needs.plan.outputs.channel }}
+        run: |
+          set -euo pipefail
+          aws s3 cp "manifests/$CHANNEL.json" \
+            "s3://$PKG_BUCKET/manifest/v1/$CHANNEL.json" \
+            --content-type application/json \
+            --cache-control "public, max-age=60, must-revalidate"
+
   dispatch-nightly-after-canary:
     name: Queue nightly after canary publish
-    needs: [plan, publish-pkg-boundaryml-com, smoke-go-release]
+    needs: [plan, publish-pkg-channel]
     if: ${{ needs.plan.outputs.dispatch_nightly_after_canary == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     permissions:

--- a/scripts/assemble-go-sdk-mirror
+++ b/scripts/assemble-go-sdk-mirror
@@ -4,16 +4,21 @@
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 from pathlib import Path
 
 
 MODULE_PATH = "github.com/boundaryml/baml-go"
+RUNTIME_VERSION_RE = re.compile(
+    r'^const DefaultRuntimeVersion = "([^"]+)"$', re.MULTILINE
+)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--version", required=True)
     args = parser.parse_args()
 
     repository = Path(__file__).resolve().parents[1]
@@ -35,6 +40,14 @@ def main() -> None:
     module_line = (destination / "go.mod").read_text(encoding="utf-8").splitlines()[0]
     if module_line != f"module {MODULE_PATH}":
         raise SystemExit(f"unexpected Go module declaration: {module_line!r}")
+
+    version_source = (destination / "version.go").read_text(encoding="utf-8")
+    version_matches = RUNTIME_VERSION_RE.findall(version_source)
+    if version_matches != [args.version]:
+        raise SystemExit(
+            "unexpected Go runtime version constants: "
+            f"{version_matches!r}; expected exactly {args.version!r}"
+        )
 
     for path in destination.rglob("*"):
         if path.is_symlink():

--- a/scripts/baml-release-manifests
+++ b/scripts/baml-release-manifests
@@ -69,10 +69,11 @@ def collect_artifacts(
 
 def collect_cffi_artifacts(root: Path, version: str) -> dict[str, dict[str, str]]:
     """The engine cdylibs (`libbaml_cffi-<triple>.{so,dylib}` /
-    `baml_cffi-<triple>.dll`), recorded as bookkeeping — the dylib-loader SDKs
-    construct these GitHub-release URLs directly, so the manifest does not need
-    to be consulted at load time. Only the targets actually built are recorded
-    (experimental targets may be absent), so no required/extra check applies.
+    `baml_cffi-<triple>.dll`). The public Go module resolves these exact URLs
+    and checksums from the immutable version manifest; other loaders may
+    construct the same URLs directly. Only the targets actually built are
+    recorded (experimental targets may be absent), so no required/extra check
+    applies.
     """
     tag = f"baml-language-{version}"
     artifacts: dict[str, dict[str, str]] = {}

--- a/scripts/smoke-go-release.py
+++ b/scripts/smoke-go-release.py
@@ -285,7 +285,9 @@ def main() -> None:
             "CGO_ENABLED": "1",
             "GOCACHE": str(root / "go-build-cache"),
             "GOMODCACHE": str(root / "go-module-cache"),
-            "GOPROXY": "https://proxy.golang.org,direct",
+            # No `direct` fallback: channel promotion must prove the immutable
+            # mirror tag has propagated through the public Go module proxy.
+            "GOPROXY": "https://proxy.golang.org",
             "GOSUMDB": "sum.golang.org",
             "GOWORK": "off",
         }
@@ -295,7 +297,12 @@ def main() -> None:
     run([str(cli), "generate", "--from", "."], cwd=consumer, env=env)
     if "replace " in (consumer / "go.mod").read_text(encoding="utf-8"):
         fail("external consumer unexpectedly contains a Go replace directive")
-    run(["go", "mod", "download", f"{GO_MODULE}@{module_version}"], cwd=consumer, env=env, attempts=4)
+    run(
+        ["go", "mod", "download", f"{GO_MODULE}@{module_version}"],
+        cwd=consumer,
+        env=env,
+        attempts=6,
+    )
     module_json = json.loads(
         run(
             ["go", "list", "-m", "-json", GO_MODULE],


### PR DESCRIPTION
## Summary

Hardens the `baml_language` release path that publishes `github.com/boundaryml/baml-go` to the mirror repository.

- publishes and validates the immutable exact-version runtime manifest before exposing the Go tag
- synchronizes the verified mirror artifact by checksum and asserts the module path and embedded runtime version before tagging
- requires the tag to propagate through `proxy.golang.org` without a direct Git fallback
- promotes the mutable `canary`/`nightly` manifest only after clean Linux, macOS, and Windows consumers load the released native runtime and execute a generated BAML call

## End-user behavior

Before this change, a Go module tag could become permanently visible through the Go proxy while its required runtime manifest was absent. A same-size, same-mtime `version.go` could also be skipped by `rsync`, leaving a new tag with the preceding release's embedded fallback version.

After this change, publication proceeds in this order:

1. native assets and exact-version manifest
2. byte-verified Go mirror tag
3. public-proxy external consumer smoke tests on Linux, macOS, and Windows
4. mutable channel promotion

A failed publish or smoke leaves the previous channel release active instead of advertising an incomplete Go release.

## Verification

- `actionlint .github/workflows/release-baml-language.yml .github/workflows/build2-bridge-cffi.reusable.yaml`
- `scripts/baml-language-version check`
- `go test ./...` and `go vet ./...` in `baml_language/sdks/go/baml_go`
- `cargo test -p sdkgen_go` — 84 passed
- `cargo test -p baml_release` — 39 passed
- clean mirror assembly plus wrong-version rejection
- dependency graph cycle/order assertion
- regression reproduction using the actual same-size, same-mtime `a`/`b` release artifact pattern

Previously published immutable tags are intentionally unchanged; the hardened guarantees apply to newly versioned releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved Go module publishing validation, including exact-version manifest checks and runtime version verification.
  * Added checksum-based synchronization checks to prevent release artifacts from drifting.
  * Channel promotion now occurs only after Go publication and smoke tests succeed.

* **Reliability**
  * Improved release smoke-test resilience with additional download retries.
  * Go module downloads now use the public Go proxy exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->