### PR TITLE
Fix C# release plan schema contract

### DIFF
--- a/scripts/baml-csharp-release-contract
+++ b/scripts/baml-csharp-release-contract
@@ -418,8 +418,8 @@ def stage_native(args: argparse.Namespace) -> None:
 
 def load_plan(path: Path) -> tuple[str, str]:
     plan = load_json(path, "release plan")
-    if not isinstance(plan, dict) or plan.get("schema") != 2:
-        fail("release plan must be a schema-2 JSON object")
+    if not isinstance(plan, dict) or plan.get("schema") != 3:
+        fail("release plan must be a schema-3 JSON object")
     canonical = require_string(plan.get("canonical_version"), "canonical_version")
     registry_versions = plan.get("registry_versions")
     if not isinstance(registry_versions, dict):

--- a/scripts/baml-language-version
+++ b/scripts/baml-language-version
@@ -66,10 +66,9 @@ CANONICAL_RE = re.compile(
 )
 SHA_RE = re.compile(r"^[a-z]$")
 
-# Release-plan schema. Version 2 carries per-registry versions in a
-# `registry_versions` map instead of a flat `pypi_version` field, so a new
-# registry adds a map entry rather than a top-level field. The loader fails
-# closed on any other schema.
+# Release-plan schema. Version 3 carries every shipping registry version in
+# `registry_versions` and binds release metadata to a deterministic
+# `released_at` timestamp. The loader fails closed on any other schema.
 PLAN_SCHEMA = 3
 
 # Registries whose package version this plan carries. npm, crates.io, NuGet,

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_TOOL = ROOT / "scripts" / "baml-csharp-release-contract"
+VERSION_TOOL = ROOT / "scripts" / "baml-language-version"
 PLATFORMS = ROOT / "release" / "platforms.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
 SIZE_POLICY = ROOT / "release" / "csharp-package-size-policy.json"
@@ -372,6 +373,7 @@ class CSharpReleaseContractTests(unittest.TestCase):
         *,
         check: bool = True,
     ) -> subprocess.CompletedProcess[str]:
+        plan = json.loads(self.write_plan(root).read_text(encoding="utf-8"))
         return self.run_tool(
             "stage-native",
             "--downloads",
@@ -381,7 +383,7 @@ class CSharpReleaseContractTests(unittest.TestCase):
             "--source-sha",
             "1" * 40,
             "--release-version",
-            "1.2.3-nightly.20260723.a",
+            plan["canonical_version"],
             "--workflow-run-id",
             "29989654236",
             "--provenance",
@@ -393,25 +395,33 @@ class CSharpReleaseContractTests(unittest.TestCase):
 
     def write_plan(self, root: Path) -> Path:
         path = root / "release-plan.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "schema": 2,
-                    "canonical_version": "1.2.3-nightly.20260723.a",
-                    "registry_versions": {
-                        "nuget": "1.2.3-nightly.20260723.a",
-                    },
-                }
-            ),
-            encoding="utf-8",
+        subprocess.run(
+            [
+                str(VERSION_TOOL),
+                "plan",
+                "--channel",
+                "canary",
+                "--out",
+                str(path),
+            ],
+            cwd=ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
         )
         return path
 
-    def verify(self, root: Path, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def verify(
+        self,
+        root: Path,
+        *,
+        plan: Path | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
         return self.run_tool(
             "verify-product",
             "--release-plan",
-            str(self.write_plan(root)),
+            str(plan or self.write_plan(root)),
             "--source-sha",
             "1" * 40,
             "--provenance",
@@ -422,6 +432,25 @@ class CSharpReleaseContractTests(unittest.TestCase):
             str(root / "staging"),
             check=check,
         )
+
+    def test_version_tool_plan_is_accepted_and_schema_2_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.stage(root, self.make_downloads(root))
+            plan_path = self.write_plan(root)
+            plan = json.loads(plan_path.read_text(encoding="utf-8"))
+            self.assertEqual(plan["schema"], 3)
+            self.assertIn("nuget", plan["registry_versions"])
+            self.verify(root, plan=plan_path)
+
+            plan["schema"] = 2
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            result = self.verify(root, plan=plan_path, check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "release plan must be a schema-3 JSON object",
+                result.stderr,
+            )
 
     def test_library_and_checksum_are_accepted_and_cffi_only_extra_is_ignored(
         self,


### PR DESCRIPTION
## What changed

- Make the C# release contract require the current schema-3 release plan.
- Correct the stale release-plan schema documentation.
- Replace the hand-written schema-2 C# test fixture with plans generated by `scripts/baml-language-version`.
- Add a regression proving the producer's schema-3 plan is accepted and a downgraded schema-2 plan is rejected.

## Root cause

The release-plan producer moved to schema 3 when NuGet, Maven, Gradle, SwiftPM, and deterministic `released_at` metadata were added. The C# verifier and its isolated fixture still required schema 2. Release package assembly therefore rejected the valid frozen plan before NuGet packaging, even after the LLVM tooling fix passed.

Observed in release run [30066212741](https://github.com/BoundaryML/baml/actions/runs/30066212741/job/89399285632):

```
error: release plan must be a schema-2 JSON object
```

## Impact

This restores the fail-closed producer/consumer contract without accepting obsolete schema-2 plans and unblocks C# product package verification and downstream NuGet publication.

## Validation

- `python3 -m unittest scripts.tests.test_release_pipeline_contract scripts.tests.test_baml_language_version`
- 13 tests passed.
- Commit hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Pipeline**
  - Updated release plans to schema version 3, including registry-specific versions and deterministic release timestamps.
  - Release tooling now rejects outdated or unsupported plan formats with clear validation errors.
  - Version inputs are generated consistently from the release plan, improving reliability across release channels.

- **Tests**
  - Added coverage confirming schema 3 plans are accepted and schema 2 plans are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->