### PR TITLE
Allow immutable release tags to assume manifest role

### DIFF
--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -69,6 +69,9 @@ PRIMITIVE_CONSUMER = (
     / "Baml.Bridge.PrimitivePackageConsumer"
     / "verify.sh"
 )
+PKG_BOUNDARYML_COM_STACK = (
+    ROOT / "tools" / "pkg_boundaryml_com" / "lib" / "pkg-boundaryml-com-stack.ts"
+)
 
 
 class CSharpReleaseContractTests(unittest.TestCase):
@@ -746,6 +749,7 @@ class WorkflowGraphTests(unittest.TestCase):
     def test_production_release_is_ci_attested_and_least_privilege(self) -> None:
         release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        pkg_stack = PKG_BOUNDARYML_COM_STACK.read_text(encoding="utf-8")
         plan = job_block(release, "plan")
         prerequisites = job_block(release, "release-prerequisites-complete")
         complete = job_block(release, "release-complete")
@@ -811,6 +815,22 @@ class WorkflowGraphTests(unittest.TestCase):
             nightly,
         )
         self.assertNotIn("--ref canary", nightly)
+        self.assertIn(
+            "`repo:${GITHUB_REPO}:ref:refs/heads/canary`",
+            pkg_stack,
+        )
+        self.assertIn(
+            "`repo:${GITHUB_REPO}:ref:refs/tags/baml-language-source-*`",
+            pkg_stack,
+        )
+        self.assertIn(
+            "'token.actions.githubusercontent.com:sub': GITHUB_OIDC_SUBJECTS",
+            pkg_stack,
+        )
+        self.assertNotIn(
+            "`repo:${GITHUB_REPO}:ref:*`",
+            pkg_stack,
+        )
 
     def test_release_graph_has_early_preflight_parallel_producers_and_complete_fanin(
         self,

--- a/tools/pkg_boundaryml_com/lib/pkg-boundaryml-com-stack.ts
+++ b/tools/pkg_boundaryml_com/lib/pkg-boundaryml-com-stack.ts
@@ -6,6 +6,10 @@ import { Construct } from 'constructs';
 const GITHUB_REPO = 'BoundaryML/baml';
 const GITHUB_OIDC_PROVIDER_ARN =
   'arn:aws:iam::277707123528:oidc-provider/token.actions.githubusercontent.com';
+const GITHUB_OIDC_SUBJECTS = [
+  `repo:${GITHUB_REPO}:ref:refs/heads/canary`,
+  `repo:${GITHUB_REPO}:ref:refs/tags/baml-language-source-*`,
+];
 
 export class PkgBoundarymlComStack extends cdk.Stack {
   public readonly bucket: s3.Bucket;
@@ -31,13 +35,13 @@ export class PkgBoundarymlComStack extends cdk.Stack {
 
     this.githubReleaseRole = new iam.Role(this, 'GitHubReleaseRole', {
       roleName: 'pkg-boundaryml-com-github-release',
-      description: `Assumed by GitHub Actions in ${GITHUB_REPO} from refs/heads/canary to publish to the pkg.boundaryml.com bucket`,
+      description: `Assumed by GitHub Actions in ${GITHUB_REPO} from canary or an immutable release tag to publish to the pkg.boundaryml.com bucket`,
       assumedBy: new iam.OpenIdConnectPrincipal(githubProvider, {
         StringEquals: {
           'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
         },
         StringLike: {
-          'token.actions.githubusercontent.com:sub': `repo:${GITHUB_REPO}:ref:refs/heads/canary`,
+          'token.actions.githubusercontent.com:sub': GITHUB_OIDC_SUBJECTS,
         },
       }),
       maxSessionDuration: cdk.Duration.hours(1),


### PR DESCRIPTION
## Summary

- allow the `pkg.boundaryml.com` GitHub OIDC role to trust immutable `baml-language-source-*` release tags
- retain the existing `canary` subject for canary dry-run uploads
- add release-contract coverage tying the immutable workflow ref to the CDK trust policy

## Root cause

Production releases are now dispatched from immutable source tags, but the IAM trust policy still accepted only `refs/heads/canary`. AWS therefore rejected the manifest publisher with `sts:AssumeRoleWithWebIdentity`, which correctly prevented the dependent Go publication and channel promotion.

## Validation

- `mise exec -- python -m unittest scripts.tests.test_release_pipeline_contract`
- `mise exec -- pnpm run build` in `tools/pkg_boundaryml_com`
- `mise exec -- pnpm exec cdk synth --json` and exact synthesized-subject assertion
- `git diff --check`

## Deployment note

The CDK stack must be deployed after merge to update the live IAM role before the next release reaches the manifest publisher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Restricted release permissions to approved canary branches and immutable source tags.
  * Added GitHub Actions identity validation for authorized release workflows.
  * Prevented broad wildcard reference access in production release permissions.

* **Tests**
  * Added coverage verifying release workflows enforce least-privilege access and identity conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->