### PR TITLE
Pin release workflow definition to source commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1209,18 +1209,52 @@ jobs:
     if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref_name == 'canary' }}
     permissions:
       actions: write
-      contents: read
+      contents: write
     steps:
-      - name: Dispatch release for this commit
+      - name: Create immutable release workflow ref
+        id: release-workflow-ref
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # --ref canary selects the workflow *definition* from canary HEAD;
-          # source_sha pins the commit that actually gets built and released.
+          release_ref="baml-language-source-$GITHUB_SHA"
+          ref_endpoint="repos/$GITHUB_REPOSITORY/git/ref/tags/$release_ref"
+
+          if ref_json="$(gh api "$ref_endpoint" 2>/dev/null)"; then
+            :
+          elif gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/$release_ref" \
+            -f sha="$GITHUB_SHA" >/dev/null; then
+            ref_json="$(gh api "$ref_endpoint")"
+          else
+            # A rerun can race another attempt creating the same immutable tag.
+            # Re-read it and fail below unless it is the exact ref we intended.
+            ref_json="$(gh api "$ref_endpoint")"
+          fi
+
+          ref_type="$(jq -r '.object.type // ""' <<<"$ref_json")"
+          ref_sha="$(jq -r '.object.sha // ""' <<<"$ref_json")"
+          if [[ "$ref_type" != "commit" || "$ref_sha" != "$GITHUB_SHA" ]]; then
+            echo "::error::release ref $release_ref resolves to $ref_type $ref_sha, expected commit $GITHUB_SHA"
+            exit 1
+          fi
+
+          echo "ref=$release_ref" >> "$GITHUB_OUTPUT"
+          echo "Release workflow ref: $release_ref ($ref_sha)"
+
+      - name: Dispatch release for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_WORKFLOW_REF: ${{ steps.release-workflow-ref.outputs.ref }}
+        run: |
+          set -euo pipefail
+          # Load the workflow definition from the same immutable commit that the
+          # release checks out, even if canary advances while this CI run finishes.
           gh workflow run release-baml-language.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref canary \
+            --ref "$RELEASE_WORKFLOW_REF" \
             -f channel=auto \
             -f dry_run=false \
             -f source_sha="$GITHUB_SHA" \

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -99,6 +99,9 @@ jobs:
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
           SOURCE_CI_RUN_ID: ${{ inputs.source_ci_run_id }}
+          WORKFLOW_SOURCE_SHA: ${{ github.sha }}
+          WORKFLOW_REF_NAME: ${{ github.ref_name }}
+          WORKFLOW_REF_TYPE: ${{ github.ref_type }}
         run: |
           set -euo pipefail
           if [[ "$INPUT_DRY_RUN" != "false" ]]; then
@@ -111,6 +114,18 @@ jobs:
           fi
           if [[ ! "$SOURCE_CI_RUN_ID" =~ ^[0-9]+$ ]]; then
             echo "::error::production releases require a numeric source_ci_run_id"
+            exit 1
+          fi
+
+          expected_workflow_ref="baml-language-source-$INPUT_SOURCE_SHA"
+          if [[ "$WORKFLOW_SOURCE_SHA" != "$INPUT_SOURCE_SHA" ]]; then
+            echo "::error::release workflow SHA $WORKFLOW_SOURCE_SHA does not match source_sha $INPUT_SOURCE_SHA"
+            exit 1
+          fi
+          if [[ "$WORKFLOW_REF_TYPE" != "tag" ||
+                "$WORKFLOW_REF_NAME" != "$expected_workflow_ref" ]]; then
+            echo "::error::production release workflow ref must be tag $expected_workflow_ref"
+            echo "actual ref type=$WORKFLOW_REF_TYPE name=$WORKFLOW_REF_NAME"
             exit 1
           fi
 
@@ -1973,13 +1988,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
           SOURCE_CI_RUN_ID: ${{ needs.plan.outputs.source_ci_run_id }}
+          SOURCE_WORKFLOW_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # Pin the nightly to the commit this canary released, not to whatever
-          # canary HEAD happens to be by the time this job runs.
+          # Reuse the immutable workflow ref from this canary release so the
+          # nightly cannot combine a newer workflow with the pinned source.
           gh workflow run release-baml-language.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref canary \
+            --ref "$SOURCE_WORKFLOW_REF" \
             -f channel=nightly \
             -f dry_run=false \
             -f source_sha="$SOURCE_SHA" \

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -686,6 +686,28 @@ class WorkflowGraphTests(unittest.TestCase):
             '-f source_ci_run_id="$GITHUB_RUN_ID"',
             ci_dispatch,
         )
+        self.assertIn("contents: write", ci_dispatch)
+        self.assertIn(
+            'release_ref="baml-language-source-$GITHUB_SHA"',
+            ci_dispatch,
+        )
+        self.assertIn(
+            '-f ref="refs/tags/$release_ref"',
+            ci_dispatch,
+        )
+        self.assertIn(
+            'ref_type" != "commit"',
+            ci_dispatch,
+        )
+        self.assertIn(
+            'ref_sha" != "$GITHUB_SHA"',
+            ci_dispatch,
+        )
+        self.assertIn(
+            '--ref "$RELEASE_WORKFLOW_REF"',
+            ci_dispatch,
+        )
+        self.assertNotIn("--ref canary", ci_dispatch)
 
     def test_production_release_is_ci_attested_and_least_privilege(self) -> None:
         release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
@@ -707,6 +729,21 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn('"$branch" != "canary"', plan)
         self.assertIn('"$head_sha" != "$INPUT_SOURCE_SHA"', plan)
         self.assertIn('"$conclusion" != "success"', plan)
+        self.assertIn('WORKFLOW_SOURCE_SHA: ${{ github.sha }}', plan)
+        self.assertIn('WORKFLOW_REF_NAME: ${{ github.ref_name }}', plan)
+        self.assertIn('WORKFLOW_REF_TYPE: ${{ github.ref_type }}', plan)
+        self.assertIn(
+            '"$WORKFLOW_SOURCE_SHA" != "$INPUT_SOURCE_SHA"',
+            plan,
+        )
+        self.assertIn(
+            '"$WORKFLOW_REF_TYPE" != "tag"',
+            plan,
+        )
+        self.assertIn(
+            '"$WORKFLOW_REF_NAME" != "$expected_workflow_ref"',
+            plan,
+        )
         self.assertIn('if ! run_json="$(gh api', plan)
         self.assertIn("gh api call failed (attempt $attempt/30); retrying", plan)
         self.assertIn(
@@ -731,6 +768,15 @@ class WorkflowGraphTests(unittest.TestCase):
             '-f source_ci_run_id="$SOURCE_CI_RUN_ID"',
             nightly,
         )
+        self.assertIn(
+            'SOURCE_WORKFLOW_REF: ${{ github.ref_name }}',
+            nightly,
+        )
+        self.assertIn(
+            '--ref "$SOURCE_WORKFLOW_REF"',
+            nightly,
+        )
+        self.assertNotIn("--ref canary", nightly)
 
     def test_release_graph_has_early_preflight_parallel_producers_and_complete_fanin(
         self,


### PR DESCRIPTION
## What changed

- create an immutable `baml-language-source-<sha>` tag after canary CI succeeds
- dispatch the production release workflow from that tag instead of mutable `canary`
- attest that the workflow event SHA, requested `source_sha`, and checked-out SHA are identical
- reuse the same immutable workflow ref for the follow-on nightly release
- add release-pipeline contract coverage for the dispatch and attestation invariants

## Why

A delayed CI run could dispatch `release-baml-language.yml` from the latest `canary` workflow while checking out an older `source_sha`. That combined pipeline instructions from one commit with product files from another. The observed failure loaded the new CFFI export-allowlist path from the newer workflow against an older checkout where that path did not exist.

Release stamping already freezes package metadata and product source, but GitHub chooses the workflow YAML before checkout and stamping. This change pins that missing workflow identity.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v` (25 tests)
- pre-commit hooks, including YAML validation
- `actionlint .github/workflows/release-baml-language.yml`
- `git diff --check`

The existing `release` GitHub environment also needs the `baml-language-source-*` deployment-tag policy before merge; no new environment is introduced and `boundary-tools-prod` requires no change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Release workflows now use immutable source tags, ensuring production and nightly releases are built from the exact intended commit.
  - Added validation to confirm release metadata and source references match before publishing.
  - Improved handling of concurrent release reruns.

- **Tests**
  - Expanded automated checks to verify immutable release references, permissions, and workflow attestation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->