### PR TITLE
Fix bridge blog MDX build failure

### DIFF
--- a/typescript2/app-website/blog-content/2026-07-24-software-factories-need-human-operators.mdx
+++ b/typescript2/app-website/blog-content/2026-07-24-software-factories-need-human-operators.mdx
@@ -76,7 +76,7 @@ It took me 2 months to design and implement all of this for Python and Typescrip
 
 In addition to all of these shared designs and implementation patterns, we also set up test infrastructure to exercise end-to-end tests of each SDK:
 
-- a standardized pattern for running SDK tests for each bridge (`cargo nextest run -p sdk_test_python_pydantic2`, `cargo nextest run -p sdk_test_typescript_node`, `cargo nextest run -p sdk_test_<bridge>)
+- a standardized pattern for running SDK tests for each bridge (`cargo nextest run -p sdk_test_python_pydantic2`, `cargo nextest run -p sdk_test_typescript_node`, `cargo nextest run -p sdk_test_<bridge>`)
 - each SDK test suite's setup builds the universal interface and the bridge-specific library that loads the C interface from `HEAD`
 - each SDK test suite then also runs type checking and each test case in that language
 - CI workflows that do all of the above, fanning out across Linux, MacOS, and Windows


### PR DESCRIPTION
## What changed

Closed the inline code span around `sdk_test_<bridge>` in the bridge week blog post.

## Root cause

The code span was missing its closing backtick, so MDX parsed `<bridge>` as an opening HTML tag. During static prerendering, `next-mdx-remote` failed because the tag had no matching close tag.

## Impact

The bridge week article can now be prerendered and the Vercel production build completes successfully.

## Validation

- Reproduced the original `Expected a closing tag for <bridge>` error against merge commit `6c694181` with `next-mdx-remote`.
- Confirmed the article compiles after the fix.
- Ran `NEXT_PUBLIC_ATB_CONVEX_URL=https://example.com bash scripts/vercel-build.sh`; all 172 static pages generated successfully, including `/blog/software-factories-need-human-operators`, and sitemap generation completed.