### PR TITLE
fix(cli): clarify baml update command

### DIFF
--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -54,7 +54,7 @@ pub(crate) mod util;
 // pub(crate) mod propelauth;
 // pub(crate) mod tui;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 
 #[derive(Debug, Clone)]
 pub enum ExitCode {
@@ -120,6 +120,13 @@ impl From<ExitCode> for u32 {
 /// `format`, or `language-server`. `baml run` is the top-level entry for
 /// standalone execution.
 pub fn run_cli(argv: Vec<String>) -> Result<ExitCode> {
+    if argv.get(1).map(String::as_str) == Some("update") {
+        return Err(anyhow!(
+            "`baml update` is ambiguous.\n\
+             To use the latest version of BAML, run `baml toolchain update`.\n\
+             To use the latest BAML toolchain selector, run `baml self-update`."
+        ));
+    }
     let cli = commands::RuntimeCli::parse_from_smart(argv);
     cli.run()
 }

--- a/baml_language/crates/baml_cli/tests/update_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/update_e2e.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+#[test]
+fn update_suggests_the_toolchain_and_wrapper_commands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_baml-cli"))
+        .arg("update")
+        .env("BAML_CLI_ALLOW_DIRECT", "1")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("`baml update` is ambiguous."), "{stderr}");
+    assert!(
+        stderr.contains("To use the latest version of BAML, run `baml toolchain update`."),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("To use the latest BAML toolchain selector, run `baml self-update`."),
+        "{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- handle ambiguous `baml update` invocations in `baml-cli` before Clap parsing
- direct users to `baml toolchain update` or `baml self-update` based on what they want to update
- keep the compatibility command out of normal help while covering the behavior end to end

## Why

`baml update` has two plausible meanings: updating the selected language toolchain or updating the wrapper binary. Keeping this compatibility handling in `baml-cli` makes the guidance available through both wrapper-delegated and direct/package-managed invocations without making the wrapper own a toolchain command.

## Impact

Users who run `baml update` receive actionable guidance instead of Clap's unknown-command response. Existing documented update commands are unchanged.

## Testing

- `cargo fmt --package baml_cli -- --check`
- `cargo test -p baml_cli --test update_e2e`
- `cargo test -p baml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified that the ambiguous `baml update` command is no longer supported.
  * Added guidance to use `baml toolchain update` or `baml self-update` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->