### PR TITLE
Stop caching pnpm in docs publishing

### DIFF
--- a/.github/workflows/docs.reusable.yaml
+++ b/.github/workflows/docs.reusable.yaml
@@ -36,11 +36,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: docs-${{ inputs.is_canary && 'prod' || 'dev' }}
 
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-node
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          node-action-version: 'v6'
-          install-dependencies: false
+          node-version: '20'
 
       - name: Install Fern
         run: npm install -g fern-api


### PR DESCRIPTION
## Summary

- use `actions/setup-node@v6` directly in the docs publishing job
- preserve Node 20 while avoiding pnpm setup and cache registration in this npm-only job

## Root cause

The canary CI run published the Fern docs successfully, then failed during the post-job cleanup for the shared Node/pnpm composite action. The docs job sets `install-dependencies: false`, so no pnpm store is created, but `actions/setup-node` still attempts to save that configured cache and fails with `Path Validation Error`.

A failed docs job blocks `CI-v2 Failure Alert` and prevents the attested BAML Language Release dispatcher from running.

## Impact

The docs job still installs Fern globally with npm and publishes exactly as before. It no longer initializes or caches pnpm state it never uses, so successful publication is not converted into a failed job during cleanup.

## Validation

- `actionlint` on `.github/workflows/docs.reusable.yaml`
- YAML parsing
- 19 release-pipeline contract tests
- `git diff --check`
- repository pre-commit hooks

The canary docs job is the decisive end-to-end validation because the original failure occurred in the action's post-job cache hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to use Node.js 20 through the official setup action.
  * Documentation publishing behavior remains otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->