### PR TITLE
docs(cli): update generator describe syntax

### DIFF
--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -191,10 +191,28 @@ vertex-ai:
 generator:
   summary: "Configures code generation for a target language."
   syntax: |
-    generator python {
-      output_type "python/pydantic"
-      output_dir "../generated"
-    }
+    # baml.toml
+    [generator.python_client]
+    output_type = "python/pydantic"
+    output_dir = "."
+    naming_convention = "preserve-case"
+  details: |
+    Generators are declared in `baml.toml` as `[generator.<name>]` tables, where `<name>` is an arbitrary identifier. `output_type` and `naming_convention` are required. `output_dir` is optional and defaults to `..`; BAML creates a `baml_sdk` directory inside it (`baml_client` for C#).
+
+    Accepted `output_type` values:
+
+    - `"python/pydantic"` — Python with Pydantic v2 models
+    - `"python/pydantic/v1"` — Python with Pydantic v1 models
+    - `"typescript/node"` — TypeScript for Node.js
+    - `"typescript/web"` — TypeScript for web/WASM
+    - `"swift"` — Swift
+    - `"go"` — Go
+    - `"rust"` — Rust
+    - `"java"` — Java
+    - `"cpp"` — C++17
+    - `"csharp"` — C#
+
+    `naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`.
 
 test:
   summary: "Defines a named executable test."

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -1058,6 +1058,12 @@ fn render_keyword_class() {
 }
 
 #[test]
+fn render_keyword_generator() {
+    let output = capture_keyword("generator");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn render_keyword_if() {
     let output = capture_keyword("if");
     insta::assert_snapshot!(output);

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -384,7 +384,7 @@ fn discover_generators(root: &Path) -> (Vec<GeneratorDef>, Vec<Diagnostic>) {
             name,
             "output_type",
             generator.output_type.as_ref(),
-            r#"one of: "python/pydantic", "python/pydantic/v1", "typescript/node", "typescript/web", "go", "rust", "java", "cpp", "csharp""#,
+            r#"one of: "python/pydantic", "python/pydantic/v1", "typescript/node", "typescript/web", "swift", "go", "rust", "java", "cpp", "csharp""#,
             table_range,
             &mut diags,
         );

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_generator.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_generator.snap
@@ -1,0 +1,29 @@
+---
+source: crates/baml_cli/src/describe_command_tests.rs
+expression: output
+---
+generator — Configures code generation for a target language.
+
+Syntax:
+  # baml.toml
+  [generator.python_client]
+  output_type = "python/pydantic"
+  output_dir = "."
+  naming_convention = "preserve-case"
+
+Generators are declared in `baml.toml` as `[generator.<name>]` tables, where `<name>` is an arbitrary identifier. `output_type` and `naming_convention` are required. `output_dir` is optional and defaults to `..`; BAML creates a `baml_sdk` directory inside it (`baml_client` for C#).
+
+Accepted `output_type` values:
+
+- `"python/pydantic"` — Python with Pydantic v2 models
+- `"python/pydantic/v1"` — Python with Pydantic v1 models
+- `"typescript/node"` — TypeScript for Node.js
+- `"typescript/web"` — TypeScript for web/WASM
+- `"swift"` — Swift
+- `"go"` — Go
+- `"rust"` — Rust
+- `"java"` — Java
+- `"cpp"` — C++17
+- `"csharp"` — C#
+
+`naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`.


### PR DESCRIPTION
## Summary

- replace the legacy `generator { ... }` example in `baml describe generator` with `[generator.<name>]` configuration in `baml.toml`
- enumerate all accepted `output_type` values and document generator field requirements
- include `swift` in the invalid-`output_type` diagnostic so it matches the accepted enum
- add snapshot coverage for the rendered generator topic

## Why

The built-in generator topic still described the legacy BAML block syntax even though generators now live in `baml.toml`. It also did not enumerate the currently accepted targets, making the command misleading for new projects.

## Validation

- `cargo test -p baml_cli describe_command_tests` (94 passed)
- `cargo fmt --check`
- manually ran `cargo run -p baml_cli -- describe generator --from /tmp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generator configuration examples to use the current `baml.toml` format.
  * Documented required fields, output directories, naming conventions, supported output types, and Go-specific requirements.

* **Bug Fixes**
  * Updated generator validation messages to include Swift as a supported output type.

* **Tests**
  * Added coverage for rendering the generator keyword documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->