### PR TITLE
Fix musl C# consumer repository path scan

### DIFF
--- a/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
+++ b/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
@@ -156,7 +156,10 @@ if find "$publish" -type f \
   echo "published consumer contains a forbidden source/tooling asset" >&2
   exit 1
 fi
-if rg -a -F -l "$repository_root" "$publish" | grep -q .; then
+# Include the path separator so a short mount point such as /work does not
+# mistake an unrelated path segment such as /worker.rs for a repository path.
+repository_path_prefix="${repository_root%/}/"
+if rg -a -F -l "$repository_path_prefix" "$publish" | grep -q .; then
   echo "published consumer contains a repository path" >&2
   exit 1
 fi

--- a/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
+++ b/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
@@ -1,6 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+verify_repository_paths() (
+  local repository_root="$1"
+  local publish="$2"
+  local repository_path_prefix
+  local scan_status
+
+  # Include the path separator so a short mount point such as /work does not
+  # mistake an unrelated path segment such as /worker.rs for a repository path.
+  repository_path_prefix="${repository_root%/}/"
+  if rg -a -F -l -- "$repository_path_prefix" "$publish" > /dev/null; then
+    echo "published consumer contains a repository path" >&2
+    return 1
+  else
+    scan_status="$?"
+    if [[ "$scan_status" -ne 1 ]]; then
+      echo "failed to scan published consumer for repository paths" >&2
+      return "$scan_status"
+    fi
+  fi
+)
+
+if [[ "${1:-}" == "--verify-repository-paths" ]]; then
+  if [[ "$#" -ne 3 ]]; then
+    echo "usage: verify.sh --verify-repository-paths <repository-root> <publish-dir>" >&2
+    exit 2
+  fi
+  verify_repository_paths "$2" "$3"
+  exit 0
+fi
+
 if [[ "$#" -lt 1 || "$#" -gt 4 ]]; then
   echo "usage: verify.sh <exact-package> [rid] [canonical-native-name] [generated-source-root]" >&2
   exit 2
@@ -156,13 +186,7 @@ if find "$publish" -type f \
   echo "published consumer contains a forbidden source/tooling asset" >&2
   exit 1
 fi
-# Include the path separator so a short mount point such as /work does not
-# mistake an unrelated path segment such as /worker.rs for a repository path.
-repository_path_prefix="${repository_root%/}/"
-if rg -a -F -l "$repository_path_prefix" "$publish" | grep -q .; then
-  echo "published consumer contains a repository path" >&2
-  exit 1
-fi
+verify_repository_paths "$repository_root" "$publish"
 
 mismatch="$work/mismatch"
 mkdir -p "$mismatch"

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -921,7 +921,7 @@ class WorkflowGraphTests(unittest.TestCase):
             primitive_consumer,
         )
         self.assertIn(
-            'rg -a -F -l "$repository_path_prefix" "$publish"',
+            'rg -a -F -l -- "$repository_path_prefix" "$publish"',
             primitive_consumer,
         )
         self.assertNotIn(
@@ -931,22 +931,46 @@ class WorkflowGraphTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
-            benign = root / "benign.bin"
-            leaked = root / "leaked.bin"
+            benign_publish = root / "benign"
+            leaked_publish = root / "leaked"
+            benign_publish.mkdir()
+            leaked_publish.mkdir()
+            benign = benign_publish / "benign.bin"
+            leaked = leaked_publish / "leaked.bin"
             benign.write_bytes(
                 b"cargo-home/registry/src/tokio/src/runtime/metrics/worker.rs"
             )
             leaked.write_bytes(b"debug source: /work/baml/src/runtime.rs")
 
-            result = subprocess.run(
-                ["rg", "-a", "-F", "-l", "/work/", str(root)],
-                check=True,
+            benign_result = subprocess.run(
+                [
+                    str(PRIMITIVE_CONSUMER),
+                    "--verify-repository-paths",
+                    "/work",
+                    str(benign_publish),
+                ],
+                check=False,
                 text=True,
                 capture_output=True,
             )
-            self.assertEqual(
-                {Path(path).name for path in result.stdout.splitlines()},
-                {leaked.name},
+            self.assertEqual(benign_result.returncode, 0, benign_result.stderr)
+            self.assertIn(b"/worker.rs", benign.read_bytes())
+
+            leaked_result = subprocess.run(
+                [
+                    str(PRIMITIVE_CONSUMER),
+                    "--verify-repository-paths",
+                    "/work",
+                    str(leaked_publish),
+                ],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(leaked_result.returncode, 1)
+            self.assertIn(
+                "published consumer contains a repository path",
+                leaked_result.stderr,
             )
 
 

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -914,6 +914,41 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("right.ReadExactly(rightChunk)", normalizer)
         self.assertNotIn("left.Read(leftBuffer)", normalizer)
 
+    def test_csharp_consumer_repository_path_scan_requires_a_separator(self) -> None:
+        primitive_consumer = PRIMITIVE_CONSUMER.read_text(encoding="utf-8")
+        self.assertIn(
+            'repository_path_prefix="${repository_root%/}/"',
+            primitive_consumer,
+        )
+        self.assertIn(
+            'rg -a -F -l "$repository_path_prefix" "$publish"',
+            primitive_consumer,
+        )
+        self.assertNotIn(
+            'rg -a -F -l "$repository_root" "$publish"',
+            primitive_consumer,
+        )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            benign = root / "benign.bin"
+            leaked = root / "leaked.bin"
+            benign.write_bytes(
+                b"cargo-home/registry/src/tokio/src/runtime/metrics/worker.rs"
+            )
+            leaked.write_bytes(b"debug source: /work/baml/src/runtime.rs")
+
+            result = subprocess.run(
+                ["rg", "-a", "-F", "-l", "/work/", str(root)],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(
+                {Path(path).name for path in result.stdout.splitlines()},
+                {leaked.name},
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- require a trailing path separator when scanning published C# consumers for the repository root
- add regression coverage proving `/worker.rs` is allowed while a real `/work/...` build path is rejected

## Root cause

The musl consumer runs with the repository mounted at `/work`. Its previous fixed-string scan searched for the bare value `/work`, which also matched the start of innocent path segments such as `/worker.rs` embedded in Tokio source metadata. Both musl consumers therefore failed after the package had already built and executed successfully.

The corrected scan searches for `/work/`, preserving detection of real repository descendants without treating `worker.rs` as a leak.

## Validation

- all 26 release-contract tests pass
- pre-commit hooks pass
- shell syntax validation passes
- the corrected prefix does not match either failed release musl native
- the exact failed `linux-musl-x64` package consumer now passes end-to-end in the same pinned Alpine/.NET container, including the expected unsupported-RID and NativeAOT negative tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository path validation for C# package outputs to avoid false positives from unrelated path segments.
  * Ensured scans detect only genuine repository path leaks.

* **Tests**
  * Added coverage confirming repository path scans use a trailing-separator match, and correctly fail when leaked repository-specific paths are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->