### PR TITLE
fix(compiler): unify empty-array catch arms with try-block element type

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -8338,7 +8338,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         } else {
             self.infer_expr(base_expr_id, body)
         };
-        let mut result_members = vec![base_ty];
+        let mut result_members = vec![base_ty.clone()];
         let mut residual = self.catch_base_throw_types(base_expr_id, body);
 
         for clause in clauses {
@@ -8506,7 +8506,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // leaking `EvolvingList(Never)`. Mirrors the base above.
                 let arm_ty = match expected {
                     Some(expected) => self.check_expr(arm.body, body, expected),
-                    None => self.infer_expr(arm.body, body),
+                    None => self.infer_catch_arm_with_base_expectation(arm.body, body, &base_ty),
                 };
                 result_members.push(arm_ty);
 
@@ -8557,6 +8557,143 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.catch_residual_throws
             .insert(catch_expr_id, residual.clone());
         Self::join_all(&result_members)
+    }
+
+    /// Infer a catch arm in synthesis position while using the try-block type
+    /// as a soft, bidirectional expectation.
+    ///
+    /// A catch expression is still allowed to widen into a union when an arm
+    /// genuinely returns a different type. The base type therefore cannot be
+    /// passed to [`Self::check_expr`] as a hard expectation: doing so would
+    /// reject that valid union. Instead, infer the arm first and then adopt the
+    /// base type only when the expression fits it contextually. This is
+    /// significant for invariant container literals, where an empty `[]` (or
+    /// nested empty container) has no element type of its own but can adopt one
+    /// from the try-block.
+    fn infer_catch_arm_with_base_expectation(
+        &mut self,
+        arm_expr_id: ExprId,
+        body: &ExprBody,
+        base_ty: &Ty,
+    ) -> Ty {
+        let inferred = self.infer_expr(arm_expr_id, body);
+        let mut updates = Vec::new();
+        if self.collect_contextual_expr_updates(arm_expr_id, body, base_ty, &mut updates) {
+            for (expr_id, ty) in updates {
+                self.record_expr_type(expr_id, ty);
+            }
+            base_ty.clone()
+        } else {
+            inferred
+        }
+    }
+
+    /// Check whether an already-inferred expression can adopt `expected`
+    /// without emitting a hard mismatch, collecting the expression-type
+    /// rewrites needed for container literals.
+    ///
+    /// Ordinary subtypes need no rewrite. Container literals are checked
+    /// element-by-element because lists and maps are invariant: `[1]` may
+    /// contextually become `json[]`, while a non-literal `int[]` value may not.
+    /// Updates are accumulated transactionally so a partially matching nested
+    /// literal is left untouched when another element makes the whole literal
+    /// incompatible.
+    fn collect_contextual_expr_updates(
+        &self,
+        expr_id: ExprId,
+        body: &ExprBody,
+        expected: &Ty,
+        updates: &mut Vec<(ExprId, Ty)>,
+    ) -> bool {
+        let Some(inferred) = self.expressions.get(&expr_id) else {
+            return false;
+        };
+        if self.is_subtype(inferred, expected) {
+            return true;
+        }
+
+        let update_start = updates.len();
+        let adopted = match &body.exprs[expr_id] {
+            Expr::Array { elements } => self
+                .adopted_container_for_literal(expected, ContainerLiteralKind::List)
+                .and_then(|container| {
+                    let (Ty::List(element_ty, _) | Ty::EvolvingList(element_ty, _)) = &container
+                    else {
+                        unreachable!("adopted list container has list shape")
+                    };
+                    elements
+                        .iter()
+                        .all(|element| {
+                            self.collect_contextual_expr_updates(
+                                *element, body, element_ty, updates,
+                            )
+                        })
+                        .then_some(container)
+                }),
+            Expr::Map { entries } => self
+                .adopted_container_for_literal(expected, ContainerLiteralKind::Map)
+                .and_then(|container| {
+                    let (Ty::Map {
+                        key: key_ty,
+                        value: value_ty,
+                        ..
+                    }
+                    | Ty::EvolvingMap(key_ty, value_ty, _)) = &container
+                    else {
+                        unreachable!("adopted map container has map shape")
+                    };
+                    entries
+                        .iter()
+                        .all(|(key, value)| {
+                            self.collect_contextual_expr_updates(*key, body, key_ty, updates)
+                                && self.collect_contextual_expr_updates(
+                                    *value, body, value_ty, updates,
+                                )
+                        })
+                        .then_some(container)
+                }),
+            Expr::Object {
+                type_name,
+                type_args,
+                fields,
+                spreads,
+                ..
+            } if Self::is_map_object_literal(type_name, type_args, spreads) => self
+                .adopted_container_for_literal(expected, ContainerLiteralKind::Map)
+                .and_then(|container| {
+                    let (Ty::Map {
+                        key: key_ty,
+                        value: value_ty,
+                        ..
+                    }
+                    | Ty::EvolvingMap(key_ty, value_ty, _)) = &container
+                    else {
+                        unreachable!("adopted map container has map shape")
+                    };
+                    if !fields.is_empty() && !self.is_subtype(&Ty::string(), key_ty) {
+                        None
+                    } else if fields.iter().all(|(_, value)| {
+                        self.collect_contextual_expr_updates(*value, body, value_ty, updates)
+                    }) {
+                        Some(container)
+                    } else {
+                        None
+                    }
+                }),
+            Expr::Block { stmts, tail_expr } if stmts.is_empty() => tail_expr.and_then(|tail| {
+                self.collect_contextual_expr_updates(tail, body, expected, updates)
+                    .then_some(expected.clone())
+            }),
+            _ => None,
+        };
+
+        if let Some(adopted) = adopted {
+            updates.push((expr_id, adopted));
+            true
+        } else {
+            updates.truncate(update_start);
+            false
+        }
     }
 
     /// Validate declared `throws` against effective escaping throws from the body.

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -2364,8 +2364,8 @@ function baml.llm.Client.execute_once_oneshot<T>(self: baml.llm.Client, context:
             }
           else
             { : never
-              let error_body = : string | "" -> string
-                catch (http_response.text() : string) : string | ""
+              let error_body = : string
+                catch (http_response.text() : string) : string
                   catch (e)
                     _ =>
                       { : ""

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_throw/baml_tests__compiles__catch_throw__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_throw/baml_tests__compiles__catch_throw__04_tir.snap
@@ -78,8 +78,8 @@ function user.MultipleCatchArms(x: int) -> string throws never {
 }
 function user.NestedCatch(x: int) -> string throws never {
   { : string
-    let inner = : string | "inner caught" -> string
-      catch (MayFail(x) : string) : string | "inner caught"
+    let inner = : string
+      catch (MayFail(x) : string) : string
         catch (e)
           _ =>
             "inner caught" : "inner caught"

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
@@ -62,6 +62,125 @@ function f() -> int {
 }
 
 #[test]
+fn catch_empty_array_adopts_base_type_in_synthesis_positions() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"enum Err { Boom }
+
+function docs() -> int[] throws Err.Boom {
+  throw Err.Boom
+}
+
+function for_in_use() -> int {
+  for (let value in (docs() catch_all (e) { _ => [] })) {}
+  0
+}
+
+function direct_use() -> int {
+  (docs() catch_all (e) { _ => [] }).length()
+}
+
+function let_bound_use() -> int {
+  let values = docs() catch_all (e) { _ => [] }
+  values.length()
+}"#,
+    );
+
+    let output = render_tir(&db, file);
+    assert!(
+        !output.contains("cannot iterate over type"),
+        "for-in should see one concrete int[] catch result, got:\n{output}"
+    );
+    assert!(
+        output.contains("catch (docs() : int[]) : int[]") && output.contains("[] : int[]"),
+        "the synthesized catch result and arm should both be int[], got:\n{output}"
+    );
+    assert!(
+        output.contains(".length() : int"),
+        "direct and let-bound catch results should resolve array methods, got:\n{output}"
+    );
+}
+
+#[test]
+fn catch_container_literals_adopt_base_type_recursively() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"enum Err { Boom }
+
+function nested_docs() -> int[][] throws Err.Boom {
+  throw Err.Boom
+}
+
+function nested_fallback() -> int {
+  let values = nested_docs() catch_all (e) { _ => [[]] }
+  values.length()
+}
+
+function docs() -> int[] throws Err.Boom {
+  throw Err.Boom
+}
+
+function non_empty_fallback() -> int {
+  let values = docs() catch_all (e) { _ => [1] }
+  values.length()
+}
+
+function map_docs() -> map<string, int> throws Err.Boom {
+  throw Err.Boom
+}
+
+function empty_map_fallback() -> int {
+  let values = map_docs() catch_all (e) { _ => map {} }
+  values.length()
+}"#,
+    );
+
+    let output = render_tir(&db, file);
+    assert!(
+        output.contains("[[]] : int[][]"),
+        "nested empty arrays should recursively adopt int[][], got:\n{output}"
+    );
+    assert!(
+        output.contains("[1] : int[]"),
+        "a compatible non-empty literal arm should keep the base int[] type, got:\n{output}"
+    );
+    assert!(
+        output.contains("map {  } : map<string, int>"),
+        "an empty map arm should adopt the base map type, got:\n{output}"
+    );
+}
+
+#[test]
+fn catch_incompatible_arm_still_forms_union() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"enum Err { Boom }
+
+function docs() -> int[] throws Err.Boom {
+  throw Err.Boom
+}
+
+function union_result() -> int {
+  let values = docs() catch_all (e) { _ => ["fallback"] }
+  0
+}"#,
+    );
+
+    let output = render_tir(&db, file);
+    assert!(
+        output.contains("int[] | string[]") || output.contains("string[] | int[]"),
+        "a genuinely different catch arm should still form a union, got:\n{output}"
+    );
+    assert!(
+        !output.contains("type mismatch"),
+        "forming an inferred catch union should not introduce a mismatch, got:\n{output}"
+    );
+}
+
+#[test]
 fn throws_never_contract_violation_reports_error() {
     let mut db = make_db();
     let file = db.add_file(


### PR DESCRIPTION
Fixes B-616

Use the try-block type as a soft expectation for synthesized catch arms so compatible empty and nested container literals adopt it without rejecting genuinely different union members.

Tests cover for-in, direct and let-bound use, nested and non-empty array literals, empty maps, and heterogeneous catch results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for `catch` expressions, including empty and nested arrays, maps, and object literals.
  * Catch results now correctly support downstream operations such as iteration and length checks.
  * Incompatible catch-arm types now produce an appropriate union type instead of an erroneous mismatch.

* **Tests**
  * Added coverage for catch-all result type synthesis and nested container inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->