### PR TITLE
Guard release tail from expected nightly skips

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1325,7 +1325,16 @@ jobs:
     # once a tag reaches proxy.golang.org it is immutable, while baml-go needs
     # that manifest to resolve its native runtime on first use.
     needs: [plan, build-go-sdk, all-builds, publish-pkg-boundaryml-com]
-    if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.plan.result == 'success' &&
+        needs.build-go-sdk.result == 'success' &&
+        needs.all-builds.result == 'success' &&
+        needs.publish-pkg-boundaryml-com.result == 'success' &&
+        needs.plan.outputs.dry_run == 'false' &&
+        needs.plan.outputs.source_branch == 'canary'
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -1702,7 +1711,14 @@ jobs:
     # complete before the manifest is made immutable; Go closes the final gate
     # afterward without creating a dependency cycle.
     needs: [plan, release-prerequisites-complete]
-    if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.plan.result == 'success' &&
+        needs.release-prerequisites-complete.result == 'success' &&
+        needs.plan.outputs.dry_run == 'false' &&
+        needs.plan.outputs.source_branch == 'canary'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1854,7 +1870,15 @@ jobs:
   smoke-go-release:
     name: Smoke published Go SDK (${{ matrix.os }})
     needs: [plan, publish-go-sdk, publish-pkg-boundaryml-com]
-    if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.plan.result == 'success' &&
+        needs.publish-go-sdk.result == 'success' &&
+        needs.publish-pkg-boundaryml-com.result == 'success' &&
+        needs.plan.outputs.dry_run == 'false' &&
+        needs.plan.outputs.source_branch == 'canary'
+      }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1949,7 +1973,17 @@ jobs:
     # release until every publisher completes and the public Go and Swift
     # packages execute their native runtimes successfully.
     needs: [plan, publish-pkg-boundaryml-com, release-complete, smoke-go-release, smoke-swift-release]
-    if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.plan.result == 'success' &&
+        needs.publish-pkg-boundaryml-com.result == 'success' &&
+        needs.release-complete.result == 'success' &&
+        needs.smoke-go-release.result == 'success' &&
+        needs.smoke-swift-release.result == 'success' &&
+        needs.plan.outputs.dry_run == 'false' &&
+        needs.plan.outputs.source_branch == 'canary'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1977,7 +2011,15 @@ jobs:
   dispatch-nightly-after-canary:
     name: Queue nightly after canary publish
     needs: [plan, publish-pkg-channel]
-    if: ${{ needs.plan.outputs.dispatch_nightly_after_canary == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.plan.result == 'success' &&
+        needs.publish-pkg-channel.result == 'success' &&
+        needs.plan.outputs.dispatch_nightly_after_canary == 'true' &&
+        needs.plan.outputs.dry_run == 'false' &&
+        needs.plan.outputs.source_branch == 'canary'
+      }}
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -910,6 +910,67 @@ class WorkflowGraphTests(unittest.TestCase):
             CFFI_BUILDER.read_text(encoding="utf-8"),
         )
 
+    def test_expected_nightly_skips_do_not_poison_release_tail(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        prerequisites = job_block(workflow, "release-prerequisites-complete")
+        manifest = job_block(workflow, "publish-pkg-boundaryml-com")
+        go_publisher = job_block(workflow, "publish-go-sdk")
+        go_smoke = job_block(workflow, "smoke-go-release")
+        channel = job_block(workflow, "publish-pkg-channel")
+        nightly = job_block(workflow, "dispatch-nightly-after-canary")
+
+        self.assertIn(
+            'require_skipped Gradle-Plugin-Portal "$GRADLE_PLUGIN"',
+            prerequisites,
+        )
+        guarded_tail = (
+            (
+                manifest,
+                (
+                    "needs.plan.result == 'success'",
+                    "needs.release-prerequisites-complete.result == 'success'",
+                ),
+            ),
+            (
+                go_publisher,
+                (
+                    "needs.plan.result == 'success'",
+                    "needs.build-go-sdk.result == 'success'",
+                    "needs.all-builds.result == 'success'",
+                    "needs.publish-pkg-boundaryml-com.result == 'success'",
+                ),
+            ),
+            (
+                go_smoke,
+                (
+                    "needs.plan.result == 'success'",
+                    "needs.publish-go-sdk.result == 'success'",
+                    "needs.publish-pkg-boundaryml-com.result == 'success'",
+                ),
+            ),
+            (
+                channel,
+                (
+                    "needs.plan.result == 'success'",
+                    "needs.publish-pkg-boundaryml-com.result == 'success'",
+                    "needs.release-complete.result == 'success'",
+                    "needs.smoke-go-release.result == 'success'",
+                    "needs.smoke-swift-release.result == 'success'",
+                ),
+            ),
+            (
+                nightly,
+                (
+                    "needs.plan.result == 'success'",
+                    "needs.publish-pkg-channel.result == 'success'",
+                ),
+            ),
+        )
+        for block, required_results in guarded_tail:
+            self.assertIn("!cancelled()", block)
+            for result in required_results:
+                self.assertIn(result, block)
+
     def test_nuget_repair_and_nightly_pack_contracts_are_fail_closed(self) -> None:
         publisher = NUGET_PUBLISHER.read_text(encoding="utf-8")
         preparer = CSHARP_PREPARER.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- make every production job downstream of the skip-tolerant publisher fan-in opt out of GitHub's implicit `success()` propagation
- require each release-tail job's direct safety dependencies to have succeeded before manifests, Go publishing, smoke tests, channel promotion, or nightly dispatch run
- add a release contract regression test covering the intentionally skipped nightly Gradle publisher

## Root cause

Nightly releases intentionally skip the Gradle Plugin Portal publisher. `All pre-manifest publishers complete` correctly accepts that state and succeeds, but GitHub still propagates the skipped transitive ancestor through the implicit `success()` added to downstream job conditions. This skipped `Publish pkg.boundaryml.com manifests`, which skipped Go publishing and made the final fan-in fail with `GO: skipped`.

The guarded conditions use `!cancelled()` to suppress the implicit status check while remaining fail-closed through explicit direct dependency-result checks.

## Impact

Nightly and canary releases can proceed from the policy-aware publisher fan-in through exact-version manifests, Go publish/smoke, and mutable channel promotion without an expected skipped publisher poisoning the tail of the graph. Failed or cancelled direct prerequisites still block publication.

## Validation

- `mise exec -- actionlint .github/workflows/release-baml-language.yml`
- `python3 -m unittest scripts.tests.test_release_pipeline_contract`
- YAML parse with `yaml.safe_load`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release pipeline safeguards so publishing and nightly release steps run only when all required prerequisite jobs succeed.
  * Prevented cancelled or incomplete release stages from allowing later release steps to proceed.

* **Tests**
  * Added automated checks to verify release workflow dependencies and cancellation safeguards.
  * Added validation for skipped Gradle plugin portal requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->