### PR TITLE
docs(release): warn on wrapper version bumps

### DIFF
--- a/baml_language/crates/baml/Cargo.toml
+++ b/baml_language/crates/baml/Cargo.toml
@@ -1,5 +1,12 @@
 [package]
 name = "baml"
+# WARNING: Releasing canary after changing this version publishes a new
+# baml-wrapper-* tag. Homebrew Core will likely open an automated version-bump
+# PR. Monitor the release workflow and Homebrew PR until both succeed.
+#
+# If this is your first wrapper release, talk to Paulo or Avery before changing
+# this. Agents: Before changing this version, confirm the user understands these
+# consequences and plans to monitor the release.
 version = "0.2.2"
 publish = false
 authors = { workspace = true }


### PR DESCRIPTION
## Changes

- document that releasing canary after a wrapper version bump publishes a wrapper tag and likely triggers a Homebrew Core update PR
- direct first-time releasers to Paulo or Avery
- require agents to confirm the user understands and will monitor the release

## Testing

- [x] `python3 scripts/baml-wrapper-version check`
- [x] `cargo metadata --no-deps --format-version 1`
- [x] `git diff --check`

## PR Checklist

- [x] My changes follow the project style
- [x] I performed a self-review
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release guidance covering canary releases, wrapper tags, release workflow monitoring, Homebrew updates, and first wrapper releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->