### PR TITLE
chore: use latest aws-actions/configure-aws-credentials

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1758,7 +1758,7 @@ jobs:
         with:
           name: swift-xcframework
           path: dist/swift
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -1993,7 +1993,7 @@ jobs:
         with:
           name: release-manifests
           path: manifests
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -2251,7 +2251,7 @@ jobs:
         with:
           name: dry-run-release-files
           path: dry-run
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         if: ${{ needs.plan.outputs.source_branch == 'canary' }}
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `aws-actions/configure-aws-credentials` from v4 to v6 in the release workflow.

## Changes

- Updated three occurrences of `configure-aws-credentials@v4` to `@v6`:
  1. In `publish-pkg-boundaryml-com` job
  2. In `publish-pkg-channel` job  
  3. In `dry-run-artifacts` job

## Context

This addresses the requirement to switch the "Publish pkg.boundaryml.com manifests" job and related jobs to use the latest v6 of the configure-aws-credentials action.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1785183567792489?thread_ts=1785183567.792489&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-b4b1a3a2-9429-5a93-8af5-4486d9fbf8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4b1a3a2-9429-5a93-8af5-4486d9fbf8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS credential configuration for release publishing, channel promotion, and dry-run workflows.
  * No changes to release behavior, inputs, conditions, or generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->