### PR TITLE
Fix C# release scanner dependency

### DIFF
--- a/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
+++ b/baml_language/sdks/csharp/bridge_csharp/tests/Baml.Bridge.PrimitivePackageConsumer/verify.sh
@@ -10,7 +10,7 @@ verify_repository_paths() (
   # Include the path separator so a short mount point such as /work does not
   # mistake an unrelated path segment such as /worker.rs for a repository path.
   repository_path_prefix="${repository_root%/}/"
-  if rg -a -F -l -- "$repository_path_prefix" "$publish" > /dev/null; then
+  if grep -r -a -F -l -- "$repository_path_prefix" "$publish" > /dev/null; then
     echo "published consumer contains a repository path" >&2
     return 1
   else

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -921,13 +921,14 @@ class WorkflowGraphTests(unittest.TestCase):
             primitive_consumer,
         )
         self.assertIn(
-            'rg -a -F -l -- "$repository_path_prefix" "$publish"',
+            'grep -r -a -F -l -- "$repository_path_prefix" "$publish"',
             primitive_consumer,
         )
         self.assertNotIn(
-            'rg -a -F -l "$repository_root" "$publish"',
+            'grep -r -a -F -l -- "$repository_root" "$publish"',
             primitive_consumer,
         )
+        self.assertNotIn("rg -a", primitive_consumer)
 
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## What changed

- replace the primitive C# product consumer's repository-path scan from `rg` to recursive fixed-string `grep`
- keep the existing fail-closed distinction between a match, no match, and a scanner error
- update the release-contract regression to require the dependency-free implementation

## Root cause

The BAML Language Release package assembly runner does not install ripgrep. The older pipeline accidentally treated `rg: command not found` as a clean scan because the command was hidden inside an `if` pipeline. The fail-closed scanner introduced in #4184 correctly surfaced exit 127, but that caused `Verify C# SDK product package / Assemble one provenance-bound package` to fail after the package had otherwise built and executed successfully.

`grep` is already required and exercised earlier in the same consumer verifier, so this removes the undeclared cross-platform dependency without adding runner provisioning.

## Validation

- all 19 release-pipeline contract tests pass
- repository commit hooks pass
- Bash syntax and ShellCheck pass
- the exact failed package passes `linux-x64` end to end with a PATH that contains no `rg`
- the exact failed package passes `linux-musl-x64` in the pinned Alpine/.NET image with ripgrep deliberately absent
- both exact-package runs finish with `primitive_exact_package=ok`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification when checking published C# consumer packages for repository path leaks.
  * Updated validation to use a more widely available search command, improving compatibility across environments.

* **Tests**
  * Updated release pipeline checks to reflect the revised package scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->