### PR TITLE
fix: handle capture-rooted places during MIR optimization

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1621,7 +1621,11 @@ fn has_side_effect(kind: &StatementKind, rvalue_reads: &HashSet<Local>) -> bool 
         StatementKind::Assign { destination, value } => {
             // Check if this assignment modifies a variable (or field/index of a variable)
             // that the rvalue reads from.
-            let base_local = get_base_local(destination);
+            let Some(base_local) = destination.base_local() else {
+                // Capture reads are not represented in `rvalue_reads`, so a
+                // capture-rooted write must conservatively block inlining.
+                return true;
+            };
             if rvalue_reads.contains(&base_local) {
                 return true;
             }
@@ -1634,18 +1638,6 @@ fn has_side_effect(kind: &StatementKind, rvalue_reads: &HashSet<Local>) -> bool 
         StatementKind::VizEnter(_) | StatementKind::VizExit(_) => true, // VizEnter/VizExit emit notifications
         StatementKind::Intrinsic { .. } => true, // Intrinsics emit events — observable side effect
         StatementKind::Nop => false,
-    }
-}
-
-/// Get the base local from a place, following field/index projections.
-///
-/// Panics for `Place::Capture` — captures have no base local.
-fn get_base_local(place: &Place) -> Local {
-    match place {
-        Place::Local(local) => *local,
-        Place::Capture(_) => panic!("Place::Capture has no base local"),
-        Place::Field { base, .. } => get_base_local(base),
-        Place::Index { base, .. } => get_base_local(base),
     }
 }
 

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -650,14 +650,12 @@ impl Place {
         Place::Local(local)
     }
 
-    /// Get the base local of this place.
-    ///
-    /// Panics for `Place::Capture` — captures have no local base.
-    pub fn base_local(&self) -> Local {
+    /// Get the base local of this place, if it is rooted in a local.
+    pub fn base_local(&self) -> Option<Local> {
         match self {
-            Place::Local(l) => *l,
+            Place::Local(l) => Some(*l),
             Place::Field { base, .. } | Place::Index { base, .. } => base.base_local(),
-            Place::Capture(_) => panic!("Place::Capture has no base local"),
+            Place::Capture(_) => None,
         }
     }
 }

--- a/baml_language/crates/baml_compiler2_mir/src/optimize.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize.rs
@@ -545,9 +545,9 @@ fn count_local_defs(body: &MirFunctionBody) -> Vec<usize> {
     for block in &body.blocks {
         for stmt in &block.statements {
             if let crate::StatementKind::Assign { destination, .. } = &stmt.kind {
-                // Place::Capture has no local base — skip def counting for capture stores.
-                if !matches!(destination, Place::Capture(_)) {
-                    defs[destination.base_local().0] += 1;
+                // Capture-rooted places have no local definition to count.
+                if let Some(local) = destination.base_local() {
+                    defs[local.0] += 1;
                 }
             }
         }
@@ -561,8 +561,8 @@ fn count_local_defs(body: &MirFunctionBody) -> Vec<usize> {
                 | Terminator::Await { destination, .. }
                 | Terminator::AwaitAny { destination, .. }
                 | Terminator::ShortCircuit { destination, .. },
-            ) => Some(destination.base_local()),
-            Some(Terminator::Spawn { future, .. }) => Some(future.base_local()),
+            ) => destination.base_local(),
+            Some(Terminator::Spawn { future, .. }) => future.base_local(),
             _ => None,
         } {
             defs[dest.0] += 1;
@@ -1143,11 +1143,11 @@ fn eliminate_dead_locals(body: &mut MirFunctionBody, arity: usize) {
     for block in &body.blocks {
         if let Some(term) = &block.terminator {
             let dest_local = match term {
-                Terminator::Call { destination, .. } => Some(destination.base_local()),
-                Terminator::VirtualCall { destination, .. } => Some(destination.base_local()),
-                Terminator::Await { destination, .. } => Some(destination.base_local()),
-                Terminator::AwaitAny { destination, .. } => Some(destination.base_local()),
-                Terminator::SysOp { destination, .. } => Some(destination.base_local()),
+                Terminator::Call { destination, .. } => destination.base_local(),
+                Terminator::VirtualCall { destination, .. } => destination.base_local(),
+                Terminator::Await { destination, .. } => destination.base_local(),
+                Terminator::AwaitAny { destination, .. } => destination.base_local(),
+                Terminator::SysOp { destination, .. } => destination.base_local(),
                 Terminator::NarrowBind { destination, .. } => Some(*destination),
                 // ShortCircuit is side-effect-free (pure control flow), so its
                 // destination can be dead-eliminated like any other local.

--- a/baml_language/crates/bex_engine/tests/fn_typed_slots.rs
+++ b/baml_language/crates/bex_engine/tests/fn_typed_slots.rs
@@ -4,6 +4,7 @@ mod common;
 use std::sync::Arc;
 
 use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder};
+use bex_heap::CollectionLevel;
 use common::compile_for_engine;
 use sys_native::SysOpsExt;
 
@@ -46,6 +47,85 @@ async fn clean_lambda_into_class_field() {
     "#)
     .await;
     assert_eq!(r, BexExternalValue::Int(42));
+}
+
+#[tokio::test]
+async fn returned_callbacks_share_captured_mutable_state() {
+    let source = r#"
+        class Callbacks {
+            increment: () -> null throws never
+            observe: () -> int throws never
+        }
+
+        class State {
+            count: int
+        }
+
+        function make_callbacks() -> Callbacks {
+            let state = State { count: 0 }
+            Callbacks {
+                increment: () -> null {
+                    state.count += 1
+                    null
+                },
+                observe: () -> int {
+                    state.count
+                }
+            }
+        }
+
+        function increment_callback(callbacks: Callbacks) -> () -> null throws never {
+            callbacks.increment
+        }
+
+        function observe_callback(callbacks: Callbacks) -> () -> int throws never {
+            callbacks.observe
+        }
+    "#;
+    let snapshot = compile_for_engine(source);
+    let engine = Arc::new(
+        BexEngine::new(snapshot, Arc::new(sys_native::SysOps::native()), Vec::new())
+            .expect("engine"),
+    );
+    let context = || FunctionCallContextBuilder::new(sys_types::CallId::next()).build();
+
+    let callbacks = engine
+        .call_function("make_callbacks", vec![], context(), false)
+        .await
+        .expect("callbacks should be returned as a rooted handle");
+    assert!(matches!(callbacks, BexExternalValue::Handle(_)));
+
+    let increment = engine
+        .call_function(
+            "increment_callback",
+            vec![callbacks.clone()],
+            context(),
+            false,
+        )
+        .await
+        .expect("increment callback should be returned as a rooted handle");
+    let BexExternalValue::Handle(increment) = increment else {
+        panic!("increment callback should be a handle");
+    };
+    let observe = engine
+        .call_function("observe_callback", vec![callbacks], context(), false)
+        .await
+        .expect("observe callback should be returned as a rooted handle");
+    let BexExternalValue::Handle(observe) = observe else {
+        panic!("observe callback should be a handle");
+    };
+
+    engine
+        .call_callable(increment, vec![], context(), true)
+        .await
+        .expect("increment callback should run");
+    engine.collect_garbage(CollectionLevel::Major).await;
+    let observed = engine
+        .call_callable(observe, vec![], context(), true)
+        .await
+        .expect("observe callback should run after garbage collection");
+
+    assert_eq!(observed, BexExternalValue::Int(1));
 }
 
 /// Throws semantics around fn-typed slots: an omitted `throws` on a callback


### PR DESCRIPTION
## What changed

- Make `Place::base_local` return `None` for capture-rooted places instead of panicking.
- Skip local definition and liveness bookkeeping when a destination is rooted in a closure capture.
- Conservatively block emitter inlining across capture-rooted writes.
- Add an end-to-end runtime regression for two returned callbacks sharing mutable captured state across major GC.

## Root cause

MIR copy propagation treated every field or index projection as if it ultimately had a local base. A write such as `capture[0].count += 1` therefore called `Place::base_local()` and panicked with `Place::Capture has no base local`.

## Impact

Stateful callbacks that mutate captured objects can now pass `baml check` and `baml generate`. The runtime regression extracts both callbacks as independent handles, releases the outer class handle, invokes the mutator, forces major GC, and verifies that the observer sees the shared updated state.

## Validation

- `cargo test -p bex_engine --test fn_typed_slots`
- `cargo test -p bex_engine --features heap_debug --test fn_typed_slots returned_callbacks_share_captured_mutable_state`
- `cargo test -p baml_compiler2_mir -p baml_compiler2_emit`
- `cargo clippy -p baml_compiler2_mir -p baml_compiler2_emit -p bex_engine --test fn_typed_slots -- -D warnings`
- Original minimal reproduction succeeds with the locally built `baml-cli check` and `baml-cli generate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compiler handling of assignments and destinations tied to captured state, preventing crashes during optimization.
  - Corrected copy propagation and dead-local analysis for operations involving captured values.

- **Tests**
  - Added coverage confirming that returned callbacks share and preserve captured mutable state, including across garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->