### PR TITLE
Fix C# package verification LLVM setup

### DIFF
--- a/.github/workflows/verify-csharp-product-slice.reusable.yaml
+++ b/.github/workflows/verify-csharp-product-slice.reusable.yaml
@@ -38,6 +38,17 @@ jobs:
         with:
           dotnet-version: 10.0.301
 
+      - name: Install cross-platform package inspection tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends llvm-18
+          llvm_bin="/usr/lib/llvm-18/bin"
+          for tool in llvm-nm llvm-objdump llvm-readobj; do
+            test -x "$llvm_bin/$tool"
+          done
+          echo "$llvm_bin" >> "$GITHUB_PATH"
+
       - uses: actions/download-artifact@v4
         with:
           pattern: bridge-cffi-*


### PR DESCRIPTION
## What changed

- Install the Ubuntu `llvm-18` package in the C# product-package assembly job.
- Verify `llvm-nm`, `llvm-objdump`, and `llvm-readobj` are present.
- Add `/usr/lib/llvm-18/bin` to the following steps' `PATH`.

## Why

Release run [30059621238](https://github.com/BoundaryML/baml/actions/runs/30059621238/job/89381497571) passed generated-source integrity, then failed in `pack-product.sh` because `llvm-nm` was unavailable. The Ubuntu x64 runner image includes Clang, but does not install the full LLVM inspection tool package. The C# packer needs LLVM's cross-format inspectors for the ELF, Mach-O, and COFF assets in the product package.

This keeps those package checks fail-closed instead of weakening or removing them.

## Validation

- Repository commit hooks passed, including YAML validation.
- `git diff --check` passed.
- In a clean `ubuntu:24.04` container, installing `llvm-18` produced executable `llvm-nm`, `llvm-objdump`, and `llvm-readobj` under `/usr/lib/llvm-18/bin`; each reported LLVM 18.1.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cross-platform build and packaging verification.
  * Added additional validation tools to help ensure generated product artifacts are inspected consistently before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->