### PR TITLE
fix(release): isolate wrapper publication

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -700,6 +700,15 @@ jobs:
     steps:
       - run: echo "all release build jobs completed"
 
+  wrapper-builds:
+    name: All wrapper builds gate
+    runs-on: ubuntu-latest
+    needs:
+      - plan
+      - build-wrapper
+    steps:
+      - run: echo "all wrapper build jobs completed"
+
   publish-pypi:
     name: Publish Python PyPI
     needs: [plan, all-builds]
@@ -1112,7 +1121,7 @@ jobs:
 
   publish-wrapper-release:
     name: Publish wrapper release assets
-    needs: [plan, all-builds]
+    needs: [plan, wrapper-builds]
     if: ${{ needs.plan.outputs.wrapper_changed == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     env:
@@ -1532,6 +1541,7 @@ jobs:
       - publish-crates-io
       - publish-homebrew
       - publish-aur
+      - publish-wrapper-manifest
     if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     steps:
@@ -1551,6 +1561,7 @@ jobs:
           CRATES_IO: ${{ needs.publish-crates-io.result }}
           HOMEBREW: ${{ needs.publish-homebrew.result }}
           AUR: ${{ needs.publish-aur.result }}
+          WRAPPER_MANIFEST: ${{ needs.publish-wrapper-manifest.result }}
           CHANNEL: ${{ needs.plan.outputs.channel }}
           WRAPPER_CHANGED: ${{ needs.plan.outputs.wrapper_changed }}
         run: |
@@ -1593,10 +1604,12 @@ jobs:
             require_success wrapper-assets "$WRAPPER"
             require_success Homebrew "$HOMEBREW"
             require_success AUR "$AUR"
+            require_success wrapper-manifest "$WRAPPER_MANIFEST"
           else
             require_skipped wrapper-assets "$WRAPPER"
             require_skipped Homebrew "$HOMEBREW"
             require_skipped AUR "$AUR"
+            require_skipped wrapper-manifest "$WRAPPER_MANIFEST"
           fi
 
   publish-pkg-boundaryml-com:
@@ -1650,7 +1663,6 @@ jobs:
           role-session-name: baml-language-release-${{ github.run_id }}
       - name: Generate release manifests
         env:
-          WRAPPER_CHANGED: ${{ needs.plan.outputs.wrapper_changed }}
           CRATES_IO_VERSION: ${{ needs.plan.outputs.crates_io_version }}
           NUGET_VERSION: ${{ needs.plan.outputs.nuget_version }}
           SWIFTPM_VERSION: ${{ needs.plan.outputs.swiftpm_version }}
@@ -1662,9 +1674,6 @@ jobs:
         run: |
           set -euo pipefail
           args=()
-          if [[ "$WRAPPER_CHANGED" == "true" ]]; then
-            args+=(--wrapper-changed)
-          fi
           (
             cd dist/csharp
             sha256sum -c product-package.sha256
@@ -1743,11 +1752,6 @@ jobs:
 
           version="${{ needs.plan.outputs.version }}"
           upload_immutable "manifests/version/$version.json" "manifest/v1/version/$version.json"
-          if [[ -f manifests/wrapper.json ]]; then
-            aws s3 cp manifests/wrapper.json "s3://$PKG_BUCKET/manifest/v1/wrapper.json" \
-              --content-type application/json \
-              --cache-control "public, max-age=60, must-revalidate"
-          fi
           aws s3 cp scripts/install.sh "s3://$PKG_BUCKET/install.sh" --content-type text/x-shellscript --cache-control "public, max-age=60, must-revalidate"
           aws s3 cp scripts/install.ps1 "s3://$PKG_BUCKET/install.ps1" --content-type text/plain --cache-control "public, max-age=60, must-revalidate"
           aws s3 cp tools/pkg_boundaryml_com/data/index.html "s3://$PKG_BUCKET/index.html" --content-type text/html --cache-control "public, max-age=300"
@@ -1898,7 +1902,7 @@ jobs:
 
   publish-homebrew:
     name: Publish Homebrew wrapper formula
-    needs: [plan, all-builds, publish-wrapper-release]
+    needs: [plan, wrapper-builds, publish-wrapper-release]
     if: ${{ needs.plan.outputs.wrapper_changed == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: macos-14
     steps:
@@ -1950,7 +1954,7 @@ jobs:
 
   publish-aur:
     name: Publish AUR wrapper packages
-    needs: [plan, all-builds, publish-wrapper-release]
+    needs: [plan, wrapper-builds, publish-wrapper-release]
     if: ${{ needs.plan.outputs.wrapper_changed == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     steps:
@@ -2002,6 +2006,45 @@ jobs:
             git push origin HEAD
             cd ..
           done
+
+  publish-wrapper-manifest:
+    name: Publish wrapper manifest
+    needs: [plan, publish-wrapper-release, publish-homebrew, publish-aur]
+    if: ${{ needs.plan.outputs.wrapper_changed == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.plan.outputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wrapper-*
+          path: dist/wrapper
+          merge-multiple: true
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: baml-wrapper-release-${{ github.run_id }}
+      - name: Generate wrapper manifest
+        env:
+          RELEASED_AT: ${{ needs.plan.outputs.released_at }}
+          WRAPPER_VERSION: ${{ needs.plan.outputs.wrapper_version }}
+        run: |
+          set -euo pipefail
+          scripts/baml-release-manifests \
+            --wrapper-only \
+            --wrapper-dir dist/wrapper \
+            --out manifests \
+            --released-at "$RELEASED_AT" \
+            --wrapper-version "$WRAPPER_VERSION"
+      - name: Upload wrapper manifest
+        run: |
+          aws s3 cp manifests/wrapper.json \
+            "s3://$PKG_BUCKET/manifest/v1/wrapper.json" \
+            --content-type application/json \
+            --cache-control "public, max-age=60, must-revalidate"
 
   dry-run-artifacts:
     name: Generate dry-run manifests and package files

--- a/scripts/baml-release-manifests
+++ b/scripts/baml-release-manifests
@@ -16,7 +16,9 @@ def _toolchain_required_targets() -> list[str]:
     set lives in one machine-readable place instead of a hand-copied list.
     Required = the `toolchain` artifact is present and not experimental."""
     contract = json.loads(
-        (Path(__file__).resolve().parent.parent / "release" / "platforms.json").read_text()
+        (
+            Path(__file__).resolve().parent.parent / "release" / "platforms.json"
+        ).read_text()
     )
     targets = []
     for target in contract["targets"]:
@@ -63,7 +65,9 @@ def collect_artifacts(
     missing = sorted(set(TARGETS) - set(artifacts))
     extra = sorted(set(artifacts) - set(TARGETS))
     if missing or extra:
-        raise SystemExit(f"{product} artifact target mismatch missing={missing} extra={extra}")
+        raise SystemExit(
+            f"{product} artifact target mismatch missing={missing} extra={extra}"
+        )
     return artifacts
 
 
@@ -98,17 +102,31 @@ def collect_cffi_artifacts(root: Path, version: str) -> dict[str, dict[str, str]
     return artifacts
 
 
+def write_wrapper_manifest(
+    out: Path, wrapper_dir: Path, wrapper_version: str, released_at: str
+) -> None:
+    wrapper = {
+        "schema": 1,
+        "version": wrapper_version,
+        "released_at": released_at,
+        "artifacts": collect_artifacts(wrapper_dir, "baml-wrapper", wrapper_version),
+    }
+    (out / "wrapper.json").write_text(
+        json.dumps(wrapper, indent=2, sort_keys=True) + "\n"
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--toolchain-dir", required=True, type=Path)
-    parser.add_argument("--cffi-dir", required=True, type=Path)
+    parser.add_argument("--toolchain-dir", type=Path)
+    parser.add_argument("--cffi-dir", type=Path)
     parser.add_argument("--wrapper-dir", required=True, type=Path)
-    parser.add_argument("--vsix-dir", required=True, type=Path)
+    parser.add_argument("--vsix-dir", type=Path)
     parser.add_argument("--out", required=True, type=Path)
-    parser.add_argument("--channel", required=True, choices=["canary", "nightly"])
-    parser.add_argument("--version", required=True)
+    parser.add_argument("--channel", choices=["canary", "nightly"])
+    parser.add_argument("--version")
     parser.add_argument("--released-at", required=True)
-    parser.add_argument("--pypi-version", required=True)
+    parser.add_argument("--pypi-version")
     # Registry coordinates are optional to keep this utility useful for partial
     # fixture generation; the release workflow supplies every enabled SDK only
     # after its publisher succeeds.
@@ -119,6 +137,7 @@ def main() -> None:
     parser.add_argument("--swift-package-sha256", default=None)
     parser.add_argument("--wrapper-version", required=True)
     parser.add_argument("--wrapper-changed", action="store_true")
+    parser.add_argument("--wrapper-only", action="store_true")
     args = parser.parse_args()
 
     for version, digest, version_flag, digest_flag in (
@@ -145,15 +164,31 @@ def main() -> None:
         ):
             raise SystemExit(f"{digest_flag} must be a lowercase SHA-256 digest")
     try:
-        released_at = dt.datetime.fromisoformat(
-            args.released_at.replace("Z", "+00:00")
-        )
+        released_at = dt.datetime.fromisoformat(args.released_at.replace("Z", "+00:00"))
     except ValueError as exc:
         raise SystemExit("--released-at must be an ISO-8601 timestamp") from exc
     if released_at.tzinfo is None or not args.released_at.endswith("Z"):
         raise SystemExit("--released-at must be a UTC timestamp ending in Z")
 
     args.out.mkdir(parents=True, exist_ok=True)
+    if args.wrapper_only:
+        write_wrapper_manifest(
+            args.out, args.wrapper_dir, args.wrapper_version, args.released_at
+        )
+        return
+
+    required = {
+        "--toolchain-dir": args.toolchain_dir,
+        "--cffi-dir": args.cffi_dir,
+        "--vsix-dir": args.vsix_dir,
+        "--channel": args.channel,
+        "--version": args.version,
+        "--pypi-version": args.pypi_version,
+    }
+    missing = [flag for flag, value in required.items() if value is None]
+    if missing:
+        parser.error(f"the following arguments are required: {', '.join(missing)}")
+
     (args.out / "version").mkdir(parents=True, exist_ok=True)
     released_at = args.released_at
 
@@ -165,7 +200,9 @@ def main() -> None:
         "version": args.version,
         "channel": args.channel,
         "released_at": released_at,
-        "artifacts": collect_artifacts(args.toolchain_dir, "baml-language", args.version),
+        "artifacts": collect_artifacts(
+            args.toolchain_dir, "baml-language", args.version
+        ),
         "vsix": {
             "url": artifact_url(f"baml-language-{args.version}", vsix),
             "sha256": sha256(vsix),
@@ -210,13 +247,9 @@ def main() -> None:
     (args.out / f"{args.channel}.json").write_text(text)
 
     if args.wrapper_changed:
-        wrapper = {
-            "schema": 1,
-            "version": args.wrapper_version,
-            "released_at": released_at,
-            "artifacts": collect_artifacts(args.wrapper_dir, "baml-wrapper", args.wrapper_version),
-        }
-        (args.out / "wrapper.json").write_text(json.dumps(wrapper, indent=2, sort_keys=True) + "\n")
+        write_wrapper_manifest(
+            args.out, args.wrapper_dir, args.wrapper_version, released_at
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_baml_release_manifests.py
+++ b/scripts/tests/test_baml_release_manifests.py
@@ -24,6 +24,12 @@ class ReleaseManifestTests(unittest.TestCase):
             directory.mkdir()
 
         contract = json.loads(PLATFORMS.read_text(encoding="utf-8"))
+        self.required_targets = {
+            target["triple"]
+            for target in contract["targets"]
+            if target["artifacts"].get("toolchain") is not None
+            and not target["artifacts"]["toolchain"].get("experimental", False)
+        }
         for target in contract["targets"]:
             triple = target["triple"]
             suffix = ".zip" if target["os"] == "windows" else ".tar.gz"
@@ -120,6 +126,28 @@ class ReleaseManifestTests(unittest.TestCase):
                 "verified_package_sha256": digest,
             },
         )
+
+    def test_wrapper_manifest_can_be_generated_independently(self) -> None:
+        output = self.root / "wrapper-only"
+        subprocess.run(
+            [
+                str(MANIFEST_TOOL),
+                "--wrapper-only",
+                "--wrapper-dir",
+                str(self.wrapper),
+                "--out",
+                str(output),
+                "--released-at",
+                "2026-07-23T12:34:56Z",
+                "--wrapper-version",
+                "9.8.7",
+            ],
+            cwd=ROOT,
+            check=True,
+        )
+        manifest = json.loads((output / "wrapper.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["version"], "9.8.7")
+        self.assertEqual(set(manifest["artifacts"]), self.required_targets)
 
     def test_partial_or_invalid_native_sdk_identity_fails(self) -> None:
         cases = (

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -17,15 +17,10 @@ RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
 SIZE_POLICY = ROOT / "release" / "csharp-package-size-policy.json"
 NUGET_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-csharp-sdk.yaml"
 CSHARP_VERIFIER = (
-    ROOT
-    / ".github"
-    / "workflows"
-    / "verify-csharp-product-slice.reusable.yaml"
+    ROOT / ".github" / "workflows" / "verify-csharp-product-slice.reusable.yaml"
 )
 CARGO_TESTS = ROOT / ".github" / "workflows" / "cargo-tests.reusable.yaml"
-CFFI_BUILDER = (
-    ROOT / ".github" / "workflows" / "build2-bridge-cffi.reusable.yaml"
-)
+CFFI_BUILDER = ROOT / ".github" / "workflows" / "build2-bridge-cffi.reusable.yaml"
 PACK_PRODUCT = (
     ROOT
     / "baml_language"
@@ -277,7 +272,9 @@ class CSharpReleaseContractTests(unittest.TestCase):
         )
         return path
 
-    def verify(self, root: Path, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def verify(
+        self, root: Path, *, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
         return self.run_tool(
             "verify-product",
             "--release-plan",
@@ -315,7 +312,10 @@ class CSharpReleaseContractTests(unittest.TestCase):
             {"duplicate_target": target},
         )
         for option in options:
-            with self.subTest(option=option), tempfile.TemporaryDirectory() as temporary:
+            with (
+                self.subTest(option=option),
+                tempfile.TemporaryDirectory() as temporary,
+            ):
                 root = Path(temporary)
                 result = self.stage(
                     root,
@@ -373,7 +373,12 @@ class WorkflowGraphTests(unittest.TestCase):
         cffi = job_block(workflow, "build-bridge-cffi")
         verify = job_block(workflow, "verify-csharp-sdk")
         all_builds = job_block(workflow, "all-builds")
+        wrapper_builds = job_block(workflow, "wrapper-builds")
         nuget = job_block(workflow, "publish-csharp-sdk")
+        wrapper_release = job_block(workflow, "publish-wrapper-release")
+        homebrew = job_block(workflow, "publish-homebrew")
+        aur = job_block(workflow, "publish-aur")
+        wrapper_manifest = job_block(workflow, "publish-wrapper-manifest")
         prerequisites = job_block(workflow, "release-prerequisites-complete")
         complete = job_block(workflow, "release-complete")
         manifest = job_block(workflow, "publish-pkg-boundaryml-com")
@@ -389,6 +394,15 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("build-bridge-cffi", verify)
         self.assertIn("- verify-csharp-sdk", all_builds)
         self.assertIn("all-builds", nuget)
+        self.assertIn("- build-wrapper", wrapper_builds)
+        self.assertNotIn("all-builds", wrapper_builds)
+        for publisher in (wrapper_release, homebrew, aur):
+            self.assertIn("wrapper-builds", publisher)
+            self.assertNotIn("all-builds", publisher)
+        self.assertIn("publish-wrapper-release", wrapper_manifest)
+        self.assertIn("publish-homebrew", wrapper_manifest)
+        self.assertIn("publish-aur", wrapper_manifest)
+        self.assertIn("--wrapper-only", wrapper_manifest)
         for publisher in (
             "publish-pypi",
             "publish-nodejs-sdk",
@@ -403,6 +417,7 @@ class WorkflowGraphTests(unittest.TestCase):
             "publish-crates-io",
             "publish-homebrew",
             "publish-aur",
+            "publish-wrapper-manifest",
         ):
             self.assertIn(f"- {publisher}", prerequisites)
         self.assertIn(
@@ -424,7 +439,6 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("--swift-package-sha256", dry_run)
         for block in (manifest, dry_run):
             for output, variable in (
-                ("wrapper_changed", "WRAPPER_CHANGED"),
                 ("crates_io_version", "CRATES_IO_VERSION"),
                 ("nuget_version", "NUGET_VERSION"),
                 ("swiftpm_version", "SWIFTPM_VERSION"),
@@ -438,6 +452,11 @@ class WorkflowGraphTests(unittest.TestCase):
                     f"{variable}: ${{{{ needs.plan.outputs.{output} }}}}",
                     block,
                 )
+        self.assertIn(
+            "WRAPPER_CHANGED: ${{ needs.plan.outputs.wrapper_changed }}",
+            dry_run,
+        )
+        self.assertNotIn("WRAPPER_CHANGED", manifest)
 
         swift_verify = job_block(workflow, "verify-swift-sdk")
         swift_smoke = job_block(workflow, "smoke-swift-release")
@@ -456,9 +475,9 @@ class WorkflowGraphTests(unittest.TestCase):
         cargo_tests = CARGO_TESTS.read_text(encoding="utf-8")
         pack = PACK_PRODUCT.read_text(encoding="utf-8")
         normalizer = NUGET_NORMALIZER.read_text(encoding="utf-8")
-        self.assertIn('404)', publisher)
+        self.assertIn("404)", publisher)
         self.assertIn('echo "publish=true"', publisher)
-        self.assertIn('200)', publisher)
+        self.assertIn("200)", publisher)
         self.assertIn('compare "$PACKAGE"', publisher)
         self.assertIn(
             "if: ${{ steps.existing.outputs.publish == 'true' }}",
@@ -472,7 +491,7 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn(".registry_versions.nuget", pack)
         self.assertIn('-p:PackageVersion="$nuget_version"', pack)
         self.assertIn('-p:InformationalVersion="$canonical_version"', pack)
-        self.assertNotIn("baml-language-version\" show", pack)
+        self.assertNotIn('baml-language-version" show', pack)
         self.assertNotIn("workflow_run_attempt", pack)
         self.assertNotIn("baml-language-version show", verifier)
         self.assertIn(".registry_versions.nuget", verifier)


### PR DESCRIPTION
## Summary

- gate wrapper release assets on wrapper builds instead of the full language build fan-in
- publish Homebrew, AUR, and the wrapper manifest independently of unrelated SDK failures
- add wrapper-only manifest generation and workflow contract coverage

## Validation

- `python3 -m unittest scripts.tests.test_baml_release_manifests scripts.tests.test_baml_package_manager_artifacts scripts.tests.test_release_pipeline_contract`
- `mise exec -- actionlint .github/workflows/release-baml-language.yml`
- `mise exec -- ruff check scripts/baml-release-manifests scripts/tests/test_baml_release_manifests.py scripts/tests/test_release_pipeline_contract.py`
- changed-file prek hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent generation and publishing of the wrapper manifest.
  * Wrapper-related releases can now proceed based solely on wrapper build artifacts.
  * Added support for generating `wrapper.json` independently through a dedicated option.

* **Bug Fixes**
  * Improved release workflow gating so wrapper publications no longer wait for unrelated build artifacts.

* **Tests**
  * Added coverage validating standalone wrapper manifest generation and release workflow requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->