### PR TITLE
fix(compiler): match-binding narrowing and diagnostics improvements

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -1855,11 +1855,11 @@ impl LoweringContext {
     }
 
     /// Lower a `BINDING_PATTERN` (`let WORD` / `const WORD`). The parser routes
-    /// `let _` / `const _` to
-    /// `WILDCARD_PATTERN` before it ever reaches here, so the WORD's text is
-    /// never `_`. The only defensive case is a malformed `let` without a
-    /// following WORD (parse error like `let = 1`), which we recover as
-    /// wildcard.
+    /// bare `let _` / `const _` to `WILDCARD_PATTERN`; an ascribed discard
+    /// (`let _: PATTERN`) reaches here so its sub-pattern can be preserved
+    /// without introducing a binding named `_`. The other defensive case is a
+    /// malformed `let` without a following WORD (parse error like `let = 1`),
+    /// which we recover as wildcard.
     fn lower_binding_pattern(&mut self, node: &SyntaxNode) -> PatId {
         let name_token = node
             .children_with_tokens()
@@ -1893,6 +1893,9 @@ impl LoweringContext {
             .map(|pat_node| self.lower_pattern(&pat_node));
 
         let pat = match name {
+            Some(name) if name.as_str() == "_" => subpat
+                .map(|subpat| self.patterns[subpat].clone())
+                .unwrap_or(Pattern::Wildcard),
             Some(name) => Pattern::Bind { name, subpat },
             None => Pattern::Wildcard,
         };

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -856,6 +856,10 @@ pub struct TypeInferenceBuilder<'db> {
     /// before checking. Used to resolve `PatId` → `TextRange` when emitting
     /// pattern-position diagnostics.
     body_source_map: Option<AstSourceMap>,
+    /// True only while lowering a source `match` arm pattern. Lets unresolved
+    /// bare type patterns suggest the binding syntax without adding that hint
+    /// to ordinary annotations or `is` tests.
+    suggest_match_binding_hint: bool,
     /// Depth counter for `OptionalChain` scopes. When > 0, `FieldAccess` and
     /// `Index` auto-unwrap nullable bases (null is caught by the chain wrapper).
     /// When 0, accessing a member on a nullable type is a type error.
@@ -1150,6 +1154,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             scoped_local_declarations: Vec::new(),
             scoped_local_assignments: Vec::new(),
             body_source_map: None,
+            suggest_match_binding_hint: false,
             resolutions: FxHashMap::default(),
             res_ctx,
             package_items,
@@ -4756,7 +4761,32 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             Expr::Binary { op, lhs, rhs } => {
                 let lhs_ty = self.infer_expr(*lhs, body);
+
+                // Short-circuit flow: the RHS of `a && b` runs only when `a`
+                // is true, while the RHS of `a || b` runs only when `a` is
+                // false. Infer it under those transient facts, then restore
+                // the surrounding scope before continuing.
+                let lhs_narrowings = matches!(op, ast::BinaryOp::And | ast::BinaryOp::Or)
+                    .then(|| self.uncaptured_condition_narrowings(*lhs, body))
+                    .unwrap_or_default();
+                let saved = if lhs_narrowings.is_empty() {
+                    None
+                } else {
+                    let saved =
+                        crate::narrowing::apply_then_narrowings(&lhs_narrowings, &mut self.locals);
+                    if matches!(op, ast::BinaryOp::Or) {
+                        crate::narrowing::restore_and_apply_else(
+                            &lhs_narrowings,
+                            &saved,
+                            &mut self.locals,
+                        );
+                    }
+                    Some(saved)
+                };
                 let rhs_ty = self.infer_expr(*rhs, body);
+                if let Some(saved) = saved {
+                    crate::narrowing::restore_narrowings(saved, &mut self.locals);
+                }
                 self.report_chaining_lints(*op, &lhs_ty, *lhs, *rhs, expr_id, body);
                 self.infer_binary_op(*op, &lhs_ty, &rhs_ty, expr_id)
             }
@@ -8046,16 +8076,25 @@ impl<'db> TypeInferenceBuilder<'db> {
         let mut matrix_arms: Vec<crate::exhaustiveness::DPat> = Vec::new();
         let mut matrix_arm_ids: Vec<ExprId> = Vec::new();
         let mut match_had_pattern_error = false;
+        let mut residual_ty = scrutinee_ty.clone();
 
         for arm_id in arms {
             let arm = &body.match_arms[*arm_id];
             let pattern_id = arm.pattern;
 
             let diag_count_before_pattern = self.context.diagnostic_count();
+            let previous_binding_hint = self.suggest_match_binding_hint;
+            self.suggest_match_binding_hint = true;
             let result = self.analyze_and_lower(pattern_id, &scrutinee_ty, body, arm.body);
+            self.suggest_match_binding_hint = previous_binding_hint;
             let pattern_had_error = self.context.diagnostic_count() > diag_count_before_pattern;
             match_had_pattern_error |= pattern_had_error;
-            let narrowed = result.matched_ty.clone();
+            // The arm body can only observe values not consumed by earlier
+            // unguarded arms. Intersecting the pattern's matched type with
+            // that residual makes a trailing wildcard inherit useful facts
+            // (`null => ..., _ => v + 1` narrows `v` to non-null) without
+            // trying to represent value-level exclusions such as `int - 5`.
+            let narrowed = self.intersect_pattern_flow_types(&residual_ty, &result.matched_ty);
 
             // Snapshot/restore the scope for this arm's bindings.
             let snapshot = self.snapshot_scoped_locals();
@@ -8081,6 +8120,15 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             // Guarded arms don't contribute to coverage.
             if arm.guard.is_none() {
+                // Structural patterns can filter values *within* one top-level
+                // type member (class fields, array length/elements), which the
+                // flow type cannot represent. Only subtract type-only patterns;
+                // the helper itself stays conservative for singleton literals
+                // over open primitives.
+                if Self::pattern_is_type_only_for_residual(pattern_id, body) {
+                    residual_ty =
+                        crate::narrowing::subtract_pattern_type(&residual_ty, &result.matched_ty);
+                }
                 matrix_arms.push(result.dpat);
                 matrix_arm_ids.push(arm.body);
             }
@@ -8933,6 +8981,23 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    /// Whether a pattern's coverage is representable solely by subtracting its
+    /// matched top-level type from the scrutinee union. Structural patterns can
+    /// reject values within a class/list member, so subtracting that whole
+    /// member would make later-arm narrowing unsound.
+    fn pattern_is_type_only_for_residual(pat_id: PatId, body: &ExprBody) -> bool {
+        match &body.patterns[pat_id] {
+            ast::Pattern::Wildcard | ast::Pattern::Type(_) => true,
+            ast::Pattern::Bind { subpat, .. } => {
+                subpat.is_none_or(|subpat| Self::pattern_is_type_only_for_residual(subpat, body))
+            }
+            ast::Pattern::Or(parts) => parts
+                .iter()
+                .all(|part| Self::pattern_is_type_only_for_residual(*part, body)),
+            ast::Pattern::Class { .. } | ast::Pattern::Array { .. } => false,
+        }
+    }
+
     fn check_or_binding_type_compatibility(
         &mut self,
         bindings_by_name: &FxHashMap<Name, Vec<(PatId, Ty)>>,
@@ -9030,7 +9095,30 @@ impl<'db> TypeInferenceBuilder<'db> {
             },
             &mut diags,
         );
-        for diag in diags {
+        let bare_binding_name = match &ty.kind {
+            TypeExprKind::Path {
+                segments,
+                generic_args,
+                associated_type_bindings,
+                ..
+            } if segments.len() == 1
+                && generic_args.is_empty()
+                && associated_type_bindings.is_empty() =>
+            {
+                Some(segments[0].clone())
+            }
+            _ => None,
+        };
+        for mut diag in diags {
+            if self.suggest_match_binding_hint
+                && let (Some(binding_name), TirTypeError::UnresolvedType { name, suggestions }) =
+                    (&bare_binding_name, &mut diag)
+                && name == binding_name
+                && suggestions.is_empty()
+            {
+                *suggestions =
+                    vec![Name::new(format!("let {binding_name}: T =>"))].into_boxed_slice();
+            }
             self.report_at_pat_or_expr(diag, pat_id, fallback_expr);
         }
         if let Some(sm) = self.body_source_map.as_ref() {

--- a/baml_language/crates/baml_compiler2_tir/src/narrowing.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/narrowing.rs
@@ -1,8 +1,8 @@
 //! Type narrowing for control-flow-dependent type refinement.
 //!
 //! Analyzes condition expressions to produce narrowing information that refines
-//! variable types inside then/else branches of `if` expressions, and after
-//! diverging branches (early-return narrowing).
+//! variable types inside then/else branches of `if` expressions, short-circuit
+//! boolean operands, and after diverging branches (early-return narrowing).
 //!
 //! ## Patterns recognized
 //!
@@ -14,6 +14,8 @@
 //!   union minus the matched members (TypeScript-style for `typeof` /
 //!   `instanceof`; falls back to the original scrutinee type when the
 //!   subtraction doesn't simplify, e.g. literal patterns on primitives)
+//! - `a && b` → then: facts guaranteed by both operands, else: original
+//! - `a || b` → then: original, else: facts guaranteed by both operands
 //!
 //! ## Early-return narrowing
 //!
@@ -57,9 +59,7 @@ pub struct Narrowing {
 /// Extract narrowing information from a condition expression.
 ///
 /// Walks the condition looking for patterns that constrain a local variable's
-/// type. Returns a `Vec<Narrowing>` — one per narrowed variable. Most conditions
-/// narrow zero or one variable; `&&` chains could narrow multiple, but we don't
-/// handle that yet.
+/// type. Returns a `Vec<Narrowing>` — one per narrowed variable.
 ///
 /// # Parameters
 /// - `condition`: the `ExprId` of the condition expression (already inferred)
@@ -174,6 +174,45 @@ fn collect_narrowings(
             collect_narrowings(*inner, body, expr_types, pattern_types, !negated, out);
         }
 
+        // Short-circuit boolean composition. For `a && b`, a true result
+        // guarantees both operands were true, while a false result does not
+        // guarantee either individual false branch. `a || b` is dual: only a
+        // false result guarantees both operands were false. Under `!`, De
+        // Morgan swaps the effective operator and flips each operand's facts.
+        Expr::Binary {
+            op: op @ (BinaryOp::And | BinaryOp::Or),
+            lhs,
+            rhs,
+        } => {
+            let mut lhs_narrowings = Vec::new();
+            let mut rhs_narrowings = Vec::new();
+            collect_narrowings(
+                *lhs,
+                body,
+                expr_types,
+                pattern_types,
+                negated,
+                &mut lhs_narrowings,
+            );
+            collect_narrowings(
+                *rhs,
+                body,
+                expr_types,
+                pattern_types,
+                negated,
+                &mut rhs_narrowings,
+            );
+
+            let effective_and = matches!(op, BinaryOp::And) != negated;
+            compose_short_circuit_narrowings(
+                lhs_narrowings,
+                rhs_narrowings,
+                expr_types,
+                effective_and,
+                out,
+            );
+        }
+
         // `name is <pattern>` — narrow `name` to the pattern's matched type
         // in the then-branch (or in the else-branch if negated). The
         // opposite branch tries to subtract the matched members from the
@@ -237,6 +276,96 @@ fn collect_narrowings(
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Compose narrowing facts for an effective `&&` (`effective_and = true`) or
+/// `||` (`false`). The RHS was inferred under the LHS short-circuit facts, so
+/// when both sides constrain the same name its type already includes the LHS
+/// constraint and may safely win.
+///
+/// The non-guaranteed branch is deliberately restored to the pre-condition
+/// type. For example, `x != null && predicate(x)` being false does not imply
+/// that `x` is null, and `x == null || predicate(x)` being true does not imply
+/// that it is null.
+fn compose_short_circuit_narrowings(
+    lhs: Vec<Narrowing>,
+    rhs: Vec<Narrowing>,
+    expr_types: &FxHashMap<ExprId, Ty>,
+    effective_and: bool,
+    out: &mut Vec<Narrowing>,
+) {
+    let mut by_name: indexmap::IndexMap<Name, (Option<Narrowing>, Option<Narrowing>)> =
+        indexmap::IndexMap::new();
+    for narrowing in lhs {
+        let name = narrowing.name.clone();
+        by_name.entry(name).or_default().0 = Some(narrowing);
+    }
+    for narrowing in rhs {
+        let name = narrowing.name.clone();
+        by_name.entry(name).or_default().1 = Some(narrowing);
+    }
+
+    for (name, (lhs, rhs)) in by_name {
+        let representative = lhs.as_ref().or(rhs.as_ref()).expect("entry has a fact");
+        let original = lhs
+            .as_ref()
+            .and_then(|n| expr_types.get(&n.subject))
+            .or_else(|| expr_types.get(&representative.subject))
+            .cloned()
+            .unwrap_or_else(|| join_types(&representative.then_type, &representative.else_type));
+
+        let guaranteed = if effective_and {
+            rhs.as_ref()
+                .map(|n| n.then_type.clone())
+                .or_else(|| lhs.as_ref().map(|n| n.then_type.clone()))
+        } else {
+            rhs.as_ref()
+                .map(|n| n.else_type.clone())
+                .or_else(|| lhs.as_ref().map(|n| n.else_type.clone()))
+        }
+        .expect("entry has a fact");
+
+        let (then_type, else_type) = if effective_and {
+            (guaranteed, original)
+        } else {
+            (original, guaranteed)
+        };
+        out.push(Narrowing {
+            subject: representative.subject,
+            name,
+            then_type,
+            else_type,
+        });
+    }
+}
+
+/// Small, shape-based union join used only as a recovery fallback when the
+/// original expression type is unavailable.
+fn join_types(a: &Ty, b: &Ty) -> Ty {
+    if ty_shape_eq(a, b) {
+        return a.clone();
+    }
+    let mut members = Vec::new();
+    let mut push = |ty: &Ty| match ty {
+        Ty::Union(inner, _) => {
+            for member in inner {
+                if !members.iter().any(|seen| ty_shape_eq(seen, member)) {
+                    members.push(member.clone());
+                }
+            }
+        }
+        _ if !members.iter().any(|seen| ty_shape_eq(seen, ty)) => members.push(ty.clone()),
+        _ => {}
+    };
+    push(a);
+    push(b);
+    match members.len() {
+        0 => Ty::Never {
+            attr: TyAttr::default(),
+        },
+        1 => members.pop().unwrap(),
+        _ => Ty::Union(members, TyAttr::default()),
+    }
+}
 
 /// Check if a binary comparison is `name op null` or `null op name`.
 ///

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -5248,6 +5248,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a binding-introducer-prefixed pattern. Either:
     /// - `let _` / `const _` — `WILDCARD_PATTERN`
+    /// - `let _: PATTERN` / `const _: PATTERN` — discarded typed binding
     /// - `let WORD` / `const WORD` — simple `BINDING_PATTERN`
     /// - `let PATH { fields }` / `const PATH { fields }` — `DESTRUCTURE_PATTERN`
     fn parse_let_pattern(&mut self) {
@@ -5262,10 +5263,19 @@ impl<'a> Parser<'a> {
             return;
         }
 
-        // `let _` is a wildcard, not a binding to a name called `_`.
+        // Bare `let _` is a wildcard, not a binding to a name called `_`.
+        // With an ascription, keep a BINDING_PATTERN wrapper so AST lowering
+        // can preserve the sub-pattern while discarding the binding name:
+        // `let _: int` matches `int` without introducing `_` into scope.
         if self.at_wildcard_word() {
             self.bump(); // _
-            self.wrap_events_in_node(start, SyntaxKind::WILDCARD_PATTERN);
+            if self.at(TokenKind::Colon) {
+                self.bump(); // :
+                self.parse_pattern();
+                self.wrap_events_in_node(start, SyntaxKind::BINDING_PATTERN);
+            } else {
+                self.wrap_events_in_node(start, SyntaxKind::WILDCARD_PATTERN);
+            }
             self.finish_node();
             return;
         }
@@ -10364,6 +10374,40 @@ function Demo() -> int {
             )
         });
         assert!(has_let, "`let _` wildcard must keep the KW_LET token");
+    }
+
+    #[test]
+    fn pattern_typed_let_underscore_preserves_ascription() {
+        let source = r#"
+function Demo(x: int) -> int {
+  match (x) {
+    let _: int => 0,
+  }
+}
+"#;
+
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+
+        let arm = root
+            .descendants()
+            .find(|node| node.kind() == SyntaxKind::MATCH_ARM)
+            .expect("expected MATCH_ARM");
+        let pattern = arm
+            .children()
+            .find(|node| node.kind() == SyntaxKind::PATTERN)
+            .expect("expected PATTERN");
+        assert_eq!(
+            child_kinds(&pattern),
+            vec![SyntaxKind::BINDING_PATTERN],
+            "typed `let _` must preserve its nested type pattern"
+        );
+        assert!(
+            pattern
+                .descendants()
+                .any(|node| node.kind() == SyntaxKind::TYPE_PATTERN),
+            "typed `let _` must contain a TYPE_PATTERN"
+        );
     }
 
     #[test]

--- a/baml_language/crates/baml_tests/tests/match_flow_ergonomics.rs
+++ b/baml_language/crates/baml_tests/tests/match_flow_ergonomics.rs
@@ -1,0 +1,205 @@
+use baml_compiler_diagnostics::{DiagnosticId, Severity};
+use baml_project::{collect_diagnostics, testing::setup_test_db};
+
+fn errors(source: &str) -> Vec<baml_compiler_diagnostics::Diagnostic> {
+    let db = setup_test_db(source);
+    collect_diagnostics(&db)
+        .into_iter()
+        .filter(|diag| matches!(diag.severity, Severity::Error))
+        .collect()
+}
+
+#[test]
+fn wildcard_match_arm_uses_residual_scrutinee_type() {
+    let source = r#"
+        function main() -> int {
+            let v: int | null = 5;
+            match (v) {
+                null => 0,
+                _ => v + 1,
+            }
+        }
+    "#;
+    assert!(errors(source).is_empty());
+}
+
+#[test]
+fn guarded_match_arm_does_not_consume_residual_type() {
+    let source = r#"
+        function main(flag: bool) -> int {
+            let v: int | null = 5;
+            match (v) {
+                null if flag => 0,
+                _ => v + 1,
+            }
+        }
+    "#;
+    assert!(
+        errors(source)
+            .iter()
+            .any(|diag| diag.id == DiagnosticId::InvalidOperator),
+        "a guarded null arm must not remove null from the wildcard residual"
+    );
+}
+
+#[test]
+fn structural_match_arm_does_not_consume_its_whole_type_member() {
+    let source = r#"
+        class Box {
+            flag bool
+        }
+
+        function main(value: Box | null) -> int {
+            match (value) {
+                Box { flag: true } => 0,
+                _ => match (value) {
+                    Box {} => 1,
+                    null => 2,
+                },
+            }
+        }
+    "#;
+    assert!(
+        errors(source).is_empty(),
+        "a field-constrained class arm must leave other class values in the residual"
+    );
+}
+
+#[test]
+fn logical_and_narrows_rhs_and_then_branch() {
+    let source = r#"
+        function main() -> int {
+            let f: int? = 1;
+            if (f != null && f > 0) {
+                f + 1
+            } else {
+                0
+            }
+        }
+    "#;
+    assert!(errors(source).is_empty());
+}
+
+#[test]
+fn logical_or_narrows_rhs_and_else_branch() {
+    let source = r#"
+        function main() -> int {
+            let f: int? = 1;
+            if (f == null || f > 0) {
+                0
+            } else {
+                f + 1
+            }
+        }
+    "#;
+    assert!(errors(source).is_empty());
+}
+
+#[test]
+fn logical_and_false_branch_stays_conservative() {
+    let source = r#"
+        function main() -> int {
+            let f: int? = 1;
+            if (f != null && f > 0) {
+                0
+            } else {
+                f + 1
+            }
+        }
+    "#;
+    assert!(
+        errors(source)
+            .iter()
+            .any(|diag| diag.id == DiagnosticId::InvalidOperator),
+        "a false `&&` result does not prove that the optional is non-null"
+    );
+}
+
+#[test]
+fn logical_or_true_branch_stays_conservative() {
+    let source = r#"
+        function main() -> int {
+            let f: int? = 1;
+            if (f == null || f > 0) {
+                f + 1
+            } else {
+                0
+            }
+        }
+    "#;
+    assert!(
+        errors(source)
+            .iter()
+            .any(|diag| diag.id == DiagnosticId::InvalidOperator),
+        "a true `||` result does not prove that the optional is non-null"
+    );
+}
+
+#[test]
+fn typed_wildcard_binding_discards_the_name() {
+    let source = r#"
+        function main() -> int {
+            let x: int = 5;
+            match (x) {
+                let _: int => 0,
+            }
+        }
+    "#;
+    assert!(errors(source).is_empty());
+}
+
+#[test]
+fn bare_identifier_match_pattern_suggests_binding_syntax() {
+    let source = r#"
+        function main() -> int {
+            let v: int = 5;
+            match (v) {
+                x => x,
+            }
+        }
+    "#;
+    let diagnostics = errors(source);
+    let unresolved_type = diagnostics
+        .iter()
+        .find(|diag| diag.id == DiagnosticId::UnknownType)
+        .expect("expected an unresolved-type diagnostic");
+    assert!(
+        unresolved_type.message.contains("let x: T =>"),
+        "expected binding syntax hint, got: {}",
+        unresolved_type.message
+    );
+}
+
+#[test]
+fn unresolved_is_pattern_does_not_suggest_a_match_binding() {
+    let source = r#"
+        function main() -> bool {
+            let v: int = 5;
+            v is Missing
+        }
+    "#;
+    let diagnostics = errors(source);
+    let unresolved_type = diagnostics
+        .iter()
+        .find(|diag| diag.id == DiagnosticId::UnknownType)
+        .expect("expected an unresolved-type diagnostic");
+    assert!(
+        !unresolved_type.message.contains("let Missing: T =>"),
+        "the binding hint is specific to match arms: {}",
+        unresolved_type.message
+    );
+}
+
+#[test]
+fn braceless_return_match_arm_is_accepted() {
+    let source = r#"
+        function main() -> int {
+            let x: int = 5;
+            match (x) {
+                5 => return 1,
+                _ => 0,
+            }
+        }
+    "#;
+    assert!(errors(source).is_empty());
+}


### PR DESCRIPTION
## Summary

- carry residual match-arm types into later wildcard arms without treating guarded or structural patterns as exhaustive
- propagate flow narrowing through short-circuit `&&` and `||` expressions and their resulting branches
- accept typed wildcard binders while discarding the binding, and guide bare match-arm identifiers toward `let x: T =>`

## Diagnostic coverage

- Item 5 already works on canary; this adds a regression test for a braceless `return` arm.
- Item 6 is intentionally unchanged: the stdlib signature remains intact, and there was no cheap, precise immediate-use diagnostic to add.
- Item 7 is intentionally unchanged: postfix `!` already emits a targeted diagnostic suggesting supported null-handling forms.

## Validation

- `cargo test -p baml_compiler_parser`
- `cargo test -p baml_tests --test match_flow_ergonomics`
- `cargo test -p baml_tests --test match_union_typevar`
- `cargo test -p baml_tests --test narrow_bind`
- `cargo clippy -p baml_compiler2_tir -p baml_compiler2_ast -p baml_compiler_parser --all-targets -- -D warnings`
- `cargo clippy -p baml_tests --test match_flow_ergonomics -- -D warnings`
- `cargo fmt --all -- --check`
- exact CLI repros for match, boolean-flow, wildcard-binding, and diagnostic behavior

Fixes B-268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of discard patterns such as `let _` and typed discard patterns.
  - Corrected type narrowing for `&&` and `||` conditions and match arms.
  - Prevented match patterns and guards from incorrectly consuming remaining possible values.
  - Improved diagnostics with clearer suggestions for match binding syntax.
  - Ensured braceless `return` expressions in match arms are accepted.

- **Tests**
  - Added coverage for match narrowing, discard patterns, guarded arms, short-circuit conditions, and diagnostic suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->