### PR TITLE
fix(compiler): align catch effects for to_string fallback

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -9365,6 +9365,19 @@ impl<'db> TypeInferenceBuilder<'db> {
                 for arg in args {
                     self.collect_throw_facts_from_expr(arg.expr, body, out);
                 }
+                // Keep catch-domain inference aligned with the whole-body
+                // throws walker: an unresolved `recv.to_string()` call on a
+                // known receiver is the total `string.from(recv)` fallback,
+                // not an unaccounted call that contributes `unknown`.
+                if arg_exprs.is_empty()
+                    && crate::throws_analysis::is_to_string_fallback_callee(
+                        &BuilderThrowsAnalysis { builder: self },
+                        *callee,
+                        body,
+                    )
+                {
+                    return;
+                }
                 crate::throws_analysis::collect_callee_escaping_throws(
                     &BuilderThrowsAnalysis { builder: self },
                     *callee,

--- a/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
@@ -63,7 +63,7 @@ pub fn is_to_string_call_callee(expr: &Expr) -> bool {
 /// `to_string` call shape the type checker left untyped (`Unknown`/`Error`)
 /// because the receiver has no real `to_string` method. Such a call lowers to
 /// `string.from(recv)`, which is `throws never`.
-fn is_to_string_fallback_callee<C: ThrowsAnalysisContext>(
+pub(crate) fn is_to_string_fallback_callee<C: ThrowsAnalysisContext>(
     context: &C,
     callee: ExprId,
     body: &ExprBody,

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/catch/match_arm_throw_propagation.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/catch/match_arm_throw_propagation.baml
@@ -1,0 +1,139 @@
+// B-624: throws from calls nested in match arms must contribute to the
+// enclosing match expression's catch_all domain.
+
+class NumV {
+  n int
+}
+
+class BoolV {
+  b bool
+}
+
+function ev(x: string) -> NumV | BoolV throws baml.errors.ParseError | baml.errors.InvalidArgument {
+  if (x == "parse") {
+    throw baml.errors.ParseError { message: x }
+  }
+  if (x == "invalid") {
+    throw baml.errors.InvalidArgument { message: x }
+  }
+  if (x == "num") {
+    NumV { n: 1 }
+  } else {
+    BoolV { b: true }
+  }
+}
+
+function PlainCall(x: string) -> string {
+  ev(x).to_string() catch_all (e) {
+    let pe: baml.errors.ParseError => "parse",
+    let ie: baml.errors.InvalidArgument => "type",
+    _ => "other",
+  }
+}
+
+function MatchWrapped(x: string) -> string {
+  match (ev(x)) {
+    NumV { n: let n } => n.to_string(),
+    BoolV { b: let b } => b.to_string(),
+  } catch_all (e) {
+    let pe: baml.errors.ParseError => "parse",
+    let ie: baml.errors.InvalidArgument => "type",
+    _ => "other",
+  }
+}
+
+// The same two forms also agree when the known throw types are handled
+// without a wildcard: neither has a spurious `unknown` tail.
+function PlainCallWithoutWildcard(x: string) -> string {
+  ev(x).to_string() catch_all (e) {
+    let pe: baml.errors.ParseError => "parse",
+    let ie: baml.errors.InvalidArgument => "type",
+  }
+}
+
+function MatchWrappedWithoutWildcard(x: string) -> string {
+  match (ev(x)) {
+    NumV { n: let n } => n.to_string(),
+    BoolV { b: let b } => b.to_string(),
+  } catch_all (e) {
+    let pe: baml.errors.ParseError => "parse",
+    let ie: baml.errors.InvalidArgument => "type",
+  }
+}
+
+// A genuinely unknown-throwing callback remains unknown both at top level and
+// when nested in match arms, so wildcard catch_all arms stay reachable.
+function UnknownPlain(cb: (value: int) -> string throws unknown) -> string {
+  cb(1) catch_all (e) {
+    _ => "other",
+  }
+}
+
+function UnknownMatchWrapped(
+  cb: (value: int) -> string throws unknown,
+  select: bool,
+) -> string {
+  match (select) {
+    true => cb(1),
+    false => cb(2),
+  } catch_all (e) {
+    _ => "other",
+  }
+}
+
+// Omitting the wildcard from either genuinely-unknown form is non-exhaustive.
+function UnknownPlainWithoutWildcard(
+  cb: (value: int) -> string throws unknown,
+) -> string {
+  cb(1) catch_all (e) {
+    let pe: baml.errors.ParseError => "parse",
+  }
+}
+
+function UnknownMatchWrappedWithoutWildcard(
+  cb: (value: int) -> string throws unknown,
+  select: bool,
+) -> string {
+  match (select) {
+    true => cb(1),
+    false => cb(2),
+  } catch_all (e) {
+    let pe: baml.errors.ParseError => "parse",
+  }
+}
+
+//----
+//- diagnostics
+// E0063
+//
+//   ⚠ unreachable arm
+//     ╭─[catch_match_arm_throw_propagation.baml:30:10]
+//  30 │     _ => "other",
+//     ·          ───────
+//     ╰────
+// E0063
+//
+//   ⚠ unreachable arm
+//     ╭─[catch_match_arm_throw_propagation.baml:41:10]
+//  41 │     _ => "other",
+//     ·          ───────
+//     ╰────
+// E0062
+//
+//   × non-exhaustive catch_all on type unknown; missing: unknown
+//     ╭─[catch_match_arm_throw_propagation.baml:88:3]
+//  88 │ ╭─▶   cb(1) catch_all (e) {
+//  89 │ │       let pe: baml.errors.ParseError => "parse",
+//  90 │ ╰─▶   }
+//     ╰────
+// E0062
+//
+//   × non-exhaustive catch_all on type unknown; missing: unknown
+//      ╭─[catch_match_arm_throw_propagation.baml:97:3]
+//   97 │ ╭─▶   match (select) {
+//   98 │ │       true => cb(1),
+//   99 │ │       false => cb(2),
+//  100 │ │     } catch_all (e) {
+//  101 │ │       let pe: baml.errors.ParseError => "parse",
+//  102 │ ╰─▶   }
+//      ╰────


### PR DESCRIPTION
## Summary

- align catch-domain throw inference with the existing total `to_string` fallback semantics
- make plain and match-wrapped `to_string` forms report identical wildcard reachability
- add regressions proving genuinely `unknown`-throwing calls still propagate through match arms

## Root cause

On current canary, both throw walkers already recurse through match arms. The inconsistency came from the catch-specific walker treating an unresolved `recv.to_string()` fallback as an unaccounted call and adding `unknown`, even though that fallback lowers to `string.from(recv)` and is declared `throws never`.

The fix removes that spurious top-level `unknown` instead of injecting one into the match form. As a result, a redundant wildcard now reports E0063 in both ticket forms, removing it is exhaustive when the two declared errors are covered, and genuinely unknown-throwing callbacks still require a wildcard with E0062 in both plain and match-wrapped forms.

## Validation

- `cargo fmt --all`
- `cargo test -p baml_compiler2_tir --lib`
- `cargo test -p baml_lsp2_actions_tests --lib`
- `cargo clippy -p baml_compiler2_tir --lib -- -D warnings`

Fixes B-624
