### PR TITLE
Reflection + matching on futures

### DIFF
--- a/baml_language/TYPE_SYSTEM.md
+++ b/baml_language/TYPE_SYSTEM.md
@@ -4,7 +4,7 @@ At the time of this document's writing, not all BAML type system features work a
 
 # The BAML Type System
 
-The BAML programming language has a strong static type system. While it uses TypeScript-like syntax, it provides stronger guarantees and identity which also permit safe runtime validation (e.g. `match` over union types).
+The BAML programming language has a strong, statically checked, dynamically monomorphized type system. While it uses TypeScript-like syntax, it provides stronger guarantees and identity which also permit safe runtime validation (e.g. `match` over union types).
 
 BAML has a set-theoretic type system. It has unions like TypeScript (but more strongly typed) and type bound-based interfaces like Rust traits/Swift protocols. This enables flexibility while upholding correctness.
 
@@ -67,7 +67,7 @@ BAML's type system has the following properties:
    let a: int[] = [1, 2, 3];
    let b: (int | string)[] = a; // if covariant, this would be valid
    b[1] = "hello"; // The type `int | string` allows `string`
-   let c: int = b[1]; // oops!!!!! it's actually a `string`
+   let c: int = a[1]; // oops!!!!! it's actually a `string`
    ```
    This is a major point in which TypeScript fails: it would permit the above unsound code, resulting in `c` having a potentially cascading type/state mismatch.
 2. Union members are covariant: all members are subtypes of the union (as are their subtypes).
@@ -119,9 +119,10 @@ In nearly all contexts, we can thus simplify types and maintain equivalence: `1 
 
 ## Pattern Matching
 
-Pattern matching ([BEP-015](https://beps.boundaryml.com/beps/15)) on types falls naturally out of BAML's subset-based subtyping system. For any given value, BAML can determine whether a value is a member of a given type. A `match` expression can be thought of as checking each arm in order to see if the value is a member of the type-set (though various optimizations allow us to implement this more efficiently in many cases).
+Pattern matching ([BEP-015](https://beps.boundaryml.com/beps/15)) on types falls naturally out of BAML's subset-based subtyping system. For any given value, BAML can determine whether a value is a member of a given type. A `match` expression with type-pattern arms can be thought of as checking each arm in order to see if the value is a member of the type-set (though various optimizations allow us to implement this more efficiently in many cases).
 
-To check pattern fallibility/infallibility/exhaustiveness, BAML ensures that the union of the matched patterns represent a superset of the scrutinee's type, or defines a diverging path for fallible patterns if not. `match` also rejects cases that can provably never be reached. While these do not necessarily violate the type system, they are dead code that could be misleading.
+To check pattern fallibility/infallibility/exhaustiveness, BAML ensures that the union of the matched patterns represent a superset of the scrutinee's type, or defines a diverging path for fallible patterns if not.
+`match` also rejects arms that can provably never be reached. While these do not necessarily violate the type system, they are dead code that could be misleading. A `match` arm `A(N)` is unreachable if and only if `SCRUTINEE ∩ (A(0) ∪ A(1) ∪ ... ∪ A(N-1)) = SCRUTINEE ∩ (A(0) ∪ A(1) ∪ ... ∪ A(N-1) ∪ A(N))`. If we cannot prove either way, we err towards saying it is reachable (for example, we exclude all arms with an `if` expression-guard from consideration in reachability and say they do not contribute to exhaustiveness as we can make no guarantees about the evaluated expression).
 
 ## Type Variables
 
@@ -130,7 +131,7 @@ There are several types of type variables in BAML: generics, associated types, a
 - Generics are used in [type constructors](https://en.wikipedia.org/wiki/Type_constructor) ("generic types") and as type parameters on functions. The type they hold is provided by the caller.
 - Associated types are used in interfaces. The type they hold is provided by the interface implementor.
 - `Self` is used in interfaces to refer to the concrete implementor type
-  - If the concrete type is generic, it refers to the generic-specialized type (the result of the type constructor, rather than the type constructor itself: `Foo<int>`/`Foo<string>`/..., not `Foo<T>`)
+  - If the concrete type is generic, it refers to the monomorphized type (the result of the type constructor, rather than the type constructor itself: `Foo<int>`/`Foo<string>`/..., not `Foo<T>`)
   - In an interface's default method implementation, it behaves a bit like an associated type with the interface as its bound, since it may be realized to any implementing type.
 
 As previously noted, type variables with interface bounds can only be filled by concrete types. This includes `Self`: when used in a class body, it must correspond to a specialization of the concrete class type, and when in an `interface`/`implements` block it is a type variable bounded by the interface.
@@ -149,7 +150,7 @@ function bar<T extends baml.ops.Add>(a: T, b: T) -> T {
 }
 ```
 
-BAML has generic type parameters. When a generic function is called, the caller provides realized[^1] type arguments for each parameter. While they can often be inferred, they must still be known unambiguously at the call site. In terms of identity, `bar<int>` can be considered a distinct, non-equivalent function from `bar<string>`, even if the implementation does not actually monomorphize. We call `bar<int>` a _specialization_ of `bar`.
+BAML has generic type parameters. When a generic function is called, the caller provides realized[^1] type arguments for each parameter. While they can often be inferred, they must still be known unambiguously at the call site. In terms of identity, `bar<int>` can be considered a distinct, non-equivalent function from `bar<string>`, even if the implementation does not statically monomorphize. We call `bar<int>` a _specialization_ of `bar`.
 
 It may be helpful to think of it this way: function `bar` takes in three parameters. One is a type-parameter `T` and the others are value-parameters `a` and `b`. We check statically during compilation to ensure that whatever `T` ends up being, it will be valid at run-time. Like how value-parameters are constrained by a type (`a: T`), a type-parameter may be constrained by interfaces (`T extends baml.ops.Add`). At some call sites, we may know at compile time what we are passing as `T`. At others it will depend on the caller's own type arguments. When interacting with the outside world (e.g. bridges), we may have to validate and pass it dynamically.
 
@@ -167,7 +168,7 @@ As a result, while an unconstrained type-parameter like in `foo<T>` may be any t
 
 ### Realized vs Unrealized Types
 
-As used in BAML, "realized" types are types which contain _no_ type variables (fully "real" types). Unrealized types contain type variables. Types are always realized when they are used at run-time, either statically or via binding of type parameters (generics).
+As used in BAML, "realized" types are types which contain _no_ type variables (fully monomorphized types). Unrealized types contain type variables (are still polymorphic). Types are always realized when they are used at run-time, either statically or via runtime binding of type parameters (generics).
 
 In the following example, the unspecialized generic function `foo` uses unrealized type `Box<T>`.
 
@@ -204,7 +205,7 @@ For the function call `foo<int>(123)`, the run time `foo` function effectively r
 
 ### Generics on Types (Type Constructors)
 
-A type constructor, as the name suggests, constructs types! They are very familiar to us as generics on types: `Box<int>` has type constructor `Box` which takes in type parameter `int` and produces a realized type. BAML doesn't permit `Box` by itself as a type: while BAML syntax permits it in some locations, this is only valid if we can unambiguously infer the parameters. Since BAML generics are invariant, `Box<A>` has a subtyping relationship with `Box<B>` if and only if `A == B`.
+A type constructor, as the name suggests, constructs types! They are very familiar to us as generics on types: `Box<int>` has type constructor `Box` which takes in type parameter `int` and produces a realized type (bindings all type parameters is also called _monomorphization_). BAML doesn't permit `Box` by itself as a type: while BAML syntax permits it in some locations, this is only valid if we can unambiguously infer the parameters. Since BAML generics are invariant, `Box<A>` has a subtyping relationship with `Box<B>` if and only if `A == B`.
 
 ### Associated Types
 
@@ -297,12 +298,19 @@ function bad() -> void {
 }
 ```
 
+There are a few different positions where `Self` might be used, which have different resolution paths:
+
+1. In free functions and type aliases: compiler error. There is no type for `Self` to refer to
+2. In class fields and methods: refers to the class type, accepting its type args.
+3. In interface `implements` methods: refers to the `for`-target type, accepting its type args.
+4. In `interface` default method bodies: the implementor for which the current call occurred. Since we do not expect the compiler to be able to fully monomorphize, this is typically not known until dynamically at call-time. As such, it is emitted as its own type arg.
+
 ## Functions
 
 A function signature in BAML includes:
 
-- Arguments: a tuple of types
-- Keyword/optional arguments: an unordered mapping of parameter names to types
+- Arguments (required, positional): a tuple of types
+- Kwargs (optional, by-name): an unordered mapping of parameter names to types
 - Return type: a single type. This is the only place that `void` is valid user-syntax.
 - Error type: a single type.
 
@@ -313,7 +321,7 @@ All components of a function signature must be defined explicitly except for the
 3. Other function and lambda declarations may omit a `throws` clause:
    - If declared, the compiler statically verifies that the body cannot throw an undeclared type.
    - If omitted, the compiler infers a `throws` clause from the content of the body.
-   - A `throws` clause may also be *partial*: a `_` wildcard member (`throws AppError | _`) declares the named types **and** opens the remainder to inference. The body may then throw anything; the `_` is filled with the body's inferred throw set, and callers see the full union (declared names ∪ inferred). This is the precise counterpart of `throws unknown` — it keeps the named types in the contract and the inferred types exact, instead of widening the whole error type to `unknown`. A plain `throws T` (no `_`) stays exhaustive: every thrown type must be covered. Use `_` to avoid re-declaring infrastructural stdlib throws (e.g. `baml.json.*`) while still naming your own domain errors.
+   - A `throws` clause may also be _partial_: a `_` wildcard member (`throws AppError | _`) declares the named types **and** opens the remainder to inference. The body may then throw anything; the `_` is filled with the body's inferred throw set, and callers see the full union (declared names ∪ inferred). This is the precise counterpart of `throws unknown` — it keeps the named types in the contract and the inferred types exact, instead of widening the whole error type to `unknown`. A plain `throws T` (no `_`) stays exhaustive: every thrown type must be covered. Use `_` to avoid re-declaring infrastructural stdlib throws (e.g. `baml.json.*`) while still naming your own domain errors.
 4. Function signature types used as function arguments or keyword arguments may omit a `throws` clause:
    - If declared, then the `throws` clause is used.
    - If omitted, then the compiler will add an implicit generic parameter to the surrounding function and use it as the function-typed-argument's `throws` clause:
@@ -326,7 +334,7 @@ function foo/*<E>*/(arg: () -> void /* throws E */) -> void /* throws E */ {
 
 5. Otherwise, the `throws` clause MUST be declared.
 
-As previously noted, BAML function declarations may include generics. However, all function calls and function-values must have their type parameters specified:
+As previously noted, BAML function declarations may include generics. However, all function calls and function-values must have their type parameters specified — or unambiguously inferable from context — to enable monomorphization at call-time:
 
 ```baml
 function foo<T>(a: T) -> T { a }
@@ -342,7 +350,7 @@ Since we can infer the type parameter(s), this should usually not be a major syn
 
 ## Interfaces
 
-Interfaces are contracts defining the behavior and/or shape of types. They are specified in [BEP-044](https://beps.boundaryml.com/beps/44). They include both fields and methods, but use Rust/Swift-like bounds rather than inheritance. Associated types are defined in [BEP-057](https://beps.boundaryml.com/beps/57). Only concrete types may implement interfaces. Blanket/bounds-based implementations simply apply an `implements` block to all concrete types satisfying the bounds.
+Interfaces are contracts defining the behavior and/or shape of types. They are specified in [BEP-044](https://beps.boundaryml.com/beps/44). They include both fields and methods, but use Rust/Swift-like bounds rather than inheritance. Associated types are defined in [BEP-057](https://beps.boundaryml.com/beps/57). Only concrete types may implement interfaces. Blanket/bounds-based implementations simply apply an `implements` block to all concrete types satisfying the bounds. They are best thought of as paralleling Rust traits and much of their implementation is inspired by the structures used by Rust.
 
 However, interfaces are (technically) not themselves types. Instead, each interface is used to create types:
 
@@ -353,7 +361,7 @@ However, interfaces are (technically) not themselves types. Instead, each interf
 
 Coherence: As specified in BEP-044, each concrete type can have at most one implementation of a given interface. Like Rust's [orphan rule](https://doc.rust-lang.org/reference/items/implementations.html#r-items.impl.trait.orphan-rule), BAML requires that either the interface or the implementing type be defined in the current package to allow out-of-body `implements` blocks.
 
-Like generic classes, generic interfaces must always have their type args specified unless in a position where they can unambiguously be inferred. If any generic args are specified, all non-defaulted generic args must be specified — except that an individual arg may be written as the `_` wildcard to infer just that position while keeping the rest explicit (e.g. `let fs: baml.future.Future<int, _>[] = [spawn { … }]` keeps the value type `int` explicit and infers the error type from the spawned body). A `_` is a real inference hole filled from context (the binding's initializer), not a synonym for the `unknown` top type: the filled-in type is exact, so it is not erased and downstream uses (such as `await`) see the precise type. `_` is only meaningful where the slot can be inferred from context (today: a `let` binding annotation and `throws`-clause members); it is not supported in positions with nothing to infer from, such as a bare function parameter or return type. Following Rust, in some places (e.g. whenever used as an interface-existential type), the associated types must also be specified. Naturally, type args/associated types with defaults may be omitted and will use said defaults.
+Like generic classes, generic interfaces must always have their type args explicitly specified unless in a position where they can unambiguously be inferred. If any generic args are specified, all non-defaulted generic args must be specified — except that an individual arg may be written as the `_` wildcard to infer just that position while keeping the rest explicit (e.g. `let fs: baml.future.Future<int, _>[] = [spawn { … }]` keeps the value type `int` explicit and infers the error type from the spawned body). A `_` is a real inference hole filled from context (the binding's initializer), not a synonym for the `unknown` top type: the filled-in type is exact, so it is not erased and downstream uses (such as `await`) see the precise type. `_` is only meaningful where the slot can be inferred from context (today: a `let` binding annotation and `throws`-clause members); it is not supported in positions with nothing to infer from, such as a bare function parameter or return type. Following Rust, in some places (e.g. whenever used as an interface-existential type), the associated types must also be specified. Naturally, type args/associated types with defaults may be omitted and will use said defaults.
 
 While BAML tries to be permissive in where it will do unambiguous type inference, it is best practice to always explicitly parameterize all types.
 
@@ -404,6 +412,33 @@ function add_makes_int<O, T extends baml.ops.Add<O, Output=int>>(
 	lhs + rhs
 }
 ```
+
+### Interface Implementations
+
+Like in Rust, a fully realized concrete type `C` implements a fully realized interface `I` if and only if there exists some `implements` block where some generic instantiation produces `I` and `C` for its interface and "for" targets, respectively:
+
+```baml
+/// For all types `T`, `int` implements `Foo<T>`.
+implements<T> Foo<T> for int {}
+```
+
+There is an alternate shorthand syntax which allows `implements` blocks inside of `class` definitions:
+
+```baml
+class Bar<T extends Bound> {
+    implements Foo<T> {}
+}
+```
+
+This is shorthand for the out-of-body `implements` block, and should be considered equivalent to
+
+```baml
+class Bar<T extends Bound> {}
+/// transformed: takes the same generic args declaration and adds `for` that fills them all in.
+implements<T extends Bound> Foo<T> for Bar<T> {}
+```
+
+The only substantive difference here is that the in-body class `implements` block form permits field links while the out-of-body variant does not. This is because only classes have fields, so restricting to in-body `implements` blocks gives us this check for free. However, at a later date it would not be unsound to permit field links in out-of-body `implements` blocks if and only if the `for` target provably only matches classes. Either way, the implementation should use a unified path for both forms beyond the syntax layers.
 
 ### Interface Coherence
 

--- a/baml_language/crates/baml_builtins2/baml_std/testing/registry.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/testing/registry.baml
@@ -393,16 +393,16 @@ function aggregate_reports(named_results: NamedChildReport[]) -> TestSetReport {
   }
 }
 
-function run_children_parallel(children: TestSetChild[]) -> TestSetReport {
-  let futures: baml.future.Future<NamedChildReport, null>[] = []
+function run_children_parallel(children: TestSetChild[]) -> TestSetReport throws never {
+  let futures: baml.future.Future<NamedChildReport, never>[] = []
   for (let child in children) {
     futures.push(spawn {
       NamedChildReport { name: child.name, report: child.run() }
     })
   }
-  let named_results = (await baml.future.all_complete(futures)) catch_all (e) {
-    _ => baml.sys.panic("unexpected test child failure")
-  }
+  // No catch: the children's bodies cannot throw, so the futures are
+  // `Future<NamedChildReport, never>` and awaiting them is infallible.
+  let named_results = await baml.future.all_complete(futures)
   root.aggregate_reports(named_results)
 }
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -863,6 +863,13 @@ impl LoweringContext {
     /// which the MIR lowering then handles via `lower_lambda` to emit
     /// the proper `MakeClosure`. The name expression is parsed in the
     /// outer context (where it can reference outer bindings).
+    ///
+    /// That body-is-a-lambda invariant is upheld here rather than assumed
+    /// downstream: with no `BLOCK_EXPR` there is no lambda to build, so the
+    /// whole `spawn` lowers to [`Expr::Missing`] instead of a `Spawn` wrapping
+    /// a non-lambda body. Inference projects the body's return type and reads
+    /// its effective throws out of the lambda side table, neither of which
+    /// exists for a non-lambda.
     fn lower_spawn_expr(&mut self, node: &SyntaxNode) -> ExprId {
         use baml_compiler_syntax::ast as cst_ast;
 
@@ -964,7 +971,13 @@ impl LoweringContext {
             }
         }
 
-        let body = body_lambda.unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.span_range()));
+        // No block — an incomplete `spawn` (an editor prefix typed before the
+        // body exists, or a syntax error the parser has already reported).
+        // There is no lambda to hang the spawn off, so the expression itself is
+        // what is missing.
+        let Some(body) = body_lambda else {
+            return self.alloc_expr(Expr::Missing, node.span_range());
+        };
         self.alloc_expr(
             Expr::Spawn {
                 name,

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -2345,17 +2345,20 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 closure,
                 name,
                 config,
+                future_ty,
                 future,
                 resume,
             } => {
-                // Push closure, name, then config. The runtime `OpCode::Spawn`
-                // pops them in reverse: config first, then name, then closure.
-                // Config is null when there is no `with` clause, so a fixed
-                // three values are always pushed (BEP-034 spawn options).
+                // Push closure, name, config, then the future's `T`/`E`. The
+                // runtime `OpCode::Spawn` pops them in reverse. Config is null
+                // when there is no `with` clause, so a fixed five values are
+                // always pushed (BEP-034 spawn options).
                 self.emit_operand_pull(closure);
                 self.emit_operand_pull(name);
                 let null_config = Operand::Constant(Constant::Null);
                 self.emit_operand_pull(config.as_deref().unwrap_or(&null_config));
+                unwrap_infallible(self.load_type(&future_ty.returns));
+                unwrap_infallible(self.load_type(&future_ty.throws));
                 self.emit(Instruction::Spawn);
                 self.emit_store_place(future);
                 self.emit_jump_unless_fallthrough(*resume);
@@ -3374,6 +3377,7 @@ impl PullSink for StackifyCodegen<'_, '_> {
             // value matcher.
             TyTemplate::List(..)
             | TyTemplate::Map { .. }
+            | TyTemplate::Future(..)
             | TyTemplate::TypeArgRef(_)
             | TyTemplate::Interface(..)
             | TyTemplate::AssociatedTypeProjection { .. }

--- a/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
@@ -696,7 +696,10 @@ fn simulate_terminator_stack(
                 return false;
             }
             // Config operand is pushed last (null when there is no `with`
-            // clause). Mirror `emit`: always push three, pop three.
+            // clause). Mirror `emit`: always push three, pop three. The
+            // future's `T`/`E` types are pushed after it by `load_type` and
+            // popped again by `Spawn`, so like `alloc_array`'s element type
+            // they leave the net stack effect unchanged.
             let null_config = Operand::Constant(Constant::Null);
             let config_op = config.as_deref().unwrap_or(&null_config);
             if pull_semantics::walk_operand_pull(&mut sink, config_op).is_err() {

--- a/baml_language/crates/baml_compiler2_mir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/builder.rs
@@ -551,6 +551,7 @@ impl MirBuilder {
         closure: Operand,
         name: Operand,
         config: Option<Box<Operand>>,
+        future_ty: Box<crate::ir::SpawnFutureTy>,
         future: Place,
         resume: BlockId,
     ) {
@@ -562,6 +563,7 @@ impl MirBuilder {
             closure,
             name,
             config,
+            future_ty,
             future,
             resume,
         });

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -576,9 +576,8 @@ pub enum Terminator {
 pub struct SpawnFutureTy {
     /// The `T` of `Future<T, E>` — the value the spawned body returns.
     pub returns: TyTemplate,
-    /// The `E` of `Future<T, E>` — what the spawned body may throw. A body
-    /// that statically cannot throw spells this `null`, per the BEP's
-    /// `Future<T, never> ≈ Future<T, null>` approximation.
+    /// The `E` of `Future<T, E>` — what the spawned body may throw. A body that
+    /// statically cannot throw spells this `never`.
     pub throws: TyTemplate,
 }
 

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -482,6 +482,9 @@ pub enum Terminator {
         /// Boxed to keep `Terminator`'s footprint down (clippy
         /// `large_enum_variant`): `Spawn` is rare relative to `Call`/`Goto`.
         config: Option<Box<Operand>>,
+        /// The `T`/`E` of the `Future<T, E>` this spawn yields. Boxed for the
+        /// same footprint reason as `config`.
+        future_ty: Box<SpawnFutureTy>,
         /// Where to store the resulting Future handle.
         future: Place,
         /// Block to resume after the spawn schedules.
@@ -560,6 +563,23 @@ pub enum Terminator {
         eval_rhs: BlockId,
         join: BlockId,
     },
+}
+
+/// The type arguments of the `Future<T, E>` a [`Terminator::Spawn`] yields.
+///
+/// Held as [`TyTemplate`]s rather than resolved types so a spawn inside a
+/// generic function (`fn f<T>(x: T) { spawn { x } }`) resolves against the
+/// frame's type arguments at runtime, exactly as an array literal's element
+/// type does. The runtime stores the resolved pair on the heap `Future` so
+/// reflection and `is`/`match` can see the future's generic parameters.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpawnFutureTy {
+    /// The `T` of `Future<T, E>` — the value the spawned body returns.
+    pub returns: TyTemplate,
+    /// The `E` of `Future<T, E>` — what the spawned body may throw. A body
+    /// that statically cannot throw spells this `null`, per the BEP's
+    /// `Future<T, never> ≈ Future<T, null>` approximation.
+    pub throws: TyTemplate,
 }
 
 impl Terminator {

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1275,7 +1275,7 @@ fn tag_conflated_shape(ty: &RuntimeTy) -> Option<TagConflatedShape> {
 ///
 /// Generic-argument positions are invariant (`TYPE_SYSTEM.md` "Variance"): `int[]`,
 /// `string[]`, and `json[]` are mutually unrelated types, as are
-/// `Future<int, null>` and `Future<string, null>`. So the coarse "any list" /
+/// `Future<int, never>` and `Future<string, never>`. So the coarse "any list" /
 /// "any map" / "any future" tag is sound only when no value the scrutinee admits
 /// could carry that tag with different type arguments than the arm. That holds
 /// when every same-shape member of the scrutinee shares the arm's constructor

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1242,44 +1242,70 @@ fn member_is_opaque_for_tag_proof(m: &RuntimeTy) -> bool {
     }
 }
 
-/// Whether a coarse `LIST`/`MAP` type-tag test for the container arm `arm` is a
-/// *provably sound* substitute for the element-discriminating structural test,
-/// for values of the scrutinee's resolved static type `scrutinee`.
+/// A parametric shape whose every instantiation collapses onto one coarse type
+/// tag. Two arms at different instantiations therefore dedup onto the same
+/// jump-table slot, and the first swallows the rest — the conflation
+/// [`parametric_arm_tag_sufficient`] has to rule out. Values of *different*
+/// shapes carry different tags and can never collide.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TagConflatedShape {
+    List,
+    Map,
+    /// A `Future<T, E>`: every instantiation is `FUTURE`-tagged, and a spawned
+    /// future carries the `<T, E>` its spawn site was typed at, so the tag alone
+    /// no longer pins which arm a value belongs to.
+    Future,
+}
+
+/// The [`TagConflatedShape`] of `ty`, or `None` when its tag already pins its
+/// values (a primitive, a monomorphic class, …).
+fn tag_conflated_shape(ty: &RuntimeTy) -> Option<TagConflatedShape> {
+    match ty {
+        RuntimeTy::List(..) => Some(TagConflatedShape::List),
+        RuntimeTy::Map { .. } => Some(TagConflatedShape::Map),
+        RuntimeTy::Future(..) => Some(TagConflatedShape::Future),
+        _ => None,
+    }
+}
+
+/// Whether a coarse `LIST`/`MAP`/`FUTURE` type-tag test for the parametric arm
+/// `arm` is a *provably sound* substitute for the argument-discriminating
+/// structural test, for values of the scrutinee's resolved static type
+/// `scrutinee`.
 ///
 /// Generic-argument positions are invariant (`TYPE_SYSTEM.md` "Variance"): `int[]`,
-/// `string[]`, and `json[]` are mutually unrelated types. So the coarse "any
-/// list" / "any map" tag is sound only when no value the scrutinee admits could
-/// carry that tag with a different element type than the arm. That holds when
-/// every same-shape (list/map) member of the scrutinee shares the arm's
-/// constructor identity, and every other member carries a tag that provably
-/// can't be the arm's — a different-shape container or a concrete non-container
-/// leaf.
+/// `string[]`, and `json[]` are mutually unrelated types, as are
+/// `Future<int, null>` and `Future<string, null>`. So the coarse "any list" /
+/// "any map" / "any future" tag is sound only when no value the scrutinee admits
+/// could carry that tag with different type arguments than the arm. That holds
+/// when every same-shape member of the scrutinee shares the arm's constructor
+/// identity, and every other member carries a tag that provably can't be the
+/// arm's — a different parametric shape or a concrete leaf.
 ///
 /// We **fail closed**: an opaque member (see [`member_is_opaque_for_tag_proof`])
-/// could hide a container of a differing element type, so it blocks the proof
+/// could hide an instantiation with differing arguments, so it blocks the proof
 /// and routes the arm through the structural matcher. In particular a `json`
 /// scrutinee (an opaque alias leaf) no longer makes an element-specific `int[]`
 /// arm "tag-sufficient" — that was fail-*open* covariance, matching any array.
 ///
-/// Returns `false` for a non-container `arm` (the caller only asks about one).
-fn container_arm_tag_sufficient(arm: &RuntimeTy, scrutinee: &RuntimeTy) -> bool {
+/// Returns `false` for a non-parametric `arm` (the caller only asks about one).
+fn parametric_arm_tag_sufficient(arm: &RuntimeTy, scrutinee: &RuntimeTy) -> bool {
     use baml_compiler2_tir::exhaustiveness::ty_ctor_identity;
-    let arm_is_list = match arm {
-        RuntimeTy::List(..) => true,
-        RuntimeTy::Map { .. } => false,
-        _ => return false,
+    let Some(arm_shape) = tag_conflated_shape(arm) else {
+        return false;
     };
     let arm_id = ty_ctor_identity(arm.as_ty());
     let mut members = Vec::new();
     flatten_runtime_union(scrutinee, &mut members);
-    members.iter().all(|m| match m {
-        // Same-shape container: sound only for the arm's exact instantiation.
-        RuntimeTy::List(..) if arm_is_list => ty_ctor_identity(m.as_ty()) == arm_id,
-        RuntimeTy::Map { .. } if !arm_is_list => ty_ctor_identity(m.as_ty()) == arm_id,
-        // Anything else is sound iff it cannot secretly be a differing-element
-        // container — i.e. iff it is not opaque. A different-shape container and
-        // every concrete leaf carry a tag that can't be the arm's, so they pass.
-        _ => !member_is_opaque_for_tag_proof(m),
+    members.iter().all(|m| match tag_conflated_shape(m) {
+        // Same shape: sound only for the arm's exact instantiation.
+        Some(shape) if shape == arm_shape => ty_ctor_identity(m.as_ty()) == arm_id,
+        // A different parametric shape carries a tag that can't be the arm's.
+        Some(_) => true,
+        // Anything else is sound iff it cannot secretly be a differing
+        // instantiation — i.e. iff it is not opaque. Every concrete leaf carries
+        // a tag that can't be the arm's, so it passes.
+        None => !member_is_opaque_for_tag_proof(m),
     })
 }
 
@@ -1292,7 +1318,7 @@ fn container_arm_tag_sufficient(arm: &RuntimeTy, scrutinee: &RuntimeTy) -> bool 
 /// first arm carrying that tag. A member is tag-sufficient only when no value
 /// the scrutinee admits could be conflated onto it:
 ///
-/// - a list/map member defers to [`container_arm_tag_sufficient`] (which
+/// - a list/map/future member defers to [`parametric_arm_tag_sufficient`] (which
 ///   deliberately treats opaque scrutinee members as non-blockers, preserving
 ///   the pre-structural erased semantics the chain path keeps for them); with
 ///   no scrutinee the equivalence is unprovable, so it fails closed to the
@@ -1308,8 +1334,8 @@ fn container_arm_tag_sufficient(arm: &RuntimeTy, scrutinee: &RuntimeTy) -> bool 
 fn switch_member_tag_sufficient(member: &RuntimeTy, scrutinee: Option<&RuntimeTy>) -> bool {
     use baml_compiler2_tir::exhaustiveness::ty_ctor_identity;
     match member {
-        RuntimeTy::List(..) | RuntimeTy::Map { .. } => {
-            scrutinee.is_some_and(|scrutinee| container_arm_tag_sufficient(member, scrutinee))
+        RuntimeTy::List(..) | RuntimeTy::Map { .. } | RuntimeTy::Future(..) => {
+            scrutinee.is_some_and(|scrutinee| parametric_arm_tag_sufficient(member, scrutinee))
         }
         // Every enum collapses onto the single shared `ENUM` type tag, so the
         // jump table can key an enum-type arm only when no *other* enum type
@@ -1978,7 +2004,7 @@ struct LoweringContext<'db> {
     /// across nested matches). A container arm's runtime type test consults this
     /// — guarded on the local matching — to decide whether a coarse `LIST`/`MAP`
     /// tag suffices in place of a structural element check (see
-    /// [`container_arm_tag_sufficient`]). `None` outside a match, and the local
+    /// [`parametric_arm_tag_sufficient`]). `None` outside a match, and the local
     /// guard keeps `is` / standalone tests element-precise even inside one.
     match_scrutinee: Option<(Local, RuntimeTy)>,
 
@@ -3903,6 +3929,26 @@ impl<'db> LoweringContext<'db> {
                 TyTemplate::from(RealizedTy::unknown()),
             ),
         }
+    }
+
+    /// The `T`/`E` templates for a `spawn` expression — the arguments of its
+    /// `Future<T, E>` static type — for [`Terminator::Spawn`]. TIR has already
+    /// folded any `with` transformers into that type, so this is the future the
+    /// spawn actually hands back. Falls back to `unknown` when the recorded type
+    /// is not a future (error recovery).
+    fn spawn_future_ty(&self, expr_id: AstExprId) -> Box<crate::ir::SpawnFutureTy> {
+        let generic_params = self.enclosing_generic_params();
+        let (returns, throws) = match self.tir_expr_type(self.expr_metadata_key(expr_id)) {
+            Some(Tir2Ty::Future(value, error, _)) => (
+                self.ty_to_template(value, &generic_params),
+                self.ty_to_template(error, &generic_params),
+            ),
+            _ => (
+                TyTemplate::from(RealizedTy::unknown()),
+                TyTemplate::from(RealizedTy::unknown()),
+            ),
+        };
+        Box::new(crate::ir::SpawnFutureTy { returns, throws })
     }
 
     fn object_class_type_arg_templates(
@@ -5971,26 +6017,28 @@ impl LoweringContext<'_> {
             Some(Box::new(Operand::Copy(Place::Local(cur))))
         };
 
-        // Allocate the future temp. Phase C uses a defaulted `Null` type
-        // for the future local; the TIR-tracked value/error types flow
-        // through to runtime via the surrounding context. A follow-up
-        // can plumb `Tir2Ty::Future` directly through `convert_tir_ty_for_runtime`
-        // here once we read it from `self.expr_types`.
-        let future_local = self.builder.temp(RuntimeTy::Null {
-            attr: TyAttr::default(),
-        });
+        // Allocate the future temp, typed as the `Future<T, E>` TIR inferred.
+        let future_local = self.builder.temp(self.expr_ty(expr_id));
         let future_place = Place::Local(future_local);
 
+        // The same `Future<T, E>`, as templates: the runtime resolves them
+        // against the spawning frame's type args and stores the pair on the
+        // heap `Future` for reflection and `is`/`match`.
+        let future_ty = self.spawn_future_ty(expr_id);
+
         let resume = self.builder.create_block();
-        self.builder
-            .spawn(closure_op, name_op, config_op, future_place.clone(), resume);
+        self.builder.spawn(
+            closure_op,
+            name_op,
+            config_op,
+            future_ty,
+            future_place.clone(),
+            resume,
+        );
         self.builder.set_current_block(resume);
         // The result of `spawn` is the Future handle.
         self.builder
             .assign(dest, Rvalue::Use(Operand::Copy(future_place)));
-        // Phase C: `expr_id` is recorded for source-span tracking but
-        // is not used for type lookup here.
-        let _ = expr_id;
     }
 
     /// Lower `await expr` into a `Terminator::Await` whose destination is
@@ -13015,24 +13063,25 @@ impl LoweringContext<'_> {
                 }
             }
         } else {
-            // If this is a container arm whose element the emitter would otherwise
-            // check structurally, but the enclosing match's scrutinee statically
-            // proves a coarse `LIST`/`MAP` tag suffices, emit the tag test
-            // directly. Guarded on the scrutinee local so an `is` / nested test
-            // against a different value stays element-precise.
+            // If this is a parametric arm whose type arguments the emitter would
+            // otherwise check structurally, but the enclosing match's scrutinee
+            // statically proves a coarse `LIST`/`MAP`/`FUTURE` tag suffices,
+            // emit the tag test directly. Guarded on the scrutinee local so an
+            // `is` / nested test against a different value stays arg-precise.
             if self
                 .match_scrutinee
                 .as_ref()
                 .is_some_and(|(local, scrutinee_ty)| {
-                    *local == scrutinee && container_arm_tag_sufficient(&ty, scrutinee_ty)
+                    *local == scrutinee && parametric_arm_tag_sufficient(&ty, scrutinee_ty)
                 })
             {
                 let tag = match &ty {
                     RuntimeTy::List(..) => baml_type::typetag::LIST,
                     RuntimeTy::Map { .. } => baml_type::typetag::MAP,
-                    // `container_arm_tag_sufficient` returns false for every
-                    // non-container arm.
-                    other => unreachable!("tag-sufficient non-container arm: {other}"),
+                    RuntimeTy::Future(..) => baml_type::typetag::FUTURE,
+                    // `parametric_arm_tag_sufficient` returns false for every
+                    // non-parametric arm.
+                    other => unreachable!("tag-sufficient non-parametric arm: {other}"),
                 };
                 self.emit_is_type_tag_branch(scrutinee, tag, success, failure);
                 return;

--- a/baml_language/crates/baml_compiler2_mir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/pretty.rs
@@ -356,10 +356,15 @@ fn write_terminator(f: &mut impl Write, term: &Terminator) -> fmt::Result {
             closure,
             name,
             config,
+            future_ty,
             future,
             resume,
         } => {
-            write!(f, "{future} = spawn ")?;
+            write!(
+                f,
+                "{future} = spawn<{}, {}> ",
+                future_ty.returns, future_ty.throws
+            )?;
             write_operand(f, closure)?;
             write!(f, " name=")?;
             write_operand(f, name)?;

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -5453,29 +5453,18 @@ impl<'db> TypeInferenceBuilder<'db> {
             Ty::Function { ret, .. } => ret.as_ref().clone(),
             _ => lambda_ty.clone(),
         };
-        // Read the body's effective throws from the side table
-        // populated by `infer_lambda_body`. `Never` means the
-        // body throws nothing; BAML lacks a `never` type
-        // variant, so approximate with `Null` (per the BEP's
-        // "Future<T, never> ≈ Future<T, null> in v1" note).
+        // Read the body's effective throws from the side table populated by
+        // `infer_lambda_body`, which computes it for every lambda it infers and
+        // collapses "throws nothing" to `Never` — so a body that statically
+        // cannot throw types the future as `Future<T, never>`. `Expr::Spawn`'s
+        // body is always the synthetic `<spawn>` lambda (`lower_spawn_expr`
+        // lowers a block-less `spawn` to `Expr::Missing` outright rather than
+        // building a `Spawn` around a non-lambda body), so the entry exists.
         let throws_ty = self
             .lambda_effective_throws
             .get(&spawn_body)
             .cloned()
-            .map_or_else(
-                || Ty::Null {
-                    attr: TyAttr::default(),
-                },
-                |t| {
-                    if matches!(t, Ty::Never { .. }) {
-                        Ty::Null {
-                            attr: TyAttr::default(),
-                        }
-                    } else {
-                        t
-                    }
-                },
-            );
+            .unwrap_or_else(|| unreachable!("Unknown effective lambda throws"));
 
         // BEP-034 middleware: fold the `with` transformers left-to-right.
         // The body seeds an implicit `SpawnParams<T0, E0>`; each transformer
@@ -5488,8 +5477,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         // spawn's `Future`. Type-changing transformers (e.g. a fallback
         // erasing the error type) fall out naturally.
         // Widen fresh literal types out of the seed (`spawn with t { 1 }`
-        // must read `SpawnParams<int, null>` in diagnostics and bindings,
-        // not `SpawnParams<1, null>`).
+        // must read `SpawnParams<int, never>` in diagnostics and bindings,
+        // not `SpawnParams<1, never>`).
         let mut cur_value = value_ty.widen_fresh();
         let mut cur_error = throws_ty.widen_fresh();
         for with_id in with_exprs {
@@ -15258,7 +15247,7 @@ impl crate::exhaustiveness::PatCtx for TypeInferenceBuilder<'_> {
             // A same-instantiation `Future<T, E>` pattern *is* such a row
             // (`dpat_for_type` lowers it to a wildcard once the column is
             // already that instantiation), so a single arm still exhausts a
-            // `Future<int, null>` scrutinee; a differently-instantiated pattern
+            // `Future<int, never>` scrutinee; a differently-instantiated pattern
             // claims a different union member instead (`atoms_overlap`).
             Ty::Future(..) => vec![Ctor::NonExhaustive],
             // Slice path in `split_ctors` enumerates length classes from
@@ -16126,8 +16115,8 @@ impl TypeInferenceBuilder<'_> {
             // Future: same head AND both type arguments could be the same
             // realized argument — invariant positions, exactly like the
             // containers above. A spawned future carries the `<T, E>` its spawn
-            // site was typed at, so a `Future<int, null>` pattern does not
-            // target a `Future<string, null>` member.
+            // site was typed at, so a `Future<int, never>` pattern does not
+            // target a `Future<string, never>` member.
             (Ty::Future(a_value, a_error, _), Ty::Future(b_value, b_error, _)) => {
                 self.dispatch_args_compatible(a_value, b_value)
                     && self.dispatch_args_compatible(a_error, b_error)

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -15253,9 +15253,13 @@ impl crate::exhaustiveness::PatCtx for TypeInferenceBuilder<'_> {
             // Open interfaces always require a wildcard — new implementors
             // can appear in any file. See BEP-044 §"Interaction with match".
             Ty::Interface(_, _, _, _) => vec![Ctor::NonExhaustive],
-            // Futures are non-exhaustive at the pattern level: there is
-            // no surface syntax to match against `Future<T, E>` other
-            // than a wildcard.
+            // `Future`'s instantiations cannot be enumerated, so a `Future`
+            // column is covered only by a row that is wildcard-shaped at it.
+            // A same-instantiation `Future<T, E>` pattern *is* such a row
+            // (`dpat_for_type` lowers it to a wildcard once the column is
+            // already that instantiation), so a single arm still exhausts a
+            // `Future<int, null>` scrutinee; a differently-instantiated pattern
+            // claims a different union member instead (`atoms_overlap`).
             Ty::Future(..) => vec![Ctor::NonExhaustive],
             // Slice path in `split_ctors` enumerates length classes from
             // the matrix; this branch is only reached if the algorithm
@@ -16119,6 +16123,15 @@ impl TypeInferenceBuilder<'_> {
                 }
                 | Ty::EvolvingMap(b_k, b_v, _),
             ) => self.dispatch_args_compatible(a_k, b_k) && self.dispatch_args_compatible(a_v, b_v),
+            // Future: same head AND both type arguments could be the same
+            // realized argument — invariant positions, exactly like the
+            // containers above. A spawned future carries the `<T, E>` its spawn
+            // site was typed at, so a `Future<int, null>` pattern does not
+            // target a `Future<string, null>` member.
+            (Ty::Future(a_value, a_error, _), Ty::Future(b_value, b_error, _)) => {
+                self.dispatch_args_compatible(a_value, b_value)
+                    && self.dispatch_args_compatible(a_error, b_error)
+            }
             // Function: arities match AND every param pair overlaps AND
             // returns overlap. A `(int) -> int` pattern can never match a
             // `(string) -> int` value, so they must not be reported as

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -1513,8 +1513,8 @@ const BLANKET_IMPL_BOUND_DEPTH: u32 = 16;
 ///
 /// This is a broader question than [`Ty::is_valid_impl_subject`], which asks
 /// whether a type may be a *written* impl's for-type: `Future` is excluded there
-/// (a top-level `implement I for Future<T>` would bake an undispatchable rule)
-/// but is a valid blanket *receiver* here — the blanket's for-template is a
+/// only because written impls on it are not implemented yet (see that doc), but
+/// it is a valid blanket *receiver* here — the blanket's for-template is a
 /// wildcard that binds the concrete `Future<…>` at runtime.
 fn is_concrete_receiver(ty: &Ty) -> bool {
     matches!(

--- a/baml_language/crates/baml_tests/baml_src/ns_future_types/future_types.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_future_types/future_types.baml
@@ -1,0 +1,203 @@
+// Tests for the runtime type identity of a spawned future (BEP-034).
+//
+// A heap `Future` carries the `<T, E>` its spawn site was typed at, so `is` and
+// `match` relate those arguments invariantly — the way `int[]` is not
+// `string[]` — instead of admitting every future through the coarse FUTURE type
+// tag. A body that statically cannot throw spells its error type `null`.
+//
+// Helpers live at top level rather than inline in the test blocks: `is` and
+// `match` inspect a value's runtime type, and a boxed test-block local
+// misreports (same caveat as ns_is_operator).
+
+// ── 1. The value type discriminates ───────────────────────────────────────────
+
+function int_future_is_int_future_fn() -> bool {
+    let f = spawn { 1 };
+    let observed = f is baml.future.Future<int, null>;
+    let _ = await f;
+    observed
+}
+
+test "int_future_is_int_future" {
+    assert.is_true(int_future_is_int_future_fn())
+}
+
+function int_future_is_string_future_fn() -> bool {
+    let f = spawn { 1 };
+    let observed = f is baml.future.Future<string, null>;
+    let _ = await f;
+    observed
+}
+
+test "int_future_is_not_string_future" {
+    assert.is_true(!int_future_is_string_future_fn())
+}
+
+// ── 2. The error type discriminates ───────────────────────────────────────────
+
+function fail_io() -> int throws baml.errors.Io {
+    throw baml.errors.Io { message: "x" }
+}
+
+// Same value type as `spawn { 1 }`, different error type: the future must not
+// pass a `Future<int, null>` test.
+function throwing_future_is_non_throwing_future_fn() -> bool {
+    let f = spawn { fail_io() };
+    let observed = f is baml.future.Future<int, null>;
+    let _ = (await f) catch (e) { baml.errors.Io => 0 };
+    observed
+}
+
+test "throwing_future_is_not_non_throwing_future" {
+    assert.is_true(!throwing_future_is_non_throwing_future_fn())
+}
+
+// ── 3. A body that captures a local still reports the precise type ────────────
+
+// The spawn body closes over `v`, so the value reaches the future through a
+// capture cell rather than a literal in the body. The future's type is still the
+// body's type, not the cell's.
+function captured_local_future_is_int_future_fn() -> bool {
+    let v: int = 1;
+    let f = spawn { v };
+    let observed = f is baml.future.Future<int, null>;
+    let _ = await f;
+    observed
+}
+
+test "captured_local_future_is_int_future" {
+    assert.is_true(captured_local_future_is_int_future_fn())
+}
+
+// ── 4. A spawn in a generic frame resolves against the caller's type args ─────
+
+// The spawned body's type is the frame's `T`, so this future's value type is
+// whatever `T` was specialized to at the call site — not a compile-time constant
+// of this function. The spawn lowers `T` to a frame reference (`all_complete<T,
+// E>` emits `spawn<#0[], #1>`; see the `__baml_std__` MIR snapshot) that the
+// runtime resolves against the caller-supplied type args.
+function spawn_is_int_future<T>(v: T) -> bool {
+    let f = spawn { v };
+    let observed = f is baml.future.Future<int, null>;
+    let _ = await f;
+    observed
+}
+
+// Explicit type args at the call site.
+function generic_spawn_at_int_fn() -> bool {
+    let v: int = 1;
+    spawn_is_int_future<int>(v)
+}
+
+test "generic_spawn_at_int_is_int_future" {
+    assert.is_true(generic_spawn_at_int_fn())
+}
+
+function generic_spawn_at_string_fn() -> bool {
+    let v: string = "a";
+    spawn_is_int_future<string>(v)
+}
+
+test "generic_spawn_at_string_is_not_int_future" {
+    assert.is_true(!generic_spawn_at_string_fn())
+}
+
+// The same pair with `T` INFERRED from the argument rather than written. This is
+// the case that used to report `unknown`, so it is worth pinning separately from
+// the explicit form above.
+function inferred_generic_spawn_at_int_fn() -> bool {
+    let v: int = 1;
+    spawn_is_int_future(v)
+}
+
+test "inferred_generic_spawn_at_int_is_int_future" {
+    assert.is_true(inferred_generic_spawn_at_int_fn())
+}
+
+function inferred_generic_spawn_at_string_fn() -> bool {
+    let v: string = "a";
+    spawn_is_int_future(v)
+}
+
+test "inferred_generic_spawn_at_string_is_not_int_future" {
+    assert.is_true(!inferred_generic_spawn_at_string_fn())
+}
+
+// ── 5. `match` arms discriminate on the same footing ──────────────────────────
+
+// No wildcard arm: the two arms target one union member each, so between them
+// they exhaust the scrutinee. (Adding a `_` here is an `unreachable arm` error —
+// which is itself the proof that the arms discriminate on the type arguments
+// rather than each swallowing every future.)
+function classify_future(
+    f: baml.future.Future<int, null> | baml.future.Future<string, null>,
+) -> string {
+    match (f) {
+        let a: baml.future.Future<int, null> => "int",
+        let b: baml.future.Future<string, null> => "string",
+    }
+}
+
+function classify_int_future_fn() -> string {
+    let f = spawn { 1 };
+    let observed = classify_future(f);
+    let _ = await f;
+    observed
+}
+
+test "match_picks_int_future_arm" {
+    assert.equal(classify_int_future_fn(), "int")
+}
+
+function classify_string_future_fn() -> string {
+    let f = spawn { "a" };
+    let observed = classify_future(f);
+    let _ = await f;
+    observed
+}
+
+test "match_picks_string_future_arm" {
+    assert.equal(classify_string_future_fn(), "string")
+}
+
+// ── 6. Two future arms on the jump-table path ────────────────────────────────
+
+// Bare (unbound) type arms at 4+ distinct tags lower to a tag-keyed jump table
+// rather than the sequential chain. Every `Future<T, E>` carries the single
+// FUTURE tag, so without a tag-sufficiency guard the two future arms dedup onto
+// one slot and the first swallows the second — a `Future<string, null>` value
+// would answer "int-future". Both conditions are load-bearing: `let a: T` arms
+// encode as a chain, and fewer than four tags skips the table.
+function classify_tagged(
+    v: baml.future.Future<int, null> | baml.future.Future<string, null> | int | string | bool,
+) -> string {
+    match (v) {
+        baml.future.Future<int, null> => "int-future",
+        baml.future.Future<string, null> => "string-future",
+        int => "int",
+        string => "string",
+        bool => "bool",
+    }
+}
+
+function tagged_string_future_fn() -> string {
+    let f = spawn { "a" };
+    let observed = classify_tagged(f);
+    let _ = await f;
+    observed
+}
+
+test "jump_table_picks_string_future_arm" {
+    assert.equal(tagged_string_future_fn(), "string-future")
+}
+
+function tagged_int_future_fn() -> string {
+    let f = spawn { 1 };
+    let observed = classify_tagged(f);
+    let _ = await f;
+    observed
+}
+
+test "jump_table_picks_int_future_arm" {
+    assert.equal(tagged_int_future_fn(), "int-future")
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_future_types/future_types.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_future_types/future_types.baml
@@ -3,7 +3,7 @@
 // A heap `Future` carries the `<T, E>` its spawn site was typed at, so `is` and
 // `match` relate those arguments invariantly — the way `int[]` is not
 // `string[]` — instead of admitting every future through the coarse FUTURE type
-// tag. A body that statically cannot throw spells its error type `null`.
+// tag. A body that statically cannot throw spells its error type `never`.
 //
 // Helpers live at top level rather than inline in the test blocks: `is` and
 // `match` inspect a value's runtime type, and a boxed test-block local
@@ -11,9 +11,9 @@
 
 // ── 1. The value type discriminates ───────────────────────────────────────────
 
-function int_future_is_int_future_fn() -> bool {
+function int_future_is_int_future_fn() -> bool throws never {
     let f = spawn { 1 };
-    let observed = f is baml.future.Future<int, null>;
+    let observed = f is baml.future.Future<int, never>;
     let _ = await f;
     observed
 }
@@ -22,9 +22,9 @@ test "int_future_is_int_future" {
     assert.is_true(int_future_is_int_future_fn())
 }
 
-function int_future_is_string_future_fn() -> bool {
+function int_future_is_string_future_fn() -> bool throws never {
     let f = spawn { 1 };
-    let observed = f is baml.future.Future<string, null>;
+    let observed = f is baml.future.Future<string, never>;
     let _ = await f;
     observed
 }
@@ -40,10 +40,10 @@ function fail_io() -> int throws baml.errors.Io {
 }
 
 // Same value type as `spawn { 1 }`, different error type: the future must not
-// pass a `Future<int, null>` test.
-function throwing_future_is_non_throwing_future_fn() -> bool {
+// pass a `Future<int, never>` test.
+function throwing_future_is_non_throwing_future_fn() -> bool throws never {
     let f = spawn { fail_io() };
-    let observed = f is baml.future.Future<int, null>;
+    let observed = f is baml.future.Future<int, never>;
     let _ = (await f) catch (e) { baml.errors.Io => 0 };
     observed
 }
@@ -57,10 +57,10 @@ test "throwing_future_is_not_non_throwing_future" {
 // The spawn body closes over `v`, so the value reaches the future through a
 // capture cell rather than a literal in the body. The future's type is still the
 // body's type, not the cell's.
-function captured_local_future_is_int_future_fn() -> bool {
+function captured_local_future_is_int_future_fn() -> bool throws never {
     let v: int = 1;
     let f = spawn { v };
-    let observed = f is baml.future.Future<int, null>;
+    let observed = f is baml.future.Future<int, never>;
     let _ = await f;
     observed
 }
@@ -76,15 +76,15 @@ test "captured_local_future_is_int_future" {
 // of this function. The spawn lowers `T` to a frame reference (`all_complete<T,
 // E>` emits `spawn<#0[], #1>`; see the `__baml_std__` MIR snapshot) that the
 // runtime resolves against the caller-supplied type args.
-function spawn_is_int_future<T>(v: T) -> bool {
+function spawn_is_int_future<T>(v: T) -> bool throws never {
     let f = spawn { v };
-    let observed = f is baml.future.Future<int, null>;
+    let observed = f is baml.future.Future<int, never>;
     let _ = await f;
     observed
 }
 
 // Explicit type args at the call site.
-function generic_spawn_at_int_fn() -> bool {
+function generic_spawn_at_int_fn() -> bool throws never {
     let v: int = 1;
     spawn_is_int_future<int>(v)
 }
@@ -93,7 +93,7 @@ test "generic_spawn_at_int_is_int_future" {
     assert.is_true(generic_spawn_at_int_fn())
 }
 
-function generic_spawn_at_string_fn() -> bool {
+function generic_spawn_at_string_fn() -> bool throws never {
     let v: string = "a";
     spawn_is_int_future<string>(v)
 }
@@ -105,7 +105,7 @@ test "generic_spawn_at_string_is_not_int_future" {
 // The same pair with `T` INFERRED from the argument rather than written. This is
 // the case that used to report `unknown`, so it is worth pinning separately from
 // the explicit form above.
-function inferred_generic_spawn_at_int_fn() -> bool {
+function inferred_generic_spawn_at_int_fn() -> bool throws never {
     let v: int = 1;
     spawn_is_int_future(v)
 }
@@ -114,7 +114,7 @@ test "inferred_generic_spawn_at_int_is_int_future" {
     assert.is_true(inferred_generic_spawn_at_int_fn())
 }
 
-function inferred_generic_spawn_at_string_fn() -> bool {
+function inferred_generic_spawn_at_string_fn() -> bool throws never {
     let v: string = "a";
     spawn_is_int_future(v)
 }
@@ -130,15 +130,15 @@ test "inferred_generic_spawn_at_string_is_not_int_future" {
 // which is itself the proof that the arms discriminate on the type arguments
 // rather than each swallowing every future.)
 function classify_future(
-    f: baml.future.Future<int, null> | baml.future.Future<string, null>,
-) -> string {
+    f: baml.future.Future<int, never> | baml.future.Future<string, never>,
+) -> string throws never {
     match (f) {
-        let a: baml.future.Future<int, null> => "int",
-        let b: baml.future.Future<string, null> => "string",
+        let a: baml.future.Future<int, never> => "int",
+        let b: baml.future.Future<string, never> => "string",
     }
 }
 
-function classify_int_future_fn() -> string {
+function classify_int_future_fn() -> string throws never {
     let f = spawn { 1 };
     let observed = classify_future(f);
     let _ = await f;
@@ -149,7 +149,7 @@ test "match_picks_int_future_arm" {
     assert.equal(classify_int_future_fn(), "int")
 }
 
-function classify_string_future_fn() -> string {
+function classify_string_future_fn() -> string throws never {
     let f = spawn { "a" };
     let observed = classify_future(f);
     let _ = await f;
@@ -165,22 +165,22 @@ test "match_picks_string_future_arm" {
 // Bare (unbound) type arms at 4+ distinct tags lower to a tag-keyed jump table
 // rather than the sequential chain. Every `Future<T, E>` carries the single
 // FUTURE tag, so without a tag-sufficiency guard the two future arms dedup onto
-// one slot and the first swallows the second — a `Future<string, null>` value
+// one slot and the first swallows the second — a `Future<string, never>` value
 // would answer "int-future". Both conditions are load-bearing: `let a: T` arms
 // encode as a chain, and fewer than four tags skips the table.
 function classify_tagged(
-    v: baml.future.Future<int, null> | baml.future.Future<string, null> | int | string | bool,
-) -> string {
+    v: baml.future.Future<int, never> | baml.future.Future<string, never> | int | string | bool,
+) -> string throws never {
     match (v) {
-        baml.future.Future<int, null> => "int-future",
-        baml.future.Future<string, null> => "string-future",
+        baml.future.Future<int, never> => "int-future",
+        baml.future.Future<string, never> => "string-future",
         int => "int",
         string => "string",
         bool => "bool",
     }
 }
 
-function tagged_string_future_fn() -> string {
+function tagged_string_future_fn() -> string throws never {
     let f = spawn { "a" };
     let observed = classify_tagged(f);
     let _ = await f;
@@ -191,7 +191,7 @@ test "jump_table_picks_string_future_arm" {
     assert.equal(tagged_string_future_fn(), "string-future")
 }
 
-function tagged_int_future_fn() -> string {
+function tagged_int_future_fn() -> string throws never {
     let f = spawn { 1 };
     let observed = classify_tagged(f);
     let _ = await f;
@@ -200,4 +200,31 @@ function tagged_int_future_fn() -> string {
 
 test "jump_table_picks_int_future_arm" {
     assert.equal(tagged_int_future_fn(), "int-future")
+}
+
+// ── 7. A future's arguments carry through a container element type ────────────
+
+// `Future<T, E>[]` is how the combinators take their inputs
+// (`baml.future.all_complete(futures)`), so the element type has to keep
+// discriminating once it is a future.
+function future_array_matches_fn() -> bool throws never {
+    let fs: baml.future.Future<int, never>[] = [spawn { 1 }];
+    let observed = fs is baml.future.Future<int, never>[];
+    let _ = await fs[0];
+    observed
+}
+
+test "future_array_matches_element_type" {
+    assert.is_true(future_array_matches_fn())
+}
+
+function wrong_future_array_fn() -> bool throws never {
+    let fs: baml.future.Future<string, never>[] = [spawn { "a" }];
+    let observed = fs is baml.future.Future<int, never>[];
+    let _ = await fs[0];
+    observed
+}
+
+test "future_array_rejects_other_element_type" {
+    assert.is_true(!wrong_future_array_fn())
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_spawn_semantics/spawn_semantics.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_spawn_semantics/spawn_semantics.baml
@@ -42,7 +42,7 @@ test "three_level_nested_spawn_sum" {
     assert.is_true(baml.deep_equals(three_level_nested_spawn_sum_fn(), 111))
 }
 
-function spawn_child() -> baml.future.Future<int, null> {
+function spawn_child() -> baml.future.Future<int, never> {
     spawn { 99 }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -342,6 +342,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_cascade.snap
@@ -38,6 +38,8 @@ function cancel_cascade.cancel_after_gc_relocation_still_settles() -> int {
     make_closure .<lambda(cancel_after_gc_relocation_still_settles, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3
@@ -105,6 +107,8 @@ function cancel_cascade.cancel_from_handle_then_await_catches_cancelled() -> int
     make_closure .<lambda(cancel_from_handle_then_await_catches_cancelled, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3
@@ -140,6 +144,8 @@ function cancel_cascade.cancel_unblocks_await_on_non_descendant_fn() -> bool {
     make_closure .<lambda(cancel_unblocks_await_on_non_descendant_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_var _4
@@ -148,6 +154,8 @@ function cancel_cascade.cancel_unblocks_await_on_non_descendant_fn() -> bool {
     make_closure .<lambda(cancel_unblocks_await_on_non_descendant_fn, 1)>, 1
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _7
     load_var _7
@@ -199,6 +207,8 @@ function cancel_cascade.cancelled_child_future_state_is_cancelled() -> baml.futu
     make_closure .<lambda(cancelled_child_future_state_is_cancelled, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3
@@ -207,6 +217,8 @@ function cancel_cascade.cancelled_child_future_state_is_cancelled() -> baml.futu
     make_closure .<lambda(cancelled_child_future_state_is_cancelled, 1)>, 1
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _6
     load_var _6

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_token.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_token.snap
@@ -58,6 +58,8 @@ function cancel_token.await_token_cancelled_catches() -> int {
     load_var _3
     load_const null
     load_var _9
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _10
     load_var tok
@@ -104,6 +106,8 @@ function cancel_token.detached_spawn_completes() -> int {
     load_var _2
     load_const null
     load_var _7
+    load_type int
+    load_type null
     spawn
     store_var _8
     load_var _8
@@ -153,6 +157,8 @@ function cancel_token.uncancelled_token_completes() -> int {
     load_var _3
     load_const null
     load_var _9
+    load_type int
+    load_type null
     spawn
     store_var _10
     load_var _10

--- a/baml_language/crates/baml_tests/snapshots/baml_src/cancel_token.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/cancel_token.snap
@@ -88,7 +88,7 @@ function cancel_token.detached_spawn_completes() -> int {
     make_closure .<lambda(detached_spawn_completes, 0)>, 0
     store_var _2
     load_type int
-    load_type null
+    load_type never
     load_const <omitted>
     load_const <omitted>
     load_const true
@@ -107,7 +107,7 @@ function cancel_token.detached_spawn_completes() -> int {
     load_const null
     load_var _7
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _8
     load_var _8
@@ -139,7 +139,7 @@ function cancel_token.uncancelled_token_completes() -> int {
     make_closure .<lambda(uncancelled_token_completes, 0)>, 0
     store_var _3
     load_type int
-    load_type null
+    load_type never
     load_const <omitted>
     load_var tok
     load_const <omitted>
@@ -158,7 +158,7 @@ function cancel_token.uncancelled_token_completes() -> int {
     load_const null
     load_var _9
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _10
     load_var _10

--- a/baml_language/crates/baml_tests/snapshots/baml_src/defer.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/defer.snap
@@ -174,7 +174,7 @@ function defer.defer_await_inside_main() -> string[] {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _14
     load_var _14
@@ -192,7 +192,7 @@ function defer.defer_await_inside_main() -> string[] {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _8
     load_var _8

--- a/baml_language/crates/baml_tests/snapshots/baml_src/defer.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/defer.snap
@@ -173,6 +173,8 @@ function defer.defer_await_inside_main() -> string[] {
     make_closure .<lambda(defer_await_inside_main, 1)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _14
     load_var _14
@@ -189,6 +191,8 @@ function defer.defer_await_inside_main() -> string[] {
     make_closure .<lambda(defer_await_inside_main, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _8
     load_var _8

--- a/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
@@ -44,6 +44,8 @@ function future_methods.methods_after_cancel() -> baml.future.FutureState {
     make_closure .<lambda(methods_after_cancel, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3
@@ -60,6 +62,8 @@ function future_methods.methods_after_successful_settle() -> bool[] {
     make_closure .<lambda(methods_after_successful_settle, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _3
     load_var _3
@@ -85,6 +89,8 @@ function future_methods.methods_on_errored_future() -> baml.future.FutureState {
     make_closure .<lambda(methods_on_errored_future, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3
@@ -111,6 +117,8 @@ function future_methods.methods_on_pending_future() -> baml.future.FutureState {
     make_closure .<lambda(methods_on_pending_future, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/future_methods.snap
@@ -63,7 +63,7 @@ function future_methods.methods_after_successful_settle() -> bool[] {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/future_types.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/future_types.snap
@@ -86,6 +86,20 @@ function future_types.$init_test_ns_future_types_future_types(registry: testing.
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "future_array_matches_element_type"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 12)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "future_array_rejects_other_element_type"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 13)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
     load_const null
     return
 }
@@ -101,12 +115,12 @@ function future_types.captured_local_future_is_int_future_fn() -> bool {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _4
     load_var _4
     store_var_load_var f
-    is_type future<int, null>
+    is_type future<int, never>
     pop_jump_if_false L0
     jump L1
 
@@ -127,11 +141,11 @@ function future_types.captured_local_future_is_int_future_fn() -> bool {
     return
 }
 
-function future_types.classify_future(f: future<int, null> | future<string, null>) -> string {
+function future_types.classify_future(f: future<int, never> | future<string, never>) -> string {
     load_var f
     store_var _2
     load_var _2
-    narrow_bind future<int, null>, slot=2
+    narrow_bind future<int, never>, slot=2
     pop_jump_if_false L0
     jump L1
 
@@ -151,7 +165,7 @@ function future_types.classify_int_future_fn() -> string {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -170,7 +184,7 @@ function future_types.classify_string_future_fn() -> string {
     load_const null
     load_const null
     load_type string
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -184,15 +198,15 @@ function future_types.classify_string_future_fn() -> string {
     return
 }
 
-function future_types.classify_tagged(v: future<int, null> | future<string, null> | int | string | bool) -> string {
+function future_types.classify_tagged(v: future<int, never> | future<string, never> | int | string | bool) -> string {
     load_var v
-    is_type future<int, null>
+    is_type future<int, never>
     pop_jump_if_false L0
     jump L7
 
   L0:
     load_var v
-    is_type future<string, null>
+    is_type future<string, never>
     pop_jump_if_false L1
     jump L6
 
@@ -237,6 +251,41 @@ function future_types.fail_io() -> int {
     throw
 }
 
+function future_types.future_array_matches_fn() -> bool {
+    make_closure .<lambda(future_array_matches_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type int
+    load_type never
+    spawn
+    store_var _4
+    load_var _4
+    load_type future<int, never>
+    alloc_array 1
+    store_var_load_var fs
+    is_type future<int, never>[]
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    store_var observed
+    jump L2
+
+  L1:
+    load_const true
+    store_var observed
+
+  L2:
+    load_var fs
+    load_const 0
+    load_array_element
+    await
+    pop 1
+    load_var observed
+    return
+}
+
 function future_types.generic_spawn_at_int_fn() -> bool {
     load_type int
     load_const 1
@@ -270,12 +319,12 @@ function future_types.int_future_is_int_future_fn() -> bool {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
     store_var_load_var f
-    is_type future<int, null>
+    is_type future<int, never>
     pop_jump_if_false L0
     jump L1
 
@@ -301,7 +350,7 @@ function future_types.int_future_is_string_future_fn() -> bool {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -338,12 +387,12 @@ function future_types.spawn_is_int_future(v: T) -> bool {
     load_const null
     load_const null
     load_type #0
-    load_type null
+    load_type never
     spawn
     store_var _4
     load_var _4
     store_var_load_var f
-    is_type future<int, null>
+    is_type future<int, never>
     pop_jump_if_false L0
     jump L1
 
@@ -369,7 +418,7 @@ function future_types.tagged_int_future_fn() -> string {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -388,7 +437,7 @@ function future_types.tagged_string_future_fn() -> string {
     load_const null
     load_const null
     load_type string
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -441,6 +490,42 @@ function future_types.throwing_future_is_non_throwing_future_fn() -> bool {
     rethrow
 
   L4:
+    load_var observed
+    return
+}
+
+function future_types.wrong_future_array_fn() -> bool {
+    make_closure .<lambda(wrong_future_array_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type string
+    load_type never
+    spawn
+    store_var _4
+    load_var _4
+    load_type future<string, never>
+    alloc_array 1
+    store_var_load_var fs
+    pop 1
+    load_const false
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    store_var observed
+    jump L2
+
+  L1:
+    load_const true
+    store_var observed
+
+  L2:
+    load_var fs
+    load_const 0
+    load_array_element
+    await
+    pop 1
     load_var observed
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/future_types.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/future_types.snap
@@ -1,0 +1,446 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function future_types.$init_test_ns_future_types_future_types(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.future_types"
+    load_const "int_future_is_int_future"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "int_future_is_not_string_future"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "throwing_future_is_not_non_throwing_future"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "captured_local_future_is_int_future"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "generic_spawn_at_int_is_int_future"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "generic_spawn_at_string_is_not_int_future"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 5)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "inferred_generic_spawn_at_int_is_int_future"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 6)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "inferred_generic_spawn_at_string_is_not_int_future"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 7)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "match_picks_int_future_arm"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 8)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "match_picks_string_future_arm"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 9)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "jump_table_picks_string_future_arm"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 10)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.future_types"
+    load_const "jump_table_picks_int_future_arm"
+    make_closure .<lambda($init_test_ns_future_types_future_types, 11)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function future_types.captured_local_future_is_int_future_fn() -> bool {
+    load_var ?1
+    make_cell
+    store_var ?1
+    load_const 1
+    store_deref ?1
+    load_var v
+    make_closure .<lambda(captured_local_future_is_int_future_fn, 0)>, 1
+    load_const null
+    load_const null
+    load_type int
+    load_type null
+    spawn
+    store_var _4
+    load_var _4
+    store_var_load_var f
+    is_type future<int, null>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    store_var observed
+    jump L2
+
+  L1:
+    load_const true
+    store_var observed
+
+  L2:
+    load_var f
+    await
+    pop 1
+    load_var observed
+    return
+}
+
+function future_types.classify_future(f: future<int, null> | future<string, null>) -> string {
+    load_var f
+    store_var _2
+    load_var _2
+    narrow_bind future<int, null>, slot=2
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const "string"
+    jump L2
+
+  L1:
+    load_const "int"
+
+  L2:
+    return
+}
+
+function future_types.classify_int_future_fn() -> string {
+    make_closure .<lambda(classify_int_future_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type int
+    load_type null
+    spawn
+    store_var _3
+    load_var _3
+    store_var_load_var f
+    call user.future_types.classify_future
+    store_var observed
+    load_var f
+    await
+    pop 1
+    load_var observed
+    return
+}
+
+function future_types.classify_string_future_fn() -> string {
+    make_closure .<lambda(classify_string_future_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type string
+    load_type null
+    spawn
+    store_var _3
+    load_var _3
+    store_var_load_var f
+    call user.future_types.classify_future
+    store_var observed
+    load_var f
+    await
+    pop 1
+    load_var observed
+    return
+}
+
+function future_types.classify_tagged(v: future<int, null> | future<string, null> | int | string | bool) -> string {
+    load_var v
+    is_type future<int, null>
+    pop_jump_if_false L0
+    jump L7
+
+  L0:
+    load_var v
+    is_type future<string, null>
+    pop_jump_if_false L1
+    jump L6
+
+  L1:
+    load_var v
+    is_type int
+    pop_jump_if_false L2
+    jump L5
+
+  L2:
+    load_var v
+    is_type string
+    pop_jump_if_false L3
+    jump L4
+
+  L3:
+    load_const "bool"
+    jump L8
+
+  L4:
+    load_const "string"
+    jump L8
+
+  L5:
+    load_const "int"
+    jump L8
+
+  L6:
+    load_const "string-future"
+    jump L8
+
+  L7:
+    load_const "int-future"
+
+  L8:
+    return
+}
+
+function future_types.fail_io() -> int {
+    load_const "x"
+    init_instance baml.errors.Io .message
+    throw
+}
+
+function future_types.generic_spawn_at_int_fn() -> bool {
+    load_type int
+    load_const 1
+    call user.future_types.spawn_is_int_future
+    return
+}
+
+function future_types.generic_spawn_at_string_fn() -> bool {
+    load_type string
+    load_const "a"
+    call user.future_types.spawn_is_int_future
+    return
+}
+
+function future_types.inferred_generic_spawn_at_int_fn() -> bool {
+    load_type int
+    load_const 1
+    call user.future_types.spawn_is_int_future
+    return
+}
+
+function future_types.inferred_generic_spawn_at_string_fn() -> bool {
+    load_type string
+    load_const "a"
+    call user.future_types.spawn_is_int_future
+    return
+}
+
+function future_types.int_future_is_int_future_fn() -> bool {
+    make_closure .<lambda(int_future_is_int_future_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type int
+    load_type null
+    spawn
+    store_var _3
+    load_var _3
+    store_var_load_var f
+    is_type future<int, null>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    store_var observed
+    jump L2
+
+  L1:
+    load_const true
+    store_var observed
+
+  L2:
+    load_var f
+    await
+    pop 1
+    load_var observed
+    return
+}
+
+function future_types.int_future_is_string_future_fn() -> bool {
+    make_closure .<lambda(int_future_is_string_future_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type int
+    load_type null
+    spawn
+    store_var _3
+    load_var _3
+    store_var_load_var f
+    pop 1
+    load_const false
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    store_var observed
+    jump L2
+
+  L1:
+    load_const true
+    store_var observed
+
+  L2:
+    load_var f
+    await
+    pop 1
+    load_var observed
+    return
+}
+
+function future_types.spawn_is_int_future(v: T) -> bool {
+    load_var ?1
+    make_cell
+    store_var ?1
+    load_type #0
+    load_var v
+    make_closure .<lambda(spawn_is_int_future, 0)>, captures=1, ntypeargs=1
+    load_const null
+    load_const null
+    load_type #0
+    load_type null
+    spawn
+    store_var _4
+    load_var _4
+    store_var_load_var f
+    is_type future<int, null>
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    store_var observed
+    jump L2
+
+  L1:
+    load_const true
+    store_var observed
+
+  L2:
+    load_var f
+    await
+    pop 1
+    load_var observed
+    return
+}
+
+function future_types.tagged_int_future_fn() -> string {
+    make_closure .<lambda(tagged_int_future_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type int
+    load_type null
+    spawn
+    store_var _3
+    load_var _3
+    store_var_load_var f
+    call user.future_types.classify_tagged
+    store_var observed
+    load_var f
+    await
+    pop 1
+    load_var observed
+    return
+}
+
+function future_types.tagged_string_future_fn() -> string {
+    make_closure .<lambda(tagged_string_future_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type string
+    load_type null
+    spawn
+    store_var _3
+    load_var _3
+    store_var_load_var f
+    call user.future_types.classify_tagged
+    store_var observed
+    load_var f
+    await
+    pop 1
+    load_var observed
+    return
+}
+
+function future_types.throwing_future_is_non_throwing_future_fn() -> bool {
+    make_closure .<lambda(throwing_future_is_non_throwing_future_fn, 0)>, 0
+    load_const null
+    load_const null
+    load_type int
+    load_type baml.errors.Io
+    spawn
+    store_var _3
+    load_var _3
+    store_var_load_var f
+    pop 1
+    load_const false
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    store_var observed
+    jump L2
+
+  L1:
+    load_const true
+    store_var observed
+
+  L2:
+    load_var f
+    await
+    pop 1
+    jump L4
+    load_var e
+    is_type baml.errors.Io
+    pop_jump_if_false L3
+    jump L4
+
+  L3:
+    load_var e
+    rethrow
+
+  L4:
+    load_var observed
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/http_server.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/http_server.snap
@@ -143,6 +143,8 @@ function http_server.server_bound_method_handler() -> string {
     make_closure .<lambda(server_bound_method_handler, 0)>, 2
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _5
     load_const "POST"
@@ -179,6 +181,8 @@ function http_server.server_custom_config() -> int {
     make_closure .<lambda(server_custom_config, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "GET"
@@ -215,6 +219,8 @@ function http_server.server_isolates_handler_panic() -> bool {
     make_closure .<lambda(server_isolates_handler_panic, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "http://"
@@ -264,6 +270,8 @@ function http_server.server_rejects_oversized_body() -> int {
     make_closure .<lambda(server_rejects_oversized_body, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "POST"
@@ -300,6 +308,8 @@ function http_server.server_reserve_after_cancel() -> string {
     make_closure .<lambda(server_reserve_after_cancel, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "http://"
@@ -323,6 +333,8 @@ function http_server.server_reserve_after_cancel() -> string {
     make_closure .<lambda(server_reserve_after_cancel, 2)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _15
     load_const "http://"
@@ -357,6 +369,8 @@ function http_server.server_response_headers() -> string | null {
     make_closure .<lambda(server_response_headers, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "http://"
@@ -396,6 +410,8 @@ function http_server.server_roundtrip() -> string {
     make_closure .<lambda(server_roundtrip, 0)>, 2
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _5
     load_const "POST"
@@ -432,6 +448,8 @@ function http_server.server_status_code() -> int {
     make_closure .<lambda(server_status_code, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "http://"
@@ -462,6 +480,8 @@ function http_server.server_strips_framing_headers() -> string {
     make_closure .<lambda(server_strips_framing_headers, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "http://"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_basic.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_basic.snap
@@ -32,7 +32,7 @@ function spawn_basic.spawn_returning_int_literal() -> int {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -45,7 +45,7 @@ function spawn_basic.spawn_returning_string() -> string {
     load_const null
     load_const null
     load_type string
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -58,7 +58,7 @@ function spawn_basic.spawn_with_name_literal() -> int {
     load_const "answer"
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_basic.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_basic.snap
@@ -31,6 +31,8 @@ function spawn_basic.spawn_returning_int_literal() -> int {
     make_closure .<lambda(spawn_returning_int_literal, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _3
     load_var _3
@@ -42,6 +44,8 @@ function spawn_basic.spawn_returning_string() -> string {
     make_closure .<lambda(spawn_returning_string, 0)>, 0
     load_const null
     load_const null
+    load_type string
+    load_type null
     spawn
     store_var _3
     load_var _3
@@ -53,6 +57,8 @@ function spawn_basic.spawn_with_name_literal() -> int {
     make_closure .<lambda(spawn_with_name_literal, 0)>, 0
     load_const "answer"
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _3
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_name_object.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_name_object.snap
@@ -24,6 +24,8 @@ function spawn_name_object.spawn_name_then_map_literal_body_fn() -> int {
     make_closure .<lambda(spawn_name_then_map_literal_body_fn, 0)>, 0
     load_const "task"
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _5
     load_var _5
@@ -35,6 +37,8 @@ function spawn_name_object.spawn_name_then_struct_body_parses_correctly_fn() -> 
     make_closure .<lambda(spawn_name_then_struct_body_parses_correctly_fn, 0)>, 0
     load_const "task"
     load_const null
+    load_type spawn_name_object.B
+    load_type null
     spawn
     store_var _5
     load_var _5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_name_object.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_name_object.snap
@@ -25,7 +25,7 @@ function spawn_name_object.spawn_name_then_map_literal_body_fn() -> int {
     load_const "task"
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _5
     load_var _5
@@ -38,7 +38,7 @@ function spawn_name_object.spawn_name_then_struct_body_parses_correctly_fn() -> 
     load_const "task"
     load_const null
     load_type spawn_name_object.B
-    load_type null
+    load_type never
     spawn
     store_var _5
     load_var _5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_semantics.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_semantics.snap
@@ -48,7 +48,7 @@ function spawn_semantics.mid() -> int {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -63,7 +63,7 @@ function spawn_semantics.multiple_awaits_on_same_future_return_cached_value_fn()
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -83,12 +83,12 @@ function spawn_semantics.multiple_awaits_on_same_future_return_cached_value_fn()
     return
 }
 
-function spawn_semantics.spawn_child() -> future<int, null> {
+function spawn_semantics.spawn_child() -> future<int, never> {
     make_closure .<lambda(spawn_child, 0)>, 0
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _2
     load_var _2
@@ -100,7 +100,7 @@ function spawn_semantics.three_level_nested_spawn_sum_fn() -> int {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3
@@ -113,7 +113,7 @@ function spawn_semantics.top() -> int {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _3
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_semantics.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_semantics.snap
@@ -47,6 +47,8 @@ function spawn_semantics.mid() -> int {
     make_closure .<lambda(mid, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _3
     load_var _3
@@ -60,6 +62,8 @@ function spawn_semantics.multiple_awaits_on_same_future_return_cached_value_fn()
     make_closure .<lambda(multiple_awaits_on_same_future_return_cached_value_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _3
     load_var _3
@@ -83,6 +87,8 @@ function spawn_semantics.spawn_child() -> future<int, null> {
     make_closure .<lambda(spawn_child, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _2
     load_var _2
@@ -93,6 +99,8 @@ function spawn_semantics.three_level_nested_spawn_sum_fn() -> int {
     make_closure .<lambda(three_level_nested_spawn_sum_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _3
     load_var _3
@@ -104,6 +112,8 @@ function spawn_semantics.top() -> int {
     make_closure .<lambda(top, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     store_var _3
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
@@ -200,7 +200,7 @@ function spawn_throws.racing_successful_spawn_returns_cleanly_fn() -> int {
     load_const null
     load_const null
     load_type int
-    load_type null
+    load_type never
     spawn
     pop 1
     load_const 7

--- a/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/spawn_throws.snap
@@ -52,6 +52,8 @@ function spawn_throws.await_rethrows_caught_by_user_catch_fn() -> int {
     make_closure .<lambda(await_rethrows_caught_by_user_catch_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3
@@ -77,6 +79,8 @@ function spawn_throws.await_uncaught_spawns_io_fn() -> int {
     make_closure .<lambda(await_uncaught_spawns_io_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3
@@ -100,6 +104,8 @@ function spawn_throws.caught_after_sleep_not_double_surfaced_fn() -> int {
     make_closure .<lambda(caught_after_sleep_not_double_surfaced_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_const 30n
@@ -129,11 +135,15 @@ function spawn_throws.caught_not_preempted_by_unrelated_await_fn() -> int {
     make_closure .<lambda(caught_not_preempted_by_unrelated_await_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     make_closure .<lambda(caught_not_preempted_by_unrelated_await_fn, 1)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _6
     load_var _6
@@ -162,6 +172,8 @@ function spawn_throws.racing_caught_not_double_surfaced_fn() -> int {
     make_closure .<lambda(racing_caught_not_double_surfaced_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _3
     load_var _3
@@ -187,6 +199,8 @@ function spawn_throws.racing_successful_spawn_returns_cleanly_fn() -> int {
     make_closure .<lambda(racing_successful_spawn_returns_cleanly_fn, 0)>, 0
     load_const null
     load_const null
+    load_type int
+    load_type null
     spawn
     pop 1
     load_const 7

--- a/baml_language/crates/baml_tests/snapshots/baml_src/streaming_parsing.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/streaming_parsing.snap
@@ -397,6 +397,8 @@ function streaming_parsing.parse_stream_companion_class_in_namespace_fn() -> str
     make_closure .<lambda(parse_stream_companion_class_in_namespace_fn, 0)>, 2
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _6
     load_const "world"
@@ -454,6 +456,8 @@ function streaming_parsing.stream_done_signal_required_fn() -> bool {
     make_closure .<lambda(stream_done_signal_required_fn, 0)>, 2
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _5
     load_const "world"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/streaming_sse_primitives.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/streaming_sse_primitives.snap
@@ -106,6 +106,8 @@ function streaming_sse_primitives.sse_close_does_not_hang_fn() -> bool {
     make_closure .<lambda(sse_close_does_not_hang_fn, 0)>, 2
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _5
     load_const "GET"
@@ -149,6 +151,8 @@ function streaming_sse_primitives.sse_custom_headers_fn() -> bool {
     make_closure .<lambda(sse_custom_headers_fn, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_type string
@@ -212,6 +216,8 @@ function streaming_sse_primitives.sse_empty_stream_returns_null_fn() -> string {
     make_closure .<lambda(sse_empty_stream_returns_null_fn, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "GET"
@@ -265,6 +271,8 @@ function streaming_sse_primitives.sse_event_fields_in_json_fn() -> bool {
     make_closure .<lambda(sse_event_fields_in_json_fn, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "GET"
@@ -352,6 +360,8 @@ function streaming_sse_primitives.sse_event_id_null_when_not_set_fn() -> bool {
     make_closure .<lambda(sse_event_id_null_when_not_set_fn, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "GET"
@@ -429,6 +439,8 @@ function streaming_sse_primitives.sse_fetch_and_next_returns_events_fn() -> bool
     make_closure .<lambda(sse_fetch_and_next_returns_events_fn, 0)>, 2
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _5
     load_const "GET"
@@ -490,6 +502,8 @@ function streaming_sse_primitives.sse_fetch_error_on_bad_status_fn() -> bool {
     make_closure .<lambda(sse_fetch_error_on_bad_status_fn, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "GET"
@@ -549,6 +563,8 @@ function streaming_sse_primitives.sse_http_4xx_error_fn() -> bool {
     make_closure .<lambda(sse_http_4xx_error_fn, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "GET"
@@ -621,6 +637,8 @@ function streaming_sse_primitives.sse_large_event_payload_fn() -> bool {
     make_closure .<lambda(sse_large_event_payload_fn, 0)>, 2
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _8
     load_const "GET"
@@ -677,6 +695,8 @@ function streaming_sse_primitives.sse_next_after_close_returns_null_fn() -> stri
     make_closure .<lambda(sse_next_after_close_returns_null_fn, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "GET"
@@ -738,6 +758,8 @@ function streaming_sse_primitives.sse_next_returns_null_when_done_fn() -> bool {
     make_closure .<lambda(sse_next_returns_null_when_done_fn, 0)>, 2
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _5
     load_const "GET"
@@ -803,6 +825,8 @@ function streaming_sse_primitives.sse_post_with_body_fn() -> bool {
     make_closure .<lambda(sse_post_with_body_fn, 0)>, 1
     load_const null
     load_const null
+    load_type never
+    load_type baml.errors.Io
     spawn
     store_var _4
     load_const "POST"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/task_group.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/task_group.snap
@@ -220,7 +220,7 @@ function task_group.queues_excess_and_all_complete() -> int {
     make_closure .<lambda(queues_excess_and_all_complete, 0)>, 0
     store_var _3
     load_type int
-    load_type null
+    load_type never
     load_var g
     load_const <omitted>
     load_const <omitted>
@@ -239,13 +239,13 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_const null
     load_var _9
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _10
     make_closure .<lambda(queues_excess_and_all_complete, 1)>, 0
     store_var _12
     load_type int
-    load_type null
+    load_type never
     load_var g
     load_const <omitted>
     load_const <omitted>
@@ -264,13 +264,13 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_const null
     load_var _18
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _19
     make_closure .<lambda(queues_excess_and_all_complete, 2)>, 0
     store_var _21
     load_type int
-    load_type null
+    load_type never
     load_var g
     load_const <omitted>
     load_const <omitted>
@@ -289,13 +289,13 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_const null
     load_var _27
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _28
     make_closure .<lambda(queues_excess_and_all_complete, 3)>, 0
     store_var _30
     load_type int
-    load_type null
+    load_type never
     load_var g
     load_const <omitted>
     load_const <omitted>
@@ -314,13 +314,13 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_const null
     load_var _36
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _37
     make_closure .<lambda(queues_excess_and_all_complete, 4)>, 0
     store_var _39
     load_type int
-    load_type null
+    load_type never
     load_var g
     load_const <omitted>
     load_const <omitted>
@@ -339,7 +339,7 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_const null
     load_var _45
     load_type int
-    load_type null
+    load_type never
     spawn
     store_var _46
     load_var _10

--- a/baml_language/crates/baml_tests/snapshots/baml_src/task_group.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/task_group.snap
@@ -60,6 +60,8 @@ function task_group.caps_active_and_queues_rest() -> int {
     load_var _2
     load_const null
     load_var _8
+    load_type int
+    load_type baml.errors.Io
     spawn
     pop 1
     make_closure .<lambda(caps_active_and_queues_rest, 1)>, 0
@@ -83,6 +85,8 @@ function task_group.caps_active_and_queues_rest() -> int {
     load_var _10
     load_const null
     load_var _16
+    load_type int
+    load_type baml.errors.Io
     spawn
     pop 1
     make_closure .<lambda(caps_active_and_queues_rest, 2)>, 0
@@ -106,6 +110,8 @@ function task_group.caps_active_and_queues_rest() -> int {
     load_var _18
     load_const null
     load_var _24
+    load_type int
+    load_type baml.errors.Io
     spawn
     pop 1
     make_closure .<lambda(caps_active_and_queues_rest, 3)>, 0
@@ -129,6 +135,8 @@ function task_group.caps_active_and_queues_rest() -> int {
     load_var _26
     load_const null
     load_var _32
+    load_type int
+    load_type baml.errors.Io
     spawn
     pop 1
     load_var g
@@ -176,6 +184,8 @@ function task_group.group_cancel_cancels_member() -> int {
     load_var _3
     load_const null
     load_var _9
+    load_type int
+    load_type baml.errors.Io
     spawn
     store_var _10
     load_var g
@@ -228,6 +238,8 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_var _3
     load_const null
     load_var _9
+    load_type int
+    load_type null
     spawn
     store_var _10
     make_closure .<lambda(queues_excess_and_all_complete, 1)>, 0
@@ -251,6 +263,8 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_var _12
     load_const null
     load_var _18
+    load_type int
+    load_type null
     spawn
     store_var _19
     make_closure .<lambda(queues_excess_and_all_complete, 2)>, 0
@@ -274,6 +288,8 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_var _21
     load_const null
     load_var _27
+    load_type int
+    load_type null
     spawn
     store_var _28
     make_closure .<lambda(queues_excess_and_all_complete, 3)>, 0
@@ -297,6 +313,8 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_var _30
     load_const null
     load_var _36
+    load_type int
+    load_type null
     spawn
     store_var _37
     make_closure .<lambda(queues_excess_and_all_complete, 4)>, 0
@@ -320,6 +338,8 @@ function task_group.queues_excess_and_all_complete() -> int {
     load_var _39
     load_const null
     load_var _45
+    load_type int
+    load_type null
     spawn
     store_var _46
     load_var _10

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -2876,11 +2876,11 @@ fn baml.future.all_complete(futures: future<T, E>[]) -> future<T[], E> {
     let _0: future<T[], E> // _0 // return
     let _1: future<T, E>[] // futures // param [captured]
     let _2: null
-    let _3: null
+    let _3: future<T[], E>
 
     bb0: {
         _2 = make_closure lambda[0]<2 type_args>(copy _1);
-        _3 = spawn copy _2 name=const null -> bb1;
+        _3 = spawn<#0[], #1> copy _2 name=const null -> bb1;
     }
 
     bb1: {
@@ -2935,11 +2935,11 @@ fn baml.future.all(futures: future<T, E>[]) -> future<T[], E> {
     let _0: future<T[], E> // _0 // return
     let _1: future<T, E>[] // futures // param [captured]
     let _2: null
-    let _3: null
+    let _3: future<T[], E>
 
     bb0: {
         _2 = make_closure lambda[0]<2 type_args>(copy _1);
-        _3 = spawn copy _2 name=const null -> bb1;
+        _3 = spawn<#0[], #1> copy _2 name=const null -> bb1;
     }
 
     bb1: {
@@ -3094,11 +3094,11 @@ fn baml.future.race(futures: future<T, E>[]) -> future<T, E> {
     let _0: future<T, E> // _0 // return
     let _1: future<T, E>[] // futures // param [captured]
     let _2: null
-    let _3: null
+    let _3: future<T, E>
 
     bb0: {
         _2 = make_closure lambda[0]<2 type_args>(copy _1);
-        _3 = spawn copy _2 name=const null -> bb1;
+        _3 = spawn<#0, #1> copy _2 name=const null -> bb1;
     }
 
     bb1: {
@@ -3171,11 +3171,11 @@ fn baml.future.any(futures: future<T, Err>[]) -> future<T, baml.future.AllFailed
     let _0: future<T, baml.future.AllFailed<Err>> // _0 // return
     let _1: future<T, Err>[] // futures // param [captured]
     let _2: null
-    let _3: null
+    let _3: future<T, baml.future.AllFailed<Err>>
 
     bb0: {
         _2 = make_closure lambda[0]<2 type_args>(copy _1);
-        _3 = spawn copy _2 name=const null -> bb1;
+        _3 = spawn<#0, baml.future.AllFailed<#1>> copy _2 name=const null -> bb1;
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -2315,6 +2315,8 @@ function baml.future.all(futures: future<T, E>[]) -> future<T[], E> {
     make_closure .<lambda(all, 0)>, captures=1, ntypeargs=2
     load_const null
     load_const null
+    load_type #0[]
+    load_type #1
     spawn
     store_var _3
     load_var _3
@@ -2331,6 +2333,8 @@ function baml.future.all_complete(futures: future<T, E>[]) -> future<T[], E> {
     make_closure .<lambda(all_complete, 0)>, captures=1, ntypeargs=2
     load_const null
     load_const null
+    load_type #0[]
+    load_type #1
     spawn
     store_var _3
     load_var _3
@@ -2347,6 +2351,8 @@ function baml.future.any(futures: future<T, Err>[]) -> future<T, baml.future.All
     make_closure .<lambda(any, 0)>, captures=1, ntypeargs=2
     load_const null
     load_const null
+    load_type #0
+    load_type baml.future.AllFailed<#1>
     spawn
     store_var _3
     load_var _3
@@ -2363,6 +2369,8 @@ function baml.future.race(futures: future<T, E>[]) -> future<T, E> {
     make_closure .<lambda(race, 0)>, captures=1, ntypeargs=2
     load_const null
     load_const null
+    load_type #0
+    load_type #1
     spawn
     store_var _3
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____03_ppir.snap
@@ -194,7 +194,7 @@ function testing.run_all(self: ?) -> TestSetReport  [expr] {
   {  } root.run_testset(root.testset_children(self), null)
 }
 function testing.run_children_parallel(children: TestSetChild[]) -> TestSetReport  [expr] {
-  { let futures: baml.future.Future<NamedChildReport, null>[] = []; for child in children {  } futures.push(spawn { () -> { {  } NamedChildReport { name: child.name, report: child.run() } } }); let named_results = await baml.future.all_complete(futures) catch_all (e) { _ => baml.sys.panic("unexpected test c...") } } root.aggregate_reports(named_results)
+  { let futures: baml.future.Future<NamedChildReport, never>[] = []; for child in children {  } futures.push(spawn { () -> { {  } NamedChildReport { name: child.name, report: child.run() } } }); let named_results = await baml.future.all_complete(futures) } root.aggregate_reports(named_results)
 }
 function testing.run_filtered(self: ?, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> FlatTestReport  [expr] {
   { let selected_names = root.select_names_layered(self, profile_include, profile_exclude, cli_include, cli_exclude); let report = if (profile_include.length() Eq 0 And profile_exclude.length() Eq 0 And cli_include.length() Eq 0 And cli_exclude.length() Eq 0) {  } self.run_all() else {  } self.run_selected(selected_names) } root.flatten_with_tolerated(report, selected_names)

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
@@ -1991,26 +1991,25 @@ fn testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.Te
     // Locals:
     let _0: testing.TestSetReport // _0 // return
     let _1: testing.TestSetChild[] // children // param
-    let _2: future<testing.NamedChildReport, null>[] // futures
+    let _2: future<testing.NamedChildReport, never>[] // futures
     let _3: baml.iter.Iterator<Error = never, Item = testing.TestSetChild>
     let _4: unknown
     let _5: bool
     let _6: testing.TestSetChild
     let _7: testing.TestSetChild // child [captured]
     let _8: void
-    let _9: future<testing.NamedChildReport, null>
+    let _9: future<testing.NamedChildReport, never>
     let _10: null
-    let _11: future<testing.NamedChildReport, null>
+    let _11: future<testing.NamedChildReport, never>
     let _12: testing.NamedChildReport[] // named_results
-    let _13: unknown // e
-    let _14: null
-    let _15: future<testing.NamedChildReport, null>[]
+    let _13: null
+    let _14: future<testing.NamedChildReport, never>[]
+    let _15: type
     let _16: type
-    let _17: type
-    let _18: testing.NamedChildReport[]
+    let _17: testing.NamedChildReport[]
 
     bb0: {
-        _2 = []: future<testing.NamedChildReport, null>[];
+        _2 = []: future<testing.NamedChildReport, never>[];
         _3 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetChild, Error = never>(copy _1) -> [bb1];
     }
 
@@ -2028,7 +2027,7 @@ fn testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.Te
         fresh_cell(_7);
         _7 = copy _6;
         _10 = make_closure lambda[0](copy _7);
-        _11 = spawn<testing.NamedChildReport, null> copy _10 name=const null -> bb4;
+        _11 = spawn<testing.NamedChildReport, never> copy _10 name=const null -> bb4;
     }
 
     bb4: {
@@ -2037,30 +2036,22 @@ fn testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.Te
     }
 
     bb5: {
-        _15 = copy _2;
-        _16 = load_type(testing.NamedChildReport);
-        _17 = load_type(null);
-        _14 = call const fn baml.future.all_complete<copy _16, copy _17>(copy _15) -> [bb6, unwind: bb7];
+        _14 = copy _2;
+        _15 = load_type(testing.NamedChildReport);
+        _16 = load_type(never);
+        _13 = call const fn baml.future.all_complete<copy _15, copy _16>(copy _14) -> [bb6];
     }
 
     bb6: {
-        _12 = await _14 -> [bb9, unwind: bb7];
+        _12 = await _13 -> [bb7];
     }
 
     bb7: {
-        throw_if_panic copy _13 -> bb8;
+        _17 = copy _12;
+        _0 = call const fn testing.aggregate_reports(copy _17) -> [bb8];
     }
 
     bb8: {
-        _12 = call const fn baml.sys.panic(const "unexpected test child failure") -> [bb9];
-    }
-
-    bb9: {
-        _18 = copy _12;
-        _0 = call const fn testing.aggregate_reports(copy _18) -> [bb10];
-    }
-
-    bb10: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
@@ -2000,7 +2000,7 @@ fn testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.Te
     let _8: void
     let _9: future<testing.NamedChildReport, null>
     let _10: null
-    let _11: null
+    let _11: future<testing.NamedChildReport, null>
     let _12: testing.NamedChildReport[] // named_results
     let _13: unknown // e
     let _14: null
@@ -2028,7 +2028,7 @@ fn testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.Te
         fresh_cell(_7);
         _7 = copy _6;
         _10 = make_closure lambda[0](copy _7);
-        _11 = spawn copy _10 name=const null -> bb4;
+        _11 = spawn<testing.NamedChildReport, null> copy _10 name=const null -> bb4;
     }
 
     bb4: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_tir.snap
@@ -477,16 +477,12 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 }
 function testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.TestSetReport throws never {
   { : testing.TestSetReport
-    let futures: baml.future.Future<NamedChildReport, null>[] = [] : Future<testing.NamedChildReport, null>[]
+    let futures: baml.future.Future<NamedChildReport, never>[] = [] : Future<testing.NamedChildReport, never>[]
     for child in children
       { : int
         futures.push(spawn { () -> { ... } }) : int
       }
-    let named_results = : testing.NamedChildReport[]
-      catch (await baml.future.all_complete(futures) : testing.NamedChildReport[]) : testing.NamedChildReport[]
-        catch_all (e)
-          _ =>
-            baml.sys.panic("unexpected test c...") : never
+    let named_results = await baml.future.all_complete(futures) : testing.NamedChildReport[]
     root.aggregate_reports(named_results) : testing.TestSetReport
   }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
@@ -2755,7 +2755,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
     load_var ?5
     make_cell
     store_var ?5
-    load_type future<testing.NamedChildReport, null>
+    load_type future<testing.NamedChildReport, never>
     alloc_array 0
     store_var futures
     load_var children
@@ -2786,7 +2786,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
     load_const null
     load_const null
     load_type testing.NamedChildReport
-    load_type null
+    load_type never
     spawn
     store_var _11
     load_var2 2 6
@@ -2796,17 +2796,10 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
 
   L2:
     load_type testing.NamedChildReport
-    load_type null
+    load_type never
     load_var futures
     call baml.future.all_complete
     await
-    jump L3
-    load_var e
-    throw_if_panic
-    load_const "unexpected test child failure"
-    call baml.sys.panic
-
-  L3:
     call testing.aggregate_reports
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
@@ -2785,6 +2785,8 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
     make_closure .<lambda(run_children_parallel, 0)>, 1
     load_const null
     load_const null
+    load_type testing.NamedChildReport
+    load_type null
     spawn
     store_var _11
     load_var2 2 6

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
@@ -991,7 +991,7 @@ fn spawn_with_non_callable_reports_concrete_mismatch() {
     let output = render_tir(&db, file);
     assert!(
         output.contains(
-            "expected (baml.spawn.SpawnParams<int, null>) -> baml.spawn.SpawnParams<unknown, unknown> throws unknown, got 42"
+            "expected (baml.spawn.SpawnParams<int, never>) -> baml.spawn.SpawnParams<unknown, unknown> throws unknown, got 42"
         ),
         "non-callable `with` must report the concrete transformer shape, got:\n{output}"
     );
@@ -1023,7 +1023,7 @@ function f() -> int { let x = spawn with h() { 1 }; await x }"#,
     );
     let output = render_tir(&db, file);
     assert!(
-        output.contains("this link receives `baml.spawn.SpawnParams<int, null>`")
+        output.contains("this link receives `baml.spawn.SpawnParams<int, never>`")
             && output.contains("must return a `baml.spawn.SpawnParams`"),
         "wrong-return transformer must report the link's concrete input, got:\n{output}"
     );
@@ -1034,13 +1034,13 @@ fn spawn_with_chain_input_mismatch_is_concrete() {
     let mut db = make_db();
     let file = db.add_file(
         "test.baml",
-        r#"function fix() -> (baml.spawn.SpawnParams<string, null>) -> baml.spawn.SpawnParams<string, null> throws never { (p) -> { p } }
+        r#"function fix() -> (baml.spawn.SpawnParams<string, never>) -> baml.spawn.SpawnParams<string, never> throws never { (p) -> { p } }
 function f() -> int { let x = spawn with fix() { 1 }; await x }"#,
     );
     let output = render_tir(&db, file);
     assert!(
-        output.contains("got (baml.spawn.SpawnParams<string, null>)")
-            && output.contains("expected (baml.spawn.SpawnParams<int, null>)"),
+        output.contains("got (baml.spawn.SpawnParams<string, never>)")
+            && output.contains("expected (baml.spawn.SpawnParams<int, never>)"),
         "chain input mismatch must show both concrete SpawnParams types, got:\n{output}"
     );
 }
@@ -1077,7 +1077,7 @@ function f() -> int {
     );
     let output = render_tir(&db, file);
     assert!(
-        output.contains("this link receives `baml.spawn.SpawnParams<int, null>`"),
+        output.contains("this link receives `baml.spawn.SpawnParams<int, never>`"),
         "wrong-param variable transformer must report the link input, got:\n{output}"
     );
 }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -177,7 +177,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  102   0   make_closure 1503 0   
+  102   0   make_closure 1502 0   
         1   return                
 }
 
@@ -202,7 +202,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1498 1    
+       17   make_closure 1497 1    
        18   return                 
 }
 
@@ -241,7 +241,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1482 2    
+       29   make_closure 1481 2    
        30   return                 
 }
 
@@ -260,12 +260,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1492 1    
+       11   make_closure 1491 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  96   0   make_closure 1501 0   
+  96   0   make_closure 1500 0   
        1   return                
 }
 
@@ -2704,20 +2704,14 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         35   pop 1                              
         36   jump -25                           (to 11)
 
-  403   37   load_type 7                        
+  405   37   load_type 7                        
         38   load_type 8                        
         39   load_var 2                         (futures)
         40   call 522 ntypeargs=2               (baml.future.all_complete)
         41   await                              
-        42   jump +5                            (to 47)
-        43   load_var 7                         (e)
-        44   throw_if_panic                     
 
-  404   45   load_const 9                       ("unexpected test child failure")
-        46   call 247 ntypeargs=0               (baml.sys.panic)
-
-  406   47   call 762 ntypeargs=0               (testing.aggregate_reports)
-        48   return                             
+  406   42   call 762 ntypeargs=0               (testing.aggregate_reports)
+        43   return                             
 }
 
 function testing.run_children_sequential(children: testing.TestSetChild[], fail_fast: bool) -> testing.TestSetReport {
@@ -2791,7 +2785,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   411   3    load_var 1             (body)
-        4    make_closure 1394 1    
+        4    make_closure 1393 1    
         5    store_var 3            (base_run)
 
   435   6    load_var 2             (runner)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -2684,7 +2684,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         16   load_var 4                         (_4)
         17   is_type 5                          
         18   pop_jump_if_false +2               (to 20)
-        19   jump +16                           (to 35)
+        19   jump +18                           (to 37)
         20   load_const 6                       (null)
         21   make_cell                          
         22   store_var 5                        (child)
@@ -2695,27 +2695,29 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         26   make_closure 1384 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
-        29   spawn                              
-        30   store_var 6                        (_11)
-        31   load_var2 2 6                      
-        32   call 4 ntypeargs=0                 (baml.Array.push)
-        33   pop 1                              
-        34   jump -23                           (to 11)
+        29   load_type 7                        
+        30   load_type 8                        
+        31   spawn                              
+        32   store_var 6                        (_11)
+        33   load_var2 2 6                      
+        34   call 4 ntypeargs=0                 (baml.Array.push)
+        35   pop 1                              
+        36   jump -25                           (to 11)
 
-  403   35   load_type 7                        
-        36   load_type 8                        
-        37   load_var 2                         (futures)
-        38   call 522 ntypeargs=2               (baml.future.all_complete)
-        39   await                              
-        40   jump +5                            (to 45)
-        41   load_var 7                         (e)
-        42   throw_if_panic                     
+  403   37   load_type 7                        
+        38   load_type 8                        
+        39   load_var 2                         (futures)
+        40   call 522 ntypeargs=2               (baml.future.all_complete)
+        41   await                              
+        42   jump +5                            (to 47)
+        43   load_var 7                         (e)
+        44   throw_if_panic                     
 
-  404   43   load_const 9                       ("unexpected test child failure")
-        44   call 247 ntypeargs=0               (baml.sys.panic)
+  404   45   load_const 9                       ("unexpected test child failure")
+        46   call 247 ntypeargs=0               (baml.sys.panic)
 
-  406   45   call 762 ntypeargs=0               (testing.aggregate_reports)
-        46   return                             
+  406   47   call 762 ntypeargs=0               (testing.aggregate_reports)
+        48   return                             
 }
 
 function testing.run_children_sequential(children: testing.TestSetChild[], fail_fast: bool) -> testing.TestSetReport {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -2765,7 +2765,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         16   load_var 4                         (_4)
         17   is_type 5                          
         18   pop_jump_if_false +2               (to 20)
-        19   jump +16                           (to 35)
+        19   jump +18                           (to 37)
         20   load_const 6                       (null)
         21   make_cell                          
         22   store_var 5                        (child)
@@ -2776,27 +2776,29 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         26   make_closure 1384 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
-        29   spawn                              
-        30   store_var 6                        (_11)
-        31   load_var2 2 6                      
-        32   call 4 ntypeargs=0                 (baml.Array.push)
-        33   pop 1                              
-        34   jump -23                           (to 11)
+        29   load_type 7                        
+        30   load_type 8                        
+        31   spawn                              
+        32   store_var 6                        (_11)
+        33   load_var2 2 6                      
+        34   call 4 ntypeargs=0                 (baml.Array.push)
+        35   pop 1                              
+        36   jump -25                           (to 11)
 
-  403   35   load_type 7                        
-        36   load_type 8                        
-        37   load_var 2                         (futures)
-        38   call 522 ntypeargs=2               (baml.future.all_complete)
-        39   await                              
-        40   jump +5                            (to 45)
-        41   load_var 7                         (e)
-        42   throw_if_panic                     
+  403   37   load_type 7                        
+        38   load_type 8                        
+        39   load_var 2                         (futures)
+        40   call 522 ntypeargs=2               (baml.future.all_complete)
+        41   await                              
+        42   jump +5                            (to 47)
+        43   load_var 7                         (e)
+        44   throw_if_panic                     
 
-  404   43   load_const 9                       ("unexpected test child failure")
-        44   call 247 ntypeargs=0               (baml.sys.panic)
+  404   45   load_const 9                       ("unexpected test child failure")
+        46   call 247 ntypeargs=0               (baml.sys.panic)
 
-  406   45   call 762 ntypeargs=0               (testing.aggregate_reports)
-        46   return                             
+  406   47   call 762 ntypeargs=0               (testing.aggregate_reports)
+        48   return                             
 }
 
 function testing.run_children_sequential(children: testing.TestSetChild[], fail_fast: bool) -> testing.TestSetReport {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -177,7 +177,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  102   0   make_closure 1502 0   
+  102   0   make_closure 1501 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -204,7 +204,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1497 1    
+       17   make_closure 1496 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -245,7 +245,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1481 2    
+       29   make_closure 1480 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -266,14 +266,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1491 1    
+       11   make_closure 1490 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  96   0   make_closure 1500 0   
+  96   0   make_closure 1499 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -2785,20 +2785,14 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         35   pop 1                              
         36   jump -25                           (to 11)
 
-  403   37   load_type 7                        
+  405   37   load_type 7                        
         38   load_type 8                        
         39   load_var 2                         (futures)
         40   call 522 ntypeargs=2               (baml.future.all_complete)
         41   await                              
-        42   jump +5                            (to 47)
-        43   load_var 7                         (e)
-        44   throw_if_panic                     
 
-  404   45   load_const 9                       ("unexpected test child failure")
-        46   call 247 ntypeargs=0               (baml.sys.panic)
-
-  406   47   call 762 ntypeargs=0               (testing.aggregate_reports)
-        48   return                             
+  406   42   call 762 ntypeargs=0               (testing.aggregate_reports)
+        43   return                             
 }
 
 function testing.run_children_sequential(children: testing.TestSetChild[], fail_fast: bool) -> testing.TestSetReport {
@@ -2879,7 +2873,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   411   3    load_var 1             (body)
-        4    make_closure 1394 1    
+        4    make_closure 1393 1    
         5    store_var 3            (base_run)
 
   435   6    load_var 2             (runner)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -2942,7 +2942,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
     load_var ?5
     make_cell
     store_var ?5
-    load_type future<testing.NamedChildReport, null>
+    load_type future<testing.NamedChildReport, never>
     alloc_array 0
     store_var futures
     load_var children
@@ -2973,7 +2973,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
     load_const null
     load_const null
     load_type testing.NamedChildReport
-    load_type null
+    load_type never
     spawn
     store_var _11
     load_var2 2 6
@@ -2983,17 +2983,10 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
 
   L2:
     load_type testing.NamedChildReport
-    load_type null
+    load_type never
     load_var futures
     call baml.future.all_complete
     await
-    jump L3
-    load_var e
-    throw_if_panic
-    load_const "unexpected test child failure"
-    call baml.sys.panic
-
-  L3:
     call testing.aggregate_reports
     return
 }

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -2972,6 +2972,8 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
     make_closure .<lambda(run_children_parallel, 0)>, 1
     load_const null
     load_const null
+    load_type testing.NamedChildReport
+    load_type null
     spawn
     store_var _11
     load_var2 2 6

--- a/baml_language/crates/baml_tests/tests/spawn_specialization.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_specialization.rs
@@ -68,7 +68,7 @@ async fn captured_int_arithmetic_uses_generic_binop() {
         load_const null
         load_const null
         load_type int
-        load_type null
+        load_type never
         spawn
         store_var _4
         load_var _4
@@ -115,7 +115,7 @@ async fn spawned_closure_capture_marks_transitive_cells() {
         load_const null
         load_const null
         load_type int
-        load_type null
+        load_type never
         spawn
         store_var _5
         load_var _5
@@ -157,7 +157,7 @@ async fn captured_float_array_element_arithmetic_uses_generic_binop() {
         load_const null
         load_const null
         load_type int
-        load_type null
+        load_type never
         spawn
         store_var _4
         load_var _4

--- a/baml_language/crates/baml_tests/tests/spawn_specialization.rs
+++ b/baml_language/crates/baml_tests/tests/spawn_specialization.rs
@@ -67,6 +67,8 @@ async fn captured_int_arithmetic_uses_generic_binop() {
         make_closure .<lambda(main, 0)>, 1
         load_const null
         load_const null
+        load_type int
+        load_type null
         spawn
         store_var _4
         load_var _4
@@ -112,6 +114,8 @@ async fn spawned_closure_capture_marks_transitive_cells() {
         make_closure .<lambda(main, 1)>, 1
         load_const null
         load_const null
+        load_type int
+        load_type null
         spawn
         store_var _5
         load_var _5
@@ -152,6 +156,8 @@ async fn captured_float_array_element_arithmetic_uses_generic_binop() {
         make_closure .<lambda(main, 0)>, 1
         load_const null
         load_const null
+        load_type int
+        load_type null
         spawn
         store_var _4
         load_var _4

--- a/baml_language/crates/baml_type/src/family.rs
+++ b/baml_language/crates/baml_type/src/family.rs
@@ -189,8 +189,8 @@ ty_family! {
         /// before `await`.
         ///
         /// Carries both the value type the future resolves to and the error
-        /// type the future may throw. The error type approximates `never` as
-        /// `Null` when the body of the future statically cannot throw.
+        /// type the future may throw. A future whose body statically cannot
+        /// throw has error type `never`.
         #[axis(concrete)]
         Future(Box<Ty>, Box<Ty>, TyAttr) = 17,
         /// Opaque Rust-managed state (`$rust_type` fields in builtin class stubs,

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -152,11 +152,12 @@ impl Ty {
     /// (it has no values).
     ///
     /// Rejected:
-    ///   - `Future` — the runtime impl registry's `TyTemplate` has no constructor for
-    ///     it, so its `value`/`error` args can't carry a `TypeArgRef`: a generic
-    ///     `Future<T>` for-type would bake a `Concrete` rule carrying an unbindable bare
-    ///     `T` that never matches a real `Future<int>`. Rejected outright rather than
-    ///     silently mis-dispatching; revisit if a `TyTemplate::Future` is ever added.
+    ///   - `Future` — TODO: not implemented yet, not a limitation. The old blocker
+    ///     (no `TyTemplate` constructor, so a generic `Future<T>` for-type could not
+    ///     carry a `TypeArgRef`) is gone: `TyTemplate::Future` exists, and a heap
+    ///     future now records the `Future<T, E>` its spawn site was typed at, so a
+    ///     future value's concrete type reconstructs faithfully for `is`/`match`.
+    ///     Opening `implement I for Future<…>` is just work nobody has done.
     ///   - `Literal` / `EnumVariant` — singleton subtypes whose values dispatch
     ///     through their base (`int`, `Color`), so they have no implementor of
     ///     their own;
@@ -229,8 +230,9 @@ impl Ty {
     ///   - the recovery sentinels `Unknown` / `Error` / `Infer`.
     ///
     /// Distinct from [`Self::is_valid_impl_subject`]: that asks whether a type may be a
-    /// *written impl's* for-type (rejecting `Function`/`Future`/`RustType`, which are
-    /// concrete yet undispatchable as impl targets, and admitting `Never`/`TypeVar`/a
+    /// *written impl's* for-type (rejecting `Function`/`Future`/`RustType` — see there
+    /// for why each is closed, `Future` only for want of the work — and admitting
+    /// `Never`/`TypeVar`/a
     /// projection). This asks the broader "is it a run-time concrete type" the taxonomy
     /// defines — used to gate an interface-bounded type-parameter argument (an
     /// interface bound admits only a single run-time type, so dispatch is well-defined).
@@ -1126,8 +1128,9 @@ mod tests {
             Ty::EnumVariant(qtn("Color"), Name::new("Red"), TyAttr::default()),
             Ty::Interface(qtn("I"), vec![], vec![], TyAttr::default()),
             Ty::union([ty_int(), ty_string()]),
-            // `Future` has type args `TyTemplate` can't carry — rejected so a generic
-            // `Future<T>` for-type errors rather than baking an undispatchable rule.
+            // `Future` is dispatchable at runtime (a heap future carries its `<T, E>`);
+            // written impls on it are simply not implemented yet — see
+            // `is_valid_impl_subject`.
             Ty::Future(boxed(ty_int()), boxed(Ty::null()), TyAttr::default()),
             Ty::Function {
                 params: vec![],
@@ -1166,8 +1169,9 @@ mod tests {
 
         // Concrete: a single run-time representation dispatch can key on. Note the
         // differences from `is_valid_impl_subject` — `Function`/`Future`/`RustType`
-        // are concrete types even though they are not written-impl targets, and
-        // the `Evolving*` inference forms are lists/maps.
+        // are concrete types even though they are not written-impl targets (for
+        // `Future`, only because that is unimplemented), and the `Evolving*`
+        // inference forms are lists/maps.
         let concrete = [
             ty_int(),
             Ty::Bigint {

--- a/baml_language/crates/baml_type/src/realized_ty.rs
+++ b/baml_language/crates/baml_type/src/realized_ty.rs
@@ -40,6 +40,14 @@ impl RealizedTy {
         }
     }
 
+    /// `never` (the bottom type) with default attributes. The error type of a
+    /// future whose body statically cannot throw.
+    pub fn never() -> Self {
+        RealizedTy::Never {
+            attr: TyAttr::default(),
+        }
+    }
+
     // --- Compound constructors (default TyAttr) ---
 
     /// `T[]` (list) with default attributes.

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -583,7 +583,7 @@ mod tests {
         pm.new_permit(()).await.acquire().await
     }
 
-    /// Register a future typed as `Future<int, null>` — the shape a
+    /// Register a future typed as `Future<int, never>` — the shape a
     /// non-throwing `spawn { 1 }` produces. These tests exercise registry
     /// bookkeeping, so the types are inert here; a concrete pair is used
     /// anyway so nothing reads as "type unknown by design".
@@ -591,7 +591,7 @@ mod tests {
         guard: &mut FutureManagerGuard<'_>,
         cancel: CancellationToken,
     ) -> (FutureId, HeapPtr) {
-        guard.new_future(RealizedTy::int(), RealizedTy::null(), cancel)
+        guard.new_future(RealizedTy::int(), RealizedTy::never(), cancel)
     }
 
     #[tokio::test]

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -40,6 +40,7 @@
 //! re-executes `Await`, reads the terminal state directly from the heap,
 //! and proceeds.
 
+use ::baml_type::RealizedTy;
 use ::bex_heap::{
     HeapPermit, HeapPermitManager, InactiveHeapPermit, PermitProof, Tlab, TlabHolder,
 };
@@ -133,7 +134,16 @@ impl FutureManagerGuard<'_> {
 
     /// Registers a future with the future manager and returns a unique ID.
     ///
-    pub fn new_future(&mut self, cancel: CancellationToken) -> (FutureId, HeapPtr) {
+    /// `returns` / `throws` are the `Future<T, E>` type arguments the spawn
+    /// site was typed at, already resolved against the spawning frame. They are
+    /// stored on the heap `Future` so reflection and `is`/`match` can see the
+    /// future's generic parameters rather than only "some future".
+    pub fn new_future(
+        &mut self,
+        returns: RealizedTy,
+        throws: RealizedTy,
+        cancel: CancellationToken,
+    ) -> (FutureId, HeapPtr) {
         // The contract on `FutureId::from_usize` is "no two live ids share a
         // usize". We satisfy this by drawing the value from the manager's
         // monotonic `AtomicUsize`; uniqueness is preserved as long as the
@@ -146,7 +156,7 @@ impl FutureManagerGuard<'_> {
 
         let ptr = inner
             .tlab
-            .alloc_future(::bex_vm_types::Future::pending(id, cancel));
+            .alloc_future(::bex_vm_types::Future::pending(id, returns, throws, cancel));
 
         inner.active_futures.insert(id, FutureState { future: ptr });
         (id, ptr)
@@ -573,12 +583,23 @@ mod tests {
         pm.new_permit(()).await.acquire().await
     }
 
+    /// Register a future typed as `Future<int, null>` — the shape a
+    /// non-throwing `spawn { 1 }` produces. These tests exercise registry
+    /// bookkeeping, so the types are inert here; a concrete pair is used
+    /// anyway so nothing reads as "type unknown by design".
+    fn new_int_future(
+        guard: &mut FutureManagerGuard<'_>,
+        cancel: CancellationToken,
+    ) -> (FutureId, HeapPtr) {
+        guard.new_future(RealizedTy::int(), RealizedTy::null(), cancel)
+    }
+
     #[tokio::test]
     async fn fulfill_removes_entry() {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _ptr) = guard.new_future(CancellationToken::new());
+        let (id, _ptr) = new_int_future(&mut guard, CancellationToken::new());
         assert_eq!(guard.active_future_count(), 1);
         guard.fulfill_future(id, Value::int(42)).unwrap();
         assert_eq!(guard.active_future_count(), 0);
@@ -589,8 +610,8 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        guard.new_future(CancellationToken::new());
-        guard.new_future(CancellationToken::new());
+        new_int_future(&mut guard, CancellationToken::new());
+        new_int_future(&mut guard, CancellationToken::new());
         assert_eq!(guard.pending_join_handles().len(), 2);
     }
 
@@ -600,7 +621,7 @@ mod tests {
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
         let token = CancellationToken::new();
-        let (id, _ptr) = guard.new_future(token.clone());
+        let (id, _ptr) = new_int_future(&mut guard, token.clone());
         assert!(!token.is_cancelled());
         guard.cancel_future(id).unwrap();
         assert_eq!(guard.active_future_count(), 0);
@@ -616,8 +637,8 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id_a, _) = guard.new_future(CancellationToken::new());
-        let (id_b, _) = guard.new_future(CancellationToken::new());
+        let (id_a, _) = new_int_future(&mut guard, CancellationToken::new());
+        let (id_b, _) = new_int_future(&mut guard, CancellationToken::new());
         assert_eq!(guard.active_future_count(), 2);
         guard.err_future(id_a, Value::int(7), Vec::new()).unwrap();
         guard
@@ -642,7 +663,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = new_int_future(&mut guard, CancellationToken::new());
         let original = EngineError::TypeMismatch {
             message: "synthetic op error".into(),
         };
@@ -676,7 +697,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = new_int_future(&mut guard, CancellationToken::new());
         let original = EngineError::TypeMismatch {
             message: "stale".into(),
         };
@@ -718,7 +739,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = new_int_future(&mut guard, CancellationToken::new());
         guard.fulfill_future(id, Value::int(1)).unwrap();
         let again = guard.fulfill_future(id, Value::int(2));
         assert!(again.is_ok(), "second fulfill should be idempotent no-op");
@@ -729,7 +750,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = new_int_future(&mut guard, CancellationToken::new());
         guard.fulfill_future(id, Value::int(1)).unwrap();
         // Entry is gone; future_ready should treat it as already-resolved.
         let waiter = guard.future_ready(id).expect("expected immediate Ok");
@@ -760,7 +781,7 @@ mod tests {
         let (mgr, pm) = make_manager().await;
         let temp = temp_permit(&pm).await;
         let mut guard = mgr.acquire(temp.proof()).await;
-        let (id, _) = guard.new_future(CancellationToken::new());
+        let (id, _) = new_int_future(&mut guard, CancellationToken::new());
         let waiter = guard.future_ready(id).expect("waiter should be created");
         drop(guard);
 

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -107,7 +107,7 @@ use bex_vm::{
 };
 use bex_vm_types::{
     FunctionMeta, FunctionOrigin, GlobalPool, HeapPtr, Object, SharedGlobals, SysOp,
-    TaskGroupInner, Value, ValueKind, VmGlobals,
+    TaskGroupInner, UnscheduledFuture, Value, ValueKind, VmGlobals,
 };
 pub use conversion::test_arg_to_external;
 // Re-export CancellationToken for callers.
@@ -5062,14 +5062,18 @@ impl BexEngine {
                     // BEP-034: pull the closure + name off the
                     // `UnscheduledFuture` heap object and hand them to
                     // `spawn_thread`, which allocates the future and
-                    // dispatches the body on a fresh `BexThread`. The
-                    let (closure, name_ptr, config_ptr) = {
-                        let unscheduled = thread
-                            .vm
-                            .unscheduled_future(unscheduled)
-                            .map_err(EngineError::VmInternalError)?;
-                        (unscheduled.closure, unscheduled.name, unscheduled.config)
-                    };
+                    // dispatches the body on a fresh `BexThread`.
+                    let unscheduled = thread
+                        .vm
+                        .unscheduled_future(unscheduled)
+                        .map_err(EngineError::VmInternalError)?;
+                    let UnscheduledFuture {
+                        closure,
+                        name: name_ptr,
+                        config: config_ptr,
+                        returns,
+                        throws,
+                    } = unscheduled.clone();
                     let spawn_name: Option<String> =
                         name_ptr.and_then(|ptr| match unsafe { ptr.get() } {
                             Object::String(s) => Some(s.to_string()),
@@ -5135,7 +5139,8 @@ impl BexEngine {
 
                     let future_ptr = {
                         let mut guard = self.futures.acquire(thread.proof()).await;
-                        let (future_id, future_ptr) = guard.new_future(child_cancel.clone());
+                        let (future_id, future_ptr) =
+                            guard.new_future(returns, throws, child_cancel.clone());
                         drop(guard);
                         Arc::clone(self)
                             .spawn_thread(

--- a/baml_language/crates/bex_engine/tests/combinators.rs
+++ b/baml_language/crates/bex_engine/tests/combinators.rs
@@ -50,7 +50,7 @@ async fn await_inside_direct_closure() {
         function one() -> int { 7 }
         function main() -> int {
             let fut = spawn { one() };
-            let g = (x: baml.future.Future<int, null>) -> { await x };
+            let g = (x: baml.future.Future<int, never>) -> { await x };
             g(fut)
         }
     "#;

--- a/baml_language/crates/bex_engine/tests/middleware.rs
+++ b/baml_language/crates/bex_engine/tests/middleware.rs
@@ -167,11 +167,11 @@ async fn custom_with_retry() {
 
 /// A TYPE-CHANGING transformer (the BEP's `withFallback`): wraps the body
 /// with a catch-all, so the error type is erased — the spawn types
-/// `Future<int, never≈null>` and the failing body resolves to the default.
+/// `Future<int, never>` and the failing body resolves to the default.
 #[tokio::test]
 async fn type_changing_fallback_transformer() {
     let source = r#"
-        function withFallback<T, E>(default_value: T) -> (baml.spawn.SpawnParams<T, E>) -> baml.spawn.SpawnParams<T, null> throws never {
+        function withFallback<T, E>(default_value: T) -> (baml.spawn.SpawnParams<T, E>) -> baml.spawn.SpawnParams<T, never> throws never {
             (params) -> {
                 let original = params.body;
                 baml.spawn.SpawnParams {
@@ -195,7 +195,7 @@ async fn type_changing_fallback_transformer() {
         }
         function main() -> int {
             let f = spawn with withFallback(99) { flaky(1) };
-            // `f: Future<int, null>` — awaiting needs no catch.
+            // `f: Future<int, never>` — awaiting needs no catch.
             await f
         }
     "#;
@@ -231,8 +231,8 @@ async fn throwing_transformer_throws_at_spawn_site() {
 
 /// A transformer bound to a VARIABLE first (not called inline). The `let`
 /// binding gives generic inference no context to solve `E`, so it is supplied
-/// explicitly (`withDouble<null>()` — the spawn body throws nothing, so its
-/// `SpawnParams` error type is `null`); the pipeline still runs from the
+/// explicitly (`withDouble<never>()` — the spawn body throws nothing, so its
+/// `SpawnParams` error type is `never`); the pipeline still runs from the
 /// variable.
 #[tokio::test]
 async fn variable_bound_transformer_still_applies() {
@@ -250,7 +250,7 @@ async fn variable_bound_transformer_still_applies() {
             }
         }
         function main() -> int {
-            let t = withDouble<null>();
+            let t = withDouble<never>();
             let f = spawn with t { 21 };
             await f
         }

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -2230,7 +2230,7 @@ mod tests {
             name: Some(name),
             config: None,
             returns: RealizedTy::int(),
-            throws: RealizedTy::null(),
+            throws: RealizedTy::never(),
         })));
 
         let roots = vec![future_ptr];
@@ -2784,7 +2784,7 @@ mod tests {
             name: None,
             config: None,
             returns: RealizedTy::int(),
-            throws: RealizedTy::null(),
+            throws: RealizedTy::never(),
         })));
 
         // --- Container: Object::Instance ---

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -1313,6 +1313,7 @@ impl BexHeap {
 mod tests {
     use std::sync::Arc;
 
+    use baml_type::RealizedTy;
     use bex_vm_types::{Object, Value};
 
     use super::*;
@@ -2228,6 +2229,8 @@ mod tests {
             closure,
             name: Some(name),
             config: None,
+            returns: RealizedTy::int(),
+            throws: RealizedTy::null(),
         })));
 
         let roots = vec![future_ptr];
@@ -2249,6 +2252,8 @@ mod tests {
         // `HeapPtr` to pass to `settle_ready` for its write-barrier hook.
         let future_ptr = tlab.alloc(Object::Future(Future::pending(
             FutureId::from_usize(0),
+            RealizedTy::unknown(),
+            RealizedTy::unknown(),
             bex_vm_types::types::CancellationToken::new(),
         )));
         let Object::Future(future) = (unsafe { future_ptr.get() }) else {
@@ -2286,6 +2291,8 @@ mod tests {
 
         let future_ptr = tlab.alloc(Object::Future(Future::pending(
             FutureId::from_usize(0),
+            RealizedTy::unknown(),
+            RealizedTy::unknown(),
             bex_vm_types::types::CancellationToken::new(),
         )));
         let Object::Future(future) = (unsafe { future_ptr.get() }) else {
@@ -2776,6 +2783,8 @@ mod tests {
             closure: leaf_for_future,
             name: None,
             config: None,
+            returns: RealizedTy::int(),
+            throws: RealizedTy::null(),
         })));
 
         // --- Container: Object::Instance ---

--- a/baml_language/crates/bex_vm/src/package_reflect/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/mod.rs
@@ -198,8 +198,8 @@ fn callee_fn_ty(sig: &CallableSignature) -> RealizedTy {
     }
 }
 
-/// A value's reconstructed type, `unknown` when it has none (a nested function
-/// value, a future, an opaque handle).
+/// A value's reconstructed type, `unknown` when it has none (a bound method, an
+/// opaque handle). A future reconstructs to the `Future<T, E>` it was spawned at.
 fn value_realized_ty(vm: &BexVm, value: Value) -> RealizedTy {
     vm.value_concrete_ty(value)
         .map_or_else(RealizedTy::unknown, RealizedTy::from)
@@ -207,7 +207,7 @@ fn value_realized_ty(vm: &BexVm, value: Value) -> RealizedTy {
 
 /// Whether `value` fits the parameter type `expected`, by the canonical
 /// algebra over the runtime context. Fails OPEN when the value's type cannot
-/// be reconstructed (futures, opaque handles, bound methods): the stored
+/// be reconstructed (opaque handles, bound methods): the stored
 /// signature may itself carry erased `unknown` slots, so refusing what we
 /// cannot check would reject working calls; the callee remains dynamically
 /// safe either way (values stay tagged).

--- a/baml_language/crates/bex_vm/src/type_match.rs
+++ b/baml_language/crates/bex_vm/src/type_match.rs
@@ -36,13 +36,14 @@ pub(crate) fn value_matches_template(
     template: &TyTemplate,
     frame_type_args: &[RealizedTy],
 ) -> Result<bool, VmInternalError> {
-    // A value with no reconstructible concrete BAML type (a bound method, a
-    // future, an opaque native handle — see `value_concrete_ty`) is a member
-    // of no structural type test. Closures DO reconstruct a function type —
-    // though ones created in a generic frame reconstruct coarsely today: the
-    // stored signature erases generic positions even though the closure
-    // carries the realized type args that would fill them (see
-    // `function_object_ty`).
+    // A value with no reconstructible concrete BAML type (a bound method, an
+    // opaque native handle — see `value_concrete_ty`) is a member of no
+    // structural type test. Closures DO reconstruct a function type — though
+    // ones created in a generic frame reconstruct coarsely today: the stored
+    // signature erases generic positions even though the closure carries the
+    // realized type args that would fill them (see `function_object_ty`).
+    // Futures DO reconstruct too, at the `Future<T, E>` their spawn site was
+    // typed at.
     let Some(value_ty) = vm.value_concrete_ty(value) else {
         return Ok(false);
     };

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -801,10 +801,11 @@ pub enum VmExecState {
     /// BEP-034: VM yields a `spawn { body }` to the engine.
     ///
     /// - Input: a `HeapPtr` to the `UnscheduledFuture` object the VM
-    ///   allocated. The struct carries the body closure and the
-    ///   optional spawn name.
+    ///   allocated. The struct carries the body closure, the optional
+    ///   spawn name, and the `Future<T, E>` type arguments this spawn
+    ///   site was typed at.
     /// - Output: the engine builds a fresh `Future::Pending(id)` heap
-    ///   object, dispatches the body on a new `BexThread`, and pushes
+    ///   object at those types, dispatches the body on a new `BexThread`, and pushes
     ///   the future pointer onto the VM stack. Terminal transitions
     ///   (`Ready`/`Error`/`Cancelled`/`InternalError`) happen later
     ///   via the `FutureManager`; the VM only ever sees `Pending`
@@ -1717,6 +1718,25 @@ impl BexVm {
         Ok(ptr)
     }
 
+    /// Pop the `Object::Type` on top of the stack and clone out the type it
+    /// wraps.
+    ///
+    /// The counterpart to a preceding `LoadType`, whose pushed value is already
+    /// resolved against the frame's type args. Opcodes whose type operands ride
+    /// the stack rather than the instruction stream (`AllocArray`, `AllocMap`,
+    /// `Spawn`) consume them this way.
+    fn ensure_pop_type(&mut self) -> Result<baml_type::RealizedTy, VmInternalError> {
+        let value = self.stack.ensure_pop();
+        let ptr = self.as_object_ptr(value, ObjectType::Type)?;
+        match self.get_object(ptr) {
+            Object::Type(ty) => Ok(*ty.clone()),
+            other => Err(VmInternalError::TypeError {
+                expected: ObjectType::Type.into(),
+                got: ObjectType::of(other).into(),
+            }),
+        }
+    }
+
     /// Get string from a Value.
     pub fn as_string(&self, value: &Value) -> Result<&bex_vm_types::BexStr, VmInternalError> {
         let ptr = self.as_object_ptr(*value, ObjectType::String)?;
@@ -1922,12 +1942,13 @@ impl BexVm {
     /// The value's concrete type as a [`ConcreteRealizedTy`] — the invariant every
     /// runtime value's type satisfies (a concrete top with realized arguments, no
     /// type variables) made explicit in the type. `None` for a value kind that
-    /// has no such type (a raw function/future value or an opaque native handle).
+    /// has no such type (a compile-time definition object or an opaque native handle).
     ///
     /// Primitives construct their leaf directly; an `Instance` narrows its stored
     /// `class_type_args` into the argument list (so `Box<int>` resolves the `Box`
     /// impl at `T = int`); an enum `Variant` maps to its enum; a container narrows
-    /// its element/key/value types; a `Cell` is transparent. A value's arguments
+    /// its element/key/value types; a future reports the `Future<T, E>` its spawn
+    /// site was typed at; a `Cell` is transparent. A value's arguments
     /// are realized by construction, so a per-argument narrow (see [`realized_arg`])
     /// fails (→ `None`) only if a residual type variable leaked in — a bug.
     ///
@@ -2071,11 +2092,19 @@ impl BexVm {
             | Object::Interface(_)
             | Object::ImplRule(_) => return None,
 
-            // A `Future` *is* a concrete type, but the value holds only its
-            // resolved value and state, never its `<V, E>` type arguments, so a
-            // precise `Future<int>` can't be reconstructed; `Future` patterns are
-            // matched by the coarse `FUTURE` type tag instead.
-            Object::Future(_) | Object::UnscheduledFuture(_) => return None,
+            // A future carries the `<T, E>` it was spawned at (resolved against
+            // the spawning frame), so its concrete type is the faithful
+            // `Future<T, E>` — the subject of `is`/`match` arms and
+            // `reflect.type_of`.
+            Object::Future(fut) => ConcreteRealizedTy::Future(
+                Box::new(fut.returns().clone()),
+                Box::new(fut.throws().clone()),
+                TyAttr::default(),
+            ),
+            // An `UnscheduledFuture` is the engine's spawn-request slot, consumed
+            // before control returns to the VM. It is never a value user code can
+            // hold, so it has no type of its own.
+            Object::UnscheduledFuture(_) => return None,
 
             // Opaque native handles are not BAML data types at all.
             Object::RustData(_) | Object::Collector(_) => return None,
@@ -5910,16 +5939,7 @@ impl BexVm {
                     // The declared element type rides on top of the `size`
                     // elements: a preceding `LoadType` pushed it, already resolved
                     // against the frame's type args. Pop it before the values.
-                    let type_slot = self.stack.len() - 1;
-                    let type_value = self.stack[StackIndex::from_raw(type_slot)];
-                    let element_ty = {
-                        let ptr = self.as_object_ptr(type_value, ObjectType::Type)?;
-                        let Object::Type(ty) = self.get_object(ptr) else {
-                            unreachable!("as_object_ptr guarantees Type variant");
-                        };
-                        *ty.clone()
-                    };
-                    self.stack.truncate(type_slot);
+                    let element_ty = self.ensure_pop_type()?;
                     let drain_range = StackIndex::from_raw(self.stack.len() - size)..;
                     let array: Vec<Value> = self.stack.drain(drain_range).collect();
                     let array_index = self.tlab.alloc_array(element_ty, array);
@@ -5932,24 +5952,8 @@ impl BexVm {
                     // below it (two `LoadType`s after the entries, already
                     // resolved against the frame's type args). Pop both before
                     // the entries.
-                    let value_type_value = self.stack[StackIndex::from_raw(self.stack.len() - 1)];
-                    let key_type_value = self.stack[StackIndex::from_raw(self.stack.len() - 2)];
-                    let value_ty = {
-                        let ptr = self.as_object_ptr(value_type_value, ObjectType::Type)?;
-                        let Object::Type(ty) = self.get_object(ptr) else {
-                            unreachable!("as_object_ptr guarantees Type variant");
-                        };
-                        *ty.clone()
-                    };
-                    let key_ty = {
-                        let ptr = self.as_object_ptr(key_type_value, ObjectType::Type)?;
-                        let Object::Type(ty) = self.get_object(ptr) else {
-                            unreachable!("as_object_ptr guarantees Type variant");
-                        };
-                        *ty.clone()
-                    };
-                    let entries_top = self.stack.len() - 2;
-                    self.stack.truncate(entries_top);
+                    let value_ty = self.ensure_pop_type()?;
+                    let key_ty = self.ensure_pop_type()?;
                     let map = if n > 0 {
                         let end_of_values = self.stack.ensure_slot_from_top(2 * n - 1);
                         let end_of_keys = self.stack.ensure_slot_from_top(n - 1);
@@ -6093,7 +6097,13 @@ impl BexVm {
                 // ── Spawn (BEP-034) ────────────────────────────────────────────
                 OpCode::Spawn => {
                     // Stack layout (pushed by emit in this order): closure, name,
-                    // config. So pop in reverse: config (top), name, closure.
+                    // config, the future's `T`, the future's `E`. So pop in
+                    // reverse: `E` (top), `T`, config, name, closure. The two
+                    // types were pushed by `LoadType`, already resolved against
+                    // this frame's type args, and travel with the request so the
+                    // engine can type the heap `Future` it allocates.
+                    let throws = self.ensure_pop_type()?;
+                    let returns = self.ensure_pop_type()?;
                     // `config` is the optional `baml.spawn.SpawnConfig` from a
                     // `with baml.spawn.options(...)` clause, or null.
                     let config_value = self.stack.ensure_pop();
@@ -6132,6 +6142,8 @@ impl BexVm {
                         closure: closure_ptr,
                         name: name_ptr,
                         config: config_ptr,
+                        returns,
+                        throws,
                     };
                     let object_index = self
                         .tlab

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -458,10 +458,17 @@ pub enum Instruction {
     SysOp(GlobalIndex),
     SysOpWithRuntimeId(GlobalIndex),
 
-    /// BEP-034 `spawn { body }`. Pops `[closure_value, name_value]` from
-    /// the stack, allocates an `UnscheduledFuture { closure, name }`
-    /// into the TLAB, and yields `VmExecState::Spawn(ptr)` so the
-    /// engine routes the closure to a fresh `BexThread`.
+    /// BEP-034 `spawn { body }`. Pops `[closure, name, config, returns,
+    /// throws]` from the stack (in reverse push order), allocates an
+    /// `UnscheduledFuture` into the TLAB, and yields
+    /// `VmExecState::Spawn(ptr)` so the engine routes the closure to a fresh
+    /// `BexThread`.
+    ///
+    /// `returns` / `throws` are the `Object::Type` values a preceding pair of
+    /// `LoadType`s pushed — the `Future<T, E>` this spawn is typed at, already
+    /// resolved against the frame's type args. They travel with the request so
+    /// the engine can type the heap `Future` it allocates, which is what makes
+    /// a future's generic parameters visible to reflection and `is`/`match`.
     Spawn,
 
     /// Awaits the future on top of the stack.

--- a/baml_language/crates/bex_vm_types/src/types/future.rs
+++ b/baml_language/crates/bex_vm_types/src/types/future.rs
@@ -8,6 +8,7 @@ use std::{
     },
 };
 
+use baml_type::RealizedTy;
 use borsh::{BorshDeserialize, BorshSerialize};
 use tokio_util::sync::CancellationToken;
 
@@ -72,6 +73,10 @@ pub struct Future {
     flags: AtomicU8,
     /// Set at construction; never modified. Purely for debug/tracing.
     id: FutureId,
+    /// The return/throws types that the value will match.
+    /// Used for reflection/pattern matching.
+    /// Read-only: set once when the future is created.
+    types: Arc<FutureOutputTypes>,
     /// Written at most once by whichever writer wins the `state` CAS.
     /// Valid only when `state` indicates `Ready` or `Error`. For
     /// `Cancelled` / `InternalError`, this stays uninitialized.
@@ -219,11 +224,17 @@ impl Future {
     /// `cancel` is the future's own cancel token — fired by `f.cancel()`
     /// and observed by the producer. The caller is responsible for deriving
     /// it from the spawning thread's token so cascade cancellation works.
-    pub fn pending(id: FutureId, cancel: CancellationToken) -> Self {
+    pub fn pending(
+        id: FutureId,
+        returns: RealizedTy,
+        throws: RealizedTy,
+        cancel: CancellationToken,
+    ) -> Self {
         Self {
             state: AtomicU8::new(FutureTag::Pending as u8),
             flags: AtomicU8::new(0),
             id,
+            types: Arc::new(FutureOutputTypes { returns, throws }),
             value: UnsafeCell::new(MaybeUninit::uninit()),
             error_trace: Arc::new(OnceLock::new()),
             cancel,
@@ -234,6 +245,14 @@ impl Future {
     /// `FutureId` for debug/tracing purposes.
     pub fn id(&self) -> FutureId {
         self.id
+    }
+
+    pub fn returns(&self) -> &RealizedTy {
+        &self.types.returns
+    }
+
+    pub fn throws(&self) -> &RealizedTy {
+        &self.types.throws
     }
 
     /// Read the current state with appropriate atomic ordering.
@@ -495,6 +514,7 @@ impl Clone for Future {
             state: AtomicU8::new(0), // placeholder; rewritten below
             flags: AtomicU8::new(self.flags.load(Ordering::Acquire)),
             id: self.id,
+            types: Arc::clone(&self.types),
             value: UnsafeCell::new(MaybeUninit::uninit()),
             error_trace: Arc::clone(&self.error_trace),
             cancel: self.cancel.clone(),
@@ -579,6 +599,13 @@ pub struct UnscheduledFuture {
     /// heap. `None` when the spawn had no `with` clause. The engine reads the
     /// config's `_handle` (`SpawnConfigData`) when dispatching the spawn.
     pub config: Option<HeapPtr>,
+    /// The `T` of the `Future<T, E>` this spawn yields, already resolved
+    /// against the spawning frame's type args by `OpCode::Spawn`. Handed to
+    /// [`Future::pending`] so the scheduled future can answer reflection and
+    /// `is`/`match` on its generic parameters.
+    pub returns: RealizedTy,
+    /// The `E` of the `Future<T, E>` this spawn yields. See [`Self::returns`].
+    pub throws: RealizedTy,
 }
 
 /// A unique identifier for a future.
@@ -663,4 +690,9 @@ impl From<&Future> for FutureType {
     fn from(value: &Future) -> Self {
         Self::of(value)
     }
+}
+
+struct FutureOutputTypes {
+    returns: RealizedTy,
+    throws: RealizedTy,
 }

--- a/baml_language/crates/bex_vm_types/src/types/object.rs
+++ b/baml_language/crates/bex_vm_types/src/types/object.rs
@@ -199,7 +199,12 @@ enum ObjectWire {
     ),
     Float(f64),
     Future(crate::Future),
-    UnscheduledFuture(UnscheduledFuture),
+    // Boxed like the other large variants (and like `Object`'s own
+    // `UnscheduledFuture`): the struct carries the spawn's `Future<T, E>` type
+    // arguments, which are `RealizedTy`s, so inline it would set the whole
+    // enum's size. Borsh treats `Box<T>` transparently, so the wire form is
+    // unchanged.
+    UnscheduledFuture(Box<UnscheduledFuture>),
     Type(Box<baml_type::RealizedTy>),
 }
 
@@ -232,7 +237,7 @@ impl BorshSerialize for Object {
             ),
             Self::Float(v) => ObjectWire::Float(*v),
             Self::Future(v) => ObjectWire::Future(v.clone()),
-            Self::UnscheduledFuture(v) => ObjectWire::UnscheduledFuture((**v).clone()),
+            Self::UnscheduledFuture(v) => ObjectWire::UnscheduledFuture(v.clone()),
             Self::Type(v) => ObjectWire::Type(v.clone()),
             Self::RustData(_) => {
                 return Err(std::io::Error::new(
@@ -299,7 +304,7 @@ impl BorshDeserialize for Object {
             }),
             ObjectWire::Float(v) => Self::Float(v),
             ObjectWire::Future(v) => Self::Future(v),
-            ObjectWire::UnscheduledFuture(v) => Self::UnscheduledFuture(Box::new(v)),
+            ObjectWire::UnscheduledFuture(v) => Self::UnscheduledFuture(v),
             ObjectWire::Type(v) => Self::Type(v),
         })
     }

--- a/baml_language/sdk_tests/crates/.gitignore
+++ b/baml_language/sdk_tests/crates/.gitignore
@@ -1,3 +1,7 @@
 # Generated content inside each sdk-test crate. The `generated/` tree
 # is build.rs output — never committed; regenerated on every build.
 **/generated/
+**/.generated.baml-staging/
+**/.baml_client.baml-staging/
+**/.generated.baml-backup/
+**/.baml_client.baml-backup/


### PR DESCRIPTION
Future objects now hold their return/error types. This allows us to properly reconstruct and match on the `Future<T, E>` type. Also fixes the use of `null` instead of `never` as the error type for infallible futures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spawned futures now preserve their value and error types at runtime.
  * `is` checks and `match` expressions can distinguish futures by type parameters (including through generic spawning and within arrays), with type info preserved through awaiting, reflection, and middleware.
* **Bug Fixes**
  * Improved typing diagnostics and behavior when a `spawn` expression is incomplete.
  * Parallel test child execution no longer panics on unexpected failures.
* **Documentation**
  * Expanded the type-system specification covering variance, pattern matching reachability/exhaustiveness, interfaces, and future/error contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->