### PR TITLE
fix(compiler): allow reassigning narrowed inferred locals

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -464,6 +464,14 @@ struct ScopedLocalsSnapshot {
 #[derive(Clone)]
 pub(crate) struct LocalBinding {
     pub(crate) current_ty: Ty,
+    /// Stable assignment bound inferred at an unannotated declaration site.
+    ///
+    /// Unlike `current_ty`, narrowing and assignment never replace this type.
+    /// It is separate from `declared_ty` because explicitly annotated
+    /// containers use their annotation as an expected type when checking
+    /// literal assignments, while inferred evolving containers retain their
+    /// existing same-kind establishment behavior.
+    pub(crate) inferred_declared_ty: Option<Ty>,
     pub(crate) declared_ty: Option<Ty>,
     pub(crate) pattern: Option<PatId>,
 }
@@ -787,8 +795,9 @@ pub struct TypeInferenceBuilder<'db> {
     /// `union_targets_for_pattern`, and the opaque-scrut dispatch).
     pattern_natural_cache: FxHashMap<(PatId, NaturalKind), Ty>,
     /// Local variable bindings. Each entry keeps the flow-sensitive type used
-    /// for reads, the stable assignment contract from an explicit annotation,
-    /// and the optional pattern identity for scoped assignment propagation.
+    /// for reads, stable assignment contracts from explicit annotations or
+    /// declaration-site inference, and the optional pattern identity for
+    /// scoped assignment propagation.
     locals: FxHashMap<Name, LocalBinding>,
     /// Per-declaration restore points for active name-keyed lookup maps.
     ///
@@ -1102,7 +1111,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.locals.insert(
             name,
             LocalBinding {
-                current_ty: ty,
+                current_ty: ty.clone(),
+                inferred_declared_ty: declared_ty.is_none().then_some(ty),
                 declared_ty,
                 pattern: Some(pattern),
             },
@@ -1121,6 +1131,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 name.clone(),
                 LocalBinding {
                     current_ty: ty,
+                    inferred_declared_ty: None,
                     declared_ty: None,
                     pattern: None,
                 },
@@ -1380,6 +1391,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 name,
                 LocalBinding {
                     current_ty: ty.clone(),
+                    inferred_declared_ty: None,
                     declared_ty: Some(ty),
                     pattern: None,
                 },
@@ -1402,6 +1414,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 name,
                 LocalBinding {
                     current_ty: ty,
+                    inferred_declared_ty: None,
                     declared_ty: None,
                     pattern: None,
                 },
@@ -1462,6 +1475,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             name,
             LocalBinding {
                 current_ty: ty,
+                inferred_declared_ty: None,
                 declared_ty: None,
                 pattern: None,
             },
@@ -4964,6 +4978,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             name.clone(),
                             LocalBinding {
                                 current_ty: param.ty.clone(),
+                                inferred_declared_ty: None,
                                 declared_ty: Some(param.ty.clone()),
                                 pattern: None,
                             },
@@ -7604,6 +7619,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 } else {
                     self.get_declared_type(*target, body)
                 };
+                let inferred_declared_ty = self.get_inferred_declared_type(*target, body);
                 // A container literal assigned to a matching structural declared
                 // type is typed by `check_expr`, which adopts the declared
                 // element/key/value types *recursively* (so nested `[[]]` does not
@@ -7673,14 +7689,39 @@ impl<'db> TypeInferenceBuilder<'db> {
                             self.assign_local(segments[0].clone(), assigned_ty);
                         }
                     }
+                } else if let Some(inferred_declared_ty) = inferred_declared_ty {
+                    // An unannotated local is assignable against the stable type
+                    // inferred at its declaration, not the flow-sensitive type
+                    // used for reads. In particular, an `is` check may narrow a
+                    // union for the branch without preventing assignment of the
+                    // original union back into the local.
+                    //
+                    // Keep the evolving-empty compatibility rule from B-236:
+                    // an empty list/map can establish a concrete type of the
+                    // same kind, while unrelated or cross-kind values remain
+                    // invalid.
+                    if !self.reassignment_is_compatible(&value_ty, &inferred_declared_ty) {
+                        self.context.report(
+                            TirTypeError::TypeMismatch {
+                                expected: inferred_declared_ty,
+                                got: value_ty.clone(),
+                            },
+                            *value,
+                            Vec::new(),
+                        );
+                    }
+                    if let Expr::Path(segments) = &body.exprs[*target]
+                        && segments.len() == 1
+                    {
+                        // Assignment invalidates any prior narrowing. The
+                        // assigned value's type becomes the new flow type.
+                        self.assign_local(segments[0].clone(), value_ty);
+                    }
                 } else {
-                    // No annotated declared type. Member/index/`$id` targets are
-                    // handled structurally elsewhere; an *unannotated local*,
-                    // though, still carries a flow type in `current_ty` that a
-                    // reassignment must stay compatible with. Without this guard
-                    // `let x = {}; x = []` keeps `x` map-typed while it holds an
-                    // array at runtime, so indexing it aborts the VM with
-                    // "expected map, got array" (B-236).
+                    // Member/index targets are handled structurally elsewhere.
+                    // A path without a declaration-site assignment bound is an
+                    // error-recovery binding (for example, a seeded capture);
+                    // infer it normally without changing a local contract.
                     if let Expr::Path(segments) = &body.exprs[*target]
                         && segments.len() == 1
                         && segments[0].as_str() != "$id"
@@ -7940,8 +7981,22 @@ impl<'db> TypeInferenceBuilder<'db> {
         None
     }
 
-    /// Whether reassigning a value of type `value_ty` to an *unannotated* local
-    /// currently typed `current_ty` is sound (B-236).
+    /// Look up the stable declaration-site type inferred for an unannotated
+    /// assignment target.
+    fn get_inferred_declared_type(&self, target: ExprId, body: &ExprBody) -> Option<Ty> {
+        if let Expr::Path(segments) = &body.exprs[target] {
+            if segments.len() == 1 {
+                return self
+                    .locals
+                    .get(&segments[0])
+                    .and_then(|binding| binding.inferred_declared_ty.clone());
+            }
+        }
+        None
+    }
+
+    /// Whether reassigning a value of type `value_ty` to an unannotated local
+    /// with declaration-site type `declared_ty` is sound (B-236).
     ///
     /// A concrete local requires the new value to be a subtype — its static
     /// type and the runtime value must not diverge. An *empty evolving*
@@ -7950,19 +8005,19 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// adopt any value of the *same container kind* — `let a = []; a = [1, 2,
     /// 3]` keeps working — but never across kinds (`let x = {}; x = []` is the
     /// crash). Cross-kind and unrelated-type reassignments are rejected.
-    fn reassignment_is_compatible(&self, value_ty: &Ty, current_ty: &Ty) -> bool {
+    fn reassignment_is_compatible(&self, value_ty: &Ty, declared_ty: &Ty) -> bool {
         // Error recovery / a diverging RHS: don't pile on additional errors.
         if matches!(
             value_ty,
             Ty::Unknown { .. } | Ty::Error { .. } | Ty::Never { .. }
-        ) || matches!(current_ty, Ty::Unknown { .. } | Ty::Error { .. })
+        ) || matches!(declared_ty, Ty::Unknown { .. } | Ty::Error { .. })
         {
             return true;
         }
-        if self.is_subtype(value_ty, current_ty) {
+        if self.is_subtype(value_ty, declared_ty) {
             return true;
         }
-        match current_ty {
+        match declared_ty {
             // Empty evolving list: accepts any list-shaped value.
             Ty::List(inner, _) | Ty::EvolvingList(inner, _)
                 if matches!(**inner, Ty::Never { .. }) =>
@@ -14954,6 +15009,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     name.clone(),
                     LocalBinding {
                         current_ty: ty.clone(),
+                        inferred_declared_ty: None,
                         declared_ty: Some(ty),
                         pattern: None,
                     },

--- a/baml_language/crates/baml_compiler2_tir/src/narrowing.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/narrowing.rs
@@ -503,6 +503,7 @@ fn set_current_type(locals: &mut FxHashMap<Name, LocalBinding>, name: Name, ty: 
             name,
             LocalBinding {
                 current_ty: ty,
+                inferred_declared_ty: None,
                 declared_ty: None,
                 pattern: None,
             },

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/loops/for.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/loops/for.baml
@@ -68,6 +68,14 @@ function SumUnknownType(xs: int, b: string) -> int {
 //     ·                  ┬
 //     ·                  ╰── expected `int`, found `string`
 //     ╰────
+// E0001
+//
+//   × mismatched types
+//     ╭─[loops_for.baml:19:2]
+//  19 │     result
+//     ·     ───┬──
+//     ·        ╰── expected `int`, found `string`
+//     ╰────
 // E0006
 //
 //   × cannot iterate over type `int`

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase7.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase7.rs
@@ -427,6 +427,88 @@ fn assignment_uses_declared_type_after_narrowing() {
 }
 
 #[test]
+fn inferred_union_can_be_reassigned_after_is_narrowing() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"function pick() -> int | string {
+  5
+}
+
+function f() -> int | string {
+  let v = pick();
+  if (v is int) {
+    v = pick();
+  }
+  v
+}"#,
+    );
+    let output = render_tir(&db, file);
+    assert!(
+        !output.contains("type mismatch"),
+        "assignment should use the inferred declaration-site union, not the narrowed read type:\n{output}"
+    );
+}
+
+#[test]
+fn inferred_union_reads_narrow_then_rewiden_after_assignment() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"function pick() -> int | string {
+  5
+}
+
+function f() -> int | string {
+  let v = pick();
+  if (v is int) {
+    let narrowed: int = v;
+    v = pick();
+    let rewidened: int | string = v;
+  }
+  v
+}"#,
+    );
+    let output = render_tir(&db, file);
+    assert!(
+        output.contains("let narrowed: int = v : int"),
+        "the `is` check should still narrow reads before assignment:\n{output}"
+    );
+    assert!(
+        output.contains("let rewidened: int | string = v : int | string"),
+        "assignment should update the read type to the assigned union:\n{output}"
+    );
+    assert!(
+        !output.contains("type mismatch"),
+        "narrowing and re-widening should both type-check:\n{output}"
+    );
+}
+
+#[test]
+fn inferred_union_reassignment_rejects_value_outside_declaration_type() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"function pick() -> int | string {
+  5
+}
+
+function f() -> int | string {
+  let v = pick();
+  if (v is int) {
+    v = true;
+  }
+  v
+}"#,
+    );
+    let output = render_tir(&db, file);
+    assert!(
+        output.contains("type mismatch: expected int | string, got true"),
+        "a value outside the inferred declaration type must still be rejected:\n{output}"
+    );
+}
+
+#[test]
 fn unannotated_inner_shadow_masks_outer_declared_type() {
     let mut db = make_db();
     let file = db.add_file(


### PR DESCRIPTION
## Summary

- Preserve the declaration-site inferred type as the stable assignment bound for unannotated locals.
- Keep flow narrowing read-only and update the flow type after assignment.
- Add regressions for valid union reassignment, narrowed and re-widened reads, and invalid assignments.

## Root cause

Unannotated locals only retained their flow-sensitive current type. An is check therefore replaced the only type available to assignment checking, so the narrowed branch rejected values allowed by the original inferred declaration type.

## Validation

- cargo fmt --all
- cargo clippy -p baml_compiler2_tir -p baml_tests --lib -- -D warnings
- cargo test -p baml_tests compiler2_tir::phase7 -- --nocapture
- cargo test -p baml_tests compiler2_tir::inference -- --nocapture
- cargo test -p baml_tests compiler2_tir::phase6 -- --nocapture
- standalone baml-cli repro

Fixes B-618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking for reassignment after type narrowing by preserving an inferred declaration-site type and using it for compatibility validation.
  * Kept narrowed reads from overwriting the stable inferred declaration type, while still allowing narrowing to be reevaluated after assignment.
  * Added more precise `type mismatch` diagnostics when reassigned values fall outside the inferred union type.

* **Tests**
  * Added new Phase 7 tests for reassignment behavior with inferred union types after `is` narrowing.
  * Updated loop syntax test expected diagnostics to include the new mismatch span.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->