### PR TITLE
fix(homebrew): pass formula audit and install

### DIFF
--- a/scripts/baml-package-manager-artifacts
+++ b/scripts/baml-package-manager-artifacts
@@ -40,7 +40,6 @@ def render_formula(version: str, shas: dict[str, str]) -> str:
     return f'''class Baml < Formula
   desc "Toolchain manager and launcher for the BAML language"
   homepage "https://github.com/BoundaryML/baml"
-  version "{version}"
   license "Apache-2.0"
 
   on_macos do
@@ -68,7 +67,11 @@ def render_formula(version: str, shas: dict[str, str]) -> str:
   end
 
   def install
-    bin.install "bin/baml"
+    if (buildpath/"bin/baml").exist?
+      bin.install "bin/baml"
+    else
+      bin.install "baml"
+    end
   end
 
   def caveats

--- a/scripts/tests/test_baml_package_manager_artifacts.py
+++ b/scripts/tests/test_baml_package_manager_artifacts.py
@@ -52,7 +52,7 @@ class PackageManagerArtifactsTest(unittest.TestCase):
             )
 
             formula = (output / "homebrew/Formula/baml.rb").read_text()
-            self.assertIn(f'version "{VERSION}"', formula)
+            self.assertNotRegex(formula, r"(?m)^\s*version\s")
             self.assertNotIn("livecheck do", formula)
             self.assertIn("on_macos do", formula)
             self.assertIn("on_linux do", formula)
@@ -62,7 +62,9 @@ class PackageManagerArtifactsTest(unittest.TestCase):
                     formula,
                 )
                 self.assertIn(f'sha256 "{archive_shas[target]}"', formula)
+            self.assertIn('if (buildpath/"bin/baml").exist?', formula)
             self.assertIn('bin.install "bin/baml"', formula)
+            self.assertIn('bin.install "baml"', formula)
             self.assertIn("test do", formula)
             self.assertIn(
                 f'assert_match "baml wrapper {VERSION}"', formula


### PR DESCRIPTION
Fix the binary Homebrew formula after the 0.2.2 release exposed two issues:

- remove the explicit version that Homebrew flags as redundant
- restore the archive-layout fallback required by Homebrew extraction
- add regression assertions for both behaviors

Validated with the actual arm64 macOS wrapper artifact from release run 30140622225:

- `brew audit --strict codex/hotfix/baml`
- inferred stable version is `0.2.2`
- `brew install --build-from-source codex/hotfix/baml`
- `brew test codex/hotfix/baml`
- `brew linkage --test codex/hotfix/baml`
- package-manager and release-contract unit tests
- Ruff and changed-file pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew package installation to support binaries located in either the package root or its `bin` directory.
  * Removed the redundant version directive from generated Homebrew formulas.

* **Tests**
  * Updated package-generation checks to validate both supported binary locations and the revised formula format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->