### PR TITLE
chore(java): ignore Gradle build artifacts

### DIFF
--- a/baml_language/.gitignore
+++ b/baml_language/.gitignore
@@ -18,5 +18,9 @@ rpi/
 # Local scratch projects / fuzz repros (not part of the build)
 workflow_scratch_files/
 
+# Java/Gradle build artifacts
+sdks/java/**/.gradle/
+sdks/java/**/build/
+
 # .bamlprof artifacts (profiling is default-on; BAML_PROFILE=0 opts out)
 **/.baml/profiles/


### PR DESCRIPTION
## Summary

Add Java SDK-specific ignore rules for Gradle's per-project `.gradle` caches and `build` output directories.

## Why

Gradle TestKit and local Java builds generate large JARs under these directories. Jujutsu refuses to snapshot those files because they exceed the repository's maximum new-file size, producing noisy warnings during normal workspace operations.

## Impact

Generated Java/Gradle artifacts remain local and no longer appear as untracked files or trigger Jujutsu large-file warnings. Java source and project configuration remain tracked normally.

## Validation

Created representative files under `baml_language/sdks/java/gradle-plugin/.gradle/` and `baml_language/sdks/java/gradle-plugin/build/` and confirmed `jj status` ignored both paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude Java and Gradle build artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->