### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -44,13 +44,13 @@ policy.max_delta_pct = 3.0
 # unformatted generated SDK output).
 # macOS arm64: baseline 21.00 MB file (21_002_656), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 21_632_736
+max_file_bytes = 21_820_377
 # Linux x86_64: baseline 27.08 MB file (27_075_600), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 27_887_868
+max_file_bytes = 28_083_783
 # Windows x86_64: baseline 22.67 MB file (22_671_360), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 23_351_501
+max_file_bytes = 23_518_674
 
 [artifacts.packed-program]
 kind = "pack"
@@ -58,13 +58,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 13.77 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 14_183_432
+max_file_bytes = 14_234_586
 # Linux x86_64: baseline 17.64 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 18_170_717
+max_file_bytes = 18_210_565
 # Windows x86_64: baseline 14.70 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 15_136_696
+max_file_bytes = 15_172_856
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -88,4 +88,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.40 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_534_455
+max_gzip_bytes = 4_646_802

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-23T21:57:35Z"
-git_sha = "8b1dd912615a744e9a90819fcb18b3b267a36bf6"
+recorded_at = "2026-07-27T10:30:56Z"
+git_sha = "01f9b1a749d69ecdcd8da456a8dbeddeaba65d43"
 
 [artifacts.baml-cli]
-file_bytes = 21002656
-stripped_bytes = 21002704
-gzip_bytes = 10041129
+file_bytes = 21184832
+stripped_bytes = 21184880
+gzip_bytes = 10121944
 
 [artifacts.packed-program]
-file_bytes = 13770322
-gzip_bytes = 6378586
+file_bytes = 13819986
+gzip_bytes = 6400400

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-07-24T10:01:59Z"
-git_sha = "560dc6e23af0b3910ddcbdbf3a34153ea2c709be"
+recorded_at = "2026-07-27T10:30:56Z"
+git_sha = "01f9b1a749d69ecdcd8da456a8dbeddeaba65d43"
 
 [artifacts.bridge_wasm]
-file_bytes = 16428315
-gzip_bytes = 4481676
+file_bytes = 16540770
+gzip_bytes = 4511458

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-23T21:57:35Z"
-git_sha = "8b1dd912615a744e9a90819fcb18b3b267a36bf6"
+recorded_at = "2026-07-27T10:30:56Z"
+git_sha = "01f9b1a749d69ecdcd8da456a8dbeddeaba65d43"
 
 [artifacts.baml-cli]
-file_bytes = 22671360
-stripped_bytes = 22671360
-gzip_bytes = 10259054
+file_bytes = 22833664
+stripped_bytes = 22833664
+gzip_bytes = 10333294
 
 [artifacts.packed-program]
-file_bytes = 14695821
-gzip_bytes = 6465608
+file_bytes = 14730928
+gzip_bytes = 6494635

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-23T21:57:35Z"
-git_sha = "8b1dd912615a744e9a90819fcb18b3b267a36bf6"
+recorded_at = "2026-07-27T10:30:56Z"
+git_sha = "01f9b1a749d69ecdcd8da456a8dbeddeaba65d43"
 
 [artifacts.baml-cli]
-file_bytes = 27075600
-stripped_bytes = 27075592
-gzip_bytes = 11499682
+file_bytes = 27265808
+stripped_bytes = 27265800
+gzip_bytes = 11594361
 
 [artifacts.packed-program]
-file_bytes = 17641472
-gzip_bytes = 7266666
+file_bytes = 17680160
+gzip_bytes = 7291779


### PR DESCRIPTION
Adopted from CI run [`01f9b1a749d69ecdcd8da456a8dbeddeaba65d43`](https://github.com/BoundaryML/baml/actions/runs/30255072342).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 27.3 MB | 11.6 MB | **file** | 27.1 MB | +190.2 KB (+0.7%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 17.7 MB | 7.3 MB | **file** | 17.6 MB | +38.7 KB (+0.2%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 21.2 MB | 10.1 MB | **file** | 21.0 MB | +182.2 KB (+0.9%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 13.8 MB | 6.4 MB | **file** | 13.8 MB | +49.7 KB (+0.4%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 16.5 MB | 🔒 4.5 MB | **gzip** | 4.5 MB | +29.8 KB (+0.7%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 22.8 MB | 10.3 MB | **file** | 22.7 MB | +162.3 KB (+0.7%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 14.7 MB | 6.5 MB | **file** | 14.7 MB | +35.1 KB (+0.2%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated size thresholds for command-line, packed-program, and WebAssembly artifacts across supported platforms.
  * Refreshed recorded artifact measurements and build metadata for macOS, Linux, Windows, and WebAssembly targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->