### PR TITLE
docs(web): use Homebrew core install command

### DIFF
--- a/typescript2/app-website/app/baml-intro/_components/TryBaml.tsx
+++ b/typescript2/app-website/app/baml-intro/_components/TryBaml.tsx
@@ -31,7 +31,7 @@ const clip = (
 
 const OS_OPTS: Opt[] = [
   {
-    cmd: 'brew install boundaryml/tap/baml',
+    cmd: 'brew install baml',
     icon: (
       <svg
         aria-hidden="true"
@@ -183,7 +183,7 @@ const ENV_OPTS: Opt[] = [
 const PROMPT = `Set up BAML in this repo so I can write great agent first code.
 
 Install the toolchain (pick one for this machine):
-- Homebrew (macOS/Linux): \`brew install boundaryml/tap/baml\`
+- Homebrew (macOS/Linux): \`brew install baml\`
 - curl (macOS/Linux): \`curl -fsSL https://pkg.boundaryml.com/install.sh | sh -s\`
 - Arch: \`yay -S baml-bin\`
 - Windows: \`irm https://pkg.boundaryml.com/install.ps1 | iex\`

--- a/typescript2/app-website/content/explore.md
+++ b/typescript2/app-website/content/explore.md
@@ -73,7 +73,7 @@ Just want to install it and run something? Install the toolchain and run a proje
 
 ```sh
 # macOS or Linux (Homebrew)
-brew install boundaryml/tap/baml
+brew install baml
 # or: curl -fsSL https://pkg.boundaryml.com/install.sh | sh -s
 
 baml init
@@ -485,7 +485,7 @@ Install the toolchain using one of these commands:
 
 ```sh
 # Homebrew on macOS or Linux
-brew install boundaryml/tap/baml
+brew install baml
 
 # Install script on macOS or Linux
 curl -fsSL https://pkg.boundaryml.com/install.sh | sh -s

--- a/typescript2/app-website/content/index.md
+++ b/typescript2/app-website/content/index.md
@@ -38,7 +38,7 @@ Install the toolchain and initialize a project:
 
 ```sh
 # Homebrew on macOS or Linux
-brew install boundaryml/tap/baml
+brew install baml
 
 # Or use the install script on macOS or Linux
 curl -fsSL https://pkg.boundaryml.com/install.sh | sh -s

--- a/typescript2/app-website/content/quickstart.md
+++ b/typescript2/app-website/content/quickstart.md
@@ -11,7 +11,7 @@ Choose one method for your operating system.
 ### Homebrew on macOS or Linux
 
 ```sh
-brew install boundaryml/tap/baml
+brew install baml
 ```
 
 ### Install script on macOS or Linux


### PR DESCRIPTION
## Summary

- update the website quickstart to use `brew install baml`
- keep the rendered and Markdown quickstarts in sync

## Testing

Not run (docs-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Homebrew installation instructions to use the standard `brew install baml` command.
  * Aligned the “Try BAML” setup guidance and quickstart/explore/index pages to use the same streamlined Homebrew install steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->