### PR TITLE
Harden bridge_cffi release artifact hygiene

### DIFF
--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -194,31 +194,32 @@ jobs:
             source_root_native="$(cygpath -aw "$source_root")"
             cargo_root_native="$(cygpath -aw "$cargo_root")"
             rust_sysroot_native="$(cygpath -aw "$rust_sysroot")"
+            source_root_native_short="$(cygpath --absolute --windows --short-name "$source_root")"
+            cargo_root_native_short="$(cygpath --absolute --windows --short-name "$cargo_root")"
+            rust_sysroot_native_short="$(cygpath --absolute --windows --short-name "$rust_sysroot")"
             export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }\
           --remap-path-prefix=$source_root_native=baml-source \
           --remap-path-prefix=$cargo_root_native=cargo-home \
-          --remap-path-prefix=$rust_sysroot_native=rust-toolchain"
-            if [[ "$TARGET" == "aarch64-pc-windows-msvc" ]]; then
-              # The ARM64 runner uses clang-cl. It rejects MSVC's /pathmap,
-              # so pass Clang's equivalent through the clang-cl driver.
-              native_path_maps="\
-          /clang:-fdebug-prefix-map=$source_root_native=baml-source \
-          /clang:-fdebug-prefix-map=$cargo_root_native=cargo-home \
-          /clang:-fdebug-prefix-map=$rust_sysroot_native=rust-toolchain \
-          /clang:-Wno-builtin-macro-redefined \
-          /D__FILE__=\\\"baml-source/native\\\""
-            else
-              # MSVC's /pathmap sanitizes debug metadata but does not rewrite
-              # __FILE__. Give diagnostic strings a stable identity explicitly;
-              # /wd4005 keeps that intentional built-in redefinition compatible
-              # with native projects that promote warnings to errors.
-              native_path_maps="\
-          /pathmap:$source_root_native=baml-source \
-          /pathmap:$cargo_root_native=cargo-home \
-          /pathmap:$rust_sysroot_native=rust-toolchain \
-          /wd4005 \
-          /D__FILE__=\\\"baml-source/native\\\""
-            fi
+          --remap-path-prefix=$rust_sysroot_native=rust-toolchain \
+          --remap-path-prefix=$source_root_native_short=baml-source \
+          --remap-path-prefix=$cargo_root_native_short=cargo-home \
+          --remap-path-prefix=$rust_sysroot_native_short=rust-toolchain"
+            # MSVC's /pathmap only sanitizes debug metadata, not AWS-LC's
+            # __FILE__ strings. Use clang-cl for the native dependency build on
+            # both Windows targets: it is MSVC ABI-compatible and supports
+            # -ffile-prefix-map for debug data and predefined macros. CMake/cc
+            # may pass 8.3 short paths, so map both native representations.
+            command -v clang-cl >/dev/null
+            target_key="${TARGET//-/_}"
+            export "CC_${target_key}=clang-cl"
+            export "CXX_${target_key}=clang-cl"
+            native_path_maps="\
+          /clang:-ffile-prefix-map=$source_root_native=baml-source \
+          /clang:-ffile-prefix-map=$cargo_root_native=cargo-home \
+          /clang:-ffile-prefix-map=$rust_sysroot_native=rust-toolchain \
+          /clang:-ffile-prefix-map=$source_root_native_short=baml-source \
+          /clang:-ffile-prefix-map=$cargo_root_native_short=cargo-home \
+          /clang:-ffile-prefix-map=$rust_sysroot_native_short=rust-toolchain"
             export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"
             export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"
           elif [[ "$TARGET" == *-unknown-linux-gnu ]]; then

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -198,10 +198,44 @@ jobs:
           --remap-path-prefix=$source_root_native=baml-source \
           --remap-path-prefix=$cargo_root_native=cargo-home \
           --remap-path-prefix=$rust_sysroot_native=rust-toolchain"
-            native_path_maps="\
+            if [[ "$TARGET" == "aarch64-pc-windows-msvc" ]]; then
+              # The ARM64 runner uses clang-cl. It rejects MSVC's /pathmap,
+              # so pass Clang's equivalent through the clang-cl driver.
+              native_path_maps="\
+          /clang:-fdebug-prefix-map=$source_root_native=baml-source \
+          /clang:-fdebug-prefix-map=$cargo_root_native=cargo-home \
+          /clang:-fdebug-prefix-map=$rust_sysroot_native=rust-toolchain \
+          /clang:-Wno-builtin-macro-redefined \
+          /D__FILE__=\\\"baml-source/native\\\""
+            else
+              # MSVC's /pathmap sanitizes debug metadata but does not rewrite
+              # __FILE__. Give diagnostic strings a stable identity explicitly;
+              # /wd4005 keeps that intentional built-in redefinition compatible
+              # with native projects that promote warnings to errors.
+              native_path_maps="\
           /pathmap:$source_root_native=baml-source \
           /pathmap:$cargo_root_native=cargo-home \
-          /pathmap:$rust_sysroot_native=rust-toolchain"
+          /pathmap:$rust_sysroot_native=rust-toolchain \
+          /wd4005 \
+          /D__FILE__=\\\"baml-source/native\\\""
+            fi
+            export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"
+            export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"
+          elif [[ "$TARGET" == *-unknown-linux-gnu ]]; then
+            # cross 0.2.5's GNU images intentionally use GCC 5 to retain an old
+            # glibc floor. GCC 5 supports debug-prefix remapping but predates
+            # -ffile-prefix-map/-fmacro-prefix-map. Override the diagnostic-only
+            # __FILE__ identity so AWS-LC cannot retain its /cargo source root,
+            # while still remapping any debug metadata before stripping.
+            native_path_maps="\
+          -fdebug-prefix-map=$source_root=baml-source \
+          -fdebug-prefix-map=$cargo_root=cargo-home \
+          -fdebug-prefix-map=$rust_sysroot=rust-toolchain \
+          -fdebug-prefix-map=/project=baml-source \
+          -fdebug-prefix-map=/cargo=cargo-home \
+          -fdebug-prefix-map=/rust=rust-toolchain \
+          -Wno-builtin-macro-redefined \
+          -D__FILE__=\\\"baml-source/native\\\""
             export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"
             export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"
           else

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -236,7 +236,7 @@ jobs:
           -fdebug-prefix-map=/cargo=cargo-home \
           -fdebug-prefix-map=/rust=rust-toolchain \
           -Wno-builtin-macro-redefined \
-          -D__FILE__=\\\"baml-source/native\\\""
+          -D__FILE__=\"baml-source/native\""
             export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"
             export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"
           else

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -186,6 +186,35 @@ jobs:
           --remap-path-prefix=/project=baml-source \
           --remap-path-prefix=/cargo=cargo-home \
           --remap-path-prefix=/rust=rust-toolchain"
+          if [[ "$TARGET" == *-windows-msvc ]]; then
+            # Git Bash reports cargo's root as a POSIX path while rustc, MSVC,
+            # and CMake embed native drive-letter paths. Remap the exact native
+            # forms that those compilers see; do not assume a runner drive or
+            # username.
+            source_root_native="$(cygpath -aw "$source_root")"
+            cargo_root_native="$(cygpath -aw "$cargo_root")"
+            rust_sysroot_native="$(cygpath -aw "$rust_sysroot")"
+            export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }\
+          --remap-path-prefix=$source_root_native=baml-source \
+          --remap-path-prefix=$cargo_root_native=cargo-home \
+          --remap-path-prefix=$rust_sysroot_native=rust-toolchain"
+            native_path_maps="\
+          /pathmap:$source_root_native=baml-source \
+          /pathmap:$cargo_root_native=cargo-home \
+          /pathmap:$rust_sysroot_native=rust-toolchain"
+            export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"
+            export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"
+          else
+            native_path_maps="\
+          -ffile-prefix-map=$source_root=baml-source \
+          -ffile-prefix-map=$cargo_root=cargo-home \
+          -ffile-prefix-map=$rust_sysroot=rust-toolchain \
+          -ffile-prefix-map=/project=baml-source \
+          -ffile-prefix-map=/cargo=cargo-home \
+          -ffile-prefix-map=/rust=rust-toolchain"
+            export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"
+            export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"
+          fi
           # `bridge_cffi` is `crate-type = ["cdylib", "lib"]`; the cdylib is the
           # release artifact. `release-bridge-cffi` = release + panic = "unwind".
           #
@@ -249,6 +278,18 @@ jobs:
           echo "asset=${asset}" >> "$GITHUB_OUTPUT"
           echo "Built ${asset}"
           cat "${outdir}/${asset}.sha256"
+
+      - name: Verify shipping artifact hygiene
+        working-directory: baml_language
+        env:
+          ARTIFACT_DIR: ${{ steps.artifact.outputs.dir }}
+          ARTIFACT_ASSET: ${{ steps.artifact.outputs.asset }}
+          TARGET: ${{ matrix._.target }}
+        run: |
+          set -euo pipefail
+          ../scripts/baml-bridge-cffi-hygiene verify \
+            --native "${ARTIFACT_DIR}/${ARTIFACT_ASSET}" \
+            --target "$TARGET"
 
       - name: Smoke test the public C and C++ ABI (Unix)
         if: ${{ matrix._.smoke && !contains(matrix._.target, 'windows') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
       proto: ${{ steps.check_proto.outputs.changed }}
       # Flag for profiling-ring changes (bex_events) - triggers loom + miri
       prof: ${{ steps.check_prof.outputs.changed }}
+      # Flag for inputs that can change the shipping bridge_cffi binaries
+      bridge_cffi_release: ${{ steps.check_bridge_cffi_release.outputs.changed }}
       # Flag that is raised when perf benchmarks (CodSpeed) should run: always
       # after merge (push to main/canary) and on manual dispatch; on PRs only
       # when the PR title/body or a commit message opts in.
@@ -83,12 +85,14 @@ jobs:
             ':scripts/baml-wrapper-version' \
             ':scripts/baml-release-manifests' \
             ':scripts/baml-package-manager-artifacts' \
+            ':scripts/baml-bridge-cffi-hygiene' \
             ':scripts/install.sh' \
             ':scripts/install.ps1' \
             ':packaging/aur/**' \
             ':tools/pkg_boundaryml_com/**' \
             ':.github/workflows/ci.yaml' \
             ':.github/workflows/release-baml-language.yml' \
+            ':.github/workflows/build2-bridge-cffi.reusable.yaml' \
             ':.github/workflows/build2-python-sdk.reusable.yaml' \
             ':.github/workflows/build2-nodejs-sdk.reusable.yaml' \
             ':.github/workflows/build2-web-sdk.reusable.yaml' \
@@ -279,6 +283,28 @@ jobs:
             ':baml_language/Cargo.toml' \
             ':baml_language/rust-toolchain.toml' \
             ':.github/workflows/ci.yaml' \
+          ; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check if bridge_cffi release inputs changed
+        id: check_bridge_cffi_release
+        env:
+          MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
+        run: |
+          if git diff --quiet "${MERGE_BASE}...HEAD" -- \
+            ':.github/workflows/ci.yaml' \
+            ':.github/workflows/build2-bridge-cffi.reusable.yaml' \
+            ':.github/actions/setup-rust/**' \
+            ':scripts/baml-bridge-cffi-hygiene' \
+            ':release/platforms.json' \
+            ':baml_language/Cargo.toml' \
+            ':baml_language/Cargo.lock' \
+            ':baml_language/Cross.toml' \
+            ':baml_language/rust-toolchain.toml' \
+            ':baml_language/crates/**' \
           ; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -494,6 +520,16 @@ jobs:
           done
 
   # Call reusable workflows
+  bridge-cffi-release:
+    name: "Release bridge_cffi artifacts"
+    needs: determine_changes
+    if: ${{ needs.determine_changes.outputs.bridge_cffi_release == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/canary') }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build2-bridge-cffi.reusable.yaml
+    with:
+      source_sha: ${{ github.sha }}
+
   cargo-tests:
     name: "Cargo Tests"
     needs: determine_changes
@@ -1100,6 +1136,7 @@ jobs:
     needs:
       - prek
       - release-metadata
+      - bridge-cffi-release
       - cargo-tests
       - wasm-pack-tests
       - docs
@@ -1127,6 +1164,7 @@ jobs:
           echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| prek | ${{ needs.prek.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| release-metadata | ${{ needs.release-metadata.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| bridge-cffi-release | ${{ needs.bridge-cffi-release.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| cargo-tests | ${{ needs.cargo-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| wasm-pack-tests | ${{ needs.wasm-pack-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| docs | ${{ needs.docs.result }} |" >> $GITHUB_STEP_SUMMARY
@@ -1153,6 +1191,7 @@ jobs:
     needs:
       - prek
       - release-metadata
+      - bridge-cffi-release
       - cargo-tests
       - wasm-pack-tests
       - docs
@@ -1184,4 +1223,5 @@ jobs:
             --ref canary \
             -f channel=auto \
             -f dry_run=false \
-            -f source_sha="$GITHUB_SHA"
+            -f source_sha="$GITHUB_SHA" \
+            -f source_ci_run_id="$GITHUB_RUN_ID"

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -30,11 +30,15 @@ on:
         type: string
         default: ""
         required: false
+      source_ci_run_id:
+        description: "Successful canary CI run that attests source_sha (required for production)"
+        type: string
+        default: ""
+        required: false
 
 permissions:
-  contents: write
+  contents: read
   actions: read
-  id-token: write
 
 concurrency:
   group: ${{ inputs.dry_run == true && 'baml-language-release-dryrun' || 'baml-language-release-canary' }}
@@ -76,6 +80,7 @@ jobs:
       release_plan_json: ${{ steps.plan.outputs.release_plan_json }}
       source_sha: ${{ steps.plan.outputs.source_sha }}
       source_branch: ${{ steps.plan.outputs.source_branch }}
+      source_ci_run_id: ${{ steps.plan.outputs.source_ci_run_id }}
       dry_run: ${{ steps.plan.outputs.dry_run }}
       wrapper_version: ${{ steps.wrapper.outputs.wrapper_version }}
       wrapper_changed: ${{ steps.wrapper.outputs.wrapper_changed }}
@@ -87,17 +92,88 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
+      - name: Attest production source CI run
+        id: attest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_CI_RUN_ID: ${{ inputs.source_ci_run_id }}
+        run: |
+          set -euo pipefail
+          if [[ "$INPUT_DRY_RUN" != "false" ]]; then
+            echo "Dry run: a source CI attestation is not required."
+            exit 0
+          fi
+          if [[ ! "$INPUT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::production releases require an explicit 40-character source_sha"
+            exit 1
+          fi
+          if [[ ! "$SOURCE_CI_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::production releases require a numeric source_ci_run_id"
+            exit 1
+          fi
+
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [[ "$checked_out_sha" != "$INPUT_SOURCE_SHA" ]]; then
+            echo "::error::checked-out SHA $checked_out_sha does not match source_sha $INPUT_SOURCE_SHA"
+            exit 1
+          fi
+
+          for attempt in $(seq 1 30); do
+            run_json="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_CI_RUN_ID")"
+            workflow_name="$(jq -r '.name // ""' <<<"$run_json")"
+            workflow_path="$(jq -r '.path // ""' <<<"$run_json")"
+            event="$(jq -r '.event // ""' <<<"$run_json")"
+            branch="$(jq -r '.head_branch // ""' <<<"$run_json")"
+            head_sha="$(jq -r '.head_sha // ""' <<<"$run_json")"
+            status="$(jq -r '.status // ""' <<<"$run_json")"
+            conclusion="$(jq -r '.conclusion // ""' <<<"$run_json")"
+            url="$(jq -r '.html_url // ""' <<<"$run_json")"
+
+            if [[ "$workflow_name" != "CI - BAML Language" ||
+                  "$workflow_path" != ".github/workflows/ci.yaml" ||
+                  "$event" != "push" ||
+                  "$branch" != "canary" ||
+                  "$head_sha" != "$INPUT_SOURCE_SHA" ]]; then
+              echo "::error::source CI run does not attest this canary commit"
+              echo "workflow=$workflow_name path=$workflow_path event=$event branch=$branch head_sha=$head_sha"
+              exit 1
+            fi
+
+            if [[ "$status" == "completed" ]]; then
+              if [[ "$conclusion" != "success" ]]; then
+                echo "::error::source CI run concluded $conclusion, expected success: $url"
+                exit 1
+              fi
+              echo "source_branch=$branch" >> "$GITHUB_OUTPUT"
+              echo "Attested production source with successful CI run: $url"
+              exit 0
+            fi
+
+            echo "Source CI run is $status; waiting (attempt $attempt/30): $url"
+            if [[ "$attempt" -lt 30 ]]; then
+              sleep 10
+            fi
+          done
+
+          echo "::error::timed out waiting for source CI run to complete"
+          exit 1
+
       - name: Compute release plan
         id: plan
         env:
           INPUT_CHANNEL: ${{ inputs.channel }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_SOURCE_CI_RUN_ID: ${{ inputs.source_ci_run_id }}
+          ATTESTED_SOURCE_BRANCH: ${{ steps.attest.outputs.source_branch }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           channel="${INPUT_CHANNEL:-nightly}"
           dry_run="${INPUT_DRY_RUN:-false}"
-          source_branch="${GITHUB_REF_NAME:-}"
+          source_branch="${ATTESTED_SOURCE_BRANCH:-${GITHUB_REF_NAME:-}}"
           dispatch_nightly_after_canary="false"
           if [[ "$channel" == "auto" ]]; then
             channel="nightly"
@@ -139,6 +215,7 @@ jobs:
             echo "EOF"
             echo "source_sha=$source_sha"
             echo "source_branch=$source_branch"
+            echo "source_ci_run_id=$INPUT_SOURCE_CI_RUN_ID"
             echo "dry_run=$dry_run"
             echo "dispatch_nightly_after_canary=$dispatch_nightly_after_canary"
           } >> "$GITHUB_OUTPUT"
@@ -1530,7 +1607,7 @@ jobs:
       - publish-crates-io
       - publish-homebrew
       - publish-aur
-    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    if: ${{ always() && needs.all-builds.result == 'success' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     steps:
       - name: Require every enabled immutable publisher
@@ -1606,6 +1683,9 @@ jobs:
     needs: [plan, release-prerequisites-complete]
     if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1824,7 +1904,7 @@ jobs:
   release-complete:
     name: All enabled publishers complete
     needs: [plan, release-prerequisites-complete, publish-go-sdk]
-    if: ${{ always() && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    if: ${{ always() && needs.release-prerequisites-complete.result == 'success' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     steps:
       - name: Require pre-manifest publishers and Go
@@ -1850,6 +1930,9 @@ jobs:
     needs: [plan, publish-pkg-boundaryml-com, release-complete, smoke-go-release, smoke-swift-release]
     if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -1883,6 +1966,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
+          SOURCE_CI_RUN_ID: ${{ needs.plan.outputs.source_ci_run_id }}
         run: |
           set -euo pipefail
           # Pin the nightly to the commit this canary released, not to whatever
@@ -1892,7 +1976,8 @@ jobs:
             --ref canary \
             -f channel=nightly \
             -f dry_run=false \
-            -f source_sha="$SOURCE_SHA"
+            -f source_sha="$SOURCE_SHA" \
+            -f source_ci_run_id="$SOURCE_CI_RUN_ID"
 
   publish-homebrew:
     name: Publish Homebrew wrapper formula
@@ -2006,6 +2091,9 @@ jobs:
     needs: [plan, all-builds]
     if: ${{ needs.plan.outputs.dry_run == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -121,8 +121,14 @@ jobs:
           fi
 
           for attempt in $(seq 1 30); do
-            run_json="$(gh api \
-              "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_CI_RUN_ID")"
+            if ! run_json="$(gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_CI_RUN_ID")"; then
+              echo "gh api call failed (attempt $attempt/30); retrying"
+              if [[ "$attempt" -lt 30 ]]; then
+                sleep 10
+              fi
+              continue
+            fi
             workflow_name="$(jq -r '.name // ""' <<<"$run_json")"
             workflow_path="$(jq -r '.path // ""' <<<"$run_json")"
             event="$(jq -r '.event // ""' <<<"$run_json")"

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -7,16 +7,16 @@
 # rustc silently drops the `cdylib` crate type and only the `.rlib` is built.
 #
 # `cross` runs the build inside a container and forwards only a curated set of
-# environment variables, so RUSTFLAGS must be listed here explicitly or it
-# never reaches the compiler.
+# environment variables, so the Rust and native C/C++ remapping flags must be
+# listed here explicitly or they never reach the compilers.
 [target.x86_64-unknown-linux-gnu.env]
-passthrough = ["RUSTFLAGS"]
+passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.aarch64-unknown-linux-gnu.env]
-passthrough = ["RUSTFLAGS"]
+passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.x86_64-unknown-linux-musl.env]
-passthrough = ["RUSTFLAGS"]
+passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.aarch64-unknown-linux-musl.env]
-passthrough = ["RUSTFLAGS"]
+passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]

--- a/baml_language/sdks/csharp/bridge_csharp/tools/pack-product.sh
+++ b/baml_language/sdks/csharp/bridge_csharp/tools/pack-product.sh
@@ -21,7 +21,7 @@ native_provenance="$(cd "$(dirname "$3")" && pwd -P)/$(basename "$3")"
 release_plan="$(cd "$(dirname "$4")" && pwd -P)/$(basename "$4")"
 output_directory="$5"
 
-for command in jq llvm-nm llvm-objdump llvm-readobj sha256sum strings unzip; do
+for command in jq llvm-nm llvm-objdump llvm-readobj sha256sum unzip; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "required package inspection command is unavailable: $command" >&2
     exit 1
@@ -228,23 +228,9 @@ while IFS=$'\t' read -r target os arch libc rid canonical; do
   esac
   diff -u "$expected_exports" "$exports"
 
-  strings_file="$inspection_root/$rid.strings.txt"
-  strings "$native" > "$strings_file"
-  if [[ "$os" == "windows" ]]; then
-    strings -el "$native" >> "$strings_file"
-  fi
-  if grep -Eiq \
-    '(/home/runner/(work|\.rustup)/|/Users/runner/(work|\.rustup)/|/github/workspace/|/root/(dev|\.rustup)/|/usr/local/rustup/|/builds/|[A-Z]:\\(Users|a)\\)|(^|[[:space:]=])(/project/|/cargo/|/rust/(toolchains|downloads|tmp)/|/rust/settings\.toml)' \
-    "$strings_file"; then
-    echo "shipping native contains an absolute build-tree path: $rid" >&2
-    exit 1
-  fi
-  if grep -Eiq \
-    '(-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----|github_pat_[A-Za-z0-9_]+|ghp_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16})' \
-    "$strings_file"; then
-    echo "shipping native contains credential-shaped material: $rid" >&2
-    exit 1
-  fi
+  "$repository_root/scripts/baml-bridge-cffi-hygiene" verify \
+    --native "$native" \
+    --target "$target"
 done
 
 supported_rids="$(jq -r '

--- a/scripts/baml-bridge-cffi-hygiene
+++ b/scripts/baml-bridge-cffi-hygiene
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Reject build-machine paths and credential-shaped strings in shipping CFFI binaries."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+MAX_PATH_EXAMPLES = 8
+
+ASCII_STRINGS = re.compile(rb"[\x20-\x7e]{4,}")
+UTF16LE_STRINGS = re.compile(rb"(?:[\x20-\x7e]\x00){4,}")
+
+PATH_PATTERNS = (
+    re.compile(
+        r"/home/runner/(?:work|\.cargo|\.rustup)/[^\x00\r\n\t \"']*",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"/Users/runner/(?:work|\.cargo|\.rustup)/[^\x00\r\n\t \"']*",
+        re.IGNORECASE,
+    ),
+    re.compile(r"/github/workspace/[^\x00\r\n\t \"']*", re.IGNORECASE),
+    re.compile(
+        r"/root/(?:dev|\.cargo|\.rustup)/[^\x00\r\n\t \"']*",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"/usr/local/(?:cargo|rustup)/[^\x00\r\n\t \"']*",
+        re.IGNORECASE,
+    ),
+    re.compile(r"/builds/[^\x00\r\n\t \"']*", re.IGNORECASE),
+    re.compile(
+        r"(?<![^\s=])/project/[^\x00\r\n\t \"']*",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?<![^\s=])/cargo/[^\x00\r\n\t \"']*",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?<![^\s=])/rust/(?:toolchains|downloads|tmp)/[^\x00\r\n\t \"']*",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(?<![^\s=])/rust/settings\.toml", re.IGNORECASE),
+    re.compile(
+        r"[A-Z]:[\\/](?:Users|a)[\\/][^\x00\r\n\t \"']*",
+        re.IGNORECASE,
+    ),
+)
+
+CREDENTIAL_PATTERNS = (
+    (
+        "private-key header",
+        re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    ),
+    (
+        "GitHub token",
+        re.compile(r"(?:github_pat_[A-Za-z0-9_]+|ghp_[A-Za-z0-9]{20,})"),
+    ),
+    ("AWS access key", re.compile(r"AKIA[0-9A-Z]{16}")),
+)
+
+
+def binary_strings(data: bytes) -> list[str]:
+    """Return printable ASCII and UTF-16LE strings without invoking platform tools."""
+    strings = [
+        match.group().decode("ascii", errors="strict")
+        for match in ASCII_STRINGS.finditer(data)
+    ]
+    strings.extend(
+        match.group().decode("utf-16le", errors="strict")
+        for match in UTF16LE_STRINGS.finditer(data)
+    )
+    return strings
+
+
+def redact_credentials(value: str) -> str:
+    for _category, pattern in CREDENTIAL_PATTERNS:
+        value = pattern.sub("<redacted>", value)
+    return value
+
+
+def find_path_violations(strings: list[str]) -> list[str]:
+    violations: set[str] = set()
+    for value in strings:
+        for pattern in PATH_PATTERNS:
+            for match in pattern.finditer(value):
+                violations.add(redact_credentials(match.group())[:240])
+    return sorted(violations, key=str.casefold)
+
+
+def find_credential_categories(strings: list[str]) -> list[str]:
+    categories = {
+        category
+        for value in strings
+        for category, pattern in CREDENTIAL_PATTERNS
+        if pattern.search(value)
+    }
+    return sorted(categories)
+
+
+def verify(native: Path, target: str) -> int:
+    if not native.is_file():
+        print(f"native artifact does not exist: {native}", file=sys.stderr)
+        return 1
+
+    strings = binary_strings(native.read_bytes())
+    paths = find_path_violations(strings)
+    credentials = find_credential_categories(strings)
+
+    if paths:
+        print(
+            f"shipping native contains absolute build-tree paths: {target}",
+            file=sys.stderr,
+        )
+        for path in paths[:MAX_PATH_EXAMPLES]:
+            print(f"  - {path}", file=sys.stderr)
+        if len(paths) > MAX_PATH_EXAMPLES:
+            print(
+                f"  - showing {MAX_PATH_EXAMPLES} of {len(paths)} unique paths",
+                file=sys.stderr,
+            )
+
+    if credentials:
+        print(
+            "shipping native contains credential-shaped material: "
+            f"{target} ({', '.join(credentials)})",
+            file=sys.stderr,
+        )
+
+    if paths or credentials:
+        return 1
+
+    print(f"artifact hygiene verified: {target}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    verify_parser = subparsers.add_parser(
+        "verify",
+        help="verify one shipping native artifact",
+    )
+    verify_parser.add_argument("--native", type=Path, required=True)
+    verify_parser.add_argument("--target", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "verify":
+        return verify(args.native, args.target)
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/baml-bridge-cffi-hygiene
+++ b/scripts/baml-bridge-cffi-hygiene
@@ -34,18 +34,18 @@ PATH_PATTERNS = (
     ),
     re.compile(r"/builds/[^\x00\r\n\t \"']*", re.IGNORECASE),
     re.compile(
-        r"(?<![^\s=])/project/[^\x00\r\n\t \"']*",
+        r"(?<![^\s=\"'])/project/[^\x00\r\n\t \"']*",
         re.IGNORECASE,
     ),
     re.compile(
-        r"(?<![^\s=])/cargo/[^\x00\r\n\t \"']*",
+        r"(?<![^\s=\"'])/cargo/[^\x00\r\n\t \"']*",
         re.IGNORECASE,
     ),
     re.compile(
-        r"(?<![^\s=])/rust/(?:toolchains|downloads|tmp)/[^\x00\r\n\t \"']*",
+        r"(?<![^\s=\"'])/rust/(?:toolchains|downloads|tmp)/[^\x00\r\n\t \"']*",
         re.IGNORECASE,
     ),
-    re.compile(r"(?<![^\s=])/rust/settings\.toml", re.IGNORECASE),
+    re.compile(r"(?<![^\s=\"'])/rust/settings\.toml", re.IGNORECASE),
     re.compile(
         r"[A-Z]:[\\/](?:Users|a)[\\/][^\x00\r\n\t \"']*",
         re.IGNORECASE,
@@ -79,12 +79,14 @@ def binary_strings(data: bytes) -> list[str]:
 
 
 def redact_credentials(value: str) -> str:
+    """Replace credential-shaped material before rendering diagnostics."""
     for _category, pattern in CREDENTIAL_PATTERNS:
         value = pattern.sub("<redacted>", value)
     return value
 
 
 def find_path_violations(strings: list[str]) -> list[str]:
+    """Collect unique forbidden build paths from extracted binary strings."""
     violations: set[str] = set()
     for value in strings:
         for pattern in PATH_PATTERNS:
@@ -94,6 +96,7 @@ def find_path_violations(strings: list[str]) -> list[str]:
 
 
 def find_credential_categories(strings: list[str]) -> list[str]:
+    """Return credential categories without retaining or exposing their values."""
     categories = {
         category
         for value in strings
@@ -104,6 +107,7 @@ def find_credential_categories(strings: list[str]) -> list[str]:
 
 
 def verify(native: Path, target: str) -> int:
+    """Verify one native artifact and return a process-style exit status."""
     if not native.is_file():
         print(f"native artifact does not exist: {native}", file=sys.stderr)
         return 1
@@ -140,6 +144,7 @@ def verify(native: Path, target: str) -> int:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse the hygiene checker's command-line interface."""
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
     verify_parser = subparsers.add_parser(
@@ -152,6 +157,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    """Run the requested hygiene command."""
     args = parse_args()
     if args.command == "verify":
         return verify(args.native, args.target)

--- a/scripts/baml-language-version
+++ b/scripts/baml-language-version
@@ -393,7 +393,14 @@ def released_at_for_plan() -> str:
     if not value:
         value = git_output("show", "-s", "--format=%cI", "HEAD")
     try:
-        timestamp = dt.datetime.fromisoformat(value) if value else None
+        # Python 3.10 (still present on Ubuntu 22 release runners) does not
+        # accept the ISO-8601 `Z` UTC suffix. Git 2.54 emits `%cI` in that form,
+        # so normalize it just as load_plan() does below.
+        timestamp = (
+            dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if value
+            else None
+        )
     except ValueError:
         timestamp = None
     if timestamp is None or timestamp.tzinfo is None:

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -15,7 +15,10 @@ CONTRACT_TOOL = ROOT / "scripts" / "baml-csharp-release-contract"
 VERSION_TOOL = ROOT / "scripts" / "baml-language-version"
 PLATFORMS = ROOT / "release" / "platforms.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yaml"
 SIZE_POLICY = ROOT / "release" / "csharp-package-size-policy.json"
+HYGIENE_TOOL = ROOT / "scripts" / "baml-bridge-cffi-hygiene"
+CROSS_CONFIG = ROOT / "baml_language" / "Cross.toml"
 NUGET_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-csharp-sdk.yaml"
 CSHARP_PREPARER = (
     ROOT / ".github" / "workflows" / "prepare-csharp-sdk.reusable.yaml"
@@ -502,6 +505,77 @@ class CSharpReleaseContractTests(unittest.TestCase):
                 self.assertNotEqual(result.returncode, 0)
 
 
+class BridgeCffiHygieneTests(unittest.TestCase):
+    def verify_payload(self, payload: bytes) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temporary:
+            native = Path(temporary) / "native.bin"
+            native.write_bytes(payload)
+            return subprocess.run(
+                [
+                    str(HYGIENE_TOOL),
+                    "verify",
+                    "--native",
+                    str(native),
+                    "--target",
+                    "test-target",
+                ],
+                cwd=ROOT,
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+    def test_rejects_ascii_cross_and_runner_paths(self) -> None:
+        payloads = (
+            b"prefix\0/cargo/registry/src/aws-lc/source.c\0suffix",
+            b"/home/runner/work/baml/baml/source.rs",
+            b"/root/.cargo/registry/src/dependency.c",
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                result = self.verify_payload(payload)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("absolute build-tree paths", result.stderr)
+
+    def test_rejects_utf16le_windows_paths(self) -> None:
+        secret_path = (
+            "C:\\Users\\runneradmin\\.cargo\\registry\\src\\dependency.c"
+        ).encode("utf-16le")
+        result = self.verify_payload(secret_path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("C:\\Users\\runneradmin\\.cargo", result.stderr)
+
+    def test_allows_stable_mapped_and_rust_dependency_paths(self) -> None:
+        payload = b"\0".join(
+            (
+                b"cargo-home/registry/src/dependency.c",
+                b"baml-source/crates/bridge_cffi/src/lib.rs",
+                b"rust-toolchain/lib/rustlib/src/rust/library/std/src/lib.rs",
+                b"/rust/deps/compiler_builtins/src/lib.rs",
+                b"http://metadata.google.internal/computeMetadata/v1/project/project-id",
+            )
+        )
+        result = self.verify_payload(payload)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_credentials_without_echoing_them(self) -> None:
+        credential = "ghp_" + ("A" * 30)
+        result = self.verify_payload(credential.encode())
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("GitHub token", result.stderr)
+        self.assertNotIn(credential, result.stderr)
+
+    def test_bounds_path_diagnostics(self) -> None:
+        payload = b"\0".join(
+            f"/cargo/registry/src/dependency-{index}/source.c".encode()
+            for index in range(12)
+        )
+        result = self.verify_payload(payload)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stderr.count("  - /cargo/"), 8)
+        self.assertIn("showing 8 of 12 unique paths", result.stderr)
+
+
 def job_block(text: str, job: str) -> str:
     marker = f"  {job}:\n"
     start = text.index(marker)
@@ -523,6 +597,92 @@ def job_block(text: str, job: str) -> str:
 
 
 class WorkflowGraphTests(unittest.TestCase):
+    def test_cffi_hygiene_is_enforced_at_production_and_package_boundaries(
+        self,
+    ) -> None:
+        builder = CFFI_BUILDER.read_text(encoding="utf-8")
+        cross = CROSS_CONFIG.read_text(encoding="utf-8")
+        pack = PACK_PRODUCT.read_text(encoding="utf-8")
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        ci_builder = job_block(ci, "bridge-cffi-release")
+        ci_alert = job_block(ci, "ci-failure-alert")
+        ci_dispatch = job_block(ci, "dispatch-release")
+
+        self.assertIn("-ffile-prefix-map=/cargo=cargo-home", builder)
+        self.assertIn("cygpath -aw", builder)
+        self.assertIn("/pathmap:$cargo_root_native=cargo-home", builder)
+        self.assertIn('export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"', builder)
+        self.assertIn(
+            'export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"',
+            builder,
+        )
+        self.assertLess(
+            builder.index("- name: Verify shipping artifact hygiene"),
+            builder.index("- name: Upload cdylib artifact"),
+        )
+        self.assertEqual(
+            cross.count('passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]'),
+            4,
+        )
+        self.assertIn("scripts/baml-bridge-cffi-hygiene", pack)
+        self.assertNotIn('strings "$native"', pack)
+
+        self.assertIn("bridge_cffi_release:", ci)
+        self.assertIn(
+            "uses: ./.github/workflows/build2-bridge-cffi.reusable.yaml",
+            ci_builder,
+        )
+        self.assertIn("source_sha: ${{ github.sha }}", ci_builder)
+        self.assertIn("- bridge-cffi-release", ci_alert)
+        self.assertIn("- bridge-cffi-release", ci_dispatch)
+        self.assertIn(
+            '-f source_ci_run_id="$GITHUB_RUN_ID"',
+            ci_dispatch,
+        )
+
+    def test_production_release_is_ci_attested_and_least_privilege(self) -> None:
+        release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        plan = job_block(release, "plan")
+        prerequisites = job_block(release, "release-prerequisites-complete")
+        complete = job_block(release, "release-complete")
+        manifest = job_block(release, "publish-pkg-boundaryml-com")
+        channel = job_block(release, "publish-pkg-channel")
+        dry_run = job_block(release, "dry-run-artifacts")
+        nightly = job_block(release, "dispatch-nightly-after-canary")
+
+        self.assertIn("source_ci_run_id:", release)
+        self.assertIn("Attest production source CI run", plan)
+        self.assertIn("production releases require a numeric source_ci_run_id", plan)
+        self.assertIn("CI - BAML Language", plan)
+        self.assertIn('"$workflow_path" != ".github/workflows/ci.yaml"', plan)
+        self.assertIn('"$event" != "push"', plan)
+        self.assertIn('"$branch" != "canary"', plan)
+        self.assertIn('"$head_sha" != "$INPUT_SOURCE_SHA"', plan)
+        self.assertIn('"$conclusion" != "success"', plan)
+        self.assertIn(
+            "permissions:\n  contents: read\n  actions: read\n",
+            release,
+        )
+        for block in (manifest, channel, dry_run):
+            self.assertIn("id-token: write", block)
+        self.assertIn(
+            "needs.all-builds.result == 'success'",
+            prerequisites,
+        )
+        self.assertIn(
+            "needs.release-prerequisites-complete.result == 'success'",
+            complete,
+        )
+        self.assertIn(
+            '-f source_ci_run_id="$GITHUB_RUN_ID"',
+            job_block(ci, "dispatch-release"),
+        )
+        self.assertIn(
+            '-f source_ci_run_id="$SOURCE_CI_RUN_ID"',
+            nightly,
+        )
+
     def test_release_graph_has_early_preflight_parallel_producers_and_complete_fanin(
         self,
     ) -> None:

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -612,12 +612,15 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("-fdebug-prefix-map=/cargo=cargo-home", builder)
         self.assertIn('-D__FILE__=\\\\\\"baml-source/native\\\\\\"', builder)
         self.assertIn("cygpath -aw", builder)
-        self.assertIn("/pathmap:$cargo_root_native=cargo-home", builder)
+        self.assertIn("--short-name", builder)
         self.assertIn(
-            "/clang:-fdebug-prefix-map=$cargo_root_native=cargo-home", builder
+            "/clang:-ffile-prefix-map=$cargo_root_native=cargo-home", builder
         )
-        self.assertIn("/clang:-Wno-builtin-macro-redefined", builder)
-        self.assertIn("/wd4005", builder)
+        self.assertIn(
+            "/clang:-ffile-prefix-map=$cargo_root_native_short=cargo-home", builder
+        )
+        self.assertIn('export "CC_${target_key}=clang-cl"', builder)
+        self.assertIn('export "CXX_${target_key}=clang-cl"', builder)
         self.assertIn('export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"', builder)
         self.assertIn(
             'export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"',

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -609,8 +609,15 @@ class WorkflowGraphTests(unittest.TestCase):
         ci_dispatch = job_block(ci, "dispatch-release")
 
         self.assertIn("-ffile-prefix-map=/cargo=cargo-home", builder)
+        self.assertIn("-fdebug-prefix-map=/cargo=cargo-home", builder)
+        self.assertIn('-D__FILE__=\\\\\\"baml-source/native\\\\\\"', builder)
         self.assertIn("cygpath -aw", builder)
         self.assertIn("/pathmap:$cargo_root_native=cargo-home", builder)
+        self.assertIn(
+            "/clang:-fdebug-prefix-map=$cargo_root_native=cargo-home", builder
+        )
+        self.assertIn("/clang:-Wno-builtin-macro-redefined", builder)
+        self.assertIn("/wd4005", builder)
         self.assertIn('export CFLAGS="${CFLAGS:+$CFLAGS }$native_path_maps"', builder)
         self.assertIn(
             'export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$native_path_maps"',

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -545,6 +545,19 @@ class BridgeCffiHygieneTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("C:\\Users\\runneradmin\\.cargo", result.stderr)
 
+    def test_rejects_quoted_cross_paths(self) -> None:
+        payloads = (
+            b'cargo "/project/aws-lc/source.c"',
+            b"cargo '/cargo/registry/src/dependency.c'",
+            b'rustc "/rust/toolchains/stable/lib/libstd.rlib"',
+            b"rustc '/rust/settings.toml'",
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                result = self.verify_payload(payload)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("absolute build-tree paths", result.stderr)
+
     def test_allows_stable_mapped_and_rust_dependency_paths(self) -> None:
         payload = b"\0".join(
             (
@@ -610,7 +623,7 @@ class WorkflowGraphTests(unittest.TestCase):
 
         self.assertIn("-ffile-prefix-map=/cargo=cargo-home", builder)
         self.assertIn("-fdebug-prefix-map=/cargo=cargo-home", builder)
-        self.assertIn('-D__FILE__=\\\\\\"baml-source/native\\\\\\"', builder)
+        self.assertIn('-D__FILE__=\\"baml-source/native\\"', builder)
         self.assertIn("cygpath -aw", builder)
         self.assertIn("--short-name", builder)
         self.assertIn(
@@ -670,6 +683,8 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn('"$branch" != "canary"', plan)
         self.assertIn('"$head_sha" != "$INPUT_SOURCE_SHA"', plan)
         self.assertIn('"$conclusion" != "success"', plan)
+        self.assertIn('if ! run_json="$(gh api', plan)
+        self.assertIn("gh api call failed (attempt $attempt/30); retrying", plan)
         self.assertIn(
             "permissions:\n  contents: read\n  actions: read\n",
             release,


### PR DESCRIPTION
## What changed

- remap native C/C++ build paths alongside Rust paths for every `bridge_cffi` release target
- forward `CFLAGS` and `CXXFLAGS` through all Linux `cross` containers
- correct Windows drive-letter remapping for Rust and MSVC `/pathmap`
- add a shared ASCII/UTF-16LE binary hygiene checker and run it before CFFI artifact upload and again during C# package assembly
- build the real eight-target CFFI release matrix in required PR, merge-group, and canary CI
- require production release dispatches to present the successful canary CI run that attests the exact source SHA
- reduce release workflow permissions to least privilege and avoid redundant fan-in failures

## Root cause

The producer applied `--remap-path-prefix` only to Rust. AWS-LC is compiled through CMake/C, so GNU/Linux artifacts retained `/cargo/...` source paths. Windows also compared Git Bash paths with compiler-emitted drive-letter paths, leaving `C:\Users\runneradmin\.cargo\...` strings. The defect was only detected later by the C# product-package gate because CI used fixture natives instead of the actual release matrix.

## Impact

Polluted native binaries now fail in their own producer matrix leg before upload. The same exact release matrix is required before merge and before canary release dispatch, while C# retains defense-in-depth over packaged bytes. Production releases are also bound to a successful `CI - BAML Language` canary push run for the exact source commit.

## Validation

- 24 release contract and workflow graph tests
- `scripts/baml-language-version check`
- Ruff
- actionlint on the modified workflows (with existing unrelated CI lint exceptions)
- ShellCheck and Bash syntax validation for the C# packaging script
- real `x86_64-unknown-linux-gnu` `release-bridge-cffi` build passes the new checker
- historical release artifacts reproduce the expected result: macOS/musl pass; both GNU/Linux and both Windows artifacts fail on their known build paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Reliability**
  - Added native artifact hygiene verification to flag build-path leakage and credential-like strings.
  - Strengthened production release attestation with a tracked CI run identity, plus tighter release gating.
  - Tightened workflow permissions and least-privilege publishing controls.

- **CI & Release**
  - Added a dedicated bridge CFFI release path that runs only when relevant release inputs change.
  - Improved native build setup via better compiler/debug/file-path remapping across targets.

- **Packaging**
  - Integrated hygiene verification into native artifact inspection during packaging.

- **Tests**
  - Extended pipeline contract tests for hygiene enforcement and CI-attested, least-privilege release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->