### PR TITLE
Fix unresolved class pattern binding recovery

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -8426,12 +8426,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // Probe the arm pattern's matched type for narrowing.
                 // Bindings/refutability are handled by the per-arm walk
                 // below, after the narrowed type is finalised.
+                let probe_diag_start = self.context.diagnostic_count();
                 let arm_probe = self.analyze_and_lower_no_subtype_check(
                     arm.pattern,
                     &clause_binding_ty,
                     body,
                     arm.body,
                 );
+                self.context.truncate_diagnostics(probe_diag_start);
                 let mut narrowed_ty = arm_probe.matched_ty.clone();
                 let written_arm_ty = arm_expected_ty
                     .clone()

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -8221,7 +8221,9 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         // Lower the pattern against the scrutinee type. Same machinery as
         // `match` arms — does subtype check, populates `pattern_types`.
+        let diag_count_before_pattern = self.context.diagnostic_count();
         let result = self.analyze_and_lower(pattern_id, &scrutinee_ty, body, then_branch);
+        let pattern_had_error = self.context.diagnostic_count() > diag_count_before_pattern;
         let matched_ty = result.matched_ty.clone();
 
         // Then-branch: push a fresh scope, narrow scrutinee, register
@@ -8259,19 +8261,21 @@ impl<'db> TypeInferenceBuilder<'db> {
         // Refutability check: run the matrix with a single arm. If nothing
         // is missing, the pattern covers every value of the scrutinee — the
         // else branch is dead.
-        let scrutinee_ty_for_matrix = self.matrix_normalize_scrut(&scrutinee_ty);
-        let report = crate::pattern_lowering::compute_match_usefulness(
-            self,
-            std::slice::from_ref(&result.dpat),
-            scrutinee_ty_for_matrix,
-        );
-        if report.missing.is_empty() {
-            let err = crate::infer_context::TirTypeError::IrrefutablePatternInIfLet;
-            if let Some(sm) = self.body_source_map.as_ref() {
-                self.context
-                    .report_warning_at_span(err, sm.pattern_span(pattern_id));
-            } else {
-                self.context.report_warning_simple(err, if_let_expr_id);
+        if !pattern_had_error {
+            let scrutinee_ty_for_matrix = self.matrix_normalize_scrut(&scrutinee_ty);
+            let report = crate::pattern_lowering::compute_match_usefulness(
+                self,
+                std::slice::from_ref(&result.dpat),
+                scrutinee_ty_for_matrix,
+            );
+            if report.missing.is_empty() {
+                let err = crate::infer_context::TirTypeError::IrrefutablePatternInIfLet;
+                if let Some(sm) = self.body_source_map.as_ref() {
+                    self.context
+                        .report_warning_at_span(err, sm.pattern_span(pattern_id));
+                } else {
+                    self.context.report_warning_simple(err, if_let_expr_id);
+                }
             }
         }
 
@@ -16567,13 +16571,25 @@ impl TypeInferenceBuilder<'_> {
         }
 
         if !matches!(class_ty, Ty::Class(..)) {
-            // Resolution failed; bail out with a wildcard so downstream
-            // can keep going. Diagnostics already emitted by resolver.
+            // Resolution failed. Continue through every field subpattern so
+            // its bindings and per-pattern types survive recovery, but poison
+            // the bindings so their later uses do not produce cascades.
+            let error_ty = Ty::Error {
+                attr: TyAttr::default(),
+            };
+            let mut bindings = Vec::new();
+            for field in fields {
+                let result = self.analyze_and_lower(field.pat, &error_ty, body, at_expr);
+                bindings.extend(result.bindings.into_iter().map(|mut binding| {
+                    binding.ty = error_ty.clone();
+                    binding
+                }));
+            }
             return PatternResult {
                 dpat: DPat::wildcard(scrut_ty.clone()),
                 required_ty: Some(class_ty.clone()),
                 matched_ty: class_ty,
-                bindings: Vec::new(),
+                bindings,
             };
         }
         // Missing generic args on a destructure of a generic class:

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/unresolved_class_pattern_bindings/main.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/unresolved_class_pattern_bindings/main.baml
@@ -1,0 +1,71 @@
+class Address {
+    zip: int,
+}
+
+class Person {
+    age: int,
+    address: Address,
+}
+
+function let_shorthand(person: Person) -> int {
+    let Missing { age } = person;
+    age
+}
+
+function let_renamed(person: Person) -> int {
+    let Missing { age: let years } = person;
+    years
+}
+
+function let_nested(person: Person) -> int {
+    let Missing { address: Address { zip } } = person;
+    zip;
+    zip.missing
+}
+
+function let_else_binding(person: Person) -> int {
+    let Missing { age } = person else {
+        return 0;
+    };
+    age
+}
+
+function if_let_binding(person: Person) -> int {
+    if let Missing { age } = person {
+        age
+    } else {
+        0
+    }
+}
+
+function while_let_binding(person: Person) -> int {
+    while let Missing { age } = person {
+        return age;
+    }
+    0
+}
+
+function for_binding(person: Person) -> int {
+    for (let Missing { age } in [person]) {
+        return age;
+    }
+    0
+}
+
+function match_binding(person: Person) -> int {
+    match (person) {
+        Missing { age } => age,
+        _ => 0,
+    }
+}
+
+function throws_person(person: Person) -> int throws Person {
+    throw person
+}
+
+function catch_arm_binding(person: Person) -> int {
+    throws_person(person) catch (error) {
+        Missing { age } => age,
+        _ => 0
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__03_ppir.snap
@@ -1,0 +1,48 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== PPIR ===
+class user.Address {
+  zip: int
+}
+class user.Address$stream {
+  zip: int | null
+}
+class user.Person {
+  age: int
+  address: user.Address
+}
+class user.Person$stream {
+  age: int | null
+  address: user.Address$stream | null
+}
+function user.catch_arm_binding(person: user.Person) -> int  [expr] {
+  {  } throws_person(person) catch (error) { Missing { age: age } => age, _ => 0 }
+}
+function user.for_binding(person: user.Person) -> int  [expr] {
+  { for Missing { age: age } in [person] { return age } } 0
+}
+function user.if_let_binding(person: user.Person) -> int  [expr] {
+  {  } if let Missing { age: age } = person {  } age else {  } 0
+}
+function user.let_else_binding(person: user.Person) -> int  [expr] {
+  { let Missing { age: age } = person } age
+}
+function user.let_nested(person: user.Person) -> int  [expr] {
+  { let Missing { address: Address { zip: zip } } = person; zip } zip.missing
+}
+function user.let_renamed(person: user.Person) -> int  [expr] {
+  { let Missing { age: years } = person } years
+}
+function user.let_shorthand(person: user.Person) -> int  [expr] {
+  { let Missing { age: age } = person } age
+}
+function user.match_binding(person: user.Person) -> int  [expr] {
+  {  } match (person) { Missing { age: age } => age, _ => 0 }
+}
+function user.throws_person(person: user.Person) -> int  [expr] {
+  { throw person }
+}
+function user.while_let_binding(person: user.Person) -> int  [expr] {
+  { while let Missing { age: age } = person { return age } } 0
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__04_tir.snap
@@ -1,0 +1,100 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== TIR2 ===
+class user.Address {
+  zip: int
+}
+class user.Person {
+  age: int
+  address: user.Address
+}
+function user.let_shorthand(person: user.Person) -> int throws never {
+  { : !error
+    let Missing { age: age } = person : user.Person -> unknown
+    age : !error
+  }
+  !! 139..158: unresolved name: Missing
+}
+function user.let_renamed(person: user.Person) -> int throws never {
+  { : !error
+    let Missing { age: years } = person : user.Person -> unknown
+    years : !error
+  }
+  !! 230..260: unresolved name: Missing
+}
+function user.let_nested(person: user.Person) -> int throws never {
+  { : unknown
+    let Missing { address: Address { zip: zip } } = person : user.Person -> unknown
+    zip : !error
+    zip.missing : unknown
+  }
+  !! 333..373: unresolved name: Missing
+}
+function user.let_else_binding(person: user.Person) -> int throws never {
+  { : !error
+    let Missing { age: age } = person : user.Person -> unknown
+    age : !error
+  }
+  !! 467..486: unresolved name: Missing
+}
+function user.if_let_binding(person: user.Person) -> int throws never {
+  { : !error | 0
+    if let <pat> = person { 0 stmts + tail } else { 0 stmts + tail } : !error | 0
+  }
+  !! 595..614: unresolved name: Missing
+}
+function user.while_let_binding(person: user.Person) -> int throws never {
+  { : 0
+    while let Missing { age: age } = person
+      { : never
+        return age : !error
+      }
+    0 : 0
+  }
+  !! 732..751: unresolved name: Missing
+}
+function user.for_binding(person: user.Person) -> int throws never {
+  { : 0
+    for Missing { age: age } in [person]
+      { : never
+        return age : !error
+      }
+    0 : 0
+  }
+  !! 853..872: unresolved name: Missing
+}
+function user.match_binding(person: user.Person) -> int throws never {
+  { : !error | 0
+    match (person : user.Person) : !error | 0
+      Missing { age: age } =>
+        age : !error
+      _ =>
+        0 : 0
+  }
+  !! 1000..1015: unresolved name: Missing
+}
+function user.throws_person(person: user.Person) -> int throws user.Person {
+  { : never
+    throw person : user.Person
+  }
+}
+function user.catch_arm_binding(person: user.Person) -> int throws never {
+  { : int | !error | 0
+    catch (throws_person(person) : int) : int | !error | 0
+      catch (error)
+        Missing { age: age } =>
+          age : !error
+        _ =>
+          0 : 0
+  }
+  !! 1233..1248: unresolved name: Missing
+  !! 1233..1248: unresolved name: Missing
+}
+class user.Address$stream {
+  zip: int | null
+}
+class user.Person$stream {
+  age: int | null
+  address: user.Address$stream | null
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__04_tir.snap
@@ -89,7 +89,6 @@ function user.catch_arm_binding(person: user.Person) -> int throws never {
           0 : 0
   }
   !! 1233..1248: unresolved name: Missing
-  !! 1233..1248: unresolved name: Missing
 }
 class user.Address$stream {
   zip: int | null

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__05_diagnostics.snap
@@ -1,0 +1,75 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== COMPILER2 DIAGNOSTICS ===
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:11:5]
+ 11 │     let Missing { age } = person;
+    ·     ───────────────────
+    ╰────
+
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:16:5]
+ 16 │     let Missing { age: let years } = person;
+    ·     ──────────────────────────────
+    ╰────
+
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:21:5]
+ 21 │     let Missing { address: Address { zip } } = person;
+    ·     ────────────────────────────────────────
+    ╰────
+
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:27:5]
+ 27 │     let Missing { age } = person else {
+    ·     ───────────────────
+    ╰────
+
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:34:8]
+ 34 │     if let Missing { age } = person {
+    ·        ───────────────────
+    ╰────
+
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:42:11]
+ 42 │     while let Missing { age } = person {
+    ·           ───────────────────
+    ╰────
+
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:49:10]
+ 49 │     for (let Missing { age } in [person]) {
+    ·          ───────────────────
+    ╰────
+
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:57:9]
+ 57 │         Missing { age } => age,
+    ·         ───────────────
+    ╰────
+
+  [type] E0003
+
+  × unresolved name: `Missing`
+    ╭─[main.baml:68:9]
+ 68 │         Missing { age } => age,
+    ·         ───────────────
+    ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/unresolved_class_pattern_bindings/baml_tests__diagnostic_errors__unresolved_class_pattern_bindings__10_formatter__main.snap
@@ -1,0 +1,74 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+class Address {
+    zip: int,
+}
+
+class Person {
+    age: int,
+    address: Address,
+}
+
+function let_shorthand(person: Person) -> int {
+    let Missing { age } = person;
+    age
+}
+
+function let_renamed(person: Person) -> int {
+    let Missing { age: let years } = person;
+    years
+}
+
+function let_nested(person: Person) -> int {
+    let Missing { address: Address { zip } } = person;
+    zip;
+    zip.missing
+}
+
+function let_else_binding(person: Person) -> int {
+    let Missing { age } = person else {
+        return 0;
+    };
+    age
+}
+
+function if_let_binding(person: Person) -> int {
+    if let Missing { age } = person {
+        age
+    } else {
+        0
+    }
+}
+
+function while_let_binding(person: Person) -> int {
+    while let Missing { age } = person {
+        return age;
+    }
+    0
+}
+
+function for_binding(person: Person) -> int {
+    for (let Missing { age } in [person]) {
+        return age;
+    }
+    0
+}
+
+function match_binding(person: Person) -> int {
+    match (person) {
+        Missing { age } => age,
+        _ => 0,
+    }
+}
+
+function throws_person(person: Person) -> int throws Person {
+    throw person
+}
+
+function catch_arm_binding(person: Person) -> int {
+    throws_person(person) catch (error) {
+        Missing { age } => age,
+        _ => 0
+    }
+}


### PR DESCRIPTION
## Summary

- recover bindings nested under unresolved class pattern heads
- assign recovered bindings the error type to suppress dependent diagnostics
- skip if-let usefulness warnings after pattern errors
- cover shorthand, renamed, nested, let, let else, if let, while let, for, match, and catch-arm bindings

## Testing

- `cargo fmt --manifest-path baml_language/Cargo.toml --all -- --check --config imports_granularity=Crate --config group_imports=StdExternalCrate`
- `cargo test --manifest-path baml_language/Cargo.toml -p baml_compiler2_tir`
- `cargo test --manifest-path baml_language/Cargo.toml -p baml_tests unresolved_class_pattern_bindings`
- `cargo test --manifest-path baml_language/Cargo.toml -p baml_tests patterns_class_destructure`
- `cargo clippy --manifest-path baml_language/Cargo.toml -p baml_compiler2_tir -p baml_tests --all-targets -- -D warnings`

Linear: B-923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compiler diagnostics for invalid class-pattern bindings, preserving recoverable bindings to limit cascading errors.
  - Avoided computing match-usefulness and suppressing the “irrefutable pattern in if let” warning when earlier pattern lowering produced diagnostics.
  - Enhanced class-pattern resolution recovery by continuing with error-typed bindings instead of aborting.

- **Tests**
  - Added a new diagnostic-error project covering destructuring/class-pattern bindings in `let`, `let ... else`, `if let`, loops, `match`, and `throws`/`catch`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->