### PR TITLE
fix(cli): normalize bytecode-cache rel-paths across platforms

### DIFF
--- a/baml_language/crates/baml_cli/src/bytecode_cache.rs
+++ b/baml_language/crates/baml_cli/src/bytecode_cache.rs
@@ -131,16 +131,13 @@ impl CacheContext {
             .unwrap_or_else(|| resolved.root.join(".baml").join("cache"));
         let fingerprint = compiler_fingerprint(&dir);
 
-        // Root-relative paths keep the key location-independent. Discovery
-        // order is sorted by full path; stripping the shared root prefix
-        // preserves that order.
+        // Portable root-relative paths keep the key location- and
+        // platform-independent. Discovery order is sorted by full path;
+        // stripping the shared root prefix preserves that order.
         let files: Vec<(String, &str)> = resolved
             .files
             .iter()
-            .map(|(path, content)| {
-                let rel = path.strip_prefix(&resolved.root).unwrap_or(path);
-                (rel.to_string_lossy().into_owned(), content.as_str())
-            })
+            .map(|(path, content)| (rel_path(&resolved.root, path), content.as_str()))
             .collect();
 
         let key = compute_key(&KeyInputs {
@@ -2532,6 +2529,101 @@ mod tests {
             clean,
             seeded,
         })
+    }
+
+    /// Exercise the same canonical root and on-disk source paths a real CLI
+    /// project uses. Besides proving macOS `/var` canonicalization does not
+    /// disable partial reuse, the nested file locks the cache key, manifest,
+    /// and compilation-unit path spelling to portable `/` separators.
+    #[test]
+    fn plan_reuse_real_on_disk_project_uses_portable_rel_paths() {
+        if cache_disabled() {
+            return;
+        }
+        let root = bc_root();
+        let source_root = root.join("baml_src");
+        let nested = source_root.join("nested");
+        std::fs::create_dir_all(&nested).expect("create real project");
+        std::fs::write(
+            nested.join("edited.baml"),
+            "function edited() -> int {\n  1\n}\n",
+        )
+        .expect("write edited source");
+        std::fs::write(
+            source_root.join("stable.baml"),
+            "function stable() -> int {\n  2\n}\n",
+        )
+        .expect("write stable source");
+        std::fs::write(
+            source_root.join("also_stable.baml"),
+            "function also_stable() -> int {\n  3\n}\n",
+        )
+        .expect("write second stable source");
+
+        let r1 = crate::project_load::resolve_project_sources(Some(&root))
+            .expect("resolve real project");
+        let key_files: Vec<(String, &str)> = r1
+            .files
+            .iter()
+            .map(|(path, content)| (rel_path(&r1.root, path), content.as_str()))
+            .collect();
+        let expected_key = compute_key(&KeyInputs {
+            compiler_fingerprint: compiler_fingerprint(&r1.root.join(".baml").join("cache")),
+            opt_level: CLI_OPT_LEVEL as u8,
+            emit_test_cases: false,
+            manifest: None,
+            files: &key_files,
+        });
+        let db1 = crate::project_load::build_db_from_sources(&r1, |_| {});
+        let ctx1 = CacheContext::open(&r1, false).expect("cache opens");
+        assert_eq!(ctx1.key, expected_key, "cache key uses shared rel paths");
+        let program1 =
+            compile_program(&db1, &opts(), Some(&ctx1), None).expect("v1 compile succeeds");
+        let fresh1 = ctx1
+            .collect_diagnostics_incremental(&db1, None)
+            .fresh_by_file;
+        ctx1.store_with_manifest(&db1, &program1, &fresh1, None)
+            .expect("v1 manifest stored");
+
+        let manifest_bytes = ctx1
+            .cache
+            .load_raw(&ctx1.manifest_key)
+            .expect("manifest stored");
+        let manifest: ProjectManifest =
+            borsh::from_slice(&manifest_bytes).expect("manifest decodes");
+        let manifest_paths: Vec<&str> = manifest
+            .files
+            .iter()
+            .map(|file| file.rel_path.as_str())
+            .collect();
+        assert_eq!(
+            manifest_paths,
+            [
+                "baml_src/also_stable.baml",
+                "baml_src/nested/edited.baml",
+                "baml_src/stable.baml",
+            ]
+        );
+
+        std::fs::write(
+            nested.join("edited.baml"),
+            "function edited() -> int {\n  4\n}\n",
+        )
+        .expect("edit source");
+        let r2 =
+            crate::project_load::resolve_project_sources(Some(&root)).expect("reload real project");
+        let db2 = crate::project_load::build_db_from_sources(&r2, |_| {});
+        let ctx2 = CacheContext::open(&r2, false).expect("cache reopens");
+        let plan = ctx2
+            .plan_reuse(&db2)
+            .expect("real on-disk project has a partial reuse plan");
+        assert_eq!(
+            dirty_basenames(&plan.dirty_files, &db2),
+            HashSet::from(["edited.baml".to_string()])
+        );
+        assert_eq!(plan.clean_files.len(), 2);
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// Like [`plan_after_edit`], but also runs the full incremental flow the CLI

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -3748,7 +3748,8 @@ fn compute_function_metadata<'db>(
     }
 }
 
-/// Project-root-relative display path for `file` (our `-trimpath`).
+/// `/`-separated project-root-relative display path for `file` (our
+/// `-trimpath`).
 ///
 /// `Function::source_file` is display/metadata-only (backtraces, event
 /// metadata, reflection locations) — never opened from disk — so stripping
@@ -3759,10 +3760,12 @@ fn compute_function_metadata<'db>(
 fn relative_source_path(db: &dyn baml_compiler2_mir::Db, file: baml_base::SourceFile) -> String {
     let path = file.path(db);
     let root = db.project().root(db);
-    path.strip_prefix(&root)
-        .unwrap_or(&path)
-        .display()
-        .to_string()
+    let display = path.strip_prefix(&root).unwrap_or(&path).to_string_lossy();
+    if std::path::MAIN_SEPARATOR == '/' {
+        display.into_owned()
+    } else {
+        display.replace(std::path::MAIN_SEPARATOR, "/")
+    }
 }
 
 /// Build a table of byte offsets where each line starts in the source text.
@@ -5158,6 +5161,16 @@ mod tests {
 
     #[salsa::db]
     impl Db for TestDb {}
+
+    #[test]
+    fn relative_source_paths_use_forward_slashes() {
+        let mut db = TestDb::default();
+        let root = PathBuf::from("project");
+        let file = db.add_file(root.join("nested").join("main.baml"), "");
+        db.project = Some(Project::new(&db, root, vec![file]));
+
+        assert_eq!(relative_source_path(&db, file), "nested/main.baml");
+    }
 
     // ── parse_string_attr_value ─────────────────────────────────────────
 

--- a/baml_language/crates/bex_cache/src/lib.rs
+++ b/baml_language/crates/bex_cache/src/lib.rs
@@ -89,7 +89,8 @@ pub struct KeyInputs<'a> {
     /// `baml.toml` content, if the project has one.
     pub manifest: Option<&'a str>,
     /// `(project-root-relative path, content)` for every source file,
-    /// **sorted by path**. Relative paths keep the key location-independent.
+    /// **sorted by path**. Paths use `/` separators so the key stays location-
+    /// and platform-independent.
     pub files: &'a [(String, &'a str)],
 }
 
@@ -177,7 +178,8 @@ pub struct ProjectManifest {
 
 #[derive(Debug, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct ManifestFile {
-    /// Project-root-relative path (the `Function::source_file` form).
+    /// `/`-separated project-root-relative path (the `Function::source_file`
+    /// form).
     pub rel_path: String,
     /// Hash of the file's full content.
     pub content_hash: [u8; 32],
@@ -739,15 +741,18 @@ pub fn env_flag(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|value| value == "1")
 }
 
-/// `path` relative to `root` as a display string, falling back to the full path
-/// when it is not under `root`. Manifests and cache keys store this
-/// project-root-relative form to stay location-independent; the CLI writer and
-/// the LSP reader both derive it here so their rel-path keys agree.
+/// `path` relative to `root` as a `/`-separated display string, falling back to
+/// the full path when it is not under `root`. Manifests and cache keys store
+/// this project-root-relative form to stay location- and platform-independent;
+/// the CLI writer and the LSP reader both derive it here so their rel-path keys
+/// agree.
 pub fn rel_path(root: &Path, path: &Path) -> String {
-    path.strip_prefix(root)
-        .unwrap_or(path)
-        .display()
-        .to_string()
+    let display = path.strip_prefix(root).unwrap_or(path).to_string_lossy();
+    if std::path::MAIN_SEPARATOR == '/' {
+        display.into_owned()
+    } else {
+        display.replace(std::path::MAIN_SEPARATOR, "/")
+    }
 }
 
 #[cfg(test)]
@@ -801,6 +806,13 @@ mod tests {
             compute_key(&dummy_inputs(&a)),
             compute_key(&dummy_inputs(&b))
         );
+    }
+
+    #[test]
+    fn relative_paths_use_forward_slashes() {
+        let root = Path::new("project");
+        let nested = root.join("baml_src").join("nested").join("main.baml");
+        assert_eq!(rel_path(root, &nested), "baml_src/nested/main.baml");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- normalize bytecode-cache key, manifest, and compilation-unit source paths to portable `/` separators
- keep cache rel-path generation consistent between `CacheContext::open`, manifest collection, compiler output, and LSP consumers
- add cross-platform path regressions plus a real on-disk partial-reuse scenario

## Root cause

Cache keys, manifest entries, and compiled-unit `source_file` values were rendered with platform-native separators. That made the serialized cache identity platform-dependent and could make key, manifest, or unit lookups disagree at cache boundaries on Windows.

The macOS temp-root canonicalization half was already fixed on canary by commit `2660b8b9f`, which anchors the cache test roots under a canonical temp base; the four partial-reuse tests were already ungated on this baseline. Real on-disk macOS projects were not affected by that test-harness symlink mismatch because project discovery canonicalizes existing roots and source paths, and the new real-project-style regression confirms `plan_reuse` returns `Some` with two clean files and one dirty file.

## Validation

- `BAML_CACHE_DEBUG=1 cargo test -p baml_cli plan_reuse -- --nocapture` (17 passed)
- `cargo test -p bex_cache relative_paths_use_forward_slashes -- --nocapture`
- `cargo test -p baml_compiler2_emit relative_source_paths_use_forward_slashes -- --nocapture`
- `cargo clippy -p bex_cache -p baml_compiler2_emit -p baml_cli --tests -- -D warnings`
- `cargo fmt --all -- --check`

Fixes B-748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reliability across platforms by standardizing stored file paths.
  * Fixed cache reuse behavior for projects with nested files, allowing unchanged files to remain reusable after edits.
  * Normalized displayed source paths to consistently use forward slashes on Windows and other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->