### PR TITLE
Temporarily disable Hawk checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -414,7 +414,9 @@ jobs:
       - name: "Install mise"
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "cargo:prek cargo:https://github.com/astral-sh/hawk python uv"
+          # Temporarily omit Hawk while its CI check is disabled.
+          # install_args: "cargo:prek cargo:https://github.com/astral-sh/hawk python uv"
+          install_args: "cargo:prek python uv"
 
       - name: "Cache prek"
         uses: actions/cache@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,10 +101,11 @@ repos:
         priority: 4
         stages: [manual]
 
-      - id: cargo-hawk
-        name: cargo hawk (dead public)
-        entry: bash -c 'cd baml_language && scripts/hawk'
-        language: system
-        pass_filenames: false
-        files: ^baml_language/(.*\.rs|.*Cargo\.toml|Cargo\.lock|hawk\.toml|scripts/hawk)$
-        priority: 5
+      # Temporarily disabled while the Hawk check is paused in CI.
+      # - id: cargo-hawk
+      #   name: cargo hawk (dead public)
+      #   entry: bash -c 'cd baml_language && scripts/hawk'
+      #   language: system
+      #   pass_filenames: false
+      #   files: ^baml_language/(.*\.rs|.*Cargo\.toml|Cargo\.lock|hawk\.toml|scripts/hawk)$
+      #   priority: 5


### PR DESCRIPTION
## What changed

- stop installing Hawk in the prek CI job
- comment out the `cargo-hawk` prek hook while keeping its configuration available to restore
- leave `baml_language/scripts/hawk` and `baml_language/hawk.toml` intact

## Why

Hawk takes too long to run, so its checks are temporarily disabled without deleting the underlying script or configuration.

## Validation

- `prek validate-config .pre-commit-config.yaml`
- `prek run --files .github/workflows/ci.yaml .pre-commit-config.yaml --show-diff-on-failure`
- `git diff --check`