### PR TITLE
Stop caching pnpm in npm publishers

### DIFF
--- a/.github/workflows/publish2-nodejs-sdk.yaml
+++ b/.github/workflows/publish2-nodejs-sdk.yaml
@@ -61,14 +61,13 @@ jobs:
           name: nodejs-umbrella-dist
           path: baml_language/sdks/typescript/bridge_typescript/dist
       - name: Setup Node.js
-        # Mirror legacy release.yml publish-to-npm: the composite sets registry-url
-        # (writes the .npmrc that npm/pnpm OIDC trusted publishing keys off of) and
-        # provides pnpm. latest ships an npm new enough for OIDC (checked below).
-        uses: ./.github/actions/setup-node
+        # The publisher only uses npm. Avoid the repository composite here because
+        # it always enables pnpm caching, whose post-job save fails when this job
+        # intentionally does not install a pnpm store.
+        uses: actions/setup-node@v6
         with:
-          node-action-version: v6
           node-version: latest
-          install-dependencies: false
+          registry-url: "https://registry.npmjs.org"
       - name: Ensure npm CLI supports trusted publishing
         run: |
           set -euo pipefail

--- a/.github/workflows/publish2-web-sdk.yaml
+++ b/.github/workflows/publish2-web-sdk.yaml
@@ -48,11 +48,13 @@ jobs:
           path: baml_language/sdks/typescript/bridge_typescript_web/dist
 
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        # This publisher only uses npm. Enabling the repository composite's pnpm
+        # cache without installing dependencies makes its post-job cache save fail
+        # after a successful publish.
+        uses: actions/setup-node@v6
         with:
-          node-action-version: v6
           node-version: latest
-          install-dependencies: false
+          registry-url: "https://registry.npmjs.org"
 
       - name: Ensure npm CLI supports trusted publishing
         run: |

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -616,6 +616,36 @@ def job_block(text: str, job: str) -> str:
     return "".join(lines[:next_job])
 
 
+def step_block(job: str, step: str) -> str:
+    marker = f"      - name: {step}\n"
+    start = job.index(marker)
+    remainder = job[start + len(marker) :]
+    lines = remainder.splitlines(keepends=True)
+    next_step = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.startswith("      - ")
+        ),
+        None,
+    )
+    if next_step is None:
+        return remainder
+    return "".join(lines[:next_step])
+
+
+def step_inputs(step: str) -> dict[str, str]:
+    marker = "        with:\n"
+    start = step.index(marker)
+    inputs: dict[str, str] = {}
+    for line in step[start + len(marker) :].splitlines():
+        if not line.startswith("          "):
+            break
+        key, value = line.strip().split(":", maxsplit=1)
+        inputs[key] = value.strip().strip("\"'")
+    return inputs
+
+
 class WorkflowGraphTests(unittest.TestCase):
     def test_cffi_hygiene_is_enforced_at_production_and_package_boundaries(
         self,
@@ -935,10 +965,16 @@ class WorkflowGraphTests(unittest.TestCase):
         for path in (NODE_NPM_PUBLISHER, WEB_NPM_PUBLISHER):
             with self.subTest(workflow=path.name):
                 publisher = path.read_text(encoding="utf-8")
-                self.assertIn("uses: actions/setup-node@v6", publisher)
-                self.assertIn('registry-url: "https://registry.npmjs.org"', publisher)
-                self.assertNotIn("uses: ./.github/actions/setup-node", publisher)
-                self.assertNotIn("cache: pnpm", publisher)
+                publish_job = job_block(publisher, "publish-npm")
+                setup = step_block(publish_job, "Setup Node.js")
+                inputs = step_inputs(setup)
+                self.assertIn("        uses: actions/setup-node@v6", setup)
+                self.assertNotIn("./.github/actions/setup-node", setup)
+                self.assertEqual(
+                    inputs["registry-url"],
+                    "https://registry.npmjs.org",
+                )
+                self.assertNotEqual(inputs.get("cache"), "pnpm")
 
     def test_csharp_consumer_repository_path_scan_requires_a_separator(self) -> None:
         primitive_consumer = PRIMITIVE_CONSUMER.read_text(encoding="utf-8")

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -23,6 +23,10 @@ BRIDGE_CFFI_PUBLIC_EXPORTS = (
 HYGIENE_TOOL = ROOT / "scripts" / "baml-bridge-cffi-hygiene"
 CROSS_CONFIG = ROOT / "baml_language" / "Cross.toml"
 NUGET_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-csharp-sdk.yaml"
+NODE_NPM_PUBLISHER = (
+    ROOT / ".github" / "workflows" / "publish2-nodejs-sdk.yaml"
+)
+WEB_NPM_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-web-sdk.yaml"
 CSHARP_PREPARER = (
     ROOT / ".github" / "workflows" / "prepare-csharp-sdk.reusable.yaml"
 )
@@ -926,6 +930,15 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("left.ReadExactly(leftChunk)", normalizer)
         self.assertIn("right.ReadExactly(rightChunk)", normalizer)
         self.assertNotIn("left.Read(leftBuffer)", normalizer)
+
+    def test_npm_publishers_do_not_enable_an_unused_pnpm_cache(self) -> None:
+        for path in (NODE_NPM_PUBLISHER, WEB_NPM_PUBLISHER):
+            with self.subTest(workflow=path.name):
+                publisher = path.read_text(encoding="utf-8")
+                self.assertIn("uses: actions/setup-node@v6", publisher)
+                self.assertIn('registry-url: "https://registry.npmjs.org"', publisher)
+                self.assertNotIn("uses: ./.github/actions/setup-node", publisher)
+                self.assertNotIn("cache: pnpm", publisher)
 
     def test_csharp_consumer_repository_path_scan_requires_a_separator(self) -> None:
         primitive_consumer = PRIMITIVE_CONSUMER.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- use `actions/setup-node@v6` directly in the Node.js and Web npm-only publishers
- preserve the npm registry configuration required for trusted publishing
- add a release-contract regression test that prevents either publisher from re-enabling the unused pnpm cache

## Why

The `0.15.1-nightly.20260727.a` Node and Web packages were successfully uploaded with OIDC provenance, but both release jobs failed afterward in the shared setup action's pnpm cache post-step. These publisher jobs intentionally install no pnpm dependency tree, so the cache path does not exist and should not be configured.

## Validation

- `python3 -m unittest scripts.tests.test_release_pipeline_contract` (20 tests)
- YAML parsing for both changed workflows
- `actionlint` for both changed workflows (excluding pre-existing SC2055 in untouched Web publish code)
- applicable pre-commit hooks
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Node.js and Web SDK publishing workflows to use a standardized Node.js setup and to explicitly configure npm registry access.
  * Ensured npm publishing no longer relies on pnpm-specific caching behavior.

* **Tests**
  * Added contract tests that verify both npm publishing workflows keep the expected Node.js setup and registry configuration, and do not enable pnpm caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->