### PR TITLE
fix(go): harden context and callback handling

### DIFF
--- a/baml_language/sdks/go/baml_go/json_test.go
+++ b/baml_language/sdks/go/baml_go/json_test.go
@@ -38,6 +38,56 @@ func TestJSONDecodesCanonicalRecursiveValueAlgebra(t *testing.T) {
 	}
 }
 
+func TestJSONDecodesListsOfObjectsWithHeterogeneousKeysets(t *testing.T) {
+	stringValue := func(value string) *cffi.BamlOutboundValue {
+		return &cffi.BamlOutboundValue{Value: &cffi.BamlOutboundValue_StringValue{StringValue: value}}
+	}
+	mapValue := func(entries ...*cffi.BamlOutboundMapEntry) *cffi.BamlOutboundValue {
+		return &cffi.BamlOutboundValue{Value: &cffi.BamlOutboundValue_MapValue{
+			MapValue: &cffi.BamlValueMap{Entries: entries},
+		}}
+	}
+
+	withCacheControl := mapValue(
+		&cffi.BamlOutboundMapEntry{Key: "type", Value: stringValue("text")},
+		&cffi.BamlOutboundMapEntry{Key: "text", Value: stringValue("first")},
+		&cffi.BamlOutboundMapEntry{Key: "cache_control", Value: mapValue(
+			&cffi.BamlOutboundMapEntry{Key: "type", Value: stringValue("ephemeral")},
+		)},
+	)
+	withoutCacheControl := mapValue(
+		&cffi.BamlOutboundMapEntry{Key: "type", Value: stringValue("text")},
+		&cffi.BamlOutboundMapEntry{Key: "text", Value: stringValue("second")},
+	)
+	value := jsonValue(&cffi.BamlOutboundValue{Value: &cffi.BamlOutboundValue_ListValue{
+		ListValue: &cffi.BamlValueList{Items: []*cffi.BamlOutboundValue{
+			withCacheControl,
+			withoutCacheControl,
+		}},
+	}})
+
+	got, err := value.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []any{
+		map[string]any{
+			"type": "text",
+			"text": "first",
+			"cache_control": map[string]any{
+				"type": "ephemeral",
+			},
+		},
+		map[string]any{
+			"type": "text",
+			"text": "second",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON() = %#v, want %#v", got, want)
+	}
+}
+
 func TestJSONValidatesUnionEnvelopeBeforeDecoding(t *testing.T) {
 	alias := TypeAliasBAMLType("baml.json.json")
 	selected := PrimitiveBAMLType(StringType)

--- a/baml_language/sdks/go/baml_go/native_unix.go
+++ b/baml_language/sdks/go/baml_go/native_unix.go
@@ -339,13 +339,8 @@ func nativeRuntimeTarget() (string, error) {
 
 //export bamlGoResultCallback
 func bamlGoResultCallback(callID C.uint32_t, content *C.int8_t, length C.size_t) {
-	value, ok := pendingCalls.LoadAndDelete(uint32(callID))
-	if !ok {
-		return
-	}
-	call := value.(*pendingCall)
 	payload := C.GoBytes(unsafe.Pointer(content), C.int(length))
-	call.result <- payload
+	completePendingCall(uint32(callID), payload)
 }
 
 //export bamlGoHostDispatch

--- a/baml_language/sdks/go/baml_go/native_windows.go
+++ b/baml_language/sdks/go/baml_go/native_windows.go
@@ -289,13 +289,8 @@ func nativeRuntimeTarget() (string, error) {
 
 //export bamlGoResultCallback
 func bamlGoResultCallback(callID C.uint32_t, content *C.int8_t, length C.size_t) {
-	value, ok := pendingCalls.LoadAndDelete(uint32(callID))
-	if !ok {
-		return
-	}
-	call := value.(*pendingCall)
 	payload := C.GoBytes(unsafe.Pointer(content), C.int(length))
-	call.result <- payload
+	completePendingCall(uint32(callID), payload)
 }
 
 //export bamlGoHostDispatch

--- a/baml_language/sdks/go/baml_go/runtime.go
+++ b/baml_language/sdks/go/baml_go/runtime.go
@@ -60,7 +60,25 @@ type pendingCall struct {
 // serialized program. Generated projects normally call this through their
 // internal bootstrap package exactly once.
 func Initialize(bytecode []byte) error {
-	if err := ensureNativeRuntime(context.Background()); err != nil {
+	return InitializeContext(context.Background(), bytecode)
+}
+
+// InitializeContext replaces the process-wide BAML runtime with the supplied
+// serialized program while honoring cancellation during native-runtime
+// resolution. Generated projects pass the context from the BAML function call
+// so first-use downloads and concurrent initialization waits remain
+// cancellable.
+func InitializeContext(ctx context.Context, bytecode []byte) error {
+	if ctx == nil {
+		return errors.New("baml_go.InitializeContext: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := ensureNativeRuntime(ctx); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 	return nativeInitialize(bytecode)
@@ -356,6 +374,17 @@ func reservePendingCall(call *pendingCall) uint32 {
 			return id
 		}
 	}
+}
+
+// completePendingCall atomically claims one terminal result. Native error,
+// panic, and success outcomes share one result envelope, so a duplicate or
+// late callback must be ignored rather than racing a send/close pair.
+func completePendingCall(callbackID uint32, payload []byte) {
+	value, ok := pendingCalls.LoadAndDelete(callbackID)
+	if !ok {
+		return
+	}
+	value.(*pendingCall).result <- payload
 }
 
 func encodeCall(callID uint64, args map[string]Input) ([]byte, error) {

--- a/baml_language/sdks/go/baml_go/runtime_test.go
+++ b/baml_language/sdks/go/baml_go/runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/boundaryml/baml-go/internal/cffi"
@@ -208,6 +209,18 @@ func TestRuntimeInitializationWaitHonorsCancellation(t *testing.T) {
 	state.release()
 }
 
+func TestInitializeContextRejectsInvalidContextBeforeRuntimeWork(t *testing.T) {
+	if err := InitializeContext(nil, nil); err == nil || !strings.Contains(err.Error(), "nil context") {
+		t.Fatalf("nil context error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := InitializeContext(ctx, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled initialization error = %v, want context.Canceled", err)
+	}
+}
+
 func TestWaitForCallResultPreservesExactContextErrorWhenResultAndDoneAreReady(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	result := make(chan []byte, 1)
@@ -228,6 +241,66 @@ func TestWaitForCallResultPreservesExactContextErrorWhenResultAndDoneAreReady(t 
 		case result <- []byte("already completed"):
 		default:
 		}
+	}
+}
+
+func TestCompletePendingCallAcceptsExactlyOneTerminalResult(t *testing.T) {
+	call := &pendingCall{result: make(chan []byte, 1)}
+	id := reservePendingCall(call)
+	t.Cleanup(func() { pendingCalls.Delete(id) })
+
+	var wait sync.WaitGroup
+	for index := range 128 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			completePendingCall(id, []byte{byte(index)})
+		}()
+	}
+	wait.Wait()
+
+	select {
+	case <-call.result:
+	default:
+		t.Fatal("no terminal callback claimed the pending call")
+	}
+	select {
+	case payload := <-call.result:
+		t.Fatalf("duplicate terminal callback delivered payload %v", payload)
+	default:
+	}
+	if _, ok := pendingCalls.Load(id); ok {
+		t.Fatal("terminal callback left the pending call registered")
+	}
+}
+
+func TestReservePendingCallIsUniqueUnderConcurrency(t *testing.T) {
+	const callCount = 512
+	ids := make(chan uint32, callCount)
+	var wait sync.WaitGroup
+	for range callCount {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			ids <- reservePendingCall(&pendingCall{result: make(chan []byte, 1)})
+		}()
+	}
+	wait.Wait()
+	close(ids)
+
+	seen := make(map[uint32]struct{}, callCount)
+	for id := range ids {
+		if id == 0 {
+			t.Fatal("reserved zero callback ID")
+		}
+		if _, duplicate := seen[id]; duplicate {
+			t.Fatalf("reserved duplicate callback ID %d", id)
+		}
+		seen[id] = struct{}{}
+		pendingCalls.Delete(id)
+	}
+	if len(seen) != callCount {
+		t.Fatalf("reserved %d callback IDs, want %d", len(seen), callCount)
 	}
 }
 

--- a/baml_language/sdks/go/sdkgen_go/src/lib.rs
+++ b/baml_language/sdks/go/sdkgen_go/src/lib.rs
@@ -1662,7 +1662,7 @@ fn render_functions(
         }
         let _ = writeln!(
             out,
-            "\tif {error_local} := {bootstrap_package}.Ensure(); {error_local} != nil {{"
+            "\tif {error_local} := {bootstrap_package}.Ensure({context_parameter}); {error_local} != nil {{"
         );
         if function_returns_only_error(&function.return_type) {
             let _ = writeln!(out, "\t\treturn {error_local}\n\t}}");
@@ -4305,9 +4305,9 @@ fn render_go_literal_value(literal: &GoLiteral, runtime: &str) -> String {
 fn render_bootstrap(bytecode: &[u8]) -> String {
     let mut out = String::from(BANNER);
     out.push_str("package bootstrap\n\n");
-    out.push_str("import (\n\t\"sync\"\n\n");
+    out.push_str("import (\n\t\"context\"\n\t\"errors\"\n\n");
     let _ = writeln!(out, "\t\"{BAML_GO_MODULE}\"\n)\n");
-    out.push_str("var (\n\tonce          sync.Once\n\tinitializeErr error\n)\n\n");
+    out.push_str("var (\n\tinitialization = make(chan struct{}, 1)\n\tinitialized    bool\n)\n\n");
     out.push_str("var bytecode = []byte{\n");
     for chunk in bytecode.chunks(20) {
         let line = chunk
@@ -4318,9 +4318,21 @@ fn render_bootstrap(bytecode: &[u8]) -> String {
         let _ = writeln!(out, "\t{line},");
     }
     out.push_str("}\n\n");
-    out.push_str("func Ensure() error {\n");
-    out.push_str("\tonce.Do(func() { initializeErr = baml_go.Initialize(bytecode) })\n");
-    out.push_str("\treturn initializeErr\n}\n");
+    out.push_str("func init() {\n\tinitialization <- struct{}{}\n}\n\n");
+    out.push_str("func Ensure(ctx context.Context) error {\n");
+    out.push_str(
+        "\tif ctx == nil {\n\t\treturn errors.New(\"BAML bootstrap: nil context\")\n\t}\n",
+    );
+    out.push_str("\tif err := ctx.Err(); err != nil {\n\t\treturn err\n\t}\n");
+    out.push_str(
+        "\tselect {\n\tcase <-ctx.Done():\n\t\treturn ctx.Err()\n\tcase <-initialization:\n\t}\n",
+    );
+    out.push_str("\tdefer func() { initialization <- struct{}{} }()\n");
+    out.push_str("\tif initialized {\n\t\treturn nil\n\t}\n");
+    out.push_str(
+        "\tif err := baml_go.InitializeContext(ctx, bytecode); err != nil {\n\t\treturn err\n\t}\n",
+    );
+    out.push_str("\tinitialized = true\n\treturn nil\n}\n");
     out
 }
 
@@ -4608,10 +4620,12 @@ mod tests {
         );
         assert!(functions.contains("\"user.echo_text\""));
         assert!(functions.contains("baml_go.String(value)"));
-        assert!(
-            files[&PathBuf::from("internal/bootstrap/bootstrap.go")]
-                .contains("var bytecode = []byte{\n\t1, 2, 3,")
-        );
+        assert!(functions.contains("bootstrap.Ensure(ctx_)"));
+        let bootstrap = &files[&PathBuf::from("internal/bootstrap/bootstrap.go")];
+        assert!(bootstrap.contains("var bytecode = []byte{\n\t1, 2, 3,"));
+        assert!(bootstrap.contains("func Ensure(ctx context.Context) error"));
+        assert!(bootstrap.contains("baml_go.InitializeContext(ctx, bytecode)"));
+        assert!(!bootstrap.contains("sync.Once"));
     }
 
     #[test]
@@ -5956,7 +5970,7 @@ mod tests {
             name: BaseName::new("reserved_args"),
             generic_params: vec![],
             docstring: None,
-            arguments: ["ctx", "result", "err"]
+            arguments: ["context", "ctx", "result", "err"]
                 .into_iter()
                 .map(|name| FunctionArgument {
                     name: BaseName::new(name),
@@ -5978,7 +5992,7 @@ mod tests {
             "example.com/project/baml_sdk",
         );
         assert!(files[&PathBuf::from("functions.go")].contains(
-            "func ReservedArgs(ctx_ context.Context, ctx string, result string, err string)"
+            "func ReservedArgs(ctx_ context.Context, context_ string, ctx string, result string, err string)"
         ));
     }
 


### PR DESCRIPTION
## Summary

- pass each generated BAML function's `context.Context` through bootstrap and native-runtime resolution
- replace `sync.Once` bootstrap initialization with a serialized, context-aware gate that permits retries after cancellation or transient failures
- centralize exactly-once native callback completion and add concurrency coverage for terminal callbacks and callback IDs
- add regressions for a BAML argument named `context` and heterogeneous-key JSON objects

## Why

The legacy Go SDK accumulated several context, callback, and reflection failures, including context-package shadowing (#2393), cancellation watcher goroutine leaks (#2883), high-concurrency callback races (#3185), and heterogeneous object decoding panics (#3486).

The new Go SDK already avoids the legacy per-call watcher and reflection architectures, but generated first-use bootstrap still called `Initialize` without the caller context. That meant native-runtime waits/downloads could outlive cancellation, while `sync.Once` would permanently cache an initialization failure. This change closes that gap and adds focused regression coverage for the other historical failure classes.

## User impact

- first-use BAML calls now remain cancellable during runtime resolution and initialization waits
- canceled or transient initialization attempts no longer poison the generated SDK for the rest of the process
- duplicate or late native terminal callbacks are ignored safely
- generated code remains valid when a BAML function declares an argument named `context`

## Validation

- `go test -race ./...` in `baml_language/sdks/go/baml_go`
- `cargo nextest run -p bridge_cffi -p sdkgen_go -p sdk_test_go --no-fail-fast` (128 passed, 1 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-wide runtime initialization, native FFI callbacks, and generated bootstrap contracts; behavior changes are intentional (cancellation, retry) but affect every first BAML call.
> 
> **Overview**
> **Context-aware bootstrap and initialization.** Generated BAML functions now pass the caller’s `context.Context` into `bootstrap.Ensure(ctx)`, which uses a serialized, cancellable gate instead of `sync.Once`. Runtime setup goes through **`InitializeContext`**, so native-runtime download/wait and initialization honor cancellation and **failed or canceled first-use init can be retried** instead of poisoning the process forever.
> 
> **Exactly-once native result callbacks.** Unix and Windows `bamlGoResultCallback` paths delegate to shared **`completePendingCall`**, which atomically claims the pending call with `LoadAndDelete` so duplicate or late terminal callbacks are ignored under concurrency.
> 
> **Codegen and regressions.** The Go SDK generator wires `Ensure(ctx)` and disambiguates a BAML argument named `context` from the Go `ctx_` parameter. New tests cover heterogeneous-key JSON list decoding, invalid/canceled `InitializeContext`, and concurrent callback ID reservation and terminal completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c5e97e84eea76d54326eadfe2c8cc7cde12c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->