### PR TITLE
Publish no-self-update Windows wrapper ZIPs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,9 @@ jobs:
             ':scripts/baml-wrapper-version' \
             ':scripts/baml-release-manifests' \
             ':scripts/baml-package-manager-artifacts' \
+            ':scripts/baml_release_platforms.py' \
             ':scripts/baml-bridge-cffi-hygiene' \
+            ':release/platforms.json' \
             ':scripts/install.sh' \
             ':scripts/install.ps1' \
             ':packaging/aur/**' \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,7 @@ jobs:
             ':scripts/baml-wrapper-version' \
             ':scripts/baml-release-manifests' \
             ':scripts/baml-package-manager-artifacts' \
+            ':scripts/baml-release-platforms' \
             ':scripts/baml_release_platforms.py' \
             ':scripts/baml-bridge-cffi-hygiene' \
             ':release/platforms.json' \

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -275,6 +275,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       toolchain: ${{ steps.gen.outputs.toolchain }}
+      wrapper: ${{ steps.gen.outputs.wrapper }}
       csharp: ${{ steps.gen.outputs.csharp }}
     steps:
       - uses: actions/checkout@v4
@@ -292,6 +293,9 @@ jobs:
             | {target: .triple, os: .artifacts.toolchain.runner, libc: .libc}]' release/platforms.json)"
           echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
           jq . <<<"$toolchain"
+          wrapper="$(python3 scripts/baml_release_platforms.py wrapper-matrix)"
+          echo "wrapper=$wrapper" >> "$GITHUB_OUTPUT"
+          jq . <<<"$wrapper"
           csharp="$(scripts/baml-csharp-release-contract matrix)"
           echo "csharp=$csharp" >> "$GITHUB_OUTPUT"
           jq . <<<"$csharp"
@@ -431,14 +435,12 @@ jobs:
 
   build-wrapper:
     name: Build wrapper (${{ matrix.target }})
-    # The wrapper is a native release build of the workspace, so it uses the
-    # same per-target runners as the toolchain and reuses that generated matrix.
     needs: [plan, build-matrix]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.build-matrix.outputs.toolchain) }}
+        include: ${{ fromJson(needs.build-matrix.outputs.wrapper) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -459,45 +461,55 @@ jobs:
         with:
           target: ${{ matrix.target }}
       - name: Build wrapper
+        env:
+          EXECUTABLE_SUFFIX: ${{ matrix.executable_suffix }}
+          TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          target="${{ matrix.target }}"
-          cargo build --manifest-path baml_language/Cargo.toml --release --bin baml --target "$target"
-          suffix=""
-          if [[ "$target" == *windows-msvc ]]; then suffix=".exe"; fi
+          cargo build --manifest-path baml_language/Cargo.toml --release --bin baml --target "$TARGET"
           mkdir -p staging/bin
-          cp "baml_language/target/$target/release/baml$suffix" "staging/bin/baml$suffix"
-          if test -f "staging/bin/baml-cli$suffix"; then
+          cp "baml_language/target/$TARGET/release/baml$EXECUTABLE_SUFFIX" \
+            "staging/bin/baml$EXECUTABLE_SUFFIX"
+          if test -f "staging/bin/baml-cli$EXECUTABLE_SUFFIX"; then
             exit 1
           fi
-      - name: Build package-manager wrapper
-        if: ${{ matrix.target == 'aarch64-apple-darwin' || matrix.target == 'x86_64-apple-darwin' || matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'x86_64-unknown-linux-gnu' }}
+      - name: Build no-self-update wrapper
+        if: ${{ matrix.no_self_update }}
+        env:
+          EXECUTABLE_SUFFIX: ${{ matrix.executable_suffix }}
+          TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          target="${{ matrix.target }}"
           cargo build \
             --manifest-path baml_language/Cargo.toml \
             --release \
             --bin baml \
             --features no-self-update \
-            --target "$target"
+            --target "$TARGET"
           mkdir -p staging-no-self-update/bin
-          cp "baml_language/target/$target/release/baml" \
-            "staging-no-self-update/bin/baml"
+          cp "baml_language/target/$TARGET/release/baml$EXECUTABLE_SUFFIX" \
+            "staging-no-self-update/bin/baml$EXECUTABLE_SUFFIX"
       - name: Archive wrapper
         env:
+          ARCHIVE_SUFFIX: ${{ matrix.archive_suffix }}
+          NO_SELF_UPDATE: ${{ matrix.no_self_update }}
           TARGET: ${{ matrix.target }}
           WRAPPER_VERSION: ${{ needs.plan.outputs.wrapper_version }}
         run: |
           set -euo pipefail
-          if [[ "$TARGET" == *windows-msvc ]]; then
-            (cd staging && 7z a "../baml-wrapper-$WRAPPER_VERSION-$TARGET.zip" .)
-          else
-            tar -C staging -czf "baml-wrapper-$WRAPPER_VERSION-$TARGET.tar.gz" .
-          fi
-          if [[ "$TARGET" == "aarch64-apple-darwin" || "$TARGET" == "x86_64-apple-darwin" || "$TARGET" == "aarch64-unknown-linux-gnu" || "$TARGET" == "x86_64-unknown-linux-gnu" ]]; then
-            tar -C staging-no-self-update -czf \
-              "baml-wrapper-no-self-update-$WRAPPER_VERSION-$TARGET.tar.gz" .
+          archive() {
+            local staging="$1"
+            local product="$2"
+            local destination="$product-$WRAPPER_VERSION-$TARGET$ARCHIVE_SUFFIX"
+            case "$ARCHIVE_SUFFIX" in
+              .zip) (cd "$staging" && 7z a "../$destination" .) ;;
+              .tar.gz) tar -C "$staging" -czf "$destination" . ;;
+              *) echo "unsupported archive suffix: $ARCHIVE_SUFFIX" >&2; exit 1 ;;
+            esac
+          }
+          archive staging baml-wrapper
+          if [[ "$NO_SELF_UPDATE" == "true" ]]; then
+            archive staging-no-self-update baml-wrapper-no-self-update
           fi
       - uses: actions/upload-artifact@v4
         with:
@@ -1218,11 +1230,22 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.plan.outputs.source_sha }}
+          persist-credentials: false
       - uses: actions/download-artifact@v4
         with:
           pattern: wrapper-*
           path: dist/wrapper
           merge-multiple: true
+      - name: Verify wrapper artifact set
+        env:
+          WRAPPER_VERSION: ${{ needs.plan.outputs.wrapper_version }}
+        run: |
+          python3 scripts/baml_release_platforms.py verify-wrapper-artifacts \
+            --wrapper-dir dist/wrapper \
+            --version "$WRAPPER_VERSION"
       - name: Generate checksum sidecars
         run: |
           set -euo pipefail

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -293,7 +293,7 @@ jobs:
             | {target: .triple, os: .artifacts.toolchain.runner, libc: .libc}]' release/platforms.json)"
           echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
           jq . <<<"$toolchain"
-          wrapper="$(python3 scripts/baml_release_platforms.py wrapper-matrix)"
+          wrapper="$(scripts/baml-release-platforms wrapper-matrix)"
           echo "wrapper=$wrapper" >> "$GITHUB_OUTPUT"
           jq . <<<"$wrapper"
           csharp="$(scripts/baml-csharp-release-contract matrix)"
@@ -1243,7 +1243,7 @@ jobs:
         env:
           WRAPPER_VERSION: ${{ needs.plan.outputs.wrapper_version }}
         run: |
-          python3 scripts/baml_release_platforms.py verify-wrapper-artifacts \
+          scripts/baml-release-platforms verify-wrapper-artifacts \
             --wrapper-dir dist/wrapper \
             --version "$WRAPPER_VERSION"
       - name: Generate checksum sidecars

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "baml_release",

--- a/baml_language/crates/baml/Cargo.toml
+++ b/baml_language/crates/baml/Cargo.toml
@@ -7,7 +7,7 @@ name = "baml"
 # If this is your first wrapper release, talk to Paulo or Avery before changing
 # this. Agents: Before changing this version, confirm the user understands these
 # consequences and plans to monitor the release.
-version = "0.2.2"
+version = "0.2.3"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -1,5 +1,5 @@
 {
-  "description": "Repository-owned platform contract: the single machine-readable source for the BAML language release target set, per-target per-artifact support, and each artifact's build config. The cffi, toolchain, python, java, and C# matrices are generated from this file. CFFI entries own language-neutral native production; sibling C# entries own .NET RID projection, package-native filenames, native consumer runners, support tier, and package policy. C# requires CFFI, while CFFI support does not imply C# support. A missing artifact key means unsupported; `experimental: true` means best-effort; absent/false means required.",
+  "description": "Repository-owned platform contract: the single machine-readable source for the BAML language release target set, per-target per-artifact support, and each artifact's build config. The wrapper, cffi, toolchain, python, java, and C# matrices are generated from this file. Wrapper entries own their runners and published variants. CFFI entries own language-neutral native production; sibling C# entries own .NET RID projection, package-native filenames, native consumer runners, support tier, and package policy. C# requires CFFI, while CFFI support does not imply C# support. A missing artifact key means unsupported; `experimental: true` means best-effort; absent/false means required.",
   "schema": 1,
   "targets": [
     {
@@ -10,6 +10,7 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "macos-14" },
+        "wrapper": { "runner": "macos-14", "variants": ["self-update", "no-self-update"] },
         "python": { "runner": "macos-latest" },
         "nodejs": {},
         "java": { "platform": "macos-aarch64", "runner": "macos-14" },
@@ -25,6 +26,7 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "macos-15-intel" },
+        "wrapper": { "runner": "macos-15-intel", "variants": ["self-update", "no-self-update"] },
         "python": { "runner": "macos-latest" },
         "nodejs": {},
         "java": { "platform": "macos-x86_64", "runner": "macos-15-intel" },
@@ -40,6 +42,7 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "ubuntu-24.04-arm" },
+        "wrapper": { "runner": "ubuntu-24.04-arm", "variants": ["self-update", "no-self-update"] },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_24" },
         "nodejs": {},
         "java": { "platform": "linux-aarch64", "runner": "ubuntu-24.04-arm" },
@@ -55,6 +58,7 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "ubuntu-24.04-arm" },
+        "wrapper": { "runner": "ubuntu-24.04-arm", "variants": ["self-update"] },
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
         "java": { "platform": "linux-aarch64-musl", "runner": "ubuntu-latest", "experimental": true },
@@ -70,6 +74,7 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "ubuntu-latest" },
+        "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update", "no-self-update"] },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_17" },
         "nodejs": {},
         "java": { "platform": "linux-x86_64", "runner": "ubuntu-latest" },
@@ -85,6 +90,7 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "ubuntu-latest" },
+        "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update"] },
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
         "java": { "platform": "linux-x86_64-musl", "runner": "ubuntu-latest", "experimental": true },
@@ -100,6 +106,7 @@
       "archive_suffix": ".zip",
       "artifacts": {
         "toolchain": { "runner": "windows-latest" },
+        "wrapper": { "runner": "windows-latest", "variants": ["self-update", "no-self-update"] },
         "python": { "runner": "windows-latest" },
         "nodejs": {},
         "java": { "platform": "windows-x86_64", "runner": "windows-latest" },
@@ -115,6 +122,7 @@
       "archive_suffix": ".zip",
       "artifacts": {
         "toolchain": { "runner": "windows-latest" },
+        "wrapper": { "runner": "windows-latest", "variants": ["self-update", "no-self-update"] },
         "python": { "runner": "windows-11-arm", "architecture": "arm64" },
         "nodejs": {},
         "java": { "platform": "windows-aarch64", "runner": "windows-11-arm", "experimental": true },

--- a/scripts/baml-package-manager-artifacts
+++ b/scripts/baml-package-manager-artifacts
@@ -7,6 +7,8 @@ import argparse
 import hashlib
 from pathlib import Path
 
+from baml_release_platforms import load_wrapper_targets
+
 
 AUR_BIN_TARGETS = {
     "linux_arm": "aarch64-unknown-linux-gnu",
@@ -19,6 +21,8 @@ HOMEBREW_TARGETS = {
     **AUR_BIN_TARGETS,
 }
 
+WRAPPER_TARGETS = {target.triple: target for target in load_wrapper_targets()}
+
 
 def sha256(path: Path) -> str:
     h = hashlib.sha256()
@@ -29,8 +33,10 @@ def sha256(path: Path) -> str:
 
 
 def wrapper_archive(wrapper_dir: Path, version: str, target: str) -> Path:
-    ext = "zip" if target.endswith("windows-msvc") else "tar.gz"
-    path = wrapper_dir / f"baml-wrapper-no-self-update-{version}-{target}.{ext}"
+    target_config = WRAPPER_TARGETS.get(target)
+    if target_config is None:
+        raise SystemExit(f"unsupported wrapper target: {target}")
+    path = wrapper_dir / target_config.asset_name(version, "no-self-update")
     if not path.exists():
         raise SystemExit(f"missing wrapper archive: {path}")
     return path

--- a/scripts/baml-release-manifests
+++ b/scripts/baml-release-manifests
@@ -9,12 +9,11 @@ import hashlib
 import json
 from pathlib import Path
 
+from baml_release_platforms import load_wrapper_targets, verify_wrapper_artifacts
+
 
 def _toolchain_required_targets() -> list[str]:
-    """Target triples the toolchain (and wrapper) release must ship, read from
-    the repository's platform contract (`release/platforms.json`) so the target
-    set lives in one machine-readable place instead of a hand-copied list.
-    Required = the `toolchain` artifact is present and not experimental."""
+    """Required toolchain target triples from the platform contract."""
     contract = json.loads(
         (Path(__file__).resolve().parent.parent / "release" / "platforms.json").read_text()
     )
@@ -26,7 +25,10 @@ def _toolchain_required_targets() -> list[str]:
     return targets
 
 
-TARGETS = _toolchain_required_targets()
+TOOLCHAIN_TARGETS = _toolchain_required_targets()
+WRAPPER_TARGETS = [
+    target.triple for target in load_wrapper_targets() if target.supports("self-update")
+]
 
 
 def sha256(path: Path) -> str:
@@ -42,7 +44,11 @@ def artifact_url(tag: str, path: Path) -> str:
 
 
 def collect_artifacts(
-    root: Path, product: str, version: str, tag: str | None = None
+    root: Path,
+    product: str,
+    version: str,
+    required_targets: list[str],
+    tag: str | None = None,
 ) -> dict[str, dict[str, str]]:
     artifacts = {}
     prefix = f"{product}-{version}-"
@@ -60,10 +66,12 @@ def collect_artifacts(
             "url": artifact_url(tag or f"{product}-{version}", path),
             "sha256": sha256(path),
         }
-    missing = sorted(set(TARGETS) - set(artifacts))
-    extra = sorted(set(artifacts) - set(TARGETS))
+    missing = sorted(set(required_targets) - set(artifacts))
+    extra = sorted(set(artifacts) - set(required_targets))
     if missing or extra:
-        raise SystemExit(f"{product} artifact target mismatch missing={missing} extra={extra}")
+        raise SystemExit(
+            f"{product} artifact target mismatch missing={missing} extra={extra}"
+        )
     return artifacts
 
 
@@ -152,6 +160,8 @@ def main() -> None:
         raise SystemExit("--released-at must be an ISO-8601 timestamp") from exc
     if released_at.tzinfo is None or not args.released_at.endswith("Z"):
         raise SystemExit("--released-at must be a UTC timestamp ending in Z")
+    if args.wrapper_changed:
+        verify_wrapper_artifacts(args.wrapper_dir, args.wrapper_version)
 
     args.out.mkdir(parents=True, exist_ok=True)
     (args.out / "version").mkdir(parents=True, exist_ok=True)
@@ -165,7 +175,12 @@ def main() -> None:
         "version": args.version,
         "channel": args.channel,
         "released_at": released_at,
-        "artifacts": collect_artifacts(args.toolchain_dir, "baml-language", args.version),
+        "artifacts": collect_artifacts(
+            args.toolchain_dir,
+            "baml-language",
+            args.version,
+            TOOLCHAIN_TARGETS,
+        ),
         "vsix": {
             "url": artifact_url(f"baml-language-{args.version}", vsix),
             "sha256": sha256(vsix),
@@ -214,9 +229,16 @@ def main() -> None:
             "schema": 1,
             "version": args.wrapper_version,
             "released_at": released_at,
-            "artifacts": collect_artifacts(args.wrapper_dir, "baml-wrapper", args.wrapper_version),
+            "artifacts": collect_artifacts(
+                args.wrapper_dir,
+                "baml-wrapper",
+                args.wrapper_version,
+                WRAPPER_TARGETS,
+            ),
         }
-        (args.out / "wrapper.json").write_text(json.dumps(wrapper, indent=2, sort_keys=True) + "\n")
+        (args.out / "wrapper.json").write_text(
+            json.dumps(wrapper, indent=2, sort_keys=True) + "\n"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/baml-release-platforms
+++ b/scripts/baml-release-platforms
@@ -16,6 +16,7 @@ from baml_release_platforms import (
 
 
 def main() -> None:
+    """Emit the build matrix or validate a complete wrapper artifact set."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/scripts/baml-release-platforms
+++ b/scripts/baml-release-platforms
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Inspect and validate wrapper release platforms."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from baml_release_platforms import (
+    DEFAULT_PLATFORMS,
+    expected_wrapper_assets,
+    load_wrapper_targets,
+    verify_wrapper_artifacts,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("wrapper-matrix")
+    verify = subparsers.add_parser("verify-wrapper-artifacts")
+    verify.add_argument("--wrapper-dir", required=True, type=Path)
+    verify.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    if args.command == "wrapper-matrix":
+        matrix = [
+            target.matrix_entry() for target in load_wrapper_targets(args.platforms)
+        ]
+        print(json.dumps(matrix, separators=(",", ":")))
+    elif args.command == "verify-wrapper-artifacts":
+        verify_wrapper_artifacts(args.wrapper_dir, args.version, args.platforms)
+        print(
+            f"ok: {len(expected_wrapper_assets(args.version, args.platforms))} wrapper artifacts"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/baml_release_platforms.py
+++ b/scripts/baml_release_platforms.py
@@ -14,10 +14,12 @@ WRAPPER_VARIANTS = frozenset({"self-update", "no-self-update"})
 
 
 def fail(message: str) -> None:
+    """Exit with a platform contract validation error."""
     raise SystemExit(message)
 
 
 def require_string(value: Any, field: str) -> str:
+    """Require a nonempty string field in the platform contract."""
     if not isinstance(value, str) or not value:
         fail(f"{field} must be a non-empty string")
     return value
@@ -25,6 +27,8 @@ def require_string(value: Any, field: str) -> str:
 
 @dataclass(frozen=True)
 class WrapperTarget:
+    """Validated wrapper release metadata for one Rust target triple."""
+
     triple: str
     os: str
     arch: str
@@ -35,18 +39,22 @@ class WrapperTarget:
 
     @property
     def executable_suffix(self) -> str:
+        """Return the target platform's executable suffix."""
         return ".exe" if self.os == "windows" else ""
 
     def supports(self, variant: str) -> bool:
+        """Return whether this target publishes the requested wrapper variant."""
         return variant in self.variants
 
     def asset_name(self, version: str, variant: str) -> str:
+        """Return the canonical release asset name for a supported variant."""
         if not self.supports(variant):
             fail(f"{self.triple}: wrapper variant {variant!r} is not supported")
         infix = "" if variant == "self-update" else f"-{variant}"
         return f"baml-wrapper{infix}-{version}-{self.triple}{self.archive_suffix}"
 
     def matrix_entry(self) -> dict[str, Any]:
+        """Return this target's GitHub Actions wrapper matrix entry."""
         return {
             "target": self.triple,
             "os": self.runner,
@@ -60,6 +68,7 @@ class WrapperTarget:
 def load_wrapper_targets(
     platforms: Path = DEFAULT_PLATFORMS,
 ) -> tuple[WrapperTarget, ...]:
+    """Load and validate wrapper targets from the shared platform contract."""
     try:
         contract = json.loads(platforms.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -146,6 +155,7 @@ def load_wrapper_targets(
 def expected_wrapper_assets(
     version: str, platforms: Path = DEFAULT_PLATFORMS
 ) -> tuple[str, ...]:
+    """Return every wrapper archive required for a release version."""
     return tuple(
         target.asset_name(version, variant)
         for target in load_wrapper_targets(platforms)
@@ -156,6 +166,7 @@ def expected_wrapper_assets(
 def verify_wrapper_artifacts(
     wrapper_dir: Path, version: str, platforms: Path = DEFAULT_PLATFORMS
 ) -> None:
+    """Require the directory to contain exactly the contracted wrapper archives."""
     if not wrapper_dir.is_dir():
         fail(f"wrapper artifact directory does not exist: {wrapper_dir}")
     expected = set(expected_wrapper_assets(version, platforms))

--- a/scripts/baml_release_platforms.py
+++ b/scripts/baml_release_platforms.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python3
-"""Validate release platforms and derive wrapper release artifacts."""
+"""Shared wrapper release platform contract."""
 
 from __future__ import annotations
 
-import argparse
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -172,29 +170,3 @@ def verify_wrapper_artifacts(
     extra = sorted(actual - expected)
     if missing or extra:
         fail(f"wrapper artifact mismatch missing={missing} extra={extra}")
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    subparsers.add_parser("wrapper-matrix")
-    verify = subparsers.add_parser("verify-wrapper-artifacts")
-    verify.add_argument("--wrapper-dir", required=True, type=Path)
-    verify.add_argument("--version", required=True)
-    args = parser.parse_args()
-
-    if args.command == "wrapper-matrix":
-        matrix = [
-            target.matrix_entry() for target in load_wrapper_targets(args.platforms)
-        ]
-        print(json.dumps(matrix, separators=(",", ":")))
-    elif args.command == "verify-wrapper-artifacts":
-        verify_wrapper_artifacts(args.wrapper_dir, args.version, args.platforms)
-        print(
-            f"ok: {len(expected_wrapper_assets(args.version, args.platforms))} wrapper artifacts"
-        )
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/baml_release_platforms.py
+++ b/scripts/baml_release_platforms.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Validate release platforms and derive wrapper release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PLATFORMS = ROOT / "release" / "platforms.json"
+WRAPPER_VARIANTS = frozenset({"self-update", "no-self-update"})
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(f"{field} must be a non-empty string")
+    return value
+
+
+@dataclass(frozen=True)
+class WrapperTarget:
+    triple: str
+    os: str
+    arch: str
+    libc: str | None
+    archive_suffix: str
+    runner: str
+    variants: tuple[str, ...]
+
+    @property
+    def executable_suffix(self) -> str:
+        return ".exe" if self.os == "windows" else ""
+
+    def supports(self, variant: str) -> bool:
+        return variant in self.variants
+
+    def asset_name(self, version: str, variant: str) -> str:
+        if not self.supports(variant):
+            fail(f"{self.triple}: wrapper variant {variant!r} is not supported")
+        infix = "" if variant == "self-update" else f"-{variant}"
+        return f"baml-wrapper{infix}-{version}-{self.triple}{self.archive_suffix}"
+
+    def matrix_entry(self) -> dict[str, Any]:
+        return {
+            "target": self.triple,
+            "os": self.runner,
+            "libc": self.libc,
+            "archive_suffix": self.archive_suffix,
+            "executable_suffix": self.executable_suffix,
+            "no_self_update": self.supports("no-self-update"),
+        }
+
+
+def load_wrapper_targets(
+    platforms: Path = DEFAULT_PLATFORMS,
+) -> tuple[WrapperTarget, ...]:
+    try:
+        contract = json.loads(platforms.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"failed to read platform contract {platforms}: {exc}")
+    if not isinstance(contract, dict) or contract.get("schema") != 1:
+        fail("platform contract must be a schema-1 JSON object")
+    raw_targets = contract.get("targets")
+    if not isinstance(raw_targets, list):
+        fail("platform contract targets must be a JSON array")
+
+    seen: set[str] = set()
+    targets: list[WrapperTarget] = []
+    for index, raw_target in enumerate(raw_targets):
+        if not isinstance(raw_target, dict):
+            fail(f"platform target {index} must be a JSON object")
+        triple = require_string(
+            raw_target.get("triple"), f"platform target {index}.triple"
+        )
+        if triple in seen:
+            fail(f"duplicate platform target: {triple}")
+        seen.add(triple)
+
+        artifacts = raw_target.get("artifacts")
+        if not isinstance(artifacts, dict):
+            fail(f"{triple}: artifacts must be a JSON object")
+        wrapper = artifacts.get("wrapper")
+        if wrapper is None:
+            continue
+        if not isinstance(wrapper, dict):
+            fail(f"{triple}: wrapper artifact must be a JSON object")
+
+        os_name = require_string(raw_target.get("os"), f"{triple}: os")
+        if os_name not in {"linux", "macos", "windows"}:
+            fail(f"{triple}: unsupported os {os_name!r}")
+        arch = require_string(raw_target.get("arch"), f"{triple}: arch")
+        libc = raw_target.get("libc")
+        if libc is not None and not isinstance(libc, str):
+            fail(f"{triple}: libc must be a string or null")
+        archive_suffix = require_string(
+            raw_target.get("archive_suffix"), f"{triple}: archive_suffix"
+        )
+        expected_suffix = ".zip" if os_name == "windows" else ".tar.gz"
+        if archive_suffix != expected_suffix:
+            fail(f"{triple}: archive_suffix must be {expected_suffix!r} for {os_name}")
+
+        runner = require_string(wrapper.get("runner"), f"{triple}: wrapper.runner")
+        runner_marker = {"linux": "ubuntu", "macos": "macos", "windows": "windows"}[
+            os_name
+        ]
+        if runner_marker not in runner.lower():
+            fail(f"{triple}: wrapper runner {runner!r} does not match {os_name}")
+
+        raw_variants = wrapper.get("variants")
+        if not isinstance(raw_variants, list) or not raw_variants:
+            fail(f"{triple}: wrapper.variants must be a non-empty JSON array")
+        if any(not isinstance(variant, str) for variant in raw_variants):
+            fail(f"{triple}: wrapper variants must be strings")
+        variants = tuple(raw_variants)
+        if len(variants) != len(set(variants)):
+            fail(f"{triple}: wrapper variants must be unique")
+        unknown = sorted(set(variants) - WRAPPER_VARIANTS)
+        if unknown:
+            fail(f"{triple}: unknown wrapper variants: {unknown}")
+        if "self-update" not in variants:
+            fail(f"{triple}: wrapper variants must include 'self-update'")
+
+        targets.append(
+            WrapperTarget(
+                triple=triple,
+                os=os_name,
+                arch=arch,
+                libc=libc,
+                archive_suffix=archive_suffix,
+                runner=runner,
+                variants=variants,
+            )
+        )
+
+    if not targets:
+        fail("platform contract defines no wrapper targets")
+    return tuple(targets)
+
+
+def expected_wrapper_assets(
+    version: str, platforms: Path = DEFAULT_PLATFORMS
+) -> tuple[str, ...]:
+    return tuple(
+        target.asset_name(version, variant)
+        for target in load_wrapper_targets(platforms)
+        for variant in target.variants
+    )
+
+
+def verify_wrapper_artifacts(
+    wrapper_dir: Path, version: str, platforms: Path = DEFAULT_PLATFORMS
+) -> None:
+    if not wrapper_dir.is_dir():
+        fail(f"wrapper artifact directory does not exist: {wrapper_dir}")
+    expected = set(expected_wrapper_assets(version, platforms))
+    actual = {
+        path.name
+        for path in wrapper_dir.iterdir()
+        if path.is_file()
+        and path.name.startswith("baml-wrapper-")
+        and path.name.endswith((".tar.gz", ".zip"))
+    }
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing or extra:
+        fail(f"wrapper artifact mismatch missing={missing} extra={extra}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platforms", type=Path, default=DEFAULT_PLATFORMS)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("wrapper-matrix")
+    verify = subparsers.add_parser("verify-wrapper-artifacts")
+    verify.add_argument("--wrapper-dir", required=True, type=Path)
+    verify.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    if args.command == "wrapper-matrix":
+        matrix = [
+            target.matrix_entry() for target in load_wrapper_targets(args.platforms)
+        ]
+        print(json.dumps(matrix, separators=(",", ":")))
+    elif args.command == "verify-wrapper-artifacts":
+        verify_wrapper_artifacts(args.wrapper_dir, args.version, args.platforms)
+        print(
+            f"ok: {len(expected_wrapper_assets(args.version, args.platforms))} wrapper artifacts"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_baml_package_manager_artifacts.py
+++ b/scripts/tests/test_baml_package_manager_artifacts.py
@@ -34,6 +34,13 @@ class PackageManagerArtifactsTest(unittest.TestCase):
                 )
                 archive.write_bytes(content)
                 archive_shas[target] = hashlib.sha256(content).hexdigest()
+            for target in (
+                "aarch64-pc-windows-msvc",
+                "x86_64-pc-windows-msvc",
+            ):
+                (
+                    wrappers / f"baml-wrapper-no-self-update-{VERSION}-{target}.zip"
+                ).write_bytes(target.encode())
 
             subprocess.run(
                 [
@@ -81,6 +88,7 @@ class PackageManagerArtifactsTest(unittest.TestCase):
             self.assertNotIn(f'sha256 "{SOURCE_SHA256}"', formula)
             self.assertNotIn('depends_on "rust"', formula)
             self.assertNotIn('system "cargo"', formula)
+            self.assertNotIn("windows-msvc", formula)
             subprocess.run(
                 ["ruby", "-c", output / "homebrew/Formula/baml.rb"], check=True
             )
@@ -97,6 +105,7 @@ class PackageManagerArtifactsTest(unittest.TestCase):
             self.assertIn(
                 archive_shas["x86_64-unknown-linux-gnu"], aur_bin
             )
+            self.assertNotIn("windows-msvc", aur_bin)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_baml_release_manifests.py
+++ b/scripts/tests/test_baml_release_manifests.py
@@ -6,6 +6,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.baml_release_platforms import expected_wrapper_assets
+
 
 ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_TOOL = ROOT / "scripts" / "baml-release-manifests"
@@ -30,12 +32,11 @@ class ReleaseManifestTests(unittest.TestCase):
             (self.toolchain / f"baml-language-1.2.3-{triple}{suffix}").write_bytes(
                 triple.encode()
             )
-            (self.wrapper / f"baml-wrapper-9.8.7-{triple}{suffix}").write_bytes(
-                triple.encode()
-            )
             cffi = target["artifacts"].get("cffi")
             if cffi is not None:
                 (self.cffi / cffi["asset"]).write_bytes(triple.encode())
+        for asset in expected_wrapper_assets("9.8.7"):
+            (self.wrapper / asset).write_bytes(asset.encode())
         (self.vsix / "baml-language-1.2.3.vsix").write_bytes(b"vsix")
 
     def tearDown(self) -> None:
@@ -147,6 +148,30 @@ class ReleaseManifestTests(unittest.TestCase):
                 check=False,
             )
             self.assertNotEqual(result.returncode, 0)
+
+    def test_wrapper_manifest_validates_all_variants_but_lists_self_update(
+        self,
+    ) -> None:
+        output = self.root / "wrapper-manifest"
+        self.run_tool(output, "--wrapper-changed")
+
+        manifest = json.loads((output / "wrapper.json").read_text(encoding="utf-8"))
+        self.assertEqual(len(manifest["artifacts"]), 8)
+        self.assertIn("x86_64-pc-windows-msvc", manifest["artifacts"])
+        self.assertNotIn("no-self-update", json.dumps(manifest))
+
+        missing = (
+            self.wrapper
+            / "baml-wrapper-no-self-update-9.8.7-x86_64-pc-windows-msvc.zip"
+        )
+        missing.unlink()
+        result = self.run_tool(
+            self.root / "missing-wrapper",
+            "--wrapper-changed",
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("wrapper artifact mismatch missing=", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_baml_release_platforms.py
+++ b/scripts/tests/test_baml_release_platforms.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.baml_release_platforms import (
+    DEFAULT_PLATFORMS,
+    expected_wrapper_assets,
+    load_wrapper_targets,
+    verify_wrapper_artifacts,
+)
+
+
+VERSION = "1.2.3"
+
+
+class WrapperReleasePlatformTests(unittest.TestCase):
+    def test_wrapper_matrix_carries_variants_and_platform_suffixes(self) -> None:
+        targets = {target.triple: target for target in load_wrapper_targets()}
+
+        self.assertEqual(len(targets), 8)
+        for triple in (
+            "aarch64-apple-darwin",
+            "x86_64-apple-darwin",
+            "aarch64-unknown-linux-gnu",
+            "x86_64-unknown-linux-gnu",
+            "aarch64-pc-windows-msvc",
+            "x86_64-pc-windows-msvc",
+        ):
+            self.assertTrue(targets[triple].supports("no-self-update"))
+        for triple in (
+            "aarch64-unknown-linux-musl",
+            "x86_64-unknown-linux-musl",
+        ):
+            self.assertFalse(targets[triple].supports("no-self-update"))
+
+        windows = targets["x86_64-pc-windows-msvc"].matrix_entry()
+        self.assertEqual(windows["archive_suffix"], ".zip")
+        self.assertEqual(windows["executable_suffix"], ".exe")
+        self.assertTrue(windows["no_self_update"])
+
+    def test_expected_assets_include_both_windows_variants(self) -> None:
+        assets = set(expected_wrapper_assets(VERSION))
+
+        for triple in (
+            "aarch64-pc-windows-msvc",
+            "x86_64-pc-windows-msvc",
+        ):
+            self.assertIn(f"baml-wrapper-{VERSION}-{triple}.zip", assets)
+            self.assertIn(
+                f"baml-wrapper-no-self-update-{VERSION}-{triple}.zip",
+                assets,
+            )
+        self.assertNotIn(
+            f"baml-wrapper-no-self-update-{VERSION}-x86_64-unknown-linux-musl.tar.gz",
+            assets,
+        )
+
+    def test_wrapper_artifact_verification_requires_exact_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            wrapper_dir = Path(temporary)
+            for asset in expected_wrapper_assets(VERSION):
+                (wrapper_dir / asset).write_bytes(asset.encode())
+            verify_wrapper_artifacts(wrapper_dir, VERSION)
+
+            missing = (
+                wrapper_dir
+                / f"baml-wrapper-no-self-update-{VERSION}-x86_64-pc-windows-msvc.zip"
+            )
+            missing.unlink()
+            with self.assertRaisesRegex(
+                SystemExit, "wrapper artifact mismatch missing="
+            ):
+                verify_wrapper_artifacts(wrapper_dir, VERSION)
+
+            missing.write_bytes(b"restored")
+            unexpected = wrapper_dir / f"baml-wrapper-{VERSION}-unexpected.zip"
+            unexpected.write_bytes(b"unexpected")
+            with self.assertRaisesRegex(SystemExit, "extra=.*unexpected"):
+                verify_wrapper_artifacts(wrapper_dir, VERSION)
+
+    def test_wrapper_contract_rejects_invalid_metadata(self) -> None:
+        original = json.loads(DEFAULT_PLATFORMS.read_text(encoding="utf-8"))
+        cases = (
+            (
+                "unknown wrapper variants",
+                lambda contract: contract["targets"][0]["artifacts"]["wrapper"][
+                    "variants"
+                ].append("unknown"),
+            ),
+            (
+                "must include 'self-update'",
+                lambda contract: contract["targets"][0]["artifacts"]["wrapper"].update(
+                    variants=["no-self-update"]
+                ),
+            ),
+            (
+                "archive_suffix must be '.tar.gz'",
+                lambda contract: contract["targets"][0].update(archive_suffix=".zip"),
+            ),
+            (
+                "wrapper runner .* does not match macos",
+                lambda contract: contract["targets"][0]["artifacts"]["wrapper"].update(
+                    runner="windows-latest"
+                ),
+            ),
+        )
+        for message, mutate in cases:
+            with self.subTest(message=message), tempfile.TemporaryDirectory() as temp:
+                contract = copy.deepcopy(original)
+                mutate(contract)
+                platforms = Path(temp) / "platforms.json"
+                platforms.write_text(json.dumps(contract), encoding="utf-8")
+                with self.assertRaisesRegex(SystemExit, message):
+                    load_wrapper_targets(platforms)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_baml_release_platforms.py
+++ b/scripts/tests/test_baml_release_platforms.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -15,9 +17,24 @@ from scripts.baml_release_platforms import (
 
 
 VERSION = "1.2.3"
+ROOT = Path(__file__).resolve().parents[2]
+CLI = ROOT / "scripts" / "baml-release-platforms"
 
 
 class WrapperReleasePlatformTests(unittest.TestCase):
+    def test_extensionless_cli_generates_wrapper_matrix(self) -> None:
+        result = subprocess.run(
+            [sys.executable, CLI, "wrapper-matrix"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(
+            json.loads(result.stdout),
+            [target.matrix_entry() for target in load_wrapper_targets()],
+        )
+
     def test_wrapper_matrix_carries_variants_and_platform_suffixes(self) -> None:
         targets = {target.triple: target for target in load_wrapper_targets()}
 

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -833,7 +833,7 @@ class WorkflowGraphTests(unittest.TestCase):
         dry_run = job_block(workflow, "dry-run-artifacts")
 
         self.assertIn("baml-csharp-release-contract matrix", build_matrix)
-        self.assertIn("baml_release_platforms.py wrapper-matrix", build_matrix)
+        self.assertIn("baml-release-platforms wrapper-matrix", build_matrix)
         self.assertIn("needs.build-matrix.outputs.wrapper", wrapper)
         self.assertIn("matrix.no_self_update", wrapper)
         self.assertIn("matrix.archive_suffix", wrapper)

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -824,6 +824,7 @@ class WorkflowGraphTests(unittest.TestCase):
         all_builds = job_block(workflow, "all-builds")
         nuget = job_block(workflow, "publish-csharp-sdk")
         crates_io = job_block(workflow, "publish-crates-io")
+        wrapper_release = job_block(workflow, "publish-wrapper-release")
         prerequisites = job_block(workflow, "release-prerequisites-complete")
         complete = job_block(workflow, "release-complete")
         manifest = job_block(workflow, "publish-pkg-boundaryml-com")
@@ -832,13 +833,14 @@ class WorkflowGraphTests(unittest.TestCase):
         dry_run = job_block(workflow, "dry-run-artifacts")
 
         self.assertIn("baml-csharp-release-contract matrix", build_matrix)
-        for target in (
-            "aarch64-apple-darwin",
-            "x86_64-apple-darwin",
-            "aarch64-unknown-linux-gnu",
-            "x86_64-unknown-linux-gnu",
-        ):
-            self.assertIn(target, wrapper)
+        self.assertIn("baml_release_platforms.py wrapper-matrix", build_matrix)
+        self.assertIn("needs.build-matrix.outputs.wrapper", wrapper)
+        self.assertIn("matrix.no_self_update", wrapper)
+        self.assertIn("matrix.archive_suffix", wrapper)
+        self.assertIn("matrix.executable_suffix", wrapper)
+        self.assertIn("verify-wrapper-artifacts", wrapper_release)
+        self.assertNotIn("unknown-linux-gnu' ||", wrapper)
+        self.assertNotIn("windows-msvc", wrapper)
         self.assertIn("--features no-self-update", wrapper)
         self.assertIn("needs: [plan, build-matrix]", prepare)
         self.assertNotIn("build-bridge-cffi", prepare)


### PR DESCRIPTION
## Summary

- define wrapper runners and variants in the shared release platform contract
- publish and exactly validate no-self-update Windows x86_64 and arm64 ZIPs
- bump the wrapper version to 0.2.3 while keeping package-manager consumers scoped to their supported targets

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v`\n- `cargo test -p baml`\n- `cargo test -p baml --features no-self-update`\n- `cargo clippy -p baml --all-targets --features no-self-update -- -D warnings`\n- `cargo fmt --all -- --check`\n- Ruff, actionlint, and prek checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-specific wrapper release variants, including **self-update** and **no-self-update**, with per-platform archive/executable naming rules.
  * Introduced a wrapper release platform tool to generate wrapper matrices and verify expected wrapper assets.
* **Bug Fixes**
  * Strengthened release manifest generation and wrapper artifact verification to require an exact match (missing or extra artifacts now fail).
* **Maintenance**
  * Updated CI and release workflows to use a dedicated wrapper build matrix and consistent wrapper build/archive handling.
  * Updated `release/platforms.json` and bumped the BAML language package to **0.2.3**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->