### PR TITLE
Fix generated C# release contract and NuGet environment wiring

### DIFF
--- a/.github/workflows/prepare-csharp-sdk.reusable.yaml
+++ b/.github/workflows/prepare-csharp-sdk.reusable.yaml
@@ -95,19 +95,9 @@ jobs:
             cp "$source" "$destination"
           done < <(find "$fixture/baml_client" \
             -type f -name '*.g.cs' | LC_ALL=C sort)
-          LC_ALL=C find "$generated_output" -type f -name '*.g.cs' \
-            -printf '%P\n' | LC_ALL=C sort | diff -u <(printf '%s\n' \
-              'Baml/Csv/CsvError.g.cs' \
-              'Baml/Csv/CsvErrorKind.g.cs' \
-              'Baml/Csv/CsvPosition.g.cs' \
-              'Baml/Csv/ReaderOptions.g.cs' \
-              'Baml/Csv/WriterOptions.g.cs' \
-              'Baml/Fs/DirEntry.g.cs' \
-              'Baml/Fs/MkdirOptions.g.cs' \
-              'Baml/Generated/BamlProgram.g.cs' \
-              'Baml/Glob/ScanOptions.g.cs' \
-              'Baml/Net/Datagram.g.cs' \
-              'CsharpSlice/Functions.g.cs') -
+          scripts/baml-csharp-release-contract write-generated-manifest \
+            --root "$generated_output" \
+            --manifest "$output/generated-sources.sha256"
           cp release-plan.json "$output/"
 
       - name: Exercise NuGet payload comparison policy

--- a/.github/workflows/publish2-csharp-sdk.yaml
+++ b/.github/workflows/publish2-csharp-sdk.yaml
@@ -2,7 +2,8 @@ name: BAML SDK Release - Publish C# NuGet
 
 # Publish only the exact package produced and exercised by
 # verify-csharp-product-slice.reusable.yaml. The trusted-publishing policy on
-# nuget.org must name the calling workflow, release-baml-language.yml.
+# nuget.org must name this reusable workflow, publish2-csharp-sdk.yaml, and the
+# boundary-tools-prod environment.
 on:
   workflow_call:
     inputs:
@@ -14,10 +15,6 @@ on:
         description: "Exact repository commit whose verified package is published"
         type: string
         required: true
-    secrets:
-      NUGET_USER:
-        description: "nuget.org profile name used by the trusted-publishing policy"
-        required: true
 
 defaults:
   run:
@@ -27,6 +24,7 @@ jobs:
   publish-nuget:
     name: Publish and smoke C# NuGet
     runs-on: ubuntu-24.04
+    environment: boundary-tools-prod
     timeout-minutes: 30
     permissions:
       contents: read
@@ -84,6 +82,9 @@ jobs:
             --provenance product-package/native-provenance.json \
             --manifest product-package/native-manifest.sha256 \
             --package "$package"
+          scripts/baml-csharp-release-contract verify-generated-sources \
+            --root product-package/baml_client \
+            --manifest product-package/generated-sources.sha256
 
           digest="$(sha256sum "$package" | cut -d ' ' -f 1)"
           grep -Fxq "$digest  $(basename "$package")" \

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -750,8 +750,6 @@ jobs:
     with:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}
-    secrets:
-      NUGET_USER: ${{ secrets.NUGET_USER }}
 
   publish-maven:
     name: Publish Java Maven Central

--- a/.github/workflows/verify-csharp-product-slice.reusable.yaml
+++ b/.github/workflows/verify-csharp-product-slice.reusable.yaml
@@ -112,6 +112,9 @@ jobs:
           package_output="$product_root/packages"
           generated_output="$PWD/neutral-preparation/baml_client"
           mkdir -p "$package_output"
+          scripts/baml-csharp-release-contract verify-generated-sources \
+            --root "$generated_output" \
+            --manifest neutral-preparation/generated-sources.sha256
           baml_language/sdks/csharp/bridge_csharp/tools/pack-product.sh \
             staging \
             native-manifest.sha256 \
@@ -122,19 +125,6 @@ jobs:
             -type f -name 'baml-bridge.*.nupkg' -print)"
           test -n "$package"
           test "$(printf '%s\n' "$package" | wc -l)" -eq 1
-          LC_ALL=C find "$generated_output" -type f -name '*.g.cs' \
-            -printf '%P\n' | LC_ALL=C sort | diff -u <(printf '%s\n' \
-              'Baml/Csv/CsvError.g.cs' \
-              'Baml/Csv/CsvErrorKind.g.cs' \
-              'Baml/Csv/CsvPosition.g.cs' \
-              'Baml/Csv/ReaderOptions.g.cs' \
-              'Baml/Csv/WriterOptions.g.cs' \
-              'Baml/Fs/DirEntry.g.cs' \
-              'Baml/Fs/MkdirOptions.g.cs' \
-              'Baml/Generated/BamlProgram.g.cs' \
-              'Baml/Glob/ScanOptions.g.cs' \
-              'Baml/Net/Datagram.g.cs' \
-              'CsharpSlice/Functions.g.cs') -
           baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh \
             "$package" \
             linux-x64 \
@@ -160,6 +150,7 @@ jobs:
           cp native-manifest.sha256 product-output/
           cp native-provenance.json product-output/
           cp release-plan.json product-output/
+          cp neutral-preparation/generated-sources.sha256 product-output/
           cp -R "$generated_output" product-output/
           mkdir -p product-output/documentation
           cp \

--- a/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
+++ b/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
@@ -38,6 +38,8 @@ if [[ -z "$generated_source_root" ]]; then
 else
   generated_source_root="$(cd "$generated_source_root" && pwd -P)"
 fi
+test -f "$generated_source_root/Baml/Generated/BamlProgram.g.cs"
+test -f "$generated_source_root/CsharpSlice/Functions.g.cs"
 cp "$test_dir/Baml.Bridge.PrimitivePackageConsumer.csproj" "$consumer/"
 cp "$test_dir/NuGet.Config" "$consumer/"
 cp "$test_dir/Program.cs" "$consumer/"
@@ -48,19 +50,11 @@ while IFS= read -r source; do
   cp "$source" "$destination"
 done < <(find "$generated_source_root" -type f -name '*.g.cs' | LC_ALL=C sort)
 
-LC_ALL=C find "$consumer/baml_client" -type f -name '*.g.cs' \
-  -printf '%P\n' | LC_ALL=C sort | diff -u <(printf '%s\n' \
-    'Baml/Csv/CsvError.g.cs' \
-    'Baml/Csv/CsvErrorKind.g.cs' \
-    'Baml/Csv/CsvPosition.g.cs' \
-    'Baml/Csv/ReaderOptions.g.cs' \
-    'Baml/Csv/WriterOptions.g.cs' \
-    'Baml/Fs/DirEntry.g.cs' \
-    'Baml/Fs/MkdirOptions.g.cs' \
-    'Baml/Generated/BamlProgram.g.cs' \
-    'Baml/Glob/ScanOptions.g.cs' \
-    'Baml/Net/Datagram.g.cs' \
-    'CsharpSlice/Functions.g.cs') -
+diff -u \
+  <(LC_ALL=C find "$generated_source_root" -type f -name '*.g.cs' \
+    -printf '%P\n' | LC_ALL=C sort) \
+  <(LC_ALL=C find "$consumer/baml_client" -type f -name '*.g.cs' \
+    -printf '%P\n' | LC_ALL=C sort)
 if find "$consumer" -type f \
   \( -name '*.proto' -o -name '*.baml' -o -name '*.toml' -o -name '*.bin' \) \
   | grep -q .; then

--- a/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
+++ b/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
@@ -50,11 +50,18 @@ while IFS= read -r source; do
   cp "$source" "$destination"
 done < <(find "$generated_source_root" -type f -name '*.g.cs' | LC_ALL=C sort)
 
+list_generated_sources() {
+  (
+    cd "$1"
+    find . -type f -name '*.g.cs' -print \
+      | sed 's#^\./##' \
+      | LC_ALL=C sort
+  )
+}
+
 diff -u \
-  <(LC_ALL=C find "$generated_source_root" -type f -name '*.g.cs' \
-    -printf '%P\n' | LC_ALL=C sort) \
-  <(LC_ALL=C find "$consumer/baml_client" -type f -name '*.g.cs' \
-    -printf '%P\n' | LC_ALL=C sort)
+  <(list_generated_sources "$generated_source_root") \
+  <(list_generated_sources "$consumer/baml_client")
 if find "$consumer" -type f \
   \( -name '*.proto' -o -name '*.baml' -o -name '*.toml' -o -name '*.bin' \) \
   | grep -q .; then

--- a/scripts/baml-csharp-release-contract
+++ b/scripts/baml-csharp-release-contract
@@ -24,6 +24,10 @@ VERSION_RE = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
     r"(?:-[0-9A-Za-z](?:[0-9A-Za-z.-]*[0-9A-Za-z])?)?$"
 )
+GENERATED_SOURCE_SENTINELS = (
+    "Baml/Generated/BamlProgram.g.cs",
+    "CsharpSlice/Functions.g.cs",
+)
 
 
 class ContractError(ValueError):
@@ -198,6 +202,100 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def generated_source_digests(root: Path) -> dict[str, str]:
+    if root.is_symlink():
+        fail(f"generated source root must not be a symlink: {root}")
+    if not root.is_dir():
+        fail(f"generated source root is missing: {root}")
+
+    digests: dict[str, str] = {}
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            fail(f"generated source tree contains a symlink: {relative}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            fail(f"generated source tree contains a non-file: {relative}")
+        if not path.name.endswith(".g.cs"):
+            fail(f"generated source tree contains a non-.g.cs file: {relative}")
+        if "\n" in relative or "\r" in relative:
+            fail(f"generated source tree contains an unsafe path: {relative!r}")
+        digests[relative] = sha256(path)
+
+    missing = [
+        relative
+        for relative in GENERATED_SOURCE_SENTINELS
+        if relative not in digests
+    ]
+    if missing:
+        fail(f"generated source tree is missing required entry points: {missing}")
+    return dict(sorted(digests.items()))
+
+
+def parse_generated_source_manifest(path: Path) -> dict[str, str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        fail(f"generated source manifest does not exist: {path}")
+    except UnicodeDecodeError:
+        fail(f"generated source manifest is not UTF-8: {path}")
+
+    entries: dict[str, str] = {}
+    for index, line in enumerate(text.splitlines(), start=1):
+        match = re.fullmatch(r"([0-9a-f]{64})  ([^\r\n]+\.g\.cs)", line)
+        if match is None:
+            fail(f"generated source manifest has an invalid row {index}: {path}")
+        digest, relative = match.groups()
+        parts = Path(relative).parts
+        if (
+            relative.startswith("/")
+            or "\\" in relative
+            or Path(relative).as_posix() != relative
+            or any(part in {"", ".", ".."} for part in parts)
+        ):
+            fail(
+                f"generated source manifest has an unsafe path on row {index}: "
+                f"{relative}"
+            )
+        if relative in entries:
+            fail(f"generated source manifest repeats a path: {relative}")
+        entries[relative] = digest
+
+    if not entries:
+        fail(f"generated source manifest is empty: {path}")
+    return entries
+
+
+def write_generated_manifest(args: argparse.Namespace) -> None:
+    digests = generated_source_digests(args.root)
+    content = "".join(
+        f"{digest}  {relative}\n"
+        for relative, digest in digests.items()
+    )
+    write_new(args.manifest, content)
+
+
+def verify_generated_sources(args: argparse.Namespace) -> None:
+    actual = generated_source_digests(args.root)
+    if args.manifest is None:
+        return
+
+    expected = parse_generated_source_manifest(args.manifest)
+    missing = sorted(set(expected) - set(actual))
+    unexpected = sorted(set(actual) - set(expected))
+    modified = sorted(
+        relative
+        for relative in set(actual) & set(expected)
+        if actual[relative] != expected[relative]
+    )
+    if missing or unexpected or modified:
+        fail(
+            "generated source tree does not match its preparation manifest: "
+            f"missing={missing}, unexpected={unexpected}, modified={modified}"
+        )
 
 
 def artifact_files(root: Path) -> list[Path]:
@@ -471,6 +569,14 @@ def build_parser() -> argparse.ArgumentParser:
     matrix_parser = subparsers.add_parser("matrix")
     matrix_parser.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
 
+    write_generated = subparsers.add_parser("write-generated-manifest")
+    write_generated.add_argument("--root", type=Path, required=True)
+    write_generated.add_argument("--manifest", type=Path, required=True)
+
+    verify_generated = subparsers.add_parser("verify-generated-sources")
+    verify_generated.add_argument("--root", type=Path, required=True)
+    verify_generated.add_argument("--manifest", type=Path)
+
     stage = subparsers.add_parser("stage-native")
     stage.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
     stage.add_argument("--downloads", type=Path, required=True)
@@ -500,6 +606,12 @@ def main() -> None:
             print(f"ok: {len(targets)} required C# targets")
         elif args.command == "matrix":
             print(json.dumps(matrix(args.platforms), separators=(",", ":")))
+        elif args.command == "write-generated-manifest":
+            write_generated_manifest(args)
+            print("ok: wrote C# generated source manifest")
+        elif args.command == "verify-generated-sources":
+            verify_generated_sources(args)
+            print("ok: C# generated source integrity")
         elif args.command == "stage-native":
             stage_native(args)
         elif args.command == "verify-product":

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -16,6 +16,9 @@ PLATFORMS = ROOT / "release" / "platforms.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
 SIZE_POLICY = ROOT / "release" / "csharp-package-size-policy.json"
 NUGET_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-csharp-sdk.yaml"
+CSHARP_PREPARER = (
+    ROOT / ".github" / "workflows" / "prepare-csharp-sdk.reusable.yaml"
+)
 CSHARP_VERIFIER = (
     ROOT
     / ".github"
@@ -45,6 +48,16 @@ NUGET_NORMALIZER = (
     / "Baml.NuGetNormalizer"
     / "Program.cs"
 )
+PRIMITIVE_CONSUMER = (
+    ROOT
+    / "baml_language"
+    / "sdks"
+    / "csharp"
+    / "bridge_csharp"
+    / "tests"
+    / "Baml.Bridge.PrimitivePackageConsumer"
+    / "verify.sh"
+)
 
 
 class CSharpReleaseContractTests(unittest.TestCase):
@@ -70,6 +83,123 @@ class CSharpReleaseContractTests(unittest.TestCase):
 
     def current_contract(self) -> dict:
         return json.loads(PLATFORMS.read_text(encoding="utf-8"))
+
+    def write_generated_sources(self, root: Path) -> Path:
+        generated = root / "baml_client"
+        sources = {
+            "Baml/Generated/BamlProgram.g.cs": "program",
+            "Baml/Http/Request.g.cs": "request",
+            "CsharpSlice/Functions.g.cs": "functions",
+        }
+        for relative, content in sources.items():
+            path = generated / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        return generated
+
+    def test_generated_source_manifest_accepts_growth_and_pins_exact_content(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            generated = self.write_generated_sources(root)
+            manifest = root / "generated-sources.sha256"
+            self.run_tool(
+                "write-generated-manifest",
+                "--root",
+                str(generated),
+                "--manifest",
+                str(manifest),
+            )
+            self.run_tool(
+                "verify-generated-sources",
+                "--root",
+                str(generated),
+                "--manifest",
+                str(manifest),
+            )
+            rows = manifest.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(
+                [row.split("  ", maxsplit=1)[1] for row in rows],
+                [
+                    "Baml/Generated/BamlProgram.g.cs",
+                    "Baml/Http/Request.g.cs",
+                    "CsharpSlice/Functions.g.cs",
+                ],
+            )
+
+            (generated / "Baml/Http/Request.g.cs").write_text(
+                "modified",
+                encoding="utf-8",
+            )
+            result = self.run_tool(
+                "verify-generated-sources",
+                "--root",
+                str(generated),
+                "--manifest",
+                str(manifest),
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("modified=['Baml/Http/Request.g.cs']", result.stderr)
+
+    def test_generated_source_manifest_rejects_missing_and_unexpected_inputs(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            generated = self.write_generated_sources(root)
+            manifest = root / "generated-sources.sha256"
+            self.run_tool(
+                "write-generated-manifest",
+                "--root",
+                str(generated),
+                "--manifest",
+                str(manifest),
+            )
+            extra = generated / "Baml/Time/Duration.g.cs"
+            extra.parent.mkdir(parents=True, exist_ok=True)
+            extra.write_text("duration", encoding="utf-8")
+            result = self.run_tool(
+                "verify-generated-sources",
+                "--root",
+                str(generated),
+                "--manifest",
+                str(manifest),
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unexpected=['Baml/Time/Duration.g.cs']", result.stderr)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            generated = self.write_generated_sources(root)
+            (generated / "CsharpSlice/Functions.g.cs").unlink()
+            result = self.run_tool(
+                "write-generated-manifest",
+                "--root",
+                str(generated),
+                "--manifest",
+                str(root / "generated-sources.sha256"),
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("missing required entry points", result.stderr)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            generated = self.write_generated_sources(root)
+            (generated / "unexpected.json").write_text("{}", encoding="utf-8")
+            result = self.run_tool(
+                "write-generated-manifest",
+                "--root",
+                str(generated),
+                "--manifest",
+                str(root / "generated-sources.sha256"),
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("non-.g.cs file", result.stderr)
 
     def test_exact_required_matrix(self) -> None:
         output = self.run_tool("matrix").stdout
@@ -452,7 +582,10 @@ class WorkflowGraphTests(unittest.TestCase):
 
     def test_nuget_repair_and_nightly_pack_contracts_are_fail_closed(self) -> None:
         publisher = NUGET_PUBLISHER.read_text(encoding="utf-8")
+        preparer = CSHARP_PREPARER.read_text(encoding="utf-8")
         verifier = CSHARP_VERIFIER.read_text(encoding="utf-8")
+        primitive_consumer = PRIMITIVE_CONSUMER.read_text(encoding="utf-8")
+        release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         cargo_tests = CARGO_TESTS.read_text(encoding="utf-8")
         pack = PACK_PRODUCT.read_text(encoding="utf-8")
         normalizer = NUGET_NORMALIZER.read_text(encoding="utf-8")
@@ -468,6 +601,18 @@ class WorkflowGraphTests(unittest.TestCase):
             "- name: Restore and execute the exact public version from a clean cache"
         )
         self.assertNotIn("\n        if:", publisher[smoke : smoke + 300])
+        self.assertIn("environment: boundary-tools-prod", publisher)
+        self.assertIn("publish2-csharp-sdk.yaml", publisher)
+        self.assertNotIn("\n    secrets:\n", publisher)
+        self.assertIn("user: ${{ secrets.NUGET_USER }}", publisher)
+        self.assertNotIn("NUGET_USER: ${{ secrets.NUGET_USER }}", release)
+        self.assertIn("write-generated-manifest", preparer)
+        self.assertIn("verify-generated-sources", verifier)
+        self.assertIn("generated-sources.sha256", verifier)
+        self.assertIn("verify-generated-sources", publisher)
+        self.assertNotIn("Baml/Csv/CsvError.g.cs", preparer)
+        self.assertNotIn("Baml/Csv/CsvError.g.cs", verifier)
+        self.assertNotIn("Baml/Csv/CsvError.g.cs", primitive_consumer)
 
         self.assertIn(".registry_versions.nuget", pack)
         self.assertIn('-p:PackageVersion="$nuget_version"', pack)

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -613,6 +613,8 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertNotIn("Baml/Csv/CsvError.g.cs", preparer)
         self.assertNotIn("Baml/Csv/CsvError.g.cs", verifier)
         self.assertNotIn("Baml/Csv/CsvError.g.cs", primitive_consumer)
+        self.assertIn("list_generated_sources", primitive_consumer)
+        self.assertNotIn("-printf", primitive_consumer)
 
         self.assertIn(".registry_versions.nuget", pack)
         self.assertIn('-p:PackageVersion="$nuget_version"', pack)


### PR DESCRIPTION
## Summary

- replace the stale 11-file C# generator assertion with a preparation-time SHA-256 manifest that binds the complete generated source tree through verification and publication
- retain essential generated entry-point checks and exact copy verification in the clean package consumer
- attach the reusable NuGet publisher to the existing `boundary-tools-prod` environment so Infisical-hydrated `NUGET_USER` is resolved where `NuGet/login` runs
- align the documented trusted-publishing identity with `publish2-csharp-sdk.yaml` and remove the invalid caller-to-reusable-workflow secret forwarding

## Why

The release integration itself was green after #4158, but the production release failed during C# preparation because Dhilan's Swift/release work also expanded the generated C# stdlib surface from 11 to 35 legitimate `.g.cs` files. The hard-coded filename snapshot was not a sound product invariant. This keeps Dhilan's generator output and changes the release contract to pin what preparation actually produced, including paths and hashes, so later additions, removals, or content changes still fail closed.

The NuGet trusted-publisher policy is configured for the reusable workflow and existing `boundary-tools-prod` environment. GitHub environment secrets are resolved in the called job; they are not passed from the caller.

## Validation

- regenerated `sdk_tests/crates/csharp/primitive_slice` with the current CLI
- wrote and verified a manifest for all 35 generated `.g.cs` files
- `python3 -m unittest scripts.tests.test_release_pipeline_contract` (9 tests)
- Python compile checks
- workflow YAML parse checks
- `bash -n` on the package consumer
- `git diff --check`
- repository pre-commit hooks, including YAML validation

## Safety

No compiler/runtime semantics, stdlib implementation, platform support, or shared CFFI artifact format is changed. This PR does not trigger a production release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added SHA-256–based integrity validation for generated C# client sources via a generated `generated-sources.sha256` manifest.
  * Workflow verification now produces and checks the manifest for the generated sources directory, including carrying it into product outputs.
  * NuGet publishing workflow updates to rely on the reusable workflow’s own trusted-publishing secret configuration.
* **Bug Fixes**
  * Replaced brittle hardcoded `*.g.cs` filename list comparisons with manifest-driven validation (missing/unexpected/modified detection).
* **Tests**
  * Expanded contract and pipeline tests to cover manifest “growth,” exact pinned content, missing/extra inputs, and invalid manifest data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->