### PR TITLE
fix(lsp): resolve authoring and hover quality issues

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -701,7 +701,9 @@ name = "baml_builtins2"
 version = "0.0.0-beta"
 dependencies = [
  "baml_base",
+ "serde",
  "serde_json",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -779,7 +781,6 @@ dependencies = [
  "toml_edit 0.22.27",
  "uuid",
  "webbrowser",
- "yaml_serde",
 ]
 
 [[package]]

--- a/baml_language/crates/baml_base/src/language.rs
+++ b/baml_language/crates/baml_base/src/language.rs
@@ -1,0 +1,127 @@
+//! Compiler-owned registry for built-in language constructs.
+//!
+//! This module contains semantic metadata shared by parsing, validation, and
+//! editor tooling. Human-readable documentation lives in `baml_builtins2` and
+//! is keyed by the stable names exposed here.
+
+/// The argument shape accepted by a built-in schema attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaAttributeArguments {
+    None,
+    String { placeholder: &'static str },
+}
+
+/// Semantic metadata for a built-in schema attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaAttributeSpec {
+    pub name: &'static str,
+    pub arguments: SchemaAttributeArguments,
+    pub repeatable: bool,
+}
+
+impl SchemaAttributeSpec {
+    /// Render the attribute without its contextual `@`/`@@` prefix.
+    pub fn signature(self) -> String {
+        match self.arguments {
+            SchemaAttributeArguments::None => self.name.to_string(),
+            SchemaAttributeArguments::String { placeholder } => {
+                format!(r#"{}("{placeholder}")"#, self.name)
+            }
+        }
+    }
+}
+
+pub const SCHEMA_ATTRIBUTE_SPECS: &[SchemaAttributeSpec] = &[
+    SchemaAttributeSpec {
+        name: "description",
+        arguments: SchemaAttributeArguments::String {
+            placeholder: "text",
+        },
+        repeatable: false,
+    },
+    SchemaAttributeSpec {
+        name: "alias",
+        arguments: SchemaAttributeArguments::String {
+            placeholder: "name",
+        },
+        repeatable: false,
+    },
+    SchemaAttributeSpec {
+        name: "skip",
+        arguments: SchemaAttributeArguments::None,
+        repeatable: false,
+    },
+];
+
+pub fn schema_attribute_spec(name: &str) -> Option<&'static SchemaAttributeSpec> {
+    SCHEMA_ATTRIBUTE_SPECS.iter().find(|spec| spec.name == name)
+}
+
+/// Presentation-neutral identity and signature for a well-known client
+/// configuration key. Provider-specific validation remains owned by the
+/// client-options/type schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClientConfigKeySpec {
+    pub name: &'static str,
+    pub signature: &'static str,
+}
+
+pub const CLIENT_CONFIG_KEY_SPECS: &[ClientConfigKeySpec] = &[
+    ClientConfigKeySpec {
+        name: "provider",
+        signature: "provider <name>",
+    },
+    ClientConfigKeySpec {
+        name: "options",
+        signature: "options { ... }",
+    },
+    ClientConfigKeySpec {
+        name: "model",
+        signature: "model <name>",
+    },
+    ClientConfigKeySpec {
+        name: "http",
+        signature: "http { ... }",
+    },
+    ClientConfigKeySpec {
+        name: "request_timeout_ms",
+        signature: "request_timeout_ms <milliseconds>",
+    },
+    ClientConfigKeySpec {
+        name: "retry_policy",
+        signature: "retry_policy <name>",
+    },
+];
+
+pub fn client_config_key_spec(name: &str) -> Option<&'static ClientConfigKeySpec> {
+    CLIENT_CONFIG_KEY_SPECS
+        .iter()
+        .find(|spec| spec.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_attribute_lookup_and_signatures() {
+        assert_eq!(
+            schema_attribute_spec("alias").map(|spec| spec.signature()),
+            Some(r#"alias("name")"#.to_string())
+        );
+        assert_eq!(
+            schema_attribute_spec("skip").map(|spec| spec.signature()),
+            Some("skip".to_string())
+        );
+        assert!(schema_attribute_spec("stream.done").is_none());
+    }
+
+    #[test]
+    fn client_config_key_lookup() {
+        assert_eq!(
+            client_config_key_spec("request_timeout_ms").map(|spec| spec.signature),
+            Some("request_timeout_ms <milliseconds>")
+        );
+        assert!(client_config_key_spec("temperature").is_none());
+    }
+}

--- a/baml_language/crates/baml_base/src/lib.rs
+++ b/baml_language/crates/baml_base/src/lib.rs
@@ -8,6 +8,7 @@ pub mod core_types;
 pub mod dedent;
 pub mod escape;
 pub mod files;
+pub mod language;
 pub mod num_lit;
 pub mod qualified_name;
 
@@ -16,6 +17,7 @@ pub use attr::*;
 pub use client_options::*;
 pub use core_types::*;
 pub use files::*;
+pub use language::*;
 pub use qualified_name::{BAML_STD_PREFIX, Namespace, QualifiedName};
 
 /// Package name for the BAML standard library / builtins.

--- a/baml_language/crates/baml_builtins2/Cargo.toml
+++ b/baml_language/crates/baml_builtins2/Cargo.toml
@@ -16,7 +16,9 @@ doctest = false
 
 [dependencies]
 baml_base = { workspace = true }
+serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 
 [lints]
 workspace = true

--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -91,6 +91,36 @@ enum:
       Blue,
     }
 
+alias:
+  summary: "Overrides the serialized and parsed name of a class, enum, field, or enum variant. Expects exactly one string argument."
+  syntax: |
+    class User {
+      user_id string @alias("id")
+      @@alias("user")
+    }
+  details: |
+    `@alias("name")` applies to fields and enum variants. `@@alias("name")` applies to classes and enums. Each declaration accepts at most one alias, and the argument must be a string literal.
+
+description:
+  summary: "Attaches a human-readable description to a class, enum, field, or enum variant. Expects exactly one string argument."
+  syntax: |
+    class User {
+      name string @description("The user's display name")
+      @@description("A user returned by the API")
+    }
+  details: |
+    `@description("text")` applies to fields and enum variants. `@@description("text")` applies to classes and enums. Each declaration accepts at most one description, and the argument must be a string literal.
+
+skip:
+  summary: "Excludes a field or enum variant from generated schemas. Takes no arguments."
+  syntax: |
+    class InternalRecord {
+      public_value string
+      internal_value string @skip
+    }
+  details: |
+    `@skip` takes no arguments and may appear at most once on a declaration.
+
 function:
   summary: "Declares a named callable with typed parameters and a return type."
   syntax: |
@@ -141,6 +171,51 @@ client:
         model "gpt-4o"
         temperature 0.7
       }
+    }
+
+provider:
+  summary: "Selects the provider implementation used by this LLM client."
+  syntax: |
+    client<llm> MyClient {
+      provider openai
+    }
+
+options:
+  summary: "Contains provider-specific client configuration such as the model, credentials, and HTTP settings."
+  syntax: |
+    client<llm> MyClient {
+      provider openai
+      options {
+        model "gpt-4o"
+      }
+    }
+
+client_option:
+  summary: "A provider-specific configuration property for this LLM client."
+  details: |
+    Available option names and value types depend on the selected provider.
+
+model:
+  summary: "A provider configuration property that selects the model used for requests."
+  syntax: |
+    options {
+      model "gpt-4o"
+    }
+
+http:
+  summary: "A provider configuration property that groups HTTP transport and timeout settings."
+  syntax: |
+    options {
+      http {
+        request_timeout_ms 30000
+      }
+    }
+
+request_timeout_ms:
+  summary: "A provider configuration property that sets the request timeout in milliseconds. Use `0` for no timeout."
+  syntax: |
+    http {
+      request_timeout_ms 30000
     }
 
 google-ai:
@@ -215,18 +290,18 @@ generator:
     `naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`.
 
 test:
-  summary: "Defines a named executable test."
+  summary: "Defines a named executable test using ordinary BAML expressions."
   syntax: |
     test "extracts a resume" {
       let resume = ExtractResume("John Doe, Software Engineer")
       assert.equal(resume.name, "John Doe")
     }
   details: |
-    A modern test is named with a string and contains ordinary BAML expressions. Top-level tests have canonical IDs such as `root::extracts a resume`; tests declared in a namespace start with that namespace, such as `root.payments::refunds`. Tests inside a testset add each enclosing quoted name with `::`.
+    A test is named with a string and its body can call functions, bind values, and make assertions directly. Pick a runner with an optional `with` clause: `test "name" with <runner> { ... }`.
+
+    Top-level tests have canonical IDs such as `root::extracts a resume`; tests declared in a namespace start with that namespace, such as `root.payments::refunds`. Tests inside a testset add each enclosing quoted name with `::`.
 
     Run `baml test --list` to discover canonical IDs. `baml test -i <selector>` and `-x <selector>` match them; plain selectors are substring matches, while selectors containing `*` are anchored globs. Run `baml test --help` for selector and profile configuration.
-
-    The legacy config-block form (`test Name { functions [...] args { ... } }`) remains supported.
 
 testset:
   summary: "Groups related tests, optionally sharing setup, under a quoted name."
@@ -279,6 +354,31 @@ type:
     }
   details: |
     At top level, `type Name = ...` creates an alias. Inside an interface, `type Item`, `type Item extends Bound`, `type Item = Default`, and `type Item extends Bound = Default` declare associated types. Inside an `implements` block, bind associated types with `type Item = Concrete`.
+
+void:
+  summary: "The return type of a function that produces no value."
+  syntax: |
+    function log_message(message: string) -> void {
+      log.info(message)
+    }
+
+never:
+  summary: "The bottom type of an expression that never returns normally."
+  syntax: |
+    function fail(message: string) -> never {
+      throw baml.errors.InvalidArgument { message: message }
+    }
+  details: |
+    `never` is also the empty throws-set: a function declared with `throws never` cannot return an ordinary error.
+
+unknown:
+  summary: "The top type for a value whose concrete type is not known statically."
+  syntax: |
+    function inspect(value: unknown) -> string {
+      return string.from(value)
+    }
+  details: |
+    Narrow an `unknown` value with pattern matching or an `is` test before using type-specific fields or methods.
 
 types:
   summary: "Concept page for BAML type syntax, aliases, generic bounds, and associated type bindings."
@@ -387,6 +487,11 @@ let:
     let name = "Alice"
     let count = items.length()
 
+const:
+  summary: "Declares a compile-time constant binding."
+  syntax: |
+    const DEFAULT_LIMIT = 100
+
 in:
   summary: "Used with `for` loops to iterate over a collection."
   syntax: |
@@ -452,6 +557,15 @@ catch_all:
     }
   details: |
     `expr catch_all (e) { ... }` binds the caught error to `e` and must cover every error type the expression can throw — either list them all or end with the wildcard `_ => ...`. The compiler reports a non-exhaustive `catch_all` if a throw type is left unhandled. Panics (`baml.panics.*`, such as `baml.panics.Cancelled`) are not part of an expression's throws-set, so the `_` wildcard does not catch them — a panic keeps unwinding past `catch_all`. To intercept a panic, name its type explicitly in an arm, e.g. `risky_call() catch (e) { baml.panics.Cancelled => ... }`; the bare `_` never catches panics.
+
+catch_all_panics:
+  summary: "Handles every panic raised by a preceding expression."
+  syntax: |
+    let result = risky_call() catch_all_panics (panic) {
+      _ => fallback_value,
+    }
+  details: |
+    Use `catch_all` for ordinary declared errors. `catch_all_panics` is the explicit boundary for runtime panics.
 
 defer:
   summary: "Schedules a block to run when the enclosing block exits, in LIFO order."
@@ -814,41 +928,6 @@ await:
   syntax: |
     let future = spawn { compute() }
     let result = await future
-
-dynamic:
-  summary: "Prefix inside a `type_builder` block that makes a class/enum extensible at runtime."
-  syntax: |
-    test MyTest {
-      functions [Fn]
-      type_builder {
-        dynamic class DynamicInner {
-          c string
-        }
-        dynamic enum DynamicEnum {
-          P
-          Q
-        }
-      }
-      args { from_text "test" }
-    }
-  details: |
-    `dynamic` is a prefix on a `class` or `enum` declared inside a test's `type_builder` block (`dynamic class Foo { ... }`), not a class suffix. It marks the type so the type-builder API can add fields/variants at runtime. See `baml describe type_builder`.
-
-type_builder:
-  summary: "Block inside a `test` that declares extra types for that test."
-  syntax: |
-    test MyTest {
-      functions [Fn]
-      type_builder {
-        class InnerClass { b int }
-        dynamic class DynamicInner { c string }
-        enum InnerEnum { X Y }
-        type MyAlias = string | int
-      }
-      args { from_text "test" }
-    }
-  details: |
-    `type_builder { ... }` appears inside a `test` body and may contain `class`, `enum`, and `type` declarations, optionally prefixed with `dynamic`. It is not a modifier on a top-level class. See `baml describe dynamic`.
 
 with:
   summary: "Optional clause that attaches a runner to a test/testset or options to a spawn."

--- a/baml_language/crates/baml_builtins2/src/language_docs.rs
+++ b/baml_language/crates/baml_builtins2/src/language_docs.rs
@@ -1,0 +1,105 @@
+//! Shared, embedded language-reference documentation.
+//!
+//! The CLI and editor tooling consume these typed registries instead of
+//! maintaining presentation-specific keyword and attribute tables.
+
+use std::{collections::HashMap, sync::LazyLock};
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct LanguageTopic {
+    pub summary: String,
+    #[serde(default)]
+    pub syntax: Option<String>,
+    #[serde(default)]
+    pub details: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct TypescriptCrosswalkTopic {
+    pub message: String,
+    #[serde(default)]
+    pub see: Option<String>,
+}
+
+static LANGUAGE_TOPICS: LazyLock<HashMap<String, LanguageTopic>> = LazyLock::new(|| {
+    serde_yaml::from_str(crate::BAML_KEYWORDS_YAML)
+        .expect("failed to parse embedded BAML language topics")
+});
+
+static TYPESCRIPT_CROSSWALK_TOPICS: LazyLock<HashMap<String, TypescriptCrosswalkTopic>> =
+    LazyLock::new(|| {
+        serde_yaml::from_str(crate::TS_KEYWORDS_YAML)
+            .expect("failed to parse embedded TypeScript crosswalk topics")
+    });
+
+pub fn language_topic(name: &str) -> Option<&'static LanguageTopic> {
+    LANGUAGE_TOPICS.get(name)
+}
+
+pub fn language_topics() -> &'static HashMap<String, LanguageTopic> {
+    &LANGUAGE_TOPICS
+}
+
+pub fn typescript_crosswalk_topic(name: &str) -> Option<&'static TypescriptCrosswalkTopic> {
+    TYPESCRIPT_CROSSWALK_TOPICS.get(name)
+}
+
+pub fn typescript_crosswalk_topics() -> &'static HashMap<String, TypescriptCrosswalkTopic> {
+    &TYPESCRIPT_CROSSWALK_TOPICS
+}
+
+pub fn has_describe_topic(name: &str) -> bool {
+    language_topic(name).is_some() || typescript_crosswalk_topic(name).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_attributes_and_intrinsic_types_have_topics() {
+        for spec in baml_base::SCHEMA_ATTRIBUTE_SPECS {
+            assert!(
+                language_topic(spec.name).is_some(),
+                "missing topic for schema attribute `{}`",
+                spec.name
+            );
+        }
+        for spec in baml_base::CLIENT_CONFIG_KEY_SPECS {
+            assert!(
+                language_topic(spec.name).is_some(),
+                "missing topic for client config key `{}`",
+                spec.name
+            );
+        }
+        for name in ["void", "never", "unknown"] {
+            assert!(language_topic(name).is_some(), "missing topic for `{name}`");
+        }
+    }
+
+    #[test]
+    fn language_and_crosswalk_topics_share_one_lookup_boundary() {
+        assert!(has_describe_topic("class"));
+        assert!(has_describe_topic("instanceof"));
+        assert!(!has_describe_topic("definitely_not_a_language_topic"));
+    }
+
+    #[test]
+    fn test_topic_uses_expression_body_syntax() {
+        let topic = language_topic("test").expect("missing test topic");
+        let syntax = topic
+            .syntax
+            .as_deref()
+            .expect("test topic should show syntax");
+        assert!(syntax.contains("test \""));
+        assert!(!syntax.contains("functions ["));
+        assert!(!syntax.contains("args {"));
+        assert!(
+            !topic
+                .details
+                .as_deref()
+                .unwrap_or_default()
+                .contains("functions [")
+        );
+    }
+}

--- a/baml_language/crates/baml_builtins2/src/lib.rs
+++ b/baml_language/crates/baml_builtins2/src/lib.rs
@@ -58,11 +58,17 @@ pub const PACKAGE_BOUNDARY: &str = "boundary";
 /// generated code or committed artifacts).
 pub const BAML_STD_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/baml_std");
 
-/// YAML documentation for BAML keywords, embedded at compile time.
+/// YAML documentation for BAML language-reference topics, embedded at compile time.
 pub const BAML_KEYWORDS_YAML: &str = include_str!("../keyword_docs/baml_keywords.yaml");
 
 /// YAML crosswalk documentation for TypeScript/JS keywords, embedded at compile time.
 pub const TS_KEYWORDS_YAML: &str = include_str!("../keyword_docs/ts_keywords.yaml");
+
+mod language_docs;
+pub use language_docs::{
+    LanguageTopic, TypescriptCrosswalkTopic, has_describe_topic, language_topic, language_topics,
+    typescript_crosswalk_topic, typescript_crosswalk_topics,
+};
 
 /// Builtin registration macro: package, relative virtual path, filesystem include path.
 macro_rules! builtin {

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -59,7 +59,6 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking", "json", "rustls" ] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 strsim = { workspace = true }
 tar = { workspace = true }

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use std::{collections::HashMap, path::PathBuf, sync::LazyLock};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use baml_db::baml_compiler2_hir;
@@ -9,34 +9,6 @@ use baml_project::ProjectDatabase;
 use clap::Args;
 
 use crate::util::{line_number_at_offset, relative_path};
-
-/// Parsed documentation entry for a BAML keyword topic.
-#[derive(serde::Deserialize)]
-struct BamlKeywordDoc {
-    summary: String,
-    #[serde(default)]
-    syntax: Option<String>,
-    #[serde(default)]
-    details: Option<String>,
-}
-
-/// Parsed documentation entry for a TypeScript/JavaScript keyword topic.
-#[derive(serde::Deserialize)]
-struct TsKeywordDoc {
-    message: String,
-    #[serde(default)]
-    see: Option<String>,
-}
-
-static BAML_KEYWORDS: LazyLock<HashMap<String, BamlKeywordDoc>> = LazyLock::new(|| {
-    serde_yaml::from_str(baml_builtins2::BAML_KEYWORDS_YAML)
-        .expect("failed to parse baml_keywords.yaml")
-});
-
-static TS_KEYWORDS: LazyLock<HashMap<String, TsKeywordDoc>> = LazyLock::new(|| {
-    serde_yaml::from_str(baml_builtins2::TS_KEYWORDS_YAML)
-        .expect("failed to parse ts_keywords.yaml")
-});
 
 /// Describe BAML symbols and language concepts.
 ///
@@ -220,19 +192,12 @@ pub fn dispatch<'db>(db: &'db ProjectDatabase, name: &str) -> Option<ResolvedTar
     // `string.length` → `baml.String.length`. Checked before the keyword
     // crosswalk so `baml describe string` shows the class (with its methods),
     // not keyword docs.
-    let (alias_head, alias_rest) = name.split_once('.').unwrap_or((name, ""));
-    if let Some(class_path) = builtin_alias_class_path(alias_head) {
-        let baml_pkg = baml_compiler2_hir::package::PackageId::new(db, baml_db::Name::new("baml"));
-        let target = if alias_rest.is_empty() {
-            class_path.to_string()
-        } else {
-            format!("{class_path}.{alias_rest}")
-        };
-        return baml_lsp2_actions::resolve_target(db, baml_pkg, &target);
+    if let Some(target) = baml_lsp2_actions::resolve_builtin_type_target(db, name) {
+        return Some(target);
     }
 
     // Check for keyword (BAML or TS/JS crosswalk) before package routing.
-    if BAML_KEYWORDS.contains_key(name) || TS_KEYWORDS.contains_key(name) {
+    if baml_builtins2::has_describe_topic(name) {
         return Some(ResolvedTarget::Keyword(name.to_string()));
     }
 
@@ -262,27 +227,6 @@ pub fn dispatch<'db>(db: &'db ProjectDatabase, name: &str) -> Option<ResolvedTar
     }
 
     resolve_unqualified_builtin_member(db, name)
-}
-
-/// Map a lowercase primitive/keyword alias to the path of its builtin `baml`
-/// companion class, relative to the `baml` package. Mirrors the alias set in
-/// `baml_compiler2_tir::ty::PrimitiveType::alias` plus the `json` type alias.
-fn builtin_alias_class_path(name: &str) -> Option<&'static str> {
-    Some(match name {
-        "string" => "String",
-        "int" => "Int",
-        "bigint" => "Bigint",
-        "float" => "Float",
-        "bool" => "Bool",
-        "null" => "Null",
-        "uint8array" => "Uint8Array",
-        "image" => "media.Image",
-        "audio" => "media.Audio",
-        "video" => "media.Video",
-        "pdf" => "media.Pdf",
-        "json" => "json.json",
-        _ => return None,
-    })
 }
 
 /// Resolve `Array.reduce`/`String.split`-style builtin class member lookups.
@@ -493,7 +437,7 @@ impl DescribeArgs {
 /// Render keyword documentation to a writer.
 pub fn write_keyword(w: &mut impl std::io::Write, name: &str) -> std::io::Result<()> {
     let painter = crate::paint::Painter::stdout();
-    if let Some(doc) = BAML_KEYWORDS.get(name) {
+    if let Some(doc) = baml_builtins2::language_topic(name) {
         writeln!(w, "{} — {}", painter.keyword(name), doc.summary)?;
         if let Some(ref syntax) = doc.syntax {
             writeln!(w)?;
@@ -506,7 +450,7 @@ pub fn write_keyword(w: &mut impl std::io::Write, name: &str) -> std::io::Result
             writeln!(w)?;
             writeln!(w, "{details}")?;
         }
-    } else if let Some(doc) = TS_KEYWORDS.get(name) {
+    } else if let Some(doc) = baml_builtins2::typescript_crosswalk_topic(name) {
         writeln!(w, "{} — {}", painter.keyword(name), doc.message)?;
         if let Some(ref see) = doc.see {
             writeln!(w)?;
@@ -523,7 +467,7 @@ fn render_keyword(name: &str) {
 
 /// Render keyword documentation as JSON.
 fn render_keyword_json(name: &str) -> serde_json::Value {
-    if let Some(doc) = BAML_KEYWORDS.get(name) {
+    if let Some(doc) = baml_builtins2::language_topic(name) {
         serde_json::json!({
             "type": "keyword",
             "name": name,
@@ -531,7 +475,7 @@ fn render_keyword_json(name: &str) -> serde_json::Value {
             "syntax": doc.syntax,
             "details": doc.details,
         })
-    } else if let Some(doc) = TS_KEYWORDS.get(name) {
+    } else if let Some(doc) = baml_builtins2::typescript_crosswalk_topic(name) {
         serde_json::json!({
             "type": "crosswalk",
             "name": name,

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -1231,6 +1231,25 @@ fn dispatch_language_topic_resolves_to_keyword() {
 }
 
 #[test]
+fn dispatch_schema_attributes_and_intrinsic_types_resolve_to_topics() {
+    let db = simple_project();
+    for name in ["alias", "description", "skip", "void", "never", "unknown"] {
+        assert!(
+            matches!(dispatch(&db, name), Some(ResolvedTarget::Keyword(_))),
+            "`baml describe {name}` should resolve to a shared language topic"
+        );
+    }
+}
+
+#[test]
+fn render_schema_attribute_topic() {
+    let output = capture_keyword("alias");
+    assert!(output.contains("Overrides the serialized and parsed name"));
+    assert!(output.contains(r#"@alias("name")"#));
+    assert!(output.contains(r#"@@alias("name")"#));
+}
+
+#[test]
 fn render_keyword_interface() {
     let output = capture_keyword("interface");
     insta::assert_snapshot!(output);

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_test.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_test.snap
@@ -2,7 +2,7 @@
 source: crates/baml_cli/src/describe_command_tests.rs
 expression: output
 ---
-test — Defines a named executable test.
+test — Defines a named executable test using ordinary BAML expressions.
 
 Syntax:
   test "extracts a resume" {
@@ -10,8 +10,8 @@ Syntax:
     assert.equal(resume.name, "John Doe")
   }
 
-A modern test is named with a string and contains ordinary BAML expressions. Top-level tests have canonical IDs such as `root::extracts a resume`; tests declared in a namespace start with that namespace, such as `root.payments::refunds`. Tests inside a testset add each enclosing quoted name with `::`.
+A test is named with a string and its body can call functions, bind values, and make assertions directly. Pick a runner with an optional `with` clause: `test "name" with <runner> { ... }`.
+
+Top-level tests have canonical IDs such as `root::extracts a resume`; tests declared in a namespace start with that namespace, such as `root.payments::refunds`. Tests inside a testset add each enclosing quoted name with `::`.
 
 Run `baml test --list` to discover canonical IDs. `baml test -i <selector>` and `-x <selector>` match them; plain selectors are substring matches, while selectors containing `*` are anchored globs. Run `baml test --help` for selector and profile configuration.
-
-The legacy config-block form (`test Name { functions [...] args { ... } }`) remains supported.

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -1937,7 +1937,10 @@ impl<'db> SemanticIndexBuilder<'db> {
         let mut occurrences: Vec<(&str, Vec<TextRange>)> = Vec::new();
         for attr in attributes {
             let name = attr.name.as_str();
-            if !matches!(name, "description" | "alias" | "skip") {
+            let Some(spec) = baml_base::schema_attribute_spec(name) else {
+                continue;
+            };
+            if spec.repeatable {
                 continue;
             }
             if let Some(entry) = occurrences.iter_mut().find(|(n, _)| *n == name) {
@@ -1956,9 +1959,13 @@ impl<'db> SemanticIndexBuilder<'db> {
         }
 
         for attr in attributes {
-            match attr.name.as_str() {
-                "description" | "alias" => {
-                    let attr_name = attr.name.as_str();
+            let Some(spec) = baml_base::schema_attribute_spec(attr.name.as_str()) else {
+                // Unknown attributes pass through (e.g. `@stream.*`).
+                continue;
+            };
+            match spec.arguments {
+                baml_base::SchemaAttributeArguments::String { .. } => {
+                    let attr_name = spec.name;
                     if attr.args.len() != 1 {
                         self.diagnostics.push(Hir2Diagnostic::DiagnosticMessage {
                             diagnostic_id: DiagnosticId::InvalidAttributeArg,
@@ -1978,17 +1985,14 @@ impl<'db> SemanticIndexBuilder<'db> {
                         });
                     }
                 }
-                "skip" if !attr.args.is_empty() => {
+                baml_base::SchemaAttributeArguments::None if !attr.args.is_empty() => {
                     self.diagnostics.push(Hir2Diagnostic::DiagnosticMessage {
                         diagnostic_id: DiagnosticId::UnexpectedAttributeArg,
-                        message: "`@skip` does not take any arguments".to_string(),
+                        message: format!("`@{}` does not take any arguments", spec.name),
                         span: attr.span,
                     });
                 }
-                "skip" => {}
-                _ => {
-                    // Unknown attributes passed through silently (e.g. @stream.*)
-                }
+                baml_base::SchemaAttributeArguments::None => {}
             }
         }
     }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -7009,7 +7009,7 @@ impl LoweringContext<'_> {
                     .iter()
                     .filter(|m| !matches!(m, RuntimeTy::Null { .. }))
                     .all(|m| match kind(m, include_string) {
-                        Some(kind) => first.get_or_insert(kind.clone()) == &kind,
+                        Some(kind) => first.get_or_insert(kind) == &kind,
                         None => false,
                     })
                     && first.is_some()
@@ -14877,7 +14877,7 @@ mod tests {
         )
     }
 
-    fn primitive(primitive: &PrimitiveType) -> Tir2Ty {
+    fn primitive(primitive: PrimitiveType) -> Tir2Ty {
         let attr = baml_compiler2_tir::ty::TyAttr::default();
         match primitive {
             PrimitiveType::Int => Tir2Ty::Int { attr },
@@ -14913,11 +14913,11 @@ mod tests {
     #[test]
     fn block_selection_checks_assoc_when_request_omits_generic_args() {
         let aliases = HashMap::new();
-        let impl_args = vec![primitive(&PrimitiveType::String)];
+        let impl_args = vec![primitive(PrimitiveType::String)];
         let requested_args = Vec::new();
-        let requested_assoc = vec![(Name::new("Value"), primitive(&PrimitiveType::Int))];
+        let requested_assoc = vec![(Name::new("Value"), primitive(PrimitiveType::Int))];
 
-        let int_impl_assoc = vec![(Name::new("Value"), primitive(&PrimitiveType::Int))];
+        let int_impl_assoc = vec![(Name::new("Value"), primitive(PrimitiveType::Int))];
         assert!(implements_block_matches_request(
             &impl_args,
             &int_impl_assoc,
@@ -14927,7 +14927,7 @@ mod tests {
             &aliases,
         ));
 
-        let string_impl_assoc = vec![(Name::new("Value"), primitive(&PrimitiveType::String))];
+        let string_impl_assoc = vec![(Name::new("Value"), primitive(PrimitiveType::String))];
         assert!(!implements_block_matches_request(
             &impl_args,
             &string_impl_assoc,

--- a/baml_language/crates/baml_compiler2_tir/src/ty.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/ty.rs
@@ -11,9 +11,10 @@ pub use baml_base::{Name, attr::TyAttr};
 // `baml_type` (the single home for the shared type vocabulary). Re-exported
 // here so existing `crate::ty::…` paths keep working.
 pub use baml_type::{
-    CanonicalTyRender, Freshness, FunctionParamMode, FunctionParamTy, MediaKind, Package, ParamTy,
-    PrimitiveType, QualifiedTypeName, RESERVED_USER_PACKAGE, RuntimeGenericLayout,
-    SYNTHETIC_EFFECT_PARAM_PREFIX, Ty, TyRenderStrategy, is_synthetic_effect_param,
+    BuiltinTypeName, CanonicalTyRender, Freshness, FunctionParamMode, FunctionParamTy, MediaKind,
+    Package, ParamTy, PrimitiveType, QualifiedTypeName, RESERVED_USER_PACKAGE,
+    RuntimeGenericLayout, SYNTHETIC_EFFECT_PARAM_PREFIX, Ty, TyRenderStrategy,
+    is_synthetic_effect_param,
 };
 
 /// Re-export `baml_base::Literal` as `LiteralValue` for backward compatibility.

--- a/baml_language/crates/baml_lsp2_actions/Cargo.toml
+++ b/baml_language/crates/baml_lsp2_actions/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 baml_base = { workspace = true }
+baml_builtins2 = { workspace = true }
 baml_compiler2_ast = { workspace = true }
 baml_compiler2_hir = { workspace = true }
 baml_compiler2_ppir = { workspace = true }
@@ -24,6 +25,5 @@ serde = { workspace = true, features = [ "derive" ] }
 text-size = { workspace = true }
 
 [dev-dependencies]
-baml_builtins2 = { workspace = true }
 baml_workspace = { workspace = true }
 insta = { workspace = true }

--- a/baml_language/crates/baml_lsp2_actions/src/completions.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/completions.rs
@@ -156,6 +156,16 @@ pub enum CompletionKind {
     Parameter,
 }
 
+/// How an editor should interpret [`Completion::insert_text`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CompletionInsertTextFormat {
+    /// Insert the text literally.
+    #[default]
+    PlainText,
+    /// Interpret LSP snippet tabstops such as `$0` and `${1:Name}`.
+    Snippet,
+}
+
 // ── Completion ────────────────────────────────────────────────────────────────
 
 /// A single completion item returned by `completions_at`.
@@ -171,6 +181,8 @@ pub struct Completion {
     pub detail: Option<String>,
     /// Text inserted on acceptance (defaults to `label` if `None`).
     pub insert_text: Option<String>,
+    /// Whether `insert_text` is literal text or an LSP snippet.
+    pub insert_text_format: CompletionInsertTextFormat,
     /// Sort key (lower sorts first).
     pub sort_text: Option<String>,
 }
@@ -183,6 +195,7 @@ impl Completion {
             kind,
             detail: None,
             insert_text: None,
+            insert_text_format: CompletionInsertTextFormat::PlainText,
             sort_text: None,
         }
     }
@@ -199,6 +212,12 @@ impl Completion {
 
     fn with_insert_text(mut self, insert_text: impl Into<String>) -> Self {
         self.insert_text = Some(insert_text.into());
+        self
+    }
+
+    fn with_snippet(mut self, snippet: impl Into<String>) -> Self {
+        self.insert_text = Some(snippet.into());
+        self.insert_text_format = CompletionInsertTextFormat::Snippet;
         self
     }
 }
@@ -1011,7 +1030,7 @@ fn completions_for_class_methods(
 /// For a `Ty::Class`, looks up resolved class fields and returns the field's type.
 fn resolve_field_type(db: &dyn Db, ty: &Ty, field_name: &str) -> Option<Ty> {
     match ty {
-        Ty::Class(qn, _, _) => {
+        Ty::Class(qn, type_args, _) => {
             let pkg_info_name = qn.package().as_str();
             let pkg_id = PackageId::new(db, Name::new(pkg_info_name));
             let pkg = package_items(db, pkg_id);
@@ -1021,10 +1040,15 @@ fn resolve_field_type(db: &dyn Db, ty: &Ty, field_name: &str) -> Option<Ty> {
                 return None;
             };
 
+            let class_generic_params = baml_compiler2_tir::class_generic_params(db, class_loc);
+            let bindings =
+                baml_compiler2_tir::generics::bind_type_vars(&class_generic_params, type_args);
             let resolved = baml_compiler2_tir::inference::resolve_class_fields(db, class_loc);
             for (name, field_ty, _) in &resolved.fields {
                 if name.as_str() == field_name {
-                    return Some(field_ty.clone());
+                    return Some(baml_compiler2_tir::generics::substitute_ty(
+                        field_ty, &bindings,
+                    ));
                 }
             }
             None
@@ -1117,7 +1141,7 @@ fn find_path_segments_for_word_after_dot(token: &baml_compiler_syntax::SyntaxTok
 /// Returns completions for the members of `ty`.
 fn completions_for_ty_members(db: &dyn Db, file: SourceFile, ty: &Ty) -> Vec<Completion> {
     match ty {
-        Ty::Class(qn, _, _) => {
+        Ty::Class(qn, type_args, _) => {
             // Find the class definition and return its fields and methods.
             let pkg_info_name = qn.package().as_str();
             let pkg_id = PackageId::new(db, Name::new(pkg_info_name));
@@ -1130,18 +1154,24 @@ fn completions_for_ty_members(db: &dyn Db, file: SourceFile, ty: &Ty) -> Vec<Com
 
             let mut items = Vec::new();
 
-            // Fields from resolved class fields.
+            let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
+            let class_generic_params = baml_compiler2_tir::class_generic_params(db, class_loc);
+            let bindings =
+                baml_compiler2_tir::generics::bind_type_vars(&class_generic_params, type_args);
+
+            // Fields from resolved class fields, specialized for the receiver's
+            // concrete type arguments.
             let resolved = baml_compiler2_tir::inference::resolve_class_fields(db, class_loc);
             for (field_name, field_ty, _field_attrs) in &resolved.fields {
+                let field_ty = baml_compiler2_tir::generics::substitute_ty(field_ty, &bindings);
                 items.push(
                     Completion::new(field_name.as_str(), CompletionKind::Field)
-                        .with_detail(utils::display_ty_for_file(db, file, field_ty))
+                        .with_detail(utils::display_ty_for_file(db, file, &field_ty))
                         .with_sort(format!("0_{}", field_name.as_str())),
                 );
             }
 
             // Methods from the class's firewall data.
-            let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
             for &func_loc in &class_data.methods {
                 let method = baml_compiler2_ppir::item_data::function_data(db, func_loc);
                 items.push(
@@ -1586,33 +1616,45 @@ fn completions_for_top_level() -> Vec<Completion> {
     vec![
         Completion::new("class", CompletionKind::Keyword)
             .with_detail("class declaration")
+            .with_snippet("class ${1:Name} {\n  ${2:field} ${3:string}\n  $0\n}")
             .with_sort("00_class"),
         Completion::new("enum", CompletionKind::Keyword)
             .with_detail("enum declaration")
+            .with_snippet("enum ${1:Name} {\n  ${2:Value}\n  $0\n}")
             .with_sort("01_enum"),
         Completion::new("function", CompletionKind::Keyword)
             .with_detail("function declaration")
+            .with_snippet("function ${1:Name}(${2}) -> ${3:string} {\n  $0\n}")
             .with_sort("02_function"),
         Completion::new("client", CompletionKind::Keyword)
             .with_detail("LLM client declaration")
+            .with_snippet(
+                "client<llm> ${1:Name} {\n  provider ${2:openai}\n  options {\n    model ${3:gpt-4o}\n  }\n  $0\n}",
+            )
             .with_sort("03_client"),
         Completion::new("test", CompletionKind::Keyword)
             .with_detail("test case declaration")
+            .with_snippet("test \"${1:test name}\" {\n  $0\n}")
             .with_sort("05_test"),
         Completion::new("retry_policy", CompletionKind::Keyword)
             .with_detail("retry policy declaration")
+            .with_snippet("retry_policy ${1:Name} {\n  max_retries ${2:3}\n  $0\n}")
             .with_sort("06_retry_policy"),
         Completion::new("template_string", CompletionKind::Keyword)
             .with_detail("template string declaration")
+            .with_snippet("template_string ${1:Name}(${2}) #\"\n  $0\n\"#")
             .with_sort("07_template_string"),
         Completion::new("type", CompletionKind::Keyword)
             .with_detail("type alias declaration")
+            .with_snippet("type ${1:Name} = ${2:string}$0")
             .with_sort("08_type"),
         Completion::new("interface", CompletionKind::Keyword)
             .with_detail("interface declaration")
+            .with_snippet("interface ${1:Name} {\n  $0\n}")
             .with_sort("09_interface"),
         Completion::new("implements", CompletionKind::Keyword)
             .with_detail("out-of-body interface implementation")
+            .with_snippet("implements ${1:Interface} for ${2:Class} {\n  $0\n}")
             .with_sort("10_implements"),
     ]
 }

--- a/baml_language/crates/baml_lsp2_actions/src/describe.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/describe.rs
@@ -1313,6 +1313,8 @@ fn resolve_type_for_item(db: &dyn Db, def: Option<Definition<'_>>) -> Option<Str
         TypeInfo::TypeAlias { expansion, .. } => Some(expansion),
         TypeInfo::TemplateString { .. } => Some("template_string".to_string()),
         TypeInfo::LocalVar { ty, .. } => Some(ty),
+        TypeInfo::Symbol { declaration } => Some(declaration),
+        TypeInfo::Documentation { label, .. } => Some(label),
         TypeInfo::OtherItem { kind, .. } => Some(kind.to_string()),
     }
 }

--- a/baml_language/crates/baml_lsp2_actions/src/lib.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/lib.rs
@@ -90,7 +90,7 @@ pub use annotations::{AnnotationKind, InlineAnnotation, file_annotations};
 // depend on `baml_compiler2_hir` directly just for type conversions.
 pub use baml_compiler2_hir::contributions::DefinitionKind;
 pub use check::check_file;
-pub use completions::{Completion, CompletionKind, completions_at};
+pub use completions::{Completion, CompletionInsertTextFormat, CompletionKind, completions_at};
 pub use definition::{Location, definition_at};
 pub use describe::{
     DepRef, RefSite, SymbolDescription, describe, describe_by_definition, describe_item_member,
@@ -99,7 +99,7 @@ pub use env_vars::all_env_var_names;
 pub use fixes::{Fix, FixKind, fixes_at};
 pub use listing::{
     ListingEntry, ResolvedTarget, list_namespace_items, list_package_items, non_user_package_names,
-    resolve_target,
+    resolve_builtin_type_target, resolve_target,
 };
 pub use outline::{OutlineItem, file_outline};
 pub use search::{SymbolInfo, search_symbols};

--- a/baml_language/crates/baml_lsp2_actions/src/listing.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/listing.rs
@@ -5,7 +5,7 @@ use baml_compiler2_hir::{
     contributions::{Definition, DefinitionKind},
     package::{PackageId, PackageItems, package_items},
 };
-use baml_compiler2_tir::ty::Package;
+use baml_compiler2_tir::ty::{BuiltinTypeName, Package};
 
 use crate::Db;
 
@@ -124,6 +124,29 @@ pub fn resolve_target<'db>(
     }
 
     None
+}
+
+/// Resolve a lowercase builtin type spelling, optionally followed by a member,
+/// to its definition in the `baml` package.
+///
+/// Intrinsic types (`void`, `never`, `unknown`) intentionally return `None`
+/// because they have language-reference topics rather than addressable stdlib
+/// definitions.
+pub fn resolve_builtin_type_target<'db>(
+    db: &'db dyn Db,
+    name: &str,
+) -> Option<ResolvedTarget<'db>> {
+    let (alias, member_path) = name.split_once('.').unwrap_or((name, ""));
+    let builtin = BuiltinTypeName::from_alias(alias)?;
+    let definition_path = builtin.builtin_definition_path()?;
+    let mut target = definition_path.join(".");
+    if !member_path.is_empty() {
+        target.push('.');
+        target.push_str(member_path);
+    }
+
+    let package = PackageId::new(db, Name::new(baml_base::BAML_PACKAGE));
+    resolve_target(db, package, &target)
 }
 
 /// Check if the given namespace path exists in the package (either as an exact

--- a/baml_language/crates/baml_lsp2_actions/src/type_info.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/type_info.rs
@@ -35,11 +35,12 @@
 //! - `ResolvedName::Unknown` or cursor not on a WORD token — returns `None`.
 
 use baml_base::{Name, SourceFile};
-use baml_compiler_syntax::SyntaxKind;
+use baml_compiler_syntax::{SyntaxKind, SyntaxToken};
 use baml_compiler2_hir::{
     contributions::Definition, scope::ScopeKind, semantic_index::DefinitionSite,
 };
-use text_size::TextSize;
+use baml_compiler2_tir::ty::BuiltinTypeName;
+use text_size::{TextRange, TextSize};
 
 use crate::{Db, utils};
 
@@ -111,6 +112,10 @@ pub enum TypeInfo {
     TemplateString { name: String },
     /// A local variable (let binding or parameter): name + inferred/declared type.
     LocalVar { name: String, ty: String },
+    /// A declaration or resolved expression already rendered as canonical BAML.
+    Symbol { declaration: String },
+    /// Concise language documentation for a primitive, literal, or keyword.
+    Documentation { label: String, detail: String },
     /// A non-structural top-level item (client, generator, test, `retry_policy`).
     OtherItem { name: String, kind: &'static str },
 }
@@ -187,6 +192,8 @@ impl TypeInfo {
             TypeInfo::TypeAlias { name, expansion } => format!("type {name} = {expansion}"),
             TypeInfo::TemplateString { name } => format!("template_string {name}"),
             TypeInfo::LocalVar { name, ty } => format!("{name}: {ty}"),
+            TypeInfo::Symbol { declaration } => declaration.clone(),
+            TypeInfo::Documentation { label, .. } => label.clone(),
             TypeInfo::OtherItem { name, kind } => format!("{kind} {name}"),
         }
     }
@@ -229,6 +236,9 @@ impl TypeInfo {
                 }
                 out
             }
+            TypeInfo::Documentation { detail, .. } => {
+                format!("```baml\n{}\n```\n\n{detail}", self.to_describe_block())
+            }
             _ => format!("```baml\n{}\n```", self.to_describe_block()),
         }
     }
@@ -248,6 +258,26 @@ pub fn type_at(db: &dyn Db, file: SourceFile, offset: TextSize) -> Option<TypeIn
     // ── Step 1: find the token at the cursor ─────────────────────────────────
     let token = utils::find_token_at_offset(db, file, offset)?;
 
+    if let Some(info) = literal_type_info(&token) {
+        return Some(info);
+    }
+
+    if let Some(info) = builtin_type_info(db, &token) {
+        return Some(info);
+    }
+
+    if let Some(info) = client_config_key_type_info(&token) {
+        return Some(info);
+    }
+
+    if let Some(info) = attribute_type_info(&token) {
+        return Some(info);
+    }
+
+    if token.kind().is_keyword() {
+        return keyword_type_info(token.text());
+    }
+
     // Only WORD tokens can be names.
     if token.kind() != SyntaxKind::WORD {
         return None;
@@ -255,6 +285,31 @@ pub fn type_at(db: &dyn Db, file: SourceFile, offset: TextSize) -> Option<TypeIn
 
     let name_text = token.text();
     let name = Name::new(name_text);
+
+    if let Some(info) = generic_type_parameter_info_at(db, file, offset, &name) {
+        return Some(info);
+    }
+
+    // Declaration tokens for fields, methods, enum variants, and interface
+    // signatures are not package-level names. Resolve them through their item
+    // source maps before attempting ordinary scope resolution.
+    if let Some(info) = declaration_type_info_at(db, file, offset, &name) {
+        return Some(info);
+    }
+
+    // Function parameters need a direct signature fallback. In particular,
+    // declarative LLM functions have synthesized expression bodies whose scope
+    // range does not always map back through the ordinary local-binding path.
+    if let Some(info) = function_parameter_type_info_at(db, file, offset, &name) {
+        return Some(info);
+    }
+
+    // Fields, methods, enum variants, and qualified builtin functions are
+    // resolved by expression inference rather than bare-name lookup. Use the
+    // inferred per-segment type so generic receiver arguments are realized.
+    if let Some(info) = member_type_info_at(db, file, offset, name_text) {
+        return Some(info);
+    }
 
     // A let/for binding is not visible to expression resolution until after its
     // declaration statement. Hovers on the declaration token itself still need
@@ -284,6 +339,744 @@ pub fn type_at(db: &dyn Db, file: SourceFile, offset: TextSize) -> Option<TypeIn
         }
         | baml_compiler2_tir::resolve::ResolvedName::Unknown => None,
     }
+}
+
+fn client_config_key_type_info(token: &SyntaxToken) -> Option<TypeInfo> {
+    let config_item = token.parent()?;
+    if config_item.kind() != SyntaxKind::CONFIG_ITEM
+        || !config_item
+            .ancestors()
+            .any(|ancestor| ancestor.kind() == SyntaxKind::CLIENT_DEF)
+    {
+        return None;
+    }
+
+    let key = config_item
+        .children_with_tokens()
+        .filter_map(rowan::NodeOrToken::into_token)
+        .find(|candidate| {
+            matches!(
+                candidate.kind(),
+                SyntaxKind::WORD | SyntaxKind::KW_RETRY_POLICY
+            )
+        })?;
+    if key.text_range() != token.text_range() {
+        return None;
+    }
+
+    let spec = baml_base::client_config_key_spec(token.text());
+    let label = spec.map_or(token.text(), |spec| spec.signature);
+    let detail = spec
+        .and_then(|spec| baml_builtins2::language_topic(spec.name))
+        .or_else(|| baml_builtins2::language_topic("client_option"))
+        .map(|topic| topic.summary.as_str())?;
+
+    Some(TypeInfo::Documentation {
+        label: label.to_string(),
+        detail: detail.to_string(),
+    })
+}
+
+fn attribute_type_info(token: &SyntaxToken) -> Option<TypeInfo> {
+    let attribute = token.parent()?;
+    let prefix = match attribute.kind() {
+        SyntaxKind::ATTRIBUTE => "@",
+        SyntaxKind::BLOCK_ATTRIBUTE => "@@",
+        _ => return None,
+    };
+
+    let name = attribute
+        .children_with_tokens()
+        .filter_map(rowan::NodeOrToken::into_token)
+        .find(|candidate| candidate.kind() == SyntaxKind::WORD)?;
+    if name.text_range() != token.text_range() {
+        return None;
+    }
+
+    let spec = baml_base::schema_attribute_spec(token.text())?;
+    let detail = baml_builtins2::language_topic(spec.name)?.summary.clone();
+
+    Some(TypeInfo::Documentation {
+        label: format!("{prefix}{}", spec.signature()),
+        detail,
+    })
+}
+
+fn literal_type_info(token: &SyntaxToken) -> Option<TypeInfo> {
+    let (label, ty, detail) = match (token.kind(), token.text()) {
+        (_, "true" | "false") => (token.text().to_string(), "bool", "A boolean literal type."),
+        (_, "null") => (token.text().to_string(), "null", "The `null` literal type."),
+        (SyntaxKind::INTEGER_LITERAL, _) => (
+            token.text().to_string(),
+            "int",
+            "An exact `int` literal type.",
+        ),
+        (SyntaxKind::BIGINT_LITERAL, _) => (
+            token.text().to_string(),
+            "bigint",
+            "An exact arbitrary-precision `bigint` literal type.",
+        ),
+        (SyntaxKind::FLOAT_LITERAL, _) => (
+            token.text().to_string(),
+            "float",
+            "An exact `float` literal type.",
+        ),
+        _ => {
+            if token.parent_ancestors().any(|node| {
+                matches!(
+                    node.kind(),
+                    SyntaxKind::TEMPLATE_INTERPOLATION | SyntaxKind::BACKTICK_INTERPOLATION
+                )
+            }) {
+                return None;
+            }
+            let string = token.parent_ancestors().find(|node| {
+                matches!(
+                    node.kind(),
+                    SyntaxKind::STRING_LITERAL
+                        | SyntaxKind::RAW_STRING_LITERAL
+                        | SyntaxKind::BYTE_STRING_LITERAL
+                )
+            })?;
+            let label = string.text().to_string();
+            let (ty, detail) = if string.kind() == SyntaxKind::BYTE_STRING_LITERAL {
+                ("uint8array", "A byte-string literal type.")
+            } else {
+                ("string", "An exact `string` literal type.")
+            };
+            return Some(TypeInfo::Documentation {
+                label,
+                detail: format!("{detail} Its base type is `{ty}`."),
+            });
+        }
+    };
+
+    Some(TypeInfo::Documentation {
+        label,
+        detail: format!("{detail} Its base type is `{ty}`."),
+    })
+}
+
+fn builtin_type_info(db: &dyn Db, token: &SyntaxToken) -> Option<TypeInfo> {
+    let builtin = BuiltinTypeName::from_alias(token.text())?;
+    let detail = match builtin {
+        BuiltinTypeName::Primitive(_) => {
+            let crate::ResolvedTarget::Item(Definition::Class(class_loc)) =
+                crate::resolve_builtin_type_target(db, builtin.alias())?
+            else {
+                return None;
+            };
+            let data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
+            first_docstring_paragraph(data.docstring.as_deref()?)?
+        }
+        BuiltinTypeName::Void | BuiltinTypeName::Never | BuiltinTypeName::Unknown => {
+            baml_builtins2::language_topic(builtin.alias())?
+                .summary
+                .clone()
+        }
+        // `json` is a real type alias and follows ordinary semantic name
+        // resolution below rather than being intercepted as an intrinsic.
+        BuiltinTypeName::Json => return None,
+    };
+    Some(TypeInfo::Documentation {
+        label: builtin.alias().to_string(),
+        detail,
+    })
+}
+
+fn keyword_type_info(keyword: &str) -> Option<TypeInfo> {
+    let detail = baml_builtins2::language_topic(keyword)
+        .map(|topic| topic.summary.clone())
+        .or_else(|| {
+            baml_builtins2::typescript_crosswalk_topic(keyword).map(|topic| topic.message.clone())
+        })?;
+
+    Some(TypeInfo::Documentation {
+        label: keyword.to_string(),
+        detail,
+    })
+}
+
+fn first_docstring_paragraph(docstring: &str) -> Option<String> {
+    let paragraph = docstring.split("\n\n").next()?.trim();
+    (!paragraph.is_empty()).then(|| {
+        paragraph
+            .lines()
+            .map(str::trim)
+            .collect::<Vec<_>>()
+            .join(" ")
+    })
+}
+
+fn range_contains(range: TextRange, offset: TextSize) -> bool {
+    range.contains(offset) || range.end() == offset
+}
+
+fn generic_type_parameter_info_at(
+    db: &dyn Db,
+    file: SourceFile,
+    offset: TextSize,
+    name: &Name,
+) -> Option<TypeInfo> {
+    use baml_compiler2_ppir::item_data;
+
+    let mut candidates: Vec<(TextSize, String, Option<String>)> = Vec::new();
+
+    for func_loc in item_data::file_functions(db, file) {
+        let source_map = item_data::function_source_map(db, *func_loc);
+        if !range_contains(source_map.span, offset) {
+            continue;
+        }
+        let data = item_data::function_data(db, *func_loc);
+        if let Some(param_idx) = data.generic_params.iter().position(|param| param == name) {
+            let origin = item_data::file_classes(db, file)
+                .iter()
+                .find_map(|class_loc| {
+                    let class = item_data::class_data(db, *class_loc);
+                    class
+                        .methods
+                        .contains(func_loc)
+                        .then(|| format!("method {}.{}", class.name.as_str(), data.name.as_str()))
+                })
+                .or_else(|| {
+                    item_data::file_interfaces(db, file)
+                        .iter()
+                        .find_map(|iface_loc| {
+                            let iface = item_data::interface_data(db, *iface_loc);
+                            iface.default_methods.contains(func_loc).then(|| {
+                                format!("method {}.{}", iface.name.as_str(), data.name.as_str())
+                            })
+                        })
+                })
+                .unwrap_or_else(|| format!("function {}", data.name.as_str()));
+            let bound = data
+                .generic_param_bounds
+                .get(param_idx)
+                .and_then(|bound| *bound)
+                .map(|id| data.type_refs.display(id).to_string());
+            candidates.push((source_map.span.len(), origin, bound));
+        }
+    }
+
+    for class_loc in item_data::file_classes(db, file) {
+        let source_map = item_data::class_source_map(db, *class_loc);
+        if !range_contains(source_map.span, offset) {
+            continue;
+        }
+        let data = item_data::class_data(db, *class_loc);
+        if let Some(param_idx) = data.generic_params.iter().position(|param| param == name) {
+            let bound = data
+                .generic_param_bounds
+                .get(param_idx)
+                .and_then(|bound| *bound)
+                .map(|id| data.type_refs.display(id).to_string());
+            candidates.push((
+                source_map.span.len(),
+                format!("class {}", data.name.as_str()),
+                bound,
+            ));
+        }
+    }
+
+    for iface_loc in item_data::file_interfaces(db, file) {
+        let source_map = item_data::interface_source_map(db, *iface_loc);
+        if !range_contains(source_map.span, offset) {
+            continue;
+        }
+        let data = item_data::interface_data(db, *iface_loc);
+        for (method_idx, method) in data.required_methods.iter().enumerate() {
+            let Some(method_source_map) = source_map.required_method_spans.get(method_idx) else {
+                continue;
+            };
+            if !range_contains(method_source_map.span, offset) {
+                continue;
+            }
+            if let Some(param_idx) = method.generic_params.iter().position(|param| param == name) {
+                let bound = method
+                    .generic_param_bounds
+                    .get(param_idx)
+                    .and_then(|bound| *bound)
+                    .map(|id| data.type_refs.display(id).to_string());
+                candidates.push((
+                    method_source_map.span.len(),
+                    format!("method {}.{}", data.name.as_str(), method.name.as_str()),
+                    bound,
+                ));
+            }
+        }
+        if let Some(param_idx) = data.generic_params.iter().position(|param| param == name) {
+            let bound = data
+                .generic_param_bounds
+                .get(param_idx)
+                .and_then(|bound| *bound)
+                .map(|id| data.type_refs.display(id).to_string());
+            candidates.push((
+                source_map.span.len(),
+                format!("interface {}", data.name.as_str()),
+                bound,
+            ));
+        }
+    }
+
+    candidates.sort_by_key(|(span_len, _, _)| *span_len);
+    let (_, origin, bound) = candidates.into_iter().next()?;
+    let bound = bound
+        .map(|bound| format!(" extends {bound}"))
+        .unwrap_or_default();
+    Some(TypeInfo::Documentation {
+        label: format!("type parameter {}{bound}", name.as_str()),
+        detail: format!("Declared by `{origin}`."),
+    })
+}
+
+fn render_generic_params(
+    names: &[Name],
+    bounds: &[Option<baml_compiler2_hir::type_ref::TypeRefId>],
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+) -> Vec<String> {
+    names
+        .iter()
+        .enumerate()
+        .map(|(idx, name)| {
+            bounds
+                .get(idx)
+                .and_then(|bound| *bound)
+                .map(|id| format!("{} extends {}", name.as_str(), store.display(id)))
+                .unwrap_or_else(|| name.as_str().to_string())
+        })
+        .collect()
+}
+
+fn declaration_type_info_at(
+    db: &dyn Db,
+    file: SourceFile,
+    offset: TextSize,
+    name: &Name,
+) -> Option<TypeInfo> {
+    use baml_compiler2_ppir::item_data;
+
+    let index = baml_compiler2_hir::file_semantic_index(db, file);
+    let scope_id = index.scope_at_offset(offset, None);
+    let scope = &index.scopes[scope_id.index() as usize];
+    let preferred_class = if matches!(scope.kind, ScopeKind::Class) {
+        scope.name.as_ref().and_then(
+            |class_name| match baml_compiler2_tir::resolve::resolve_name_at(
+                db, file, offset, class_name,
+            ) {
+                baml_compiler2_tir::resolve::ResolvedName::Item(Definition::Class(loc))
+                | baml_compiler2_tir::resolve::ResolvedName::Builtin(Definition::Class(loc)) => {
+                    Some(loc)
+                }
+                _ => None,
+            },
+        )
+    } else {
+        None
+    };
+    let class_locs = preferred_class
+        .into_iter()
+        .chain(
+            item_data::file_classes(db, file)
+                .iter()
+                .copied()
+                .filter(|loc| Some(*loc) != preferred_class),
+        )
+        .collect::<Vec<_>>();
+
+    for class_loc in class_locs {
+        let class = item_data::class_data(db, class_loc);
+        let source_map = item_data::class_source_map(db, class_loc);
+        for (field_idx, field) in class.fields.iter().enumerate() {
+            let Some(name_span) = source_map.field_name_spans.get(field_idx) else {
+                continue;
+            };
+            if field.name == *name && range_contains(*name_span, offset) {
+                let ty = field
+                    .type_ref
+                    .map(|id| utils::display_type_ref(&class.type_refs, id))
+                    .unwrap_or_else(|| "unknown".to_string());
+                return Some(TypeInfo::LocalVar {
+                    name: name.as_str().to_string(),
+                    ty,
+                });
+            }
+        }
+    }
+
+    for enum_loc in item_data::file_enums(db, file) {
+        let enum_data = item_data::enum_data(db, *enum_loc);
+        let source_map = item_data::enum_source_map(db, *enum_loc);
+        for (variant_idx, variant) in enum_data.variants.iter().enumerate() {
+            let Some(name_span) = source_map.variant_name_spans.get(variant_idx) else {
+                continue;
+            };
+            if variant.name == *name && range_contains(*name_span, offset) {
+                return Some(TypeInfo::Symbol {
+                    declaration: format!(
+                        "{}.{}: {}",
+                        enum_data.name.as_str(),
+                        variant.name.as_str(),
+                        enum_data.name.as_str()
+                    ),
+                });
+            }
+        }
+    }
+
+    for iface_loc in item_data::file_interfaces(db, file) {
+        let iface = item_data::interface_data(db, *iface_loc);
+        let source_map = item_data::interface_source_map(db, *iface_loc);
+
+        for (field_idx, field) in iface.fields.iter().enumerate() {
+            let Some(name_span) = source_map.field_name_spans.get(field_idx) else {
+                continue;
+            };
+            if field.name == *name && range_contains(*name_span, offset) {
+                let ty = field
+                    .type_ref
+                    .map(|id| utils::display_type_ref(&iface.type_refs, id))
+                    .unwrap_or_else(|| "unknown".to_string());
+                return Some(TypeInfo::LocalVar {
+                    name: name.as_str().to_string(),
+                    ty,
+                });
+            }
+        }
+
+        for (method_idx, method) in iface.required_methods.iter().enumerate() {
+            let Some(method_spans) = source_map.required_method_spans.get(method_idx) else {
+                continue;
+            };
+            if method.name == *name && range_contains(method_spans.name_span, offset) {
+                return Some(TypeInfo::Symbol {
+                    declaration: render_interface_method_signature(iface, method),
+                });
+            }
+
+            for (param_idx, param) in method.params.iter().enumerate() {
+                let Some(param_span) = method_spans.param_spans.get(param_idx) else {
+                    continue;
+                };
+                if param.name == *name && range_contains(*param_span, offset) {
+                    let ty = param
+                        .type_ref
+                        .map(|id| utils::display_type_ref(&iface.type_refs, id))
+                        .unwrap_or_else(|| {
+                            if param.name.as_str() == "self" {
+                                "Self".to_string()
+                            } else {
+                                "unknown".to_string()
+                            }
+                        });
+                    return Some(TypeInfo::LocalVar {
+                        name: name.as_str().to_string(),
+                        ty,
+                    });
+                }
+            }
+        }
+    }
+
+    // Class/default-interface method declarations are ordinary FunctionLocs,
+    // but they are intentionally absent from package contributions.
+    for func_loc in item_data::file_functions(db, file) {
+        let source_map = item_data::function_source_map(db, *func_loc);
+        if range_contains(source_map.name_span, offset)
+            && item_data::function_data(db, *func_loc).name == *name
+        {
+            if matches!(
+                baml_compiler2_tir::resolve::resolve_name_at(db, file, offset, name),
+                baml_compiler2_tir::resolve::ResolvedName::Item(Definition::Function(_))
+                    | baml_compiler2_tir::resolve::ResolvedName::Builtin(Definition::Function(_))
+            ) {
+                continue;
+            }
+            return Some(TypeInfo::Symbol {
+                declaration: render_function_data_signature(item_data::function_data(
+                    db, *func_loc,
+                )),
+            });
+        }
+    }
+
+    None
+}
+
+fn render_function_data_signature(
+    function: &baml_compiler2_ppir::item_data::FunctionData,
+) -> String {
+    let generic_params = render_generic_params(
+        &function.generic_params,
+        &function.generic_param_bounds,
+        &function.type_refs,
+    );
+    let generics = if generic_params.is_empty() {
+        String::new()
+    } else {
+        format!("<{}>", generic_params.join(", "))
+    };
+    let params = function
+        .params
+        .iter()
+        .map(|param| {
+            let optional = if param.has_default { "?" } else { "" };
+            match param.type_ref {
+                Some(id) => format!(
+                    "{}{}: {}",
+                    param.name.as_str(),
+                    optional,
+                    function.type_refs.display(id)
+                ),
+                None => param.name.as_str().to_string(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let ret = function
+        .return_type
+        .map(|id| format!(" -> {}", function.type_refs.display(id)))
+        .unwrap_or_default();
+    let throws = function
+        .throws
+        .map(|id| format!(" throws {}", function.type_refs.display(id)))
+        .unwrap_or_else(|| " throws never".to_string());
+    format!(
+        "function {}{generics}({params}){ret}{throws}",
+        function.name.as_str()
+    )
+}
+
+fn render_interface_method_signature(
+    iface: &baml_compiler2_ppir::item_data::InterfaceData<'_>,
+    method: &baml_compiler2_ppir::item_data::InterfaceMethodSigData,
+) -> String {
+    let generic_params = render_generic_params(
+        &method.generic_params,
+        &method.generic_param_bounds,
+        &iface.type_refs,
+    );
+    let generics = if generic_params.is_empty() {
+        String::new()
+    } else {
+        format!("<{}>", generic_params.join(", "))
+    };
+    let params = method
+        .params
+        .iter()
+        .map(|param| {
+            let optional = if param.has_default { "?" } else { "" };
+            match param.type_ref {
+                Some(id) => format!(
+                    "{}{}: {}",
+                    param.name.as_str(),
+                    optional,
+                    iface.type_refs.display(id)
+                ),
+                None => param.name.as_str().to_string(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let ret = method
+        .return_type
+        .map(|id| format!(" -> {}", iface.type_refs.display(id)))
+        .unwrap_or_default();
+    let throws = method
+        .throws
+        .map(|id| format!(" throws {}", iface.type_refs.display(id)))
+        .unwrap_or_default();
+    format!(
+        "function {}{generics}({params}){ret}{throws}",
+        method.name.as_str()
+    )
+}
+
+fn function_parameter_type_info_at(
+    db: &dyn Db,
+    file: SourceFile,
+    offset: TextSize,
+    name: &Name,
+) -> Option<TypeInfo> {
+    use baml_compiler2_ast::ast::FunctionOrigin;
+    use baml_compiler2_ppir::item_data;
+
+    let mut candidates = item_data::file_functions(db, file)
+        .iter()
+        .copied()
+        .filter(|&loc| {
+            let source_map = item_data::function_source_map(db, loc);
+            let data = item_data::function_data(db, loc);
+            let matching_param = data
+                .params
+                .iter()
+                .enumerate()
+                .find(|(_, param)| param.name == *name);
+            let Some((param_idx, _)) = matching_param else {
+                return false;
+            };
+            let on_declaration = source_map
+                .param_spans
+                .get(param_idx)
+                .is_some_and(|span| range_contains(*span, offset));
+            let in_llm_body = item_data::function_llm_meta(db, loc).is_some()
+                && range_contains(source_map.span, offset);
+            on_declaration || in_llm_body
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|&loc| {
+        let data = item_data::function_data(db, loc);
+        let source_map = item_data::function_source_map(db, loc);
+        (
+            source_map.span.len(),
+            match data.metadata.origin {
+                FunctionOrigin::UserDefined => 0u8,
+                FunctionOrigin::Companion => 1,
+                FunctionOrigin::Internal => 2,
+                FunctionOrigin::AutoDerive => 3,
+            },
+        )
+    });
+
+    let func_loc = candidates.into_iter().next()?;
+    let data = item_data::function_data(db, func_loc);
+    let param = data.params.iter().find(|param| param.name == *name)?;
+    Some(TypeInfo::LocalVar {
+        name: name.as_str().to_string(),
+        ty: param
+            .type_ref
+            .map(|id| data.type_refs.display(id).to_string())
+            .unwrap_or_else(|| {
+                if param.name.as_str() == "self" {
+                    "Self".to_string()
+                } else {
+                    "unknown".to_string()
+                }
+            }),
+    })
+}
+
+fn member_type_info_at(
+    db: &dyn Db,
+    file: SourceFile,
+    offset: TextSize,
+    token_text: &str,
+) -> Option<TypeInfo> {
+    use baml_compiler2_ast::Expr;
+    use baml_compiler2_hir::body::FunctionBody;
+    use baml_compiler2_tir::inference::MemberResolution;
+
+    let index = baml_compiler2_hir::file_semantic_index(db, file);
+    let scope_id = index.scope_at_offset(offset, None);
+    let enclosing_func_scope = index
+        .ancestor_scopes(scope_id)
+        .into_iter()
+        .find(|ancestor_id| {
+            matches!(
+                index.scopes[ancestor_id.index() as usize].kind,
+                ScopeKind::Function
+            )
+        })?;
+    let func_scope_range = index.scopes[enclosing_func_scope.index() as usize].range;
+    let func_loc = utils::function_at_scope_range(db, file, func_scope_range)?;
+    let function_body = baml_compiler2_hir::body::function_body(db, func_loc);
+    let FunctionBody::Expr(expr_body) = function_body.as_ref() else {
+        return None;
+    };
+    let source_map = baml_compiler2_hir::body::function_body_source_map(db, func_loc)?;
+    let inference = baml_compiler2_tir::inference::infer_scope_types(
+        db,
+        index.scope_ids[enclosing_func_scope.index() as usize],
+    );
+    let bare_name_is_local = matches!(
+        baml_compiler2_tir::resolve::resolve_name_at(db, file, offset, &Name::new(token_text),),
+        baml_compiler2_tir::resolve::ResolvedName::Local { .. }
+    );
+
+    let mut best: Option<(baml_compiler2_ast::ExprId, TextRange, Option<usize>)> = None;
+    for (expr_id, expr) in expr_body.exprs.iter() {
+        match expr {
+            Expr::MemberAccess { member, .. } if member.as_str() == token_text => {
+                let span = source_map.expr_span(expr_id);
+                if range_contains(span, offset)
+                    && best.is_none_or(|(_, previous, _)| span.len() < previous.len())
+                {
+                    best = Some((expr_id, span, None));
+                }
+            }
+            Expr::Path(segments) if segments.len() >= 2 => {
+                let segment_idx = segments[1..]
+                    .iter()
+                    .enumerate()
+                    .find(|(idx, segment)| {
+                        segment.as_str() == token_text
+                            && range_contains(
+                                source_map.path_segment_span(expr_id, *idx + 1),
+                                offset,
+                            )
+                    })
+                    .map(|(idx, _)| idx + 1);
+                if let Some(segment_idx) = segment_idx {
+                    let span = source_map.expr_span(expr_id);
+                    if best.is_none_or(|(_, previous, _)| span.len() < previous.len()) {
+                        best = Some((expr_id, span, Some(segment_idx)));
+                    }
+                }
+            }
+            Expr::Path(segments)
+                if bare_name_is_local
+                    && segments.len() == 1
+                    && segments[0].as_str() == token_text =>
+            {
+                let span = source_map.expr_span(expr_id);
+                if range_contains(span, offset)
+                    && best.is_none_or(|(_, previous, _)| span.len() < previous.len())
+                {
+                    best = Some((expr_id, span, None));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let (expr_id, _, path_segment_idx) = best?;
+    let resolution = match path_segment_idx {
+        Some(segment_idx) => inference
+            .path_member_resolution(expr_id)
+            .and_then(|items| items.get(segment_idx - 1))
+            .or_else(|| inference.resolution(expr_id)),
+        None => inference.resolution(expr_id),
+    };
+
+    if let Some(MemberResolution::Free { func_loc }) = resolution {
+        return Some(type_info_for_definition(
+            db,
+            Definition::Function(*func_loc),
+        ));
+    }
+
+    if let Some(MemberResolution::Variant {
+        enum_loc,
+        variant_name,
+    }) = resolution
+    {
+        let enum_data = baml_compiler2_ppir::item_data::enum_data(db, *enum_loc);
+        return Some(TypeInfo::Symbol {
+            declaration: format!(
+                "{}.{}: {}",
+                enum_data.name.as_str(),
+                variant_name.as_str(),
+                enum_data.name.as_str()
+            ),
+        });
+    }
+
+    let ty = path_segment_idx
+        .and_then(|segment_idx| inference.path_segment_type(expr_id, segment_idx))
+        .or_else(|| inference.expression_type(expr_id))?;
+    Some(TypeInfo::LocalVar {
+        name: token_text.to_string(),
+        ty: utils::display_ty_for_file(db, file, ty),
+    })
 }
 
 fn declaration_site_at(
@@ -409,11 +1202,11 @@ pub fn type_info_for_definition(db: &dyn Db, def: Definition<'_>) -> TypeInfo {
             let canonical_fqn = utils::canonical_fqn_string(&qtn);
             let methods = crate::describe::class_method_sigs(db, class_loc);
 
-            let generic_params = class_data
-                .generic_params
-                .iter()
-                .map(|n| n.as_str().to_string())
-                .collect();
+            let generic_params = render_generic_params(
+                &class_data.generic_params,
+                &class_data.generic_param_bounds,
+                &class_data.type_refs,
+            );
 
             TypeInfo::Class {
                 name: class_name,
@@ -441,9 +1234,18 @@ pub fn type_info_for_definition(db: &dyn Db, def: Definition<'_>) -> TypeInfo {
 
         Definition::Interface(iface_loc) => {
             let iface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
-            TypeInfo::OtherItem {
-                name: iface.name.as_str().to_string(),
-                kind: "interface",
+            let generic_params = render_generic_params(
+                &iface.generic_params,
+                &iface.generic_param_bounds,
+                &iface.type_refs,
+            );
+            let generics = if generic_params.is_empty() {
+                String::new()
+            } else {
+                format!("<{}>", generic_params.join(", "))
+            };
+            TypeInfo::Symbol {
+                declaration: format!("interface {}{generics}", iface.name.as_str()),
             }
         }
 
@@ -647,12 +1449,14 @@ fn local_type_info(
 
     match site {
         DefinitionSite::Parameter(param_idx) => {
-            // Get the declared parameter type from the function signature.
-            let sig = baml_compiler2_hir::signature::function_signature(db, func_loc);
-            let ty_str = sig
+            // Render from the arena-backed signature data so generic arguments
+            // are preserved (`Lorem<int>`, not the legacy AST display `Lorem`).
+            let data = baml_compiler2_ppir::item_data::function_data(db, func_loc);
+            let ty_str = data
                 .params
                 .get(param_idx)
-                .map(|param| utils::display_type_expr(&param.ty))
+                .and_then(|param| param.type_ref)
+                .map(|id| data.type_refs.display(id).to_string())
                 .unwrap_or_else(|| "unknown".to_string());
             Some(TypeInfo::LocalVar {
                 name: name.as_str().to_string(),

--- a/baml_language/crates/baml_lsp2_actions/src/type_info_tests.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/type_info_tests.rs
@@ -1,6 +1,84 @@
 use crate::{testing::CursorTest, type_info::type_at};
 
 #[test]
+fn client_config_hover_only_documents_the_key_token() {
+    let key = CursorTest::new(
+        r#"client<llm> Example {
+  prov<[CURSOR]ider openai
+}"#,
+    );
+    let key_markdown = type_at(&key.db, key.cursor.file, key.cursor.offset)
+        .expect("config key hover info")
+        .to_hover_markdown();
+    assert!(key_markdown.contains("provider <name>"));
+
+    let value = CursorTest::new(
+        r#"client<llm> Example {
+  provider open<[CURSOR]ai
+}"#,
+    );
+    let value_markdown = type_at(&value.db, value.cursor.file, value.cursor.offset)
+        .map(|info| info.to_hover_markdown());
+    assert!(
+        value_markdown
+            .as_deref()
+            .is_none_or(|markdown| !markdown.contains("provider <name>"))
+    );
+}
+
+#[test]
+fn schema_attribute_hover_only_documents_the_attribute_name() {
+    let name = CursorTest::new(
+        r#"class Example {
+  value string @descrip<[CURSOR]tion("Displayed value")
+}"#,
+    );
+    let name_markdown = type_at(&name.db, name.cursor.file, name.cursor.offset)
+        .expect("attribute name hover info")
+        .to_hover_markdown();
+    assert!(name_markdown.contains(r#"@description("text")"#));
+
+    let argument = CursorTest::new(
+        r#"class Example {
+  value string @description("Displayed <[CURSOR]value")
+}"#,
+    );
+    let argument_markdown = type_at(&argument.db, argument.cursor.file, argument.cursor.offset)
+        .expect("string literal hover info")
+        .to_hover_markdown();
+    assert!(!argument_markdown.contains(r#"@description("text")"#));
+}
+
+#[test]
+fn builtin_type_hover_uses_stdlib_docstring() {
+    let test = CursorTest::new(
+        r#"class Example {
+  value i<[CURSOR]nt
+}"#,
+    );
+    let markdown = type_at(&test.db, test.cursor.file, test.cursor.offset)
+        .expect("builtin type hover info")
+        .to_hover_markdown();
+
+    assert!(markdown.contains("A 63-bit signed integer. Range: -2^62 to 2^62-1"));
+    assert!(!markdown.contains("with checked arithmetic"));
+}
+
+#[test]
+fn intrinsic_type_hover_uses_language_topic() {
+    let test = CursorTest::new(
+        r#"function stop() -> ne<[CURSOR]ver {
+  throw "stop"
+}"#,
+    );
+    let markdown = type_at(&test.db, test.cursor.file, test.cursor.offset)
+        .expect("intrinsic type hover info")
+        .to_hover_markdown();
+
+    assert!(markdown.contains("The bottom type of an expression that never returns normally."));
+}
+
+#[test]
 fn function_hover_uses_resolved_callback_surface() {
     let test = CursorTest::new(
         r#"function <[CURSOR]forward(cb: (x: int) -> int) -> int {

--- a/baml_language/crates/baml_lsp2_actions_tests/src/lib.rs
+++ b/baml_language/crates/baml_lsp2_actions_tests/src/lib.rs
@@ -1,4 +1,8 @@
 #[cfg(test)]
+mod lsp_issues_authoring;
+#[cfg(test)]
+mod lsp_issues_generic_hover;
+#[cfg(test)]
 mod memoization;
 pub mod parser;
 pub mod runner;

--- a/baml_language/crates/baml_lsp2_actions_tests/src/lsp_issues_authoring.rs
+++ b/baml_language/crates/baml_lsp2_actions_tests/src/lsp_issues_authoring.rs
@@ -1,0 +1,65 @@
+use std::path::Path;
+
+use baml_lsp2_actions::{CompletionInsertTextFormat, CompletionKind, completions_at};
+use baml_project::ProjectDatabase;
+use text_size::TextSize;
+
+#[test]
+fn function_completion_is_a_snippet() {
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(Path::new("."));
+    let source = "fun";
+    let file = db.add_or_update_file(Path::new("b974_function_completion.baml"), source);
+
+    let completions = completions_at(&db, file, TextSize::from(source.len() as u32));
+    for label in [
+        "class",
+        "enum",
+        "function",
+        "client",
+        "test",
+        "retry_policy",
+        "template_string",
+        "type",
+        "interface",
+        "implements",
+    ] {
+        let item = completions
+            .iter()
+            .find(|item| item.label == label)
+            .unwrap_or_else(|| panic!("top-level completion should offer `{label}`"));
+        assert!(
+            item.insert_text.is_some(),
+            "`{label}` should insert a declaration skeleton"
+        );
+        assert_eq!(
+            item.insert_text_format,
+            CompletionInsertTextFormat::Snippet,
+            "`{label}` should preserve snippet tabstops"
+        );
+    }
+
+    let function = completions
+        .iter()
+        .find(|item| item.label == "function")
+        .expect("top-level completion should offer `function`");
+
+    assert_eq!(function.kind, CompletionKind::Keyword);
+    assert_eq!(
+        function.insert_text.as_deref(),
+        Some("function ${1:Name}(${2}) -> ${3:string} {\n  $0\n}")
+    );
+    assert_eq!(
+        function.insert_text_format,
+        CompletionInsertTextFormat::Snippet
+    );
+
+    let test = completions
+        .iter()
+        .find(|item| item.label == "test")
+        .expect("top-level completion should offer `test`");
+    assert_eq!(
+        test.insert_text.as_deref(),
+        Some("test \"${1:test name}\" {\n  $0\n}")
+    );
+}

--- a/baml_language/crates/baml_lsp2_actions_tests/src/lsp_issues_generic_hover.rs
+++ b/baml_language/crates/baml_lsp2_actions_tests/src/lsp_issues_generic_hover.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use baml_lsp2_actions::completions_at;
+use baml_project::ProjectDatabase;
+use text_size::TextSize;
+
+#[test]
+fn instantiated_field_completion_uses_realized_type() {
+    let marked = r#"class Lorem<T> {
+  a: T
+}
+
+function lorem(a: Lorem<int>) -> void {
+  a.<[CURSOR]
+}
+"#;
+    let cursor = marked.find("<[CURSOR]").expect("cursor marker");
+    let source = marked.replace("<[CURSOR]", "");
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(Path::new("."));
+    let file = db.add_or_update_file(
+        Path::new("b982_instantiated_field_completion.baml"),
+        &source,
+    );
+
+    let completions = completions_at(&db, file, TextSize::from(cursor as u32));
+    let field = completions
+        .iter()
+        .find(|item| item.label == "a")
+        .expect("field completion should offer `a`");
+
+    assert_eq!(
+        field.detail.as_deref(),
+        Some("int"),
+        "B-982: completion detail should use the receiver-instantiated field type"
+    );
+}

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_authoring/b966_template_interpolation_hover_highlight.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_authoring/b966_template_interpolation_hover_highlight.baml
@@ -1,0 +1,42 @@
+function RenderViolations(violations: string[]) -> string {
+  let result = ""
+  for (let violation in violations) {
+    result = result + ` - ${viola<[CURSOR]tion}`
+  }
+  result
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b966_template_interpolation_hover_highlight.baml:4:34
+// ```baml
+// violation: string
+// ```
+//
+//- semantic_tokens
+// b966_template_interpolation_hover_highlight.baml:1:1 (keyword) len=8 "function"
+// b966_template_interpolation_hover_highlight.baml:1:10 (function) [declaration] len=16 "RenderViolations"
+// b966_template_interpolation_hover_highlight.baml:1:27 (parameter) [declaration] len=10 "violations"
+// b966_template_interpolation_hover_highlight.baml:1:39 (type) [defaultLibrary] len=6 "string"
+// b966_template_interpolation_hover_highlight.baml:1:52 (type) [defaultLibrary] len=6 "string"
+// b966_template_interpolation_hover_highlight.baml:2:3 (keyword) len=3 "let"
+// b966_template_interpolation_hover_highlight.baml:2:7 (variable) [declaration] len=6 "result"
+// b966_template_interpolation_hover_highlight.baml:2:14 (operator) len=1 "="
+// b966_template_interpolation_hover_highlight.baml:2:16 (string) len=2 "\"\""
+// b966_template_interpolation_hover_highlight.baml:3:3 (keyword) len=3 "for"
+// b966_template_interpolation_hover_highlight.baml:3:8 (keyword) len=3 "let"
+// b966_template_interpolation_hover_highlight.baml:3:12 (variable) [declaration] len=9 "violation"
+// b966_template_interpolation_hover_highlight.baml:3:22 (keyword) len=2 "in"
+// b966_template_interpolation_hover_highlight.baml:3:25 (parameter) len=10 "violations"
+// b966_template_interpolation_hover_highlight.baml:4:5 (variable) len=6 "result"
+// b966_template_interpolation_hover_highlight.baml:4:12 (operator) len=1 "="
+// b966_template_interpolation_hover_highlight.baml:4:14 (variable) len=6 "result"
+// b966_template_interpolation_hover_highlight.baml:4:21 (operator) len=1 "+"
+// b966_template_interpolation_hover_highlight.baml:4:23 (string) len=1 "`"
+// b966_template_interpolation_hover_highlight.baml:4:25 (string) len=1 "-"
+// b966_template_interpolation_hover_highlight.baml:4:29 (variable) len=9 "violation"
+// b966_template_interpolation_hover_highlight.baml:4:39 (string) len=1 "`"
+// b966_template_interpolation_hover_highlight.baml:6:3 (variable) len=6 "result"

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_authoring/b967_config_block_hover_highlight.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_authoring/b967_config_block_hover_highlight.baml
@@ -1,0 +1,54 @@
+client<llm> ConfiguredClient {
+  prov<[CURSOR]ider openai
+  opt<[CURSOR]ions {
+    mod<[CURSOR]el "gpt-4o-mini"
+    ht<[CURSOR]tp {
+      request_time<[CURSOR]out_ms 30000
+    }
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b967_config_block_hover_highlight.baml:2:7
+// ```baml
+// provider <name>
+// ```
+// Selects the provider implementation used by this LLM client.
+// hover at b967_config_block_hover_highlight.baml:3:6
+// ```baml
+// options { ... }
+// ```
+// Contains provider-specific client configuration such as the model, credentials, and HTTP settings.
+// hover at b967_config_block_hover_highlight.baml:4:8
+// ```baml
+// model <name>
+// ```
+// A provider configuration property that selects the model used for requests.
+// hover at b967_config_block_hover_highlight.baml:5:7
+// ```baml
+// http { ... }
+// ```
+// A provider configuration property that groups HTTP transport and timeout settings.
+// hover at b967_config_block_hover_highlight.baml:6:19
+// ```baml
+// request_timeout_ms <milliseconds>
+// ```
+// A provider configuration property that sets the request timeout in milliseconds. Use `0` for no timeout.
+//
+//- semantic_tokens
+// b967_config_block_hover_highlight.baml:1:1 (keyword) len=6 "client"
+// b967_config_block_hover_highlight.baml:1:7 (operator) len=1 "<"
+// b967_config_block_hover_highlight.baml:1:8 (type) len=3 "llm"
+// b967_config_block_hover_highlight.baml:1:11 (operator) len=1 ">"
+// b967_config_block_hover_highlight.baml:1:13 (struct) [declaration] len=16 "ConfiguredClient"
+// b967_config_block_hover_highlight.baml:2:3 (property) len=8 "provider"
+// b967_config_block_hover_highlight.baml:3:3 (property) len=7 "options"
+// b967_config_block_hover_highlight.baml:4:5 (property) len=5 "model"
+// b967_config_block_hover_highlight.baml:4:11 (string) len=13 "\"gpt-4o-mini\""
+// b967_config_block_hover_highlight.baml:5:5 (property) len=4 "http"
+// b967_config_block_hover_highlight.baml:6:7 (property) len=18 "request_timeout_ms"
+// b967_config_block_hover_highlight.baml:6:26 (number) len=5 "30000"

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_authoring/b974_top_level_snippet_completion.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_authoring/b974_top_level_snippet_completion.baml
@@ -1,0 +1,16 @@
+fun<[CURSOR]
+
+//----
+//- diagnostics
+// E0010
+//
+//   × unexpected token
+//    ╭─[b974_top_level_snippet_completion.baml:1:1]
+//  1 │ fun
+//    · ─┬─
+//    ·  ╰── expected `top-level declaration`, found `identifier`
+//    ╰────
+//
+//- completions
+// (The inline action harness checks the label; the Rust action test checks snippet text and format.)
+// SHOULD_CONTAIN: function

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_authoring/b976_type_attribute_hover_highlight.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_authoring/b976_type_attribute_hover_highlight.baml
@@ -1,0 +1,29 @@
+class Detection {
+  finding string @descrip<[CURSOR]tion("The detected finding")
+  confidence float @description("Confidence in the finding")
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b976_type_attribute_hover_highlight.baml:2:26
+// ```baml
+// @description("text")
+// ```
+// Attaches a human-readable description to a class, enum, field, or enum variant. Expects exactly one string argument.
+//
+//- semantic_tokens
+// b976_type_attribute_hover_highlight.baml:1:1 (keyword) len=5 "class"
+// b976_type_attribute_hover_highlight.baml:1:7 (class) [declaration] len=9 "Detection"
+// b976_type_attribute_hover_highlight.baml:2:3 (property) [declaration] len=7 "finding"
+// b976_type_attribute_hover_highlight.baml:2:11 (type) [defaultLibrary] len=6 "string"
+// b976_type_attribute_hover_highlight.baml:2:18 (decorator) len=1 "@"
+// b976_type_attribute_hover_highlight.baml:2:19 (decorator) len=11 "description"
+// b976_type_attribute_hover_highlight.baml:2:31 (string) len=22 "\"The detected finding\""
+// b976_type_attribute_hover_highlight.baml:3:3 (property) [declaration] len=10 "confidence"
+// b976_type_attribute_hover_highlight.baml:3:14 (type) [defaultLibrary] len=5 "float"
+// b976_type_attribute_hover_highlight.baml:3:20 (decorator) len=1 "@"
+// b976_type_attribute_hover_highlight.baml:3:21 (decorator) len=11 "description"
+// b976_type_attribute_hover_highlight.baml:3:33 (string) len=27 "\"Confidence in the finding\""

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_968_builtin_function.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_968_builtin_function.baml
@@ -1,0 +1,13 @@
+function CopyValue() -> int {
+  return baml.deep_<[CURSOR]copy(1)
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_968_builtin_function.baml:2:20
+// ```baml
+// function deep_copy(value: T) -> T throws never
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_969_enum_variant.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_969_enum_variant.baml
@@ -1,0 +1,22 @@
+enum Status {
+  Rea<[CURSOR]dy
+  Waiting
+}
+
+function GetStatus() -> Status {
+  return Status.Re<[CURSOR]ady
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_969_enum_variant.baml:2:6
+// ```baml
+// Status.Ready: Status
+// ```
+// hover at b_969_enum_variant.baml:7:19
+// ```baml
+// Status.Ready: Status
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_970_primitive_types.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_970_primitive_types.baml
@@ -1,0 +1,32 @@
+class PrimitiveFields {
+  name str<[CURSOR]ing
+  count i<[CURSOR]nt
+  active bo<[CURSOR]ol
+  score flo<[CURSOR]at
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_970_primitive_types.baml:2:11
+// ```baml
+// string
+// ```
+// A UTF-8 encoded string.
+// hover at b_970_primitive_types.baml:3:10
+// ```baml
+// int
+// ```
+// A 63-bit signed integer. Range: -2^62 to 2^62-1 (`-4_611_686_018_427_387_904` to `4_611_686_018_427_387_903`).
+// hover at b_970_primitive_types.baml:4:12
+// ```baml
+// bool
+// ```
+// A boolean value — either `true` or `false`.
+// hover at b_970_primitive_types.baml:5:12
+// ```baml
+// float
+// ```
+// A 64-bit IEEE 754 floating-point number (f64).

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_971_class_member_references.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_971_class_member_references.baml
@@ -1,0 +1,26 @@
+class Person<T> {
+  name T
+
+  function greeting(self) -> T {
+    return self.name
+  }
+}
+
+function ReadPerson(person: Person<string>) -> string {
+  let name = person.na<[CURSOR]me
+  return person.gree<[CURSOR]ting()
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_971_class_member_references.baml:10:23
+// ```baml
+// name: string
+// ```
+// hover at b_971_class_member_references.baml:11:21
+// ```baml
+// greeting: () -> string throws never
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_972_literal_values.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_972_literal_values.baml
@@ -1,0 +1,32 @@
+class LiteralFields {
+  mode "fa<[CURSOR]st" | "slow"
+  count 4<[CURSOR]2 | 100
+  enabled tr<[CURSOR]ue
+  empty nu<[CURSOR]ll
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_972_literal_values.baml:2:11
+// ```baml
+// "fast"
+// ```
+// An exact `string` literal type. Its base type is `string`.
+// hover at b_972_literal_values.baml:3:10
+// ```baml
+// 42
+// ```
+// An exact `int` literal type. Its base type is `int`.
+// hover at b_972_literal_values.baml:4:13
+// ```baml
+// true
+// ```
+// A boolean literal type. Its base type is `bool`.
+// hover at b_972_literal_values.baml:5:11
+// ```baml
+// null
+// ```
+// The `null` literal type. Its base type is `null`.

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_973_llm_function_arguments.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_973_llm_function_arguments.baml
@@ -1,0 +1,31 @@
+class Email {
+  subject string
+}
+
+client<llm> TestClient {
+  provider openai
+  options {
+    model "gpt-4o-mini"
+  }
+}
+
+function ClassifyEmail(em<[CURSOR]ail: Email) -> string {
+  client TestClient
+  prompt #"
+    Subject: {{ em<[CURSOR]ail.subject }}
+  "#
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_973_llm_function_arguments.baml:12:26
+// ```baml
+// email: Email
+// ```
+// hover at b_973_llm_function_arguments.baml:15:19
+// ```baml
+// email: Email
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_975_keywords.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_975_keywords.baml
@@ -1,0 +1,28 @@
+cl<[CURSOR]ass KeywordExample {
+  value string
+}
+
+fun<[CURSOR]ction UseKeywordExample(value: KeywordExample) -> string {
+  re<[CURSOR]turn value.value
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_975_keywords.baml:1:3
+// ```baml
+// class
+// ```
+// Defines a structured data type with named fields.
+// hover at b_975_keywords.baml:5:4
+// ```baml
+// function
+// ```
+// Declares a named callable with typed parameters and a return type.
+// hover at b_975_keywords.baml:6:5
+// ```baml
+// return
+// ```
+// Returns a value from the current function.

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_977_method_and_field_declarations.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_977_method_and_field_declarations.baml
@@ -1,0 +1,34 @@
+interface Named {
+  display_na<[CURSOR]me string
+  function dis<[CURSOR]play(self) -> string throws never
+}
+
+class Person {
+  na<[CURSOR]me string
+
+  function gree<[CURSOR]ting(self) -> string {
+    return self.name
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_977_method_and_field_declarations.baml:2:13
+// ```baml
+// display_name: string
+// ```
+// hover at b_977_method_and_field_declarations.baml:3:15
+// ```baml
+// function display(self) -> string throws never
+// ```
+// hover at b_977_method_and_field_declarations.baml:7:5
+// ```baml
+// name: string
+// ```
+// hover at b_977_method_and_field_declarations.baml:9:16
+// ```baml
+// function greeting(self) -> string throws never
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_978_interface_method_parameters.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_basic_hover/b_978_interface_method_parameters.baml
@@ -1,0 +1,17 @@
+interface Mapper<Input, Output> {
+  function map(se<[CURSOR]lf, va<[CURSOR]lue: Input) -> Output throws never
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// hover at b_978_interface_method_parameters.baml:2:18
+// ```baml
+// self: Self
+// ```
+// hover at b_978_interface_method_parameters.baml:2:24
+// ```baml
+// value: Input
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b979_interface_generics.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b979_interface_generics.baml
@@ -1,0 +1,19 @@
+interface Foo<T> {
+  function value(self) -> T throws never
+}
+
+function use(foo: Foo<int>) -> int {
+  let ignored = F<[CURSOR]oo
+  return foo.value()
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// (B-979: hovering an interface reference should include its generic parameters.)
+// hover at b979_interface_generics.baml:6:18
+// ```baml
+// interface Foo<T>
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b980_generic_bounds.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b980_generic_bounds.baml
@@ -1,0 +1,16 @@
+interface Foo<T> {
+  function value(self) -> T throws never
+}
+
+class Lore<[CURSOR]m<T extends Foo<int>> {}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// (B-980: hovering a generic class should include each type parameter's bound.)
+// hover at b980_generic_bounds.baml:5:11
+// ```baml
+// class Lorem<T extends Foo<int>> {}
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b981_typevar_hover.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b981_typevar_hover.baml
@@ -1,0 +1,24 @@
+interface Foo<T> {
+  function value(self) -> T throws never
+}
+
+class Lorem<<[CURSOR]T extends Foo<int>> {
+  value: <[CURSOR]T
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// (B-981: hovering T should show that it is Lorem's type parameter and is bounded by Foo<int>.)
+// hover at b981_typevar_hover.baml:5:13
+// ```baml
+// type parameter T extends Foo<int>
+// ```
+// Declared by `class Lorem`.
+// hover at b981_typevar_hover.baml:6:10
+// ```baml
+// type parameter T extends Foo<int>
+// ```
+// Declared by `class Lorem`.

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b983_item_access_shadowing.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b983_item_access_shadowing.baml
@@ -1,0 +1,19 @@
+class Lorem<T> {
+  a: T
+}
+
+function use(a: Lorem<int>) -> void {
+  let b: Lorem<int> = a
+  b.a<[CURSOR]
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// (B-983: hovering b.a should show the instantiated field type `a: int`, not the same-named parameter's type.)
+// hover at b983_item_access_shadowing.baml:7:6
+// ```baml
+// a: int
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b984_parameter_generics.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b984_parameter_generics.baml
@@ -1,0 +1,22 @@
+class Lorem<T> {
+  value: T
+}
+
+function use(<[CURSOR]a: Lorem<int>) -> void {
+  let b: Lorem<int> = <[CURSOR]a
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// (B-984: hovering a parameter reference should preserve the generic argument in `Lorem<int>`.)
+// hover at b984_parameter_generics.baml:5:14
+// ```baml
+// a: Lorem<int>
+// ```
+// hover at b984_parameter_generics.baml:6:23
+// ```baml
+// a: Lorem<int>
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b985_narrowed_binding.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b985_narrowed_binding.baml
@@ -1,0 +1,22 @@
+class Lorem<T> {}
+
+function use(a: int | Lorem<int>) -> void {
+  let b: int | Lorem<int> = a
+  match (b) {
+    int => {
+      let c: int = b<[CURSOR]
+    }
+    Lorem<int> => {}
+  }
+}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// (B-985: hovering b in the int match arm should show the narrowed `b: int` type.)
+// hover at b985_narrowed_binding.baml:7:21
+// ```baml
+// b: int
+// ```

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b986_implicit_throws_never.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/lsp_issues_generic_hover/b986_implicit_throws_never.baml
@@ -1,0 +1,12 @@
+function <[CURSOR]bar() -> void {}
+
+//----
+//- diagnostics
+// <no-diagnostics-expected>
+//
+//- on_hover expressions
+// (B-986: a non-throwing function hover should omit implicit `throws never`.)
+// hover at b986_implicit_throws_never.baml:1:10
+// ```baml
+// function bar() -> void
+// ```

--- a/baml_language/crates/baml_lsp_server/src/lib.rs
+++ b/baml_language/crates/baml_lsp_server/src/lib.rs
@@ -431,6 +431,36 @@ enum PlaygroundOpenTarget {
     Browser,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlaygroundExitSeverity {
+    Info,
+    Error,
+}
+
+fn playground_exit_severity(error: &anyhow::Error) -> PlaygroundExitSeverity {
+    if error
+        .downcast_ref::<playground_server::PlaygroundNotConfigured>()
+        .is_some()
+    {
+        PlaygroundExitSeverity::Info
+    } else {
+        PlaygroundExitSeverity::Error
+    }
+}
+
+fn log_playground_exit(error: &anyhow::Error) {
+    match playground_exit_severity(error) {
+        PlaygroundExitSeverity::Info => {
+            tracing::info!(
+                "Playground not configured; running without playground support: {error}"
+            );
+        }
+        PlaygroundExitSeverity::Error => {
+            tracing::error!("Playground server exited: {error}");
+        }
+    }
+}
+
 fn run_server_inner(
     playground_open_target: PlaygroundOpenTarget,
     workspace_roots: Vec<PathBuf>,
@@ -683,7 +713,7 @@ fn run_server_inner(
             )
             .await
             {
-                tracing::error!("Playground server exited: {e}");
+                log_playground_exit(&e);
             }
         });
     } else if matches!(playground_open_target, PlaygroundOpenTarget::Browser) {
@@ -988,6 +1018,21 @@ mod tests {
 
     fn framed(body: &str) -> Vec<u8> {
         format!("Content-Length: {}\r\n\r\n{body}", body.len()).into_bytes()
+    }
+
+    #[test]
+    fn missing_playground_configuration_is_not_an_error_exit() {
+        let unconfigured = anyhow::Error::new(playground_server::PlaygroundNotConfigured);
+        assert_eq!(
+            playground_exit_severity(&unconfigured),
+            PlaygroundExitSeverity::Info
+        );
+
+        let real_failure = anyhow::anyhow!("playground listener failed");
+        assert_eq!(
+            playground_exit_severity(&real_failure),
+            PlaygroundExitSeverity::Error
+        );
     }
 
     #[test]

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -60,6 +60,10 @@ use crate::{
     playground_ws::{RunListFilter, RunListKind, RunListVisibility, WsInMessage, WsOutMessage},
 };
 
+#[derive(Debug, thiserror::Error)]
+#[error("Playground server requires either BAML_PLAYGROUND_DEV_PORT or BAML_PLAYGROUND_DIR")]
+pub(crate) struct PlaygroundNotConfigured;
+
 fn to_ws_text(msg: &WsOutMessage) -> Option<AxumWsMsg> {
     match serde_json::to_string(msg) {
         Ok(json) => Some(AxumWsMsg::Text(json.into())),
@@ -1034,9 +1038,7 @@ fn build_router(
         tracing::info!("Playground: serving static files from {dir}");
         static_router(dir)
     } else {
-        anyhow::bail!(
-            "Playground server requires either BAML_PLAYGROUND_DEV_PORT or BAML_PLAYGROUND_DIR"
-        )
+        return Err(PlaygroundNotConfigured.into());
     };
 
     Ok(api.fallback_service(fallback))

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -1082,7 +1082,7 @@ mod tests {
             PrimitiveType::Pdf,
         ] {
             assert_eq!(
-                Ty::from_primitive(primitive.clone(), TyAttr::default()).to_string(),
+                Ty::from_primitive(primitive, TyAttr::default()).to_string(),
                 primitive.alias()
             );
         }

--- a/baml_language/crates/baml_type/src/names.rs
+++ b/baml_language/crates/baml_type/src/names.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use baml_base::Name;
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::PrimitiveType;
+use crate::{BuiltinTypeName, PrimitiveType};
 
 /// Which package a type is defined in. `Local` is the user's own (implicit
 /// root) package — the "current" package for everything a user writes;
@@ -242,18 +242,18 @@ impl QualifiedTypeName {
     /// such as `baml.json.JsonObject`).
     ///
     /// This is the single collapse rule used by the describe/hover canonical
-    /// type printer; it must stay in sync with
-    /// [`PrimitiveType::builtin_class_path`].
+    /// type printer and delegates to [`BuiltinTypeName`]'s registry.
     pub fn builtin_alias(&self) -> Option<&'static str> {
-        // `json` is the `baml.json.json` type alias, not a `PrimitiveType`.
-        if self.package().as_str() == "baml"
-            && self.namespace.len() == 1
-            && self.namespace[0].as_str() == "json"
-            && self.name.as_str() == "json"
-        {
-            return Some("json");
+        if self.package().as_str() != "baml" {
+            return None;
         }
-        self.builtin_primitive().map(|p| p.alias())
+        let path: Vec<&str> = self
+            .namespace
+            .iter()
+            .map(Name::as_str)
+            .chain(std::iter::once(self.name.as_str()))
+            .collect();
+        BuiltinTypeName::from_builtin_definition_path(&path).map(BuiltinTypeName::alias)
     }
 }
 
@@ -292,23 +292,11 @@ mod alias_tests {
 
     #[test]
     fn primitive_alias_class_path_roundtrips() {
-        for p in [
-            PrimitiveType::Int,
-            PrimitiveType::Bigint,
-            PrimitiveType::Float,
-            PrimitiveType::String,
-            PrimitiveType::Bool,
-            PrimitiveType::Null,
-            PrimitiveType::Uint8Array,
-            PrimitiveType::Image,
-            PrimitiveType::Audio,
-            PrimitiveType::Video,
-            PrimitiveType::Pdf,
-        ] {
+        for p in PrimitiveType::ALL {
             let path = p.builtin_class_path();
             assert_eq!(
                 PrimitiveType::from_builtin_class_path(path),
-                Some(p.clone()),
+                Some(p),
                 "round-trip failed for {p:?} via {path:?}"
             );
             // The alias matches the Display spelling.

--- a/baml_language/crates/baml_type/src/primitive.rs
+++ b/baml_language/crates/baml_type/src/primitive.rs
@@ -4,7 +4,9 @@ use std::fmt;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, BorshSerialize, BorshDeserialize,
+)]
 pub enum PrimitiveType {
     Int,
     Bigint,
@@ -20,6 +22,20 @@ pub enum PrimitiveType {
 }
 
 impl PrimitiveType {
+    pub const ALL: [PrimitiveType; 11] = [
+        PrimitiveType::Int,
+        PrimitiveType::Bigint,
+        PrimitiveType::Float,
+        PrimitiveType::Bool,
+        PrimitiveType::Null,
+        PrimitiveType::String,
+        PrimitiveType::Uint8Array,
+        PrimitiveType::Image,
+        PrimitiveType::Audio,
+        PrimitiveType::Video,
+        PrimitiveType::Pdf,
+    ];
+
     /// Map primitives with builtin companion classes to their class path in the `baml` package.
     ///
     /// Media primitives (`image`, `audio`, `video`, `pdf`) have corresponding
@@ -70,29 +86,126 @@ impl PrimitiveType {
         }
     }
 
+    /// Resolve a lowercase source spelling to its semantic primitive.
+    pub fn from_alias(alias: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|primitive| primitive.alias() == alias)
+    }
+
     /// Inverse of [`builtin_class_path`](Self::builtin_class_path): map a class
     /// path (relative to the `baml` package, e.g. `["media", "Image"]`) back to
     /// the primitive it is the companion class for.
     pub fn from_builtin_class_path(path: &[&str]) -> Option<Self> {
-        const ALL: [PrimitiveType; 11] = [
-            PrimitiveType::Int,
-            PrimitiveType::Bigint,
-            PrimitiveType::Float,
-            PrimitiveType::Bool,
-            PrimitiveType::Null,
-            PrimitiveType::String,
-            PrimitiveType::Uint8Array,
-            PrimitiveType::Image,
-            PrimitiveType::Audio,
-            PrimitiveType::Video,
-            PrimitiveType::Pdf,
-        ];
-        ALL.into_iter().find(|p| p.builtin_class_path() == path)
+        Self::ALL
+            .into_iter()
+            .find(|primitive| primitive.builtin_class_path() == path)
     }
 }
 
 impl fmt::Display for PrimitiveType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.alias())
+    }
+}
+
+/// A built-in source-level type name.
+///
+/// Primitive values have companion classes in the `baml` package. `json` is a
+/// stdlib type alias, while `void`, `never`, and `unknown` are compiler
+/// intrinsics with no addressable definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuiltinTypeName {
+    Primitive(PrimitiveType),
+    Json,
+    Void,
+    Never,
+    Unknown,
+}
+
+impl BuiltinTypeName {
+    pub fn from_alias(alias: &str) -> Option<Self> {
+        if let Some(primitive) = PrimitiveType::from_alias(alias) {
+            return Some(Self::Primitive(primitive));
+        }
+        Some(match alias {
+            "json" => Self::Json,
+            "void" => Self::Void,
+            "never" => Self::Never,
+            "unknown" => Self::Unknown,
+            _ => return None,
+        })
+    }
+
+    pub fn alias(self) -> &'static str {
+        match self {
+            Self::Primitive(primitive) => primitive.alias(),
+            Self::Json => "json",
+            Self::Void => "void",
+            Self::Never => "never",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// The path of this type's definition relative to the `baml` package.
+    ///
+    /// Compiler intrinsics deliberately return `None`: their documentation is
+    /// supplied by the language-topic registry instead.
+    pub fn builtin_definition_path(self) -> Option<&'static [&'static str]> {
+        match self {
+            Self::Primitive(primitive) => Some(primitive.builtin_class_path()),
+            Self::Json => Some(&["json", "json"]),
+            Self::Void | Self::Never | Self::Unknown => None,
+        }
+    }
+
+    pub fn from_builtin_definition_path(path: &[&str]) -> Option<Self> {
+        if path == ["json", "json"] {
+            return Some(Self::Json);
+        }
+        PrimitiveType::from_builtin_class_path(path).map(Self::Primitive)
+    }
+}
+
+impl fmt::Display for BuiltinTypeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.alias())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_aliases_roundtrip() {
+        for primitive in PrimitiveType::ALL {
+            assert_eq!(
+                PrimitiveType::from_alias(primitive.alias()),
+                Some(primitive)
+            );
+        }
+        assert_eq!(PrimitiveType::from_alias("void"), None);
+    }
+
+    #[test]
+    fn builtin_type_names_distinguish_definitions_from_intrinsics() {
+        assert_eq!(
+            BuiltinTypeName::from_alias("string")
+                .and_then(BuiltinTypeName::builtin_definition_path),
+            Some(&["String"][..])
+        );
+        assert_eq!(
+            BuiltinTypeName::from_alias("json").and_then(BuiltinTypeName::builtin_definition_path),
+            Some(&["json", "json"][..])
+        );
+        assert_eq!(
+            BuiltinTypeName::from_alias("never").and_then(BuiltinTypeName::builtin_definition_path),
+            None
+        );
+        assert_eq!(
+            BuiltinTypeName::from_builtin_definition_path(&["json", "json"]),
+            Some(BuiltinTypeName::Json)
+        );
     }
 }

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
@@ -193,6 +193,11 @@ struct BexMulitProject {
     /// before negotiation never freezes a default.
     negotiated_encoding: std::sync::Arc<OnceLock<PositionEncoding>>,
 
+    /// Whether the client advertised completion-item snippet support during
+    /// `initialize`. Connection-scoped because capabilities belong to one
+    /// client session.
+    snippet_support: std::sync::Arc<OnceLock<bool>>,
+
     /// Workspace root directories provided by the LSP client during
     /// `initialize`. Used by `on_notification_initialized` to scope
     /// project discovery instead of walking the entire filesystem.
@@ -306,6 +311,7 @@ impl BexMulitProject {
             sender,
             playground_sender,
             negotiated_encoding: std::sync::Arc::new(OnceLock::new()),
+            snippet_support: std::sync::Arc::new(OnceLock::new()),
             workspace_roots: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             fs,
             spawner,
@@ -317,10 +323,10 @@ impl BexMulitProject {
     }
 
     /// Connection-scoped dispatcher: shares the process-owned project
-    /// registry (and everything hanging off it) but owns a fresh
-    /// position-encoding negotiation, fresh initialize workspace
-    /// roots, and a fresh semantic-token delta cache (encoding-dependent),
-    /// and writes only through the connection's revocable `sender`.
+    /// registry (and everything hanging off it) but owns fresh capability
+    /// negotiation, fresh initialize workspace roots, and a fresh
+    /// semantic-token delta cache (encoding-dependent), and writes only
+    /// through the connection's revocable `sender`.
     /// After browser takeover revokes that sender, a retained clone of
     /// this session fails `send_*` with `ClientClosed` instead of leaking
     /// into the replacement session.
@@ -331,6 +337,7 @@ impl BexMulitProject {
         let mut session = self.clone();
         session.sender = sender;
         session.negotiated_encoding = std::sync::Arc::new(OnceLock::new());
+        session.snippet_support = std::sync::Arc::new(OnceLock::new());
         session.workspace_roots = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         session.semantic_tokens_cache =
             std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
@@ -375,6 +382,33 @@ impl BexMulitProject {
             .negotiated_encoding
             .get()
             .expect("negotiated encoding was just set")
+    }
+
+    fn negotiate_snippet_support(
+        &self,
+        client_capabilities: &lsp_types::ClientCapabilities,
+    ) -> bool {
+        let supported = client_capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.completion.as_ref())
+            .and_then(|completion| completion.completion_item.as_ref())
+            .and_then(|completion_item| completion_item.snippet_support)
+            .unwrap_or(false);
+        // First negotiation wins; a duplicate initialize cannot flip it.
+        let _ = self.snippet_support.set(supported);
+        *self
+            .snippet_support
+            .get()
+            .expect("snippet support was just set")
+    }
+
+    fn snippet_support_for_request(&self) -> Result<bool, LspError> {
+        self.snippet_support.get().copied().ok_or_else(|| {
+            LspError::ServerNotInitialized(
+                "completion capabilities have not been negotiated yet".to_string(),
+            )
+        })
     }
 
     fn get_path_from_uri(&self, uri: &lsp_types::Url) -> Result<vfs::VfsPath, LspError> {
@@ -2347,7 +2381,7 @@ mod tests {
     }
 
     /// A connection-scoped session shares the project registry but owns its
-    /// own encoding negotiation and workspace roots and routes output
+    /// own capability negotiation and workspace roots and routes output
     /// through its own sender.
     #[test]
     fn connection_scoped_session_is_fresh_but_shares_projects() {
@@ -2366,6 +2400,18 @@ mod tests {
         let _ = root
             .negotiated_encoding
             .set(crate::bex_lsp::position_codec::PositionEncoding::UTF8);
+        let snippet_capabilities = serde_json::from_value(serde_json::json!({
+            "textDocument": {
+                "completion": {
+                    "completionItem": {
+                        "snippetSupport": true
+                    }
+                }
+            }
+        }))
+        .expect("valid client capabilities");
+        assert!(root.negotiate_snippet_support(&snippet_capabilities));
+        assert!(root.snippet_support_for_request().unwrap());
         root.workspace_roots
             .lock()
             .unwrap()
@@ -2385,6 +2431,13 @@ mod tests {
         // entries are encoded per-connection); shared project registry and
         // result-id sequence.
         assert!(session.negotiated_encoding.get().is_none());
+        assert!(session.snippet_support.get().is_none());
+        assert!(matches!(
+            session.snippet_support_for_request(),
+            Err(LspError::ServerNotInitialized(_))
+        ));
+        assert!(!session.negotiate_snippet_support(&lsp_types::ClientCapabilities::default()));
+        assert!(!session.snippet_support_for_request().unwrap());
         assert!(session.workspace_roots.lock().unwrap().is_empty());
         assert!(session.semantic_tokens_cache.lock().unwrap().is_empty());
         assert!(Arc::ptr_eq(&session.projects, &root.projects));

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -154,6 +154,7 @@ impl BexLspRequest for BexMulitProject {
         // Negotiate the position encoding first: UTF-8 when offered,
         // UTF-16 baseline otherwise. Everything after this reads the cell.
         let encoding = self.negotiate_encoding(&params.capabilities);
+        let snippet_support = self.negotiate_snippet_support(&params.capabilities);
 
         let mut roots = Vec::new();
 
@@ -175,9 +176,10 @@ impl BexLspRequest for BexMulitProject {
         }
 
         tracing::info!(
-            "Workspace roots: {:?}; position encoding: {:?}",
+            "Workspace roots: {:?}; position encoding: {:?}; snippet support: {}",
             roots.iter().map(vfs::VfsPath::as_str).collect::<Vec<_>>(),
             encoding,
+            snippet_support,
         );
 
         *self.workspace_roots.lock().unwrap() = roots;
@@ -537,8 +539,6 @@ impl BexLspRequest for BexMulitProject {
         &self,
         params: lsp_request_params!("textDocument/completion"),
     ) -> Result<lsp_request_result!("textDocument/completion"), LspError> {
-        use lsp_types::CompletionItemKind;
-
         // Use compiler2 completions_at — context-aware completions from CST + HIR/TIR.
         let completions = self.compute_on_position(
             &params.text_document_position,
@@ -546,42 +546,10 @@ impl BexLspRequest for BexMulitProject {
         )?;
 
         // Convert domain Completion → LSP CompletionItem.
+        let snippet_support = self.snippet_support_for_request()?;
         let items: Vec<_> = completions
             .into_iter()
-            .map(|item| lsp_types::CompletionItem {
-                label: item.label,
-                kind: Some(match item.kind {
-                    baml_lsp2_actions::CompletionKind::Keyword => CompletionItemKind::KEYWORD,
-                    baml_lsp2_actions::CompletionKind::Function => CompletionItemKind::FUNCTION,
-                    baml_lsp2_actions::CompletionKind::Class => CompletionItemKind::CLASS,
-                    baml_lsp2_actions::CompletionKind::Enum => CompletionItemKind::ENUM,
-                    baml_lsp2_actions::CompletionKind::EnumVariant => {
-                        CompletionItemKind::ENUM_MEMBER
-                    }
-                    baml_lsp2_actions::CompletionKind::Field => CompletionItemKind::FIELD,
-                    baml_lsp2_actions::CompletionKind::Variable => CompletionItemKind::VARIABLE,
-                    baml_lsp2_actions::CompletionKind::Primitive => {
-                        CompletionItemKind::TYPE_PARAMETER
-                    }
-                    baml_lsp2_actions::CompletionKind::TypeAlias => {
-                        CompletionItemKind::TYPE_PARAMETER
-                    }
-                    baml_lsp2_actions::CompletionKind::TemplateString => {
-                        CompletionItemKind::FUNCTION
-                    }
-                    baml_lsp2_actions::CompletionKind::Client => CompletionItemKind::MODULE,
-                    baml_lsp2_actions::CompletionKind::Generator => CompletionItemKind::MODULE,
-                    baml_lsp2_actions::CompletionKind::Test => CompletionItemKind::METHOD,
-                    baml_lsp2_actions::CompletionKind::RetryPolicy => CompletionItemKind::MODULE,
-                    baml_lsp2_actions::CompletionKind::Method => CompletionItemKind::METHOD,
-                    baml_lsp2_actions::CompletionKind::Module => CompletionItemKind::MODULE,
-                    baml_lsp2_actions::CompletionKind::Parameter => CompletionItemKind::FIELD,
-                }),
-                detail: item.detail,
-                insert_text: item.insert_text,
-                sort_text: item.sort_text,
-                ..Default::default()
-            })
+            .map(|item| completion_to_lsp(item, snippet_support))
             .collect();
 
         if items.is_empty() {
@@ -903,6 +871,52 @@ impl BexLspRequest for BexMulitProject {
     }
 }
 
+fn completion_to_lsp(
+    item: baml_lsp2_actions::Completion,
+    snippet_support: bool,
+) -> lsp_types::CompletionItem {
+    use lsp_types::{CompletionItemKind, InsertTextFormat};
+
+    let (insert_text, insert_text_format) = match item.insert_text_format {
+        baml_lsp2_actions::CompletionInsertTextFormat::Snippet if !snippet_support => (None, None),
+        baml_lsp2_actions::CompletionInsertTextFormat::PlainText => {
+            (item.insert_text, Some(InsertTextFormat::PLAIN_TEXT))
+        }
+        baml_lsp2_actions::CompletionInsertTextFormat::Snippet => {
+            (item.insert_text, Some(InsertTextFormat::SNIPPET))
+        }
+    };
+
+    lsp_types::CompletionItem {
+        label: item.label,
+        kind: Some(match item.kind {
+            baml_lsp2_actions::CompletionKind::Keyword => CompletionItemKind::KEYWORD,
+            baml_lsp2_actions::CompletionKind::Function => CompletionItemKind::FUNCTION,
+            baml_lsp2_actions::CompletionKind::Class => CompletionItemKind::CLASS,
+            baml_lsp2_actions::CompletionKind::Enum => CompletionItemKind::ENUM,
+            baml_lsp2_actions::CompletionKind::EnumVariant => CompletionItemKind::ENUM_MEMBER,
+            baml_lsp2_actions::CompletionKind::Field => CompletionItemKind::FIELD,
+            baml_lsp2_actions::CompletionKind::Variable => CompletionItemKind::VARIABLE,
+            baml_lsp2_actions::CompletionKind::Primitive
+            | baml_lsp2_actions::CompletionKind::TypeAlias => CompletionItemKind::TYPE_PARAMETER,
+            baml_lsp2_actions::CompletionKind::TemplateString => CompletionItemKind::FUNCTION,
+            baml_lsp2_actions::CompletionKind::Client
+            | baml_lsp2_actions::CompletionKind::Generator
+            | baml_lsp2_actions::CompletionKind::RetryPolicy
+            | baml_lsp2_actions::CompletionKind::Module => CompletionItemKind::MODULE,
+            baml_lsp2_actions::CompletionKind::Test | baml_lsp2_actions::CompletionKind::Method => {
+                CompletionItemKind::METHOD
+            }
+            baml_lsp2_actions::CompletionKind::Parameter => CompletionItemKind::FIELD,
+        }),
+        detail: item.detail,
+        insert_text,
+        insert_text_format,
+        sort_text: item.sort_text,
+        ..Default::default()
+    }
+}
+
 /// Delta-encode classified tokens through the connection's negotiated codec
 /// into the LSP wire format. `delta_start` and `length` are in negotiated code
 /// units, not bytes. Shared by the `full` and `range` requests.
@@ -1211,5 +1225,31 @@ mod tests {
             server_capabilities(PositionEncoding::UTF16).position_encoding,
             Some(lsp_types::PositionEncodingKind::UTF16)
         );
+    }
+
+    #[test]
+    fn completion_conversion_preserves_snippet_format() {
+        let completion = baml_lsp2_actions::Completion {
+            label: "function".to_string(),
+            kind: baml_lsp2_actions::CompletionKind::Keyword,
+            detail: Some("function declaration".to_string()),
+            insert_text: Some("function ${1:Name}() {\n  $0\n}".to_string()),
+            insert_text_format: baml_lsp2_actions::CompletionInsertTextFormat::Snippet,
+            sort_text: Some("02_function".to_string()),
+        };
+        let item = completion_to_lsp(completion.clone(), true);
+
+        assert_eq!(
+            item.insert_text.as_deref(),
+            Some("function ${1:Name}() {\n  $0\n}")
+        );
+        assert_eq!(
+            item.insert_text_format,
+            Some(lsp_types::InsertTextFormat::SNIPPET)
+        );
+
+        let item = completion_to_lsp(completion, false);
+        assert_eq!(item.insert_text, None);
+        assert_eq!(item.insert_text_format, None);
     }
 }


### PR DESCRIPTION
## Summary

- add exhaustive regression coverage for the 22 concrete LSP issues tracked under B-1022, with 21 reproduced and fixed and B-966 verified already fixed on current backtick-template syntax
- extend hover resolution across literals, primitives, keywords, config keys, schema attributes, authored declarations, LLM parameters, inferred members, narrowed locals, generics, bounds, type variables, and explicit `throws never`
- centralize builtin type aliases, schema attributes, client configuration keys, and language/keyword documentation in shared registries consumed by validation, the CLI, and the LSP
- expose builtin aliases and intrinsic language topics through `baml describe`, including `baml describe alias`
- specialize member completion details with receiver generic arguments
- add top-level declaration snippets and preserve snippet format through the LSP conversion boundary
- classify missing standalone playground configuration as an expected `INFO` condition while preserving `ERROR` for real playground failures

## Reproduction coverage

The new `baml_lsp2_actions_tests` fixtures cover B-966 through B-986, including the cross-project B-972 issue. B-982 uses a direct action-level completion assertion because the fixture DSL only asserts completion labels. B-1001 is below the action boundary, so it has server unit coverage plus an exact process-level verification.

No characterization-only assertions remain: every reproduced action issue is committed as a positive regression.

## Validation

- `cargo fmt --all --check`
- `cargo check -p baml_base -p baml_type -p baml_builtins2 -p baml_compiler2_hir -p baml_lsp2_actions -p baml_cli`
- `cargo clippy -p baml_base -p baml_type -p baml_builtins2 -p baml_compiler2_hir -p baml_lsp2_actions --lib -- -D warnings`
- `cargo test -p baml_type --lib`
- `cargo test -p baml_builtins2 --lib`
- `cargo test -p baml_lsp2_actions --lib`
- `cargo test -p baml_lsp2_actions_tests --lib lsp_issues_basic_hover`
- `cargo test -p baml_cli --lib describe_command_tests`
- targeted `baml_tests` coverage for duplicate attributes and attribute validation
- standalone `baml-cli lsp` reproduction exits 0 and logs absent playground configuration at `INFO`, with no false `ERROR`

Tracks Linear B-1022 and its concrete LSP issue inventory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Top-level completion keywords now insert editable snippet templates.
  - Completion items now indicate whether inserted text is plain text or a snippet.
  - Hover/type-info rendering is more precise and cursor-aware, including improved generic field/member detail, symbol/keyword documentation, and consistent `throws never` signatures.
- **Bug Fixes**
  - Playground startup “not configured” is now treated as informational instead of an error.
- **Tests**
  - Added/expanded LSP tests covering snippet completion insertion, cursor-sensitive hover behavior, and generic instantiation correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes B-1022