### PR TITLE
test(homebrew): keep formula checks offline

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "baml_release",

--- a/baml_language/crates/baml/Cargo.toml
+++ b/baml_language/crates/baml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baml"
-version = "0.2.1"
+version = "0.2.2"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/scripts/baml-package-manager-artifacts
+++ b/scripts/baml-package-manager-artifacts
@@ -74,11 +74,10 @@ def render_formula(version: str, source_sha256: str) -> str:
     ENV["HOME"] = testpath.to_s
     ENV.delete "BAML_VERSION"
 
-    system bin/"baml", "toolchain", "use", "canary"
-    system bin/"baml", "init", "--name", "homebrew-test"
-    assert_path_exists testpath/"baml.toml"
-    assert_path_exists testpath/"baml_src/main.baml"
-    system bin/"baml", "check"
+    assert_match "baml wrapper {version}",
+                 shell_output("#{{bin}}/baml --version")
+    assert_match "installed toolchains: (none)",
+                 shell_output("#{{bin}}/baml toolchain list")
     assert_match "self-update is disabled in this build",
                  shell_output("#{{bin}}/baml self-update 2>&1", 1)
   end

--- a/scripts/tests/test_baml_package_manager_artifacts.py
+++ b/scripts/tests/test_baml_package_manager_artifacts.py
@@ -54,11 +54,15 @@ class PackageManagerArtifactsTest(unittest.TestCase):
             self.assertIn('features: "no-self-update"', formula)
             self.assertIn("test do", formula)
             self.assertIn(
-                'system bin/"baml", "toolchain", "use", "canary"', formula
+                f'assert_match "baml wrapper {VERSION}"', formula
             )
-            self.assertIn('system bin/"baml", "init"', formula)
-            self.assertIn('system bin/"baml", "check"', formula)
+            self.assertIn('shell_output("#{bin}/baml --version")', formula)
+            self.assertIn('assert_match "installed toolchains: (none)"', formula)
+            self.assertIn('shell_output("#{bin}/baml toolchain list")', formula)
             self.assertIn("self-update is disabled in this build", formula)
+            self.assertNotIn('"toolchain", "use"', formula)
+            self.assertNotIn('system bin/"baml", "init"', formula)
+            self.assertNotIn('system bin/"baml", "check"', formula)
             self.assertNotIn('toolchains/1.2.3', formula)
             self.assertNotIn("on_macos", formula)
             self.assertNotIn("/releases/download/", formula)


### PR DESCRIPTION
## Summary

- replace network-dependent Homebrew formula tests with wrapper-local checks
- verify the wrapper version, local toolchain inventory, and disabled self-update behavior
- prevent package-manager artifact tests from reintroducing network-dependent commands
- bump the wrapper to 0.2.2 so the release republishes the updated Homebrew formula

## Validation

- `scripts/baml-wrapper-version check`
- `cargo check -p baml --features no-self-update`
- `cargo test -p baml`
- `cargo test -p baml --features no-self-update`
- `python3 -m unittest scripts.tests.test_baml_package_manager_artifacts`
- `mise exec -- ruff check scripts/baml-package-manager-artifacts scripts/tests/test_baml_package_manager_artifacts.py`
- changed-file `prek` hooks
- generated formula: `brew audit --strict --new --online`
- generated formula: `brew style --formula`
- generated formula: `HOMEBREW_FORMULA_TEST_NETWORK=deny brew test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Homebrew formula validation to assert the wrapper’s `--version` output and that `baml toolchain list` reports no installed toolchains.
  * Adjusted expectations to confirm the formula does not run toolchain init/check/toolchain-use related commands during installation/runtime validation.

* **Chores**
  * Bumped the `baml` crate version from `0.2.1` to `0.2.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->