### PR TITLE
Use boundary-tools-prod for crates.io releases

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1522,7 +1522,7 @@ jobs:
     # like PyPI/npm above. Match the builder's runner + toolchain so the
     # repackaged `.crate` is byte-reproducible.
     runs-on: ubuntu-22.04
-    environment: release
+    environment: boundary-tools-prod
     permissions:
       id-token: write
       contents: read

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -788,6 +788,7 @@ class WorkflowGraphTests(unittest.TestCase):
         verify = job_block(workflow, "verify-csharp-sdk")
         all_builds = job_block(workflow, "all-builds")
         nuget = job_block(workflow, "publish-csharp-sdk")
+        crates_io = job_block(workflow, "publish-crates-io")
         prerequisites = job_block(workflow, "release-prerequisites-complete")
         complete = job_block(workflow, "release-complete")
         manifest = job_block(workflow, "publish-pkg-boundaryml-com")
@@ -803,6 +804,8 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("build-bridge-cffi", verify)
         self.assertIn("- verify-csharp-sdk", all_builds)
         self.assertIn("all-builds", nuget)
+        self.assertIn("environment: boundary-tools-prod", crates_io)
+        self.assertNotIn("environment: release", crates_io)
         for publisher in (
             "publish-pypi",
             "publish-nodejs-sdk",


### PR DESCRIPTION
## Summary

- run the crates.io publisher under the existing `boundary-tools-prod` GitHub environment
- add a release-pipeline contract assertion that rejects the obsolete `release` environment

## Root cause

The Rust publisher was the only job in `release-baml-language.yml` still targeting `environment: release`. That environment requires manual approval, so an otherwise automatic canary language release stopped at the crates.io publisher.

## Impact

Future crates.io publishing jobs use the same Infisical-backed production environment as the rest of the release pipeline and no longer wait on the obsolete `release` approval gate. OIDC permissions and the crates.io trusted-publishing workflow identity are unchanged.

This cannot alter the already-started release run: GitHub reruns use the workflow definition from the original run SHA. That run must either receive approval for its existing `release` deployment or be superseded by a new post-merge canary release.

## Validation

- `python3 -m unittest scripts.tests.test_release_pipeline_contract` (19 tests)
- `actionlint .github/workflows/release-baml-language.yml`
- YAML parse
- `git diff --check`
- repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Pipeline**
  * Updated the crates.io publishing workflow to use the `boundary-tools-prod` release environment.
  * Added validation to ensure the publishing workflow continues using the correct environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->