### PR TITLE
fix(homebrew): restore binary tap formula

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -471,7 +471,7 @@ jobs:
             exit 1
           fi
       - name: Build package-manager wrapper
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ matrix.target == 'aarch64-apple-darwin' || matrix.target == 'x86_64-apple-darwin' || matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
           set -euo pipefail
           target="${{ matrix.target }}"
@@ -495,7 +495,7 @@ jobs:
           else
             tar -C staging -czf "baml-wrapper-$WRAPPER_VERSION-$TARGET.tar.gz" .
           fi
-          if [[ "$TARGET" == "aarch64-unknown-linux-gnu" || "$TARGET" == "x86_64-unknown-linux-gnu" ]]; then
+          if [[ "$TARGET" == "aarch64-apple-darwin" || "$TARGET" == "x86_64-apple-darwin" || "$TARGET" == "aarch64-unknown-linux-gnu" || "$TARGET" == "x86_64-unknown-linux-gnu" ]]; then
             tar -C staging-no-self-update -czf \
               "baml-wrapper-no-self-update-$WRAPPER_VERSION-$TARGET.tar.gz" .
           fi

--- a/scripts/baml-package-manager-artifacts
+++ b/scripts/baml-package-manager-artifacts
@@ -43,11 +43,6 @@ def render_formula(version: str, shas: dict[str, str]) -> str:
   version "{version}"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    regex(/^baml-wrapper[._-]v?(\\d+(?:\\.\\d+)+)$/i)
-  end
-
   on_macos do
     on_arm do
       url "https://github.com/BoundaryML/baml/releases/download/baml-wrapper-{version}/baml-wrapper-no-self-update-{version}-{HOMEBREW_TARGETS["mac_arm"]}.tar.gz"

--- a/scripts/baml-package-manager-artifacts
+++ b/scripts/baml-package-manager-artifacts
@@ -13,6 +13,12 @@ AUR_BIN_TARGETS = {
     "linux_intel": "x86_64-unknown-linux-gnu",
 }
 
+HOMEBREW_TARGETS = {
+    "mac_arm": "aarch64-apple-darwin",
+    "mac_intel": "x86_64-apple-darwin",
+    **AUR_BIN_TARGETS,
+}
+
 
 def sha256(path: Path) -> str:
     h = hashlib.sha256()
@@ -30,12 +36,11 @@ def wrapper_archive(wrapper_dir: Path, version: str, target: str) -> Path:
     return path
 
 
-def render_formula(version: str, source_sha256: str) -> str:
+def render_formula(version: str, shas: dict[str, str]) -> str:
     return f'''class Baml < Formula
   desc "Toolchain manager and launcher for the BAML language"
   homepage "https://github.com/BoundaryML/baml"
-  url "https://github.com/BoundaryML/baml/archive/refs/tags/baml-wrapper-{version}.tar.gz"
-  sha256 "{source_sha256}"
+  version "{version}"
   license "Apache-2.0"
 
   livecheck do
@@ -43,15 +48,32 @@ def render_formula(version: str, source_sha256: str) -> str:
     regex(/^baml-wrapper[._-]v?(\\d+(?:\\.\\d+)+)$/i)
   end
 
-  depends_on "cmake" => :build
-  depends_on "rust" => :build
+  on_macos do
+    on_arm do
+      url "https://github.com/BoundaryML/baml/releases/download/baml-wrapper-{version}/baml-wrapper-no-self-update-{version}-{HOMEBREW_TARGETS["mac_arm"]}.tar.gz"
+      sha256 "{shas[HOMEBREW_TARGETS["mac_arm"]]}"
+    end
+
+    on_intel do
+      url "https://github.com/BoundaryML/baml/releases/download/baml-wrapper-{version}/baml-wrapper-no-self-update-{version}-{HOMEBREW_TARGETS["mac_intel"]}.tar.gz"
+      sha256 "{shas[HOMEBREW_TARGETS["mac_intel"]]}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/BoundaryML/baml/releases/download/baml-wrapper-{version}/baml-wrapper-no-self-update-{version}-{HOMEBREW_TARGETS["linux_arm"]}.tar.gz"
+      sha256 "{shas[HOMEBREW_TARGETS["linux_arm"]]}"
+    end
+
+    on_intel do
+      url "https://github.com/BoundaryML/baml/releases/download/baml-wrapper-{version}/baml-wrapper-no-self-update-{version}-{HOMEBREW_TARGETS["linux_intel"]}.tar.gz"
+      sha256 "{shas[HOMEBREW_TARGETS["linux_intel"]]}"
+    end
+  end
 
   def install
-    system "cargo", "install",
-           *std_cargo_args(
-             path:     "baml_language/crates/baml",
-             features: "no-self-update",
-           )
+    bin.install "bin/baml"
   end
 
   def caveats
@@ -119,15 +141,13 @@ def main() -> None:
 
     args.out.mkdir(parents=True, exist_ok=True)
     shas = {
-        name: sha256(wrapper_archive(args.wrapper_dir, args.version, target))
-        for name, target in AUR_BIN_TARGETS.items()
+        target: sha256(wrapper_archive(args.wrapper_dir, args.version, target))
+        for target in HOMEBREW_TARGETS.values()
     }
 
     formula_dir = args.out / "homebrew" / "Formula"
     formula_dir.mkdir(parents=True, exist_ok=True)
-    (formula_dir / "baml.rb").write_text(
-        render_formula(args.version, args.source_sha256)
-    )
+    (formula_dir / "baml.rb").write_text(render_formula(args.version, shas))
 
     pkgver = args.version.replace("-", "_")
     aur_source = (
@@ -142,8 +162,8 @@ def main() -> None:
         .read_text()
         .replace("__VERSION__", pkgver)
         .replace("__VERSION_ORIG__", args.version)
-        .replace("__SHA256_X86_64__", shas["linux_intel"])
-        .replace("__SHA256_AARCH64__", shas["linux_arm"])
+        .replace("__SHA256_X86_64__", shas[AUR_BIN_TARGETS["linux_intel"]])
+        .replace("__SHA256_AARCH64__", shas[AUR_BIN_TARGETS["linux_arm"]])
     )
 
     aur_dir = args.out / "aur"
@@ -159,9 +179,9 @@ def main() -> None:
             pkgver,
             [
                 f"\tsource_x86_64 = https://github.com/BoundaryML/baml/releases/download/baml-wrapper-{args.version}/baml-wrapper-no-self-update-{args.version}-x86_64-unknown-linux-gnu.tar.gz",
-                f"\tsha256sums_x86_64 = {shas['linux_intel']}",
+                f"\tsha256sums_x86_64 = {shas[AUR_BIN_TARGETS['linux_intel']]}",
                 f"\tsource_aarch64 = https://github.com/BoundaryML/baml/releases/download/baml-wrapper-{args.version}/baml-wrapper-no-self-update-{args.version}-aarch64-unknown-linux-gnu.tar.gz",
-                f"\tsha256sums_aarch64 = {shas['linux_arm']}",
+                f"\tsha256sums_aarch64 = {shas[AUR_BIN_TARGETS['linux_arm']]}",
             ],
         )
     )

--- a/scripts/tests/test_baml_package_manager_artifacts.py
+++ b/scripts/tests/test_baml_package_manager_artifacts.py
@@ -53,9 +53,7 @@ class PackageManagerArtifactsTest(unittest.TestCase):
 
             formula = (output / "homebrew/Formula/baml.rb").read_text()
             self.assertIn(f'version "{VERSION}"', formula)
-            self.assertIn(
-                r"regex(/^baml-wrapper[._-]v?(\d+(?:\.\d+)+)$/i)", formula
-            )
+            self.assertNotIn("livecheck do", formula)
             self.assertIn("on_macos do", formula)
             self.assertIn("on_linux do", formula)
             for target in targets:

--- a/scripts/tests/test_baml_package_manager_artifacts.py
+++ b/scripts/tests/test_baml_package_manager_artifacts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import subprocess
 import tempfile
 import unittest
@@ -10,23 +11,29 @@ ROOT = Path(__file__).resolve().parents[2]
 GENERATOR = ROOT / "scripts" / "baml-package-manager-artifacts"
 VERSION = "1.2.3"
 SOURCE_SHA256 = "a" * 64
-EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 
 class PackageManagerArtifactsTest(unittest.TestCase):
-    def test_generates_source_formula_and_no_self_update_aur_packages(self) -> None:
+    def test_generates_binary_formula_and_no_self_update_aur_packages(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             temp_path = Path(temp)
             wrappers = temp_path / "wrappers"
             output = temp_path / "output"
             wrappers.mkdir()
-            for target in (
+            targets = (
+                "aarch64-apple-darwin",
+                "x86_64-apple-darwin",
                 "aarch64-unknown-linux-gnu",
                 "x86_64-unknown-linux-gnu",
-            ):
-                (
+            )
+            archive_shas = {}
+            for target in targets:
+                content = target.encode()
+                archive = (
                     wrappers / f"baml-wrapper-no-self-update-{VERSION}-{target}.tar.gz"
-                ).touch()
+                )
+                archive.write_bytes(content)
+                archive_shas[target] = hashlib.sha256(content).hexdigest()
 
             subprocess.run(
                 [
@@ -45,13 +52,19 @@ class PackageManagerArtifactsTest(unittest.TestCase):
             )
 
             formula = (output / "homebrew/Formula/baml.rb").read_text()
-            self.assertIn(f"archive/refs/tags/baml-wrapper-{VERSION}.tar.gz", formula)
-            self.assertIn(f'sha256 "{SOURCE_SHA256}"', formula)
+            self.assertIn(f'version "{VERSION}"', formula)
             self.assertIn(
                 r"regex(/^baml-wrapper[._-]v?(\d+(?:\.\d+)+)$/i)", formula
             )
-            self.assertIn('depends_on "rust" => :build', formula)
-            self.assertIn('features: "no-self-update"', formula)
+            self.assertIn("on_macos do", formula)
+            self.assertIn("on_linux do", formula)
+            for target in targets:
+                self.assertIn(
+                    f"baml-wrapper-no-self-update-{VERSION}-{target}.tar.gz",
+                    formula,
+                )
+                self.assertIn(f'sha256 "{archive_shas[target]}"', formula)
+            self.assertIn('bin.install "bin/baml"', formula)
             self.assertIn("test do", formula)
             self.assertIn(
                 f'assert_match "baml wrapper {VERSION}"', formula
@@ -64,8 +77,10 @@ class PackageManagerArtifactsTest(unittest.TestCase):
             self.assertNotIn('system bin/"baml", "init"', formula)
             self.assertNotIn('system bin/"baml", "check"', formula)
             self.assertNotIn('toolchains/1.2.3', formula)
-            self.assertNotIn("on_macos", formula)
-            self.assertNotIn("/releases/download/", formula)
+            self.assertNotIn("archive/refs/tags", formula)
+            self.assertNotIn(f'sha256 "{SOURCE_SHA256}"', formula)
+            self.assertNotIn('depends_on "rust"', formula)
+            self.assertNotIn('system "cargo"', formula)
             subprocess.run(
                 ["ruby", "-c", output / "homebrew/Formula/baml.rb"], check=True
             )
@@ -76,7 +91,12 @@ class PackageManagerArtifactsTest(unittest.TestCase):
 
             aur_bin = (output / "aur/baml-bin/PKGBUILD").read_text()
             self.assertIn(f"baml-wrapper-no-self-update-{VERSION}", aur_bin)
-            self.assertIn(EMPTY_SHA256, aur_bin)
+            self.assertIn(
+                archive_shas["aarch64-unknown-linux-gnu"], aur_bin
+            )
+            self.assertIn(
+                archive_shas["x86_64-unknown-linux-gnu"], aur_bin
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -783,6 +783,7 @@ class WorkflowGraphTests(unittest.TestCase):
     ) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         build_matrix = job_block(workflow, "build-matrix")
+        wrapper = job_block(workflow, "build-wrapper")
         prepare = job_block(workflow, "prepare-csharp-sdk")
         cffi = job_block(workflow, "build-bridge-cffi")
         verify = job_block(workflow, "verify-csharp-sdk")
@@ -797,6 +798,14 @@ class WorkflowGraphTests(unittest.TestCase):
         dry_run = job_block(workflow, "dry-run-artifacts")
 
         self.assertIn("baml-csharp-release-contract matrix", build_matrix)
+        for target in (
+            "aarch64-apple-darwin",
+            "x86_64-apple-darwin",
+            "aarch64-unknown-linux-gnu",
+            "x86_64-unknown-linux-gnu",
+        ):
+            self.assertIn(target, wrapper)
+        self.assertIn("--features no-self-update", wrapper)
         self.assertIn("needs: [plan, build-matrix]", prepare)
         self.assertNotIn("build-bridge-cffi", prepare)
         self.assertIn("needs: [plan]", cffi)


### PR DESCRIPTION
## Summary

- restore prebuilt binary installation for the BoundaryML Homebrew tap
- publish `no-self-update` wrapper archives for macOS and Linux on ARM and Intel
- keep the tap formula tests offline
- leave the separate Homebrew Core source formula for a later upstream submission

## Validation

- `python3 -m unittest scripts.tests.test_baml_package_manager_artifacts scripts.tests.test_release_pipeline_contract`
- `mise exec -- ruff check scripts/baml-package-manager-artifacts scripts/tests/test_baml_package_manager_artifacts.py scripts/tests/test_release_pipeline_contract.py`
- `mise exec -- actionlint .github/workflows/release-baml-language.yml`
- changed-file `prek` hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added binary Homebrew and Arch Linux package artifacts for macOS and Linux platforms.
  * Added platform-specific checksums to package metadata.
  * Added no-self-update wrapper packages for additional Apple targets.

* **Bug Fixes**
  * Improved release packaging coverage across supported target platforms.

* **Tests**
  * Expanded release pipeline and package artifact validation for platform-specific archives and checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->